### PR TITLE
Add fail-closed multichain prediction asset foundation

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -147,3 +147,17 @@ condition = "AND"
 regexTarget = "line"
 paths = ['''tests/dexscreener-shadow\.test\.ts''']
 regexes = ['''^\s*tokenAddress:\s*"0x9ea1917b68aa295d3a59be8c3934bcb45a1e449b",\s*$''']
+
+[[allowlists]]
+description = "Prediction V2 pins the decoded public Solana token program identities"
+condition = "AND"
+regexTarget = "match"
+paths = [
+  '''docs/operations/PREDICTION-ASSET-IDENTITY-V2\.md''',
+  '''lib/prediction-market-assets-v2\.ts''',
+  '''tests/prediction-market-assets-v2\.test\.ts''',
+]
+regexes = [
+  '''(?i)0x06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9''',
+  '''(?i)0x06ddf6e1ee758fde18425dbce46ccddab61afc4d83b90d27febdf928d8a18bfc''',
+]

--- a/app/api/prediction/asset-discovery/route.ts
+++ b/app/api/prediction/asset-discovery/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { readPredictionAssetDiscoveryV2 } from
-  "@/lib/market-data/prediction-asset-discovery-v2.server";
 import { isPredictionSourceNetworkIdV2 } from
   "@/lib/prediction-market-assets-v2";
+import { getPredictionV2ReleaseBinding } from
+  "@/lib/prediction-v2/release-binding.server";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -29,7 +29,24 @@ function invalidQuery() {
   );
 }
 
+function unavailableRelease() {
+  return NextResponse.json(
+    { error: "Not found" },
+    {
+      status: 404,
+      headers: {
+        "Cache-Control": "no-store",
+        "X-Content-Type-Options": "nosniff",
+      },
+    },
+  );
+}
+
 export async function GET(request: NextRequest) {
+  if (getPredictionV2ReleaseBinding().status === "disabled") {
+    return unavailableRelease();
+  }
+
   const search = request.nextUrl.searchParams;
   if (
     [...search.keys()].some((key) => !QUERY_PARAMETERS.has(key)) ||
@@ -49,6 +66,9 @@ export async function GET(request: NextRequest) {
     return invalidQuery();
   }
 
+  const { readPredictionAssetDiscoveryV2 } = await import(
+    "@/lib/market-data/prediction-asset-discovery-v2.server"
+  );
   const result = await readPredictionAssetDiscoveryV2(
     { mode: "custom", sourceNetwork: network, assetLocator: locator },
     { signal: request.signal },

--- a/app/api/prediction/asset-discovery/route.ts
+++ b/app/api/prediction/asset-discovery/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { readPredictionAssetDiscoveryV2 } from
+  "@/lib/market-data/prediction-asset-discovery-v2.server";
+import { isPredictionSourceNetworkIdV2 } from
+  "@/lib/prediction-market-assets-v2";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 5;
+
+const QUERY_PARAMETERS = new Set(["network", "locator"]);
+const AVAILABLE_CACHE_CONTROL =
+  "public, max-age=0, s-maxage=15, stale-while-revalidate=30";
+
+function responseHeaders(available: boolean) {
+  return {
+    "Cache-Control": available ? AVAILABLE_CACHE_CONTROL : "no-store",
+    "X-Content-Type-Options": "nosniff",
+    "X-Programmable-Market-Provider": "dexscreener",
+    "X-Programmable-Read-Purpose": "informational-only",
+  };
+}
+
+function invalidQuery() {
+  return NextResponse.json(
+    { error: "Choose one supported network and enter its exact token locator" },
+    { status: 400, headers: responseHeaders(false) },
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const search = request.nextUrl.searchParams;
+  if (
+    [...search.keys()].some((key) => !QUERY_PARAMETERS.has(key)) ||
+    search.getAll("network").length !== 1 ||
+    search.getAll("locator").length !== 1
+  ) {
+    return invalidQuery();
+  }
+
+  const network = search.get("network") ?? "";
+  const locator = search.get("locator")?.trim() ?? "";
+  if (
+    !isPredictionSourceNetworkIdV2(network) ||
+    locator.length === 0 ||
+    locator.length > 128
+  ) {
+    return invalidQuery();
+  }
+
+  const result = await readPredictionAssetDiscoveryV2(
+    { mode: "custom", sourceNetwork: network, assetLocator: locator },
+    { signal: request.signal },
+  );
+  if (result.status === "available") {
+    return NextResponse.json(result, {
+      headers: responseHeaders(true),
+    });
+  }
+
+  const status = result.reason === "invalid-selection"
+    ? 400
+    : result.reason === "not-found"
+      ? 404
+      : 503;
+  return NextResponse.json(result, {
+    status,
+    headers: {
+      ...responseHeaders(false),
+      ...(status === 503 ? { "Retry-After": "5" } : {}),
+    },
+  });
+}

--- a/app/api/prediction/preset-discovery/route.ts
+++ b/app/api/prediction/preset-discovery/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getPredictionV2ReleaseBinding } from
+  "@/lib/prediction-v2/release-binding.server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 5;
+
+function responseHeaders(cacheSeconds: number | null) {
+  return {
+    "Cache-Control": cacheSeconds === null
+      ? "no-store"
+      : `public, max-age=0, s-maxage=${cacheSeconds}, must-revalidate`,
+    "X-Content-Type-Options": "nosniff",
+    "X-Programmable-Market-Provider": "coingecko-keyless-public",
+    "X-Programmable-Read-Purpose":
+      "display-only-not-eligibility-or-settlement",
+    "X-Programmable-Provider-Service-Level": "best-effort-no-sla",
+  };
+}
+
+function unavailableRelease() {
+  return NextResponse.json(
+    { error: "Not found" },
+    {
+      status: 404,
+      headers: {
+        "Cache-Control": "no-store",
+        "X-Content-Type-Options": "nosniff",
+      },
+    },
+  );
+}
+
+export async function GET(request: NextRequest) {
+  if (getPredictionV2ReleaseBinding().status === "disabled") {
+    return unavailableRelease();
+  }
+
+  if ([...request.nextUrl.searchParams.keys()].length !== 0) {
+    return NextResponse.json(
+      { error: "Preset discovery does not accept query parameters" },
+      { status: 400, headers: responseHeaders(null) },
+    );
+  }
+
+  const { readPredictionPresetDiscoveryV2 } = await import(
+    "@/lib/market-data/prediction-preset-discovery-v2.server"
+  );
+  const result = await readPredictionPresetDiscoveryV2({
+    signal: request.signal,
+  });
+  if (result.status === "available") {
+    const remainingCacheSeconds = Math.floor(
+      (new Date(result.cacheExpiresAt).getTime() - Date.now()) / 1_000,
+    );
+    return NextResponse.json(result, {
+      headers: responseHeaders(
+        Number.isFinite(remainingCacheSeconds) && remainingCacheSeconds > 0
+          ? Math.min(60, remainingCacheSeconds)
+          : null,
+      ),
+    });
+  }
+
+  return NextResponse.json(result, {
+    status: 503,
+    headers: {
+      ...responseHeaders(null),
+      "Retry-After": result.reason === "rate-limited" ? "60" : "5",
+    },
+  });
+}

--- a/app/docs/economics/page.tsx
+++ b/app/docs/economics/page.tsx
@@ -42,6 +42,12 @@ const feeRows = [
     treatment: PROGRAMMABLE_FEE_TABLE.standardCustom.chargeMode,
   },
   {
+    path: "Prediction Markets",
+    total: "Defined by the active protocol release",
+    split: "Fees, recipients and creator rewards are release-specific.",
+    treatment: "Separately versioned",
+  },
+  {
     path: "Public template",
     total: formatBps(PROGRAMMABLE_FEE_TABLE.publicTemplate.totalBps),
     split: `${formatBps(PROGRAMMABLE_FEE_TABLE.publicTemplate.creatorBps)} to the template creator and ${formatBps(PROGRAMMABLE_FEE_TABLE.publicTemplate.programmableBps)} to Programmable.`,
@@ -112,7 +118,13 @@ export default function EconomicsDocsPage() {
             The policy describes the split; the matching release and public
             record determine whether a particular launch, template or recipient
             can use it. Public template intake is controlled by the repository
-            instructions. This policy page is not an execution receipt.
+            instructions. Prediction Markets keeps its current economics in the{" "}
+            <DocsExternalLink
+              href={PROGRAMMABLE_PUBLIC_REPOSITORIES.predictionMarkets}
+            >
+              canonical Prediction Markets repository
+            </DocsExternalLink>
+            . This policy page is not an execution receipt.
           </p>
         </div>
       </section>

--- a/components/docs-public-policy.ts
+++ b/components/docs-public-policy.ts
@@ -16,6 +16,8 @@ export type DocsProductState = Readonly<{
 export const PROGRAMMABLE_PUBLIC_REPOSITORIES = {
   developers: "https://github.com/0xprogrammable/developers",
   hookbuilder: "https://github.com/0xprogrammable/hookbuilder",
+  predictionMarkets:
+    "https://github.com/0xprogrammable/programmable-prediction-markets",
   product: "https://github.com/0xprogrammable/programmable",
   productIssues: "https://github.com/0xprogrammable/programmable/issues",
   submitLaunch: "https://github.com/0xprogrammable/submit-launch",

--- a/components/prediction-market-asset-selector-v2.module.css
+++ b/components/prediction-market-asset-selector-v2.module.css
@@ -1,0 +1,296 @@
+.root {
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-card);
+  color: var(--webde-ink);
+  display: grid;
+  gap: 24px;
+  min-width: 0;
+  padding: 28px;
+}
+
+.heading {
+  align-items: start;
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+}
+
+.heading h2 {
+  font-size: 26px;
+  font-weight: 590;
+  letter-spacing: -0.03em;
+  line-height: 1.16;
+  margin: 0;
+}
+
+.heading p {
+  color: var(--webde-muted);
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 6px 0 0;
+  text-wrap: pretty;
+}
+
+.modeSwitch {
+  background: var(--webde-control);
+  border: 1px solid var(--webde-line);
+  border-radius: 15px;
+  display: grid;
+  flex: 0 0 auto;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  padding: 4px;
+}
+
+.modeSwitch button {
+  background: transparent;
+  border: 0;
+  border-radius: 10px;
+  color: var(--webde-muted);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 650;
+  min-height: 44px;
+  padding-inline: 16px;
+  transition:
+    background-color 150ms var(--webde-ease),
+    color 150ms var(--webde-ease),
+    transform 120ms var(--webde-ease);
+  white-space: nowrap;
+}
+
+.modeSwitch button[data-active="true"] {
+  background: var(--webde-ink);
+  color: var(--webde-canvas);
+}
+
+.presetGrid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.preset {
+  align-items: start;
+  background: var(--webde-control);
+  border: 1px solid var(--webde-line);
+  border-radius: 15px;
+  color: var(--webde-muted);
+  display: grid;
+  font: inherit;
+  gap: 3px;
+  min-height: 72px;
+  padding: 14px;
+  text-align: start;
+  transition:
+    background-color 150ms var(--webde-ease),
+    border-color 150ms var(--webde-ease),
+    color 150ms var(--webde-ease),
+    transform 120ms var(--webde-ease);
+}
+
+.preset strong {
+  color: var(--webde-ink);
+  font-size: 15px;
+  font-weight: 680;
+  line-height: 1.2;
+}
+
+.preset span {
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.preset[data-selected="true"] {
+  background: var(--webde-surface-raised);
+  border-color: color-mix(in srgb, var(--webde-ink) 54%, var(--webde-line));
+  color: var(--webde-ink);
+}
+
+.customFields {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(180px, 0.72fr) minmax(0, 1.28fr);
+}
+
+.field {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+}
+
+.field > span {
+  color: var(--webde-ink);
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.field input,
+.field select {
+  -webkit-appearance: none;
+  appearance: none;
+  background: var(--webde-control);
+  border: 1px solid var(--webde-line);
+  border-radius: 13px;
+  color: var(--webde-ink);
+  font: inherit;
+  font-size: 16px;
+  min-height: 56px;
+  min-width: 0;
+  padding-inline: 14px;
+  transition:
+    background-color 150ms var(--webde-ease),
+    border-color 150ms var(--webde-ease);
+  width: 100%;
+}
+
+.field select {
+  background-image:
+    linear-gradient(45deg, transparent 50%, currentColor 50%),
+    linear-gradient(135deg, currentColor 50%, transparent 50%);
+  background-position:
+    calc(100% - 18px) 25px,
+    calc(100% - 13px) 25px;
+  background-repeat: no-repeat;
+  background-size: 5px 5px, 5px 5px;
+  padding-inline-end: 38px;
+}
+
+.field input::placeholder {
+  color: var(--webde-dim);
+}
+
+.field input[aria-invalid="true"],
+.field select[aria-invalid="true"] {
+  border-color: color-mix(in srgb, var(--danger) 70%, var(--webde-line));
+}
+
+.field small {
+  color: var(--webde-muted);
+  font-size: 12px;
+  line-height: 1.45;
+  min-height: 1.45em;
+  overflow-wrap: anywhere;
+}
+
+.referenceData {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 0;
+}
+
+.referenceData > div {
+  background: var(--webde-control);
+  border-radius: 14px;
+  display: grid;
+  gap: 5px;
+  padding: 14px 16px;
+}
+
+.referenceData dt {
+  color: var(--webde-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.referenceData dd {
+  color: var(--webde-ink);
+  font-size: 18px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.marketState {
+  background: var(--webde-control);
+  border: 1px solid var(--webde-line);
+  border-radius: 15px;
+  display: grid;
+  gap: 4px;
+  padding: 15px 16px;
+}
+
+.marketState strong {
+  color: var(--webde-ink);
+  font-size: 14px;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.marketState span {
+  color: var(--webde-muted);
+  font-size: 13px;
+  line-height: 1.45;
+  text-wrap: pretty;
+}
+
+.marketState[data-state="available"] {
+  border-color: color-mix(in srgb, var(--success) 46%, var(--webde-line));
+}
+
+.modeSwitch button:focus-visible,
+.preset:focus-visible,
+.field input:focus-visible,
+.field select:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 3px;
+}
+
+.modeSwitch button:disabled,
+.preset:disabled,
+.field input:disabled,
+.field select:disabled {
+  cursor: default;
+  opacity: 0.56;
+}
+
+.modeSwitch button:active:not(:disabled),
+.preset:active:not(:disabled) {
+  transform: scale(0.96);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .modeSwitch button:not([data-active="true"]):not(:disabled):hover,
+  .preset:not([data-selected="true"]):not(:disabled):hover {
+    background: var(--webde-surface-raised);
+    color: var(--webde-ink);
+  }
+}
+
+@media (max-width: 720px) {
+  .heading {
+    align-items: stretch;
+    display: grid;
+  }
+
+  .modeSwitch {
+    width: 100%;
+  }
+
+  .presetGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .customFields {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 520px) {
+  .root {
+    border-radius: 20px;
+    gap: 20px;
+    padding: 19px;
+  }
+
+  .heading {
+    gap: 16px;
+  }
+
+  .referenceData {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/components/prediction-market-asset-selector-v2.module.css
+++ b/components/prediction-market-asset-selector-v2.module.css
@@ -6,7 +6,7 @@
   display: grid;
   gap: 24px;
   min-width: 0;
-  padding: 28px;
+  padding: 32px;
 }
 
 .heading {
@@ -17,10 +17,10 @@
 }
 
 .heading h2 {
-  font-size: 26px;
+  font-size: 24px;
   font-weight: 590;
   letter-spacing: -0.03em;
-  line-height: 1.16;
+  line-height: 32px;
   margin: 0;
 }
 
@@ -28,14 +28,14 @@
   color: var(--webde-muted);
   font-size: 14px;
   line-height: 1.5;
-  margin: 6px 0 0;
+  margin: 4px 0 0;
   text-wrap: pretty;
 }
 
 .modeSwitch {
   background: var(--webde-control);
   border: 1px solid var(--webde-line);
-  border-radius: 15px;
+  border-radius: 16px;
   display: grid;
   flex: 0 0 auto;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -45,10 +45,10 @@
 .modeSwitch button {
   background: transparent;
   border: 0;
-  border-radius: 10px;
+  border-radius: 12px;
   color: var(--webde-muted);
   font: inherit;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 650;
   min-height: 44px;
   padding-inline: 16px;
@@ -74,7 +74,7 @@
   align-items: start;
   background: var(--webde-control);
   border: 1px solid var(--webde-line);
-  border-radius: 15px;
+  border-radius: 16px;
   color: var(--webde-muted);
   display: grid;
   font: inherit;
@@ -91,7 +91,7 @@
 
 .preset strong {
   color: var(--webde-ink);
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 680;
   line-height: 1.2;
 }
@@ -119,7 +119,7 @@
   min-width: 0;
 }
 
-.field > span {
+.field > label {
   color: var(--webde-ink);
   font-size: 14px;
   font-weight: 650;
@@ -131,7 +131,7 @@
   appearance: none;
   background: var(--webde-control);
   border: 1px solid var(--webde-line);
-  border-radius: 13px;
+  border-radius: 12px;
   color: var(--webde-ink);
   font: inherit;
   font-size: 16px;
@@ -182,7 +182,7 @@
 
 .referenceData > div {
   background: var(--webde-control);
-  border-radius: 14px;
+  border-radius: 16px;
   display: grid;
   gap: 5px;
   padding: 14px 16px;
@@ -204,10 +204,14 @@
   margin: 0;
 }
 
+.statusRegion {
+  min-width: 0;
+}
+
 .marketState {
   background: var(--webde-control);
   border: 1px solid var(--webde-line);
-  border-radius: 15px;
+  border-radius: 16px;
   display: grid;
   gap: 4px;
   padding: 15px 16px;
@@ -227,8 +231,14 @@
   text-wrap: pretty;
 }
 
-.marketState[data-state="available"] {
-  border-color: color-mix(in srgb, var(--success) 46%, var(--webde-line));
+.srOnly {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 
 .modeSwitch button:focus-visible,
@@ -283,7 +293,7 @@
   .root {
     border-radius: 20px;
     gap: 20px;
-    padding: 19px;
+    padding: 24px;
   }
 
   .heading {

--- a/components/prediction-market-asset-selector-v2.tsx
+++ b/components/prediction-market-asset-selector-v2.tsx
@@ -112,8 +112,8 @@ export function PredictionMarketAssetSelectorV2({
         </div>
       ) : (
         <div className={styles.customFields}>
-          <label className={styles.field} htmlFor={networkId}>
-            <span>Network</span>
+          <div className={styles.field}>
+            <label htmlFor={networkId}>Network</label>
             <select
               aria-describedby={
                 validation.errors.sourceNetwork
@@ -139,7 +139,7 @@ export function PredictionMarketAssetSelectorV2({
               }}
               value={value.sourceNetwork}
             >
-              <option value="">Select network</option>
+              <option value="">Choose network</option>
               {PREDICTION_SOURCE_NETWORKS_V2.map((network) => (
                 <option key={network.id} value={network.id}>
                   {network.label}
@@ -149,10 +149,10 @@ export function PredictionMarketAssetSelectorV2({
             <small id={`${networkId}-feedback`}>
               {validation.errors.sourceNetwork ?? "\u00a0"}
             </small>
-          </label>
+          </div>
 
-          <label className={styles.field} htmlFor={locatorId}>
-            <span>{locatorLabel}</span>
+          <div className={styles.field}>
+            <label htmlFor={locatorId}>{locatorLabel}</label>
             <input
               aria-describedby={locatorFeedbackId}
               aria-invalid={
@@ -176,17 +176,20 @@ export function PredictionMarketAssetSelectorV2({
             <small id={locatorFeedbackId}>
               {validation.errors.assetLocator ??
                 (sourceNetwork?.namespace === "solana"
-                  ? "Use the Solana mainnet token mint."
-                  : "The address alone does not identify its network.")}
+                  ? "Use the token mint on Solana mainnet."
+                  : "Use the token contract on the selected network.")}
             </small>
-          </label>
+          </div>
         </div>
       )}
 
       {matchingSnapshot ? (
-        <dl className={styles.referenceData} aria-label="Current asset data">
+        <dl
+          className={styles.referenceData}
+          aria-label="Current asset data, informational only"
+        >
           <div>
-            <dt>Current price · info only</dt>
+            <dt>Current price</dt>
             <dd>
               {formatPredictionAssetUsdV2(
                 matchingSnapshot.currentPriceUsd,
@@ -195,7 +198,7 @@ export function PredictionMarketAssetSelectorV2({
             </dd>
           </div>
           <div>
-            <dt>Market cap · info only</dt>
+            <dt>Market cap</dt>
             <dd>
               {formatPredictionAssetUsdV2(
                 matchingSnapshot.marketCapUsd,
@@ -206,14 +209,15 @@ export function PredictionMarketAssetSelectorV2({
         </dl>
       ) : null}
 
-      <div
-        className={styles.marketState}
-        data-state={marketState.state}
-        role="status"
-        aria-live="polite"
-      >
-        <strong>{marketState.title}</strong>
-        <span>{marketState.detail}</span>
+      <div className={styles.statusRegion} role="status" aria-live="polite">
+        {marketState.state === "unavailable" ? (
+          <div className={styles.marketState} data-state={marketState.state}>
+            <strong>{marketState.title}</strong>
+            <span>{marketState.detail}</span>
+          </div>
+        ) : (
+          <span className={styles.srOnly}>{marketState.detail}</span>
+        )}
       </div>
     </section>
   );

--- a/components/prediction-market-asset-selector-v2.tsx
+++ b/components/prediction-market-asset-selector-v2.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useId } from "react";
+
+import styles from "@/components/prediction-market-asset-selector-v2.module.css";
+import {
+  PREDICTION_PRESET_ASSETS_V2,
+  PREDICTION_SOURCE_NETWORKS_V2,
+  formatPredictionAssetUsdV2,
+  isPredictionSourceNetworkIdV2,
+  predictionAssetMarketStateV2,
+  predictionAssetSnapshotMatchesSelectionV2,
+  predictionSourceNetworkV2,
+  validatePredictionAssetSelectionV2,
+  type PredictionAssetDiscoverySnapshotV2,
+  type PredictionAssetReleaseRegistryV2,
+  type PredictionAssetSelectionV2,
+  type PredictionPresetAssetIdV2,
+} from "@/lib/prediction-market-assets-v2";
+
+export type PredictionMarketAssetSelectorV2Props = Readonly<{
+  value: PredictionAssetSelectionV2;
+  onChange: (selection: PredictionAssetSelectionV2) => void;
+  releaseRegistry?: PredictionAssetReleaseRegistryV2 | null;
+  discoverySnapshot?: PredictionAssetDiscoverySnapshotV2 | null;
+  disabled?: boolean;
+}>;
+
+export function PredictionMarketAssetSelectorV2({
+  value,
+  onChange,
+  releaseRegistry,
+  discoverySnapshot,
+  disabled = false,
+}: PredictionMarketAssetSelectorV2Props) {
+  const generatedId = useId();
+  const headingId = `${generatedId}-heading`;
+  const networkId = `${generatedId}-network`;
+  const locatorId = `${generatedId}-locator`;
+  const locatorFeedbackId = `${generatedId}-locator-feedback`;
+  const validation = validatePredictionAssetSelectionV2(value);
+  const marketState = predictionAssetMarketStateV2(value, releaseRegistry);
+  const sourceNetwork =
+    value.mode === "custom"
+      ? predictionSourceNetworkV2(value.sourceNetwork)
+      : undefined;
+  const locatorLabel =
+    sourceNetwork?.namespace === "solana" ? "Token mint" : "Contract address";
+  const locatorPlaceholder =
+    sourceNetwork?.namespace === "solana" ? "Solana token mint" : "0x…";
+  const matchingSnapshot = predictionAssetSnapshotMatchesSelectionV2(
+    discoverySnapshot,
+    value,
+  )
+    ? discoverySnapshot
+    : null;
+
+  function selectPreset(presetId: PredictionPresetAssetIdV2) {
+    onChange({ mode: "preset", presetId });
+  }
+
+  return (
+    <section className={styles.root} aria-labelledby={headingId}>
+      <div className={styles.heading}>
+        <div>
+          <h2 id={headingId}>Asset</h2>
+          <p>Choose a popular asset or add a token.</p>
+        </div>
+        <div className={styles.modeSwitch} role="group" aria-label="Asset type">
+          <button
+            aria-pressed={value.mode === "preset"}
+            data-active={value.mode === "preset"}
+            disabled={disabled}
+            onClick={() => selectPreset("btc")}
+            type="button"
+          >
+            Popular
+          </button>
+          <button
+            aria-pressed={value.mode === "custom"}
+            data-active={value.mode === "custom"}
+            disabled={disabled}
+            onClick={() =>
+              onChange({ mode: "custom", sourceNetwork: "", assetLocator: "" })
+            }
+            type="button"
+          >
+            Custom token
+          </button>
+        </div>
+      </div>
+
+      {value.mode === "preset" ? (
+        <div className={styles.presetGrid} role="group" aria-label="Popular assets">
+          {PREDICTION_PRESET_ASSETS_V2.map((asset) => {
+            const selected = value.presetId === asset.id;
+            return (
+              <button
+                aria-pressed={selected}
+                className={styles.preset}
+                data-selected={selected}
+                disabled={disabled}
+                key={asset.id}
+                onClick={() => selectPreset(asset.id)}
+                type="button"
+              >
+                <strong>{asset.symbol}</strong>
+                <span>{asset.name}</span>
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <div className={styles.customFields}>
+          <label className={styles.field} htmlFor={networkId}>
+            <span>Network</span>
+            <select
+              aria-describedby={
+                validation.errors.sourceNetwork
+                  ? `${networkId}-feedback`
+                  : undefined
+              }
+              aria-invalid={
+                value.sourceNetwork
+                  ? Boolean(validation.errors.sourceNetwork)
+                  : undefined
+              }
+              disabled={disabled}
+              id={networkId}
+              name="predictionSourceNetwork"
+              onChange={(event) => {
+                const candidate = event.target.value;
+                onChange({
+                  ...value,
+                  sourceNetwork: isPredictionSourceNetworkIdV2(candidate)
+                    ? candidate
+                    : "",
+                });
+              }}
+              value={value.sourceNetwork}
+            >
+              <option value="">Select network</option>
+              {PREDICTION_SOURCE_NETWORKS_V2.map((network) => (
+                <option key={network.id} value={network.id}>
+                  {network.label}
+                </option>
+              ))}
+            </select>
+            <small id={`${networkId}-feedback`}>
+              {validation.errors.sourceNetwork ?? "\u00a0"}
+            </small>
+          </label>
+
+          <label className={styles.field} htmlFor={locatorId}>
+            <span>{locatorLabel}</span>
+            <input
+              aria-describedby={locatorFeedbackId}
+              aria-invalid={
+                value.assetLocator.trim()
+                  ? Boolean(validation.errors.assetLocator)
+                  : undefined
+              }
+              autoCapitalize="none"
+              autoComplete="off"
+              disabled={disabled}
+              id={locatorId}
+              name="predictionAssetLocator"
+              onChange={(event) =>
+                onChange({ ...value, assetLocator: event.target.value })
+              }
+              placeholder={locatorPlaceholder}
+              spellCheck={false}
+              type="text"
+              value={value.assetLocator}
+            />
+            <small id={locatorFeedbackId}>
+              {validation.errors.assetLocator ??
+                (sourceNetwork?.namespace === "solana"
+                  ? "Use the Solana mainnet token mint."
+                  : "The address alone does not identify its network.")}
+            </small>
+          </label>
+        </div>
+      )}
+
+      {matchingSnapshot ? (
+        <dl className={styles.referenceData} aria-label="Current asset data">
+          <div>
+            <dt>Current price · info only</dt>
+            <dd>
+              {formatPredictionAssetUsdV2(
+                matchingSnapshot.currentPriceUsd,
+                "price",
+              )}
+            </dd>
+          </div>
+          <div>
+            <dt>Market cap · info only</dt>
+            <dd>
+              {formatPredictionAssetUsdV2(
+                matchingSnapshot.marketCapUsd,
+                "market-cap",
+              )}
+            </dd>
+          </div>
+        </dl>
+      ) : null}
+
+      <div
+        className={styles.marketState}
+        data-state={marketState.state}
+        role="status"
+        aria-live="polite"
+      >
+        <strong>{marketState.title}</strong>
+        <span>{marketState.detail}</span>
+      </div>
+    </section>
+  );
+}

--- a/components/prediction-markets-docs.tsx
+++ b/components/prediction-markets-docs.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 
 import { DocsExternalLink } from "@/components/docs-external-link";
-import { PROGRAMMABLE_PUBLIC_REPOSITORIES } from "@/components/docs-public-policy";
 import { DocsShell } from "@/components/docs-shell";
 import styles from "@/components/docs-experience.module.css";
 
@@ -43,7 +42,7 @@ export function PredictionMarketsDocs() {
             Open Prediction Markets
           </DocsExternalLink>
           <DocsExternalLink
-            href={PROGRAMMABLE_PUBLIC_REPOSITORIES.predictionMarkets}
+            href="https://github.com/0xprogrammable/programmable-prediction-markets"
             variant="chip"
           >
             Current source and release details

--- a/components/prediction-markets-docs.tsx
+++ b/components/prediction-markets-docs.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import { DocsExternalLink } from "@/components/docs-external-link";
+import { PROGRAMMABLE_PUBLIC_REPOSITORIES } from "@/components/docs-public-policy";
 import { DocsShell } from "@/components/docs-shell";
 import styles from "@/components/docs-experience.module.css";
 
@@ -42,7 +43,7 @@ export function PredictionMarketsDocs() {
             Open Prediction Markets
           </DocsExternalLink>
           <DocsExternalLink
-            href="https://github.com/0xprogrammable/programmable-prediction-markets"
+            href={PROGRAMMABLE_PUBLIC_REPOSITORIES.predictionMarkets}
             variant="chip"
           >
             Current source and release details

--- a/config/prediction-v2-release-binding.v1.json
+++ b/config/prediction-v2-release-binding.v1.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "releaseVersion": "prediction-v2",
+  "status": "disabled"
+}

--- a/docs/operations/PREDICTION-ASSET-IDENTITY-V2.md
+++ b/docs/operations/PREDICTION-ASSET-IDENTITY-V2.md
@@ -1,0 +1,57 @@
+# Prediction asset identity V2
+
+This document defines the website boundary between token discovery and a released Prediction V2 market. It is a
+candidate integration contract, not evidence that Protocol V2 is deployed or enabled.
+
+## Two keys with different authority
+
+`selectionKey` is a website and provider lookup key. Examples are `preset:btc`,
+`evm:8453:0x…`, and `solana:<mainnet-genesis-base58>:<mint>`. Discovery responses contain this key only. Current USD
+price and market capitalization are informational display data and cannot make a market eligible for settlement.
+
+`onchainAssetKey` is the exact `AssetRegistryV2` key:
+
+```text
+keccak256(abi.encode(
+  keccak256("PROGRAMMABLE_ASSET_KEY_V2"),
+  sourceNamespace,
+  sourceChain,
+  assetIdentifier,
+  assetStandard
+))
+```
+
+The website must never pass `selectionKey` where a protocol `bytes32 assetKey` is required.
+
+## Canonical identities
+
+Preset assets are global native identities:
+
+```text
+GLOBAL_CRYPTO / GLOBAL / BTC / NATIVE
+GLOBAL_CRYPTO / GLOBAL / ETH / NATIVE
+GLOBAL_CRYPTO / GLOBAL / SOL / NATIVE
+GLOBAL_CRYPTO / GLOBAL / BNB / NATIVE
+```
+
+An EVM custom token uses `EIP155`, a numeric chain ID encoded as `bytes32`, a nonzero contract address zero-left-padded
+to `bytes32`, and `ERC20`. The supported source chain IDs are Ethereum `1`, BNB Chain `56`, Base `8453`, and Robinhood
+Chain `4663`. The user must choose the source chain; the same address can exist on several chains, so the website does
+not claim to infer it from a contract address.
+
+A Solana custom token uses `SOLANA`, the raw decoded mainnet genesis hash, the raw decoded nonzero 32-byte mint, and the
+raw Token Program or Token-2022 program public key. Discovery can look up the mint without deciding its program. A
+release entry must bind the exact verified program before the market becomes available.
+
+## Release-ready entry
+
+One ready or paused entry binds all of the following:
+
+- `selectionKey` for the exact UI selection;
+- `onchainAssetKey` recomputed from the included canonical four-field identity;
+- Registry snapshot `assetKey`, positive revision, and nonzero `snapshotHash`;
+- nonempty release ID and Oracle policy ID;
+- the Robinhood Chain settlement profile and the `usd-price-at-utc` market type.
+
+The runtime validator fails closed if identity, hash, snapshot, release, network, or status disagree. Missing entries are
+unsupported. Multiple matching entries are ambiguous. Discovery availability never overrides either state.

--- a/docs/operations/PREDICTION-V2-UI-INTEGRATION-FOUNDATION.md
+++ b/docs/operations/PREDICTION-V2-UI-INTEGRATION-FOUNDATION.md
@@ -1,0 +1,45 @@
+# Protocol V2 UI integration foundation
+
+Status: local foundation only. It is not connected to the production prediction-market routes and must not be described as live.
+
+## Exact protocol closure
+
+The isolated `lib/prediction-v2` lane binds only the current Protocol V2 surface:
+
+- `GenericPredictionMarketFactoryV2`: 10-field `markets`, `assetRegistry`, `activeMarketId`, pool-key reads, and the exact identity + observation + threshold `createMarketWithPermit` signature.
+- `AssetRegistryV2`: canonical identity, 17-field `OraclePolicy`, full `Snapshot`, `hashSnapshot`, and current-active-revision bindings.
+- `PredictionQuoterV2`: 9-field `BuyQuote` and 8-field `SellQuote`, each containing the 6-field live v4 swap result.
+- `ExecutionRouterV2`: exact buy and sell request tuples and EIP-2612 permit signatures.
+- `GlobalExposureControllerV2`: `requireIncreaseCapacity(address,uint256)` as a reverting view preflight with no return value.
+- `PredictionVaultV2`: `exposureController()` and `finalize(bytes)`. The Chainlink helper encodes exactly two adjacent nonzero `uint80` round IDs and sends zero native value.
+
+No V1 module, production route, Gates code, Indexer code, or Dune code is changed by this foundation.
+
+## Fail-closed transaction rules
+
+- A buy permit must equal `requestedCollateralAtoms + floor(requestedCollateralAtoms * 10 / 10_000)`. It cannot authorize collateral alone.
+- A sell permit must equal the exact outcome-token input.
+- Buy minimum receive is floored from quoted outcome atoms. Sell minimum proceeds is floored from net collateral after the 10 bps protocol fee, never from gross collateral.
+- Every quote is bound to chain 4663, exact Quoter, vault, five-field pool key, side, requested amount, sqrt-price limit, confirmed block number, and block hash. Preparation rejects cross-market, cross-side, changed-limit, changed-amount, and stale-block reuse.
+- BUY preparation also requires successful `vault.exposureController()` and `controller.requireIncreaseCapacity(vault, requestedCollateralAtoms)` calls at the quote's exact block number and hash. Capacity uses the full requested split notional, not executed collateral, because the Router splits before applying the price-limit refund.
+- Capacity is never promised. The read is point-in-state and execution rechecks atomically; another transaction can consume capacity first. Refresh quote and capacity together immediately before signing and present a normal revert as a race, not as lost funds.
+- Creation binds `selectionKey`, canonical identity, derived onchain asset key, full Registry snapshot, locally reproduced `hashSnapshot`, live Registry `hashSnapshot` result, Factory `activeMarketId` snapshot hash, and the released snapshot hash. All four hashes must agree.
+- Pool fee and tick spacing are fixed to the deployed V2 invariants: 200 pips and 10.
+
+## Pre-sign preview model
+
+The V2 preview model exposes maximum and actual fee-inclusive payment, protocol fee, refunds, quoted and minimum shares, average executable price, current-to-post probability, signed percentage-point impact, relative impact, live LP and directional PoolManager fee, gross winning payout, signed net profit, conservative maximum loss, and neutral payout. Sell previews expose gross proceeds, fee, net proceeds, net minimum, and both token-refund classes.
+
+Liquidity remains conservative. Without a separately verified live-depth read, callers must use `factory-backstop-only`; the preview then always reports thin depth and the 2 USDG backstop warning, including for a small quote below the impact thresholds. That warning remains the highest-priority message. With verified depth, price impact warns from two percentage points. From five percentage points, `riskState` is `explicit-confirmation-required`; the trade must not remain a normal one-click action. Complement-token refunds suppress a misleading cash-only sell average. Signed minimum profit remains signed when it is negative.
+
+## Remaining release blockers
+
+1. Add a signed deployment/release manifest for exact V2 Factory, Registry, Quoter, Router, Vault implementations, runtime code hashes, deployment blocks, and the release snapshot hashes.
+2. Implement a same-confirmed-block read orchestrator for Factory market record, Registry active revision and snapshot hash, pool key, current slot0, Quoter result, Vault exposure-controller getter, capacity preflight, and block hash. Revalidate quote and capacity immediately before wallet submission; neither read removes the execution race.
+3. Add the V2 read model and Indexer projection for 10-field market identity, Registry revision/hash, lifecycle, outcomes, balances, and transactions. This lane intentionally does not touch Indexer or Gates.
+4. Connect the isolated preview and prepared transactions to a V2-only UI route. Do not reuse or reinterpret V1 tuple results.
+5. Add wallet E2E on the released contracts: create with permit, quote/buy, partial-fill refund, sell with net minimum, deadline/slippage rejection, finalization proof, redemption, reorg/stale-quote rejection, and mobile/desktop browser checks.
+6. Add an exact executable-depth read. Until then the UI must retain the backstop-only warning and cannot upgrade the depth label from thin.
+7. Add the adjacent Chainlink-round discovery service and confirm its proof against the market's exact checkpoint policy before offering finalization.
+8. Add a server-only bounded/cached CoinGecko public `simple/price` reader for fixed BTC/ETH/SOL/BNB IDs if preset discovery is required. The existing discovery route covers custom contract/mint selections only. This data is informational and must never decide settlement or release eligibility.
+9. Add production configuration, browser evidence, and onchain receipts before any live claim. A green unit test or build is not release evidence.

--- a/docs/operations/PREDICTION-V2-UI-INTEGRATION-FOUNDATION.md
+++ b/docs/operations/PREDICTION-V2-UI-INTEGRATION-FOUNDATION.md
@@ -6,40 +6,47 @@ Status: local foundation only. It is not connected to the production prediction-
 
 The isolated `lib/prediction-v2` lane binds only the current Protocol V2 surface:
 
-- `GenericPredictionMarketFactoryV2`: 10-field `markets`, `assetRegistry`, `activeMarketId`, pool-key reads, and the exact identity + observation + threshold `createMarketWithPermit` signature.
-- `AssetRegistryV2`: canonical identity, 17-field `OraclePolicy`, full `Snapshot`, `hashSnapshot`, and current-active-revision bindings.
+- `GenericPredictionMarketFactoryV2`: 10-field `markets`, `assetRegistry`, `manager`, `activeMarketId`, pool-key reads, and `createMarketWithPermit(identity, observationTime, threshold, expectedMarketId, permit...)`.
+- `AssetRegistryV2`: canonical identity, 17-field `OraclePolicy`, full current and historical `Snapshot` reads, `hashSnapshot`, and current-active-revision bindings.
 - `PredictionQuoterV2`: 9-field `BuyQuote` and 8-field `SellQuote`, each containing the 6-field live v4 swap result.
 - `ExecutionRouterV2`: exact buy and sell request tuples and EIP-2612 permit signatures.
 - `GlobalExposureControllerV2`: `requireIncreaseCapacity(address,uint256)` as a reverting view preflight with no return value.
-- `PredictionVaultV2`: `exposureController()` and `finalize(bytes)`. The Chainlink helper encodes exactly two adjacent nonzero `uint80` round IDs and sends zero native value.
+- `PredictionVaultV2`: exact dependency, identity, accounting and lifecycle reads plus `finalize`, atomic `finalizeAndRedeem`, unavailable/unproven fallbacks, terminal consumption, and `redeem`. Chainlink lifecycle helpers send zero native value and every prepared payload is pinned to chain 4663.
+- `IPriceCheckpointV2`: adapter-neutral status, result, deadline, fallback, policy and resolution reads/actions. Adapter-specific proof discovery remains server-side.
+- `PoolManager`: raw `extsload(bytes32)` only. The UI derives `poolId = keccak256(abi.encode(PoolKey))` and the v4 `pools[poolId]` state slot, then decodes the packed current sqrt price, tick, directional protocol fee, and LP fee.
 
 No V1 module, production route, Gates code, Indexer code, or Dune code is changed by this foundation.
+
+The committed release binding is deliberately `disabled` and contains no address or environment indirection. Its
+schema cannot be turned live by adding fields; activation requires a separately reviewed, fully pinned production
+binding. This prevents a dormant UI foundation from being mistaken for a deployed release.
 
 ## Fail-closed transaction rules
 
 - A buy permit must equal `requestedCollateralAtoms + floor(requestedCollateralAtoms * 10 / 10_000)`. It cannot authorize collateral alone.
 - A sell permit must equal the exact outcome-token input.
 - Buy minimum receive is floored from quoted outcome atoms. Sell minimum proceeds is floored from net collateral after the 10 bps protocol fee, never from gross collateral.
-- Every quote is bound to chain 4663, exact Quoter, vault, five-field pool key, side, requested amount, sqrt-price limit, confirmed block number, and block hash. Preparation rejects cross-market, cross-side, changed-limit, changed-amount, and stale-block reuse.
+- Every quote is decoded from and retains the raw successful Quoter `eth_call`: exact target, exact encoded calldata, exact result bytes, vault, five-field pool key, side, requested amount, sqrt-price limit, chain 4663, confirmed block number, and block hash. The same quote also retains raw `vault.checkpoint()`, `checkpoint.isTradingHealthy()`, `vault.yesToken()`, `vault.noToken()`, and PoolManager `extsload(poolStateSlot)` calls and results from that exact block. Preparation reconstructs and decodes every call instead of trusting caller-labelled token roles, health, price, fee, or tuple metadata, and refuses to prepare a trade while checkpoint health is false. Cross-market, swapped-role, cross-side, changed-limit, changed-amount, malformed-result, changed-slot, and stale-block reuse fail closed.
 - BUY preparation also requires successful `vault.exposureController()` and `controller.requireIncreaseCapacity(vault, requestedCollateralAtoms)` calls at the quote's exact block number and hash. Capacity uses the full requested split notional, not executed collateral, because the Router splits before applying the price-limit refund.
 - Capacity is never promised. The read is point-in-state and execution rechecks atomically; another transaction can consume capacity first. Refresh quote and capacity together immediately before signing and present a normal revert as a race, not as lost funds.
-- Creation binds `selectionKey`, canonical identity, derived onchain asset key, full Registry snapshot, locally reproduced `hashSnapshot`, live Registry `hashSnapshot` result, Factory `activeMarketId` snapshot hash, and the released snapshot hash. All four hashes must agree.
-- Pool fee and tick spacing are fixed to the deployed V2 invariants: 200 pips and 10.
+- Every prepared transaction carries `chainId: 4663`; the wallet integration must refuse submission after any chain change and must never silently reinterpret the payload on another network.
+- Creation binds `selectionKey`, canonical identity, derived onchain asset key, full Registry snapshot, locally reproduced `hashSnapshot`, live Registry `hashSnapshot` result, Factory `activeMarketId` market id/snapshot hash/revision, and the released snapshot hash. The exact nonzero `expectedMarketId` is encoded after `threshold`, so a Registry revision between preview/signing and mining reverts before creator permit funding instead of silently creating under changed oracle semantics.
+- Pool fee and tick spacing are fixed to the Protocol V2 candidate invariants: 200 pips and 10.
 
 ## Pre-sign preview model
 
-The V2 preview model exposes maximum and actual fee-inclusive payment, protocol fee, refunds, quoted and minimum shares, average executable price, current-to-post probability, signed percentage-point impact, relative impact, live LP and directional PoolManager fee, gross winning payout, signed net profit, conservative maximum loss, and neutral payout. Sell previews expose gross proceeds, fee, net proceeds, net minimum, and both token-refund classes.
+The V2 preview model exposes maximum and actual fee-inclusive payment, protocol fee, refunds, quoted and minimum shares, average executable price, current-to-post probability, signed percentage-point impact, relative impact, live LP and directional PoolManager fee, gross winning payout, signed net profit, conservative maximum loss, and neutral payout. Sell previews expose gross proceeds, fee, net proceeds, net minimum, and both token-refund classes. Side, pool orientation, token roles, current price, and directional fee are derived from the raw same-block evidence bound into the quote. BUY cannot lower the selected outcome probability; SELL cannot raise it. A reversed sqrt-price or selected-probability direction fails closed, while a zero-execution partial quote may leave it unchanged.
 
-Liquidity remains conservative. Without a separately verified live-depth read, callers must use `factory-backstop-only`; the preview then always reports thin depth and the 2 USDG backstop warning, including for a small quote below the impact thresholds. That warning remains the highest-priority message. With verified depth, price impact warns from two percentage points. From five percentage points, `riskState` is `explicit-confirmation-required`; the trade must not remain a normal one-click action. Complement-token refunds suppress a misleading cash-only sell average. Signed minimum profit remains signed when it is negative.
+Liquidity remains conservative. This foundation has no caller-controlled depth label: every preview reports thin depth and the 2 USDG backstop warning until a separately reviewed live-depth evidence binder exists. An extra `verified-live-depth` property cannot upgrade that result. `priceImpactRiskState` is normal through 199 bps, warns from 200 through 499 bps, and requires explicit confirmation from 500 bps. That final threshold is an executable buy/sell preparation gate, not display copy: calldata preparation throws unless the caller supplies the confirmation state. The backstop warning remains the highest-priority message, while `partialFill` and the price-impact state remain independently readable. Complement-token refunds suppress a misleading cash-only sell average. Signed minimum profit remains signed when it is negative.
 
 ## Remaining release blockers
 
 1. Add a signed deployment/release manifest for exact V2 Factory, Registry, Quoter, Router, Vault implementations, runtime code hashes, deployment blocks, and the release snapshot hashes.
-2. Implement a same-confirmed-block read orchestrator for Factory market record, Registry active revision and snapshot hash, pool key, current slot0, Quoter result, Vault exposure-controller getter, capacity preflight, and block hash. Revalidate quote and capacity immediately before wallet submission; neither read removes the execution race.
-3. Add the V2 read model and Indexer projection for 10-field market identity, Registry revision/hash, lifecycle, outcomes, balances, and transactions. This lane intentionally does not touch Indexer or Gates.
+2. Implement the RPC orchestration that executes the provided exact call encodings at one confirmed block for Factory market record, Registry active revision and snapshot hash, pool key, Vault token roles, raw PoolManager slot0, Quoter result, Vault exposure-controller getter, capacity preflight, and block hash. Revalidate the fully bound quote and capacity immediately before wallet submission; neither read removes the execution race.
+3. Add the first V2 read model using bounded Factory pagination and same-block RPC reads. An Indexer projection may be added later for scale; this lane intentionally does not touch the protected Indexer or Gates work.
 4. Connect the isolated preview and prepared transactions to a V2-only UI route. Do not reuse or reinterpret V1 tuple results.
 5. Add wallet E2E on the released contracts: create with permit, quote/buy, partial-fill refund, sell with net minimum, deadline/slippage rejection, finalization proof, redemption, reorg/stale-quote rejection, and mobile/desktop browser checks.
 6. Add an exact executable-depth read. Until then the UI must retain the backstop-only warning and cannot upgrade the depth label from thin.
-7. Add the adjacent Chainlink-round discovery service and confirm its proof against the market's exact checkpoint policy before offering finalization.
-8. Add a server-only bounded/cached CoinGecko public `simple/price` reader for fixed BTC/ETH/SOL/BNB IDs if preset discovery is required. The existing discovery route covers custom contract/mint selections only. This data is informational and must never decide settlement or release eligibility.
+7. Add the Chainlink-round discovery service and confirm its same-phase adjacent-round proof against the market's exact checkpoint policy before offering finalization. A feed phase rollover after the observation time invalidates the old-phase proof and resolves through the neutral fallback; never infer proof rules from a display symbol.
+8. Review provider availability and terms for the server-only BTC/ETH/SOL/BNB preset reader. The implemented keyless CoinGecko endpoint is bounded, short-cached, best-effort and display-only; the existing DexScreener route covers custom contract/mint display data. Neither source decides settlement or Registry eligibility.
 9. Add production configuration, browser evidence, and onchain receipts before any live claim. A green unit test or build is not release evidence.

--- a/lib/developer-docs-content.ts
+++ b/lib/developer-docs-content.ts
@@ -4,7 +4,10 @@ import {
   PROGRAMMABLE_LAUNCH_STAMP_RESOURCES,
   PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI,
 } from "@/components/launch-stamp-docs-contract";
-import { V4_TOKEN_ADDRESS } from "@/components/docs-public-policy";
+import {
+  PROGRAMMABLE_PUBLIC_REPOSITORIES,
+  V4_TOKEN_ADDRESS,
+} from "@/components/docs-public-policy";
 
 export const developerDocsPath = "/docs/developers";
 export const developerDocsMarkdownPath = "/docs/developers.md";
@@ -187,7 +190,7 @@ export function buildProgrammableHomeMarkdown(): string {
   return [
     "# Programmable",
     "",
-    "> Discover verified launches, understand what their Uniswap v4 hooks do, and use the website to create or interact with tokens on Ethereum.",
+    "> Discover verified launches, understand what their Uniswap v4 hooks do, and use the website to create or interact with token and outcome markets.",
     "",
     "Programmable brings token discovery, launch creation, market context, creator pages, trading preparation, profiles, and reward claims into one website. Human-facing wallet actions still require an explicit user confirmation.",
     "",
@@ -204,10 +207,17 @@ export function buildProgrammableHomeMarkdown(): string {
     "## Main destinations",
     "",
     "- Explore: https://programmable.market/explore",
+    "- Prediction Markets: https://programmable.market/markets",
     "- Create: https://programmable.market/launch",
     "- Profile, projects, and rewards: https://programmable.market/profile",
     "- Documentation: https://programmable.market/docs",
     "- Developer documentation: https://programmable.market/docs/developers",
+    "",
+    "## Prediction Markets",
+    "",
+    "Prediction Markets is separately versioned. Use its canonical repository for current networks, market types, economics, resolution rules, contract addresses, and release status instead of copying release constants into this product overview.",
+    "",
+    `- Canonical source and releases: ${PROGRAMMABLE_PUBLIC_REPOSITORIES.predictionMarkets}`,
     "",
     "## Machine-readable resources",
     "",
@@ -229,11 +239,12 @@ export function buildProgrammableLlmsIndex(): string {
   return [
     "# Programmable",
     "",
-    "> Agent guide for discovering verified Programmable launches and selecting the correct public read-only resource on Ethereum.",
+    "> Agent guide for discovering verified Programmable launches and selecting the correct public read-only resource for each product.",
     "",
     "## When to use Programmable",
     "",
     "- Discover verified Classic V3 launches and Registry-verified Custom launches.",
+    "- Open the current Prediction Markets product and its separately versioned canonical release record.",
     "- Look up one displayed token by Ethereum address without depending on optional market enrichment for identity.",
     "- Understand the public scope, creator information, launch provenance, and available market context before directing a user to the website.",
     "- Integrate a read-only terminal, wallet, scanner, catalog, or research tool with the documented public endpoints.",
@@ -244,6 +255,7 @@ export function buildProgrammableLlmsIndex(): string {
     "- Safety, endorsement, audit coverage, liquidity, price accuracy, tradability, or future value from a verified identity.",
     "- Public eligibility for Classic V1, other Classic V2 launches, any Stock family, or a Custom launch that has not passed Registry verification.",
     "- Transaction authority. The public OpenAPI description intentionally excludes launch, trade, claim, profile-write, and wallet-signing actions.",
+    "- Sponsored or autonomous Prediction Market creation unless the active canonical release explicitly enables it and publishes the required service boundary.",
     "",
     "## Public identity scope",
     "",
@@ -252,12 +264,15 @@ export function buildProgrammableLlmsIndex(): string {
     "- Excluded: all other Classic V1 or V2 launches, every Stock family, and unverified Custom launches.",
     "- Router records are provenance evidence and identity-mapping details, not a public category.",
     "- Dexscreener is optional market enrichment. An enrichment outage must not hide an already verified token identity.",
+    `- Prediction Markets uses separate versioned release records. Current source and release status: ${PROGRAMMABLE_PUBLIC_REPOSITORIES.predictionMarkets}.`,
     "",
     "## Public machine-readable resources",
     "",
     "- OpenAPI: https://programmable.market/openapi.json",
     "- API index: https://programmable.market/api",
     "- Explore catalog: https://programmable.market/api/explore",
+    "- Prediction Markets: https://programmable.market/markets",
+    `- Prediction Markets source and releases: ${PROGRAMMABLE_PUBLIC_REPOSITORIES.predictionMarkets}`,
     "- Token lookup: https://programmable.market/api/explore/token?address=0x7987f03462200b3D8A072E02C89A8A41dCB124EE",
     "- Custom Registry readiness: https://programmable.market/api/custom-launch/registry/v2/readiness",
     "- Custom Registry manifest: https://programmable.market/api/custom-launch/registry/v2/manifest",

--- a/lib/market-data/prediction-asset-discovery-v2.server.ts
+++ b/lib/market-data/prediction-asset-discovery-v2.server.ts
@@ -4,6 +4,7 @@ import {
   isEvmPredictionAssetLocatorV2,
   isPredictionSourceNetworkIdV2,
   isSolanaPredictionAssetLocatorV2,
+  predictionAssetSelectionKeyV2,
   predictionSourceNetworkV2,
   type PredictionCustomAssetSelectionV2,
   type PredictionSourceNetworkIdV2,
@@ -223,12 +224,14 @@ function discoveryBinding(
   }
   const network = predictionSourceNetworkV2(selection.sourceNetwork);
   if (!network) return null;
+  const selectionKey = predictionAssetSelectionKeyV2(selection);
+  if (!selectionKey) return null;
   const locator = selection.assetLocator.trim();
   if (network.namespace === "evm") {
     if (!isEvmPredictionAssetLocatorV2(locator)) return null;
     const canonicalLocator = locator.toLowerCase();
     return {
-      selectionKey: `evm:${network.chainReference}:${canonicalLocator}`,
+      selectionKey,
       providerChainId:
         DEXSCREENER_CHAIN_ID_BY_SOURCE_NETWORK[selection.sourceNetwork],
       locator: canonicalLocator,
@@ -237,7 +240,7 @@ function discoveryBinding(
   }
   if (!isSolanaPredictionAssetLocatorV2(locator)) return null;
   return {
-    selectionKey: `solana:${network.chainReference}:${locator}`,
+    selectionKey,
     providerChainId:
       DEXSCREENER_CHAIN_ID_BY_SOURCE_NETWORK[selection.sourceNetwork],
     locator,

--- a/lib/market-data/prediction-asset-discovery-v2.server.ts
+++ b/lib/market-data/prediction-asset-discovery-v2.server.ts
@@ -1,0 +1,554 @@
+import "server-only";
+
+import {
+  isEvmPredictionAssetLocatorV2,
+  isPredictionSourceNetworkIdV2,
+  isSolanaPredictionAssetLocatorV2,
+  predictionSourceNetworkV2,
+  type PredictionCustomAssetSelectionV2,
+  type PredictionSourceNetworkIdV2,
+} from "../prediction-market-assets-v2";
+
+const DEXSCREENER_TOKEN_PAIRS_ENDPOINT =
+  "https://api.dexscreener.com/token-pairs/v1" as const;
+const DEFAULT_TIMEOUT_MS = 3_000;
+const DEFAULT_MAXIMUM_RESPONSE_BYTES = 512_000;
+const DEFAULT_MAXIMUM_ROWS = 256;
+
+const DEXSCREENER_CHAIN_ID_BY_SOURCE_NETWORK = Object.freeze({
+  ethereum: "ethereum",
+  base: "base",
+  bnb: "bsc",
+  robinhood: "robinhood",
+  solana: "solana",
+} as const satisfies Record<PredictionSourceNetworkIdV2, string>);
+
+export const PREDICTION_ASSET_DISCOVERY_SOURCE_V2 = "dexscreener" as const;
+export const PREDICTION_ASSET_DISCOVERY_USAGE_V2 =
+  "informational-only" as const;
+
+export type PredictionAssetDiscoveryUnavailableReasonV2 =
+  | "invalid-selection"
+  | "aborted"
+  | "timeout"
+  | "rate-limited"
+  | "provider-unavailable"
+  | "response-too-large"
+  | "response-invalid"
+  | "not-found"
+  | "market-data-unavailable";
+
+type PredictionAssetDiscoveryResultBaseV2 = Readonly<{
+  schemaVersion: 2;
+  /** Provider lookup identity only; never a release or settlement bytes32 key. */
+  selectionKey: string | null;
+  source: typeof PREDICTION_ASSET_DISCOVERY_SOURCE_V2;
+  observedAt: string;
+  usage: typeof PREDICTION_ASSET_DISCOVERY_USAGE_V2;
+}>;
+
+export type PredictionAssetDiscoveryAvailableV2 =
+  PredictionAssetDiscoveryResultBaseV2 & Readonly<{
+    selectionKey: string;
+    status: "available";
+    currentPriceUsd: number;
+    marketCapUsd: number;
+    pair: Readonly<{
+      providerChainId: string;
+      dexId: string;
+      pairAddress: string;
+      liquidityUsd: number;
+    }>;
+  }>;
+
+export type PredictionAssetDiscoveryUnavailableV2 =
+  PredictionAssetDiscoveryResultBaseV2 & Readonly<{
+    status: "unavailable";
+    reason: PredictionAssetDiscoveryUnavailableReasonV2;
+  }>;
+
+export type PredictionAssetDiscoveryResultV2 =
+  | PredictionAssetDiscoveryAvailableV2
+  | PredictionAssetDiscoveryUnavailableV2;
+
+export type PredictionAssetDiscoveryReaderOptionsV2 = Readonly<{
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+  timeoutMs?: number;
+  maximumResponseBytes?: number;
+  maximumRows?: number;
+}>;
+
+export type PredictionAssetDiscoveryReadOptionsV2 = Readonly<{
+  signal?: AbortSignal;
+}>;
+
+export type PredictionAssetDiscoveryReaderV2 = Readonly<{
+  read(
+    selection: PredictionCustomAssetSelectionV2,
+    options?: PredictionAssetDiscoveryReadOptionsV2,
+  ): Promise<PredictionAssetDiscoveryResultV2>;
+}>;
+
+type DiscoveryBinding = Readonly<{
+  selectionKey: string;
+  providerChainId: string;
+  locator: string;
+  namespace: "evm" | "solana";
+}>;
+
+type PairCandidate = Readonly<{
+  dexId: string;
+  pairAddress: string;
+  priceUsd: number;
+  marketCapUsd: number;
+  liquidityUsd: number;
+}>;
+
+class PredictionAssetDiscoveryReadError extends Error {
+  constructor(
+    readonly reason: PredictionAssetDiscoveryUnavailableReasonV2,
+  ) {
+    super(`Prediction asset discovery failed: ${reason}`);
+    this.name = "PredictionAssetDiscoveryReadError";
+  }
+}
+
+export function createPredictionAssetDiscoveryReaderV2(
+  options: PredictionAssetDiscoveryReaderOptionsV2 = {},
+): PredictionAssetDiscoveryReaderV2 {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? (() => new Date());
+  const timeoutMs = boundedInteger(
+    options.timeoutMs,
+    DEFAULT_TIMEOUT_MS,
+    1,
+    30_000,
+    "timeoutMs",
+  );
+  const maximumResponseBytes = boundedInteger(
+    options.maximumResponseBytes,
+    DEFAULT_MAXIMUM_RESPONSE_BYTES,
+    2,
+    2_000_000,
+    "maximumResponseBytes",
+  );
+  const maximumRows = boundedInteger(
+    options.maximumRows,
+    DEFAULT_MAXIMUM_ROWS,
+    1,
+    1_000,
+    "maximumRows",
+  );
+
+  function unavailable(
+    binding: DiscoveryBinding | null,
+    reason: PredictionAssetDiscoveryUnavailableReasonV2,
+  ): PredictionAssetDiscoveryUnavailableV2 {
+    return {
+      schemaVersion: 2,
+      selectionKey: binding?.selectionKey ?? null,
+      status: "unavailable",
+      reason,
+      source: PREDICTION_ASSET_DISCOVERY_SOURCE_V2,
+      observedAt: now().toISOString(),
+      usage: PREDICTION_ASSET_DISCOVERY_USAGE_V2,
+    };
+  }
+
+  return Object.freeze({
+    async read(selection, readOptions = {}) {
+      const binding = discoveryBinding(selection);
+      if (binding === null) return unavailable(null, "invalid-selection");
+      if (readOptions.signal?.aborted) return unavailable(binding, "aborted");
+
+      try {
+        const payload = await requestDexscreenerPairs({
+          binding,
+          fetchImpl,
+          timeoutMs,
+          maximumResponseBytes,
+          signal: readOptions.signal,
+        });
+        const candidates = parsePairCandidates(
+          payload,
+          binding,
+          maximumRows,
+        );
+        if (candidates.status !== "available") {
+          return unavailable(binding, candidates.status);
+        }
+
+        const selected = [...candidates.pairs].sort(comparePairCandidates)[0];
+        if (!selected) return unavailable(binding, "market-data-unavailable");
+        return {
+          schemaVersion: 2,
+          selectionKey: binding.selectionKey,
+          status: "available",
+          source: PREDICTION_ASSET_DISCOVERY_SOURCE_V2,
+          observedAt: now().toISOString(),
+          usage: PREDICTION_ASSET_DISCOVERY_USAGE_V2,
+          currentPriceUsd: selected.priceUsd,
+          marketCapUsd: selected.marketCapUsd,
+          pair: {
+            providerChainId: binding.providerChainId,
+            dexId: selected.dexId,
+            pairAddress: selected.pairAddress,
+            liquidityUsd: selected.liquidityUsd,
+          },
+        };
+      } catch (error) {
+        return unavailable(
+          binding,
+          error instanceof PredictionAssetDiscoveryReadError
+            ? error.reason
+            : "provider-unavailable",
+        );
+      }
+    },
+  });
+}
+
+function discoveryBinding(
+  selection: PredictionCustomAssetSelectionV2,
+): DiscoveryBinding | null {
+  if (
+    !selection ||
+    typeof selection !== "object" ||
+    selection.mode !== "custom" ||
+    !isPredictionSourceNetworkIdV2(selection.sourceNetwork) ||
+    typeof selection.assetLocator !== "string"
+  ) {
+    return null;
+  }
+  const network = predictionSourceNetworkV2(selection.sourceNetwork);
+  if (!network) return null;
+  const locator = selection.assetLocator.trim();
+  if (network.namespace === "evm") {
+    if (!isEvmPredictionAssetLocatorV2(locator)) return null;
+    const canonicalLocator = locator.toLowerCase();
+    return {
+      selectionKey: `evm:${network.chainReference}:${canonicalLocator}`,
+      providerChainId:
+        DEXSCREENER_CHAIN_ID_BY_SOURCE_NETWORK[selection.sourceNetwork],
+      locator: canonicalLocator,
+      namespace: "evm",
+    };
+  }
+  if (!isSolanaPredictionAssetLocatorV2(locator)) return null;
+  return {
+    selectionKey: `solana:${network.chainReference}:${locator}`,
+    providerChainId:
+      DEXSCREENER_CHAIN_ID_BY_SOURCE_NETWORK[selection.sourceNetwork],
+    locator,
+    namespace: "solana",
+  };
+}
+
+async function requestDexscreenerPairs(input: Readonly<{
+  binding: DiscoveryBinding;
+  fetchImpl: typeof fetch;
+  timeoutMs: number;
+  maximumResponseBytes: number;
+  signal?: AbortSignal;
+}>): Promise<unknown> {
+  if (input.signal?.aborted) {
+    throw new PredictionAssetDiscoveryReadError("aborted");
+  }
+  const controller = new AbortController();
+  let rejectDeadline!: (error: PredictionAssetDiscoveryReadError) => void;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    rejectDeadline = reject;
+  });
+  let deadlineSettled = false;
+  const abortWith = (reason: "aborted" | "timeout") => {
+    if (deadlineSettled) return;
+    deadlineSettled = true;
+    controller.abort();
+    rejectDeadline(new PredictionAssetDiscoveryReadError(reason));
+  };
+  const abortFromCaller = () => abortWith("aborted");
+  const timer = setTimeout(() => abortWith("timeout"), input.timeoutMs);
+  input.signal?.addEventListener("abort", abortFromCaller, { once: true });
+
+  try {
+    const url = `${DEXSCREENER_TOKEN_PAIRS_ENDPOINT}/${
+      encodeURIComponent(input.binding.providerChainId)
+    }/${encodeURIComponent(input.binding.locator)}`;
+    const response = await Promise.race([
+      input.fetchImpl(url, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        cache: "no-store",
+        redirect: "error",
+        signal: controller.signal,
+      }),
+      deadline,
+    ]);
+
+    if (response.status === 429) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionAssetDiscoveryReadError("rate-limited");
+    }
+    if (!response.ok) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionAssetDiscoveryReadError("provider-unavailable");
+    }
+    const contentType = response.headers.get("content-type");
+    if (!contentType?.toLowerCase().startsWith("application/json")) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionAssetDiscoveryReadError("response-invalid");
+    }
+
+    const body = await readBoundedResponseBody(
+      response,
+      input.maximumResponseBytes,
+      deadline,
+      controller,
+    );
+    try {
+      return JSON.parse(body) as unknown;
+    } catch {
+      throw new PredictionAssetDiscoveryReadError("response-invalid");
+    }
+  } finally {
+    deadlineSettled = true;
+    clearTimeout(timer);
+    input.signal?.removeEventListener("abort", abortFromCaller);
+  }
+}
+
+async function readBoundedResponseBody(
+  response: Response,
+  maximumBytes: number,
+  deadline: Promise<never>,
+  controller: AbortController,
+): Promise<string> {
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null) {
+    if (!/^(?:0|[1-9][0-9]*)$/u.test(declaredLength)) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionAssetDiscoveryReadError("response-invalid");
+    }
+    if (BigInt(declaredLength) > BigInt(maximumBytes)) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionAssetDiscoveryReadError("response-too-large");
+    }
+  }
+
+  if (response.body === null || response.body === undefined) {
+    const body = await Promise.race([response.text(), deadline]);
+    if (new TextEncoder().encode(body).byteLength > maximumBytes) {
+      controller.abort();
+      throw new PredictionAssetDiscoveryReadError("response-too-large");
+    }
+    return body;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const next = await Promise.race([reader.read(), deadline]);
+      if (next.done) break;
+      if (!(next.value instanceof Uint8Array)) {
+        throw new PredictionAssetDiscoveryReadError("response-invalid");
+      }
+      totalBytes += next.value.byteLength;
+      if (totalBytes > maximumBytes) {
+        controller.abort();
+        void reader.cancel().catch(() => undefined);
+        throw new PredictionAssetDiscoveryReadError("response-too-large");
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // The request AbortController owns a body read that outlives its caller.
+    }
+  }
+
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new PredictionAssetDiscoveryReadError("response-invalid");
+  }
+}
+
+function abortUnreadResponse(
+  response: Response,
+  controller: AbortController,
+) {
+  controller.abort();
+  if (response.body !== null && response.body !== undefined) {
+    void response.body.cancel().catch(() => undefined);
+  }
+}
+
+function parsePairCandidates(
+  payload: unknown,
+  binding: DiscoveryBinding,
+  maximumRows: number,
+):
+  | Readonly<{ status: "available"; pairs: readonly PairCandidate[] }>
+  | Readonly<{ status: "not-found" | "market-data-unavailable" }> {
+  if (!Array.isArray(payload) || payload.length > maximumRows) {
+    throw new PredictionAssetDiscoveryReadError("response-invalid");
+  }
+
+  let boundPairCount = 0;
+  const pairs: PairCandidate[] = [];
+  for (const row of payload) {
+    if (!isPlainRecord(row)) {
+      throw new PredictionAssetDiscoveryReadError("response-invalid");
+    }
+    const chainId = optionalBoundedString(row.chainId, 64);
+    if (chainId === null || chainId !== binding.providerChainId) continue;
+    if (row.baseToken !== undefined && !isPlainRecord(row.baseToken)) {
+      throw new PredictionAssetDiscoveryReadError("response-invalid");
+    }
+    const baseAddress = isPlainRecord(row.baseToken)
+      ? optionalBoundedString(row.baseToken.address, 128)
+      : null;
+    if (baseAddress === null || !sameLocator(baseAddress, binding)) continue;
+    boundPairCount += 1;
+
+    const dexId = optionalBoundedString(row.dexId, 64);
+    const pairAddress = optionalBoundedString(row.pairAddress, 128);
+    const priceUsd = optionalPositiveDecimal(row.priceUsd);
+    const marketCapUsd = optionalNonNegativeNumber(row.marketCap);
+    if (
+      row.liquidity !== undefined &&
+      row.liquidity !== null &&
+      !isPlainRecord(row.liquidity)
+    ) {
+      throw new PredictionAssetDiscoveryReadError("response-invalid");
+    }
+    const liquidityUsd = isPlainRecord(row.liquidity)
+      ? optionalNonNegativeNumber(row.liquidity.usd)
+      : null;
+    if (
+      dexId === null ||
+      pairAddress === null ||
+      priceUsd === null ||
+      marketCapUsd === null ||
+      liquidityUsd === null
+    ) {
+      continue;
+    }
+    pairs.push({
+      dexId: dexId.toLowerCase(),
+      pairAddress: binding.namespace === "evm"
+        ? pairAddress.toLowerCase()
+        : pairAddress,
+      priceUsd,
+      marketCapUsd,
+      liquidityUsd,
+    });
+  }
+
+  if (pairs.length > 0) return { status: "available", pairs };
+  return boundPairCount > 0
+    ? { status: "market-data-unavailable" }
+    : { status: "not-found" };
+}
+
+function sameLocator(candidate: string, binding: DiscoveryBinding) {
+  return binding.namespace === "evm"
+    ? candidate.toLowerCase() === binding.locator
+    : candidate === binding.locator;
+}
+
+function optionalBoundedString(candidate: unknown, maximumLength: number) {
+  if (candidate === undefined || candidate === null) return null;
+  if (
+    typeof candidate !== "string" ||
+    candidate.length === 0 ||
+    candidate.length > maximumLength
+  ) {
+    throw new PredictionAssetDiscoveryReadError("response-invalid");
+  }
+  return candidate;
+}
+
+function optionalPositiveDecimal(candidate: unknown) {
+  if (candidate === undefined || candidate === null) return null;
+  if (
+    typeof candidate !== "string" ||
+    candidate.length > 128 ||
+    !/^(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$/u.test(candidate)
+  ) {
+    throw new PredictionAssetDiscoveryReadError("response-invalid");
+  }
+  const value = Number(candidate);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new PredictionAssetDiscoveryReadError("response-invalid");
+  }
+  return value;
+}
+
+function optionalNonNegativeNumber(candidate: unknown) {
+  if (candidate === undefined || candidate === null) return null;
+  if (
+    typeof candidate !== "number" ||
+    !Number.isFinite(candidate) ||
+    candidate < 0
+  ) {
+    throw new PredictionAssetDiscoveryReadError("response-invalid");
+  }
+  return candidate;
+}
+
+function comparePairCandidates(first: PairCandidate, second: PairCandidate) {
+  if (first.liquidityUsd !== second.liquidityUsd) {
+    return first.liquidityUsd > second.liquidityUsd ? -1 : 1;
+  }
+  const pairAddress = compareText(first.pairAddress, second.pairAddress);
+  if (pairAddress !== 0) return pairAddress;
+  const dexId = compareText(first.dexId, second.dexId);
+  if (dexId !== 0) return dexId;
+  if (first.priceUsd !== second.priceUsd) {
+    return first.priceUsd < second.priceUsd ? -1 : 1;
+  }
+  if (first.marketCapUsd !== second.marketCapUsd) {
+    return first.marketCapUsd < second.marketCapUsd ? -1 : 1;
+  }
+  return 0;
+}
+
+function compareText(first: string, second: string) {
+  if (first === second) return 0;
+  return first < second ? -1 : 1;
+}
+
+function isPlainRecord(candidate: unknown): candidate is Record<string, unknown> {
+  return Boolean(
+    candidate && typeof candidate === "object" && !Array.isArray(candidate),
+  );
+}
+
+function boundedInteger(
+  candidate: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+  label: string,
+) {
+  const value = candidate ?? fallback;
+  if (!Number.isInteger(value) || value < minimum || value > maximum) {
+    throw new RangeError(`${label} must be an integer from ${minimum} to ${maximum}`);
+  }
+  return value;
+}
+
+export const readPredictionAssetDiscoveryV2 =
+  createPredictionAssetDiscoveryReaderV2().read;

--- a/lib/market-data/prediction-preset-discovery-v2.server.ts
+++ b/lib/market-data/prediction-preset-discovery-v2.server.ts
@@ -1,0 +1,541 @@
+import "server-only";
+
+const COINGECKO_SIMPLE_PRICE_ENDPOINT =
+  "https://api.coingecko.com/api/v3/simple/price" as const;
+const DEFAULT_TIMEOUT_MS = 3_000;
+const DEFAULT_MAXIMUM_RESPONSE_BYTES = 32_768;
+const DEFAULT_SUCCESS_CACHE_TTL_MS = 60_000;
+const DEFAULT_MAXIMUM_DATA_AGE_MS = 10 * 60_000;
+const DEFAULT_MAXIMUM_FUTURE_SKEW_MS = 5 * 60_000;
+
+const PRESET_BINDINGS = Object.freeze([
+  {
+    presetId: "btc",
+    selectionKey: "preset:btc",
+    symbol: "BTC",
+    providerId: "bitcoin",
+  },
+  {
+    presetId: "eth",
+    selectionKey: "preset:eth",
+    symbol: "ETH",
+    providerId: "ethereum",
+  },
+  {
+    presetId: "sol",
+    selectionKey: "preset:sol",
+    symbol: "SOL",
+    providerId: "solana",
+  },
+  {
+    presetId: "bnb",
+    selectionKey: "preset:bnb",
+    symbol: "BNB",
+    providerId: "binancecoin",
+  },
+] as const);
+
+export const PREDICTION_PRESET_DISCOVERY_SOURCE_V2 =
+  "coingecko-keyless-public" as const;
+export const PREDICTION_PRESET_DISCOVERY_USAGE_V2 =
+  "display-only-not-eligibility-or-settlement" as const;
+export const PREDICTION_PRESET_DISCOVERY_SERVICE_LEVEL_V2 =
+  "best-effort-no-sla" as const;
+
+export type PredictionPresetDiscoveryUnavailableReasonV2 =
+  | "aborted"
+  | "timeout"
+  | "rate-limited"
+  | "provider-unavailable"
+  | "response-too-large"
+  | "response-invalid"
+  | "incomplete-provider-data"
+  | "stale-provider-data";
+
+type PredictionPresetDiscoveryResultBaseV2 = Readonly<{
+  schemaVersion: 2;
+  source: typeof PREDICTION_PRESET_DISCOVERY_SOURCE_V2;
+  providerTier: "keyless-public";
+  observedAt: string;
+  usage: typeof PREDICTION_PRESET_DISCOVERY_USAGE_V2;
+  serviceLevel: typeof PREDICTION_PRESET_DISCOVERY_SERVICE_LEVEL_V2;
+}>;
+
+export type PredictionPresetMarketDataV2 = Readonly<{
+  presetId: (typeof PRESET_BINDINGS)[number]["presetId"];
+  selectionKey: (typeof PRESET_BINDINGS)[number]["selectionKey"];
+  symbol: (typeof PRESET_BINDINGS)[number]["symbol"];
+  providerId: (typeof PRESET_BINDINGS)[number]["providerId"];
+  currentPriceUsd: number;
+  marketCapUsd: number;
+  sourceUpdatedAt: string;
+}>;
+
+export type PredictionPresetDiscoveryAvailableV2 =
+  PredictionPresetDiscoveryResultBaseV2 & Readonly<{
+    status: "available";
+    cacheExpiresAt: string;
+    presets: readonly PredictionPresetMarketDataV2[];
+  }>;
+
+export type PredictionPresetDiscoveryUnavailableV2 =
+  PredictionPresetDiscoveryResultBaseV2 & Readonly<{
+    status: "unavailable";
+    reason: PredictionPresetDiscoveryUnavailableReasonV2;
+  }>;
+
+export type PredictionPresetDiscoveryResultV2 =
+  | PredictionPresetDiscoveryAvailableV2
+  | PredictionPresetDiscoveryUnavailableV2;
+
+export type PredictionPresetDiscoveryReaderOptionsV2 = Readonly<{
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+  timeoutMs?: number;
+  maximumResponseBytes?: number;
+  successCacheTtlMs?: number;
+  maximumDataAgeMs?: number;
+  maximumFutureSkewMs?: number;
+}>;
+
+export type PredictionPresetDiscoveryReadOptionsV2 = Readonly<{
+  signal?: AbortSignal;
+}>;
+
+export type PredictionPresetDiscoveryReaderV2 = Readonly<{
+  read(
+    options?: PredictionPresetDiscoveryReadOptionsV2,
+  ): Promise<PredictionPresetDiscoveryResultV2>;
+}>;
+
+class PredictionPresetDiscoveryReadError extends Error {
+  constructor(
+    readonly reason: PredictionPresetDiscoveryUnavailableReasonV2,
+  ) {
+    super(`Prediction preset discovery failed: ${reason}`);
+    this.name = "PredictionPresetDiscoveryReadError";
+  }
+}
+
+/**
+ * CoinGecko documents its keyless public tier as dynamically rate-limited,
+ * best-effort access for light experimentation. This dormant reader therefore
+ * never supplies eligibility or settlement data, never serves expired cache,
+ * and returns unavailable instead of inventing or silently retaining prices.
+ */
+export function createPredictionPresetDiscoveryReaderV2(
+  options: PredictionPresetDiscoveryReaderOptionsV2 = {},
+): PredictionPresetDiscoveryReaderV2 {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? (() => new Date());
+  const timeoutMs = boundedInteger(
+    options.timeoutMs,
+    DEFAULT_TIMEOUT_MS,
+    1,
+    30_000,
+    "timeoutMs",
+  );
+  const maximumResponseBytes = boundedInteger(
+    options.maximumResponseBytes,
+    DEFAULT_MAXIMUM_RESPONSE_BYTES,
+    128,
+    131_072,
+    "maximumResponseBytes",
+  );
+  const successCacheTtlMs = boundedInteger(
+    options.successCacheTtlMs,
+    DEFAULT_SUCCESS_CACHE_TTL_MS,
+    1,
+    300_000,
+    "successCacheTtlMs",
+  );
+  const maximumDataAgeMs = boundedInteger(
+    options.maximumDataAgeMs,
+    DEFAULT_MAXIMUM_DATA_AGE_MS,
+    1_000,
+    3_600_000,
+    "maximumDataAgeMs",
+  );
+  const maximumFutureSkewMs = boundedInteger(
+    options.maximumFutureSkewMs,
+    DEFAULT_MAXIMUM_FUTURE_SKEW_MS,
+    0,
+    300_000,
+    "maximumFutureSkewMs",
+  );
+
+  let cached:
+    | Readonly<{
+      expiresAtMs: number;
+      result: PredictionPresetDiscoveryAvailableV2;
+    }>
+    | null = null;
+
+  function observation() {
+    const date = now();
+    const timestampMs = date.getTime();
+    if (!Number.isFinite(timestampMs)) {
+      throw new RangeError("now must return a valid Date");
+    }
+    return { timestampMs, iso: date.toISOString() } as const;
+  }
+
+  function unavailable(
+    observedAt: string,
+    reason: PredictionPresetDiscoveryUnavailableReasonV2,
+  ): PredictionPresetDiscoveryUnavailableV2 {
+    return Object.freeze({
+      schemaVersion: 2,
+      status: "unavailable",
+      reason,
+      source: PREDICTION_PRESET_DISCOVERY_SOURCE_V2,
+      providerTier: "keyless-public",
+      observedAt,
+      usage: PREDICTION_PRESET_DISCOVERY_USAGE_V2,
+      serviceLevel: PREDICTION_PRESET_DISCOVERY_SERVICE_LEVEL_V2,
+    });
+  }
+
+  return Object.freeze({
+    async read(readOptions = {}) {
+      const observed = observation();
+      if (readOptions.signal?.aborted) {
+        return unavailable(observed.iso, "aborted");
+      }
+      if (cached !== null && observed.timestampMs < cached.expiresAtMs) {
+        return cached.result;
+      }
+
+      try {
+        const payload = await requestCoinGeckoPresetData({
+          fetchImpl,
+          timeoutMs,
+          maximumResponseBytes,
+          signal: readOptions.signal,
+        });
+        const presets = parsePresetPayload(
+          payload,
+          observed.timestampMs,
+          maximumDataAgeMs,
+          maximumFutureSkewMs,
+        );
+        const sourceFreshUntilMs = Math.min(
+          ...presets.map(({ sourceUpdatedAt }) =>
+            new Date(sourceUpdatedAt).getTime() + maximumDataAgeMs
+          ),
+        );
+        const cacheExpiresAtMs = Math.min(
+          observed.timestampMs + successCacheTtlMs,
+          sourceFreshUntilMs,
+        );
+        const result = Object.freeze({
+          schemaVersion: 2,
+          status: "available",
+          source: PREDICTION_PRESET_DISCOVERY_SOURCE_V2,
+          providerTier: "keyless-public",
+          observedAt: observed.iso,
+          usage: PREDICTION_PRESET_DISCOVERY_USAGE_V2,
+          serviceLevel: PREDICTION_PRESET_DISCOVERY_SERVICE_LEVEL_V2,
+          cacheExpiresAt: new Date(cacheExpiresAtMs).toISOString(),
+          presets,
+        } as const satisfies PredictionPresetDiscoveryAvailableV2);
+        cached = Object.freeze({
+          expiresAtMs: cacheExpiresAtMs,
+          result,
+        });
+        return result;
+      } catch (error) {
+        return unavailable(
+          observed.iso,
+          error instanceof PredictionPresetDiscoveryReadError
+            ? error.reason
+            : "provider-unavailable",
+        );
+      }
+    },
+  });
+}
+
+async function requestCoinGeckoPresetData(input: Readonly<{
+  fetchImpl: typeof fetch;
+  timeoutMs: number;
+  maximumResponseBytes: number;
+  signal?: AbortSignal;
+}>): Promise<unknown> {
+  if (input.signal?.aborted) {
+    throw new PredictionPresetDiscoveryReadError("aborted");
+  }
+
+  const controller = new AbortController();
+  let rejectDeadline!: (error: PredictionPresetDiscoveryReadError) => void;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    rejectDeadline = reject;
+  });
+  let deadlineSettled = false;
+  let abortReason: "aborted" | "timeout" | null = null;
+  const abortWith = (reason: "aborted" | "timeout") => {
+    if (deadlineSettled) return;
+    abortReason = reason;
+    deadlineSettled = true;
+    controller.abort();
+    rejectDeadline(new PredictionPresetDiscoveryReadError(reason));
+  };
+  const abortFromCaller = () => abortWith("aborted");
+  const timer = setTimeout(() => abortWith("timeout"), input.timeoutMs);
+  input.signal?.addEventListener("abort", abortFromCaller, { once: true });
+
+  try {
+    const url = new URL(COINGECKO_SIMPLE_PRICE_ENDPOINT);
+    url.searchParams.set(
+      "ids",
+      PRESET_BINDINGS.map(({ providerId }) => providerId).join(","),
+    );
+    url.searchParams.set("vs_currencies", "usd");
+    url.searchParams.set("include_market_cap", "true");
+    url.searchParams.set("include_last_updated_at", "true");
+    url.searchParams.set("precision", "full");
+
+    let response: Response;
+    try {
+      response = await Promise.race([
+        input.fetchImpl(url.toString(), {
+          method: "GET",
+          headers: { Accept: "application/json" },
+          cache: "no-store",
+          redirect: "error",
+          signal: controller.signal,
+        }),
+        deadline,
+      ]);
+    } catch (error) {
+      if (abortReason !== null) {
+        throw new PredictionPresetDiscoveryReadError(abortReason);
+      }
+      throw error;
+    }
+
+    if (response.status === 429) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionPresetDiscoveryReadError("rate-limited");
+    }
+    if (!response.ok) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionPresetDiscoveryReadError("provider-unavailable");
+    }
+    const contentType = response.headers.get("content-type");
+    if (!contentType?.toLowerCase().startsWith("application/json")) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionPresetDiscoveryReadError("response-invalid");
+    }
+
+    const body = await readBoundedResponseBody(
+      response,
+      input.maximumResponseBytes,
+      deadline,
+      controller,
+    );
+    try {
+      return JSON.parse(body) as unknown;
+    } catch {
+      throw new PredictionPresetDiscoveryReadError("response-invalid");
+    }
+  } finally {
+    deadlineSettled = true;
+    clearTimeout(timer);
+    input.signal?.removeEventListener("abort", abortFromCaller);
+  }
+}
+
+async function readBoundedResponseBody(
+  response: Response,
+  maximumBytes: number,
+  deadline: Promise<never>,
+  controller: AbortController,
+): Promise<string> {
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null) {
+    if (!/^(?:0|[1-9][0-9]*)$/u.test(declaredLength)) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionPresetDiscoveryReadError("response-invalid");
+    }
+    if (BigInt(declaredLength) > BigInt(maximumBytes)) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionPresetDiscoveryReadError("response-too-large");
+    }
+  }
+
+  if (response.body === null || response.body === undefined) {
+    const body = await Promise.race([response.text(), deadline]);
+    if (new TextEncoder().encode(body).byteLength > maximumBytes) {
+      controller.abort();
+      throw new PredictionPresetDiscoveryReadError("response-too-large");
+    }
+    return body;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const next = await Promise.race([reader.read(), deadline]);
+      if (next.done) break;
+      if (!(next.value instanceof Uint8Array)) {
+        throw new PredictionPresetDiscoveryReadError("response-invalid");
+      }
+      totalBytes += next.value.byteLength;
+      if (totalBytes > maximumBytes) {
+        controller.abort();
+        void reader.cancel().catch(() => undefined);
+        throw new PredictionPresetDiscoveryReadError("response-too-large");
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // The request AbortController owns a body read that outlives its caller.
+    }
+  }
+
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new PredictionPresetDiscoveryReadError("response-invalid");
+  }
+}
+
+function abortUnreadResponse(
+  response: Response,
+  controller: AbortController,
+) {
+  controller.abort();
+  if (response.body !== null && response.body !== undefined) {
+    void response.body.cancel().catch(() => undefined);
+  }
+}
+
+function parsePresetPayload(
+  payload: unknown,
+  observedAtMs: number,
+  maximumDataAgeMs: number,
+  maximumFutureSkewMs: number,
+): readonly PredictionPresetMarketDataV2[] {
+  if (!isPlainRecord(payload)) {
+    throw new PredictionPresetDiscoveryReadError("response-invalid");
+  }
+  const expectedProviderIds = PRESET_BINDINGS.map(({ providerId }) =>
+    providerId
+  );
+  if (!hasExactKeys(payload, expectedProviderIds)) {
+    const missingExpected = expectedProviderIds.some((providerId) =>
+      !Object.hasOwn(payload, providerId)
+    );
+    throw new PredictionPresetDiscoveryReadError(
+      missingExpected ? "incomplete-provider-data" : "response-invalid",
+    );
+  }
+
+  const presets = PRESET_BINDINGS.map((binding) => {
+    const row = payload[binding.providerId];
+    if (!isPlainRecord(row)) {
+      throw new PredictionPresetDiscoveryReadError(
+        "incomplete-provider-data",
+      );
+    }
+    if (!hasExactKeys(row, ["usd", "usd_market_cap", "last_updated_at"])) {
+      throw new PredictionPresetDiscoveryReadError("response-invalid");
+    }
+
+    const currentPriceUsd = positiveFiniteNumber(row.usd);
+    const marketCapUsd = positiveFiniteNumber(row.usd_market_cap);
+    const updatedAtSeconds = positiveInteger(row.last_updated_at);
+    if (
+      currentPriceUsd === null ||
+      marketCapUsd === null ||
+      updatedAtSeconds === null
+    ) {
+      throw new PredictionPresetDiscoveryReadError(
+        "incomplete-provider-data",
+      );
+    }
+
+    const sourceUpdatedAtMs = updatedAtSeconds * 1_000;
+    if (
+      !Number.isSafeInteger(sourceUpdatedAtMs) ||
+      sourceUpdatedAtMs > observedAtMs + maximumFutureSkewMs ||
+      observedAtMs - sourceUpdatedAtMs > maximumDataAgeMs
+    ) {
+      throw new PredictionPresetDiscoveryReadError("stale-provider-data");
+    }
+
+    return Object.freeze({
+      presetId: binding.presetId,
+      selectionKey: binding.selectionKey,
+      symbol: binding.symbol,
+      providerId: binding.providerId,
+      currentPriceUsd,
+      marketCapUsd,
+      sourceUpdatedAt: new Date(sourceUpdatedAtMs).toISOString(),
+    });
+  });
+
+  return Object.freeze(presets);
+}
+
+function hasExactKeys(
+  candidate: Record<string, unknown>,
+  expectedKeys: readonly string[],
+) {
+  const keys = Object.keys(candidate);
+  return keys.length === expectedKeys.length &&
+    expectedKeys.every((key) => Object.hasOwn(candidate, key));
+}
+
+function positiveFiniteNumber(candidate: unknown) {
+  return typeof candidate === "number" &&
+      Number.isFinite(candidate) &&
+      candidate > 0
+    ? candidate
+    : null;
+}
+
+function positiveInteger(candidate: unknown) {
+  return typeof candidate === "number" &&
+      Number.isSafeInteger(candidate) &&
+      candidate > 0
+    ? candidate
+    : null;
+}
+
+function isPlainRecord(candidate: unknown): candidate is Record<string, unknown> {
+  return Boolean(
+    candidate && typeof candidate === "object" && !Array.isArray(candidate),
+  );
+}
+
+function boundedInteger(
+  candidate: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+  label: string,
+) {
+  const value = candidate ?? fallback;
+  if (!Number.isInteger(value) || value < minimum || value > maximum) {
+    throw new RangeError(
+      `${label} must be an integer from ${minimum} to ${maximum}`,
+    );
+  }
+  return value;
+}
+
+export const readPredictionPresetDiscoveryV2 =
+  createPredictionPresetDiscoveryReaderV2().read;

--- a/lib/prediction-market-assets-v2.ts
+++ b/lib/prediction-market-assets-v2.ts
@@ -1,0 +1,454 @@
+export const PREDICTION_MARKET_TYPE_V2 = "usd-price-at-utc" as const;
+export const PREDICTION_SETTLEMENT_NETWORK_V2 = Object.freeze({
+  id: "robinhood",
+  chainId: 4_663,
+  label: "Robinhood Chain",
+} as const);
+
+export const PREDICTION_SOURCE_NETWORKS_V2 = Object.freeze([
+  {
+    id: "ethereum",
+    label: "Ethereum",
+    namespace: "evm",
+    chainReference: "1",
+  },
+  {
+    id: "base",
+    label: "Base",
+    namespace: "evm",
+    chainReference: "8453",
+  },
+  {
+    id: "bnb",
+    label: "BNB Chain",
+    namespace: "evm",
+    chainReference: "56",
+  },
+  {
+    id: "robinhood",
+    label: "Robinhood Chain",
+    namespace: "evm",
+    chainReference: "4663",
+  },
+  {
+    id: "solana",
+    label: "Solana",
+    namespace: "solana",
+    chainReference: "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+  },
+] as const);
+
+export type PredictionSourceNetworkV2 =
+  (typeof PREDICTION_SOURCE_NETWORKS_V2)[number];
+export type PredictionSourceNetworkIdV2 = PredictionSourceNetworkV2["id"];
+
+export const PREDICTION_PRESET_ASSETS_V2 = Object.freeze([
+  { id: "btc", name: "Bitcoin", symbol: "BTC" },
+  { id: "eth", name: "Ethereum", symbol: "ETH" },
+  { id: "sol", name: "Solana", symbol: "SOL" },
+  { id: "bnb", name: "BNB", symbol: "BNB" },
+] as const);
+
+export type PredictionPresetAssetV2 =
+  (typeof PREDICTION_PRESET_ASSETS_V2)[number];
+export type PredictionPresetAssetIdV2 = PredictionPresetAssetV2["id"];
+
+export type PredictionPresetAssetSelectionV2 = Readonly<{
+  mode: "preset";
+  presetId: PredictionPresetAssetIdV2;
+}>;
+
+export type PredictionCustomAssetSelectionV2 = Readonly<{
+  mode: "custom";
+  sourceNetwork: PredictionSourceNetworkIdV2 | "";
+  assetLocator: string;
+}>;
+
+export type PredictionAssetSelectionV2 =
+  | PredictionPresetAssetSelectionV2
+  | PredictionCustomAssetSelectionV2;
+
+export const DEFAULT_PREDICTION_ASSET_SELECTION_V2 = Object.freeze({
+  mode: "preset",
+  presetId: "btc",
+} as const satisfies PredictionAssetSelectionV2);
+
+export type PredictionMarketDraftV2 = Readonly<{
+  schemaVersion: 2;
+  asset: PredictionAssetSelectionV2;
+  marketType: typeof PREDICTION_MARKET_TYPE_V2;
+  comparator: "greater-than-or-equal";
+  quoteCurrency: "USD";
+  strikeUsd: string;
+  observationUtc: string;
+}>;
+
+export const PREDICTION_MARKET_DRAFT_SCHEMA_V2 = Object.freeze({
+  schemaVersion: 2,
+  settlementNetwork: PREDICTION_SETTLEMENT_NETWORK_V2,
+  marketType: PREDICTION_MARKET_TYPE_V2,
+  comparator: "greater-than-or-equal",
+  quoteCurrency: "USD",
+  observationTimezone: "UTC",
+  sourceNetworks: PREDICTION_SOURCE_NETWORKS_V2.map(({ id }) => id),
+} as const);
+
+export type PredictionAssetReleaseEntryV2 = Readonly<{
+  assetKey: string;
+  marketType: typeof PREDICTION_MARKET_TYPE_V2;
+  oracleStatus: "ready" | "unknown" | "unsupported" | "paused";
+  oraclePolicyId?: string;
+  releaseId?: string;
+}>;
+
+export type PredictionAssetReleaseRegistryV2 = Readonly<{
+  schemaVersion: 2;
+  settlementNetwork: Readonly<{
+    id: "robinhood";
+    chainId: 4_663;
+  }>;
+  entries: readonly PredictionAssetReleaseEntryV2[];
+}>;
+
+export type PredictionAssetDiscoverySnapshotV2 = Readonly<{
+  assetKey: string;
+  status: "available" | "unavailable";
+  observedAt?: string;
+  currentPriceUsd?: number;
+  marketCapUsd?: number;
+}>;
+
+export type PredictionAssetSelectionValidationV2 = Readonly<{
+  ok: boolean;
+  errors: Readonly<{
+    sourceNetwork?: string;
+    assetLocator?: string;
+  }>;
+  assetKey?: string;
+}>;
+
+export type PredictionAssetMarketStateV2 = Readonly<{
+  state: "available" | "unavailable" | "incomplete";
+  code:
+    | "ready"
+    | "selection-incomplete"
+    | "release-unconfigured"
+    | "release-invalid"
+    | "oracle-unsupported"
+    | "oracle-unknown"
+    | "oracle-paused"
+    | "oracle-ambiguous";
+  title: string;
+  detail: string;
+  assetKey?: string;
+}>;
+
+const EVM_ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/u;
+const SOLANA_BASE58_PATTERN = /^[1-9A-HJ-NP-Za-km-z]+$/u;
+const SOLANA_BASE58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+function decodeBase58Length(value: string) {
+  const bytes = [0];
+  for (const character of value) {
+    const alphabetIndex = SOLANA_BASE58_ALPHABET.indexOf(character);
+    if (alphabetIndex < 0) return -1;
+    let carry = alphabetIndex;
+    for (let index = 0; index < bytes.length; index += 1) {
+      carry += bytes[index] * 58;
+      bytes[index] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  let leadingZeroCount = 0;
+  while (leadingZeroCount < value.length && value[leadingZeroCount] === "1") {
+    leadingZeroCount += 1;
+  }
+  return (
+    bytes.length +
+    leadingZeroCount -
+    (bytes.length === 1 && bytes[0] === 0 ? 1 : 0)
+  );
+}
+
+export function isPredictionSourceNetworkIdV2(
+  candidate: string,
+): candidate is PredictionSourceNetworkIdV2 {
+  return PREDICTION_SOURCE_NETWORKS_V2.some(({ id }) => id === candidate);
+}
+
+export function predictionSourceNetworkV2(
+  id: PredictionSourceNetworkIdV2 | "",
+) {
+  return PREDICTION_SOURCE_NETWORKS_V2.find((network) => network.id === id);
+}
+
+export function isEvmPredictionAssetLocatorV2(candidate: string) {
+  return EVM_ADDRESS_PATTERN.test(candidate.trim());
+}
+
+export function isSolanaPredictionAssetLocatorV2(candidate: string) {
+  const normalized = candidate.trim();
+  return (
+    normalized.length >= 32 &&
+    normalized.length <= 44 &&
+    SOLANA_BASE58_PATTERN.test(normalized) &&
+    decodeBase58Length(normalized) === 32
+  );
+}
+
+export function predictionAssetKeyV2(
+  selection: PredictionAssetSelectionV2,
+): string | null {
+  if (selection.mode === "preset") {
+    return PREDICTION_PRESET_ASSETS_V2.some(
+      ({ id }) => id === selection.presetId,
+    )
+      ? `preset:${selection.presetId}`
+      : null;
+  }
+
+  const network = predictionSourceNetworkV2(selection.sourceNetwork);
+  if (!network) return null;
+  const locator = selection.assetLocator.trim();
+  if (network.namespace === "evm") {
+    if (!isEvmPredictionAssetLocatorV2(locator)) return null;
+    return `evm:${network.chainReference}:${locator.toLowerCase()}`;
+  }
+  if (!isSolanaPredictionAssetLocatorV2(locator)) return null;
+  return `solana:${network.chainReference}:${locator}`;
+}
+
+export function validatePredictionAssetSelectionV2(
+  selection: PredictionAssetSelectionV2,
+): PredictionAssetSelectionValidationV2 {
+  if (selection.mode === "preset") {
+    const assetKey = predictionAssetKeyV2(selection);
+    return assetKey
+      ? { ok: true, errors: {}, assetKey }
+      : { ok: false, errors: { assetLocator: "Choose a listed asset." } };
+  }
+
+  if (!selection.sourceNetwork) {
+    return {
+      ok: false,
+      errors: { sourceNetwork: "Choose the token network." },
+    };
+  }
+
+  const network = predictionSourceNetworkV2(selection.sourceNetwork);
+  if (!network) {
+    return {
+      ok: false,
+      errors: { sourceNetwork: "Choose a supported network." },
+    };
+  }
+
+  if (!selection.assetLocator.trim()) {
+    return {
+      ok: false,
+      errors: {
+        assetLocator:
+          network.namespace === "solana"
+            ? "Enter the token mint."
+            : "Enter the contract address.",
+      },
+    };
+  }
+
+  const assetKey = predictionAssetKeyV2(selection);
+  if (!assetKey) {
+    return {
+      ok: false,
+      errors: {
+        assetLocator:
+          network.namespace === "solana"
+            ? "Enter a valid Solana token mint."
+            : "Enter a valid EVM contract address.",
+      },
+    };
+  }
+
+  return { ok: true, errors: {}, assetKey };
+}
+
+function isPlainRecord(candidate: unknown): candidate is Record<string, unknown> {
+  return Boolean(
+    candidate && typeof candidate === "object" && !Array.isArray(candidate),
+  );
+}
+
+export function isPredictionAssetReleaseRegistryV2(
+  candidate: unknown,
+): candidate is PredictionAssetReleaseRegistryV2 {
+  if (!isPlainRecord(candidate) || candidate.schemaVersion !== 2) return false;
+  const settlementNetwork = candidate.settlementNetwork;
+  if (
+    !isPlainRecord(settlementNetwork) ||
+    settlementNetwork.id !== PREDICTION_SETTLEMENT_NETWORK_V2.id ||
+    settlementNetwork.chainId !== PREDICTION_SETTLEMENT_NETWORK_V2.chainId ||
+    !Array.isArray(candidate.entries)
+  ) {
+    return false;
+  }
+
+  return candidate.entries.every((entry) => {
+    if (!isPlainRecord(entry)) return false;
+    if (
+      typeof entry.assetKey !== "string" ||
+      entry.assetKey.length === 0 ||
+      entry.marketType !== PREDICTION_MARKET_TYPE_V2 ||
+      !["ready", "unknown", "unsupported", "paused"].includes(
+        String(entry.oracleStatus),
+      )
+    ) {
+      return false;
+    }
+    if (entry.oracleStatus !== "ready") return true;
+    return (
+      typeof entry.oraclePolicyId === "string" &&
+      entry.oraclePolicyId.trim().length > 0 &&
+      typeof entry.releaseId === "string" &&
+      entry.releaseId.trim().length > 0
+    );
+  });
+}
+
+export function predictionAssetMarketStateV2(
+  selection: PredictionAssetSelectionV2,
+  registry?: PredictionAssetReleaseRegistryV2 | null,
+): PredictionAssetMarketStateV2 {
+  const validation = validatePredictionAssetSelectionV2(selection);
+  if (!validation.ok || !validation.assetKey) {
+    const sourceNetwork =
+      selection.mode === "custom"
+        ? predictionSourceNetworkV2(selection.sourceNetwork)
+        : undefined;
+    return {
+      state: "incomplete",
+      code: "selection-incomplete",
+      title: "Choose an asset",
+      detail:
+        sourceNetwork?.namespace === "solana"
+          ? "Enter a valid Solana token mint."
+          : "Choose a network and enter a valid contract address.",
+    };
+  }
+
+  if (registry === undefined || registry === null) {
+    return {
+      state: "unavailable",
+      code: "release-unconfigured",
+      title: "Not available yet",
+      detail: "No released price source is configured for this asset.",
+      assetKey: validation.assetKey,
+    };
+  }
+  if (!isPredictionAssetReleaseRegistryV2(registry)) {
+    return {
+      state: "unavailable",
+      code: "release-invalid",
+      title: "Not available yet",
+      detail: "The price source configuration could not be verified.",
+      assetKey: validation.assetKey,
+    };
+  }
+
+  const entries = registry.entries.filter(
+    (entry) =>
+      entry.assetKey === validation.assetKey &&
+      entry.marketType === PREDICTION_MARKET_TYPE_V2,
+  );
+  if (entries.length === 0) {
+    return {
+      state: "unavailable",
+      code: "oracle-unsupported",
+      title: "Not available yet",
+      detail: "This asset does not have a released price source.",
+      assetKey: validation.assetKey,
+    };
+  }
+  if (entries.length !== 1) {
+    return {
+      state: "unavailable",
+      code: "oracle-ambiguous",
+      title: "Not available yet",
+      detail: "The price source configuration is ambiguous.",
+      assetKey: validation.assetKey,
+    };
+  }
+
+  const [entry] = entries;
+  if (entry.oracleStatus === "unknown") {
+    return {
+      state: "unavailable",
+      code: "oracle-unknown",
+      title: "Not available yet",
+      detail: "The price source has not been verified.",
+      assetKey: validation.assetKey,
+    };
+  }
+  if (entry.oracleStatus === "unsupported") {
+    return {
+      state: "unavailable",
+      code: "oracle-unsupported",
+      title: "Not available yet",
+      detail: "This asset does not have a released price source.",
+      assetKey: validation.assetKey,
+    };
+  }
+  if (entry.oracleStatus === "paused") {
+    return {
+      state: "unavailable",
+      code: "oracle-paused",
+      title: "Temporarily unavailable",
+      detail: "New markets are paused for this asset.",
+      assetKey: validation.assetKey,
+    };
+  }
+
+  return {
+    state: "available",
+    code: "ready",
+    title: "Ready for a price market",
+    detail: "The result uses the released price source at the selected UTC time.",
+    assetKey: validation.assetKey,
+  };
+}
+
+export function predictionAssetSnapshotMatchesSelectionV2(
+  snapshot: PredictionAssetDiscoverySnapshotV2 | null | undefined,
+  selection: PredictionAssetSelectionV2,
+) {
+  const assetKey = predictionAssetKeyV2(selection);
+  return Boolean(
+    snapshot &&
+      snapshot.status === "available" &&
+      assetKey &&
+      snapshot.assetKey === assetKey,
+  );
+}
+
+export function formatPredictionAssetUsdV2(
+  value: number | undefined,
+  kind: "price" | "market-cap",
+) {
+  if (value === undefined || !Number.isFinite(value) || value < 0) return "—";
+  if (kind === "market-cap") {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      notation: "compact",
+      maximumFractionDigits: 2,
+    }).format(value);
+  }
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: value < 1 ? 6 : 2,
+  }).format(value);
+}

--- a/lib/prediction-market-assets-v2.ts
+++ b/lib/prediction-market-assets-v2.ts
@@ -1,3 +1,14 @@
+import {
+  bytesToHex,
+  encodeAbiParameters,
+  keccak256,
+  numberToHex,
+  padHex,
+  parseAbiParameters,
+  stringToHex,
+  type Hex,
+} from "viem";
+
 export const PREDICTION_MARKET_TYPE_V2 = "usd-price-at-utc" as const;
 export const PREDICTION_SETTLEMENT_NETWORK_V2 = Object.freeze({
   id: "robinhood",
@@ -6,30 +17,10 @@ export const PREDICTION_SETTLEMENT_NETWORK_V2 = Object.freeze({
 } as const);
 
 export const PREDICTION_SOURCE_NETWORKS_V2 = Object.freeze([
-  {
-    id: "ethereum",
-    label: "Ethereum",
-    namespace: "evm",
-    chainReference: "1",
-  },
-  {
-    id: "base",
-    label: "Base",
-    namespace: "evm",
-    chainReference: "8453",
-  },
-  {
-    id: "bnb",
-    label: "BNB Chain",
-    namespace: "evm",
-    chainReference: "56",
-  },
-  {
-    id: "robinhood",
-    label: "Robinhood Chain",
-    namespace: "evm",
-    chainReference: "4663",
-  },
+  { id: "ethereum", label: "Ethereum", namespace: "evm", chainReference: "1" },
+  { id: "base", label: "Base", namespace: "evm", chainReference: "8453" },
+  { id: "bnb", label: "BNB Chain", namespace: "evm", chainReference: "56" },
+  { id: "robinhood", label: "Robinhood Chain", namespace: "evm", chainReference: "4663" },
   {
     id: "solana",
     label: "Solana",
@@ -41,12 +32,40 @@ export const PREDICTION_SOURCE_NETWORKS_V2 = Object.freeze([
 export type PredictionSourceNetworkV2 =
   (typeof PREDICTION_SOURCE_NETWORKS_V2)[number];
 export type PredictionSourceNetworkIdV2 = PredictionSourceNetworkV2["id"];
+export type PredictionBytes32V2 = `0x${string}`;
+
+export type PredictionAssetIdentityV2 = Readonly<{
+  sourceNamespace: PredictionBytes32V2;
+  sourceChain: PredictionBytes32V2;
+  assetIdentifier: PredictionBytes32V2;
+  assetStandard: PredictionBytes32V2;
+}>;
+
+const ASSET_KEY_DOMAIN_V2 = keccak256(
+  stringToHex("PROGRAMMABLE_ASSET_KEY_V2"),
+) as PredictionBytes32V2;
+const ASSET_KEY_PARAMETERS_V2 = parseAbiParameters(
+  "bytes32 domain, bytes32 sourceNamespace, bytes32 sourceChain, bytes32 assetIdentifier, bytes32 assetStandard",
+);
+const GLOBAL_CRYPTO_NAMESPACE_V2 = bytes32TextV2("GLOBAL_CRYPTO");
+const GLOBAL_CHAIN_V2 = bytes32TextV2("GLOBAL");
+const NATIVE_STANDARD_V2 = bytes32TextV2("NATIVE");
+const EIP155_NAMESPACE_V2 = bytes32TextV2("EIP155");
+const ERC20_STANDARD_V2 = bytes32TextV2("ERC20");
+const SOLANA_NAMESPACE_V2 = bytes32TextV2("SOLANA");
+
+export const PREDICTION_SOLANA_MAINNET_GENESIS_V2 =
+  "0x45296998a6f8e2a784db5d9f95e18fc23f70441a1039446801089879b08c7ef0" as const;
+export const PREDICTION_SOLANA_TOKEN_PROGRAM_V2 =
+  "0x06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9" as const;
+export const PREDICTION_SOLANA_TOKEN_2022_PROGRAM_V2 =
+  "0x06ddf6e1ee758fde18425dbce46ccddab61afc4d83b90d27febdf928d8a18bfc" as const;
 
 export const PREDICTION_PRESET_ASSETS_V2 = Object.freeze([
-  { id: "btc", name: "Bitcoin", symbol: "BTC" },
-  { id: "eth", name: "Ethereum", symbol: "ETH" },
-  { id: "sol", name: "Solana", symbol: "SOL" },
-  { id: "bnb", name: "BNB", symbol: "BNB" },
+  { id: "btc", name: "Bitcoin", symbol: "BTC", identity: globalPresetIdentityV2("BTC") },
+  { id: "eth", name: "Ethereum", symbol: "ETH", identity: globalPresetIdentityV2("ETH") },
+  { id: "sol", name: "Solana", symbol: "SOL", identity: globalPresetIdentityV2("SOL") },
+  { id: "bnb", name: "BNB", symbol: "BNB", identity: globalPresetIdentityV2("BNB") },
 ] as const);
 
 export type PredictionPresetAssetV2 =
@@ -60,6 +79,7 @@ export type PredictionPresetAssetSelectionV2 = Readonly<{
 
 export type PredictionCustomAssetSelectionV2 = Readonly<{
   mode: "custom";
+  /** A contract address cannot identify its EVM network, so this is explicit. */
   sourceNetwork: PredictionSourceNetworkIdV2 | "";
   assetLocator: string;
 }>;
@@ -93,38 +113,58 @@ export const PREDICTION_MARKET_DRAFT_SCHEMA_V2 = Object.freeze({
   sourceNetworks: PREDICTION_SOURCE_NETWORKS_V2.map(({ id }) => id),
 } as const);
 
-export type PredictionAssetReleaseEntryV2 = Readonly<{
-  assetKey: string;
-  marketType: typeof PREDICTION_MARKET_TYPE_V2;
-  oracleStatus: "ready" | "unknown" | "unsupported" | "paused";
-  oraclePolicyId?: string;
-  releaseId?: string;
+export type PredictionAssetSnapshotBindingV2 = Readonly<{
+  assetKey: PredictionBytes32V2;
+  revision: number;
+  snapshotHash: PredictionBytes32V2;
 }>;
+
+export type PredictionAssetReleaseBindingV2 = Readonly<{
+  id: string;
+  oraclePolicyId: string;
+}>;
+
+type PredictionAssetReleaseEntryBaseV2 = Readonly<{
+  /** UI/provider lookup identity. It is never passed to the protocol as assetKey. */
+  selectionKey: string;
+  /** Exact AssetRegistryV2 assetKey derived from identity. */
+  onchainAssetKey: PredictionBytes32V2;
+  identity: PredictionAssetIdentityV2;
+  marketType: typeof PREDICTION_MARKET_TYPE_V2;
+}>;
+
+export type PredictionAssetReleaseEntryV2 =
+  | (PredictionAssetReleaseEntryBaseV2 & Readonly<{
+    oracleStatus: "ready" | "paused";
+    snapshot: PredictionAssetSnapshotBindingV2;
+    release: PredictionAssetReleaseBindingV2;
+  }>)
+  | (PredictionAssetReleaseEntryBaseV2 & Readonly<{
+    oracleStatus: "unknown" | "unsupported";
+    snapshot: null;
+    release: null;
+  }>);
 
 export type PredictionAssetReleaseRegistryV2 = Readonly<{
   schemaVersion: 2;
-  settlementNetwork: Readonly<{
-    id: "robinhood";
-    chainId: 4_663;
-  }>;
+  settlementNetwork: Readonly<{ id: "robinhood"; chainId: 4_663 }>;
   entries: readonly PredictionAssetReleaseEntryV2[];
 }>;
 
 export type PredictionAssetDiscoverySnapshotV2 = Readonly<{
-  assetKey: string;
+  /** Informational provider lookup identity only. */
+  selectionKey: string;
   status: "available" | "unavailable";
   observedAt?: string;
   currentPriceUsd?: number;
+  /** Display-only discovery data. It never decides settlement eligibility. */
   marketCapUsd?: number;
 }>;
 
 export type PredictionAssetSelectionValidationV2 = Readonly<{
   ok: boolean;
-  errors: Readonly<{
-    sourceNetwork?: string;
-    assetLocator?: string;
-  }>;
-  assetKey?: string;
+  errors: Readonly<{ sourceNetwork?: string; assetLocator?: string }>;
+  selectionKey?: string;
 }>;
 
 export type PredictionAssetMarketStateV2 = Readonly<{
@@ -140,39 +180,81 @@ export type PredictionAssetMarketStateV2 = Readonly<{
     | "oracle-ambiguous";
   title: string;
   detail: string;
-  assetKey?: string;
+  selectionKey?: string;
+  onchainAssetKey?: PredictionBytes32V2;
 }>;
 
 const EVM_ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/u;
+const ZERO_EVM_ADDRESS_V2 = `0x${"0".repeat(40)}`;
+const BYTES32_PATTERN = /^0x[0-9a-f]{64}$/u;
+const ZERO_BYTES32_V2 = `0x${"0".repeat(64)}`;
 const SOLANA_BASE58_PATTERN = /^[1-9A-HJ-NP-Za-km-z]+$/u;
 const SOLANA_BASE58_ALPHABET =
   "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
-function decodeBase58Length(value: string) {
-  const bytes = [0];
+function bytes32TextV2(value: string) {
+  return stringToHex(value, { size: 32 }) as PredictionBytes32V2;
+}
+
+function globalPresetIdentityV2(
+  symbol: "BTC" | "ETH" | "SOL" | "BNB",
+): PredictionAssetIdentityV2 {
+  return Object.freeze({
+    sourceNamespace: GLOBAL_CRYPTO_NAMESPACE_V2,
+    sourceChain: GLOBAL_CHAIN_V2,
+    assetIdentifier: bytes32TextV2(symbol),
+    assetStandard: NATIVE_STANDARD_V2,
+  });
+}
+
+function decodeBase58Bytes(value: string): Uint8Array | null {
+  if (!value || !SOLANA_BASE58_PATTERN.test(value)) return null;
+  const littleEndian = [0];
   for (const character of value) {
     const alphabetIndex = SOLANA_BASE58_ALPHABET.indexOf(character);
-    if (alphabetIndex < 0) return -1;
+    if (alphabetIndex < 0) return null;
     let carry = alphabetIndex;
-    for (let index = 0; index < bytes.length; index += 1) {
-      carry += bytes[index] * 58;
-      bytes[index] = carry & 0xff;
+    for (let index = 0; index < littleEndian.length; index += 1) {
+      carry += littleEndian[index] * 58;
+      littleEndian[index] = carry & 0xff;
       carry >>= 8;
     }
     while (carry > 0) {
-      bytes.push(carry & 0xff);
+      littleEndian.push(carry & 0xff);
       carry >>= 8;
     }
   }
+
   let leadingZeroCount = 0;
   while (leadingZeroCount < value.length && value[leadingZeroCount] === "1") {
     leadingZeroCount += 1;
   }
-  return (
-    bytes.length +
-    leadingZeroCount -
-    (bytes.length === 1 && bytes[0] === 0 ? 1 : 0)
-  );
+  const decodedLength = littleEndian.length + leadingZeroCount -
+    (littleEndian.length === 1 && littleEndian[0] === 0 ? 1 : 0);
+  const decoded = new Uint8Array(decodedLength);
+  for (let index = 0; index < littleEndian.length; index += 1) {
+    const target = decoded.length - 1 - index;
+    if (target >= leadingZeroCount) decoded[target] = littleEndian[index];
+  }
+  return decoded;
+}
+
+function isBytes32V2(candidate: unknown): candidate is PredictionBytes32V2 {
+  return typeof candidate === "string" && BYTES32_PATTERN.test(candidate);
+}
+
+function isNonzeroBytes32V2(candidate: unknown): candidate is PredictionBytes32V2 {
+  return isBytes32V2(candidate) && candidate !== ZERO_BYTES32_V2;
+}
+
+function samePredictionAssetIdentityV2(
+  left: PredictionAssetIdentityV2,
+  right: PredictionAssetIdentityV2,
+) {
+  return left.sourceNamespace === right.sourceNamespace &&
+    left.sourceChain === right.sourceChain &&
+    left.assetIdentifier === right.assetIdentifier &&
+    left.assetStandard === right.assetStandard;
 }
 
 export function isPredictionSourceNetworkIdV2(
@@ -188,26 +270,24 @@ export function predictionSourceNetworkV2(
 }
 
 export function isEvmPredictionAssetLocatorV2(candidate: string) {
-  return EVM_ADDRESS_PATTERN.test(candidate.trim());
+  const normalized = candidate.trim();
+  return EVM_ADDRESS_PATTERN.test(normalized) &&
+    normalized.toLowerCase() !== ZERO_EVM_ADDRESS_V2;
 }
 
 export function isSolanaPredictionAssetLocatorV2(candidate: string) {
   const normalized = candidate.trim();
-  return (
-    normalized.length >= 32 &&
-    normalized.length <= 44 &&
-    SOLANA_BASE58_PATTERN.test(normalized) &&
-    decodeBase58Length(normalized) === 32
-  );
+  if (normalized.length < 32 || normalized.length > 44) return false;
+  const decoded = decodeBase58Bytes(normalized);
+  return decoded?.length === 32 && decoded.some((byte) => byte !== 0);
 }
 
-export function predictionAssetKeyV2(
+/** UI/provider lookup key. It is deliberately not the protocol bytes32 assetKey. */
+export function predictionAssetSelectionKeyV2(
   selection: PredictionAssetSelectionV2,
 ): string | null {
   if (selection.mode === "preset") {
-    return PREDICTION_PRESET_ASSETS_V2.some(
-      ({ id }) => id === selection.presetId,
-    )
+    return PREDICTION_PRESET_ASSETS_V2.some(({ id }) => id === selection.presetId)
       ? `preset:${selection.presetId}`
       : null;
   }
@@ -223,99 +303,238 @@ export function predictionAssetKeyV2(
   return `solana:${network.chainReference}:${locator}`;
 }
 
+/**
+ * Exact identities compatible with one selection. Solana has two candidates because
+ * the mint's owning Token Program is release evidence, not safe client-side inference.
+ */
+export function predictionAssetIdentityCandidatesV2(
+  selection: PredictionAssetSelectionV2,
+): readonly PredictionAssetIdentityV2[] {
+  if (selection.mode === "preset") {
+    const preset = PREDICTION_PRESET_ASSETS_V2.find(({ id }) => id === selection.presetId);
+    return preset ? [preset.identity] : [];
+  }
+
+  const network = predictionSourceNetworkV2(selection.sourceNetwork);
+  const locator = selection.assetLocator.trim();
+  if (!network) return [];
+  if (network.namespace === "evm") {
+    if (!isEvmPredictionAssetLocatorV2(locator)) return [];
+    return [{
+      sourceNamespace: EIP155_NAMESPACE_V2,
+      sourceChain: numberToHex(BigInt(network.chainReference), { size: 32 }) as PredictionBytes32V2,
+      assetIdentifier: padHex(locator.toLowerCase() as Hex, { size: 32 }) as PredictionBytes32V2,
+      assetStandard: ERC20_STANDARD_V2,
+    }];
+  }
+
+  const mintBytes = decodeBase58Bytes(locator);
+  if (
+    !mintBytes ||
+    mintBytes.length !== 32 ||
+    !mintBytes.some((byte) => byte !== 0)
+  ) return [];
+  const assetIdentifier = bytesToHex(mintBytes) as PredictionBytes32V2;
+  const sharedIdentity = {
+    sourceNamespace: SOLANA_NAMESPACE_V2,
+    sourceChain: PREDICTION_SOLANA_MAINNET_GENESIS_V2,
+    assetIdentifier,
+  } as const;
+  return [
+    { ...sharedIdentity, assetStandard: PREDICTION_SOLANA_TOKEN_PROGRAM_V2 },
+    { ...sharedIdentity, assetStandard: PREDICTION_SOLANA_TOKEN_2022_PROGRAM_V2 },
+  ];
+}
+
+export function predictionOnchainAssetKeyV2(
+  identity: PredictionAssetIdentityV2,
+) {
+  return keccak256(encodeAbiParameters(ASSET_KEY_PARAMETERS_V2, [
+    ASSET_KEY_DOMAIN_V2,
+    identity.sourceNamespace,
+    identity.sourceChain,
+    identity.assetIdentifier,
+    identity.assetStandard,
+  ])) as PredictionBytes32V2;
+}
+
 export function validatePredictionAssetSelectionV2(
   selection: PredictionAssetSelectionV2,
 ): PredictionAssetSelectionValidationV2 {
   if (selection.mode === "preset") {
-    const assetKey = predictionAssetKeyV2(selection);
-    return assetKey
-      ? { ok: true, errors: {}, assetKey }
+    const selectionKey = predictionAssetSelectionKeyV2(selection);
+    return selectionKey
+      ? { ok: true, errors: {}, selectionKey }
       : { ok: false, errors: { assetLocator: "Choose a listed asset." } };
   }
-
   if (!selection.sourceNetwork) {
-    return {
-      ok: false,
-      errors: { sourceNetwork: "Choose the token network." },
-    };
+    return { ok: false, errors: { sourceNetwork: "Choose the token network." } };
   }
-
   const network = predictionSourceNetworkV2(selection.sourceNetwork);
   if (!network) {
-    return {
-      ok: false,
-      errors: { sourceNetwork: "Choose a supported network." },
-    };
+    return { ok: false, errors: { sourceNetwork: "Choose a supported network." } };
   }
-
   if (!selection.assetLocator.trim()) {
     return {
       ok: false,
       errors: {
-        assetLocator:
-          network.namespace === "solana"
-            ? "Enter the token mint."
-            : "Enter the contract address.",
+        assetLocator: network.namespace === "solana"
+          ? "Enter the token mint."
+          : "Enter the contract address.",
       },
     };
   }
-
-  const assetKey = predictionAssetKeyV2(selection);
-  if (!assetKey) {
+  const selectionKey = predictionAssetSelectionKeyV2(selection);
+  if (!selectionKey) {
     return {
       ok: false,
       errors: {
-        assetLocator:
-          network.namespace === "solana"
-            ? "Enter a valid Solana token mint."
-            : "Enter a valid EVM contract address.",
+        assetLocator: network.namespace === "solana"
+          ? "Enter a valid Solana token mint."
+          : "Enter a valid EVM contract address.",
       },
     };
   }
-
-  return { ok: true, errors: {}, assetKey };
+  return { ok: true, errors: {}, selectionKey };
 }
 
 function isPlainRecord(candidate: unknown): candidate is Record<string, unknown> {
-  return Boolean(
-    candidate && typeof candidate === "object" && !Array.isArray(candidate),
+  return Boolean(candidate && typeof candidate === "object" && !Array.isArray(candidate));
+}
+
+function hasExactKeysV2(
+  candidate: Record<string, unknown>,
+  expected: readonly string[],
+) {
+  const keys = Object.keys(candidate);
+  return keys.length === expected.length &&
+    expected.every((key) => Object.hasOwn(candidate, key));
+}
+
+function selectionFromKeyV2(selectionKey: string): PredictionAssetSelectionV2 | null {
+  if (selectionKey.startsWith("preset:")) {
+    const presetId = selectionKey.slice("preset:".length);
+    const preset = PREDICTION_PRESET_ASSETS_V2.find(({ id }) => id === presetId);
+    return preset ? { mode: "preset", presetId: preset.id } : null;
+  }
+  const [namespace, chainReference, locator, ...extra] = selectionKey.split(":");
+  if (extra.length > 0 || !namespace || !chainReference || !locator) return null;
+  const network = PREDICTION_SOURCE_NETWORKS_V2.find((candidate) =>
+    candidate.namespace === namespace && candidate.chainReference === chainReference
   );
+  if (!network) return null;
+  const selection: PredictionCustomAssetSelectionV2 = {
+    mode: "custom",
+    sourceNetwork: network.id,
+    assetLocator: locator,
+  };
+  return predictionAssetSelectionKeyV2(selection) === selectionKey ? selection : null;
+}
+
+function isPredictionAssetIdentityV2(
+  candidate: unknown,
+): candidate is PredictionAssetIdentityV2 {
+  return isPlainRecord(candidate) &&
+    hasExactKeysV2(candidate, [
+      "sourceNamespace",
+      "sourceChain",
+      "assetIdentifier",
+      "assetStandard",
+    ]) &&
+    isNonzeroBytes32V2(candidate.sourceNamespace) &&
+    isNonzeroBytes32V2(candidate.sourceChain) &&
+    isNonzeroBytes32V2(candidate.assetIdentifier) &&
+    isNonzeroBytes32V2(candidate.assetStandard);
+}
+
+function isPredictionAssetSnapshotBindingV2(
+  candidate: unknown,
+  onchainAssetKey: PredictionBytes32V2,
+): candidate is PredictionAssetSnapshotBindingV2 {
+  return isPlainRecord(candidate) &&
+    hasExactKeysV2(candidate, ["assetKey", "revision", "snapshotHash"]) &&
+    candidate.assetKey === onchainAssetKey &&
+    Number.isSafeInteger(candidate.revision) &&
+    Number(candidate.revision) > 0 &&
+    isNonzeroBytes32V2(candidate.snapshotHash);
+}
+
+function isPredictionAssetReleaseBindingV2(
+  candidate: unknown,
+): candidate is PredictionAssetReleaseBindingV2 {
+  return isPlainRecord(candidate) &&
+    hasExactKeysV2(candidate, ["id", "oraclePolicyId"]) &&
+    typeof candidate.id === "string" &&
+    candidate.id.trim() === candidate.id &&
+    candidate.id.length > 0 &&
+    typeof candidate.oraclePolicyId === "string" &&
+    candidate.oraclePolicyId.trim() === candidate.oraclePolicyId &&
+    candidate.oraclePolicyId.length > 0;
+}
+
+function isPredictionAssetReleaseEntryV2(
+  candidate: unknown,
+): candidate is PredictionAssetReleaseEntryV2 {
+  if (
+    !isPlainRecord(candidate) ||
+    !hasExactKeysV2(candidate, [
+      "selectionKey",
+      "onchainAssetKey",
+      "identity",
+      "marketType",
+      "oracleStatus",
+      "snapshot",
+      "release",
+    ]) ||
+    typeof candidate.selectionKey !== "string" ||
+    !isNonzeroBytes32V2(candidate.onchainAssetKey) ||
+    candidate.marketType !== PREDICTION_MARKET_TYPE_V2 ||
+    !["ready", "unknown", "unsupported", "paused"].includes(String(candidate.oracleStatus))
+  ) return false;
+
+  const candidateIdentity = candidate.identity;
+  if (!isPredictionAssetIdentityV2(candidateIdentity)) return false;
+  const selection = selectionFromKeyV2(candidate.selectionKey);
+  if (!selection) return false;
+  const identityMatches = predictionAssetIdentityCandidatesV2(selection).some(
+    (identity) => samePredictionAssetIdentityV2(identity, candidateIdentity),
+  );
+  if (!identityMatches || predictionOnchainAssetKeyV2(candidateIdentity) !== candidate.onchainAssetKey) {
+    return false;
+  }
+
+  if (candidate.oracleStatus === "ready" || candidate.oracleStatus === "paused") {
+    return isPredictionAssetSnapshotBindingV2(candidate.snapshot, candidate.onchainAssetKey) &&
+      isPredictionAssetReleaseBindingV2(candidate.release);
+  }
+  return candidate.snapshot === null && candidate.release === null;
 }
 
 export function isPredictionAssetReleaseRegistryV2(
   candidate: unknown,
 ): candidate is PredictionAssetReleaseRegistryV2 {
-  if (!isPlainRecord(candidate) || candidate.schemaVersion !== 2) return false;
+  if (
+    !isPlainRecord(candidate) ||
+    !hasExactKeysV2(candidate, ["schemaVersion", "settlementNetwork", "entries"]) ||
+    candidate.schemaVersion !== 2
+  ) return false;
   const settlementNetwork = candidate.settlementNetwork;
   if (
     !isPlainRecord(settlementNetwork) ||
+    !hasExactKeysV2(settlementNetwork, ["id", "chainId"]) ||
     settlementNetwork.id !== PREDICTION_SETTLEMENT_NETWORK_V2.id ||
     settlementNetwork.chainId !== PREDICTION_SETTLEMENT_NETWORK_V2.chainId ||
-    !Array.isArray(candidate.entries)
-  ) {
-    return false;
-  }
+    !Array.isArray(candidate.entries) ||
+    !candidate.entries.every(isPredictionAssetReleaseEntryV2)
+  ) return false;
 
-  return candidate.entries.every((entry) => {
-    if (!isPlainRecord(entry)) return false;
-    if (
-      typeof entry.assetKey !== "string" ||
-      entry.assetKey.length === 0 ||
-      entry.marketType !== PREDICTION_MARKET_TYPE_V2 ||
-      !["ready", "unknown", "unsupported", "paused"].includes(
-        String(entry.oracleStatus),
-      )
-    ) {
-      return false;
-    }
-    if (entry.oracleStatus !== "ready") return true;
-    return (
-      typeof entry.oraclePolicyId === "string" &&
-      entry.oraclePolicyId.trim().length > 0 &&
-      typeof entry.releaseId === "string" &&
-      entry.releaseId.trim().length > 0
-    );
-  });
+  const selectionByOnchainAssetKey = new Map<string, string>();
+  for (const entry of candidate.entries) {
+    const priorSelection = selectionByOnchainAssetKey.get(entry.onchainAssetKey);
+    if (priorSelection && priorSelection !== entry.selectionKey) return false;
+    selectionByOnchainAssetKey.set(entry.onchainAssetKey, entry.selectionKey);
+  }
+  return true;
 }
 
 export function predictionAssetMarketStateV2(
@@ -323,19 +542,17 @@ export function predictionAssetMarketStateV2(
   registry?: PredictionAssetReleaseRegistryV2 | null,
 ): PredictionAssetMarketStateV2 {
   const validation = validatePredictionAssetSelectionV2(selection);
-  if (!validation.ok || !validation.assetKey) {
-    const sourceNetwork =
-      selection.mode === "custom"
-        ? predictionSourceNetworkV2(selection.sourceNetwork)
-        : undefined;
+  if (!validation.ok || !validation.selectionKey) {
+    const sourceNetwork = selection.mode === "custom"
+      ? predictionSourceNetworkV2(selection.sourceNetwork)
+      : undefined;
     return {
       state: "incomplete",
       code: "selection-incomplete",
       title: "Choose an asset",
-      detail:
-        sourceNetwork?.namespace === "solana"
-          ? "Enter a valid Solana token mint."
-          : "Choose a network and enter a valid contract address.",
+      detail: sourceNetwork?.namespace === "solana"
+        ? "Enter a valid Solana token mint."
+        : "Choose a network and enter a valid contract address.",
     };
   }
 
@@ -345,7 +562,7 @@ export function predictionAssetMarketStateV2(
       code: "release-unconfigured",
       title: "Not available yet",
       detail: "No released price source is configured for this asset.",
-      assetKey: validation.assetKey,
+      selectionKey: validation.selectionKey,
     };
   }
   if (!isPredictionAssetReleaseRegistryV2(registry)) {
@@ -354,14 +571,13 @@ export function predictionAssetMarketStateV2(
       code: "release-invalid",
       title: "Not available yet",
       detail: "The price source configuration could not be verified.",
-      assetKey: validation.assetKey,
+      selectionKey: validation.selectionKey,
     };
   }
 
-  const entries = registry.entries.filter(
-    (entry) =>
-      entry.assetKey === validation.assetKey &&
-      entry.marketType === PREDICTION_MARKET_TYPE_V2,
+  const entries = registry.entries.filter((entry) =>
+    entry.selectionKey === validation.selectionKey &&
+    entry.marketType === PREDICTION_MARKET_TYPE_V2
   );
   if (entries.length === 0) {
     return {
@@ -369,7 +585,7 @@ export function predictionAssetMarketStateV2(
       code: "oracle-unsupported",
       title: "Not available yet",
       detail: "This asset does not have a released price source.",
-      assetKey: validation.assetKey,
+      selectionKey: validation.selectionKey,
     };
   }
   if (entries.length !== 1) {
@@ -378,18 +594,22 @@ export function predictionAssetMarketStateV2(
       code: "oracle-ambiguous",
       title: "Not available yet",
       detail: "The price source configuration is ambiguous.",
-      assetKey: validation.assetKey,
+      selectionKey: validation.selectionKey,
     };
   }
 
   const [entry] = entries;
+  const stateIdentity = {
+    selectionKey: validation.selectionKey,
+    onchainAssetKey: entry.onchainAssetKey,
+  } as const;
   if (entry.oracleStatus === "unknown") {
     return {
       state: "unavailable",
       code: "oracle-unknown",
       title: "Not available yet",
       detail: "The price source has not been verified.",
-      assetKey: validation.assetKey,
+      ...stateIdentity,
     };
   }
   if (entry.oracleStatus === "unsupported") {
@@ -398,7 +618,7 @@ export function predictionAssetMarketStateV2(
       code: "oracle-unsupported",
       title: "Not available yet",
       detail: "This asset does not have a released price source.",
-      assetKey: validation.assetKey,
+      ...stateIdentity,
     };
   }
   if (entry.oracleStatus === "paused") {
@@ -407,16 +627,15 @@ export function predictionAssetMarketStateV2(
       code: "oracle-paused",
       title: "Temporarily unavailable",
       detail: "New markets are paused for this asset.",
-      assetKey: validation.assetKey,
+      ...stateIdentity,
     };
   }
-
   return {
     state: "available",
     code: "ready",
     title: "Ready for a price market",
     detail: "The result uses the released price source at the selected UTC time.",
-    assetKey: validation.assetKey,
+    ...stateIdentity,
   };
 }
 
@@ -424,12 +643,12 @@ export function predictionAssetSnapshotMatchesSelectionV2(
   snapshot: PredictionAssetDiscoverySnapshotV2 | null | undefined,
   selection: PredictionAssetSelectionV2,
 ) {
-  const assetKey = predictionAssetKeyV2(selection);
+  const selectionKey = predictionAssetSelectionKeyV2(selection);
   return Boolean(
     snapshot &&
       snapshot.status === "available" &&
-      assetKey &&
-      snapshot.assetKey === assetKey,
+      selectionKey &&
+      snapshot.selectionKey === selectionKey,
   );
 }
 

--- a/lib/prediction-market-assets-v2.ts
+++ b/lib/prediction-market-assets-v2.ts
@@ -115,7 +115,8 @@ export const PREDICTION_MARKET_DRAFT_SCHEMA_V2 = Object.freeze({
 
 export type PredictionAssetSnapshotBindingV2 = Readonly<{
   assetKey: PredictionBytes32V2;
-  revision: number;
+  /** Canonical nonzero Solidity uint64 encoded as decimal JSON text. */
+  revision: string;
   snapshotHash: PredictionBytes32V2;
 }>;
 
@@ -191,6 +192,8 @@ const ZERO_BYTES32_V2 = `0x${"0".repeat(64)}`;
 const SOLANA_BASE58_PATTERN = /^[1-9A-HJ-NP-Za-km-z]+$/u;
 const SOLANA_BASE58_ALPHABET =
   "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const NONZERO_UINT64_DECIMAL_PATTERN_V2 = /^[1-9][0-9]{0,19}$/u;
+const MAX_UINT64_V2 = (1n << 64n) - 1n;
 
 function bytes32TextV2(value: string) {
   return stringToHex(value, { size: 32 }) as PredictionBytes32V2;
@@ -245,6 +248,22 @@ function isBytes32V2(candidate: unknown): candidate is PredictionBytes32V2 {
 
 function isNonzeroBytes32V2(candidate: unknown): candidate is PredictionBytes32V2 {
   return isBytes32V2(candidate) && candidate !== ZERO_BYTES32_V2;
+}
+
+function parseNonzeroUint64DecimalV2(candidate: unknown): bigint | null {
+  if (
+    typeof candidate !== "string" ||
+    !NONZERO_UINT64_DECIMAL_PATTERN_V2.test(candidate)
+  ) return null;
+  const revision = BigInt(candidate);
+  return revision <= MAX_UINT64_V2 ? revision : null;
+}
+
+/** Convert a validated serialized Registry revision only when constructing ABI arguments. */
+export function predictionAssetRevisionForAbiV2(revision: string): bigint {
+  const parsed = parseNonzeroUint64DecimalV2(revision);
+  if (parsed === null) throw new TypeError("Invalid prediction asset Registry revision");
+  return parsed;
 }
 
 function samePredictionAssetIdentityV2(
@@ -454,8 +473,7 @@ function isPredictionAssetSnapshotBindingV2(
   return isPlainRecord(candidate) &&
     hasExactKeysV2(candidate, ["assetKey", "revision", "snapshotHash"]) &&
     candidate.assetKey === onchainAssetKey &&
-    Number.isSafeInteger(candidate.revision) &&
-    Number(candidate.revision) > 0 &&
+    parseNonzeroUint64DecimalV2(candidate.revision) !== null &&
     isNonzeroBytes32V2(candidate.snapshotHash);
 }
 
@@ -665,9 +683,15 @@ export function formatPredictionAssetUsdV2(
       maximumFractionDigits: 2,
     }).format(value);
   }
+  if (value > 0 && value < 1e-18) {
+    return "<$0.000000000000000001";
+  }
+  const maximumFractionDigits = value > 0 && value < 1
+    ? Math.min(18, Math.max(6, Math.ceil(-Math.log10(value)) + 3))
+    : 2;
   return new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: "USD",
-    maximumFractionDigits: value < 1 ? 6 : 2,
+    maximumFractionDigits,
   }).format(value);
 }

--- a/lib/prediction-v2/abi.ts
+++ b/lib/prediction-v2/abi.ts
@@ -91,6 +91,13 @@ export const PREDICTION_V2_FACTORY_ABI = [
   },
   {
     type: "function",
+    name: "manager",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
     name: "markets",
     stateMutability: "view",
     inputs: [{ name: "economicKey", type: "bytes32" }],
@@ -163,6 +170,7 @@ export const PREDICTION_V2_FACTORY_ABI = [
       { name: "identity", type: "tuple", components: assetIdentityComponents },
       { name: "observationTime", type: "uint32" },
       { name: "threshold", type: "int192" },
+      { name: "expectedMarketId", type: "bytes32" },
       { name: "permitDeadline", type: "uint256" },
       { name: "v", type: "uint8" },
       { name: "r", type: "bytes32" },
@@ -202,6 +210,18 @@ export const PREDICTION_V2_ASSET_REGISTRY_ABI = [
     name: "latestSnapshot",
     stateMutability: "view",
     inputs: [{ name: "assetKey", type: "bytes32" }],
+    outputs: [
+      { name: "snapshot", type: "tuple", components: registrySnapshotComponents },
+    ],
+  },
+  {
+    type: "function",
+    name: "getSnapshot",
+    stateMutability: "view",
+    inputs: [
+      { name: "assetKey", type: "bytes32" },
+      { name: "revision", type: "uint64" },
+    ],
     outputs: [
       { name: "snapshot", type: "tuple", components: registrySnapshotComponents },
     ],
@@ -328,6 +348,48 @@ export const PREDICTION_V2_EXPOSURE_CONTROLLER_ABI = [
 export const PREDICTION_V2_VAULT_ABI = [
   {
     type: "function",
+    name: "collateral",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "checkpoint",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "factory",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "router",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "yesToken",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "noToken",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
     name: "exposureController",
     stateMutability: "view",
     inputs: [],
@@ -335,10 +397,236 @@ export const PREDICTION_V2_VAULT_ABI = [
   },
   {
     type: "function",
+    name: "cutoff",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint64" }],
+  },
+  {
+    type: "function",
+    name: "threshold",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "int192" }],
+  },
+  {
+    type: "function",
+    name: "economicKey",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "bytes32" }],
+  },
+  {
+    type: "function",
+    name: "marketId",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "bytes32" }],
+  },
+  {
+    type: "function",
+    name: "assetKey",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "bytes32" }],
+  },
+  {
+    type: "function",
+    name: "registryRevision",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint64" }],
+  },
+  {
+    type: "function",
+    name: "registrySnapshotHash",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "bytes32" }],
+  },
+  {
+    type: "function",
+    name: "oraclePolicyHash",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "bytes32" }],
+  },
+  {
+    type: "function",
+    name: "state",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint8" }],
+  },
+  {
+    type: "function",
+    name: "accountedLiability",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "canonicalPoolId",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "bytes32" }],
+  },
+  {
+    type: "function",
     name: "finalize",
     stateMutability: "payable",
     inputs: [{ name: "proof", type: "bytes" }],
     outputs: [{ name: "finalState", type: "uint8" }],
+  },
+  {
+    type: "function",
+    name: "finalizeAndRedeem",
+    stateMutability: "payable",
+    inputs: [
+      { name: "proof", type: "bytes" },
+      { name: "yesAtoms", type: "uint256" },
+      { name: "noAtoms", type: "uint256" },
+      { name: "recipient", type: "address" },
+    ],
+    outputs: [
+      { name: "finalState", type: "uint8" },
+      { name: "collateralAtoms", type: "uint256" },
+    ],
+  },
+  {
+    type: "function",
+    name: "finalizeUnavailable",
+    stateMutability: "nonpayable",
+    inputs: [],
+    outputs: [{ name: "finalState", type: "uint8" }],
+  },
+  {
+    type: "function",
+    name: "requestUnprovenFallback",
+    stateMutability: "nonpayable",
+    inputs: [],
+    outputs: [{ name: "challengeDeadline", type: "uint32" }],
+  },
+  {
+    type: "function",
+    name: "finalizeUnproven",
+    stateMutability: "nonpayable",
+    inputs: [],
+    outputs: [{ name: "finalState", type: "uint8" }],
+  },
+  {
+    type: "function",
+    name: "finalizeResolved",
+    stateMutability: "nonpayable",
+    inputs: [],
+    outputs: [{ name: "finalState", type: "uint8" }],
+  },
+  {
+    type: "function",
+    name: "redeem",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "yesAtoms", type: "uint256" },
+      { name: "noAtoms", type: "uint256" },
+      { name: "recipient", type: "address" },
+    ],
+    outputs: [{ name: "collateralAtoms", type: "uint256" }],
+  },
+] as const satisfies Abi;
+
+/** Adapter-neutral lifecycle reads exposed by every Protocol V2 checkpoint. */
+export const PREDICTION_V2_CHECKPOINT_ABI = [
+  {
+    type: "function",
+    name: "status",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint8" }],
+  },
+  {
+    type: "function",
+    name: "resolvedPrice",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "int192" }],
+  },
+  {
+    type: "function",
+    name: "observationTime",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint32" }],
+  },
+  {
+    type: "function",
+    name: "resolutionDeadline",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint32" }],
+  },
+  {
+    type: "function",
+    name: "hardResolutionDeadline",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint32" }],
+  },
+  {
+    type: "function",
+    name: "fallbackRequestedAt",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint32" }],
+  },
+  {
+    type: "function",
+    name: "fallbackChallengeDeadline",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint32" }],
+  },
+  {
+    type: "function",
+    name: "policyHash",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "bytes32" }],
+  },
+  {
+    type: "function",
+    name: "priceDecimals",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint8" }],
+  },
+  {
+    type: "function",
+    name: "isTradingHealthy",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "resolve",
+    stateMutability: "payable",
+    inputs: [{ name: "proof", type: "bytes" }],
+    outputs: [{ name: "terminalStatus", type: "uint8" }],
+  },
+] as const satisfies Abi;
+
+/**
+ * PoolManager exposes raw storage through Extsload. Protocol V2 derives the
+ * canonical v4 pool state slot locally and binds the returned word verbatim.
+ */
+export const PREDICTION_V2_POOL_MANAGER_STATE_ABI = [
+  {
+    type: "function",
+    name: "extsload",
+    stateMutability: "view",
+    inputs: [{ name: "slot", type: "bytes32" }],
+    outputs: [{ name: "", type: "bytes32" }],
   },
 ] as const satisfies Abi;
 

--- a/lib/prediction-v2/abi.ts
+++ b/lib/prediction-v2/abi.ts
@@ -1,0 +1,392 @@
+import type { Abi, Address } from "viem";
+
+import type {
+  PredictionAssetIdentityV2,
+  PredictionBytes32V2,
+} from "../prediction-market-assets-v2";
+
+const assetIdentityComponents = [
+  { name: "sourceNamespace", type: "bytes32" },
+  { name: "sourceChain", type: "bytes32" },
+  { name: "assetIdentifier", type: "bytes32" },
+  { name: "assetStandard", type: "bytes32" },
+] as const;
+
+const poolKeyComponents = [
+  { name: "currency0", type: "address" },
+  { name: "currency1", type: "address" },
+  { name: "fee", type: "uint24" },
+  { name: "tickSpacing", type: "int24" },
+  { name: "hooks", type: "address" },
+] as const;
+
+const swapQuoteComponents = [
+  { name: "actualInput", type: "uint256" },
+  { name: "amountOut", type: "uint256" },
+  { name: "sqrtPriceX96After", type: "uint160" },
+  { name: "tickAfter", type: "int24" },
+  { name: "poolManagerProtocolFee", type: "uint24" },
+  { name: "lpFee", type: "uint24" },
+] as const;
+
+const buyQuoteComponents = [
+  { name: "requestedCollateralAtoms", type: "uint256" },
+  { name: "maximumPaymentAtoms", type: "uint256" },
+  { name: "executedCollateralAtoms", type: "uint256" },
+  { name: "collateralRefundAtoms", type: "uint256" },
+  { name: "protocolFeeAtoms", type: "uint256" },
+  { name: "feeReserveRefundAtoms", type: "uint256" },
+  { name: "actualPaymentAtoms", type: "uint256" },
+  { name: "outcomeAtoms", type: "uint256" },
+  { name: "swap", type: "tuple", components: swapQuoteComponents },
+] as const;
+
+const sellQuoteComponents = [
+  { name: "outcomeInAtoms", type: "uint256" },
+  { name: "requestedSwapAtoms", type: "uint256" },
+  { name: "grossCollateralAtoms", type: "uint256" },
+  { name: "protocolFeeAtoms", type: "uint256" },
+  { name: "netCollateralAtoms", type: "uint256" },
+  { name: "soldRefundAtoms", type: "uint256" },
+  { name: "complementRefundAtoms", type: "uint256" },
+  { name: "swap", type: "tuple", components: swapQuoteComponents },
+] as const;
+
+const oraclePolicyComponents = [
+  { name: "checkpointKind", type: "bytes32" },
+  { name: "checkpointAdapter", type: "address" },
+  { name: "checkpointAdapterCodehash", type: "bytes32" },
+  { name: "feedId", type: "bytes32" },
+  { name: "feedAddress", type: "address" },
+  { name: "feedProxyCodehash", type: "bytes32" },
+  { name: "feedPhaseId", type: "uint16" },
+  { name: "feedAggregator", type: "address" },
+  { name: "feedAggregatorCodehash", type: "bytes32" },
+  { name: "feedDescriptionHash", type: "bytes32" },
+  { name: "feedDecimals", type: "uint8" },
+  { name: "quoteCurrency", type: "bytes32" },
+  { name: "assetEvidenceHash", type: "bytes32" },
+  { name: "maxOpenInterestAtoms", type: "uint256" },
+  { name: "validUntil", type: "uint64" },
+  { name: "policyVersion", type: "uint32" },
+  { name: "active", type: "bool" },
+] as const;
+
+const registrySnapshotComponents = [
+  { name: "assetKey", type: "bytes32" },
+  { name: "revision", type: "uint64" },
+  { name: "identity", type: "tuple", components: assetIdentityComponents },
+  { name: "displaySymbol", type: "string" },
+  { name: "policy", type: "tuple", components: oraclePolicyComponents },
+] as const;
+
+/** Exact ABI closure for GenericPredictionMarketFactoryV2. No V1 overloads. */
+export const PREDICTION_V2_FACTORY_ABI = [
+  {
+    type: "function",
+    name: "assetRegistry",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "markets",
+    stateMutability: "view",
+    inputs: [{ name: "economicKey", type: "bytes32" }],
+    outputs: [
+      { name: "vault", type: "address" },
+      { name: "checkpoint", type: "address" },
+      { name: "poolId", type: "bytes32" },
+      { name: "marketId", type: "bytes32" },
+      { name: "assetKey", type: "bytes32" },
+      { name: "registrySnapshotHash", type: "bytes32" },
+      { name: "resolutionPolicyHash", type: "bytes32" },
+      { name: "registryRevision", type: "uint64" },
+      { name: "policyValidUntil", type: "uint64" },
+      { name: "snapshotAssetCap", type: "uint256" },
+    ],
+  },
+  {
+    type: "function",
+    name: "activeMarketId",
+    stateMutability: "view",
+    inputs: [
+      { name: "identity", type: "tuple", components: assetIdentityComponents },
+      { name: "observationTime", type: "uint32" },
+      { name: "threshold", type: "int192" },
+    ],
+    outputs: [
+      { name: "economicKey", type: "bytes32" },
+      { name: "marketId", type: "bytes32" },
+      { name: "snapshotHash", type: "bytes32" },
+      { name: "registryRevision", type: "uint64" },
+    ],
+  },
+  {
+    type: "function",
+    name: "economicEventKey",
+    stateMutability: "view",
+    inputs: [
+      { name: "assetKey", type: "bytes32" },
+      { name: "observationTime", type: "uint32" },
+      { name: "threshold", type: "int192" },
+    ],
+    outputs: [{ name: "", type: "bytes32" }],
+  },
+  {
+    type: "function",
+    name: "marketCount",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "marketKeyAt",
+    stateMutability: "view",
+    inputs: [{ name: "index", type: "uint256" }],
+    outputs: [{ name: "", type: "bytes32" }],
+  },
+  {
+    type: "function",
+    name: "getPoolKey",
+    stateMutability: "view",
+    inputs: [{ name: "economicKey", type: "bytes32" }],
+    outputs: [{ name: "", type: "tuple", components: poolKeyComponents }],
+  },
+  {
+    type: "function",
+    name: "createMarketWithPermit",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "identity", type: "tuple", components: assetIdentityComponents },
+      { name: "observationTime", type: "uint32" },
+      { name: "threshold", type: "int192" },
+      { name: "permitDeadline", type: "uint256" },
+      { name: "v", type: "uint8" },
+      { name: "r", type: "bytes32" },
+      { name: "s", type: "bytes32" },
+    ],
+    outputs: [
+      { name: "vaultAddress", type: "address" },
+      { name: "created", type: "bool" },
+    ],
+  },
+] as const satisfies Abi;
+
+/** Exact 17-field OraclePolicy and Snapshot bindings for AssetRegistryV2. */
+export const PREDICTION_V2_ASSET_REGISTRY_ABI = [
+  {
+    type: "function",
+    name: "assetKeyOf",
+    stateMutability: "pure",
+    inputs: [
+      { name: "identity", type: "tuple", components: assetIdentityComponents },
+    ],
+    outputs: [{ name: "", type: "bytes32" }],
+  },
+  {
+    type: "function",
+    name: "requireActiveAsset",
+    stateMutability: "view",
+    inputs: [
+      { name: "identity", type: "tuple", components: assetIdentityComponents },
+    ],
+    outputs: [
+      { name: "snapshot", type: "tuple", components: registrySnapshotComponents },
+    ],
+  },
+  {
+    type: "function",
+    name: "latestSnapshot",
+    stateMutability: "view",
+    inputs: [{ name: "assetKey", type: "bytes32" }],
+    outputs: [
+      { name: "snapshot", type: "tuple", components: registrySnapshotComponents },
+    ],
+  },
+  {
+    type: "function",
+    name: "hashSnapshot",
+    stateMutability: "pure",
+    inputs: [
+      { name: "snapshot", type: "tuple", components: registrySnapshotComponents },
+    ],
+    outputs: [{ name: "", type: "bytes32" }],
+  },
+  {
+    type: "function",
+    name: "isCurrentActiveRevision",
+    stateMutability: "view",
+    inputs: [
+      { name: "assetKey", type: "bytes32" },
+      { name: "revision", type: "uint64" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+] as const satisfies Abi;
+
+/** PredictionQuoterV2 returns one 9-field buy tuple and one 8-field sell tuple. */
+export const PREDICTION_V2_QUOTER_ABI = [
+  {
+    type: "function",
+    name: "quoteBuy",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "vault", type: "address" },
+      { name: "key", type: "tuple", components: poolKeyComponents },
+      { name: "buyYes", type: "bool" },
+      { name: "requestedCollateralAtoms", type: "uint256" },
+      { name: "sqrtPriceLimitX96", type: "uint160" },
+    ],
+    outputs: [{ name: "quote", type: "tuple", components: buyQuoteComponents }],
+  },
+  {
+    type: "function",
+    name: "quoteSellOptimal",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "vault", type: "address" },
+      { name: "key", type: "tuple", components: poolKeyComponents },
+      { name: "sellYes", type: "bool" },
+      { name: "outcomeAtoms", type: "uint256" },
+      { name: "sqrtPriceLimitX96", type: "uint160" },
+    ],
+    outputs: [{ name: "quote", type: "tuple", components: sellQuoteComponents }],
+  },
+] as const satisfies Abi;
+
+export const PREDICTION_V2_EXECUTION_ROUTER_ABI = [
+  {
+    type: "function",
+    name: "buyOutcomeWithPermit",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "vault", type: "address" },
+      { name: "key", type: "tuple", components: poolKeyComponents },
+      {
+        name: "request",
+        type: "tuple",
+        components: [
+          { name: "buyYes", type: "bool" },
+          { name: "collateralAtoms", type: "uint256" },
+          { name: "minOutcomeAtoms", type: "uint256" },
+          { name: "sqrtPriceLimitX96", type: "uint160" },
+          { name: "deadline", type: "uint256" },
+        ],
+      },
+      { name: "permitDeadline", type: "uint256" },
+      { name: "v", type: "uint8" },
+      { name: "r", type: "bytes32" },
+      { name: "s", type: "bytes32" },
+    ],
+    outputs: [{ name: "totalOutcomeAtoms", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "sellOutcomeWithPermit",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "vault", type: "address" },
+      { name: "key", type: "tuple", components: poolKeyComponents },
+      {
+        name: "request",
+        type: "tuple",
+        components: [
+          { name: "sellYes", type: "bool" },
+          { name: "outcomeAtoms", type: "uint256" },
+          { name: "swapAtoms", type: "uint256" },
+          { name: "minCollateralAtoms", type: "uint256" },
+          { name: "sqrtPriceLimitX96", type: "uint160" },
+          { name: "deadline", type: "uint256" },
+        ],
+      },
+      { name: "permitDeadline", type: "uint256" },
+      { name: "v", type: "uint8" },
+      { name: "r", type: "bytes32" },
+      { name: "s", type: "bytes32" },
+    ],
+    outputs: [{ name: "netCollateralAtoms", type: "uint256" }],
+  },
+] as const satisfies Abi;
+
+/** A successful eth_call returns empty data; insufficient or unstable capacity reverts. */
+export const PREDICTION_V2_EXPOSURE_CONTROLLER_ABI = [
+  {
+    type: "function",
+    name: "requireIncreaseCapacity",
+    stateMutability: "view",
+    inputs: [
+      { name: "vault", type: "address" },
+      { name: "delta", type: "uint256" },
+    ],
+    outputs: [],
+  },
+] as const satisfies Abi;
+
+export const PREDICTION_V2_VAULT_ABI = [
+  {
+    type: "function",
+    name: "exposureController",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "finalize",
+    stateMutability: "payable",
+    inputs: [{ name: "proof", type: "bytes" }],
+    outputs: [{ name: "finalState", type: "uint8" }],
+  },
+] as const satisfies Abi;
+
+export type PredictionV2PoolKey = Readonly<{
+  currency0: Address;
+  currency1: Address;
+  fee: number;
+  tickSpacing: number;
+  hooks: Address;
+}>;
+
+export type PredictionV2MarketRecord = Readonly<{
+  vault: Address;
+  checkpoint: Address;
+  poolId: PredictionBytes32V2;
+  marketId: PredictionBytes32V2;
+  assetKey: PredictionBytes32V2;
+  registrySnapshotHash: PredictionBytes32V2;
+  resolutionPolicyHash: PredictionBytes32V2;
+  registryRevision: bigint;
+  policyValidUntil: bigint;
+  snapshotAssetCap: bigint;
+}>;
+
+export type PredictionV2OraclePolicy = Readonly<{
+  checkpointKind: PredictionBytes32V2;
+  checkpointAdapter: Address;
+  checkpointAdapterCodehash: PredictionBytes32V2;
+  feedId: PredictionBytes32V2;
+  feedAddress: Address;
+  feedProxyCodehash: PredictionBytes32V2;
+  feedPhaseId: number;
+  feedAggregator: Address;
+  feedAggregatorCodehash: PredictionBytes32V2;
+  feedDescriptionHash: PredictionBytes32V2;
+  feedDecimals: number;
+  quoteCurrency: PredictionBytes32V2;
+  assetEvidenceHash: PredictionBytes32V2;
+  maxOpenInterestAtoms: bigint;
+  validUntil: bigint;
+  policyVersion: number;
+  active: boolean;
+}>;
+
+export type PredictionV2RegistrySnapshot = Readonly<{
+  assetKey: PredictionBytes32V2;
+  revision: bigint;
+  identity: PredictionAssetIdentityV2;
+  displaySymbol: string;
+  policy: PredictionV2OraclePolicy;
+}>;

--- a/lib/prediction-v2/accounting.ts
+++ b/lib/prediction-v2/accounting.ts
@@ -1,8 +1,29 @@
 import {
+  decodeFunctionResult,
+  encodeAbiParameters,
+  encodeFunctionData,
+  isAddress,
+  keccak256,
+  parseAbiParameters,
+  zeroAddress,
+  type Address,
+  type Hex,
+} from "viem";
+
+import {
+  PREDICTION_V2_CHECKPOINT_ABI,
+  PREDICTION_V2_POOL_MANAGER_STATE_ABI,
+  PREDICTION_V2_VAULT_ABI,
+  type PredictionV2PoolKey,
+} from "./abi";
+import type { PredictionBytes32V2 } from "../prediction-market-assets-v2";
+import {
   PREDICTION_V2_BPS_DENOMINATOR,
   PREDICTION_V2_FACE_SCALE,
+  PREDICTION_V2_LP_FEE_PIPS,
   PREDICTION_V2_MAX_SQRT_PRICE_X96,
   PREDICTION_V2_MIN_SQRT_PRICE_X96,
+  PREDICTION_V2_TICK_SPACING,
   type PredictionV2BuyQuote,
   type PredictionV2SellQuote,
 } from "./codec";
@@ -20,18 +41,72 @@ export type PredictionV2PriceImpact = Readonly<{
 }>;
 
 export type PredictionV2LiquidityWarning = Readonly<{
-  code:
-    | "backstop-only"
-    | "partial-fill"
-    | "price-impact-warning"
-    | "large-price-impact";
+  code: "backstop-only";
   message: string;
 }> | null;
 
 export type PredictionV2LiquidityAssessment = Readonly<{
   depth: "thin" | "low" | "moderate";
   riskState: "normal" | "warning" | "explicit-confirmation-required";
+  priceImpactRiskState: "normal" | "warning" | "explicit-confirmation-required";
+  partialFill: boolean;
   warning: PredictionV2LiquidityWarning;
+}>;
+
+export type PredictionV2OutcomeTokens = Readonly<{
+  yesToken: Address;
+  noToken: Address;
+}>;
+
+export type PredictionV2BoundMarketState = Readonly<{
+  chainId: 4_663;
+  vault: Address;
+  poolManager: Address;
+  poolKey: PredictionV2PoolKey;
+  poolId: PredictionBytes32V2;
+  poolStateSlot: PredictionBytes32V2;
+  checkpoint: Address;
+  checkpointTradingHealthy: boolean;
+  yesToken: Address;
+  noToken: Address;
+  currentSqrtPriceX96: bigint;
+  currentTick: number;
+  poolManagerProtocolFee: number;
+  lpFee: number;
+  observedBlockNumber: bigint;
+  observedBlockHash: PredictionBytes32V2;
+  checkpointCall: Readonly<{ to: Address; data: Hex }>;
+  checkpointResult: Hex;
+  checkpointTradingHealthCall: Readonly<{ to: Address; data: Hex }>;
+  checkpointTradingHealthResult: Hex;
+  yesTokenCall: Readonly<{ to: Address; data: Hex }>;
+  yesTokenResult: Hex;
+  noTokenCall: Readonly<{ to: Address; data: Hex }>;
+  noTokenResult: Hex;
+  slot0Call: Readonly<{ to: Address; data: Hex }>;
+  slot0Result: Hex;
+}>;
+
+type PredictionV2BoundBuyPreviewQuote = Readonly<{
+  chainId: 4_663;
+  vault: Address;
+  poolKey: PredictionV2PoolKey;
+  buyYes: boolean;
+  observedBlockNumber: bigint;
+  observedBlockHash: PredictionBytes32V2;
+  marketState: PredictionV2BoundMarketState;
+  quote: PredictionV2BuyQuote;
+}>;
+
+type PredictionV2BoundSellPreviewQuote = Readonly<{
+  chainId: 4_663;
+  vault: Address;
+  poolKey: PredictionV2PoolKey;
+  sellYes: boolean;
+  observedBlockNumber: bigint;
+  observedBlockHash: PredictionBytes32V2;
+  marketState: PredictionV2BoundMarketState;
+  quote: PredictionV2SellQuote;
 }>;
 
 export type PredictionV2BuyPreview = Readonly<{
@@ -78,6 +153,254 @@ function assertSqrtPrice(sqrtPriceX96: bigint) {
     sqrtPriceX96 < PREDICTION_V2_MIN_SQRT_PRICE_X96 ||
     sqrtPriceX96 > PREDICTION_V2_MAX_SQRT_PRICE_X96
   ) throw new Error("Protocol V2 pool price is outside Uniswap v4 bounds.");
+}
+
+function nonzeroAddress(value: unknown, label: string): Address {
+  if (
+    typeof value !== "string" || !isAddress(value, { strict: false }) ||
+    value.toLowerCase() === zeroAddress
+  ) throw new Error(`Invalid Protocol V2 ${label}.`);
+  return value as Address;
+}
+
+function nonzeroBytes32(value: unknown, label: string): PredictionBytes32V2 {
+  if (
+    typeof value !== "string" || !/^0x[0-9a-fA-F]{64}$/u.test(value) ||
+    /^0x0{64}$/u.test(value)
+  ) throw new Error(`Invalid Protocol V2 ${label}.`);
+  return value.toLowerCase() as PredictionBytes32V2;
+}
+
+function samePoolKey(left: PredictionV2PoolKey, right: PredictionV2PoolKey) {
+  return left.currency0.toLowerCase() === right.currency0.toLowerCase() &&
+    left.currency1.toLowerCase() === right.currency1.toLowerCase() &&
+    left.fee === right.fee && left.tickSpacing === right.tickSpacing &&
+    left.hooks.toLowerCase() === right.hooks.toLowerCase();
+}
+
+function validatePoolKey(poolKey: PredictionV2PoolKey): PredictionV2PoolKey {
+  const currency0 = nonzeroAddress(poolKey.currency0, "currency0");
+  const currency1 = nonzeroAddress(poolKey.currency1, "currency1");
+  const hooks = nonzeroAddress(poolKey.hooks, "hook");
+  if (currency0.toLowerCase() === currency1.toLowerCase()) {
+    throw new Error("Invalid Protocol V2 pool currencies.");
+  }
+  if (
+    poolKey.fee !== PREDICTION_V2_LP_FEE_PIPS ||
+    poolKey.tickSpacing !== PREDICTION_V2_TICK_SPACING
+  ) {
+    throw new Error("Invalid Protocol V2 pool configuration.");
+  }
+  return { currency0, currency1, fee: poolKey.fee, tickSpacing: poolKey.tickSpacing, hooks };
+}
+
+export function predictionV2PoolId(poolKeyInput: PredictionV2PoolKey): PredictionBytes32V2 {
+  const poolKey = validatePoolKey(poolKeyInput);
+  return keccak256(encodeAbiParameters(
+    parseAbiParameters("address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks"),
+    [poolKey.currency0, poolKey.currency1, poolKey.fee, poolKey.tickSpacing, poolKey.hooks],
+  )) as PredictionBytes32V2;
+}
+
+export function predictionV2PoolStateSlot(
+  poolKey: PredictionV2PoolKey,
+): PredictionBytes32V2 {
+  return keccak256(encodeAbiParameters(
+    parseAbiParameters("bytes32 poolId, uint256 poolsSlot"),
+    [predictionV2PoolId(poolKey), 6n],
+  )) as PredictionBytes32V2;
+}
+
+export function encodePredictionV2VaultYesTokenCall(): Hex {
+  return encodeFunctionData({ abi: PREDICTION_V2_VAULT_ABI, functionName: "yesToken" });
+}
+
+export function encodePredictionV2VaultNoTokenCall(): Hex {
+  return encodeFunctionData({ abi: PREDICTION_V2_VAULT_ABI, functionName: "noToken" });
+}
+
+export function encodePredictionV2VaultCheckpointCall(): Hex {
+  return encodeFunctionData({ abi: PREDICTION_V2_VAULT_ABI, functionName: "checkpoint" });
+}
+
+export function encodePredictionV2CheckpointTradingHealthCall(): Hex {
+  return encodeFunctionData({ abi: PREDICTION_V2_CHECKPOINT_ABI, functionName: "isTradingHealthy" });
+}
+
+export function encodePredictionV2PoolSlot0Call(poolKey: PredictionV2PoolKey): Hex {
+  return encodeFunctionData({
+    abi: PREDICTION_V2_POOL_MANAGER_STATE_ABI,
+    functionName: "extsload",
+    args: [predictionV2PoolStateSlot(poolKey)],
+  });
+}
+
+function decodeVaultAddressResult(
+  data: Hex,
+  functionName: "checkpoint" | "yesToken" | "noToken",
+) {
+  if (!/^0x0{24}[0-9a-fA-F]{40}$/u.test(data)) {
+    throw new Error(`Invalid Protocol V2 Vault ${functionName} result.`);
+  }
+  try {
+    return nonzeroAddress(decodeFunctionResult({
+      abi: PREDICTION_V2_VAULT_ABI,
+      functionName,
+      data,
+    }), `Vault ${functionName} result`);
+  } catch {
+    throw new Error(`Invalid Protocol V2 Vault ${functionName} result.`);
+  }
+}
+
+function decodeCheckpointTradingHealthResult(data: Hex) {
+  if (!/^0x(?:0{64}|0{63}1)$/u.test(data)) {
+    throw new Error("Invalid Protocol V2 checkpoint trading-health result.");
+  }
+  try {
+    return decodeFunctionResult({
+      abi: PREDICTION_V2_CHECKPOINT_ABI,
+      functionName: "isTradingHealthy",
+      data,
+    });
+  } catch {
+    throw new Error("Invalid Protocol V2 checkpoint trading-health result.");
+  }
+}
+
+function decodePoolSlot0Result(data: Hex) {
+  if (!/^0x[0-9a-fA-F]{64}$/u.test(data)) {
+    throw new Error("Invalid Protocol V2 slot0 result.");
+  }
+  let rawWord: Hex;
+  try {
+    rawWord = decodeFunctionResult({
+      abi: PREDICTION_V2_POOL_MANAGER_STATE_ABI,
+      functionName: "extsload",
+      data,
+    });
+  } catch {
+    throw new Error("Invalid Protocol V2 slot0 result.");
+  }
+  const packed = BigInt(rawWord);
+  if (packed >> 232n !== 0n) {
+    throw new Error("Invalid Protocol V2 slot0 reserved bits.");
+  }
+  const currentSqrtPriceX96 = packed & ((1n << 160n) - 1n);
+  const unsignedTick = Number((packed >> 160n) & 0xff_ffffn);
+  const currentTick = unsignedTick >= 0x80_0000 ? unsignedTick - 0x100_0000 : unsignedTick;
+  const poolManagerProtocolFee = Number((packed >> 184n) & 0xff_ffffn);
+  const lpFee = Number((packed >> 208n) & 0xff_ffffn);
+  assertSqrtPrice(currentSqrtPriceX96);
+  predictionV2DirectionalPoolManagerFeePips(poolManagerProtocolFee, true);
+  predictionV2DirectionalPoolManagerFeePips(poolManagerProtocolFee, false);
+  if (lpFee !== PREDICTION_V2_LP_FEE_PIPS) {
+    throw new Error("Invalid Protocol V2 slot0 LP fee.");
+  }
+  return { currentSqrtPriceX96, currentTick, poolManagerProtocolFee, lpFee };
+}
+
+/**
+ * Reconstructs and decodes every raw eth_call. The orchestrator must execute
+ * all five calls at observedBlockNumber and verify observedBlockHash.
+ */
+export function bindPredictionV2MarketState(
+  input: PredictionV2BoundMarketState,
+): PredictionV2BoundMarketState {
+  if (input.chainId !== 4_663) throw new Error("Invalid Protocol V2 market-state chain.");
+  const vault = nonzeroAddress(input.vault, "market-state Vault");
+  const poolManager = nonzeroAddress(input.poolManager, "market-state PoolManager");
+  const poolKey = validatePoolKey(input.poolKey);
+  if (input.observedBlockNumber <= 0n) {
+    throw new Error("Invalid Protocol V2 market-state block number.");
+  }
+  const observedBlockHash = nonzeroBytes32(input.observedBlockHash, "market-state block hash");
+  const checkpointTarget = nonzeroAddress(input.checkpointCall.to, "checkpoint call target");
+  const yesTarget = nonzeroAddress(input.yesTokenCall.to, "yesToken call target");
+  const noTarget = nonzeroAddress(input.noTokenCall.to, "noToken call target");
+  const slot0Target = nonzeroAddress(input.slot0Call.to, "slot0 call target");
+  if (
+    checkpointTarget.toLowerCase() !== vault.toLowerCase() ||
+    input.checkpointCall.data !== encodePredictionV2VaultCheckpointCall() ||
+    yesTarget.toLowerCase() !== vault.toLowerCase() ||
+    noTarget.toLowerCase() !== vault.toLowerCase() ||
+    input.yesTokenCall.data !== encodePredictionV2VaultYesTokenCall() ||
+    input.noTokenCall.data !== encodePredictionV2VaultNoTokenCall()
+  ) throw new Error("Invalid Protocol V2 outcome-token call binding.");
+  const checkpoint = decodeVaultAddressResult(input.checkpointResult, "checkpoint");
+  const checkpointHealthTarget = nonzeroAddress(
+    input.checkpointTradingHealthCall.to,
+    "checkpoint trading-health call target",
+  );
+  if (
+    checkpointHealthTarget.toLowerCase() !== checkpoint.toLowerCase() ||
+    input.checkpointTradingHealthCall.data !== encodePredictionV2CheckpointTradingHealthCall()
+  ) throw new Error("Invalid Protocol V2 checkpoint trading-health call binding.");
+  const checkpointTradingHealthy = decodeCheckpointTradingHealthResult(
+    input.checkpointTradingHealthResult,
+  );
+  const yesToken = decodeVaultAddressResult(input.yesTokenResult, "yesToken");
+  const noToken = decodeVaultAddressResult(input.noTokenResult, "noToken");
+  tradeOrientation(poolKey, { yesToken, noToken }, "YES", "BUY");
+
+  const poolId = predictionV2PoolId(poolKey);
+  const poolStateSlot = predictionV2PoolStateSlot(poolKey);
+  const suppliedPoolId = nonzeroBytes32(input.poolId, "supplied pool id");
+  const suppliedPoolStateSlot = nonzeroBytes32(
+    input.poolStateSlot,
+    "supplied pool state slot",
+  );
+  const suppliedYesToken = nonzeroAddress(input.yesToken, "supplied yesToken");
+  const suppliedNoToken = nonzeroAddress(input.noToken, "supplied noToken");
+  const suppliedCheckpoint = nonzeroAddress(input.checkpoint, "supplied checkpoint");
+  if (
+    slot0Target.toLowerCase() !== poolManager.toLowerCase() ||
+    input.slot0Call.data !== encodePredictionV2PoolSlot0Call(poolKey)
+  ) throw new Error("Invalid Protocol V2 slot0 call binding.");
+  const slot0 = decodePoolSlot0Result(input.slot0Result);
+  if (
+    suppliedPoolId !== poolId ||
+    suppliedPoolStateSlot !== poolStateSlot ||
+    suppliedCheckpoint.toLowerCase() !== checkpoint.toLowerCase() ||
+    input.checkpointTradingHealthy !== checkpointTradingHealthy ||
+    suppliedYesToken.toLowerCase() !== yesToken.toLowerCase() ||
+    suppliedNoToken.toLowerCase() !== noToken.toLowerCase() ||
+    input.currentSqrtPriceX96 !== slot0.currentSqrtPriceX96 ||
+    input.currentTick !== slot0.currentTick ||
+    input.poolManagerProtocolFee !== slot0.poolManagerProtocolFee ||
+    input.lpFee !== slot0.lpFee
+  ) throw new Error("Invalid Protocol V2 decoded market-state binding.");
+  return {
+    chainId: 4_663,
+    vault,
+    poolManager,
+    poolKey,
+    poolId,
+    poolStateSlot,
+    checkpoint,
+    checkpointTradingHealthy,
+    yesToken,
+    noToken,
+    currentSqrtPriceX96: slot0.currentSqrtPriceX96,
+    currentTick: slot0.currentTick,
+    poolManagerProtocolFee: slot0.poolManagerProtocolFee,
+    lpFee: slot0.lpFee,
+    observedBlockNumber: input.observedBlockNumber,
+    observedBlockHash,
+    checkpointCall: { to: checkpointTarget, data: input.checkpointCall.data },
+    checkpointResult: input.checkpointResult,
+    checkpointTradingHealthCall: {
+      to: checkpointHealthTarget,
+      data: input.checkpointTradingHealthCall.data,
+    },
+    checkpointTradingHealthResult: input.checkpointTradingHealthResult,
+    yesTokenCall: { to: yesTarget, data: input.yesTokenCall.data },
+    yesTokenResult: input.yesTokenResult,
+    noTokenCall: { to: noTarget, data: input.noTokenCall.data },
+    noTokenResult: input.noTokenResult,
+    slot0Call: { to: slot0Target, data: input.slot0Call.data },
+    slot0Result: input.slot0Result,
+  };
 }
 
 function roundedRatio(numerator: bigint, denominator: bigint): bigint {
@@ -163,177 +486,236 @@ function executablePriceBps(paymentAtoms: bigint, outcomeAtoms: bigint): number 
   ));
 }
 
-function liquidityAssessment(
-  liquidityEvidence: "factory-backstop-only" | "verified-live-depth",
-  partialFill: boolean,
-  priceImpact: PredictionV2PriceImpact,
-): PredictionV2LiquidityAssessment {
+function tradeOrientation(
+  poolKey: PredictionV2PoolKey,
+  outcomeTokens: PredictionV2OutcomeTokens,
+  outcome: PredictionV2Outcome,
+  action: "BUY" | "SELL",
+) {
+  const yesToken = outcomeTokens.yesToken;
+  const noToken = outcomeTokens.noToken;
   if (
-    liquidityEvidence !== "factory-backstop-only" &&
-    liquidityEvidence !== "verified-live-depth"
-  ) throw new Error("Invalid Protocol V2 liquidity evidence.");
-  const requiresExplicitConfirmation =
-    priceImpact.probabilityPointMagnitudeBps >= 500;
-  if (liquidityEvidence === "factory-backstop-only") {
-    return {
-      depth: "thin",
-      riskState: requiresExplicitConfirmation
-        ? "explicit-confirmation-required"
-        : "warning",
-      warning: {
-        code: "backstop-only",
-        message: "Only the 2 USDG protocol backstop is currently evidenced for this market.",
-      },
-    };
+    !isAddress(yesToken, { strict: false }) || !isAddress(noToken, { strict: false }) ||
+    yesToken.toLowerCase() === zeroAddress || noToken.toLowerCase() === zeroAddress ||
+    yesToken.toLowerCase() === noToken.toLowerCase()
+  ) throw new Error("Invalid Protocol V2 outcome-token binding.");
+
+  const currency0 = poolKey.currency0.toLowerCase();
+  const currency1 = poolKey.currency1.toLowerCase();
+  const yes = yesToken.toLowerCase();
+  const no = noToken.toLowerCase();
+  if (!((currency0 === yes && currency1 === no) || (currency0 === no && currency1 === yes))) {
+    throw new Error("Protocol V2 outcome tokens do not match the bound pool.");
   }
-  if (partialFill) {
-    return {
-      depth: "thin",
-      riskState: requiresExplicitConfirmation
-        ? "explicit-confirmation-required"
-        : "warning",
-      warning: {
-        code: "partial-fill",
-        message: "The price boundary limits this quote; the unused amount is refunded.",
-      },
-    };
-  }
-  if (priceImpact.probabilityPointMagnitudeBps >= 500) {
-    return {
-      depth: "thin",
-      riskState: "explicit-confirmation-required",
-      warning: {
-        code: "large-price-impact",
-        message: "This trade moves the quoted probability by at least 5 percentage points.",
-      },
-    };
-  }
-  if (priceImpact.probabilityPointMagnitudeBps >= 200) {
-    return {
-      depth: "low",
-      riskState: "warning",
-      warning: {
-        code: "price-impact-warning",
-        message: "This trade moves the quoted probability by at least 2 percentage points.",
-      },
-    };
-  }
+
+  const yesIsCurrency0 = currency0 === yes;
+  const selectedIsCurrency0 = outcome === "YES" ? yesIsCurrency0 : !yesIsCurrency0;
   return {
-    depth: "moderate",
-    riskState: "normal",
-    warning: null,
+    yesIsCurrency0,
+    selectedIsCurrency0,
+    // BUY swaps the unwanted complement into the selected outcome. SELL swaps the selected outcome out.
+    zeroForOne: action === "BUY" ? !selectedIsCurrency0 : selectedIsCurrency0,
   };
 }
 
-export function predictionV2BuyPreview(input: Readonly<{
-  quote: PredictionV2BuyQuote;
-  slippageBps: number;
-  currentSqrtPriceX96: bigint;
-  yesIsCurrency0: boolean;
-  zeroForOne: boolean;
-  outcome: PredictionV2Outcome;
-  /** Defaults must remain backstop-only until an exact live-depth read is integrated. */
-  liquidityEvidence: "factory-backstop-only" | "verified-live-depth";
-}>): PredictionV2BuyPreview {
-  const minimumOutcomeAtoms = predictionV2SlippageFloor(
-    input.quote.outcomeAtoms,
-    input.slippageBps,
+export function predictionV2PriceImpactRiskState(
+  probabilityPointMagnitudeBps: number,
+): PredictionV2LiquidityAssessment["priceImpactRiskState"] {
+  if (!Number.isInteger(probabilityPointMagnitudeBps) || probabilityPointMagnitudeBps < 0) {
+    throw new Error("Invalid Protocol V2 price-impact magnitude.");
+  }
+  return probabilityPointMagnitudeBps >= 500
+    ? "explicit-confirmation-required"
+    : probabilityPointMagnitudeBps >= 200
+    ? "warning"
+    : "normal";
+}
+
+export function requirePredictionV2PriceImpactConfirmation(
+  probabilityPointMagnitudeBps: number,
+  explicitlyConfirmed: boolean,
+) {
+  const riskState = predictionV2PriceImpactRiskState(probabilityPointMagnitudeBps);
+  if (riskState === "explicit-confirmation-required" && explicitlyConfirmed !== true) {
+    throw new Error("Invalid Protocol V2 explicit price-impact confirmation.");
+  }
+}
+
+function liquidityAssessment(
+  partialFill: boolean,
+  priceImpact: PredictionV2PriceImpact,
+): PredictionV2LiquidityAssessment {
+  const priceImpactRiskState = predictionV2PriceImpactRiskState(
+    priceImpact.probabilityPointMagnitudeBps,
   );
-  const priceImpact = predictionV2PriceImpact(
-    input.currentSqrtPriceX96,
-    input.quote.swap.sqrtPriceX96After,
-    input.yesIsCurrency0,
-    input.outcome,
-  );
-  const winningGrossPayoutAtoms = input.quote.outcomeAtoms * PREDICTION_V2_FACE_SCALE;
-  const minimumWinningGrossPayoutAtoms = minimumOutcomeAtoms * PREDICTION_V2_FACE_SCALE;
-  const totalRefundAtoms = input.quote.collateralRefundAtoms +
-    input.quote.feeReserveRefundAtoms;
   return {
-    requestedCollateralAtoms: input.quote.requestedCollateralAtoms,
-    maximumPaymentAtoms: input.quote.maximumPaymentAtoms,
-    actualPaymentAtoms: input.quote.actualPaymentAtoms,
-    protocolFeeAtoms: input.quote.protocolFeeAtoms,
+    // Exact live-depth evidence needs a future reviewed binder; callers cannot upgrade this label.
+    depth: "thin",
+    riskState: priceImpactRiskState === "explicit-confirmation-required"
+      ? "explicit-confirmation-required"
+      : "warning",
+    priceImpactRiskState,
+    partialFill,
+    warning: {
+      code: "backstop-only",
+      message: "Only the 2 USDG protocol backstop is currently evidenced for this market.",
+    },
+  };
+}
+
+function previewMarketState(
+  boundQuote: PredictionV2BoundBuyPreviewQuote | PredictionV2BoundSellPreviewQuote,
+) {
+  const state = bindPredictionV2MarketState(boundQuote.marketState);
+  const quoteVault = nonzeroAddress(boundQuote.vault, "preview Vault");
+  const quotePoolKey = validatePoolKey(boundQuote.poolKey);
+  const quoteBlockHash = nonzeroBytes32(boundQuote.observedBlockHash, "preview block hash");
+  if (
+    boundQuote.chainId !== 4_663 ||
+    state.chainId !== boundQuote.chainId ||
+    state.vault.toLowerCase() !== quoteVault.toLowerCase() ||
+    !samePoolKey(state.poolKey, quotePoolKey) ||
+    state.observedBlockNumber !== boundQuote.observedBlockNumber ||
+    state.observedBlockHash !== quoteBlockHash
+  ) throw new Error("Invalid Protocol V2 quote/market-state binding.");
+  if (
+    boundQuote.quote.swap.lpFee !== state.lpFee ||
+    boundQuote.quote.swap.poolManagerProtocolFee !== state.poolManagerProtocolFee
+  ) throw new Error("Invalid Protocol V2 quote/slot0 fee binding.");
+  return state;
+}
+
+function assertSelectedProbabilityDirection(
+  action: "BUY" | "SELL",
+  zeroForOne: boolean,
+  currentSqrtPriceX96: bigint,
+  postTradeSqrtPriceX96: bigint,
+  priceImpact: PredictionV2PriceImpact,
+) {
+  const sqrtDirectionIsValid = zeroForOne
+    ? postTradeSqrtPriceX96 <= currentSqrtPriceX96
+    : postTradeSqrtPriceX96 >= currentSqrtPriceX96;
+  const probabilityDirectionIsValid = action === "BUY"
+    ? priceImpact.probabilityPointDeltaBps >= 0
+    : priceImpact.probabilityPointDeltaBps <= 0;
+  if (!sqrtDirectionIsValid || !probabilityDirectionIsValid) {
+    throw new Error(`Invalid Protocol V2 ${action.toLowerCase()} selected-probability direction.`);
+  }
+}
+
+export function predictionV2BuyPreview(input: Readonly<{
+  boundQuote: PredictionV2BoundBuyPreviewQuote;
+  slippageBps: number;
+}>): PredictionV2BuyPreview {
+  const quote = input.boundQuote.quote;
+  const marketState = previewMarketState(input.boundQuote);
+  const outcome: PredictionV2Outcome = input.boundQuote.buyYes ? "YES" : "NO";
+  const orientation = tradeOrientation(
+    input.boundQuote.poolKey,
+    { yesToken: marketState.yesToken, noToken: marketState.noToken },
+    outcome,
+    "BUY",
+  );
+  const minimumOutcomeAtoms = predictionV2SlippageFloor(quote.outcomeAtoms, input.slippageBps);
+  const priceImpact = predictionV2PriceImpact(
+    marketState.currentSqrtPriceX96,
+    quote.swap.sqrtPriceX96After,
+    orientation.yesIsCurrency0,
+    outcome,
+  );
+  assertSelectedProbabilityDirection(
+    "BUY",
+    orientation.zeroForOne,
+    marketState.currentSqrtPriceX96,
+    quote.swap.sqrtPriceX96After,
+    priceImpact,
+  );
+  const winningGrossPayoutAtoms = quote.outcomeAtoms * PREDICTION_V2_FACE_SCALE;
+  const minimumWinningGrossPayoutAtoms = minimumOutcomeAtoms * PREDICTION_V2_FACE_SCALE;
+  const totalRefundAtoms = quote.collateralRefundAtoms + quote.feeReserveRefundAtoms;
+  return {
+    requestedCollateralAtoms: quote.requestedCollateralAtoms,
+    maximumPaymentAtoms: quote.maximumPaymentAtoms,
+    actualPaymentAtoms: quote.actualPaymentAtoms,
+    protocolFeeAtoms: quote.protocolFeeAtoms,
     totalRefundAtoms,
-    outcomeAtoms: input.quote.outcomeAtoms,
+    outcomeAtoms: quote.outcomeAtoms,
     minimumOutcomeAtoms,
-    averageExecutablePriceBps: executablePriceBps(
-      input.quote.actualPaymentAtoms,
-      input.quote.outcomeAtoms,
-    ),
-    maximumSlippagePriceBps: executablePriceBps(
-      input.quote.maximumPaymentAtoms,
-      minimumOutcomeAtoms,
-    ),
+    averageExecutablePriceBps: executablePriceBps(quote.actualPaymentAtoms, quote.outcomeAtoms),
+    maximumSlippagePriceBps: executablePriceBps(quote.maximumPaymentAtoms, minimumOutcomeAtoms),
     winningGrossPayoutAtoms,
     minimumWinningGrossPayoutAtoms,
-    potentialNetProfitAtoms: winningGrossPayoutAtoms - input.quote.actualPaymentAtoms,
-    minimumNetProfitAtoms: minimumWinningGrossPayoutAtoms - input.quote.maximumPaymentAtoms,
-    maximumLossAtoms: input.quote.maximumPaymentAtoms,
+    potentialNetProfitAtoms: winningGrossPayoutAtoms - quote.actualPaymentAtoms,
+    minimumNetProfitAtoms: minimumWinningGrossPayoutAtoms - quote.maximumPaymentAtoms,
+    maximumLossAtoms: quote.maximumPaymentAtoms,
     neutralPayoutAtoms: winningGrossPayoutAtoms / 2n,
-    lpFeePips: input.quote.swap.lpFee,
+    lpFeePips: quote.swap.lpFee,
     poolManagerProtocolFeePips: predictionV2DirectionalPoolManagerFeePips(
-      input.quote.swap.poolManagerProtocolFee,
-      input.zeroForOne,
+      quote.swap.poolManagerProtocolFee,
+      orientation.zeroForOne,
     ),
     priceImpact,
     liquidity: liquidityAssessment(
-      input.liquidityEvidence,
-      input.quote.executedCollateralAtoms < input.quote.requestedCollateralAtoms,
+      quote.executedCollateralAtoms < quote.requestedCollateralAtoms,
       priceImpact,
     ),
   };
 }
 
 export function predictionV2SellPreview(input: Readonly<{
-  quote: PredictionV2SellQuote;
+  boundQuote: PredictionV2BoundSellPreviewQuote;
   slippageBps: number;
-  currentSqrtPriceX96: bigint;
-  yesIsCurrency0: boolean;
-  zeroForOne: boolean;
-  outcome: PredictionV2Outcome;
-  /** Defaults must remain backstop-only until an exact live-depth read is integrated. */
-  liquidityEvidence: "factory-backstop-only" | "verified-live-depth";
 }>): PredictionV2SellPreview {
+  const quote = input.boundQuote.quote;
+  const marketState = previewMarketState(input.boundQuote);
+  const outcome: PredictionV2Outcome = input.boundQuote.sellYes ? "YES" : "NO";
+  const orientation = tradeOrientation(
+    input.boundQuote.poolKey,
+    { yesToken: marketState.yesToken, noToken: marketState.noToken },
+    outcome,
+    "SELL",
+  );
   const minimumNetProceedsAtoms = predictionV2SlippageFloor(
-    input.quote.netCollateralAtoms,
+    quote.netCollateralAtoms,
     input.slippageBps,
   );
   const priceImpact = predictionV2PriceImpact(
-    input.currentSqrtPriceX96,
-    input.quote.swap.sqrtPriceX96After,
-    input.yesIsCurrency0,
-    input.outcome,
+    marketState.currentSqrtPriceX96,
+    quote.swap.sqrtPriceX96After,
+    orientation.yesIsCurrency0,
+    outcome,
   );
-  const consumedSelectedOutcomeAtoms = input.quote.outcomeInAtoms -
-    input.quote.soldRefundAtoms;
+  assertSelectedProbabilityDirection(
+    "SELL",
+    orientation.zeroForOne,
+    marketState.currentSqrtPriceX96,
+    quote.swap.sqrtPriceX96After,
+    priceImpact,
+  );
+  const consumedSelectedOutcomeAtoms = quote.outcomeInAtoms - quote.soldRefundAtoms;
   if (consumedSelectedOutcomeAtoms <= 0n) {
     throw new Error("Invalid Protocol V2 sell consumption.");
   }
   return {
-    outcomeInAtoms: input.quote.outcomeInAtoms,
-    requestedSwapAtoms: input.quote.requestedSwapAtoms,
-    grossProceedsAtoms: input.quote.grossCollateralAtoms,
-    protocolFeeAtoms: input.quote.protocolFeeAtoms,
-    netProceedsAtoms: input.quote.netCollateralAtoms,
+    outcomeInAtoms: quote.outcomeInAtoms,
+    requestedSwapAtoms: quote.requestedSwapAtoms,
+    grossProceedsAtoms: quote.grossCollateralAtoms,
+    protocolFeeAtoms: quote.protocolFeeAtoms,
+    netProceedsAtoms: quote.netCollateralAtoms,
     minimumNetProceedsAtoms,
-    soldOutcomeRefundAtoms: input.quote.soldRefundAtoms,
-    complementOutcomeRefundAtoms: input.quote.complementRefundAtoms,
-    averageNetCashExitPriceBps: input.quote.complementRefundAtoms === 0n
-      ? executablePriceBps(
-        input.quote.netCollateralAtoms,
-        consumedSelectedOutcomeAtoms,
-      )
+    soldOutcomeRefundAtoms: quote.soldRefundAtoms,
+    complementOutcomeRefundAtoms: quote.complementRefundAtoms,
+    averageNetCashExitPriceBps: quote.complementRefundAtoms === 0n
+      ? executablePriceBps(quote.netCollateralAtoms, consumedSelectedOutcomeAtoms)
       : null,
-    lpFeePips: input.quote.swap.lpFee,
+    lpFeePips: quote.swap.lpFee,
     poolManagerProtocolFeePips: predictionV2DirectionalPoolManagerFeePips(
-      input.quote.swap.poolManagerProtocolFee,
-      input.zeroForOne,
+      quote.swap.poolManagerProtocolFee,
+      orientation.zeroForOne,
     ),
     priceImpact,
     liquidity: liquidityAssessment(
-      input.liquidityEvidence,
-      input.quote.swap.actualInput < input.quote.requestedSwapAtoms,
+      quote.swap.actualInput < quote.requestedSwapAtoms,
       priceImpact,
     ),
   };

--- a/lib/prediction-v2/accounting.ts
+++ b/lib/prediction-v2/accounting.ts
@@ -1,0 +1,340 @@
+import {
+  PREDICTION_V2_BPS_DENOMINATOR,
+  PREDICTION_V2_FACE_SCALE,
+  PREDICTION_V2_MAX_SQRT_PRICE_X96,
+  PREDICTION_V2_MIN_SQRT_PRICE_X96,
+  type PredictionV2BuyQuote,
+  type PredictionV2SellQuote,
+} from "./codec";
+
+export type PredictionV2Outcome = "YES" | "NO";
+
+export type PredictionV2PriceImpact = Readonly<{
+  currentProbabilityBps: number;
+  postTradeProbabilityBps: number;
+  /** Signed change where 100 bps equals one percentage point. */
+  probabilityPointDeltaBps: number;
+  probabilityPointMagnitudeBps: number;
+  /** Relative percentage change in basis points; null at a zero starting probability. */
+  relativeImpactBps: number | null;
+}>;
+
+export type PredictionV2LiquidityWarning = Readonly<{
+  code:
+    | "backstop-only"
+    | "partial-fill"
+    | "price-impact-warning"
+    | "large-price-impact";
+  message: string;
+}> | null;
+
+export type PredictionV2LiquidityAssessment = Readonly<{
+  depth: "thin" | "low" | "moderate";
+  riskState: "normal" | "warning" | "explicit-confirmation-required";
+  warning: PredictionV2LiquidityWarning;
+}>;
+
+export type PredictionV2BuyPreview = Readonly<{
+  requestedCollateralAtoms: bigint;
+  maximumPaymentAtoms: bigint;
+  actualPaymentAtoms: bigint;
+  protocolFeeAtoms: bigint;
+  totalRefundAtoms: bigint;
+  outcomeAtoms: bigint;
+  minimumOutcomeAtoms: bigint;
+  averageExecutablePriceBps: number;
+  maximumSlippagePriceBps: number;
+  winningGrossPayoutAtoms: bigint;
+  minimumWinningGrossPayoutAtoms: bigint;
+  potentialNetProfitAtoms: bigint;
+  minimumNetProfitAtoms: bigint;
+  maximumLossAtoms: bigint;
+  neutralPayoutAtoms: bigint;
+  lpFeePips: number;
+  poolManagerProtocolFeePips: number;
+  priceImpact: PredictionV2PriceImpact;
+  liquidity: PredictionV2LiquidityAssessment;
+}>;
+
+export type PredictionV2SellPreview = Readonly<{
+  outcomeInAtoms: bigint;
+  requestedSwapAtoms: bigint;
+  grossProceedsAtoms: bigint;
+  protocolFeeAtoms: bigint;
+  netProceedsAtoms: bigint;
+  minimumNetProceedsAtoms: bigint;
+  soldOutcomeRefundAtoms: bigint;
+  complementOutcomeRefundAtoms: bigint;
+  /** Null when complement-token refunds make a cash-only average misleading. */
+  averageNetCashExitPriceBps: number | null;
+  lpFeePips: number;
+  poolManagerProtocolFeePips: number;
+  priceImpact: PredictionV2PriceImpact;
+  liquidity: PredictionV2LiquidityAssessment;
+}>;
+
+function assertSqrtPrice(sqrtPriceX96: bigint) {
+  if (
+    sqrtPriceX96 < PREDICTION_V2_MIN_SQRT_PRICE_X96 ||
+    sqrtPriceX96 > PREDICTION_V2_MAX_SQRT_PRICE_X96
+  ) throw new Error("Protocol V2 pool price is outside Uniswap v4 bounds.");
+}
+
+function roundedRatio(numerator: bigint, denominator: bigint): bigint {
+  if (denominator <= 0n || numerator < 0n) {
+    throw new Error("Invalid Protocol V2 ratio.");
+  }
+  return (numerator + denominator / 2n) / denominator;
+}
+
+export function predictionV2YesProbabilityBps(
+  sqrtPriceX96: bigint,
+  yesIsCurrency0: boolean,
+): number {
+  assertSqrtPrice(sqrtPriceX96);
+  const q192 = 1n << 192n;
+  const squared = sqrtPriceX96 * sqrtPriceX96;
+  const denominator = q192 + squared;
+  const numerator = yesIsCurrency0 ? squared : q192;
+  return Number(roundedRatio(numerator * PREDICTION_V2_BPS_DENOMINATOR, denominator));
+}
+
+export function predictionV2DirectionalPoolManagerFeePips(
+  packedProtocolFee: number,
+  zeroForOne: boolean,
+): number {
+  if (!Number.isInteger(packedProtocolFee) || packedProtocolFee < 0 || packedProtocolFee > 0xff_ffff) {
+    throw new Error("Invalid Protocol V2 PoolManager fee.");
+  }
+  const fee = zeroForOne ? packedProtocolFee & 0xfff : packedProtocolFee >> 12;
+  if (fee > 1_000) throw new Error("Invalid Protocol V2 directional PoolManager fee.");
+  return fee;
+}
+
+export function predictionV2SlippageFloor(amount: bigint, slippageBps: number): bigint {
+  if (amount <= 0n || !Number.isInteger(slippageBps) || slippageBps < 1 || slippageBps > 1_000) {
+    throw new Error("Invalid Protocol V2 slippage boundary.");
+  }
+  const result = (amount * (PREDICTION_V2_BPS_DENOMINATOR - BigInt(slippageBps))) /
+    PREDICTION_V2_BPS_DENOMINATOR;
+  return result > 0n ? result : 1n;
+}
+
+function outcomeProbability(yesProbabilityBps: number, outcome: PredictionV2Outcome) {
+  return outcome === "YES" ? yesProbabilityBps : 10_000 - yesProbabilityBps;
+}
+
+export function predictionV2PriceImpact(
+  currentSqrtPriceX96: bigint,
+  postTradeSqrtPriceX96: bigint,
+  yesIsCurrency0: boolean,
+  outcome: PredictionV2Outcome,
+): PredictionV2PriceImpact {
+  const currentProbabilityBps = outcomeProbability(
+    predictionV2YesProbabilityBps(currentSqrtPriceX96, yesIsCurrency0),
+    outcome,
+  );
+  const postTradeProbabilityBps = outcomeProbability(
+    predictionV2YesProbabilityBps(postTradeSqrtPriceX96, yesIsCurrency0),
+    outcome,
+  );
+  const probabilityPointDeltaBps = postTradeProbabilityBps - currentProbabilityBps;
+  const probabilityPointMagnitudeBps = Math.abs(probabilityPointDeltaBps);
+  const relativeImpactBps = currentProbabilityBps === 0
+    ? null
+    : Math.round(probabilityPointMagnitudeBps * 10_000 / currentProbabilityBps);
+  return {
+    currentProbabilityBps,
+    postTradeProbabilityBps,
+    probabilityPointDeltaBps,
+    probabilityPointMagnitudeBps,
+    relativeImpactBps,
+  };
+}
+
+function executablePriceBps(paymentAtoms: bigint, outcomeAtoms: bigint): number {
+  const facePayoutAtoms = outcomeAtoms * PREDICTION_V2_FACE_SCALE;
+  if (paymentAtoms <= 0n || facePayoutAtoms <= 0n) {
+    throw new Error("Invalid Protocol V2 executable price.");
+  }
+  return Number(roundedRatio(
+    paymentAtoms * PREDICTION_V2_BPS_DENOMINATOR,
+    facePayoutAtoms,
+  ));
+}
+
+function liquidityAssessment(
+  liquidityEvidence: "factory-backstop-only" | "verified-live-depth",
+  partialFill: boolean,
+  priceImpact: PredictionV2PriceImpact,
+): PredictionV2LiquidityAssessment {
+  if (
+    liquidityEvidence !== "factory-backstop-only" &&
+    liquidityEvidence !== "verified-live-depth"
+  ) throw new Error("Invalid Protocol V2 liquidity evidence.");
+  const requiresExplicitConfirmation =
+    priceImpact.probabilityPointMagnitudeBps >= 500;
+  if (liquidityEvidence === "factory-backstop-only") {
+    return {
+      depth: "thin",
+      riskState: requiresExplicitConfirmation
+        ? "explicit-confirmation-required"
+        : "warning",
+      warning: {
+        code: "backstop-only",
+        message: "Only the 2 USDG protocol backstop is currently evidenced for this market.",
+      },
+    };
+  }
+  if (partialFill) {
+    return {
+      depth: "thin",
+      riskState: requiresExplicitConfirmation
+        ? "explicit-confirmation-required"
+        : "warning",
+      warning: {
+        code: "partial-fill",
+        message: "The price boundary limits this quote; the unused amount is refunded.",
+      },
+    };
+  }
+  if (priceImpact.probabilityPointMagnitudeBps >= 500) {
+    return {
+      depth: "thin",
+      riskState: "explicit-confirmation-required",
+      warning: {
+        code: "large-price-impact",
+        message: "This trade moves the quoted probability by at least 5 percentage points.",
+      },
+    };
+  }
+  if (priceImpact.probabilityPointMagnitudeBps >= 200) {
+    return {
+      depth: "low",
+      riskState: "warning",
+      warning: {
+        code: "price-impact-warning",
+        message: "This trade moves the quoted probability by at least 2 percentage points.",
+      },
+    };
+  }
+  return {
+    depth: "moderate",
+    riskState: "normal",
+    warning: null,
+  };
+}
+
+export function predictionV2BuyPreview(input: Readonly<{
+  quote: PredictionV2BuyQuote;
+  slippageBps: number;
+  currentSqrtPriceX96: bigint;
+  yesIsCurrency0: boolean;
+  zeroForOne: boolean;
+  outcome: PredictionV2Outcome;
+  /** Defaults must remain backstop-only until an exact live-depth read is integrated. */
+  liquidityEvidence: "factory-backstop-only" | "verified-live-depth";
+}>): PredictionV2BuyPreview {
+  const minimumOutcomeAtoms = predictionV2SlippageFloor(
+    input.quote.outcomeAtoms,
+    input.slippageBps,
+  );
+  const priceImpact = predictionV2PriceImpact(
+    input.currentSqrtPriceX96,
+    input.quote.swap.sqrtPriceX96After,
+    input.yesIsCurrency0,
+    input.outcome,
+  );
+  const winningGrossPayoutAtoms = input.quote.outcomeAtoms * PREDICTION_V2_FACE_SCALE;
+  const minimumWinningGrossPayoutAtoms = minimumOutcomeAtoms * PREDICTION_V2_FACE_SCALE;
+  const totalRefundAtoms = input.quote.collateralRefundAtoms +
+    input.quote.feeReserveRefundAtoms;
+  return {
+    requestedCollateralAtoms: input.quote.requestedCollateralAtoms,
+    maximumPaymentAtoms: input.quote.maximumPaymentAtoms,
+    actualPaymentAtoms: input.quote.actualPaymentAtoms,
+    protocolFeeAtoms: input.quote.protocolFeeAtoms,
+    totalRefundAtoms,
+    outcomeAtoms: input.quote.outcomeAtoms,
+    minimumOutcomeAtoms,
+    averageExecutablePriceBps: executablePriceBps(
+      input.quote.actualPaymentAtoms,
+      input.quote.outcomeAtoms,
+    ),
+    maximumSlippagePriceBps: executablePriceBps(
+      input.quote.maximumPaymentAtoms,
+      minimumOutcomeAtoms,
+    ),
+    winningGrossPayoutAtoms,
+    minimumWinningGrossPayoutAtoms,
+    potentialNetProfitAtoms: winningGrossPayoutAtoms - input.quote.actualPaymentAtoms,
+    minimumNetProfitAtoms: minimumWinningGrossPayoutAtoms - input.quote.maximumPaymentAtoms,
+    maximumLossAtoms: input.quote.maximumPaymentAtoms,
+    neutralPayoutAtoms: winningGrossPayoutAtoms / 2n,
+    lpFeePips: input.quote.swap.lpFee,
+    poolManagerProtocolFeePips: predictionV2DirectionalPoolManagerFeePips(
+      input.quote.swap.poolManagerProtocolFee,
+      input.zeroForOne,
+    ),
+    priceImpact,
+    liquidity: liquidityAssessment(
+      input.liquidityEvidence,
+      input.quote.executedCollateralAtoms < input.quote.requestedCollateralAtoms,
+      priceImpact,
+    ),
+  };
+}
+
+export function predictionV2SellPreview(input: Readonly<{
+  quote: PredictionV2SellQuote;
+  slippageBps: number;
+  currentSqrtPriceX96: bigint;
+  yesIsCurrency0: boolean;
+  zeroForOne: boolean;
+  outcome: PredictionV2Outcome;
+  /** Defaults must remain backstop-only until an exact live-depth read is integrated. */
+  liquidityEvidence: "factory-backstop-only" | "verified-live-depth";
+}>): PredictionV2SellPreview {
+  const minimumNetProceedsAtoms = predictionV2SlippageFloor(
+    input.quote.netCollateralAtoms,
+    input.slippageBps,
+  );
+  const priceImpact = predictionV2PriceImpact(
+    input.currentSqrtPriceX96,
+    input.quote.swap.sqrtPriceX96After,
+    input.yesIsCurrency0,
+    input.outcome,
+  );
+  const consumedSelectedOutcomeAtoms = input.quote.outcomeInAtoms -
+    input.quote.soldRefundAtoms;
+  if (consumedSelectedOutcomeAtoms <= 0n) {
+    throw new Error("Invalid Protocol V2 sell consumption.");
+  }
+  return {
+    outcomeInAtoms: input.quote.outcomeInAtoms,
+    requestedSwapAtoms: input.quote.requestedSwapAtoms,
+    grossProceedsAtoms: input.quote.grossCollateralAtoms,
+    protocolFeeAtoms: input.quote.protocolFeeAtoms,
+    netProceedsAtoms: input.quote.netCollateralAtoms,
+    minimumNetProceedsAtoms,
+    soldOutcomeRefundAtoms: input.quote.soldRefundAtoms,
+    complementOutcomeRefundAtoms: input.quote.complementRefundAtoms,
+    averageNetCashExitPriceBps: input.quote.complementRefundAtoms === 0n
+      ? executablePriceBps(
+        input.quote.netCollateralAtoms,
+        consumedSelectedOutcomeAtoms,
+      )
+      : null,
+    lpFeePips: input.quote.swap.lpFee,
+    poolManagerProtocolFeePips: predictionV2DirectionalPoolManagerFeePips(
+      input.quote.swap.poolManagerProtocolFee,
+      input.zeroForOne,
+    ),
+    priceImpact,
+    liquidity: liquidityAssessment(
+      input.liquidityEvidence,
+      input.quote.swap.actualInput < input.quote.requestedSwapAtoms,
+      priceImpact,
+    ),
+  };
+}

--- a/lib/prediction-v2/codec.ts
+++ b/lib/prediction-v2/codec.ts
@@ -1,0 +1,602 @@
+import {
+  decodeFunctionResult,
+  encodeAbiParameters,
+  isAddress,
+  keccak256,
+  parseAbiParameters,
+  stringToHex,
+  zeroAddress,
+  type Address,
+  type Hex,
+} from "viem";
+
+import {
+  PREDICTION_PRESET_ASSETS_V2,
+  PREDICTION_SOLANA_MAINNET_GENESIS_V2,
+  PREDICTION_SOLANA_TOKEN_2022_PROGRAM_V2,
+  PREDICTION_SOLANA_TOKEN_PROGRAM_V2,
+  predictionOnchainAssetKeyV2,
+  type PredictionAssetIdentityV2,
+  type PredictionBytes32V2,
+} from "../prediction-market-assets-v2";
+import {
+  PREDICTION_V2_ASSET_REGISTRY_ABI,
+  PREDICTION_V2_FACTORY_ABI,
+  PREDICTION_V2_QUOTER_ABI,
+  type PredictionV2MarketRecord,
+  type PredictionV2OraclePolicy,
+  type PredictionV2RegistrySnapshot,
+} from "./abi";
+
+export const PREDICTION_V2_FACE_SCALE = 10n;
+export const PREDICTION_V2_PROTOCOL_FEE_BPS = 10n;
+export const PREDICTION_V2_BPS_DENOMINATOR = 10_000n;
+export const PREDICTION_V2_BOOTSTRAP_COLLATERAL_ATOMS = 2_000_000n;
+export const PREDICTION_V2_LP_FEE_PIPS = 200;
+export const PREDICTION_V2_TICK_SPACING = 10;
+export const PREDICTION_V2_MIN_SQRT_PRICE_X96 = 4_295_128_739n;
+export const PREDICTION_V2_MAX_SQRT_PRICE_X96 =
+  1_461_446_703_485_210_103_287_273_052_203_988_822_378_723_970_342n;
+
+const ZERO_BYTES32 = `0x${"0".repeat(64)}` as PredictionBytes32V2;
+const BYTES32_PATTERN = /^0x[0-9a-fA-F]{64}$/u;
+const MAX_UINT24 = (1 << 24) - 1;
+const MIN_INT24 = -(1 << 23);
+const MAX_INT24 = (1 << 23) - 1;
+const MAX_UINT128 = (1n << 128n) - 1n;
+const GLOBAL_NAMESPACE = stringToHex("GLOBAL_CRYPTO", { size: 32 });
+const GLOBAL_CHAIN = stringToHex("GLOBAL", { size: 32 });
+const NATIVE_STANDARD = stringToHex("NATIVE", { size: 32 });
+const EIP155_NAMESPACE = stringToHex("EIP155", { size: 32 });
+const ERC20_STANDARD = stringToHex("ERC20", { size: 32 });
+const SOLANA_NAMESPACE = stringToHex("SOLANA", { size: 32 });
+const USD_QUOTE = stringToHex("USD", { size: 32 });
+const ORACLE_POLICY_HASH_DOMAIN = keccak256(stringToHex("PROGRAMMABLE_ORACLE_POLICY_V2"));
+const SNAPSHOT_HASH_DOMAIN = keccak256(stringToHex("PROGRAMMABLE_ASSET_SNAPSHOT_V2"));
+const ORACLE_POLICY_HASH_PARAMETERS = parseAbiParameters(
+  "bytes32 domain, (bytes32 checkpointKind, address checkpointAdapter, bytes32 checkpointAdapterCodehash, bytes32 feedId, address feedAddress, bytes32 feedProxyCodehash, uint16 feedPhaseId, address feedAggregator, bytes32 feedAggregatorCodehash, bytes32 feedDescriptionHash, uint8 feedDecimals, bytes32 quoteCurrency, bytes32 assetEvidenceHash, uint256 maxOpenInterestAtoms, uint64 validUntil, uint32 policyVersion, bool active) policy",
+);
+const SNAPSHOT_HASH_PARAMETERS = parseAbiParameters(
+  "bytes32 domain, bytes32 assetKey, uint64 revision, bytes32 sourceNamespace, bytes32 sourceChain, bytes32 assetIdentifier, bytes32 assetStandard, bytes32 displaySymbolHash, bytes32 oraclePolicyHash",
+);
+const SUPPORTED_EVM_CHAINS = new Set([1n, 56n, 4_663n, 8_453n]);
+
+const MARKET_FIELDS = [
+  "vault",
+  "checkpoint",
+  "poolId",
+  "marketId",
+  "assetKey",
+  "registrySnapshotHash",
+  "resolutionPolicyHash",
+  "registryRevision",
+  "policyValidUntil",
+  "snapshotAssetCap",
+] as const;
+const SWAP_FIELDS = [
+  "actualInput",
+  "amountOut",
+  "sqrtPriceX96After",
+  "tickAfter",
+  "poolManagerProtocolFee",
+  "lpFee",
+] as const;
+const BUY_FIELDS = [
+  "requestedCollateralAtoms",
+  "maximumPaymentAtoms",
+  "executedCollateralAtoms",
+  "collateralRefundAtoms",
+  "protocolFeeAtoms",
+  "feeReserveRefundAtoms",
+  "actualPaymentAtoms",
+  "outcomeAtoms",
+  "swap",
+] as const;
+const SELL_FIELDS = [
+  "outcomeInAtoms",
+  "requestedSwapAtoms",
+  "grossCollateralAtoms",
+  "protocolFeeAtoms",
+  "netCollateralAtoms",
+  "soldRefundAtoms",
+  "complementRefundAtoms",
+  "swap",
+] as const;
+const IDENTITY_FIELDS = [
+  "sourceNamespace",
+  "sourceChain",
+  "assetIdentifier",
+  "assetStandard",
+] as const;
+const POLICY_FIELDS = [
+  "checkpointKind",
+  "checkpointAdapter",
+  "checkpointAdapterCodehash",
+  "feedId",
+  "feedAddress",
+  "feedProxyCodehash",
+  "feedPhaseId",
+  "feedAggregator",
+  "feedAggregatorCodehash",
+  "feedDescriptionHash",
+  "feedDecimals",
+  "quoteCurrency",
+  "assetEvidenceHash",
+  "maxOpenInterestAtoms",
+  "validUntil",
+  "policyVersion",
+  "active",
+] as const;
+const SNAPSHOT_FIELDS = [
+  "assetKey",
+  "revision",
+  "identity",
+  "displaySymbol",
+  "policy",
+] as const;
+
+export type PredictionV2SwapQuote = Readonly<{
+  actualInput: bigint;
+  amountOut: bigint;
+  sqrtPriceX96After: bigint;
+  tickAfter: number;
+  poolManagerProtocolFee: number;
+  lpFee: number;
+}>;
+
+export type PredictionV2BuyQuote = Readonly<{
+  requestedCollateralAtoms: bigint;
+  maximumPaymentAtoms: bigint;
+  executedCollateralAtoms: bigint;
+  collateralRefundAtoms: bigint;
+  protocolFeeAtoms: bigint;
+  feeReserveRefundAtoms: bigint;
+  actualPaymentAtoms: bigint;
+  outcomeAtoms: bigint;
+  swap: PredictionV2SwapQuote;
+}>;
+
+export type PredictionV2SellQuote = Readonly<{
+  outcomeInAtoms: bigint;
+  requestedSwapAtoms: bigint;
+  grossCollateralAtoms: bigint;
+  protocolFeeAtoms: bigint;
+  netCollateralAtoms: bigint;
+  soldRefundAtoms: bigint;
+  complementRefundAtoms: bigint;
+  swap: PredictionV2SwapQuote;
+}>;
+
+function invalid(label: string): never {
+  throw new Error(`Invalid Protocol V2 ${label}.`);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function exactTuple(
+  value: unknown,
+  fields: readonly string[],
+  label: string,
+): Record<string, unknown> {
+  if (Array.isArray(value)) {
+    if (value.length !== fields.length) invalid(`${label} tuple length`);
+    return Object.fromEntries(fields.map((field, index) => [field, value[index]]));
+  }
+  if (!isPlainRecord(value)) invalid(`${label} tuple`);
+  const keys = Object.keys(value);
+  if (keys.length !== fields.length || !fields.every((field) => Object.hasOwn(value, field))) {
+    invalid(`${label} tuple fields`);
+  }
+  return value;
+}
+
+function bytes32(value: unknown, label: string, allowZero = false): PredictionBytes32V2 {
+  if (typeof value !== "string" || !BYTES32_PATTERN.test(value)) invalid(label);
+  const normalized = value.toLowerCase() as PredictionBytes32V2;
+  if (!allowZero && normalized === ZERO_BYTES32) invalid(label);
+  return normalized;
+}
+
+function address(value: unknown, label: string, allowZero = false): Address {
+  if (typeof value !== "string" || !isAddress(value, { strict: false })) invalid(label);
+  if (!allowZero && value.toLowerCase() === zeroAddress) invalid(label);
+  return value as Address;
+}
+
+function unsigned(value: unknown, label: string, allowZero = true): bigint {
+  if (typeof value !== "bigint" || value < 0n || (!allowZero && value === 0n)) invalid(label);
+  return value;
+}
+
+function smallUnsigned(value: unknown, max: number, label: string): number {
+  if (!Number.isInteger(value) || Number(value) < 0 || Number(value) > max) invalid(label);
+  return Number(value);
+}
+
+function canonicalDisplaySymbol(value: unknown): string {
+  if (typeof value !== "string" || !/^[A-Z0-9._-]{1,16}$/u.test(value)) {
+    invalid("registry display symbol");
+  }
+  return value;
+}
+
+export function isCanonicalPredictionV2Identity(
+  value: unknown,
+): value is PredictionAssetIdentityV2 {
+  let identity: Record<string, unknown>;
+  try {
+    identity = exactTuple(value, IDENTITY_FIELDS, "asset identity");
+  } catch {
+    return false;
+  }
+  if (!IDENTITY_FIELDS.every((field) => {
+    try {
+      bytes32(identity[field], `asset identity ${field}`, true);
+      return true;
+    } catch {
+      return false;
+    }
+  })) return false;
+
+  const sourceNamespace = String(identity.sourceNamespace).toLowerCase();
+  const sourceChain = String(identity.sourceChain).toLowerCase();
+  const assetIdentifier = String(identity.assetIdentifier).toLowerCase();
+  const assetStandard = String(identity.assetStandard).toLowerCase();
+
+  if (sourceNamespace === GLOBAL_NAMESPACE) {
+    return sourceChain === GLOBAL_CHAIN && assetStandard === NATIVE_STANDARD &&
+      PREDICTION_PRESET_ASSETS_V2.some((preset) =>
+        preset.identity.assetIdentifier === assetIdentifier
+      );
+  }
+  if (sourceNamespace === EIP155_NAMESPACE) {
+    const chainId = BigInt(sourceChain);
+    const addressBits = BigInt(assetIdentifier);
+    return SUPPORTED_EVM_CHAINS.has(chainId) && addressBits > 0n &&
+      (addressBits >> 160n) === 0n && assetStandard === ERC20_STANDARD;
+  }
+  if (sourceNamespace === SOLANA_NAMESPACE) {
+    return sourceChain === PREDICTION_SOLANA_MAINNET_GENESIS_V2 &&
+      assetIdentifier !== ZERO_BYTES32 &&
+      (assetStandard === PREDICTION_SOLANA_TOKEN_PROGRAM_V2 ||
+        assetStandard === PREDICTION_SOLANA_TOKEN_2022_PROGRAM_V2);
+  }
+  return false;
+}
+
+export function assertCanonicalPredictionV2Identity(
+  value: unknown,
+): PredictionAssetIdentityV2 {
+  if (!isCanonicalPredictionV2Identity(value)) invalid("asset identity");
+  const identity = exactTuple(value, IDENTITY_FIELDS, "asset identity");
+  return {
+    sourceNamespace: bytes32(identity.sourceNamespace, "source namespace"),
+    sourceChain: bytes32(identity.sourceChain, "source chain"),
+    assetIdentifier: bytes32(identity.assetIdentifier, "asset identifier"),
+    assetStandard: bytes32(identity.assetStandard, "asset standard"),
+  };
+}
+
+function decodeSwapQuote(value: unknown): PredictionV2SwapQuote {
+  const swap = exactTuple(value, SWAP_FIELDS, "swap quote");
+  const actualInput = unsigned(swap.actualInput, "swap actual input", false);
+  const amountOut = unsigned(swap.amountOut, "swap amount out", false);
+  const sqrtPriceX96After = unsigned(swap.sqrtPriceX96After, "post-swap price", false);
+  if (
+    actualInput > MAX_UINT128 || amountOut > MAX_UINT128 ||
+    sqrtPriceX96After < PREDICTION_V2_MIN_SQRT_PRICE_X96 ||
+    sqrtPriceX96After > PREDICTION_V2_MAX_SQRT_PRICE_X96
+  ) invalid("swap bounds");
+  const tickAfter = Number(swap.tickAfter);
+  if (!Number.isInteger(swap.tickAfter) || tickAfter < MIN_INT24 || tickAfter > MAX_INT24) {
+    invalid("post-swap tick");
+  }
+  const poolManagerProtocolFee = smallUnsigned(
+    swap.poolManagerProtocolFee,
+    MAX_UINT24,
+    "pool manager protocol fee",
+  );
+  if (
+    (poolManagerProtocolFee & 0xfff) > 1_000 ||
+    (poolManagerProtocolFee >> 12) > 1_000
+  ) invalid("pool manager directional protocol fee");
+  const lpFee = smallUnsigned(swap.lpFee, MAX_UINT24, "LP fee");
+  if (lpFee !== PREDICTION_V2_LP_FEE_PIPS) invalid("LP fee binding");
+  return {
+    actualInput,
+    amountOut,
+    sqrtPriceX96After,
+    tickAfter,
+    poolManagerProtocolFee,
+    lpFee,
+  };
+}
+
+export function predictionV2FeeFor(collateralAtoms: bigint): bigint {
+  if (collateralAtoms < 0n) invalid("fee input");
+  return (collateralAtoms * PREDICTION_V2_PROTOCOL_FEE_BPS) /
+    PREDICTION_V2_BPS_DENOMINATOR;
+}
+
+export function validatePredictionV2BuyQuote(value: unknown): PredictionV2BuyQuote {
+  const quote = exactTuple(value, BUY_FIELDS, "buy quote");
+  const requestedCollateralAtoms = unsigned(
+    quote.requestedCollateralAtoms,
+    "requested collateral",
+    false,
+  );
+  if (
+    requestedCollateralAtoms % PREDICTION_V2_FACE_SCALE !== 0n ||
+    requestedCollateralAtoms / PREDICTION_V2_FACE_SCALE > MAX_UINT128
+  ) invalid("requested collateral denomination");
+  const maximumPaymentAtoms = unsigned(quote.maximumPaymentAtoms, "maximum payment", false);
+  const executedCollateralAtoms = unsigned(
+    quote.executedCollateralAtoms,
+    "executed collateral",
+    false,
+  );
+  const collateralRefundAtoms = unsigned(quote.collateralRefundAtoms, "collateral refund");
+  const protocolFeeAtoms = unsigned(quote.protocolFeeAtoms, "protocol fee");
+  const feeReserveRefundAtoms = unsigned(quote.feeReserveRefundAtoms, "fee reserve refund");
+  const actualPaymentAtoms = unsigned(quote.actualPaymentAtoms, "actual payment", false);
+  const outcomeAtoms = unsigned(quote.outcomeAtoms, "outcome amount", false);
+  const swap = decodeSwapQuote(quote.swap);
+  const completeSetAtoms = requestedCollateralAtoms / PREDICTION_V2_FACE_SCALE;
+  const maximumFeeAtoms = predictionV2FeeFor(requestedCollateralAtoms);
+  const expectedExecuted = swap.actualInput * PREDICTION_V2_FACE_SCALE;
+  const expectedProtocolFee = predictionV2FeeFor(expectedExecuted);
+  if (
+    swap.actualInput > completeSetAtoms ||
+    maximumPaymentAtoms !== requestedCollateralAtoms + maximumFeeAtoms ||
+    executedCollateralAtoms !== expectedExecuted ||
+    collateralRefundAtoms !== requestedCollateralAtoms - expectedExecuted ||
+    protocolFeeAtoms !== expectedProtocolFee ||
+    feeReserveRefundAtoms !== maximumFeeAtoms - expectedProtocolFee ||
+    actualPaymentAtoms !== expectedExecuted + expectedProtocolFee ||
+    outcomeAtoms !== swap.actualInput + swap.amountOut ||
+    maximumPaymentAtoms !== actualPaymentAtoms + collateralRefundAtoms + feeReserveRefundAtoms
+  ) invalid("buy accounting");
+  return {
+    requestedCollateralAtoms,
+    maximumPaymentAtoms,
+    executedCollateralAtoms,
+    collateralRefundAtoms,
+    protocolFeeAtoms,
+    feeReserveRefundAtoms,
+    actualPaymentAtoms,
+    outcomeAtoms,
+    swap,
+  };
+}
+
+export function validatePredictionV2SellQuote(value: unknown): PredictionV2SellQuote {
+  const quote = exactTuple(value, SELL_FIELDS, "sell quote");
+  const outcomeInAtoms = unsigned(quote.outcomeInAtoms, "outcome input", false);
+  const requestedSwapAtoms = unsigned(quote.requestedSwapAtoms, "requested swap", false);
+  const grossCollateralAtoms = unsigned(quote.grossCollateralAtoms, "gross collateral", false);
+  const protocolFeeAtoms = unsigned(quote.protocolFeeAtoms, "protocol fee");
+  const netCollateralAtoms = unsigned(quote.netCollateralAtoms, "net collateral", false);
+  const soldRefundAtoms = unsigned(quote.soldRefundAtoms, "sold outcome refund");
+  const complementRefundAtoms = unsigned(
+    quote.complementRefundAtoms,
+    "complement outcome refund",
+  );
+  const swap = decodeSwapQuote(quote.swap);
+  if (
+    outcomeInAtoms > MAX_UINT128 || requestedSwapAtoms > outcomeInAtoms ||
+    swap.actualInput > requestedSwapAtoms || swap.actualInput > outcomeInAtoms
+  ) invalid("sell amount bounds");
+  const soldRemainder = outcomeInAtoms - swap.actualInput;
+  const mergeAtoms = soldRemainder < swap.amountOut ? soldRemainder : swap.amountOut;
+  const expectedGross = mergeAtoms * PREDICTION_V2_FACE_SCALE;
+  const expectedFee = predictionV2FeeFor(expectedGross);
+  if (
+    mergeAtoms === 0n ||
+    grossCollateralAtoms !== expectedGross ||
+    protocolFeeAtoms !== expectedFee ||
+    netCollateralAtoms !== expectedGross - expectedFee ||
+    soldRefundAtoms !== soldRemainder - mergeAtoms ||
+    complementRefundAtoms !== swap.amountOut - mergeAtoms
+  ) invalid("sell accounting");
+  return {
+    outcomeInAtoms,
+    requestedSwapAtoms,
+    grossCollateralAtoms,
+    protocolFeeAtoms,
+    netCollateralAtoms,
+    soldRefundAtoms,
+    complementRefundAtoms,
+    swap,
+  };
+}
+
+export function decodePredictionV2BuyQuote(data: Hex): PredictionV2BuyQuote {
+  return validatePredictionV2BuyQuote(decodeFunctionResult({
+    abi: PREDICTION_V2_QUOTER_ABI,
+    functionName: "quoteBuy",
+    data,
+  }));
+}
+
+export function decodePredictionV2SellQuote(data: Hex): PredictionV2SellQuote {
+  return validatePredictionV2SellQuote(decodeFunctionResult({
+    abi: PREDICTION_V2_QUOTER_ABI,
+    functionName: "quoteSellOptimal",
+    data,
+  }));
+}
+
+export function decodePredictionV2MarketRecord(
+  data: Hex,
+): PredictionV2MarketRecord | null {
+  const raw = decodeFunctionResult({
+    abi: PREDICTION_V2_FACTORY_ABI,
+    functionName: "markets",
+    data,
+  });
+  const market = exactTuple(raw, MARKET_FIELDS, "market");
+  const defaultRecord =
+    market.vault === zeroAddress && market.checkpoint === zeroAddress &&
+    String(market.poolId).toLowerCase() === ZERO_BYTES32 &&
+    String(market.marketId).toLowerCase() === ZERO_BYTES32 &&
+    String(market.assetKey).toLowerCase() === ZERO_BYTES32 &&
+    String(market.registrySnapshotHash).toLowerCase() === ZERO_BYTES32 &&
+    String(market.resolutionPolicyHash).toLowerCase() === ZERO_BYTES32 &&
+    market.registryRevision === 0n && market.policyValidUntil === 0n &&
+    market.snapshotAssetCap === 0n;
+  if (defaultRecord) return null;
+  return {
+    vault: address(market.vault, "market vault"),
+    checkpoint: address(market.checkpoint, "market checkpoint"),
+    poolId: bytes32(market.poolId, "market pool id"),
+    marketId: bytes32(market.marketId, "market id"),
+    assetKey: bytes32(market.assetKey, "market asset key"),
+    registrySnapshotHash: bytes32(market.registrySnapshotHash, "registry snapshot hash"),
+    resolutionPolicyHash: bytes32(market.resolutionPolicyHash, "resolution policy hash"),
+    registryRevision: unsigned(market.registryRevision, "registry revision", false),
+    policyValidUntil: unsigned(market.policyValidUntil, "policy validity", false),
+    snapshotAssetCap: unsigned(market.snapshotAssetCap, "snapshot asset cap", false),
+  };
+}
+
+function decodeIdentity(value: unknown): PredictionAssetIdentityV2 {
+  return assertCanonicalPredictionV2Identity(value);
+}
+
+function decodeOraclePolicy(value: unknown): PredictionV2OraclePolicy {
+  const policy = exactTuple(value, POLICY_FIELDS, "oracle policy");
+  const checkpointKind = bytes32(policy.checkpointKind, "checkpoint kind");
+  const checkpointAdapter = address(policy.checkpointAdapter, "checkpoint adapter");
+  const checkpointAdapterCodehash = bytes32(
+    policy.checkpointAdapterCodehash,
+    "checkpoint adapter codehash",
+  );
+  const feedId = bytes32(policy.feedId, "feed id", true);
+  const feedAddress = address(policy.feedAddress, "feed address", true);
+  const feedProxyCodehash = bytes32(policy.feedProxyCodehash, "feed proxy codehash", true);
+  const feedPhaseId = smallUnsigned(policy.feedPhaseId, 0xffff, "feed phase id");
+  const feedAggregator = address(policy.feedAggregator, "feed aggregator", true);
+  const feedAggregatorCodehash = bytes32(
+    policy.feedAggregatorCodehash,
+    "feed aggregator codehash",
+    true,
+  );
+  const feedDescriptionHash = bytes32(policy.feedDescriptionHash, "feed description hash");
+  const feedDecimals = smallUnsigned(policy.feedDecimals, 18, "feed decimals");
+  const quoteCurrency = bytes32(policy.quoteCurrency, "quote currency");
+  const assetEvidenceHash = bytes32(policy.assetEvidenceHash, "asset evidence hash");
+  const maxOpenInterestAtoms = unsigned(
+    policy.maxOpenInterestAtoms,
+    "maximum open interest",
+    false,
+  );
+  const validUntil = unsigned(policy.validUntil, "policy valid until", false);
+  const policyVersion = smallUnsigned(policy.policyVersion, 0xffff_ffff, "policy version");
+  if (typeof policy.active !== "boolean") invalid("policy active flag");
+  const usesAddressFeed = feedAddress.toLowerCase() !== zeroAddress;
+  const usesIdFeed = feedId !== ZERO_BYTES32;
+  if (usesAddressFeed === usesIdFeed) invalid("oracle feed reference");
+  if (usesAddressFeed) {
+    if (
+      feedProxyCodehash === ZERO_BYTES32 || feedPhaseId === 0 ||
+      feedAggregator.toLowerCase() === zeroAddress ||
+      feedAggregatorCodehash === ZERO_BYTES32
+    ) invalid("oracle feed phase binding");
+  } else if (
+    feedProxyCodehash !== ZERO_BYTES32 || feedPhaseId !== 0 ||
+    feedAggregator.toLowerCase() !== zeroAddress ||
+    feedAggregatorCodehash !== ZERO_BYTES32
+  ) invalid("id-based feed binding");
+  if (
+    feedDecimals === 0 || quoteCurrency !== USD_QUOTE ||
+    maxOpenInterestAtoms < PREDICTION_V2_BOOTSTRAP_COLLATERAL_ATOMS ||
+    policyVersion === 0
+  ) invalid("oracle policy invariants");
+  return {
+    checkpointKind,
+    checkpointAdapter,
+    checkpointAdapterCodehash,
+    feedId,
+    feedAddress,
+    feedProxyCodehash,
+    feedPhaseId,
+    feedAggregator,
+    feedAggregatorCodehash,
+    feedDescriptionHash,
+    feedDecimals,
+    quoteCurrency,
+    assetEvidenceHash,
+    maxOpenInterestAtoms,
+    validUntil,
+    policyVersion,
+    active: policy.active,
+  };
+}
+
+export function validatePredictionV2RegistrySnapshot(
+  value: unknown,
+): PredictionV2RegistrySnapshot {
+  const snapshot = exactTuple(value, SNAPSHOT_FIELDS, "registry snapshot");
+  const identity = decodeIdentity(snapshot.identity);
+  const assetKey = bytes32(snapshot.assetKey, "snapshot asset key");
+  if (predictionOnchainAssetKeyV2(identity) !== assetKey) {
+    invalid("snapshot asset key binding");
+  }
+  const displaySymbol = canonicalDisplaySymbol(snapshot.displaySymbol);
+  const preset = PREDICTION_PRESET_ASSETS_V2.find(({ identity: candidate }) =>
+    candidate.assetIdentifier === identity.assetIdentifier &&
+    identity.sourceNamespace === GLOBAL_NAMESPACE
+  );
+  if (preset && displaySymbol !== preset.symbol) invalid("preset display symbol binding");
+  return {
+    assetKey,
+    revision: unsigned(snapshot.revision, "snapshot revision", false),
+    identity,
+    displaySymbol,
+    policy: decodeOraclePolicy(snapshot.policy),
+  };
+}
+
+export function predictionV2OraclePolicyHash(
+  value: PredictionV2OraclePolicy,
+): PredictionBytes32V2 {
+  const policy = decodeOraclePolicy(value);
+  return keccak256(encodeAbiParameters(ORACLE_POLICY_HASH_PARAMETERS, [
+    ORACLE_POLICY_HASH_DOMAIN,
+    policy,
+  ])) as PredictionBytes32V2;
+}
+
+export function predictionV2RegistrySnapshotHash(
+  value: PredictionV2RegistrySnapshot,
+): PredictionBytes32V2 {
+  const snapshot = validatePredictionV2RegistrySnapshot(value);
+  return keccak256(encodeAbiParameters(SNAPSHOT_HASH_PARAMETERS, [
+    SNAPSHOT_HASH_DOMAIN,
+    snapshot.assetKey,
+    snapshot.revision,
+    snapshot.identity.sourceNamespace,
+    snapshot.identity.sourceChain,
+    snapshot.identity.assetIdentifier,
+    snapshot.identity.assetStandard,
+    keccak256(stringToHex(snapshot.displaySymbol)),
+    predictionV2OraclePolicyHash(snapshot.policy),
+  ])) as PredictionBytes32V2;
+}
+
+export function decodePredictionV2RegistrySnapshot(
+  data: Hex,
+  functionName: "latestSnapshot" | "requireActiveAsset",
+): PredictionV2RegistrySnapshot {
+  const snapshot = validatePredictionV2RegistrySnapshot(decodeFunctionResult({
+    abi: PREDICTION_V2_ASSET_REGISTRY_ABI,
+    functionName,
+    data,
+  }));
+  if (functionName === "requireActiveAsset" && !snapshot.policy.active) {
+    invalid("active registry snapshot");
+  }
+  return snapshot;
+}

--- a/lib/prediction-v2/codec.ts
+++ b/lib/prediction-v2/codec.ts
@@ -1,6 +1,7 @@
 import {
   decodeFunctionResult,
   encodeAbiParameters,
+  encodeFunctionResult,
   isAddress,
   keccak256,
   parseAbiParameters,
@@ -588,13 +589,21 @@ export function predictionV2RegistrySnapshotHash(
 
 export function decodePredictionV2RegistrySnapshot(
   data: Hex,
-  functionName: "latestSnapshot" | "requireActiveAsset",
+  functionName: "getSnapshot" | "latestSnapshot" | "requireActiveAsset",
 ): PredictionV2RegistrySnapshot {
   const snapshot = validatePredictionV2RegistrySnapshot(decodeFunctionResult({
     abi: PREDICTION_V2_ASSET_REGISTRY_ABI,
     functionName,
     data,
   }));
+  const canonical = encodeFunctionResult({
+    abi: PREDICTION_V2_ASSET_REGISTRY_ABI,
+    functionName,
+    result: snapshot,
+  });
+  if (canonical.toLowerCase() !== data.toLowerCase()) {
+    invalid("registry snapshot result canonicality");
+  }
   if (functionName === "requireActiveAsset" && !snapshot.policy.active) {
     invalid("active registry snapshot");
   }

--- a/lib/prediction-v2/market-draft.ts
+++ b/lib/prediction-v2/market-draft.ts
@@ -1,0 +1,364 @@
+import { formatUnits, parseUnits } from "viem";
+
+import {
+  PREDICTION_MARKET_TYPE_V2,
+  predictionAssetIdentityCandidatesV2,
+  predictionAssetSelectionKeyV2,
+  type PredictionAssetIdentityV2,
+  type PredictionBytes32V2,
+  type PredictionMarketDraftV2,
+} from "../prediction-market-assets-v2";
+import type { PredictionV2RegistrySnapshot } from "./abi";
+import {
+  predictionV2RegistrySnapshotHash,
+  validatePredictionV2RegistrySnapshot,
+} from "./codec";
+
+export const PREDICTION_V2_MINIMUM_MARKET_DURATION_SECONDS =
+  24n * 60n * 60n;
+export const PREDICTION_V2_MAXIMUM_MARKET_DURATION_SECONDS =
+  30n * 24n * 60n * 60n;
+export const PREDICTION_V2_MAX_THRESHOLD = (1n << 191n) - 1n;
+
+const MAX_UINT32 = (1n << 32n) - 1n;
+const MAX_PRICE_TEXT_LENGTH = 80;
+const BYTES32_PATTERN = /^0x[0-9a-fA-F]{64}$/u;
+const DECIMAL_PRICE_PATTERN = /^(?:0|[1-9]\d*)(?:\.(\d+))?$/u;
+const UTC_INPUT_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/u;
+
+export type PredictionV2MarketDraftBinding = Readonly<{
+  /** Exact active snapshot returned by AssetRegistryV2. */
+  registrySnapshot: unknown;
+  /** Exact result of AssetRegistryV2.hashSnapshot for the same bound read. */
+  registryHashSnapshotResult: PredictionBytes32V2;
+  /** Snapshot hash pinned by the independently verified release registry. */
+  releaseRegistrySnapshotHash: PredictionBytes32V2;
+  /** Revision pinned by that same release-registry entry. */
+  releaseRegistryRevision: bigint;
+  nowUnixSeconds: bigint;
+}>;
+
+export type PredictionV2ValidatedMarketDraft = Readonly<{
+  selectionKey: string;
+  onchainAssetKey: PredictionBytes32V2;
+  identity: PredictionAssetIdentityV2;
+  registryRevision: bigint;
+  registrySnapshotHash: PredictionBytes32V2;
+  policyValidUntil: bigint;
+  feedDecimals: number;
+  observationTime: bigint;
+  observationLabel: string;
+  thresholdAtoms: bigint;
+  strikeUsd: string;
+  thresholdLabel: string;
+  marketTitle: string;
+}>;
+
+export type PredictionV2MarketDraftErrors = Readonly<{
+  asset?: string;
+  strikeUsd?: string;
+  observationUtc?: string;
+  binding?: string;
+}>;
+
+export type PredictionV2MarketDraftValidation =
+  | Readonly<{ ok: true; market: PredictionV2ValidatedMarketDraft }>
+  | Readonly<{ ok: false; errors: PredictionV2MarketDraftErrors }>;
+
+function isFeedDecimals(value: number) {
+  return Number.isInteger(value) && value >= 1 && value <= 18;
+}
+
+function normalizedBytes32(value: unknown): PredictionBytes32V2 | null {
+  if (typeof value !== "string" || !BYTES32_PATTERN.test(value)) return null;
+  return value.toLowerCase() as PredictionBytes32V2;
+}
+
+function sameIdentity(
+  left: PredictionAssetIdentityV2,
+  right: PredictionAssetIdentityV2,
+) {
+  return left.sourceNamespace === right.sourceNamespace &&
+    left.sourceChain === right.sourceChain &&
+    left.assetIdentifier === right.assetIdentifier &&
+    left.assetStandard === right.assetStandard;
+}
+
+/**
+ * Parse a human USD strike without floating point or implicit rounding.
+ * The Registry snapshot's feedDecimals must be passed directly by the caller.
+ */
+export function parsePredictionV2StrikeUsd(
+  value: string,
+  feedDecimals: number,
+): bigint | null {
+  if (!isFeedDecimals(feedDecimals)) return null;
+  const normalized = value.trim();
+  if (
+    normalized.length === 0 ||
+    normalized.length > MAX_PRICE_TEXT_LENGTH
+  ) return null;
+  const match = DECIMAL_PRICE_PATTERN.exec(normalized);
+  if (!match || (match[1]?.length ?? 0) > feedDecimals) return null;
+
+  try {
+    const atoms = parseUnits(normalized, feedDecimals);
+    return atoms > 0n && atoms <= PREDICTION_V2_MAX_THRESHOLD
+      ? atoms
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Lossless canonical decimal text for a validated positive int192 strike. */
+export function formatPredictionV2StrikeUsd(
+  thresholdAtoms: bigint,
+  feedDecimals: number,
+) {
+  if (
+    !isFeedDecimals(feedDecimals) ||
+    thresholdAtoms <= 0n ||
+    thresholdAtoms > PREDICTION_V2_MAX_THRESHOLD
+  ) {
+    throw new TypeError("Invalid Prediction V2 USD strike");
+  }
+  return formatUnits(thresholdAtoms, feedDecimals);
+}
+
+export function formatPredictionV2StrikeLabel(
+  thresholdAtoms: bigint,
+  feedDecimals: number,
+) {
+  const [whole, fraction = ""] = formatPredictionV2StrikeUsd(
+    thresholdAtoms,
+    feedDecimals,
+  ).split(".");
+  const groupedWhole = whole.replace(/\B(?=(\d{3})+(?!\d))/gu, ",");
+  return `$${groupedWhole}${fraction ? `.${fraction}` : ""}`;
+}
+
+/** Parse the exact value emitted by a UTC-labelled datetime-local control. */
+export function parsePredictionV2ObservationUtc(value: string): bigint | null {
+  const match = UTC_INPUT_PATTERN.exec(value.trim());
+  if (!match) return null;
+
+  const [, yearText, monthText, dayText, hourText, minuteText] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const milliseconds = Date.UTC(year, month - 1, day, hour, minute, 0, 0);
+  if (!Number.isFinite(milliseconds)) return null;
+  const parsed = new Date(milliseconds);
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day ||
+    parsed.getUTCHours() !== hour ||
+    parsed.getUTCMinutes() !== minute
+  ) return null;
+
+  const seconds = milliseconds / 1_000;
+  if (!Number.isSafeInteger(seconds) || seconds < 0) return null;
+  const timestamp = BigInt(seconds);
+  return timestamp <= MAX_UINT32 ? timestamp : null;
+}
+
+export function formatPredictionV2ObservationUtc(observationTime: bigint) {
+  if (observationTime < 0n || observationTime > MAX_UINT32) {
+    throw new TypeError("Invalid Prediction V2 observation time");
+  }
+  const date = new Date(Number(observationTime) * 1_000);
+  const month = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    timeZone: "UTC",
+  }).format(date);
+  const day = date.getUTCDate();
+  const year = date.getUTCFullYear();
+  const hour = String(date.getUTCHours()).padStart(2, "0");
+  const minute = String(date.getUTCMinutes()).padStart(2, "0");
+  return `${month} ${day}, ${year} at ${hour}:${minute} UTC`;
+}
+
+function validateDraftShape(value: unknown): value is PredictionMarketDraftV2 {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const draft = value as Record<string, unknown>;
+  const keys = Object.keys(draft);
+  if (
+    keys.length !== 7 ||
+    ![
+      "schemaVersion",
+      "asset",
+      "marketType",
+      "comparator",
+      "quoteCurrency",
+      "strikeUsd",
+      "observationUtc",
+    ].every((key) => Object.hasOwn(draft, key)) ||
+    draft.schemaVersion !== 2 ||
+    draft.marketType !== PREDICTION_MARKET_TYPE_V2 ||
+    draft.comparator !== "greater-than-or-equal" ||
+    draft.quoteCurrency !== "USD" ||
+    typeof draft.strikeUsd !== "string" ||
+    typeof draft.observationUtc !== "string"
+  ) return false;
+
+  const asset = draft.asset;
+  if (!asset || typeof asset !== "object" || Array.isArray(asset)) return false;
+  const assetRecord = asset as Record<string, unknown>;
+  if (assetRecord.mode === "preset") {
+    return Object.keys(assetRecord).length === 2 &&
+      Object.hasOwn(assetRecord, "presetId") &&
+      typeof assetRecord.presetId === "string";
+  }
+  return assetRecord.mode === "custom" &&
+    Object.keys(assetRecord).length === 3 &&
+    Object.hasOwn(assetRecord, "sourceNetwork") &&
+    Object.hasOwn(assetRecord, "assetLocator") &&
+    typeof assetRecord.sourceNetwork === "string" &&
+    typeof assetRecord.assetLocator === "string";
+}
+
+function decodeBoundSnapshot(
+  binding: PredictionV2MarketDraftBinding,
+): Readonly<{
+  snapshot: PredictionV2RegistrySnapshot;
+  snapshotHash: PredictionBytes32V2;
+}> | null {
+  try {
+    const snapshot = validatePredictionV2RegistrySnapshot(
+      binding.registrySnapshot,
+    );
+    const snapshotHash = predictionV2RegistrySnapshotHash(snapshot);
+    const registryHash = normalizedBytes32(
+      binding.registryHashSnapshotResult,
+    );
+    const releaseHash = normalizedBytes32(
+      binding.releaseRegistrySnapshotHash,
+    );
+    if (
+      !snapshot.policy.active ||
+      typeof binding.releaseRegistryRevision !== "bigint" ||
+      binding.releaseRegistryRevision !== snapshot.revision ||
+      registryHash !== snapshotHash ||
+      releaseHash !== snapshotHash
+    ) return null;
+    return { snapshot, snapshotHash };
+  } catch {
+    return null;
+  }
+}
+
+export function validatePredictionV2MarketDraft(
+  draft: unknown,
+  binding: PredictionV2MarketDraftBinding,
+): PredictionV2MarketDraftValidation {
+  if (!validateDraftShape(draft)) {
+    return {
+      ok: false,
+      errors: { binding: "This market draft is not supported." },
+    };
+  }
+
+  const selectionKey = predictionAssetSelectionKeyV2(draft.asset);
+  const bound = decodeBoundSnapshot(binding);
+  const errors: {
+    asset?: string;
+    strikeUsd?: string;
+    observationUtc?: string;
+    binding?: string;
+  } = {};
+
+  if (!selectionKey) errors.asset = "Choose a released asset.";
+  if (!bound) {
+    errors.binding = "The released price source could not be verified.";
+  } else if (!predictionAssetIdentityCandidatesV2(draft.asset).some(
+    (candidate) => sameIdentity(candidate, bound.snapshot.identity),
+  )) {
+    errors.asset = "The selected asset does not match the released price source.";
+  }
+
+  const thresholdAtoms = bound
+    ? parsePredictionV2StrikeUsd(
+      draft.strikeUsd,
+      bound.snapshot.policy.feedDecimals,
+    )
+    : null;
+  if (bound && thresholdAtoms === null) {
+    errors.strikeUsd =
+      `Enter a positive USD price with no more than ${bound.snapshot.policy.feedDecimals} decimal places.`;
+  }
+
+  const observationTime = parsePredictionV2ObservationUtc(
+    draft.observationUtc,
+  );
+  const now = binding.nowUnixSeconds;
+  if (
+    typeof now !== "bigint" ||
+    now < 0n ||
+    now > MAX_UINT32
+  ) {
+    errors.binding = "The current chain time could not be verified.";
+  }
+  if (observationTime === null) {
+    errors.observationUtc = "Enter a valid date and time in UTC.";
+  } else if (typeof now === "bigint" && now >= 0n && now <= MAX_UINT32) {
+    if (
+      observationTime <= now + PREDICTION_V2_MINIMUM_MARKET_DURATION_SECONDS
+    ) {
+      errors.observationUtc =
+        "The result time must be more than 24 hours from now.";
+    } else if (
+      observationTime > now + PREDICTION_V2_MAXIMUM_MARKET_DURATION_SECONDS
+    ) {
+      errors.observationUtc =
+        "The result time must be no more than 30 days from now.";
+    } else if (
+      bound && observationTime > bound.snapshot.policy.validUntil
+    ) {
+      errors.observationUtc =
+        "The released price source expires before this result time.";
+    }
+  }
+
+  if (
+    !bound ||
+    !selectionKey ||
+    thresholdAtoms === null ||
+    observationTime === null ||
+    Object.keys(errors).length > 0
+  ) {
+    return { ok: false, errors };
+  }
+
+  const thresholdLabel = formatPredictionV2StrikeLabel(
+    thresholdAtoms,
+    bound.snapshot.policy.feedDecimals,
+  );
+  const observationLabel = formatPredictionV2ObservationUtc(observationTime);
+  return {
+    ok: true,
+    market: {
+      selectionKey,
+      onchainAssetKey: bound.snapshot.assetKey,
+      identity: bound.snapshot.identity,
+      registryRevision: bound.snapshot.revision,
+      registrySnapshotHash: bound.snapshotHash,
+      policyValidUntil: bound.snapshot.policy.validUntil,
+      feedDecimals: bound.snapshot.policy.feedDecimals,
+      observationTime,
+      observationLabel,
+      thresholdAtoms,
+      strikeUsd: formatPredictionV2StrikeUsd(
+        thresholdAtoms,
+        bound.snapshot.policy.feedDecimals,
+      ),
+      thresholdLabel,
+      marketTitle:
+        `Will ${bound.snapshot.displaySymbol} be at or above ${thresholdLabel} on ${observationLabel}?`,
+    },
+  };
+}

--- a/lib/prediction-v2/release-binding.server.ts
+++ b/lib/prediction-v2/release-binding.server.ts
@@ -1,0 +1,76 @@
+import "server-only";
+
+import releaseBindingJson from "../../config/prediction-v2-release-binding.v1.json";
+
+export const PREDICTION_V2_RELEASE_VERSION = "prediction-v2" as const;
+
+const DISABLED_RELEASE_BINDING_KEYS = Object.freeze([
+  "schemaVersion",
+  "releaseVersion",
+  "status",
+] as const);
+
+/**
+ * V1 is deliberately a disabled-only schema. A future activation must use a
+ * separately reviewed schema with a pinned attestation trust root; adding
+ * deployment fields to this document can never enable Prediction V2.
+ */
+export type PredictionV2ReleaseBinding = Readonly<{
+  schemaVersion: 1;
+  releaseVersion: typeof PREDICTION_V2_RELEASE_VERSION;
+  status: "disabled";
+}>;
+
+function invalidReleaseBinding(): never {
+  throw new Error("Invalid Prediction V2 release binding");
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+function hasOnlyKeys(
+  value: Record<string, unknown>,
+  expectedKeys: readonly string[],
+) {
+  const ownKeys = Reflect.ownKeys(value);
+  if (ownKeys.some((key) => typeof key !== "string")) return false;
+  const actualKeys = (ownKeys as string[]).sort();
+  const sortedExpectedKeys = [...expectedKeys].sort();
+  return (
+    actualKeys.length === sortedExpectedKeys.length &&
+    actualKeys.every((key, index) => key === sortedExpectedKeys[index])
+  );
+}
+
+export function parsePredictionV2ReleaseBinding(
+  value: unknown,
+): PredictionV2ReleaseBinding {
+  if (
+    !isPlainRecord(value) ||
+    !hasOnlyKeys(value, DISABLED_RELEASE_BINDING_KEYS) ||
+    value.schemaVersion !== 1 ||
+    value.releaseVersion !== PREDICTION_V2_RELEASE_VERSION ||
+    value.status !== "disabled"
+  ) {
+    return invalidReleaseBinding();
+  }
+
+  return Object.freeze({
+    schemaVersion: 1,
+    releaseVersion: PREDICTION_V2_RELEASE_VERSION,
+    status: "disabled",
+  });
+}
+
+let cachedReleaseBinding: PredictionV2ReleaseBinding | undefined;
+
+export function getPredictionV2ReleaseBinding(): PredictionV2ReleaseBinding {
+  cachedReleaseBinding ??= parsePredictionV2ReleaseBinding(releaseBindingJson);
+  return cachedReleaseBinding;
+}

--- a/lib/prediction-v2/transactions.ts
+++ b/lib/prediction-v2/transactions.ts
@@ -2,6 +2,7 @@ import {
   decodeFunctionResult,
   encodeAbiParameters,
   encodeFunctionData,
+  encodeFunctionResult,
   isAddress,
   parseAbiParameters,
   zeroAddress,
@@ -26,7 +27,14 @@ import {
   type PredictionV2PoolKey,
   type PredictionV2RegistrySnapshot,
 } from "./abi";
-import { predictionV2SlippageFloor } from "./accounting";
+import {
+  bindPredictionV2MarketState,
+  predictionV2BuyPreview,
+  predictionV2SellPreview,
+  predictionV2SlippageFloor,
+  requirePredictionV2PriceImpactConfirmation,
+  type PredictionV2BoundMarketState,
+} from "./accounting";
 import {
   PREDICTION_V2_BOOTSTRAP_COLLATERAL_ATOMS,
   PREDICTION_V2_LP_FEE_PIPS,
@@ -59,6 +67,7 @@ export type PredictionV2PermitSignature = Readonly<{
 }>;
 
 export type PredictionV2PreparedTransaction = Readonly<{
+  chainId: 4_663;
   to: Address;
   data: Hex;
   value: 0n;
@@ -69,6 +78,7 @@ export type PredictionV2PreparedCreate = PredictionV2PreparedTransaction & Reado
   onchainAssetKey: PredictionBytes32V2;
   registryRevision: bigint;
   registrySnapshotHash: PredictionBytes32V2;
+  expectedMarketId: PredictionBytes32V2;
   registrySnapshot: PredictionV2RegistrySnapshot;
 }>;
 
@@ -80,10 +90,12 @@ type PredictionV2QuoteContextBase = Readonly<{
   sqrtPriceLimitX96: bigint;
   observedBlockNumber: bigint;
   observedBlockHash: PredictionBytes32V2;
+  marketState: PredictionV2BoundMarketState;
 }>;
 
 export type PredictionV2BuyQuoteIntent = Readonly<{
   quoter: Address;
+  poolManager: Address;
   vault: Address;
   poolKey: PredictionV2PoolKey;
   buyYes: boolean;
@@ -93,6 +105,7 @@ export type PredictionV2BuyQuoteIntent = Readonly<{
 
 export type PredictionV2SellQuoteIntent = Readonly<{
   quoter: Address;
+  poolManager: Address;
   vault: Address;
   poolKey: PredictionV2PoolKey;
   sellYes: boolean;
@@ -103,12 +116,16 @@ export type PredictionV2SellQuoteIntent = Readonly<{
 export type PredictionV2BoundBuyQuote = PredictionV2QuoteContextBase & Readonly<{
   buyYes: boolean;
   requestedCollateralAtoms: bigint;
+  quoteCall: Readonly<{ to: Address; data: Hex }>;
+  quoteResult: Hex;
   quote: PredictionV2BuyQuote;
 }>;
 
 export type PredictionV2BoundSellQuote = PredictionV2QuoteContextBase & Readonly<{
   sellYes: boolean;
   outcomeAtoms: bigint;
+  quoteCall: Readonly<{ to: Address; data: Hex }>;
+  quoteResult: Hex;
   quote: PredictionV2SellQuote;
 }>;
 
@@ -187,6 +204,7 @@ function validateQuoteBlock(input: Readonly<{
   const observedBlockHash = nonzeroBytes32(input.observedBlockHash, "quote block hash");
   if (
     input.observedBlockNumber <= 0n || input.latestConfirmedBlockNumber < input.observedBlockNumber ||
+    !Number.isInteger(input.maximumQuoteAgeBlocks) || input.maximumQuoteAgeBlocks < 0 ||
     input.maximumQuoteAgeBlocks > 10 ||
     input.latestConfirmedBlockNumber - input.observedBlockNumber > BigInt(input.maximumQuoteAgeBlocks)
   ) fail("quote freshness");
@@ -279,11 +297,18 @@ export function encodePredictionV2VaultExposureControllerCall(): Hex {
 export function decodePredictionV2VaultExposureController(
   data: Hex,
 ): Address {
-  return nonzeroAddress(decodeFunctionResult({
-    abi: PREDICTION_V2_VAULT_ABI,
-    functionName: "exposureController",
-    data,
-  }), "vault exposure controller");
+  if (!/^0x0{24}[0-9a-fA-F]{40}$/u.test(data)) {
+    fail("vault exposure controller result");
+  }
+  try {
+    return nonzeroAddress(decodeFunctionResult({
+      abi: PREDICTION_V2_VAULT_ABI,
+      functionName: "exposureController",
+      data,
+    }), "vault exposure controller");
+  } catch {
+    fail("vault exposure controller result");
+  }
 }
 
 export function encodePredictionV2RequireIncreaseCapacityCall(input: Readonly<{
@@ -309,7 +334,9 @@ export function bindPredictionV2BuyQuote(input: Readonly<{
   sqrtPriceLimitX96: bigint;
   observedBlockNumber: bigint;
   observedBlockHash: PredictionBytes32V2;
-  quote: PredictionV2BuyQuote;
+  marketState: PredictionV2BoundMarketState;
+  quoteCall: Readonly<{ to: Address; data: Hex }>;
+  quoteResult: Hex;
 }>): PredictionV2BoundBuyQuote {
   if (input.chainId !== 4_663) fail("quote chain");
   const quoter = nonzeroAddress(input.quoter, "quoter");
@@ -318,12 +345,50 @@ export function bindPredictionV2BuyQuote(input: Readonly<{
   validateSqrtPriceLimit(input.sqrtPriceLimitX96);
   if (input.observedBlockNumber <= 0n) fail("quote block number");
   const observedBlockHash = nonzeroBytes32(input.observedBlockHash, "quote block hash");
-  const quote = validatePredictionV2BuyQuote(input.quote);
+  const marketState = bindPredictionV2MarketState(input.marketState);
+  if (
+    marketState.chainId !== input.chainId ||
+    marketState.vault.toLowerCase() !== vault.toLowerCase() ||
+    !samePoolKey(marketState.poolKey, poolKey) ||
+    marketState.observedBlockNumber !== input.observedBlockNumber ||
+    marketState.observedBlockHash !== observedBlockHash
+  ) fail("buy quote/market-state binding");
+  const expectedQuoteCall = encodePredictionV2BuyQuoteCall({
+    vault,
+    poolKey,
+    buyYes: input.buyYes,
+    requestedCollateralAtoms: input.requestedCollateralAtoms,
+    sqrtPriceLimitX96: input.sqrtPriceLimitX96,
+  });
+  const quoteCallTarget = nonzeroAddress(input.quoteCall.to, "buy quote call target");
+  if (
+    quoteCallTarget.toLowerCase() !== quoter.toLowerCase() ||
+    input.quoteCall.data !== expectedQuoteCall
+  ) fail("buy quote call binding");
+  let decodedQuote: unknown;
+  try {
+    decodedQuote = decodeFunctionResult({
+      abi: PREDICTION_V2_QUOTER_ABI,
+      functionName: "quoteBuy",
+      data: input.quoteResult,
+    });
+  } catch {
+    fail("buy quote result");
+  }
+  const quote = validatePredictionV2BuyQuote(decodedQuote);
+  const canonicalQuoteResult = encodeFunctionResult({
+    abi: PREDICTION_V2_QUOTER_ABI,
+    functionName: "quoteBuy",
+    result: quote,
+  });
+  if (canonicalQuoteResult.toLowerCase() !== input.quoteResult.toLowerCase()) {
+    fail("buy quote result canonicality");
+  }
   if (
     input.requestedCollateralAtoms !== quote.requestedCollateralAtoms ||
     input.requestedCollateralAtoms <= 0n
   ) fail("buy quote amount binding");
-  return {
+  const boundQuote: PredictionV2BoundBuyQuote = {
     chainId: 4_663,
     quoter,
     vault,
@@ -333,8 +398,13 @@ export function bindPredictionV2BuyQuote(input: Readonly<{
     sqrtPriceLimitX96: input.sqrtPriceLimitX96,
     observedBlockNumber: input.observedBlockNumber,
     observedBlockHash,
+    marketState,
+    quoteCall: { to: quoteCallTarget, data: input.quoteCall.data },
+    quoteResult: input.quoteResult,
     quote,
   };
+  predictionV2BuyPreview({ boundQuote, slippageBps: 1 });
+  return boundQuote;
 }
 
 export function bindPredictionV2SellQuote(input: Readonly<{
@@ -347,7 +417,9 @@ export function bindPredictionV2SellQuote(input: Readonly<{
   sqrtPriceLimitX96: bigint;
   observedBlockNumber: bigint;
   observedBlockHash: PredictionBytes32V2;
-  quote: PredictionV2SellQuote;
+  marketState: PredictionV2BoundMarketState;
+  quoteCall: Readonly<{ to: Address; data: Hex }>;
+  quoteResult: Hex;
 }>): PredictionV2BoundSellQuote {
   if (input.chainId !== 4_663) fail("quote chain");
   const quoter = nonzeroAddress(input.quoter, "quoter");
@@ -356,11 +428,49 @@ export function bindPredictionV2SellQuote(input: Readonly<{
   validateSqrtPriceLimit(input.sqrtPriceLimitX96);
   if (input.observedBlockNumber <= 0n) fail("quote block number");
   const observedBlockHash = nonzeroBytes32(input.observedBlockHash, "quote block hash");
-  const quote = validatePredictionV2SellQuote(input.quote);
+  const marketState = bindPredictionV2MarketState(input.marketState);
+  if (
+    marketState.chainId !== input.chainId ||
+    marketState.vault.toLowerCase() !== vault.toLowerCase() ||
+    !samePoolKey(marketState.poolKey, poolKey) ||
+    marketState.observedBlockNumber !== input.observedBlockNumber ||
+    marketState.observedBlockHash !== observedBlockHash
+  ) fail("sell quote/market-state binding");
+  const expectedQuoteCall = encodePredictionV2SellQuoteCall({
+    vault,
+    poolKey,
+    sellYes: input.sellYes,
+    outcomeAtoms: input.outcomeAtoms,
+    sqrtPriceLimitX96: input.sqrtPriceLimitX96,
+  });
+  const quoteCallTarget = nonzeroAddress(input.quoteCall.to, "sell quote call target");
+  if (
+    quoteCallTarget.toLowerCase() !== quoter.toLowerCase() ||
+    input.quoteCall.data !== expectedQuoteCall
+  ) fail("sell quote call binding");
+  let decodedQuote: unknown;
+  try {
+    decodedQuote = decodeFunctionResult({
+      abi: PREDICTION_V2_QUOTER_ABI,
+      functionName: "quoteSellOptimal",
+      data: input.quoteResult,
+    });
+  } catch {
+    fail("sell quote result");
+  }
+  const quote = validatePredictionV2SellQuote(decodedQuote);
+  const canonicalQuoteResult = encodeFunctionResult({
+    abi: PREDICTION_V2_QUOTER_ABI,
+    functionName: "quoteSellOptimal",
+    result: quote,
+  });
+  if (canonicalQuoteResult.toLowerCase() !== input.quoteResult.toLowerCase()) {
+    fail("sell quote result canonicality");
+  }
   if (input.outcomeAtoms !== quote.outcomeInAtoms || input.outcomeAtoms <= 0n) {
     fail("sell quote amount binding");
   }
-  return {
+  const boundQuote: PredictionV2BoundSellQuote = {
     chainId: 4_663,
     quoter,
     vault,
@@ -370,8 +480,13 @@ export function bindPredictionV2SellQuote(input: Readonly<{
     sqrtPriceLimitX96: input.sqrtPriceLimitX96,
     observedBlockNumber: input.observedBlockNumber,
     observedBlockHash,
+    marketState,
+    quoteCall: { to: quoteCallTarget, data: input.quoteCall.data },
+    quoteResult: input.quoteResult,
     quote,
   };
+  predictionV2SellPreview({ boundQuote, slippageBps: 1 });
+  return boundQuote;
 }
 
 /**
@@ -389,6 +504,9 @@ export function bindPredictionV2BuyCapacityPreflight(input: Readonly<{
   capacityResult: Hex;
 }>): PredictionV2BoundBuyCapacityPreflight {
   const boundQuote = bindPredictionV2BuyQuote(input.boundQuote);
+  if (!boundQuote.marketState.checkpointTradingHealthy) {
+    fail("checkpoint trading health");
+  }
   const observedBlockHash = nonzeroBytes32(input.observedBlockHash, "capacity block hash");
   if (
     input.observedBlockNumber !== boundQuote.observedBlockNumber ||
@@ -448,6 +566,7 @@ export function preparePredictionV2BuyWithPermit(input: Readonly<{
   slippageBps: number;
   tradeDeadline: bigint;
   permit: PredictionV2PermitSignature;
+  explicitlyConfirmedHighPriceImpact: boolean;
   nowUnixSeconds: bigint;
 }>): PredictionV2PreparedTransaction {
   validateNow(input.nowUnixSeconds);
@@ -474,12 +593,14 @@ export function preparePredictionV2BuyWithPermit(input: Readonly<{
   const intent = {
     ...input.intent,
     quoter: nonzeroAddress(input.intent.quoter, "intended quoter"),
+    poolManager: nonzeroAddress(input.intent.poolManager, "intended PoolManager"),
     vault: nonzeroAddress(input.intent.vault, "intended vault"),
     poolKey: validatePredictionV2PoolKey(input.intent.poolKey),
   };
   validateSqrtPriceLimit(intent.sqrtPriceLimitX96);
   if (
     boundQuote.quoter.toLowerCase() !== intent.quoter.toLowerCase() ||
+    boundQuote.marketState.poolManager.toLowerCase() !== intent.poolManager.toLowerCase() ||
     boundQuote.vault.toLowerCase() !== intent.vault.toLowerCase() ||
     !samePoolKey(boundQuote.poolKey, intent.poolKey) ||
     boundQuote.buyYes !== intent.buyYes ||
@@ -501,7 +622,13 @@ export function preparePredictionV2BuyWithPermit(input: Readonly<{
     input.tradeDeadline,
   );
   const minOutcomeAtoms = predictionV2SlippageFloor(quote.outcomeAtoms, input.slippageBps);
+  const preview = predictionV2BuyPreview({ boundQuote, slippageBps: input.slippageBps });
+  requirePredictionV2PriceImpactConfirmation(
+    preview.priceImpact.probabilityPointMagnitudeBps,
+    input.explicitlyConfirmedHighPriceImpact,
+  );
   return {
+    chainId: 4_663,
     to: router,
     value: 0n,
     data: encodeFunctionData({
@@ -535,20 +662,26 @@ export function preparePredictionV2SellWithPermit(input: Readonly<{
   slippageBps: number;
   tradeDeadline: bigint;
   permit: PredictionV2PermitSignature;
+  explicitlyConfirmedHighPriceImpact: boolean;
   nowUnixSeconds: bigint;
 }>): PredictionV2PreparedTransaction {
   validateNow(input.nowUnixSeconds);
   const router = nonzeroAddress(input.router, "router");
   const boundQuote = bindPredictionV2SellQuote(input.boundQuote);
+  if (!boundQuote.marketState.checkpointTradingHealthy) {
+    fail("checkpoint trading health");
+  }
   const intent = {
     ...input.intent,
     quoter: nonzeroAddress(input.intent.quoter, "intended quoter"),
+    poolManager: nonzeroAddress(input.intent.poolManager, "intended PoolManager"),
     vault: nonzeroAddress(input.intent.vault, "intended vault"),
     poolKey: validatePredictionV2PoolKey(input.intent.poolKey),
   };
   validateSqrtPriceLimit(intent.sqrtPriceLimitX96);
   if (
     boundQuote.quoter.toLowerCase() !== intent.quoter.toLowerCase() ||
+    boundQuote.marketState.poolManager.toLowerCase() !== intent.poolManager.toLowerCase() ||
     boundQuote.vault.toLowerCase() !== intent.vault.toLowerCase() ||
     !samePoolKey(boundQuote.poolKey, intent.poolKey) ||
     boundQuote.sellYes !== intent.sellYes ||
@@ -573,7 +706,13 @@ export function preparePredictionV2SellWithPermit(input: Readonly<{
     quote.netCollateralAtoms,
     input.slippageBps,
   );
+  const preview = predictionV2SellPreview({ boundQuote, slippageBps: input.slippageBps });
+  requirePredictionV2PriceImpactConfirmation(
+    preview.priceImpact.probabilityPointMagnitudeBps,
+    input.explicitlyConfirmedHighPriceImpact,
+  );
   return {
+    chainId: 4_663,
     to: router,
     value: 0n,
     data: encodeFunctionData({
@@ -609,6 +748,10 @@ export function preparePredictionV2CreateWithPermit(input: Readonly<{
   registryHashSnapshotResult: PredictionBytes32V2;
   /** Snapshot hash returned by Factory.activeMarketId for these create parameters. */
   factoryActiveSnapshotHash: PredictionBytes32V2;
+  /** Market id returned by that same Factory.activeMarketId call. */
+  factoryActiveMarketId: PredictionBytes32V2;
+  /** Registry revision returned by that same Factory.activeMarketId call. */
+  factoryActiveRegistryRevision: bigint;
   /** Snapshot hash pinned by the UI release registry. */
   releaseRegistrySnapshotHash: PredictionBytes32V2;
   observationTime: bigint;
@@ -645,10 +788,15 @@ export function preparePredictionV2CreateWithPermit(input: Readonly<{
     input.releaseRegistrySnapshotHash,
     "release Registry snapshot hash",
   );
+  const factoryActiveMarketId = nonzeroBytes32(
+    input.factoryActiveMarketId,
+    "Factory active market id",
+  );
   if (
     registryHashSnapshotResult !== computedSnapshotHash ||
     factoryActiveSnapshotHash !== computedSnapshotHash ||
-    releaseRegistrySnapshotHash !== computedSnapshotHash
+    releaseRegistrySnapshotHash !== computedSnapshotHash ||
+    input.factoryActiveRegistryRevision !== registrySnapshot.revision
   ) fail("Registry snapshot hash binding");
   if (
     input.observationTime <= input.nowUnixSeconds + MINIMUM_MARKET_DURATION_SECONDS ||
@@ -663,12 +811,14 @@ export function preparePredictionV2CreateWithPermit(input: Readonly<{
     input.nowUnixSeconds,
   );
   return {
+    chainId: 4_663,
     to: factory,
     value: 0n,
     selectionKey,
     onchainAssetKey,
     registryRevision: registrySnapshot.revision,
     registrySnapshotHash: computedSnapshotHash,
+    expectedMarketId: factoryActiveMarketId,
     registrySnapshot,
     data: encodeFunctionData({
       abi: PREDICTION_V2_FACTORY_ABI,
@@ -677,6 +827,7 @@ export function preparePredictionV2CreateWithPermit(input: Readonly<{
         identity,
         Number(input.observationTime),
         input.threshold,
+        factoryActiveMarketId,
         permit.deadline,
         permit.v,
         permit.r,
@@ -690,10 +841,17 @@ export function encodePredictionV2ChainlinkRoundProof(input: Readonly<{
   beforeRoundId: bigint;
   afterRoundId: bigint;
 }>): Hex {
+  const beforePhase = input.beforeRoundId >> 64n;
+  const afterPhase = input.afterRoundId >> 64n;
+  const beforeAggregatorRound = input.beforeRoundId & ((1n << 64n) - 1n);
+  const afterAggregatorRound = input.afterRoundId & ((1n << 64n) - 1n);
+  const samePhaseAdjacent = afterPhase === beforePhase &&
+    afterAggregatorRound === beforeAggregatorRound + 1n;
   if (
     input.beforeRoundId <= 0n || input.beforeRoundId > MAX_UINT80 ||
     input.afterRoundId <= 0n || input.afterRoundId > MAX_UINT80 ||
-    input.afterRoundId !== input.beforeRoundId + 1n
+    beforePhase === 0n || beforeAggregatorRound === 0n ||
+    !samePhaseAdjacent
   ) fail("Chainlink round proof");
   return encodeAbiParameters(
     parseAbiParameters("uint80 beforeRoundId, uint80 afterRoundId"),
@@ -709,12 +867,112 @@ export function preparePredictionV2FinalizeWithChainlinkRounds(input: Readonly<{
   const vault = nonzeroAddress(input.vault, "finalize vault");
   const proof = encodePredictionV2ChainlinkRoundProof(input);
   return {
+    chainId: 4_663,
     to: vault,
     value: 0n,
     data: encodeFunctionData({
       abi: PREDICTION_V2_VAULT_ABI,
       functionName: "finalize",
       args: [proof],
+    }),
+  };
+}
+
+function preparePredictionV2VaultNoArg(
+  vaultInput: Address,
+  functionName:
+    | "finalizeUnavailable"
+    | "requestUnprovenFallback"
+    | "finalizeUnproven"
+    | "finalizeResolved",
+): PredictionV2PreparedTransaction {
+  const vault = nonzeroAddress(vaultInput, `${functionName} vault`);
+  return {
+    chainId: 4_663,
+    to: vault,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: PREDICTION_V2_VAULT_ABI,
+      functionName,
+    }),
+  };
+}
+
+export function preparePredictionV2FinalizeUnavailable(
+  vault: Address,
+): PredictionV2PreparedTransaction {
+  return preparePredictionV2VaultNoArg(vault, "finalizeUnavailable");
+}
+
+export function preparePredictionV2RequestUnprovenFallback(
+  vault: Address,
+): PredictionV2PreparedTransaction {
+  return preparePredictionV2VaultNoArg(vault, "requestUnprovenFallback");
+}
+
+export function preparePredictionV2FinalizeUnproven(
+  vault: Address,
+): PredictionV2PreparedTransaction {
+  return preparePredictionV2VaultNoArg(vault, "finalizeUnproven");
+}
+
+export function preparePredictionV2FinalizeResolved(
+  vault: Address,
+): PredictionV2PreparedTransaction {
+  return preparePredictionV2VaultNoArg(vault, "finalizeResolved");
+}
+
+function validateRedemption(input: Readonly<{
+  yesAtoms: bigint;
+  noAtoms: bigint;
+  recipient: Address;
+}>) {
+  if (input.yesAtoms < 0n || input.noAtoms < 0n ||
+    (input.yesAtoms === 0n && input.noAtoms === 0n)) fail("redemption amount");
+  return nonzeroAddress(input.recipient, "redemption recipient");
+}
+
+export function preparePredictionV2Redeem(input: Readonly<{
+  vault: Address;
+  yesAtoms: bigint;
+  noAtoms: bigint;
+  recipient: Address;
+}>): PredictionV2PreparedTransaction {
+  const vault = nonzeroAddress(input.vault, "redeem vault");
+  const recipient = validateRedemption(input);
+  return {
+    chainId: 4_663,
+    to: vault,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: PREDICTION_V2_VAULT_ABI,
+      functionName: "redeem",
+      args: [input.yesAtoms, input.noAtoms, recipient],
+    }),
+  };
+}
+
+export function preparePredictionV2FinalizeAndRedeemWithChainlinkRounds(
+  input: Readonly<{
+    vault: Address;
+    beforeRoundId: bigint;
+    afterRoundId: bigint;
+    yesAtoms: bigint;
+    noAtoms: bigint;
+    recipient: Address;
+  }>,
+): PredictionV2PreparedTransaction {
+  const vault = nonzeroAddress(input.vault, "finalize and redeem vault");
+  const recipient = validateRedemption(input);
+  const proof = encodePredictionV2ChainlinkRoundProof(input);
+  return {
+    chainId: 4_663,
+    to: vault,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: PREDICTION_V2_VAULT_ABI,
+      functionName: "finalizeAndRedeem",
+      args: [proof, input.yesAtoms, input.noAtoms, recipient],
     }),
   };
 }

--- a/lib/prediction-v2/transactions.ts
+++ b/lib/prediction-v2/transactions.ts
@@ -1,0 +1,720 @@
+import {
+  decodeFunctionResult,
+  encodeAbiParameters,
+  encodeFunctionData,
+  isAddress,
+  parseAbiParameters,
+  zeroAddress,
+  type Address,
+  type Hex,
+} from "viem";
+
+import {
+  predictionAssetIdentityCandidatesV2,
+  predictionAssetSelectionKeyV2,
+  predictionOnchainAssetKeyV2,
+  type PredictionAssetIdentityV2,
+  type PredictionAssetSelectionV2,
+  type PredictionBytes32V2,
+} from "../prediction-market-assets-v2";
+import {
+  PREDICTION_V2_EXECUTION_ROUTER_ABI,
+  PREDICTION_V2_EXPOSURE_CONTROLLER_ABI,
+  PREDICTION_V2_FACTORY_ABI,
+  PREDICTION_V2_QUOTER_ABI,
+  PREDICTION_V2_VAULT_ABI,
+  type PredictionV2PoolKey,
+  type PredictionV2RegistrySnapshot,
+} from "./abi";
+import { predictionV2SlippageFloor } from "./accounting";
+import {
+  PREDICTION_V2_BOOTSTRAP_COLLATERAL_ATOMS,
+  PREDICTION_V2_LP_FEE_PIPS,
+  PREDICTION_V2_MAX_SQRT_PRICE_X96,
+  PREDICTION_V2_MIN_SQRT_PRICE_X96,
+  PREDICTION_V2_TICK_SPACING,
+  assertCanonicalPredictionV2Identity,
+  predictionV2RegistrySnapshotHash,
+  validatePredictionV2BuyQuote,
+  validatePredictionV2RegistrySnapshot,
+  validatePredictionV2SellQuote,
+  type PredictionV2BuyQuote,
+  type PredictionV2SellQuote,
+} from "./codec";
+
+const BYTES32_PATTERN = /^0x[0-9a-fA-F]{64}$/u;
+const ZERO_BYTES32 = `0x${"0".repeat(64)}`;
+const MAX_UINT32 = (1n << 32n) - 1n;
+const MAX_UINT80 = (1n << 80n) - 1n;
+const MAX_INT192 = (1n << 191n) - 1n;
+const MINIMUM_MARKET_DURATION_SECONDS = 24n * 60n * 60n;
+const MAXIMUM_MARKET_DURATION_SECONDS = 30n * 24n * 60n * 60n;
+
+export type PredictionV2PermitSignature = Readonly<{
+  value: bigint;
+  deadline: bigint;
+  v: 27 | 28;
+  r: PredictionBytes32V2;
+  s: PredictionBytes32V2;
+}>;
+
+export type PredictionV2PreparedTransaction = Readonly<{
+  to: Address;
+  data: Hex;
+  value: 0n;
+}>;
+
+export type PredictionV2PreparedCreate = PredictionV2PreparedTransaction & Readonly<{
+  selectionKey: string;
+  onchainAssetKey: PredictionBytes32V2;
+  registryRevision: bigint;
+  registrySnapshotHash: PredictionBytes32V2;
+  registrySnapshot: PredictionV2RegistrySnapshot;
+}>;
+
+type PredictionV2QuoteContextBase = Readonly<{
+  chainId: 4_663;
+  quoter: Address;
+  vault: Address;
+  poolKey: PredictionV2PoolKey;
+  sqrtPriceLimitX96: bigint;
+  observedBlockNumber: bigint;
+  observedBlockHash: PredictionBytes32V2;
+}>;
+
+export type PredictionV2BuyQuoteIntent = Readonly<{
+  quoter: Address;
+  vault: Address;
+  poolKey: PredictionV2PoolKey;
+  buyYes: boolean;
+  requestedCollateralAtoms: bigint;
+  sqrtPriceLimitX96: bigint;
+}>;
+
+export type PredictionV2SellQuoteIntent = Readonly<{
+  quoter: Address;
+  vault: Address;
+  poolKey: PredictionV2PoolKey;
+  sellYes: boolean;
+  outcomeAtoms: bigint;
+  sqrtPriceLimitX96: bigint;
+}>;
+
+export type PredictionV2BoundBuyQuote = PredictionV2QuoteContextBase & Readonly<{
+  buyYes: boolean;
+  requestedCollateralAtoms: bigint;
+  quote: PredictionV2BuyQuote;
+}>;
+
+export type PredictionV2BoundSellQuote = PredictionV2QuoteContextBase & Readonly<{
+  sellYes: boolean;
+  outcomeAtoms: bigint;
+  quote: PredictionV2SellQuote;
+}>;
+
+export type PredictionV2BoundBuyCapacityPreflight = Readonly<{
+  chainId: 4_663;
+  exposureController: Address;
+  vault: Address;
+  /** Full split notional, not the possibly smaller executed collateral. */
+  delta: bigint;
+  observedBlockNumber: bigint;
+  observedBlockHash: PredictionBytes32V2;
+  vaultExposureControllerCall: Readonly<{ to: Address; data: Hex }>;
+  vaultExposureControllerResult: Hex;
+  capacityCall: Readonly<{ to: Address; data: Hex }>;
+  capacityResult: "0x";
+}>;
+
+function fail(label: string): never {
+  throw new Error(`Invalid Protocol V2 ${label}.`);
+}
+
+function nonzeroAddress(value: unknown, label: string): Address {
+  if (
+    typeof value !== "string" || !isAddress(value, { strict: false }) ||
+    value.toLowerCase() === zeroAddress
+  ) fail(label);
+  return value as Address;
+}
+
+function nonzeroBytes32(value: unknown, label: string): PredictionBytes32V2 {
+  if (
+    typeof value !== "string" || !BYTES32_PATTERN.test(value) ||
+    value.toLowerCase() === ZERO_BYTES32
+  ) fail(label);
+  return value.toLowerCase() as PredictionBytes32V2;
+}
+
+function sameIdentity(
+  left: PredictionAssetIdentityV2,
+  right: PredictionAssetIdentityV2,
+) {
+  return left.sourceNamespace === right.sourceNamespace &&
+    left.sourceChain === right.sourceChain &&
+    left.assetIdentifier === right.assetIdentifier &&
+    left.assetStandard === right.assetStandard;
+}
+
+function samePoolKey(left: PredictionV2PoolKey, right: PredictionV2PoolKey) {
+  return left.currency0.toLowerCase() === right.currency0.toLowerCase() &&
+    left.currency1.toLowerCase() === right.currency1.toLowerCase() &&
+    left.fee === right.fee && left.tickSpacing === right.tickSpacing &&
+    left.hooks.toLowerCase() === right.hooks.toLowerCase();
+}
+
+function validateNow(value: bigint) {
+  if (value <= 0n || value > MAX_UINT32) fail("current timestamp");
+}
+
+function validateDeadline(deadline: bigint, nowUnixSeconds: bigint, label: string) {
+  if (deadline <= nowUnixSeconds) fail(`${label} deadline`);
+}
+
+function validateSqrtPriceLimit(value: bigint) {
+  if (
+    value <= PREDICTION_V2_MIN_SQRT_PRICE_X96 ||
+    value >= PREDICTION_V2_MAX_SQRT_PRICE_X96
+  ) fail("sqrt price limit");
+}
+
+function validateQuoteBlock(input: Readonly<{
+  observedBlockNumber: bigint;
+  observedBlockHash: PredictionBytes32V2;
+  latestConfirmedBlockNumber: bigint;
+  maximumQuoteAgeBlocks: number;
+}>) {
+  const observedBlockHash = nonzeroBytes32(input.observedBlockHash, "quote block hash");
+  if (
+    input.observedBlockNumber <= 0n || input.latestConfirmedBlockNumber < input.observedBlockNumber ||
+    input.maximumQuoteAgeBlocks > 10 ||
+    input.latestConfirmedBlockNumber - input.observedBlockNumber > BigInt(input.maximumQuoteAgeBlocks)
+  ) fail("quote freshness");
+  return observedBlockHash;
+}
+
+export function validatePredictionV2PoolKey(value: PredictionV2PoolKey): PredictionV2PoolKey {
+  const currency0 = nonzeroAddress(value.currency0, "currency0");
+  const currency1 = nonzeroAddress(value.currency1, "currency1");
+  const hooks = nonzeroAddress(value.hooks, "hook");
+  if (currency0.toLowerCase() === currency1.toLowerCase()) fail("pool currencies");
+  if (value.fee !== PREDICTION_V2_LP_FEE_PIPS) fail("pool LP fee binding");
+  if (value.tickSpacing !== PREDICTION_V2_TICK_SPACING) fail("pool tick spacing binding");
+  return { currency0, currency1, fee: value.fee, tickSpacing: value.tickSpacing, hooks };
+}
+
+function validatePermit(
+  permit: PredictionV2PermitSignature,
+  expectedValue: bigint,
+  nowUnixSeconds: bigint,
+  minimumDeadline?: bigint,
+) {
+  if (permit.value !== expectedValue) fail("permit amount");
+  validateDeadline(permit.deadline, nowUnixSeconds, "permit");
+  if (minimumDeadline !== undefined && permit.deadline < minimumDeadline) {
+    fail("permit/trade deadline ordering");
+  }
+  if (permit.v !== 27 && permit.v !== 28) fail("permit recovery id");
+  return {
+    ...permit,
+    r: nonzeroBytes32(permit.r, "permit r"),
+    s: nonzeroBytes32(permit.s, "permit s"),
+  };
+}
+
+export function encodePredictionV2BuyQuoteCall(input: Readonly<{
+  vault: Address;
+  poolKey: PredictionV2PoolKey;
+  buyYes: boolean;
+  requestedCollateralAtoms: bigint;
+  sqrtPriceLimitX96: bigint;
+}>): Hex {
+  const vault = nonzeroAddress(input.vault, "quote vault");
+  const poolKey = validatePredictionV2PoolKey(input.poolKey);
+  if (
+    input.requestedCollateralAtoms <= 0n ||
+    input.requestedCollateralAtoms % 10n !== 0n
+  ) fail("quote collateral amount");
+  validateSqrtPriceLimit(input.sqrtPriceLimitX96);
+  return encodeFunctionData({
+    abi: PREDICTION_V2_QUOTER_ABI,
+    functionName: "quoteBuy",
+    args: [
+      vault,
+      poolKey,
+      input.buyYes,
+      input.requestedCollateralAtoms,
+      input.sqrtPriceLimitX96,
+    ],
+  });
+}
+
+export function encodePredictionV2SellQuoteCall(input: Readonly<{
+  vault: Address;
+  poolKey: PredictionV2PoolKey;
+  sellYes: boolean;
+  outcomeAtoms: bigint;
+  sqrtPriceLimitX96: bigint;
+}>): Hex {
+  const vault = nonzeroAddress(input.vault, "quote vault");
+  const poolKey = validatePredictionV2PoolKey(input.poolKey);
+  if (input.outcomeAtoms <= 0n || input.outcomeAtoms > (1n << 128n) - 1n) {
+    fail("quote outcome amount");
+  }
+  validateSqrtPriceLimit(input.sqrtPriceLimitX96);
+  return encodeFunctionData({
+    abi: PREDICTION_V2_QUOTER_ABI,
+    functionName: "quoteSellOptimal",
+    args: [vault, poolKey, input.sellYes, input.outcomeAtoms, input.sqrtPriceLimitX96],
+  });
+}
+
+export function encodePredictionV2VaultExposureControllerCall(): Hex {
+  return encodeFunctionData({
+    abi: PREDICTION_V2_VAULT_ABI,
+    functionName: "exposureController",
+  });
+}
+
+export function decodePredictionV2VaultExposureController(
+  data: Hex,
+): Address {
+  return nonzeroAddress(decodeFunctionResult({
+    abi: PREDICTION_V2_VAULT_ABI,
+    functionName: "exposureController",
+    data,
+  }), "vault exposure controller");
+}
+
+export function encodePredictionV2RequireIncreaseCapacityCall(input: Readonly<{
+  vault: Address;
+  delta: bigint;
+}>): Hex {
+  const vault = nonzeroAddress(input.vault, "capacity vault");
+  if (input.delta <= 0n) fail("capacity delta");
+  return encodeFunctionData({
+    abi: PREDICTION_V2_EXPOSURE_CONTROLLER_ABI,
+    functionName: "requireIncreaseCapacity",
+    args: [vault, input.delta],
+  });
+}
+
+export function bindPredictionV2BuyQuote(input: Readonly<{
+  chainId: 4_663;
+  quoter: Address;
+  vault: Address;
+  poolKey: PredictionV2PoolKey;
+  buyYes: boolean;
+  requestedCollateralAtoms: bigint;
+  sqrtPriceLimitX96: bigint;
+  observedBlockNumber: bigint;
+  observedBlockHash: PredictionBytes32V2;
+  quote: PredictionV2BuyQuote;
+}>): PredictionV2BoundBuyQuote {
+  if (input.chainId !== 4_663) fail("quote chain");
+  const quoter = nonzeroAddress(input.quoter, "quoter");
+  const vault = nonzeroAddress(input.vault, "quote vault");
+  const poolKey = validatePredictionV2PoolKey(input.poolKey);
+  validateSqrtPriceLimit(input.sqrtPriceLimitX96);
+  if (input.observedBlockNumber <= 0n) fail("quote block number");
+  const observedBlockHash = nonzeroBytes32(input.observedBlockHash, "quote block hash");
+  const quote = validatePredictionV2BuyQuote(input.quote);
+  if (
+    input.requestedCollateralAtoms !== quote.requestedCollateralAtoms ||
+    input.requestedCollateralAtoms <= 0n
+  ) fail("buy quote amount binding");
+  return {
+    chainId: 4_663,
+    quoter,
+    vault,
+    poolKey,
+    buyYes: input.buyYes,
+    requestedCollateralAtoms: input.requestedCollateralAtoms,
+    sqrtPriceLimitX96: input.sqrtPriceLimitX96,
+    observedBlockNumber: input.observedBlockNumber,
+    observedBlockHash,
+    quote,
+  };
+}
+
+export function bindPredictionV2SellQuote(input: Readonly<{
+  chainId: 4_663;
+  quoter: Address;
+  vault: Address;
+  poolKey: PredictionV2PoolKey;
+  sellYes: boolean;
+  outcomeAtoms: bigint;
+  sqrtPriceLimitX96: bigint;
+  observedBlockNumber: bigint;
+  observedBlockHash: PredictionBytes32V2;
+  quote: PredictionV2SellQuote;
+}>): PredictionV2BoundSellQuote {
+  if (input.chainId !== 4_663) fail("quote chain");
+  const quoter = nonzeroAddress(input.quoter, "quoter");
+  const vault = nonzeroAddress(input.vault, "quote vault");
+  const poolKey = validatePredictionV2PoolKey(input.poolKey);
+  validateSqrtPriceLimit(input.sqrtPriceLimitX96);
+  if (input.observedBlockNumber <= 0n) fail("quote block number");
+  const observedBlockHash = nonzeroBytes32(input.observedBlockHash, "quote block hash");
+  const quote = validatePredictionV2SellQuote(input.quote);
+  if (input.outcomeAtoms !== quote.outcomeInAtoms || input.outcomeAtoms <= 0n) {
+    fail("sell quote amount binding");
+  }
+  return {
+    chainId: 4_663,
+    quoter,
+    vault,
+    poolKey,
+    sellYes: input.sellYes,
+    outcomeAtoms: input.outcomeAtoms,
+    sqrtPriceLimitX96: input.sqrtPriceLimitX96,
+    observedBlockNumber: input.observedBlockNumber,
+    observedBlockHash,
+    quote,
+  };
+}
+
+/**
+ * Binds two successful eth_calls at the quote's exact confirmed block:
+ * vault.exposureController() and controller.requireIncreaseCapacity(vault, requestedCollateral).
+ * This is a pre-sign diagnostic only; execution rechecks capacity atomically and can still race.
+ */
+export function bindPredictionV2BuyCapacityPreflight(input: Readonly<{
+  boundQuote: PredictionV2BoundBuyQuote;
+  observedBlockNumber: bigint;
+  observedBlockHash: PredictionBytes32V2;
+  vaultExposureControllerCall: Readonly<{ to: Address; data: Hex }>;
+  vaultExposureControllerResult: Hex;
+  capacityCall: Readonly<{ to: Address; data: Hex }>;
+  capacityResult: Hex;
+}>): PredictionV2BoundBuyCapacityPreflight {
+  const boundQuote = bindPredictionV2BuyQuote(input.boundQuote);
+  const observedBlockHash = nonzeroBytes32(input.observedBlockHash, "capacity block hash");
+  if (
+    input.observedBlockNumber !== boundQuote.observedBlockNumber ||
+    observedBlockHash !== boundQuote.observedBlockHash
+  ) fail("capacity/quote block binding");
+  const vaultExposureControllerCallTarget = nonzeroAddress(
+    input.vaultExposureControllerCall.to,
+    "exposure controller read target",
+  );
+  if (
+    vaultExposureControllerCallTarget.toLowerCase() !== boundQuote.vault.toLowerCase() ||
+    input.vaultExposureControllerCall.data !== encodePredictionV2VaultExposureControllerCall()
+  ) fail("exposure controller read binding");
+  const exposureController = decodePredictionV2VaultExposureController(
+    input.vaultExposureControllerResult,
+  );
+  const capacityCallTarget = nonzeroAddress(
+    input.capacityCall.to,
+    "capacity read target",
+  );
+  const expectedCapacityCall = encodePredictionV2RequireIncreaseCapacityCall({
+    vault: boundQuote.vault,
+    delta: boundQuote.requestedCollateralAtoms,
+  });
+  if (
+    capacityCallTarget.toLowerCase() !== exposureController.toLowerCase() ||
+    input.capacityCall.data !== expectedCapacityCall
+  ) fail("capacity call binding");
+  if (input.capacityResult !== "0x") fail("capacity result");
+  return {
+    chainId: 4_663,
+    exposureController,
+    vault: boundQuote.vault,
+    delta: boundQuote.requestedCollateralAtoms,
+    observedBlockNumber: boundQuote.observedBlockNumber,
+    observedBlockHash: boundQuote.observedBlockHash,
+    vaultExposureControllerCall: {
+      to: vaultExposureControllerCallTarget,
+      data: input.vaultExposureControllerCall.data,
+    },
+    vaultExposureControllerResult: input.vaultExposureControllerResult,
+    capacityCall: {
+      to: capacityCallTarget,
+      data: input.capacityCall.data,
+    },
+    capacityResult: "0x",
+  };
+}
+
+export function preparePredictionV2BuyWithPermit(input: Readonly<{
+  router: Address;
+  boundQuote: PredictionV2BoundBuyQuote;
+  capacityPreflight: PredictionV2BoundBuyCapacityPreflight;
+  intent: PredictionV2BuyQuoteIntent;
+  latestConfirmedBlockNumber: bigint;
+  maximumQuoteAgeBlocks: number;
+  slippageBps: number;
+  tradeDeadline: bigint;
+  permit: PredictionV2PermitSignature;
+  nowUnixSeconds: bigint;
+}>): PredictionV2PreparedTransaction {
+  validateNow(input.nowUnixSeconds);
+  const router = nonzeroAddress(input.router, "router");
+  const boundQuote = bindPredictionV2BuyQuote(input.boundQuote);
+  const capacityPreflight = bindPredictionV2BuyCapacityPreflight({
+    boundQuote,
+    observedBlockNumber: input.capacityPreflight.observedBlockNumber,
+    observedBlockHash: input.capacityPreflight.observedBlockHash,
+    vaultExposureControllerCall: input.capacityPreflight.vaultExposureControllerCall,
+    vaultExposureControllerResult: input.capacityPreflight.vaultExposureControllerResult,
+    capacityCall: input.capacityPreflight.capacityCall,
+    capacityResult: input.capacityPreflight.capacityResult,
+  });
+  if (
+    input.capacityPreflight.chainId !== 4_663 ||
+    capacityPreflight.exposureController.toLowerCase() !==
+      input.capacityPreflight.exposureController.toLowerCase() ||
+    capacityPreflight.vault.toLowerCase() !== input.capacityPreflight.vault.toLowerCase() ||
+    capacityPreflight.delta !== input.capacityPreflight.delta ||
+    capacityPreflight.vault.toLowerCase() !== boundQuote.vault.toLowerCase() ||
+    capacityPreflight.delta !== boundQuote.requestedCollateralAtoms
+  ) fail("capacity preflight binding");
+  const intent = {
+    ...input.intent,
+    quoter: nonzeroAddress(input.intent.quoter, "intended quoter"),
+    vault: nonzeroAddress(input.intent.vault, "intended vault"),
+    poolKey: validatePredictionV2PoolKey(input.intent.poolKey),
+  };
+  validateSqrtPriceLimit(intent.sqrtPriceLimitX96);
+  if (
+    boundQuote.quoter.toLowerCase() !== intent.quoter.toLowerCase() ||
+    boundQuote.vault.toLowerCase() !== intent.vault.toLowerCase() ||
+    !samePoolKey(boundQuote.poolKey, intent.poolKey) ||
+    boundQuote.buyYes !== intent.buyYes ||
+    boundQuote.requestedCollateralAtoms !== intent.requestedCollateralAtoms ||
+    boundQuote.sqrtPriceLimitX96 !== intent.sqrtPriceLimitX96
+  ) fail("buy quote intent binding");
+  validateQuoteBlock({
+    observedBlockNumber: boundQuote.observedBlockNumber,
+    observedBlockHash: boundQuote.observedBlockHash,
+    latestConfirmedBlockNumber: input.latestConfirmedBlockNumber,
+    maximumQuoteAgeBlocks: input.maximumQuoteAgeBlocks,
+  });
+  const quote = boundQuote.quote;
+  validateDeadline(input.tradeDeadline, input.nowUnixSeconds, "trade");
+  const permit = validatePermit(
+    input.permit,
+    quote.maximumPaymentAtoms,
+    input.nowUnixSeconds,
+    input.tradeDeadline,
+  );
+  const minOutcomeAtoms = predictionV2SlippageFloor(quote.outcomeAtoms, input.slippageBps);
+  return {
+    to: router,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: PREDICTION_V2_EXECUTION_ROUTER_ABI,
+      functionName: "buyOutcomeWithPermit",
+      args: [
+        boundQuote.vault,
+        boundQuote.poolKey,
+        {
+          buyYes: boundQuote.buyYes,
+          collateralAtoms: quote.requestedCollateralAtoms,
+          minOutcomeAtoms,
+          sqrtPriceLimitX96: boundQuote.sqrtPriceLimitX96,
+          deadline: input.tradeDeadline,
+        },
+        permit.deadline,
+        permit.v,
+        permit.r,
+        permit.s,
+      ],
+    }),
+  };
+}
+
+export function preparePredictionV2SellWithPermit(input: Readonly<{
+  router: Address;
+  boundQuote: PredictionV2BoundSellQuote;
+  intent: PredictionV2SellQuoteIntent;
+  latestConfirmedBlockNumber: bigint;
+  maximumQuoteAgeBlocks: number;
+  slippageBps: number;
+  tradeDeadline: bigint;
+  permit: PredictionV2PermitSignature;
+  nowUnixSeconds: bigint;
+}>): PredictionV2PreparedTransaction {
+  validateNow(input.nowUnixSeconds);
+  const router = nonzeroAddress(input.router, "router");
+  const boundQuote = bindPredictionV2SellQuote(input.boundQuote);
+  const intent = {
+    ...input.intent,
+    quoter: nonzeroAddress(input.intent.quoter, "intended quoter"),
+    vault: nonzeroAddress(input.intent.vault, "intended vault"),
+    poolKey: validatePredictionV2PoolKey(input.intent.poolKey),
+  };
+  validateSqrtPriceLimit(intent.sqrtPriceLimitX96);
+  if (
+    boundQuote.quoter.toLowerCase() !== intent.quoter.toLowerCase() ||
+    boundQuote.vault.toLowerCase() !== intent.vault.toLowerCase() ||
+    !samePoolKey(boundQuote.poolKey, intent.poolKey) ||
+    boundQuote.sellYes !== intent.sellYes ||
+    boundQuote.outcomeAtoms !== intent.outcomeAtoms ||
+    boundQuote.sqrtPriceLimitX96 !== intent.sqrtPriceLimitX96
+  ) fail("sell quote intent binding");
+  validateQuoteBlock({
+    observedBlockNumber: boundQuote.observedBlockNumber,
+    observedBlockHash: boundQuote.observedBlockHash,
+    latestConfirmedBlockNumber: input.latestConfirmedBlockNumber,
+    maximumQuoteAgeBlocks: input.maximumQuoteAgeBlocks,
+  });
+  const quote = boundQuote.quote;
+  validateDeadline(input.tradeDeadline, input.nowUnixSeconds, "trade");
+  const permit = validatePermit(
+    input.permit,
+    quote.outcomeInAtoms,
+    input.nowUnixSeconds,
+    input.tradeDeadline,
+  );
+  const minCollateralAtoms = predictionV2SlippageFloor(
+    quote.netCollateralAtoms,
+    input.slippageBps,
+  );
+  return {
+    to: router,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: PREDICTION_V2_EXECUTION_ROUTER_ABI,
+      functionName: "sellOutcomeWithPermit",
+      args: [
+        boundQuote.vault,
+        boundQuote.poolKey,
+        {
+          sellYes: boundQuote.sellYes,
+          outcomeAtoms: quote.outcomeInAtoms,
+          swapAtoms: quote.requestedSwapAtoms,
+          minCollateralAtoms,
+          sqrtPriceLimitX96: boundQuote.sqrtPriceLimitX96,
+          deadline: input.tradeDeadline,
+        },
+        permit.deadline,
+        permit.v,
+        permit.r,
+        permit.s,
+      ],
+    }),
+  };
+}
+
+export function preparePredictionV2CreateWithPermit(input: Readonly<{
+  factory: Address;
+  selection: PredictionAssetSelectionV2;
+  identity: PredictionAssetIdentityV2;
+  onchainAssetKey: PredictionBytes32V2;
+  registrySnapshot: PredictionV2RegistrySnapshot;
+  /** Exact result of AssetRegistryV2.hashSnapshot(snapshot) from the bound read. */
+  registryHashSnapshotResult: PredictionBytes32V2;
+  /** Snapshot hash returned by Factory.activeMarketId for these create parameters. */
+  factoryActiveSnapshotHash: PredictionBytes32V2;
+  /** Snapshot hash pinned by the UI release registry. */
+  releaseRegistrySnapshotHash: PredictionBytes32V2;
+  observationTime: bigint;
+  threshold: bigint;
+  permit: PredictionV2PermitSignature;
+  nowUnixSeconds: bigint;
+}>): PredictionV2PreparedCreate {
+  validateNow(input.nowUnixSeconds);
+  const factory = nonzeroAddress(input.factory, "factory");
+  const selectionKey = predictionAssetSelectionKeyV2(input.selection);
+  if (!selectionKey) fail("asset selection");
+  const identity = assertCanonicalPredictionV2Identity(input.identity);
+  if (!predictionAssetIdentityCandidatesV2(input.selection).some((candidate) =>
+    sameIdentity(candidate, identity)
+  )) fail("selection/identity binding");
+  const onchainAssetKey = nonzeroBytes32(input.onchainAssetKey, "onchain asset key");
+  if (predictionOnchainAssetKeyV2(identity) !== onchainAssetKey) fail("onchain asset key binding");
+  const registrySnapshot = validatePredictionV2RegistrySnapshot(input.registrySnapshot);
+  if (
+    registrySnapshot.assetKey !== onchainAssetKey ||
+    !sameIdentity(registrySnapshot.identity, identity) ||
+    !registrySnapshot.policy.active
+  ) fail("registry snapshot binding");
+  const computedSnapshotHash = predictionV2RegistrySnapshotHash(registrySnapshot);
+  const registryHashSnapshotResult = nonzeroBytes32(
+    input.registryHashSnapshotResult,
+    "Registry hashSnapshot result",
+  );
+  const factoryActiveSnapshotHash = nonzeroBytes32(
+    input.factoryActiveSnapshotHash,
+    "Factory active snapshot hash",
+  );
+  const releaseRegistrySnapshotHash = nonzeroBytes32(
+    input.releaseRegistrySnapshotHash,
+    "release Registry snapshot hash",
+  );
+  if (
+    registryHashSnapshotResult !== computedSnapshotHash ||
+    factoryActiveSnapshotHash !== computedSnapshotHash ||
+    releaseRegistrySnapshotHash !== computedSnapshotHash
+  ) fail("Registry snapshot hash binding");
+  if (
+    input.observationTime <= input.nowUnixSeconds + MINIMUM_MARKET_DURATION_SECONDS ||
+    input.observationTime > input.nowUnixSeconds + MAXIMUM_MARKET_DURATION_SECONDS ||
+    input.observationTime > MAX_UINT32 ||
+    input.observationTime > registrySnapshot.policy.validUntil
+  ) fail("observation time");
+  if (input.threshold <= 0n || input.threshold > MAX_INT192) fail("threshold");
+  const permit = validatePermit(
+    input.permit,
+    PREDICTION_V2_BOOTSTRAP_COLLATERAL_ATOMS,
+    input.nowUnixSeconds,
+  );
+  return {
+    to: factory,
+    value: 0n,
+    selectionKey,
+    onchainAssetKey,
+    registryRevision: registrySnapshot.revision,
+    registrySnapshotHash: computedSnapshotHash,
+    registrySnapshot,
+    data: encodeFunctionData({
+      abi: PREDICTION_V2_FACTORY_ABI,
+      functionName: "createMarketWithPermit",
+      args: [
+        identity,
+        Number(input.observationTime),
+        input.threshold,
+        permit.deadline,
+        permit.v,
+        permit.r,
+        permit.s,
+      ],
+    }),
+  };
+}
+
+export function encodePredictionV2ChainlinkRoundProof(input: Readonly<{
+  beforeRoundId: bigint;
+  afterRoundId: bigint;
+}>): Hex {
+  if (
+    input.beforeRoundId <= 0n || input.beforeRoundId > MAX_UINT80 ||
+    input.afterRoundId <= 0n || input.afterRoundId > MAX_UINT80 ||
+    input.afterRoundId !== input.beforeRoundId + 1n
+  ) fail("Chainlink round proof");
+  return encodeAbiParameters(
+    parseAbiParameters("uint80 beforeRoundId, uint80 afterRoundId"),
+    [input.beforeRoundId, input.afterRoundId],
+  );
+}
+
+export function preparePredictionV2FinalizeWithChainlinkRounds(input: Readonly<{
+  vault: Address;
+  beforeRoundId: bigint;
+  afterRoundId: bigint;
+}>): PredictionV2PreparedTransaction {
+  const vault = nonzeroAddress(input.vault, "finalize vault");
+  const proof = encodePredictionV2ChainlinkRoundProof(input);
+  return {
+    to: vault,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: PREDICTION_V2_VAULT_ABI,
+      functionName: "finalize",
+      args: [proof],
+    }),
+  };
+}

--- a/tests/prediction-asset-discovery-route.test.ts
+++ b/tests/prediction-asset-discovery-route.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  read: vi.fn(),
+}));
+
+vi.mock("../lib/market-data/prediction-asset-discovery-v2.server", () => ({
+  readPredictionAssetDiscoveryV2: mocks.read,
+}));
+
+import { NextRequest } from "next/server";
+
+import { GET } from "../app/api/prediction/asset-discovery/route";
+
+const EVM_ADDRESS = `0x${"ab".repeat(20)}`;
+const OBSERVED_AT = "2026-08-23T16:30:00.000Z";
+
+function request(query: string) {
+  return new NextRequest(
+    `http://localhost/api/prediction/asset-discovery?${query}`,
+  );
+}
+
+describe("prediction asset discovery route", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it.each([
+    "",
+    `network=base&locator=${EVM_ADDRESS}&extra=true`,
+    `network=base&network=ethereum&locator=${EVM_ADDRESS}`,
+    `network=unknown&locator=${EVM_ADDRESS}`,
+    "network=solana&locator=",
+  ])("rejects a non-canonical query without a provider read: %s", async (query) => {
+    const response = await GET(request(query));
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(mocks.read).not.toHaveBeenCalled();
+  });
+
+  it("returns an informational snapshot for one exact selection", async () => {
+    mocks.read.mockResolvedValue({
+      schemaVersion: 2,
+      selectionKey: `evm:8453:${EVM_ADDRESS}`,
+      status: "available",
+      source: "dexscreener",
+      observedAt: OBSERVED_AT,
+      usage: "informational-only",
+      currentPriceUsd: 2.5,
+      marketCapUsd: 2_500_000,
+      pair: {
+        providerChainId: "base",
+        dexId: "uniswap",
+        pairAddress: "0xpair",
+        liquidityUsd: 50_000,
+      },
+    });
+    const input = request(`network=base&locator=${EVM_ADDRESS}`);
+
+    const response = await GET(input);
+    const body = await response.json();
+
+    expect(mocks.read).toHaveBeenCalledWith(
+      {
+        mode: "custom",
+        sourceNetwork: "base",
+        assetLocator: EVM_ADDRESS,
+      },
+      { signal: input.signal },
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toContain("s-maxage=15");
+    expect(response.headers.get("x-programmable-market-provider"))
+      .toBe("dexscreener");
+    expect(response.headers.get("x-programmable-read-purpose"))
+      .toBe("informational-only");
+    expect(body).toMatchObject({
+      selectionKey: `evm:8453:${EVM_ADDRESS}`,
+      status: "available",
+      source: "dexscreener",
+      observedAt: OBSERVED_AT,
+      usage: "informational-only",
+    });
+    expect(body).not.toHaveProperty("assetKey");
+    expect(body).not.toHaveProperty("oracleStatus");
+  });
+
+  it.each([
+    ["not-found", 404],
+    ["market-data-unavailable", 503],
+    ["timeout", 503],
+    ["response-invalid", 503],
+  ] as const)("maps %s to a fail-closed HTTP response", async (
+    reason,
+    expectedStatus,
+  ) => {
+    mocks.read.mockResolvedValue({
+      schemaVersion: 2,
+      selectionKey: `evm:1:${EVM_ADDRESS}`,
+      status: "unavailable",
+      reason,
+      source: "dexscreener",
+      observedAt: OBSERVED_AT,
+      usage: "informational-only",
+    });
+
+    const response = await GET(request(
+      `network=ethereum&locator=${EVM_ADDRESS}`,
+    ));
+
+    expect(response.status).toBe(expectedStatus);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("retry-after")).toBe(
+      expectedStatus === 503 ? "5" : null,
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      status: "unavailable",
+      reason,
+      source: "dexscreener",
+      observedAt: OBSERVED_AT,
+      usage: "informational-only",
+    });
+  });
+});

--- a/tests/prediction-asset-discovery-route.test.ts
+++ b/tests/prediction-asset-discovery-route.test.ts
@@ -3,19 +3,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => ({
+  loaded: vi.fn(),
   read: vi.fn(),
 }));
 
-vi.mock("../lib/market-data/prediction-asset-discovery-v2.server", () => ({
-  readPredictionAssetDiscoveryV2: mocks.read,
-}));
+vi.mock("../lib/market-data/prediction-asset-discovery-v2.server", () => {
+  mocks.loaded();
+  return { readPredictionAssetDiscoveryV2: mocks.read };
+});
 
 import { NextRequest } from "next/server";
 
 import { GET } from "../app/api/prediction/asset-discovery/route";
 
 const EVM_ADDRESS = `0x${"ab".repeat(20)}`;
-const OBSERVED_AT = "2026-08-23T16:30:00.000Z";
 
 function request(query: string) {
   return new NextRequest(
@@ -23,104 +24,22 @@ function request(query: string) {
   );
 }
 
-describe("prediction asset discovery route", () => {
+describe("disabled Prediction V2 asset-discovery route", () => {
   beforeEach(() => vi.resetAllMocks());
 
   it.each([
     "",
+    `network=base&locator=${EVM_ADDRESS}`,
     `network=base&locator=${EVM_ADDRESS}&extra=true`,
-    `network=base&network=ethereum&locator=${EVM_ADDRESS}`,
-    `network=unknown&locator=${EVM_ADDRESS}`,
-    "network=solana&locator=",
-  ])("rejects a non-canonical query without a provider read: %s", async (query) => {
+  ])("returns a non-cacheable 404 before any provider read: %s", async (query) => {
     const response = await GET(request(query));
 
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(404);
     expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("x-programmable-market-provider")).toBeNull();
+    await expect(response.json()).resolves.toEqual({ error: "Not found" });
+    expect(mocks.loaded).not.toHaveBeenCalled();
     expect(mocks.read).not.toHaveBeenCalled();
-  });
-
-  it("returns an informational snapshot for one exact selection", async () => {
-    mocks.read.mockResolvedValue({
-      schemaVersion: 2,
-      selectionKey: `evm:8453:${EVM_ADDRESS}`,
-      status: "available",
-      source: "dexscreener",
-      observedAt: OBSERVED_AT,
-      usage: "informational-only",
-      currentPriceUsd: 2.5,
-      marketCapUsd: 2_500_000,
-      pair: {
-        providerChainId: "base",
-        dexId: "uniswap",
-        pairAddress: "0xpair",
-        liquidityUsd: 50_000,
-      },
-    });
-    const input = request(`network=base&locator=${EVM_ADDRESS}`);
-
-    const response = await GET(input);
-    const body = await response.json();
-
-    expect(mocks.read).toHaveBeenCalledWith(
-      {
-        mode: "custom",
-        sourceNetwork: "base",
-        assetLocator: EVM_ADDRESS,
-      },
-      { signal: input.signal },
-    );
-    expect(response.status).toBe(200);
-    expect(response.headers.get("cache-control")).toContain("s-maxage=15");
-    expect(response.headers.get("x-programmable-market-provider"))
-      .toBe("dexscreener");
-    expect(response.headers.get("x-programmable-read-purpose"))
-      .toBe("informational-only");
-    expect(body).toMatchObject({
-      selectionKey: `evm:8453:${EVM_ADDRESS}`,
-      status: "available",
-      source: "dexscreener",
-      observedAt: OBSERVED_AT,
-      usage: "informational-only",
-    });
-    expect(body).not.toHaveProperty("assetKey");
-    expect(body).not.toHaveProperty("oracleStatus");
-  });
-
-  it.each([
-    ["not-found", 404],
-    ["market-data-unavailable", 503],
-    ["timeout", 503],
-    ["response-invalid", 503],
-  ] as const)("maps %s to a fail-closed HTTP response", async (
-    reason,
-    expectedStatus,
-  ) => {
-    mocks.read.mockResolvedValue({
-      schemaVersion: 2,
-      selectionKey: `evm:1:${EVM_ADDRESS}`,
-      status: "unavailable",
-      reason,
-      source: "dexscreener",
-      observedAt: OBSERVED_AT,
-      usage: "informational-only",
-    });
-
-    const response = await GET(request(
-      `network=ethereum&locator=${EVM_ADDRESS}`,
-    ));
-
-    expect(response.status).toBe(expectedStatus);
-    expect(response.headers.get("cache-control")).toBe("no-store");
-    expect(response.headers.get("retry-after")).toBe(
-      expectedStatus === 503 ? "5" : null,
-    );
-    await expect(response.json()).resolves.toMatchObject({
-      status: "unavailable",
-      reason,
-      source: "dexscreener",
-      observedAt: OBSERVED_AT,
-      usage: "informational-only",
-    });
   });
 });

--- a/tests/prediction-asset-discovery-v2.test.ts
+++ b/tests/prediction-asset-discovery-v2.test.ts
@@ -1,0 +1,364 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  createPredictionAssetDiscoveryReaderV2,
+} from "../lib/market-data/prediction-asset-discovery-v2.server";
+import type {
+  PredictionCustomAssetSelectionV2,
+  PredictionSourceNetworkIdV2,
+} from "../lib/prediction-market-assets-v2";
+
+const OBSERVED_AT = "2026-08-23T16:30:00.000Z";
+const EVM_ADDRESS = `0x${"Ab".repeat(20)}`;
+const OTHER_EVM_ADDRESS = `0x${"cd".repeat(20)}`;
+const SOLANA_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+function selection(
+  sourceNetwork: PredictionSourceNetworkIdV2,
+  assetLocator = sourceNetwork === "solana" ? SOLANA_MINT : EVM_ADDRESS,
+): PredictionCustomAssetSelectionV2 {
+  return { mode: "custom", sourceNetwork, assetLocator };
+}
+
+function pair(input: Readonly<{
+  chainId: string;
+  tokenAddress: string;
+  pairAddress?: string;
+  dexId?: string;
+  priceUsd?: string | null;
+  liquidityUsd?: number | null;
+  marketCap?: number | null;
+  fdv?: number | null;
+  quoteAddress?: string;
+}>) {
+  return {
+    chainId: input.chainId,
+    dexId: input.dexId ?? "uniswap",
+    pairAddress: input.pairAddress ?? "pair-1",
+    baseToken: { address: input.tokenAddress },
+    quoteToken: { address: input.quoteAddress ?? OTHER_EVM_ADDRESS },
+    priceUsd: input.priceUsd === undefined ? "1.25" : input.priceUsd,
+    liquidity: {
+      usd: input.liquidityUsd === undefined ? 10_000 : input.liquidityUsd,
+    },
+    marketCap: input.marketCap === undefined ? 1_000_000 : input.marketCap,
+    fdv: input.fdv === undefined ? 1_200_000 : input.fdv,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200, headers?: HeadersInit) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      ...headers,
+    },
+  });
+}
+
+function reader(
+  fetchImpl: typeof fetch,
+  overrides: Partial<
+    Parameters<typeof createPredictionAssetDiscoveryReaderV2>[0]
+  > = {},
+) {
+  return createPredictionAssetDiscoveryReaderV2({
+    fetchImpl,
+    now: () => new Date(OBSERVED_AT),
+    timeoutMs: 100,
+    maximumResponseBytes: 512_000,
+    maximumRows: 256,
+    ...overrides,
+  });
+}
+
+describe("prediction asset discovery V2", () => {
+  beforeEach(() => vi.useRealTimers());
+
+  it.each([
+    ["ethereum", "ethereum", "1"],
+    ["base", "base", "8453"],
+    ["bnb", "bsc", "56"],
+    ["robinhood", "robinhood", "4663"],
+    [
+      "solana",
+      "solana",
+      "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+    ],
+  ] as const)(
+    "binds explicit %s selection to the %s provider chain",
+    async (sourceNetwork, providerChainId, chainReference) => {
+      const input = selection(sourceNetwork);
+      const expectedLocator = sourceNetwork === "solana"
+        ? SOLANA_MINT
+        : EVM_ADDRESS.toLowerCase();
+      const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
+        expect(String(url)).toBe(
+          `https://api.dexscreener.com/token-pairs/v1/${providerChainId}/${expectedLocator}`,
+        );
+        expect(init).toMatchObject({
+          method: "GET",
+          cache: "no-store",
+          redirect: "error",
+        });
+        return jsonResponse([
+          pair({
+            chainId: providerChainId,
+            tokenAddress: expectedLocator,
+            pairAddress: `pair-${providerChainId}`,
+          }),
+        ]);
+      });
+
+      const result = await reader(fetchImpl).read(input);
+
+      expect(result).toMatchObject({
+        schemaVersion: 2,
+        selectionKey: sourceNetwork === "solana"
+          ? `solana:${chainReference}:${SOLANA_MINT}`
+          : `evm:${chainReference}:${EVM_ADDRESS.toLowerCase()}`,
+        status: "available",
+        source: "dexscreener",
+        observedAt: OBSERVED_AT,
+        usage: "informational-only",
+        currentPriceUsd: 1.25,
+        marketCapUsd: 1_000_000,
+        pair: { providerChainId },
+      });
+      expect(result).not.toHaveProperty("assetKey");
+      expect(result).not.toHaveProperty("oracleStatus");
+      expect(result).not.toHaveProperty("releaseId");
+      expect(result).not.toHaveProperty("settlementEligible");
+    },
+  );
+
+  it("selects the deepest exact pair with deterministic lexical tie-breaking", async () => {
+    const exact = EVM_ADDRESS.toLowerCase();
+    const rows = [
+      pair({
+        chainId: "ethereum",
+        tokenAddress: exact,
+        pairAddress: "0xbbb",
+        dexId: "zeta",
+        priceUsd: "2.50",
+        liquidityUsd: 50_000,
+        marketCap: 2_500_000,
+      }),
+      pair({
+        chainId: "ethereum",
+        tokenAddress: exact,
+        pairAddress: "0xaaa",
+        dexId: "alpha",
+        priceUsd: "2.25",
+        liquidityUsd: 50_000,
+        marketCap: 2_250_000,
+      }),
+      pair({
+        chainId: "ethereum",
+        tokenAddress: exact,
+        pairAddress: "0xccc",
+        priceUsd: "9.99",
+        liquidityUsd: 49_999,
+        marketCap: 9_990_000,
+      }),
+    ];
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse(rows))
+      .mockResolvedValueOnce(jsonResponse([...rows].reverse()));
+    const discovery = reader(fetchImpl);
+
+    const first = await discovery.read(selection("ethereum"));
+    const reversed = await discovery.read(selection("ethereum"));
+
+    expect(first).toMatchObject({
+      status: "available",
+      currentPriceUsd: 2.25,
+      marketCapUsd: 2_250_000,
+      pair: {
+        dexId: "alpha",
+        pairAddress: "0xaaa",
+        liquidityUsd: 50_000,
+      },
+    });
+    expect(reversed).toEqual(first);
+  });
+
+  it("ignores foreign chains, wrong base tokens and quote-side-only matches", async () => {
+    const exact = EVM_ADDRESS.toLowerCase();
+    const fetchImpl = vi.fn<typeof fetch>(async () => jsonResponse([
+      pair({
+        chainId: "base",
+        tokenAddress: exact,
+        liquidityUsd: 1_000_000,
+      }),
+      pair({
+        chainId: "ethereum",
+        tokenAddress: OTHER_EVM_ADDRESS,
+        quoteAddress: exact,
+        liquidityUsd: 900_000,
+      }),
+      pair({
+        chainId: "ethereum",
+        tokenAddress: OTHER_EVM_ADDRESS,
+        liquidityUsd: 800_000,
+      }),
+      pair({
+        chainId: "ethereum",
+        tokenAddress: EVM_ADDRESS,
+        pairAddress: "0xexact",
+        liquidityUsd: 100,
+      }),
+    ]));
+
+    await expect(reader(fetchImpl).read(selection("ethereum"))).resolves
+      .toMatchObject({
+        status: "available",
+        pair: { pairAddress: "0xexact", liquidityUsd: 100 },
+      });
+  });
+
+  it("does not substitute FDV when provider market cap is unavailable", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => jsonResponse([
+      pair({
+        chainId: "bsc",
+        tokenAddress: EVM_ADDRESS.toLowerCase(),
+        marketCap: null,
+        fdv: 99_000_000,
+      }),
+    ]));
+
+    const result = await reader(fetchImpl).read(selection("bnb"));
+
+    expect(result).toMatchObject({
+      status: "unavailable",
+      reason: "market-data-unavailable",
+      source: "dexscreener",
+      observedAt: OBSERVED_AT,
+      usage: "informational-only",
+    });
+    expect(result).not.toHaveProperty("currentPriceUsd");
+    expect(result).not.toHaveProperty("marketCapUsd");
+  });
+
+  it("fails closed before fetch for incomplete or cross-namespace locators", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const discovery = reader(fetchImpl);
+
+    await expect(discovery.read({
+      mode: "custom",
+      sourceNetwork: "",
+      assetLocator: EVM_ADDRESS,
+    })).resolves.toMatchObject({
+      selectionKey: null,
+      status: "unavailable",
+      reason: "invalid-selection",
+    });
+    await expect(discovery.read({
+      mode: "custom",
+      sourceNetwork: "solana",
+      assetLocator: EVM_ADDRESS,
+    })).resolves.toMatchObject({
+      selectionKey: null,
+      status: "unavailable",
+      reason: "invalid-selection",
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [jsonResponse({ pairs: [] }), "response-invalid"],
+    [jsonResponse([pair({
+      chainId: "ethereum",
+      tokenAddress: EVM_ADDRESS.toLowerCase(),
+      marketCap: null,
+    }), "not-a-row"]), "response-invalid"],
+    [jsonResponse([pair({
+      chainId: "ethereum",
+      tokenAddress: EVM_ADDRESS.toLowerCase(),
+    })], 200, { "content-length": "999999" }), "response-too-large"],
+  ] as const)("fails closed on invalid or oversized responses", async (
+    response,
+    reason,
+  ) => {
+    const result = await reader(vi.fn(async () => response), {
+      maximumResponseBytes: 1_000,
+    }).read(selection("ethereum"));
+    expect(result).toMatchObject({ status: "unavailable", reason });
+  });
+
+  it("enforces the byte cap even when the body has no declared length", async () => {
+    const oversized = jsonResponse([
+      pair({
+        chainId: "ethereum",
+        tokenAddress: EVM_ADDRESS.toLowerCase(),
+      }),
+    ]);
+    oversized.headers.delete("content-length");
+
+    const result = await reader(vi.fn(async () => oversized), {
+      maximumResponseBytes: 64,
+    }).read(selection("ethereum"));
+
+    expect(result).toMatchObject({
+      status: "unavailable",
+      reason: "response-too-large",
+    });
+  });
+
+  it("bounds a provider that ignores AbortSignal", async () => {
+    vi.useFakeTimers();
+    let signal: AbortSignal | undefined;
+    const fetchImpl = vi.fn<typeof fetch>((_url, init) => {
+      signal = init?.signal ?? undefined;
+      return new Promise<Response>(() => undefined);
+    });
+    const pending = reader(fetchImpl, { timeoutMs: 100 })
+      .read(selection("ethereum"));
+
+    await vi.advanceTimersByTimeAsync(101);
+
+    await expect(pending).resolves.toMatchObject({
+      status: "unavailable",
+      reason: "timeout",
+    });
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it("propagates caller cancellation as an unavailable informational read", async () => {
+    let signal: AbortSignal | undefined;
+    const fetchImpl = vi.fn<typeof fetch>((_url, init) => {
+      signal = init?.signal ?? undefined;
+      return new Promise<Response>(() => undefined);
+    });
+    const controller = new AbortController();
+    const pending = reader(fetchImpl).read(selection("ethereum"), {
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+
+    controller.abort();
+
+    await expect(pending).resolves.toMatchObject({
+      status: "unavailable",
+      reason: "aborted",
+    });
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it.each([
+    [429, "rate-limited"],
+    [500, "provider-unavailable"],
+  ] as const)("classifies provider HTTP %s without exposing its body", async (
+    status,
+    reason,
+  ) => {
+    const result = await reader(vi.fn(async () => jsonResponse(
+      { secret: "provider detail" },
+      status,
+    ))).read(selection("robinhood"));
+    expect(result).toMatchObject({ status: "unavailable", reason });
+    expect(JSON.stringify(result)).not.toContain("provider detail");
+  });
+});

--- a/tests/prediction-market-asset-selector-v2.test.ts
+++ b/tests/prediction-market-asset-selector-v2.test.ts
@@ -33,7 +33,7 @@ describe("PredictionMarketAssetSelectorV2", () => {
         },
         onChange: () => undefined,
         discoverySnapshot: {
-          assetKey:
+          selectionKey:
             "evm:1:0x1111111111111111111111111111111111111111",
           status: "available",
           currentPriceUsd: 0.25,
@@ -50,6 +50,7 @@ describe("PredictionMarketAssetSelectorV2", () => {
     expect(html).toContain("Solana");
     expect(html).toContain("Contract address");
     expect(html).toContain("The address alone does not identify its network");
+    expect(html).toContain("0x1111111111111111111111111111111111111111");
     expect(html).toContain("Current price · info only");
     expect(html).toContain("Market cap · info only");
     expect(html).toContain("Not available yet");

--- a/tests/prediction-market-asset-selector-v2.test.ts
+++ b/tests/prediction-market-asset-selector-v2.test.ts
@@ -42,17 +42,18 @@ describe("PredictionMarketAssetSelectorV2", () => {
       }),
     );
 
-    expect(html).toContain("Select network");
+    expect(html).toContain("Choose network");
     expect(html).toContain("Ethereum");
     expect(html).toContain("Base");
     expect(html).toContain("BNB Chain");
     expect(html).toContain("Robinhood Chain");
     expect(html).toContain("Solana");
     expect(html).toContain("Contract address");
-    expect(html).toContain("The address alone does not identify its network");
+    expect(html).toContain("Use the token contract on the selected network");
     expect(html).toContain("0x1111111111111111111111111111111111111111");
-    expect(html).toContain("Current price · info only");
-    expect(html).toContain("Market cap · info only");
+    expect(html).toContain("Current price");
+    expect(html).toContain("Market cap");
+    expect(html).toContain("Current asset data, informational only");
     expect(html).toContain("Not available yet");
   });
 });

--- a/tests/prediction-market-asset-selector-v2.test.ts
+++ b/tests/prediction-market-asset-selector-v2.test.ts
@@ -1,0 +1,57 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { PredictionMarketAssetSelectorV2 } from "../components/prediction-market-asset-selector-v2";
+
+describe("PredictionMarketAssetSelectorV2", () => {
+  it("renders the four presets without suggesting an unreleased market is tradable", () => {
+    const html = renderToStaticMarkup(
+      createElement(PredictionMarketAssetSelectorV2, {
+        value: { mode: "preset", presetId: "btc" },
+        onChange: () => undefined,
+      }),
+    );
+
+    expect(html).toContain("Bitcoin");
+    expect(html).toContain("Ethereum");
+    expect(html).toContain("Solana");
+    expect(html).toContain("BNB");
+    expect(html).toContain("Not available yet");
+    expect(html).toContain("No released price source is configured");
+    expect(html).not.toContain("Create market");
+    expect(html).not.toContain("Market cap bet");
+  });
+
+  it("requires an explicit custom network and labels reference data as reference", () => {
+    const html = renderToStaticMarkup(
+      createElement(PredictionMarketAssetSelectorV2, {
+        value: {
+          mode: "custom",
+          sourceNetwork: "ethereum",
+          assetLocator: "0x1111111111111111111111111111111111111111",
+        },
+        onChange: () => undefined,
+        discoverySnapshot: {
+          assetKey:
+            "evm:1:0x1111111111111111111111111111111111111111",
+          status: "available",
+          currentPriceUsd: 0.25,
+          marketCapUsd: 100_000,
+        },
+      }),
+    );
+
+    expect(html).toContain("Select network");
+    expect(html).toContain("Ethereum");
+    expect(html).toContain("Base");
+    expect(html).toContain("BNB Chain");
+    expect(html).toContain("Robinhood Chain");
+    expect(html).toContain("Solana");
+    expect(html).toContain("Contract address");
+    expect(html).toContain("The address alone does not identify its network");
+    expect(html).toContain("Current price · info only");
+    expect(html).toContain("Market cap · info only");
+    expect(html).toContain("Not available yet");
+  });
+});

--- a/tests/prediction-market-assets-v2.test.ts
+++ b/tests/prediction-market-assets-v2.test.ts
@@ -3,20 +3,62 @@ import { describe, expect, it } from "vitest";
 import {
   PREDICTION_MARKET_DRAFT_SCHEMA_V2,
   PREDICTION_PRESET_ASSETS_V2,
+  PREDICTION_SOLANA_MAINNET_GENESIS_V2,
+  PREDICTION_SOLANA_TOKEN_2022_PROGRAM_V2,
+  PREDICTION_SOLANA_TOKEN_PROGRAM_V2,
   PREDICTION_SOURCE_NETWORKS_V2,
   formatPredictionAssetUsdV2,
   isPredictionAssetReleaseRegistryV2,
   isSolanaPredictionAssetLocatorV2,
-  predictionAssetKeyV2,
+  predictionAssetIdentityCandidatesV2,
   predictionAssetMarketStateV2,
+  predictionAssetSelectionKeyV2,
   predictionAssetSnapshotMatchesSelectionV2,
+  predictionOnchainAssetKeyV2,
   validatePredictionAssetSelectionV2,
+  type PredictionAssetIdentityV2,
+  type PredictionAssetReleaseEntryV2,
   type PredictionAssetReleaseRegistryV2,
   type PredictionAssetSelectionV2,
 } from "../lib/prediction-market-assets-v2";
 
 const EVM_ADDRESS = "0x1111111111111111111111111111111111111111";
 const SOLANA_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const SNAPSHOT_HASH = `0x${"ab".repeat(32)}` as const;
+
+function entryFor(
+  selection: PredictionAssetSelectionV2,
+  oracleStatus: "ready" | "unknown" | "unsupported" | "paused",
+  identityIndex = 0,
+): PredictionAssetReleaseEntryV2 {
+  const selectionKey = predictionAssetSelectionKeyV2(selection);
+  const identity = predictionAssetIdentityCandidatesV2(selection)[identityIndex];
+  if (!selectionKey || !identity) throw new Error("invalid test selection");
+  const onchainAssetKey = predictionOnchainAssetKeyV2(identity);
+  const base = {
+    selectionKey,
+    onchainAssetKey,
+    identity,
+    marketType: "usd-price-at-utc" as const,
+  };
+  if (oracleStatus === "unknown" || oracleStatus === "unsupported") {
+    return { ...base, oracleStatus, snapshot: null, release: null };
+  }
+  return {
+    ...base,
+    oracleStatus,
+    snapshot: { assetKey: onchainAssetKey, revision: 1, snapshotHash: SNAPSHOT_HASH },
+    release: { id: "protocol-v2", oraclePolicyId: "btc-usd-checkpoint-v2" },
+  };
+}
+
+function registry(entries: readonly PredictionAssetReleaseEntryV2[]) {
+  return {
+    schemaVersion: 2,
+    settlementNetwork: { id: "robinhood", chainId: 4_663 },
+    entries,
+  } as const satisfies PredictionAssetReleaseRegistryV2;
+}
 
 describe("prediction market V2 asset model", () => {
   it("keeps the market type narrow and exposes the five explicit source networks", () => {
@@ -42,172 +84,182 @@ describe("prediction market V2 asset model", () => {
     ]);
   });
 
+  it("separates the preset lookup key from its canonical GLOBAL onchain identity", () => {
+    const selection = { mode: "preset", presetId: "btc" } as const;
+    const [identity] = predictionAssetIdentityCandidatesV2(selection);
+
+    expect(predictionAssetSelectionKeyV2(selection)).toBe("preset:btc");
+    expect(identity).toEqual({
+      sourceNamespace:
+        "0x474c4f42414c5f43525950544f00000000000000000000000000000000000000",
+      sourceChain:
+        "0x474c4f42414c0000000000000000000000000000000000000000000000000000",
+      assetIdentifier:
+        "0x4254430000000000000000000000000000000000000000000000000000000000",
+      assetStandard:
+        "0x4e41544956450000000000000000000000000000000000000000000000000000",
+    });
+    expect(predictionOnchainAssetKeyV2(identity)).toBe(
+      "0x3d828bf330119f559432fd0e22c4b301bb8d7406b7f1183e70581179a3bff8c2",
+    );
+    expect(predictionOnchainAssetKeyV2(identity)).not.toBe("preset:btc");
+  });
+
   it("never infers an EVM network from the contract address", () => {
     const ethereum: PredictionAssetSelectionV2 = {
       mode: "custom",
       sourceNetwork: "ethereum",
       assetLocator: EVM_ADDRESS,
     };
-    const base: PredictionAssetSelectionV2 = {
-      ...ethereum,
-      sourceNetwork: "base",
-    };
-    expect(predictionAssetKeyV2(ethereum)).toBe(
-      `evm:1:${EVM_ADDRESS}`,
+    const base: PredictionAssetSelectionV2 = { ...ethereum, sourceNetwork: "base" };
+
+    expect(predictionAssetSelectionKeyV2(ethereum)).toBe(`evm:1:${EVM_ADDRESS}`);
+    expect(predictionAssetSelectionKeyV2(base)).toBe(`evm:8453:${EVM_ADDRESS}`);
+    const [ethereumIdentity] = predictionAssetIdentityCandidatesV2(ethereum);
+    const [baseIdentity] = predictionAssetIdentityCandidatesV2(base);
+    expect(ethereumIdentity).toMatchObject({
+      sourceNamespace:
+        "0x4549503135350000000000000000000000000000000000000000000000000000",
+      sourceChain: `0x${"0".repeat(63)}1`,
+      assetIdentifier: `0x${"0".repeat(24)}${EVM_ADDRESS.slice(2)}`,
+      assetStandard:
+        "0x4552433230000000000000000000000000000000000000000000000000000000",
+    });
+    expect(predictionOnchainAssetKeyV2(ethereumIdentity)).not.toBe(
+      predictionOnchainAssetKeyV2(baseIdentity),
     );
-    expect(predictionAssetKeyV2(base)).toBe(
-      `evm:8453:${EVM_ADDRESS}`,
-    );
-    expect(predictionAssetKeyV2(ethereum)).not.toBe(predictionAssetKeyV2(base));
-    expect(
-      validatePredictionAssetSelectionV2({
-        mode: "custom",
-        sourceNetwork: "",
-        assetLocator: EVM_ADDRESS,
-      }),
-    ).toMatchObject({
+    expect(validatePredictionAssetSelectionV2({
+      mode: "custom",
+      sourceNetwork: "ethereum",
+      assetLocator: `0x${"0".repeat(40)}`,
+    }).ok).toBe(false);
+    expect(validatePredictionAssetSelectionV2({
+      mode: "custom",
+      sourceNetwork: "",
+      assetLocator: EVM_ADDRESS,
+    })).toMatchObject({
       ok: false,
       errors: { sourceNetwork: "Choose the token network." },
     });
   });
 
-  it("validates Solana mints separately from EVM addresses", () => {
+  it("binds a Solana mainnet mint to the exact released token program", () => {
+    const selection = {
+      mode: "custom",
+      sourceNetwork: "solana",
+      assetLocator: SOLANA_MINT,
+    } as const;
     expect(isSolanaPredictionAssetLocatorV2(SOLANA_MINT)).toBe(true);
     expect(isSolanaPredictionAssetLocatorV2(EVM_ADDRESS)).toBe(false);
-    expect(
-      predictionAssetKeyV2({
-        mode: "custom",
-        sourceNetwork: "solana",
-        assetLocator: SOLANA_MINT,
-      }),
-    ).toBe(
+    expect(isSolanaPredictionAssetLocatorV2("1".repeat(32))).toBe(false);
+    expect(predictionAssetSelectionKeyV2(selection)).toBe(
       `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d:${SOLANA_MINT}`,
     );
-    expect(
-      validatePredictionAssetSelectionV2({
-        mode: "custom",
-        sourceNetwork: "ethereum",
-        assetLocator: SOLANA_MINT,
-      }).ok,
-    ).toBe(false);
+
+    const identities = predictionAssetIdentityCandidatesV2(selection);
+    expect(identities).toHaveLength(2);
+    expect(identities.map(({ sourceChain }) => sourceChain)).toEqual([
+      PREDICTION_SOLANA_MAINNET_GENESIS_V2,
+      PREDICTION_SOLANA_MAINNET_GENESIS_V2,
+    ]);
+    expect(identities.map(({ assetStandard }) => assetStandard)).toEqual([
+      PREDICTION_SOLANA_TOKEN_PROGRAM_V2,
+      PREDICTION_SOLANA_TOKEN_2022_PROGRAM_V2,
+    ]);
+    expect(identities[0].assetIdentifier).toBe(
+      "0xc6fa7af3bedbad3a3d65f36aabc97431b1bbe4c2d2f6e0e47ca60203452f5d61",
+    );
   });
 
-  it("fails closed until one released price source is ready", () => {
+  it("fails closed until one exact released snapshot is ready", () => {
     const selection = { mode: "preset", presetId: "btc" } as const;
     expect(predictionAssetMarketStateV2(selection)).toMatchObject({
       state: "unavailable",
       code: "release-unconfigured",
+      selectionKey: "preset:btc",
     });
-
-    const unsupportedRegistry: PredictionAssetReleaseRegistryV2 = {
-      schemaVersion: 2,
-      settlementNetwork: { id: "robinhood", chainId: 4_663 },
-      entries: [],
-    };
+    expect(predictionAssetMarketStateV2(selection, registry([]))).toMatchObject({
+      state: "unavailable",
+      code: "oracle-unsupported",
+    });
     expect(
-      predictionAssetMarketStateV2(selection, unsupportedRegistry),
-    ).toMatchObject({ state: "unavailable", code: "oracle-unsupported" });
+      predictionAssetMarketStateV2(selection, registry([entryFor(selection, "unknown")])),
+    ).toMatchObject({ state: "unavailable", code: "oracle-unknown" });
 
-    const unknownRegistry: PredictionAssetReleaseRegistryV2 = {
-      ...unsupportedRegistry,
-      entries: [
-        {
-          assetKey: "preset:btc",
-          marketType: "usd-price-at-utc",
-          oracleStatus: "unknown",
-        },
-      ],
-    };
-    expect(predictionAssetMarketStateV2(selection, unknownRegistry)).toMatchObject(
-      { state: "unavailable", code: "oracle-unknown" },
-    );
-
-    const readyRegistry: PredictionAssetReleaseRegistryV2 = {
-      ...unsupportedRegistry,
-      entries: [
-        {
-          assetKey: "preset:btc",
-          marketType: "usd-price-at-utc",
-          oracleStatus: "ready",
-          oraclePolicyId: "btc-usd-checkpoint-v2",
-          releaseId: "protocol-v2",
-        },
-      ],
-    };
-    expect(predictionAssetMarketStateV2(selection, readyRegistry)).toMatchObject({
+    const ready = entryFor(selection, "ready");
+    expect(predictionAssetMarketStateV2(selection, registry([ready]))).toMatchObject({
       state: "available",
       code: "ready",
+      selectionKey: "preset:btc",
+      onchainAssetKey: ready.onchainAssetKey,
     });
   });
 
-  it("rejects ambiguous and malformed release configuration", () => {
-    const malformed = {
-      schemaVersion: 2,
-      settlementNetwork: { id: "robinhood", chainId: 4_663 },
-      entries: [
-        {
-          assetKey: "preset:btc",
-          marketType: "usd-price-at-utc",
-          oracleStatus: "ready",
-        },
-      ],
+  it("rejects a lookup key masquerading as assetKey and any identity or snapshot mismatch", () => {
+    const selection = { mode: "preset", presetId: "btc" } as const;
+    const ready = entryFor(selection, "ready");
+    const invalidKey = {
+      ...registry([ready]),
+      entries: [{ ...ready, onchainAssetKey: "preset:btc" }],
     };
-    expect(isPredictionAssetReleaseRegistryV2(malformed)).toBe(false);
-    expect(
-      predictionAssetMarketStateV2(
-        { mode: "preset", presetId: "btc" },
-        malformed as PredictionAssetReleaseRegistryV2,
-      ),
-    ).toMatchObject({ state: "unavailable", code: "release-invalid" });
+    expect(isPredictionAssetReleaseRegistryV2(invalidKey)).toBe(false);
+    expect(isPredictionAssetReleaseRegistryV2({
+      ...registry([ready]),
+      entries: [{ ...ready, assetKey: ready.onchainAssetKey }],
+    })).toBe(false);
 
-    const duplicate: PredictionAssetReleaseRegistryV2 = {
-      schemaVersion: 2,
-      settlementNetwork: { id: "robinhood", chainId: 4_663 },
-      entries: [
-        {
-          assetKey: "preset:btc",
-          marketType: "usd-price-at-utc",
-          oracleStatus: "ready",
-          oraclePolicyId: "policy-a",
-          releaseId: "release-a",
-        },
-        {
-          assetKey: "preset:btc",
-          marketType: "usd-price-at-utc",
-          oracleStatus: "ready",
-          oraclePolicyId: "policy-b",
-          releaseId: "release-b",
-        },
-      ],
+    const wrongIdentity: PredictionAssetIdentityV2 = {
+      ...ready.identity,
+      assetIdentifier:
+        "0x4554480000000000000000000000000000000000000000000000000000000000",
     };
-    expect(
-      predictionAssetMarketStateV2(
-        { mode: "preset", presetId: "btc" },
-        duplicate,
-      ),
-    ).toMatchObject({ state: "unavailable", code: "oracle-ambiguous" });
+    expect(isPredictionAssetReleaseRegistryV2({
+      ...registry([ready]),
+      entries: [{
+        ...ready,
+        identity: wrongIdentity,
+        onchainAssetKey: predictionOnchainAssetKeyV2(wrongIdentity),
+        snapshot: {
+          ...ready.snapshot,
+          assetKey: predictionOnchainAssetKeyV2(wrongIdentity),
+        },
+      }],
+    })).toBe(false);
+    expect(isPredictionAssetReleaseRegistryV2({
+      ...registry([ready]),
+      entries: [{ ...ready, snapshot: { ...ready.snapshot, assetKey: `0x${"12".repeat(32)}` } }],
+    })).toBe(false);
   });
 
-  it("keeps discovery data informational and bound to the exact asset key", () => {
+  it("rejects ambiguous release configuration", () => {
+    const selection = { mode: "preset", presetId: "btc" } as const;
+    const first = entryFor(selection, "ready");
+    if (first.oracleStatus !== "ready") throw new Error("expected ready entry");
+    const duplicate = {
+      ...first,
+      release: { id: "protocol-v2-b", oraclePolicyId: "policy-b" },
+    } as const;
+    expect(isPredictionAssetReleaseRegistryV2(registry([first, duplicate]))).toBe(true);
+    expect(predictionAssetMarketStateV2(selection, registry([first, duplicate]))).toMatchObject({
+      state: "unavailable",
+      code: "oracle-ambiguous",
+    });
+  });
+
+  it("keeps discovery informational and bound only to selectionKey", () => {
     const selection = { mode: "preset", presetId: "btc" } as const;
     const snapshot = {
-      assetKey: "preset:btc",
+      selectionKey: "preset:btc",
       status: "available",
       currentPriceUsd: 61_234.5,
       marketCapUsd: 1_210_000_000_000,
     } as const;
-    expect(predictionAssetSnapshotMatchesSelectionV2(snapshot, selection)).toBe(
-      true,
-    );
-    expect(
-      predictionAssetSnapshotMatchesSelectionV2(
-        { ...snapshot, assetKey: "preset:eth" },
-        selection,
-      ),
-    ).toBe(false);
-    expect(predictionAssetMarketStateV2(selection)).toMatchObject({
-      state: "unavailable",
-    });
+    expect(predictionAssetSnapshotMatchesSelectionV2(snapshot, selection)).toBe(true);
+    expect(predictionAssetSnapshotMatchesSelectionV2(
+      { ...snapshot, selectionKey: "preset:eth" },
+      selection,
+    )).toBe(false);
+    expect(snapshot).not.toHaveProperty("onchainAssetKey");
     expect(formatPredictionAssetUsdV2(snapshot.currentPriceUsd, "price")).toBe(
       "$61,234.50",
     );

--- a/tests/prediction-market-assets-v2.test.ts
+++ b/tests/prediction-market-assets-v2.test.ts
@@ -12,6 +12,7 @@ import {
   isSolanaPredictionAssetLocatorV2,
   predictionAssetIdentityCandidatesV2,
   predictionAssetMarketStateV2,
+  predictionAssetRevisionForAbiV2,
   predictionAssetSelectionKeyV2,
   predictionAssetSnapshotMatchesSelectionV2,
   predictionOnchainAssetKeyV2,
@@ -47,7 +48,7 @@ function entryFor(
   return {
     ...base,
     oracleStatus,
-    snapshot: { assetKey: onchainAssetKey, revision: 1, snapshotHash: SNAPSHOT_HASH },
+    snapshot: { assetKey: onchainAssetKey, revision: "1", snapshotHash: SNAPSHOT_HASH },
     release: { id: "protocol-v2", oraclePolicyId: "btc-usd-checkpoint-v2" },
   };
 }
@@ -229,6 +230,60 @@ describe("prediction market V2 asset model", () => {
       ...registry([ready]),
       entries: [{ ...ready, snapshot: { ...ready.snapshot, assetKey: `0x${"12".repeat(32)}` } }],
     })).toBe(false);
+  });
+
+  it("keeps the full nonzero uint64 Registry revision exact as canonical decimal text", () => {
+    const selection = { mode: "preset", presetId: "btc" } as const;
+    const ready = entryFor(selection, "ready");
+    if (ready.oracleStatus !== "ready") throw new Error("expected ready entry");
+    const withRevision = (revision: unknown) => ({
+      ...registry([ready]),
+      entries: [{
+        ...ready,
+        snapshot: { ...ready.snapshot, revision },
+      }],
+    });
+
+    const aboveSafeInteger = withRevision("9007199254740993");
+    if (!isPredictionAssetReleaseRegistryV2(aboveSafeInteger)) {
+      throw new Error("expected revision above Number.MAX_SAFE_INTEGER to be valid");
+    }
+    const [aboveSafeIntegerEntry] = aboveSafeInteger.entries;
+    if (!aboveSafeIntegerEntry.snapshot) throw new Error("expected released snapshot");
+    expect(predictionAssetRevisionForAbiV2(aboveSafeIntegerEntry.snapshot.revision)).toBe(
+      9_007_199_254_740_993n,
+    );
+
+    const maxUint64 = withRevision("18446744073709551615");
+    if (!isPredictionAssetReleaseRegistryV2(maxUint64)) {
+      throw new Error("expected max uint64 revision to be valid");
+    }
+    const [maxEntry] = maxUint64.entries;
+    if (!maxEntry.snapshot) throw new Error("expected released snapshot");
+    expect(maxEntry.snapshot.revision).toBe("18446744073709551615");
+    expect(predictionAssetRevisionForAbiV2(maxEntry.snapshot.revision)).toBe(
+      18_446_744_073_709_551_615n,
+    );
+
+    for (const revision of [
+      "18446744073709551616",
+      "0",
+      "00",
+      "01",
+      "+1",
+      "-1",
+      " 1",
+      "1 ",
+      "1.0",
+      "1e3",
+      "",
+      1,
+      1n,
+    ]) {
+      expect(isPredictionAssetReleaseRegistryV2(withRevision(revision))).toBe(false);
+    }
+    expect(() => predictionAssetRevisionForAbiV2("0")).toThrow(TypeError);
+    expect(() => predictionAssetRevisionForAbiV2("18446744073709551616")).toThrow(TypeError);
   });
 
   it("rejects ambiguous release configuration", () => {

--- a/tests/prediction-market-assets-v2.test.ts
+++ b/tests/prediction-market-assets-v2.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PREDICTION_MARKET_DRAFT_SCHEMA_V2,
+  PREDICTION_PRESET_ASSETS_V2,
+  PREDICTION_SOURCE_NETWORKS_V2,
+  formatPredictionAssetUsdV2,
+  isPredictionAssetReleaseRegistryV2,
+  isSolanaPredictionAssetLocatorV2,
+  predictionAssetKeyV2,
+  predictionAssetMarketStateV2,
+  predictionAssetSnapshotMatchesSelectionV2,
+  validatePredictionAssetSelectionV2,
+  type PredictionAssetReleaseRegistryV2,
+  type PredictionAssetSelectionV2,
+} from "../lib/prediction-market-assets-v2";
+
+const EVM_ADDRESS = "0x1111111111111111111111111111111111111111";
+const SOLANA_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+describe("prediction market V2 asset model", () => {
+  it("keeps the market type narrow and exposes the five explicit source networks", () => {
+    expect(PREDICTION_MARKET_DRAFT_SCHEMA_V2).toMatchObject({
+      marketType: "usd-price-at-utc",
+      comparator: "greater-than-or-equal",
+      quoteCurrency: "USD",
+      observationTimezone: "UTC",
+      settlementNetwork: { id: "robinhood", chainId: 4_663 },
+    });
+    expect(PREDICTION_SOURCE_NETWORKS_V2.map(({ id }) => id)).toEqual([
+      "ethereum",
+      "base",
+      "bnb",
+      "robinhood",
+      "solana",
+    ]);
+    expect(PREDICTION_PRESET_ASSETS_V2.map(({ symbol }) => symbol)).toEqual([
+      "BTC",
+      "ETH",
+      "SOL",
+      "BNB",
+    ]);
+  });
+
+  it("never infers an EVM network from the contract address", () => {
+    const ethereum: PredictionAssetSelectionV2 = {
+      mode: "custom",
+      sourceNetwork: "ethereum",
+      assetLocator: EVM_ADDRESS,
+    };
+    const base: PredictionAssetSelectionV2 = {
+      ...ethereum,
+      sourceNetwork: "base",
+    };
+    expect(predictionAssetKeyV2(ethereum)).toBe(
+      `evm:1:${EVM_ADDRESS}`,
+    );
+    expect(predictionAssetKeyV2(base)).toBe(
+      `evm:8453:${EVM_ADDRESS}`,
+    );
+    expect(predictionAssetKeyV2(ethereum)).not.toBe(predictionAssetKeyV2(base));
+    expect(
+      validatePredictionAssetSelectionV2({
+        mode: "custom",
+        sourceNetwork: "",
+        assetLocator: EVM_ADDRESS,
+      }),
+    ).toMatchObject({
+      ok: false,
+      errors: { sourceNetwork: "Choose the token network." },
+    });
+  });
+
+  it("validates Solana mints separately from EVM addresses", () => {
+    expect(isSolanaPredictionAssetLocatorV2(SOLANA_MINT)).toBe(true);
+    expect(isSolanaPredictionAssetLocatorV2(EVM_ADDRESS)).toBe(false);
+    expect(
+      predictionAssetKeyV2({
+        mode: "custom",
+        sourceNetwork: "solana",
+        assetLocator: SOLANA_MINT,
+      }),
+    ).toBe(
+      `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d:${SOLANA_MINT}`,
+    );
+    expect(
+      validatePredictionAssetSelectionV2({
+        mode: "custom",
+        sourceNetwork: "ethereum",
+        assetLocator: SOLANA_MINT,
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("fails closed until one released price source is ready", () => {
+    const selection = { mode: "preset", presetId: "btc" } as const;
+    expect(predictionAssetMarketStateV2(selection)).toMatchObject({
+      state: "unavailable",
+      code: "release-unconfigured",
+    });
+
+    const unsupportedRegistry: PredictionAssetReleaseRegistryV2 = {
+      schemaVersion: 2,
+      settlementNetwork: { id: "robinhood", chainId: 4_663 },
+      entries: [],
+    };
+    expect(
+      predictionAssetMarketStateV2(selection, unsupportedRegistry),
+    ).toMatchObject({ state: "unavailable", code: "oracle-unsupported" });
+
+    const unknownRegistry: PredictionAssetReleaseRegistryV2 = {
+      ...unsupportedRegistry,
+      entries: [
+        {
+          assetKey: "preset:btc",
+          marketType: "usd-price-at-utc",
+          oracleStatus: "unknown",
+        },
+      ],
+    };
+    expect(predictionAssetMarketStateV2(selection, unknownRegistry)).toMatchObject(
+      { state: "unavailable", code: "oracle-unknown" },
+    );
+
+    const readyRegistry: PredictionAssetReleaseRegistryV2 = {
+      ...unsupportedRegistry,
+      entries: [
+        {
+          assetKey: "preset:btc",
+          marketType: "usd-price-at-utc",
+          oracleStatus: "ready",
+          oraclePolicyId: "btc-usd-checkpoint-v2",
+          releaseId: "protocol-v2",
+        },
+      ],
+    };
+    expect(predictionAssetMarketStateV2(selection, readyRegistry)).toMatchObject({
+      state: "available",
+      code: "ready",
+    });
+  });
+
+  it("rejects ambiguous and malformed release configuration", () => {
+    const malformed = {
+      schemaVersion: 2,
+      settlementNetwork: { id: "robinhood", chainId: 4_663 },
+      entries: [
+        {
+          assetKey: "preset:btc",
+          marketType: "usd-price-at-utc",
+          oracleStatus: "ready",
+        },
+      ],
+    };
+    expect(isPredictionAssetReleaseRegistryV2(malformed)).toBe(false);
+    expect(
+      predictionAssetMarketStateV2(
+        { mode: "preset", presetId: "btc" },
+        malformed as PredictionAssetReleaseRegistryV2,
+      ),
+    ).toMatchObject({ state: "unavailable", code: "release-invalid" });
+
+    const duplicate: PredictionAssetReleaseRegistryV2 = {
+      schemaVersion: 2,
+      settlementNetwork: { id: "robinhood", chainId: 4_663 },
+      entries: [
+        {
+          assetKey: "preset:btc",
+          marketType: "usd-price-at-utc",
+          oracleStatus: "ready",
+          oraclePolicyId: "policy-a",
+          releaseId: "release-a",
+        },
+        {
+          assetKey: "preset:btc",
+          marketType: "usd-price-at-utc",
+          oracleStatus: "ready",
+          oraclePolicyId: "policy-b",
+          releaseId: "release-b",
+        },
+      ],
+    };
+    expect(
+      predictionAssetMarketStateV2(
+        { mode: "preset", presetId: "btc" },
+        duplicate,
+      ),
+    ).toMatchObject({ state: "unavailable", code: "oracle-ambiguous" });
+  });
+
+  it("keeps discovery data informational and bound to the exact asset key", () => {
+    const selection = { mode: "preset", presetId: "btc" } as const;
+    const snapshot = {
+      assetKey: "preset:btc",
+      status: "available",
+      currentPriceUsd: 61_234.5,
+      marketCapUsd: 1_210_000_000_000,
+    } as const;
+    expect(predictionAssetSnapshotMatchesSelectionV2(snapshot, selection)).toBe(
+      true,
+    );
+    expect(
+      predictionAssetSnapshotMatchesSelectionV2(
+        { ...snapshot, assetKey: "preset:eth" },
+        selection,
+      ),
+    ).toBe(false);
+    expect(predictionAssetMarketStateV2(selection)).toMatchObject({
+      state: "unavailable",
+    });
+    expect(formatPredictionAssetUsdV2(snapshot.currentPriceUsd, "price")).toBe(
+      "$61,234.50",
+    );
+    expect(formatPredictionAssetUsdV2(snapshot.marketCapUsd, "market-cap")).toBe(
+      "$1.21T",
+    );
+  });
+});

--- a/tests/prediction-preset-discovery-route.test.ts
+++ b/tests/prediction-preset-discovery-route.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  loaded: vi.fn(),
+  read: vi.fn(),
+}));
+
+vi.mock(
+  "../lib/market-data/prediction-preset-discovery-v2.server",
+  () => {
+    mocks.loaded();
+    return { readPredictionPresetDiscoveryV2: mocks.read };
+  },
+);
+
+import { NextRequest } from "next/server";
+
+import { GET } from "../app/api/prediction/preset-discovery/route";
+
+function request(query = "") {
+  return new NextRequest(
+    `http://localhost/api/prediction/preset-discovery${query}`,
+  );
+}
+
+describe("disabled Prediction V2 preset-discovery route", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it.each(["", "?ids=dogecoin"])(
+    "returns a non-cacheable 404 before any provider read: %s",
+    async (query) => {
+      const response = await GET(request(query));
+
+      expect(response.status).toBe(404);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+      expect(response.headers.get("x-programmable-market-provider")).toBeNull();
+      await expect(response.json()).resolves.toEqual({ error: "Not found" });
+      expect(mocks.loaded).not.toHaveBeenCalled();
+      expect(mocks.read).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/tests/prediction-preset-discovery-v2.test.ts
+++ b/tests/prediction-preset-discovery-v2.test.ts
@@ -1,0 +1,267 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  createPredictionPresetDiscoveryReaderV2,
+} from "../lib/market-data/prediction-preset-discovery-v2.server";
+
+const OBSERVED_AT = "2026-08-23T16:30:00.000Z";
+const OBSERVED_AT_MS = new Date(OBSERVED_AT).getTime();
+const UPDATED_AT_SECONDS = Math.floor(OBSERVED_AT_MS / 1_000) - 30;
+
+function payload(updatedAt = UPDATED_AT_SECONDS) {
+  return {
+    bitcoin: {
+      usd: 61_234.5,
+      usd_market_cap: 1_220_000_000_000,
+      last_updated_at: updatedAt,
+    },
+    ethereum: {
+      usd: 2_345.67,
+      usd_market_cap: 282_000_000_000,
+      last_updated_at: updatedAt,
+    },
+    solana: {
+      usd: 145.25,
+      usd_market_cap: 77_000_000_000,
+      last_updated_at: updatedAt,
+    },
+    binancecoin: {
+      usd: 612.75,
+      usd_market_cap: 89_000_000_000,
+      last_updated_at: updatedAt,
+    },
+  };
+}
+
+function jsonResponse(body: unknown, status = 200, headers?: HeadersInit) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      ...headers,
+    },
+  });
+}
+
+function reader(
+  fetchImpl: typeof fetch,
+  overrides: Partial<
+    Parameters<typeof createPredictionPresetDiscoveryReaderV2>[0]
+  > = {},
+) {
+  return createPredictionPresetDiscoveryReaderV2({
+    fetchImpl,
+    now: () => new Date(OBSERVED_AT),
+    timeoutMs: 100,
+    maximumResponseBytes: 32_768,
+    successCacheTtlMs: 60_000,
+    maximumDataAgeMs: 600_000,
+    maximumFutureSkewMs: 300_000,
+    ...overrides,
+  });
+}
+
+describe("prediction preset discovery V2", () => {
+  beforeEach(() => vi.useRealTimers());
+
+  it("uses one canonical keyless CoinGecko request for the fixed preset IDs", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
+      const requestUrl = new URL(String(url));
+      expect(requestUrl.origin).toBe("https://api.coingecko.com");
+      expect(requestUrl.pathname).toBe("/api/v3/simple/price");
+      expect([...requestUrl.searchParams.keys()].sort()).toEqual([
+        "ids",
+        "include_last_updated_at",
+        "include_market_cap",
+        "precision",
+        "vs_currencies",
+      ]);
+      expect(requestUrl.searchParams.get("ids")).toBe(
+        "bitcoin,ethereum,solana,binancecoin",
+      );
+      expect(requestUrl.searchParams.get("vs_currencies")).toBe("usd");
+      expect(requestUrl.searchParams.get("include_market_cap")).toBe("true");
+      expect(requestUrl.searchParams.get("include_last_updated_at")).toBe(
+        "true",
+      );
+      expect(requestUrl.searchParams.get("precision")).toBe("full");
+      expect(requestUrl.searchParams.has("x_cg_demo_api_key")).toBe(false);
+      const headers = new Headers(init?.headers);
+      expect(headers.has("x-cg-demo-api-key")).toBe(false);
+      expect(headers.has("x-cg-pro-api-key")).toBe(false);
+      expect(init).toMatchObject({
+        method: "GET",
+        cache: "no-store",
+        redirect: "error",
+      });
+      return jsonResponse(payload());
+    });
+
+    const result = await reader(fetchImpl).read();
+
+    expect(result).toMatchObject({
+      schemaVersion: 2,
+      status: "available",
+      source: "coingecko-keyless-public",
+      providerTier: "keyless-public",
+      observedAt: OBSERVED_AT,
+      usage: "display-only-not-eligibility-or-settlement",
+      serviceLevel: "best-effort-no-sla",
+      cacheExpiresAt: "2026-08-23T16:31:00.000Z",
+      presets: [
+        {
+          presetId: "btc",
+          selectionKey: "preset:btc",
+          symbol: "BTC",
+          providerId: "bitcoin",
+          currentPriceUsd: 61_234.5,
+          marketCapUsd: 1_220_000_000_000,
+        },
+        { presetId: "eth", providerId: "ethereum" },
+        { presetId: "sol", providerId: "solana" },
+        { presetId: "bnb", providerId: "binancecoin" },
+      ],
+    });
+    expect(result).not.toHaveProperty("assetKey");
+    expect(result).not.toHaveProperty("oracleStatus");
+    expect(result).not.toHaveProperty("settlementEligible");
+  });
+
+  it("caches only a fresh success and never serves it after expiry", async () => {
+    let currentMs = OBSERVED_AT_MS;
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse(payload()))
+      .mockResolvedValueOnce(jsonResponse({ error: "down" }, 503));
+    const discovery = reader(fetchImpl, {
+      now: () => new Date(currentMs),
+    });
+
+    const first = await discovery.read();
+    currentMs += 59_000;
+    const cached = await discovery.read();
+    currentMs += 2_000;
+    const expired = await discovery.read();
+
+    expect(cached).toBe(first);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(expired).toMatchObject({
+      status: "unavailable",
+      reason: "provider-unavailable",
+    });
+    expect(expired).not.toHaveProperty("presets");
+  });
+
+  it.each([
+    [
+      (() => {
+        const value = payload() as Record<string, unknown>;
+        delete value.binancecoin;
+        return value;
+      })(),
+      "incomplete-provider-data",
+    ],
+    [{ ...payload(), dogecoin: payload().bitcoin }, "response-invalid"],
+    [
+      {
+        ...payload(),
+        bitcoin: { ...payload().bitcoin, usd_24h_change: 1 },
+      },
+      "response-invalid",
+    ],
+    [
+      {
+        ...payload(),
+        ethereum: { ...payload().ethereum, usd_market_cap: null },
+      },
+      "incomplete-provider-data",
+    ],
+  ] as const)("fails closed on a non-canonical provider payload", async (
+    body,
+    reason,
+  ) => {
+    const result = await reader(
+      vi.fn(async () => jsonResponse(body)),
+    ).read();
+
+    expect(result).toMatchObject({ status: "unavailable", reason });
+    expect(result).not.toHaveProperty("presets");
+  });
+
+  it("rejects provider timestamps outside the freshness window", async () => {
+    const staleSeconds = Math.floor((OBSERVED_AT_MS - 600_001) / 1_000);
+    const result = await reader(
+      vi.fn(async () => jsonResponse(payload(staleSeconds))),
+    ).read();
+
+    expect(result).toMatchObject({
+      status: "unavailable",
+      reason: "stale-provider-data",
+    });
+  });
+
+  it("enforces the response byte cap before trusting JSON", async () => {
+    const response = jsonResponse(payload(), 200, {
+      "content-length": "999999",
+    });
+    const result = await reader(vi.fn(async () => response), {
+      maximumResponseBytes: 1_024,
+    }).read();
+
+    expect(result).toMatchObject({
+      status: "unavailable",
+      reason: "response-too-large",
+    });
+  });
+
+  it("bounds a provider that ignores AbortSignal", async () => {
+    vi.useFakeTimers();
+    let signal: AbortSignal | undefined;
+    const fetchImpl = vi.fn<typeof fetch>((_url, init) => {
+      signal = init?.signal ?? undefined;
+      return new Promise<Response>(() => undefined);
+    });
+    const pending = reader(fetchImpl).read();
+
+    await vi.advanceTimersByTimeAsync(101);
+
+    await expect(pending).resolves.toMatchObject({
+      status: "unavailable",
+      reason: "timeout",
+    });
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it("propagates caller cancellation without returning cached-looking data", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(() =>
+      new Promise<Response>(() => undefined)
+    );
+    const controller = new AbortController();
+    const pending = reader(fetchImpl).read({ signal: controller.signal });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+
+    controller.abort();
+
+    await expect(pending).resolves.toMatchObject({
+      status: "unavailable",
+      reason: "aborted",
+    });
+  });
+
+  it.each([
+    [429, "rate-limited"],
+    [500, "provider-unavailable"],
+  ] as const)("classifies provider HTTP %s without exposing its body", async (
+    status,
+    reason,
+  ) => {
+    const result = await reader(vi.fn(async () => jsonResponse(
+      { secret: "provider detail" },
+      status,
+    ))).read();
+
+    expect(result).toMatchObject({ status: "unavailable", reason });
+    expect(JSON.stringify(result)).not.toContain("provider detail");
+  });
+});

--- a/tests/prediction-v2-abi-codec.test.ts
+++ b/tests/prediction-v2-abi-codec.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import {
+  encodeFunctionResult,
+  toFunctionSelector,
+  zeroAddress,
+} from "viem";
+
+import {
+  PREDICTION_V2_ASSET_REGISTRY_ABI,
+  PREDICTION_V2_EXPOSURE_CONTROLLER_ABI,
+  PREDICTION_V2_FACTORY_ABI,
+  PREDICTION_V2_QUOTER_ABI,
+  PREDICTION_V2_VAULT_ABI,
+} from "../lib/prediction-v2/abi";
+import {
+  decodePredictionV2BuyQuote,
+  decodePredictionV2MarketRecord,
+  decodePredictionV2RegistrySnapshot,
+  decodePredictionV2SellQuote,
+  validatePredictionV2BuyQuote,
+  validatePredictionV2SellQuote,
+} from "../lib/prediction-v2/codec";
+import {
+  ADDRESS_1,
+  ADDRESS_2,
+  BTC_ASSET_KEY,
+  BUY_QUOTE,
+  HASH_11,
+  HASH_22,
+  HASH_33,
+  HASH_44,
+  HASH_77,
+  SELL_QUOTE,
+  registrySnapshot,
+} from "./prediction-v2-fixtures";
+
+function functionEntry(abi: readonly unknown[], name: string) {
+  return abi.find((entry) =>
+    typeof entry === "object" && entry !== null &&
+    "type" in entry && entry.type === "function" &&
+    "name" in entry && entry.name === name
+  ) as {
+    inputs: readonly unknown[];
+    outputs: readonly { name: string; components?: readonly unknown[] }[];
+    stateMutability: string;
+  };
+}
+
+describe("Protocol V2 exact ABI and fail-closed decoders", () => {
+  it("pins Factory markets to ten fields and rejects the old V1 tuple shape", () => {
+    const markets = functionEntry(PREDICTION_V2_FACTORY_ABI, "markets");
+    expect(markets.outputs.map(({ name }) => name)).toEqual([
+      "vault",
+      "checkpoint",
+      "poolId",
+      "marketId",
+      "assetKey",
+      "registrySnapshotHash",
+      "resolutionPolicyHash",
+      "registryRevision",
+      "policyValidUntil",
+      "snapshotAssetCap",
+    ]);
+    expect(markets.outputs).toHaveLength(10);
+  });
+
+  it("pins the Registry policy, Quoter tuples, finalize(bytes), and create selector", () => {
+    const latestSnapshot = functionEntry(PREDICTION_V2_ASSET_REGISTRY_ABI, "latestSnapshot");
+    const snapshot = latestSnapshot.outputs[0];
+    const policy = (snapshot.components as readonly { name: string; components?: readonly unknown[] }[])
+      .find(({ name }) => name === "policy");
+    expect(policy?.components).toHaveLength(17);
+    expect((policy?.components as readonly { name: string }[]).map(({ name }) => name)).toContain(
+      "feedPhaseId",
+    );
+    expect(functionEntry(PREDICTION_V2_QUOTER_ABI, "quoteBuy").outputs[0].components)
+      .toHaveLength(9);
+    expect(functionEntry(PREDICTION_V2_QUOTER_ABI, "quoteSellOptimal").outputs[0].components)
+      .toHaveLength(8);
+    expect(toFunctionSelector(PREDICTION_V2_FACTORY_ABI.find((item) =>
+      item.type === "function" && item.name === "createMarketWithPermit"
+    )!)).toBe(toFunctionSelector(
+      "createMarketWithPermit((bytes32,bytes32,bytes32,bytes32),uint32,int192,uint256,uint8,bytes32,bytes32)",
+    ));
+    expect(toFunctionSelector(PREDICTION_V2_VAULT_ABI.find((item) =>
+      item.type === "function" && item.name === "finalize"
+    )!)).toBe(
+      toFunctionSelector("finalize(bytes)"),
+    );
+    const capacity = functionEntry(
+      PREDICTION_V2_EXPOSURE_CONTROLLER_ABI,
+      "requireIncreaseCapacity",
+    );
+    expect(capacity.inputs).toHaveLength(2);
+    expect(capacity.outputs).toHaveLength(0);
+    expect(capacity.stateMutability).toBe("view");
+    expect(toFunctionSelector(PREDICTION_V2_EXPOSURE_CONTROLLER_ABI[0])).toBe(
+      toFunctionSelector("requireIncreaseCapacity(address,uint256)"),
+    );
+    const exposureController = functionEntry(
+      PREDICTION_V2_VAULT_ABI,
+      "exposureController",
+    );
+    expect(exposureController.outputs).toHaveLength(1);
+    expect(exposureController.stateMutability).toBe("view");
+  });
+
+  it("round-trips the exact nine-field buy and eight-field sell results", () => {
+    const buyData = encodeFunctionResult({
+      abi: PREDICTION_V2_QUOTER_ABI,
+      functionName: "quoteBuy",
+      result: BUY_QUOTE,
+    });
+    const sellData = encodeFunctionResult({
+      abi: PREDICTION_V2_QUOTER_ABI,
+      functionName: "quoteSellOptimal",
+      result: SELL_QUOTE,
+    });
+    expect(decodePredictionV2BuyQuote(buyData)).toEqual(BUY_QUOTE);
+    expect(decodePredictionV2SellQuote(sellData)).toEqual(SELL_QUOTE);
+  });
+
+  it("decodes one exact ten-field market and recognizes only the all-zero absent record", () => {
+    const result = [
+      ADDRESS_1,
+      ADDRESS_2,
+      HASH_11,
+      HASH_22,
+      BTC_ASSET_KEY,
+      HASH_33,
+      HASH_44,
+      7n,
+      1_900_000_000n,
+      100_000_000n,
+    ] as const;
+    const data = encodeFunctionResult({
+      abi: PREDICTION_V2_FACTORY_ABI,
+      functionName: "markets",
+      result,
+    });
+    expect(decodePredictionV2MarketRecord(data)).toEqual({
+      vault: ADDRESS_1,
+      checkpoint: ADDRESS_2,
+      poolId: HASH_11,
+      marketId: HASH_22,
+      assetKey: BTC_ASSET_KEY,
+      registrySnapshotHash: HASH_33,
+      resolutionPolicyHash: HASH_44,
+      registryRevision: 7n,
+      policyValidUntil: 1_900_000_000n,
+      snapshotAssetCap: 100_000_000n,
+    });
+    const zeroHash = `0x${"0".repeat(64)}` as const;
+    const absent = encodeFunctionResult({
+      abi: PREDICTION_V2_FACTORY_ABI,
+      functionName: "markets",
+      result: [zeroAddress, zeroAddress, zeroHash, zeroHash, zeroHash, zeroHash, zeroHash, 0n, 0n, 0n],
+    });
+    expect(decodePredictionV2MarketRecord(absent)).toBeNull();
+    const partial = encodeFunctionResult({
+      abi: PREDICTION_V2_FACTORY_ABI,
+      functionName: "markets",
+      result: [ADDRESS_1, zeroAddress, zeroHash, zeroHash, zeroHash, zeroHash, zeroHash, 0n, 0n, 0n],
+    });
+    expect(() => decodePredictionV2MarketRecord(partial)).toThrow("market checkpoint");
+  });
+
+  it("round-trips the exact Registry snapshot and rejects identity/key or feed-phase drift", () => {
+    const snapshot = registrySnapshot();
+    const data = encodeFunctionResult({
+      abi: PREDICTION_V2_ASSET_REGISTRY_ABI,
+      functionName: "requireActiveAsset",
+      result: snapshot,
+    });
+    expect(decodePredictionV2RegistrySnapshot(data, "requireActiveAsset")).toEqual(snapshot);
+
+    const wrongKey = encodeFunctionResult({
+      abi: PREDICTION_V2_ASSET_REGISTRY_ABI,
+      functionName: "latestSnapshot",
+      result: { ...snapshot, assetKey: HASH_77 },
+    });
+    expect(() => decodePredictionV2RegistrySnapshot(wrongKey, "latestSnapshot"))
+      .toThrow("asset key binding");
+
+    const missingPhase = encodeFunctionResult({
+      abi: PREDICTION_V2_ASSET_REGISTRY_ABI,
+      functionName: "latestSnapshot",
+      result: { ...snapshot, policy: { ...snapshot.policy, feedPhaseId: 0 } },
+    });
+    expect(() => decodePredictionV2RegistrySnapshot(missingPhase, "latestSnapshot"))
+      .toThrow("feed phase binding");
+  });
+
+  it("rejects one-atom accounting drift, wrong max payment, gross sell minimum, and invalid live fees", () => {
+    expect(() => validatePredictionV2BuyQuote({
+      ...BUY_QUOTE,
+      maximumPaymentAtoms: BUY_QUOTE.maximumPaymentAtoms - 1n,
+    })).toThrow("buy accounting");
+    expect(() => validatePredictionV2BuyQuote({
+      ...BUY_QUOTE,
+      outcomeAtoms: BUY_QUOTE.outcomeAtoms + 1n,
+    })).toThrow("buy accounting");
+    expect(() => validatePredictionV2SellQuote({
+      ...SELL_QUOTE,
+      netCollateralAtoms: SELL_QUOTE.grossCollateralAtoms,
+    })).toThrow("sell accounting");
+    expect(() => validatePredictionV2SellQuote({
+      ...SELL_QUOTE,
+      swap: { ...SELL_QUOTE.swap, lpFee: 201 },
+    })).toThrow("LP fee binding");
+    expect(() => validatePredictionV2BuyQuote({
+      ...BUY_QUOTE,
+      swap: { ...BUY_QUOTE.swap, poolManagerProtocolFee: (1_001 << 12) | 123 },
+    })).toThrow("directional protocol fee");
+  });
+});

--- a/tests/prediction-v2-abi-codec.test.ts
+++ b/tests/prediction-v2-abi-codec.test.ts
@@ -7,6 +7,7 @@ import {
 
 import {
   PREDICTION_V2_ASSET_REGISTRY_ABI,
+  PREDICTION_V2_CHECKPOINT_ABI,
   PREDICTION_V2_EXPOSURE_CONTROLLER_ABI,
   PREDICTION_V2_FACTORY_ABI,
   PREDICTION_V2_QUOTER_ABI,
@@ -66,6 +67,8 @@ describe("Protocol V2 exact ABI and fail-closed decoders", () => {
 
   it("pins the Registry policy, Quoter tuples, finalize(bytes), and create selector", () => {
     const latestSnapshot = functionEntry(PREDICTION_V2_ASSET_REGISTRY_ABI, "latestSnapshot");
+    expect(functionEntry(PREDICTION_V2_ASSET_REGISTRY_ABI, "getSnapshot").inputs)
+      .toHaveLength(2);
     const snapshot = latestSnapshot.outputs[0];
     const policy = (snapshot.components as readonly { name: string; components?: readonly unknown[] }[])
       .find(({ name }) => name === "policy");
@@ -77,16 +80,22 @@ describe("Protocol V2 exact ABI and fail-closed decoders", () => {
       .toHaveLength(9);
     expect(functionEntry(PREDICTION_V2_QUOTER_ABI, "quoteSellOptimal").outputs[0].components)
       .toHaveLength(8);
+    const createWithPermitSignature =
+      "createMarketWithPermit((bytes32,bytes32,bytes32,bytes32),uint32,int192,bytes32,uint256,uint8,bytes32,bytes32)";
+    expect(toFunctionSelector(createWithPermitSignature)).toBe("0xf6bc6d85");
     expect(toFunctionSelector(PREDICTION_V2_FACTORY_ABI.find((item) =>
       item.type === "function" && item.name === "createMarketWithPermit"
-    )!)).toBe(toFunctionSelector(
-      "createMarketWithPermit((bytes32,bytes32,bytes32,bytes32),uint32,int192,uint256,uint8,bytes32,bytes32)",
-    ));
+    )!)).toBe(toFunctionSelector(createWithPermitSignature));
     expect(toFunctionSelector(PREDICTION_V2_VAULT_ABI.find((item) =>
       item.type === "function" && item.name === "finalize"
     )!)).toBe(
       toFunctionSelector("finalize(bytes)"),
     );
+    expect(toFunctionSelector(PREDICTION_V2_VAULT_ABI.find((item) =>
+      item.type === "function" && item.name === "finalizeAndRedeem"
+    )!)).toBe(toFunctionSelector("finalizeAndRedeem(bytes,uint256,uint256,address)"));
+    expect(functionEntry(PREDICTION_V2_CHECKPOINT_ABI, "resolve").stateMutability)
+      .toBe("payable");
     const capacity = functionEntry(
       PREDICTION_V2_EXPOSURE_CONTROLLER_ABI,
       "requireIncreaseCapacity",
@@ -173,6 +182,17 @@ describe("Protocol V2 exact ABI and fail-closed decoders", () => {
       result: snapshot,
     });
     expect(decodePredictionV2RegistrySnapshot(data, "requireActiveAsset")).toEqual(snapshot);
+
+    const historical = encodeFunctionResult({
+      abi: PREDICTION_V2_ASSET_REGISTRY_ABI,
+      functionName: "getSnapshot",
+      result: snapshot,
+    });
+    expect(decodePredictionV2RegistrySnapshot(historical, "getSnapshot")).toEqual(snapshot);
+    expect(() => decodePredictionV2RegistrySnapshot(
+      `${historical}00`,
+      "getSnapshot",
+    )).toThrow("result canonicality");
 
     const wrongKey = encodeFunctionResult({
       abi: PREDICTION_V2_ASSET_REGISTRY_ABI,

--- a/tests/prediction-v2-accounting.test.ts
+++ b/tests/prediction-v2-accounting.test.ts
@@ -4,9 +4,11 @@ import {
   predictionV2BuyPreview,
   predictionV2DirectionalPoolManagerFeePips,
   predictionV2PriceImpact,
+  predictionV2PriceImpactRiskState,
   predictionV2SellPreview,
   predictionV2SlippageFloor,
   predictionV2YesProbabilityBps,
+  requirePredictionV2PriceImpactConfirmation,
 } from "../lib/prediction-v2/accounting";
 import {
   PREDICTION_V2_MAX_SQRT_PRICE_X96,
@@ -14,10 +16,48 @@ import {
   validatePredictionV2SellQuote,
 } from "../lib/prediction-v2/codec";
 import {
+  ADDRESS_1,
+  ADDRESS_2,
   BUY_QUOTE,
+  POOL_KEY,
   Q96,
   SELL_QUOTE,
+  boundPredictionV2MarketState,
 } from "./prediction-v2-fixtures";
+
+function boundBuy(
+  quote = BUY_QUOTE,
+  buyYes = true,
+  marketState = boundPredictionV2MarketState(),
+) {
+  return {
+    chainId: 4_663 as const,
+    vault: ADDRESS_1,
+    poolKey: POOL_KEY,
+    buyYes,
+    observedBlockNumber: marketState.observedBlockNumber,
+    observedBlockHash: marketState.observedBlockHash,
+    marketState,
+    quote,
+  } as const;
+}
+
+function boundSell(
+  quote = SELL_QUOTE,
+  sellYes = true,
+  marketState = boundPredictionV2MarketState(),
+) {
+  return {
+    chainId: 4_663 as const,
+    vault: ADDRESS_1,
+    poolKey: POOL_KEY,
+    sellYes,
+    observedBlockNumber: marketState.observedBlockNumber,
+    observedBlockHash: marketState.observedBlockHash,
+    marketState,
+    quote,
+  } as const;
+}
 
 describe("Protocol V2 fee-aware payout and price-impact preview", () => {
   it("maps the live v4 price to YES/NO probabilities and both impact units", () => {
@@ -55,13 +95,8 @@ describe("Protocol V2 fee-aware payout and price-impact preview", () => {
 
   it("shows maximum and actual fee-inclusive payment, receive bounds, payout and signed profit", () => {
     const preview = predictionV2BuyPreview({
-      quote: BUY_QUOTE,
+      boundQuote: boundBuy(),
       slippageBps: 50,
-      currentSqrtPriceX96: Q96,
-      yesIsCurrency0: true,
-      zeroForOne: true,
-      outcome: "YES",
-      liquidityEvidence: "factory-backstop-only",
     });
     expect(preview).toMatchObject({
       requestedCollateralAtoms: 1_000_000n,
@@ -78,10 +113,12 @@ describe("Protocol V2 fee-aware payout and price-impact preview", () => {
       maximumLossAtoms: 1_001_000n,
       neutralPayoutAtoms: 950_000n,
       lpFeePips: 200,
-      poolManagerProtocolFeePips: 123,
+      poolManagerProtocolFeePips: 321,
       liquidity: {
         depth: "thin",
         riskState: "explicit-confirmation-required",
+        priceImpactRiskState: "explicit-confirmation-required",
+        partialFill: true,
         warning: { code: "backstop-only" },
       },
     });
@@ -106,13 +143,8 @@ describe("Protocol V2 fee-aware payout and price-impact preview", () => {
       },
     } as const;
     const preview = predictionV2BuyPreview({
-      quote: expensiveQuote,
+      boundQuote: boundBuy(expensiveQuote),
       slippageBps: 1_000,
-      currentSqrtPriceX96: Q96,
-      yesIsCurrency0: true,
-      zeroForOne: true,
-      outcome: "YES",
-      liquidityEvidence: "verified-live-depth",
     });
     expect(preview.minimumOutcomeAtoms).toBe(90_000n);
     expect(preview.minimumNetProfitAtoms).toBe(-101_000n);
@@ -133,22 +165,19 @@ describe("Protocol V2 fee-aware payout and price-impact preview", () => {
         ...BUY_QUOTE.swap,
         actualInput: 10_000n,
         amountOut: 10_000n,
-        sqrtPriceX96After: Q96,
+        sqrtPriceX96After: Q96 + 1n,
       },
     } as const;
     const preview = predictionV2BuyPreview({
-      quote: smallQuote,
+      boundQuote: boundBuy(smallQuote),
       slippageBps: 50,
-      currentSqrtPriceX96: Q96,
-      yesIsCurrency0: true,
-      zeroForOne: true,
-      outcome: "YES",
-      liquidityEvidence: "factory-backstop-only",
     });
     expect(preview.priceImpact.probabilityPointMagnitudeBps).toBe(0);
     expect(preview.liquidity).toEqual({
       depth: "thin",
       riskState: "warning",
+      priceImpactRiskState: "normal",
+      partialFill: false,
       warning: {
         code: "backstop-only",
         message: "Only the 2 USDG protocol backstop is currently evidenced for this market.",
@@ -156,7 +185,22 @@ describe("Protocol V2 fee-aware payout and price-impact preview", () => {
     });
   });
 
-  it("warns from 2pp and requires explicit confirmation from 5pp", () => {
+  it("classifies exact 199/200/499/500 bps boundaries and requires confirmation at 500", () => {
+    expect(predictionV2PriceImpactRiskState(199)).toBe("normal");
+    expect(predictionV2PriceImpactRiskState(200)).toBe("warning");
+    expect(predictionV2PriceImpactRiskState(499)).toBe("warning");
+    expect(predictionV2PriceImpactRiskState(500)).toBe("explicit-confirmation-required");
+    expect(() => requirePredictionV2PriceImpactConfirmation(499, false)).not.toThrow();
+    expect(() => requirePredictionV2PriceImpactConfirmation(500, false))
+      .toThrow("explicit price-impact confirmation");
+    expect(() => requirePredictionV2PriceImpactConfirmation(
+      500,
+      "yes" as unknown as boolean,
+    )).toThrow("explicit price-impact confirmation");
+    expect(() => requirePredictionV2PriceImpactConfirmation(500, true)).not.toThrow();
+  });
+
+  it("warns from 2pp and reports explicit confirmation from 5pp", () => {
     const fullQuote = {
       requestedCollateralAtoms: 100_000n,
       maximumPaymentAtoms: 100_100n,
@@ -173,61 +217,50 @@ describe("Protocol V2 fee-aware payout and price-impact preview", () => {
       },
     } as const;
     const warning = predictionV2BuyPreview({
-      quote: {
+      boundQuote: boundBuy({
         ...fullQuote,
         swap: { ...fullQuote.swap, sqrtPriceX96After: Q96 * 105n / 100n },
-      },
+      }),
       slippageBps: 50,
-      currentSqrtPriceX96: Q96,
-      yesIsCurrency0: true,
-      zeroForOne: true,
-      outcome: "YES",
-      liquidityEvidence: "verified-live-depth",
     });
     expect(warning.priceImpact.probabilityPointMagnitudeBps).toBeGreaterThanOrEqual(200);
     expect(warning.priceImpact.probabilityPointMagnitudeBps).toBeLessThan(500);
     expect(warning.liquidity).toEqual({
-      depth: "low",
+      depth: "thin",
       riskState: "warning",
+      priceImpactRiskState: "warning",
+      partialFill: false,
       warning: {
-        code: "price-impact-warning",
-        message: "This trade moves the quoted probability by at least 2 percentage points.",
+        code: "backstop-only",
+        message: "Only the 2 USDG protocol backstop is currently evidenced for this market.",
       },
     });
 
     const explicit = predictionV2BuyPreview({
-      quote: {
+      boundQuote: boundBuy({
         ...fullQuote,
         swap: { ...fullQuote.swap, sqrtPriceX96After: Q96 * 111n / 100n },
-      },
+      }),
       slippageBps: 50,
-      currentSqrtPriceX96: Q96,
-      yesIsCurrency0: true,
-      zeroForOne: true,
-      outcome: "YES",
-      liquidityEvidence: "verified-live-depth",
     });
     expect(explicit.priceImpact.probabilityPointMagnitudeBps).toBeGreaterThanOrEqual(500);
     expect(explicit.liquidity).toEqual({
       depth: "thin",
       riskState: "explicit-confirmation-required",
+      priceImpactRiskState: "explicit-confirmation-required",
+      partialFill: false,
       warning: {
-        code: "large-price-impact",
-        message: "This trade moves the quoted probability by at least 5 percentage points.",
+        code: "backstop-only",
+        message: "Only the 2 USDG protocol backstop is currently evidenced for this market.",
       },
     });
 
     const backstopExplicit = predictionV2BuyPreview({
-      quote: {
+      boundQuote: boundBuy({
         ...fullQuote,
         swap: { ...fullQuote.swap, sqrtPriceX96After: Q96 * 111n / 100n },
-      },
+      }),
       slippageBps: 50,
-      currentSqrtPriceX96: Q96,
-      yesIsCurrency0: true,
-      zeroForOne: true,
-      outcome: "YES",
-      liquidityEvidence: "factory-backstop-only",
     });
     expect(backstopExplicit.liquidity).toMatchObject({
       depth: "thin",
@@ -238,13 +271,8 @@ describe("Protocol V2 fee-aware payout and price-impact preview", () => {
 
   it("uses net sell proceeds for the minimum and avoids a misleading refund-adjusted average", () => {
     const preview = predictionV2SellPreview({
-      quote: SELL_QUOTE,
+      boundQuote: boundSell(),
       slippageBps: 100,
-      currentSqrtPriceX96: Q96,
-      yesIsCurrency0: true,
-      zeroForOne: false,
-      outcome: "YES",
-      liquidityEvidence: "verified-live-depth",
     });
     expect(preview).toMatchObject({
       grossProceedsAtoms: 520_000n,
@@ -252,7 +280,7 @@ describe("Protocol V2 fee-aware payout and price-impact preview", () => {
       netProceedsAtoms: 519_480n,
       minimumNetProceedsAtoms: 514_285n,
       averageNetCashExitPriceBps: 5_195,
-      poolManagerProtocolFeePips: 321,
+      poolManagerProtocolFeePips: 123,
     });
 
     const quoteWithSoldRefund = validatePredictionV2SellQuote({
@@ -270,13 +298,8 @@ describe("Protocol V2 fee-aware payout and price-impact preview", () => {
       },
     });
     const soldRefundPreview = predictionV2SellPreview({
-      quote: quoteWithSoldRefund,
+      boundQuote: boundSell(quoteWithSoldRefund),
       slippageBps: 50,
-      currentSqrtPriceX96: Q96,
-      yesIsCurrency0: true,
-      zeroForOne: false,
-      outcome: "YES",
-      liquidityEvidence: "verified-live-depth",
     });
     expect(soldRefundPreview.soldOutcomeRefundAtoms).toBe(10_000n);
     expect(soldRefundPreview.averageNetCashExitPriceBps).toBe(5_550);
@@ -296,15 +319,70 @@ describe("Protocol V2 fee-aware payout and price-impact preview", () => {
       },
     });
     const complementRefundPreview = predictionV2SellPreview({
-      quote: quoteWithComplementRefund,
+      boundQuote: boundSell(quoteWithComplementRefund),
       slippageBps: 50,
-      currentSqrtPriceX96: Q96,
-      yesIsCurrency0: true,
-      zeroForOne: false,
-      outcome: "YES",
-      liquidityEvidence: "verified-live-depth",
     });
     expect(complementRefundPreview.complementOutcomeRefundAtoms).toBe(10_000n);
     expect(complementRefundPreview.averageNetCashExitPriceBps).toBeNull();
+  });
+
+  it("derives side and direction from the bound pool and cannot accept unverified depth", () => {
+    const noBuyQuote = {
+      ...BUY_QUOTE,
+      swap: {
+        ...BUY_QUOTE.swap,
+        sqrtPriceX96After: Q96 / 2n,
+        tickAfter: -13_864,
+      },
+    } as const;
+    const noBuy = predictionV2BuyPreview({
+      boundQuote: boundBuy(noBuyQuote, false),
+      slippageBps: 50,
+    });
+    expect(noBuy.poolManagerProtocolFeePips).toBe(123);
+
+    const marketState = boundPredictionV2MarketState();
+    expect(() => predictionV2BuyPreview({
+      boundQuote: boundBuy(BUY_QUOTE, true, {
+        ...marketState,
+        yesToken: ADDRESS_2,
+        noToken: ADDRESS_1,
+      }),
+      slippageBps: 50,
+    })).toThrow("decoded market-state binding");
+    expect(() => predictionV2SellPreview({
+      boundQuote: boundSell(SELL_QUOTE, true, {
+        ...marketState,
+        currentSqrtPriceX96: Q96 * 2n,
+      }),
+      slippageBps: 50,
+    })).toThrow("decoded market-state binding");
+
+    expect(() => predictionV2BuyPreview({
+      boundQuote: boundBuy({
+        ...BUY_QUOTE,
+        swap: { ...BUY_QUOTE.swap, sqrtPriceX96After: Q96 / 2n },
+      }),
+      slippageBps: 50,
+    })).toThrow("buy selected-probability direction");
+    expect(() => predictionV2SellPreview({
+      boundQuote: boundSell({
+        ...SELL_QUOTE,
+        swap: { ...SELL_QUOTE.swap, sqrtPriceX96After: Q96 * 2n },
+      }),
+      slippageBps: 50,
+    })).toThrow("sell selected-probability direction");
+
+    const spoofedInput = {
+      boundQuote: boundBuy(),
+      slippageBps: 50,
+      liquidityEvidence: "verified-live-depth",
+    } as Parameters<typeof predictionV2BuyPreview>[0] & {
+      liquidityEvidence: "verified-live-depth";
+    };
+    expect(predictionV2BuyPreview(spoofedInput).liquidity).toMatchObject({
+      depth: "thin",
+      warning: { code: "backstop-only" },
+    });
   });
 });

--- a/tests/prediction-v2-accounting.test.ts
+++ b/tests/prediction-v2-accounting.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  predictionV2BuyPreview,
+  predictionV2DirectionalPoolManagerFeePips,
+  predictionV2PriceImpact,
+  predictionV2SellPreview,
+  predictionV2SlippageFloor,
+  predictionV2YesProbabilityBps,
+} from "../lib/prediction-v2/accounting";
+import {
+  PREDICTION_V2_MAX_SQRT_PRICE_X96,
+  PREDICTION_V2_MIN_SQRT_PRICE_X96,
+  validatePredictionV2SellQuote,
+} from "../lib/prediction-v2/codec";
+import {
+  BUY_QUOTE,
+  Q96,
+  SELL_QUOTE,
+} from "./prediction-v2-fixtures";
+
+describe("Protocol V2 fee-aware payout and price-impact preview", () => {
+  it("maps the live v4 price to YES/NO probabilities and both impact units", () => {
+    expect(predictionV2YesProbabilityBps(Q96, true)).toBe(5_000);
+    expect(predictionV2YesProbabilityBps(Q96 * 2n, true)).toBe(8_000);
+    expect(predictionV2YesProbabilityBps(Q96 * 2n, false)).toBe(2_000);
+    expect(predictionV2PriceImpact(Q96, Q96 * 2n, true, "YES")).toEqual({
+      currentProbabilityBps: 5_000,
+      postTradeProbabilityBps: 8_000,
+      probabilityPointDeltaBps: 3_000,
+      probabilityPointMagnitudeBps: 3_000,
+      relativeImpactBps: 6_000,
+    });
+    expect(predictionV2PriceImpact(Q96, Q96 * 2n, true, "NO"))
+      .toMatchObject({ probabilityPointDeltaBps: -3_000 });
+    expect(() => predictionV2YesProbabilityBps(
+      PREDICTION_V2_MIN_SQRT_PRICE_X96 - 1n,
+      true,
+    )).toThrow("outside Uniswap v4 bounds");
+    expect(() => predictionV2YesProbabilityBps(
+      PREDICTION_V2_MAX_SQRT_PRICE_X96 + 1n,
+      true,
+    )).toThrow("outside Uniswap v4 bounds");
+  });
+
+  it("uses a strict slippage floor and decodes directional live PoolManager fees", () => {
+    expect(predictionV2SlippageFloor(10_000n, 50)).toBe(9_950n);
+    expect(predictionV2SlippageFloor(1n, 1_000)).toBe(1n);
+    expect(() => predictionV2SlippageFloor(10_000n, 0)).toThrow("slippage");
+    expect(() => predictionV2SlippageFloor(10_000n, 1_001)).toThrow("slippage");
+    const packed = (321 << 12) | 123;
+    expect(predictionV2DirectionalPoolManagerFeePips(packed, true)).toBe(123);
+    expect(predictionV2DirectionalPoolManagerFeePips(packed, false)).toBe(321);
+  });
+
+  it("shows maximum and actual fee-inclusive payment, receive bounds, payout and signed profit", () => {
+    const preview = predictionV2BuyPreview({
+      quote: BUY_QUOTE,
+      slippageBps: 50,
+      currentSqrtPriceX96: Q96,
+      yesIsCurrency0: true,
+      zeroForOne: true,
+      outcome: "YES",
+      liquidityEvidence: "factory-backstop-only",
+    });
+    expect(preview).toMatchObject({
+      requestedCollateralAtoms: 1_000_000n,
+      maximumPaymentAtoms: 1_001_000n,
+      actualPaymentAtoms: 800_800n,
+      protocolFeeAtoms: 800n,
+      totalRefundAtoms: 200_200n,
+      outcomeAtoms: 190_000n,
+      minimumOutcomeAtoms: 189_050n,
+      winningGrossPayoutAtoms: 1_900_000n,
+      minimumWinningGrossPayoutAtoms: 1_890_500n,
+      potentialNetProfitAtoms: 1_099_200n,
+      minimumNetProfitAtoms: 889_500n,
+      maximumLossAtoms: 1_001_000n,
+      neutralPayoutAtoms: 950_000n,
+      lpFeePips: 200,
+      poolManagerProtocolFeePips: 123,
+      liquidity: {
+        depth: "thin",
+        riskState: "explicit-confirmation-required",
+        warning: { code: "backstop-only" },
+      },
+    });
+    expect(preview.averageExecutablePriceBps).toBe(4_215);
+    expect(preview.maximumSlippagePriceBps).toBe(5_295);
+  });
+
+  it("keeps a conservative minimum profit signed when slippage can make it negative", () => {
+    const expensiveQuote = {
+      requestedCollateralAtoms: 1_000_000n,
+      maximumPaymentAtoms: 1_001_000n,
+      executedCollateralAtoms: 1_000_000n,
+      collateralRefundAtoms: 0n,
+      protocolFeeAtoms: 1_000n,
+      feeReserveRefundAtoms: 0n,
+      actualPaymentAtoms: 1_001_000n,
+      outcomeAtoms: 100_001n,
+      swap: {
+        ...BUY_QUOTE.swap,
+        actualInput: 100_000n,
+        amountOut: 1n,
+      },
+    } as const;
+    const preview = predictionV2BuyPreview({
+      quote: expensiveQuote,
+      slippageBps: 1_000,
+      currentSqrtPriceX96: Q96,
+      yesIsCurrency0: true,
+      zeroForOne: true,
+      outcome: "YES",
+      liquidityEvidence: "verified-live-depth",
+    });
+    expect(preview.minimumOutcomeAtoms).toBe(90_000n);
+    expect(preview.minimumNetProfitAtoms).toBe(-101_000n);
+    expect(typeof preview.minimumNetProfitAtoms).toBe("bigint");
+  });
+
+  it("never suppresses the genesis-only backstop warning for a small low-impact quote", () => {
+    const smallQuote = {
+      requestedCollateralAtoms: 100_000n,
+      maximumPaymentAtoms: 100_100n,
+      executedCollateralAtoms: 100_000n,
+      collateralRefundAtoms: 0n,
+      protocolFeeAtoms: 100n,
+      feeReserveRefundAtoms: 0n,
+      actualPaymentAtoms: 100_100n,
+      outcomeAtoms: 20_000n,
+      swap: {
+        ...BUY_QUOTE.swap,
+        actualInput: 10_000n,
+        amountOut: 10_000n,
+        sqrtPriceX96After: Q96,
+      },
+    } as const;
+    const preview = predictionV2BuyPreview({
+      quote: smallQuote,
+      slippageBps: 50,
+      currentSqrtPriceX96: Q96,
+      yesIsCurrency0: true,
+      zeroForOne: true,
+      outcome: "YES",
+      liquidityEvidence: "factory-backstop-only",
+    });
+    expect(preview.priceImpact.probabilityPointMagnitudeBps).toBe(0);
+    expect(preview.liquidity).toEqual({
+      depth: "thin",
+      riskState: "warning",
+      warning: {
+        code: "backstop-only",
+        message: "Only the 2 USDG protocol backstop is currently evidenced for this market.",
+      },
+    });
+  });
+
+  it("warns from 2pp and requires explicit confirmation from 5pp", () => {
+    const fullQuote = {
+      requestedCollateralAtoms: 100_000n,
+      maximumPaymentAtoms: 100_100n,
+      executedCollateralAtoms: 100_000n,
+      collateralRefundAtoms: 0n,
+      protocolFeeAtoms: 100n,
+      feeReserveRefundAtoms: 0n,
+      actualPaymentAtoms: 100_100n,
+      outcomeAtoms: 20_000n,
+      swap: {
+        ...BUY_QUOTE.swap,
+        actualInput: 10_000n,
+        amountOut: 10_000n,
+      },
+    } as const;
+    const warning = predictionV2BuyPreview({
+      quote: {
+        ...fullQuote,
+        swap: { ...fullQuote.swap, sqrtPriceX96After: Q96 * 105n / 100n },
+      },
+      slippageBps: 50,
+      currentSqrtPriceX96: Q96,
+      yesIsCurrency0: true,
+      zeroForOne: true,
+      outcome: "YES",
+      liquidityEvidence: "verified-live-depth",
+    });
+    expect(warning.priceImpact.probabilityPointMagnitudeBps).toBeGreaterThanOrEqual(200);
+    expect(warning.priceImpact.probabilityPointMagnitudeBps).toBeLessThan(500);
+    expect(warning.liquidity).toEqual({
+      depth: "low",
+      riskState: "warning",
+      warning: {
+        code: "price-impact-warning",
+        message: "This trade moves the quoted probability by at least 2 percentage points.",
+      },
+    });
+
+    const explicit = predictionV2BuyPreview({
+      quote: {
+        ...fullQuote,
+        swap: { ...fullQuote.swap, sqrtPriceX96After: Q96 * 111n / 100n },
+      },
+      slippageBps: 50,
+      currentSqrtPriceX96: Q96,
+      yesIsCurrency0: true,
+      zeroForOne: true,
+      outcome: "YES",
+      liquidityEvidence: "verified-live-depth",
+    });
+    expect(explicit.priceImpact.probabilityPointMagnitudeBps).toBeGreaterThanOrEqual(500);
+    expect(explicit.liquidity).toEqual({
+      depth: "thin",
+      riskState: "explicit-confirmation-required",
+      warning: {
+        code: "large-price-impact",
+        message: "This trade moves the quoted probability by at least 5 percentage points.",
+      },
+    });
+
+    const backstopExplicit = predictionV2BuyPreview({
+      quote: {
+        ...fullQuote,
+        swap: { ...fullQuote.swap, sqrtPriceX96After: Q96 * 111n / 100n },
+      },
+      slippageBps: 50,
+      currentSqrtPriceX96: Q96,
+      yesIsCurrency0: true,
+      zeroForOne: true,
+      outcome: "YES",
+      liquidityEvidence: "factory-backstop-only",
+    });
+    expect(backstopExplicit.liquidity).toMatchObject({
+      depth: "thin",
+      riskState: "explicit-confirmation-required",
+      warning: { code: "backstop-only" },
+    });
+  });
+
+  it("uses net sell proceeds for the minimum and avoids a misleading refund-adjusted average", () => {
+    const preview = predictionV2SellPreview({
+      quote: SELL_QUOTE,
+      slippageBps: 100,
+      currentSqrtPriceX96: Q96,
+      yesIsCurrency0: true,
+      zeroForOne: false,
+      outcome: "YES",
+      liquidityEvidence: "verified-live-depth",
+    });
+    expect(preview).toMatchObject({
+      grossProceedsAtoms: 520_000n,
+      protocolFeeAtoms: 520n,
+      netProceedsAtoms: 519_480n,
+      minimumNetProceedsAtoms: 514_285n,
+      averageNetCashExitPriceBps: 5_195,
+      poolManagerProtocolFeePips: 321,
+    });
+
+    const quoteWithSoldRefund = validatePredictionV2SellQuote({
+      outcomeInAtoms: 100_000n,
+      requestedSwapAtoms: 40_000n,
+      grossCollateralAtoms: 500_000n,
+      protocolFeeAtoms: 500n,
+      netCollateralAtoms: 499_500n,
+      soldRefundAtoms: 10_000n,
+      complementRefundAtoms: 0n,
+      swap: {
+        ...SELL_QUOTE.swap,
+        actualInput: 40_000n,
+        amountOut: 50_000n,
+      },
+    });
+    const soldRefundPreview = predictionV2SellPreview({
+      quote: quoteWithSoldRefund,
+      slippageBps: 50,
+      currentSqrtPriceX96: Q96,
+      yesIsCurrency0: true,
+      zeroForOne: false,
+      outcome: "YES",
+      liquidityEvidence: "verified-live-depth",
+    });
+    expect(soldRefundPreview.soldOutcomeRefundAtoms).toBe(10_000n);
+    expect(soldRefundPreview.averageNetCashExitPriceBps).toBe(5_550);
+
+    const quoteWithComplementRefund = validatePredictionV2SellQuote({
+      outcomeInAtoms: 100_000n,
+      requestedSwapAtoms: 40_000n,
+      grossCollateralAtoms: 600_000n,
+      protocolFeeAtoms: 600n,
+      netCollateralAtoms: 599_400n,
+      soldRefundAtoms: 0n,
+      complementRefundAtoms: 10_000n,
+      swap: {
+        ...SELL_QUOTE.swap,
+        actualInput: 40_000n,
+        amountOut: 70_000n,
+      },
+    });
+    const complementRefundPreview = predictionV2SellPreview({
+      quote: quoteWithComplementRefund,
+      slippageBps: 50,
+      currentSqrtPriceX96: Q96,
+      yesIsCurrency0: true,
+      zeroForOne: false,
+      outcome: "YES",
+      liquidityEvidence: "verified-live-depth",
+    });
+    expect(complementRefundPreview.complementOutcomeRefundAtoms).toBe(10_000n);
+    expect(complementRefundPreview.averageNetCashExitPriceBps).toBeNull();
+  });
+});

--- a/tests/prediction-v2-fixtures.ts
+++ b/tests/prediction-v2-fixtures.ts
@@ -1,10 +1,25 @@
-import { stringToHex, type Address } from "viem";
+import { encodeFunctionResult, stringToHex, toHex, type Address } from "viem";
 
 import {
   PREDICTION_PRESET_ASSETS_V2,
   predictionOnchainAssetKeyV2,
 } from "../lib/prediction-market-assets-v2";
-import type { PredictionV2PoolKey } from "../lib/prediction-v2/abi";
+import {
+  PREDICTION_V2_POOL_MANAGER_STATE_ABI,
+  PREDICTION_V2_CHECKPOINT_ABI,
+  PREDICTION_V2_VAULT_ABI,
+  type PredictionV2PoolKey,
+} from "../lib/prediction-v2/abi";
+import {
+  bindPredictionV2MarketState,
+  encodePredictionV2CheckpointTradingHealthCall,
+  encodePredictionV2PoolSlot0Call,
+  encodePredictionV2VaultCheckpointCall,
+  encodePredictionV2VaultNoTokenCall,
+  encodePredictionV2VaultYesTokenCall,
+  predictionV2PoolId,
+  predictionV2PoolStateSlot,
+} from "../lib/prediction-v2/accounting";
 import type {
   PredictionV2BuyQuote,
   PredictionV2SellQuote,
@@ -36,6 +51,107 @@ export const POOL_KEY: PredictionV2PoolKey = {
   tickSpacing: 10,
   hooks: ADDRESS_3,
 };
+
+export function packedPredictionV2Slot0(input: Readonly<{
+  sqrtPriceX96?: bigint;
+  tick?: number;
+  poolManagerProtocolFee?: number;
+  lpFee?: number;
+}> = {}) {
+  const sqrtPriceX96 = input.sqrtPriceX96 ?? Q96;
+  const tick = input.tick ?? 0;
+  const poolManagerProtocolFee = input.poolManagerProtocolFee ?? ((321 << 12) | 123);
+  const lpFee = input.lpFee ?? 200;
+  const packed = sqrtPriceX96 |
+    (BigInt.asUintN(24, BigInt(tick)) << 160n) |
+    (BigInt(poolManagerProtocolFee) << 184n) |
+    (BigInt(lpFee) << 208n);
+  return toHex(packed, { size: 32 });
+}
+
+export function boundPredictionV2MarketState(input: Readonly<{
+  vault?: Address;
+  poolManager?: Address;
+  poolKey?: PredictionV2PoolKey;
+  yesToken?: Address;
+  noToken?: Address;
+  checkpoint?: Address;
+  checkpointTradingHealthy?: boolean;
+  sqrtPriceX96?: bigint;
+  tick?: number;
+  poolManagerProtocolFee?: number;
+  lpFee?: number;
+  observedBlockNumber?: bigint;
+  observedBlockHash?: typeof HASH_11;
+}> = {}) {
+  const vault = input.vault ?? ADDRESS_1;
+  const poolManager = input.poolManager ?? ADDRESS_4;
+  const poolKey = input.poolKey ?? POOL_KEY;
+  const yesToken = input.yesToken ?? poolKey.currency0;
+  const noToken = input.noToken ?? poolKey.currency1;
+  const checkpoint = input.checkpoint ?? ADDRESS_5;
+  const checkpointTradingHealthy = input.checkpointTradingHealthy ?? true;
+  const sqrtPriceX96 = input.sqrtPriceX96 ?? Q96;
+  const tick = input.tick ?? 0;
+  const poolManagerProtocolFee = input.poolManagerProtocolFee ?? ((321 << 12) | 123);
+  const lpFee = input.lpFee ?? 200;
+  return bindPredictionV2MarketState({
+    chainId: 4_663,
+    vault,
+    poolManager,
+    poolKey,
+    poolId: predictionV2PoolId(poolKey),
+    poolStateSlot: predictionV2PoolStateSlot(poolKey),
+    checkpoint,
+    checkpointTradingHealthy,
+    yesToken,
+    noToken,
+    currentSqrtPriceX96: sqrtPriceX96,
+    currentTick: tick,
+    poolManagerProtocolFee,
+    lpFee,
+    observedBlockNumber: input.observedBlockNumber ?? 10_000n,
+    observedBlockHash: input.observedBlockHash ?? HASH_11,
+    checkpointCall: { to: vault, data: encodePredictionV2VaultCheckpointCall() },
+    checkpointResult: encodeFunctionResult({
+      abi: PREDICTION_V2_VAULT_ABI,
+      functionName: "checkpoint",
+      result: checkpoint,
+    }),
+    checkpointTradingHealthCall: {
+      to: checkpoint,
+      data: encodePredictionV2CheckpointTradingHealthCall(),
+    },
+    checkpointTradingHealthResult: encodeFunctionResult({
+      abi: PREDICTION_V2_CHECKPOINT_ABI,
+      functionName: "isTradingHealthy",
+      result: checkpointTradingHealthy,
+    }),
+    yesTokenCall: { to: vault, data: encodePredictionV2VaultYesTokenCall() },
+    yesTokenResult: encodeFunctionResult({
+      abi: PREDICTION_V2_VAULT_ABI,
+      functionName: "yesToken",
+      result: yesToken,
+    }),
+    noTokenCall: { to: vault, data: encodePredictionV2VaultNoTokenCall() },
+    noTokenResult: encodeFunctionResult({
+      abi: PREDICTION_V2_VAULT_ABI,
+      functionName: "noToken",
+      result: noToken,
+    }),
+    slot0Call: { to: poolManager, data: encodePredictionV2PoolSlot0Call(poolKey) },
+    slot0Result: encodeFunctionResult({
+      abi: PREDICTION_V2_POOL_MANAGER_STATE_ABI,
+      functionName: "extsload",
+      result: packedPredictionV2Slot0({
+        sqrtPriceX96,
+        tick,
+        poolManagerProtocolFee,
+        lpFee,
+      }),
+    }),
+  });
+}
 
 export const BUY_QUOTE: PredictionV2BuyQuote = {
   requestedCollateralAtoms: 1_000_000n,

--- a/tests/prediction-v2-fixtures.ts
+++ b/tests/prediction-v2-fixtures.ts
@@ -1,0 +1,103 @@
+import { stringToHex, type Address } from "viem";
+
+import {
+  PREDICTION_PRESET_ASSETS_V2,
+  predictionOnchainAssetKeyV2,
+} from "../lib/prediction-market-assets-v2";
+import type { PredictionV2PoolKey } from "../lib/prediction-v2/abi";
+import type {
+  PredictionV2BuyQuote,
+  PredictionV2SellQuote,
+} from "../lib/prediction-v2/codec";
+
+export const Q96 = 1n << 96n;
+export const NOW = 1_800_000_000n;
+export const HASH_11 = `0x${"11".repeat(32)}` as const;
+export const HASH_22 = `0x${"22".repeat(32)}` as const;
+export const HASH_33 = `0x${"33".repeat(32)}` as const;
+export const HASH_44 = `0x${"44".repeat(32)}` as const;
+export const HASH_55 = `0x${"55".repeat(32)}` as const;
+export const HASH_66 = `0x${"66".repeat(32)}` as const;
+export const HASH_77 = `0x${"77".repeat(32)}` as const;
+export const ADDRESS_1 = "0x1111111111111111111111111111111111111111" as Address;
+export const ADDRESS_2 = "0x2222222222222222222222222222222222222222" as Address;
+export const ADDRESS_3 = "0x3333333333333333333333333333333333333333" as Address;
+export const ADDRESS_4 = "0x4444444444444444444444444444444444444444" as Address;
+export const ADDRESS_5 = "0x5555555555555555555555555555555555555555" as Address;
+export const ADDRESS_6 = "0x6666666666666666666666666666666666666666" as Address;
+
+export const BTC_IDENTITY = PREDICTION_PRESET_ASSETS_V2[0].identity;
+export const BTC_ASSET_KEY = predictionOnchainAssetKeyV2(BTC_IDENTITY);
+
+export const POOL_KEY: PredictionV2PoolKey = {
+  currency0: ADDRESS_1,
+  currency1: ADDRESS_2,
+  fee: 200,
+  tickSpacing: 10,
+  hooks: ADDRESS_3,
+};
+
+export const BUY_QUOTE: PredictionV2BuyQuote = {
+  requestedCollateralAtoms: 1_000_000n,
+  maximumPaymentAtoms: 1_001_000n,
+  executedCollateralAtoms: 800_000n,
+  collateralRefundAtoms: 200_000n,
+  protocolFeeAtoms: 800n,
+  feeReserveRefundAtoms: 200n,
+  actualPaymentAtoms: 800_800n,
+  outcomeAtoms: 190_000n,
+  swap: {
+    actualInput: 80_000n,
+    amountOut: 110_000n,
+    sqrtPriceX96After: Q96 * 2n,
+    tickAfter: 13_863,
+    poolManagerProtocolFee: (321 << 12) | 123,
+    lpFee: 200,
+  },
+};
+
+export const SELL_QUOTE: PredictionV2SellQuote = {
+  outcomeInAtoms: 100_000n,
+  requestedSwapAtoms: 48_000n,
+  grossCollateralAtoms: 520_000n,
+  protocolFeeAtoms: 520n,
+  netCollateralAtoms: 519_480n,
+  soldRefundAtoms: 0n,
+  complementRefundAtoms: 0n,
+  swap: {
+    actualInput: 48_000n,
+    amountOut: 52_000n,
+    sqrtPriceX96After: Q96 / 2n,
+    tickAfter: -13_864,
+    poolManagerProtocolFee: (321 << 12) | 123,
+    lpFee: 200,
+  },
+};
+
+export function registrySnapshot(active = true) {
+  return {
+    assetKey: BTC_ASSET_KEY,
+    revision: 1n,
+    identity: BTC_IDENTITY,
+    displaySymbol: "BTC",
+    policy: {
+      checkpointKind: stringToHex("CHAINLINK_ROUND", { size: 32 }),
+      checkpointAdapter: ADDRESS_4,
+      checkpointAdapterCodehash: HASH_11,
+      feedId: `0x${"0".repeat(64)}` as const,
+      feedAddress: ADDRESS_5,
+      feedProxyCodehash: HASH_22,
+      feedPhaseId: 1,
+      feedAggregator: ADDRESS_6,
+      feedAggregatorCodehash: HASH_33,
+      feedDescriptionHash: HASH_44,
+      feedDecimals: 8,
+      quoteCurrency: stringToHex("USD", { size: 32 }),
+      assetEvidenceHash: HASH_55,
+      maxOpenInterestAtoms: 100_000_000n,
+      validUntil: NOW + 45n * 24n * 60n * 60n,
+      policyVersion: 1,
+      active,
+    },
+  } as const;
+}

--- a/tests/prediction-v2-market-draft.test.ts
+++ b/tests/prediction-v2-market-draft.test.ts
@@ -1,0 +1,340 @@
+import { describe, expect, it } from "vitest";
+import { formatUnits } from "viem";
+
+import {
+  formatPredictionAssetUsdV2,
+  type PredictionMarketDraftV2,
+} from "../lib/prediction-market-assets-v2";
+import { predictionV2RegistrySnapshotHash } from
+  "../lib/prediction-v2/codec";
+import {
+  PREDICTION_V2_MAXIMUM_MARKET_DURATION_SECONDS,
+  PREDICTION_V2_MAX_THRESHOLD,
+  PREDICTION_V2_MINIMUM_MARKET_DURATION_SECONDS,
+  formatPredictionV2StrikeUsd,
+  parsePredictionV2ObservationUtc,
+  parsePredictionV2StrikeUsd,
+  validatePredictionV2MarketDraft,
+} from "../lib/prediction-v2/market-draft";
+import {
+  HASH_11,
+  NOW,
+  registrySnapshot,
+} from "./prediction-v2-fixtures";
+
+const MINUTE = 60n;
+const DAY = 24n * 60n * 60n;
+
+function utcInput(timestamp: bigint) {
+  return new Date(Number(timestamp) * 1_000).toISOString().slice(0, 16);
+}
+
+function snapshotWith(input: Readonly<{
+  feedDecimals?: number;
+  revision?: bigint;
+  validUntil?: bigint;
+  active?: boolean;
+}> = {}) {
+  const base = registrySnapshot(input.active ?? true);
+  return {
+    ...base,
+    revision: input.revision ?? base.revision,
+    policy: {
+      ...base.policy,
+      feedDecimals: input.feedDecimals ?? base.policy.feedDecimals,
+      validUntil: input.validUntil ?? base.policy.validUntil,
+    },
+  };
+}
+
+function draft(input: Readonly<{
+  strikeUsd?: string;
+  observationTime?: bigint;
+}> = {}): PredictionMarketDraftV2 {
+  return {
+    schemaVersion: 2,
+    asset: { mode: "preset", presetId: "btc" },
+    marketType: "usd-price-at-utc",
+    comparator: "greater-than-or-equal",
+    quoteCurrency: "USD",
+    strikeUsd: input.strikeUsd ?? "60000.125",
+    observationUtc: utcInput(input.observationTime ?? NOW + 2n * DAY),
+  };
+}
+
+function binding(
+  snapshot = snapshotWith(),
+  overrides: Readonly<{
+    registryHashSnapshotResult?: typeof HASH_11;
+    releaseRegistrySnapshotHash?: typeof HASH_11;
+    releaseRegistryRevision?: bigint;
+    nowUnixSeconds?: bigint;
+  }> = {},
+) {
+  const snapshotHash = predictionV2RegistrySnapshotHash(snapshot);
+  return {
+    registrySnapshot: snapshot,
+    registryHashSnapshotResult:
+      overrides.registryHashSnapshotResult ?? snapshotHash,
+    releaseRegistrySnapshotHash:
+      overrides.releaseRegistrySnapshotHash ?? snapshotHash,
+    releaseRegistryRevision:
+      overrides.releaseRegistryRevision ?? snapshot.revision,
+    nowUnixSeconds: overrides.nowUnixSeconds ?? NOW,
+  };
+}
+
+describe("Prediction V2 USD strike codec", () => {
+  it.each([6, 8, 18])(
+    "parses exact positive values at %i feed decimals",
+    (feedDecimals) => {
+      const scale = 10n ** BigInt(feedDecimals);
+      const minimum = `0.${"0".repeat(feedDecimals - 1)}1`;
+
+      expect(parsePredictionV2StrikeUsd("123.45", feedDecimals)).toBe(
+        12345n * (scale / 100n),
+      );
+      expect(parsePredictionV2StrikeUsd(minimum, feedDecimals)).toBe(1n);
+      expect(formatPredictionV2StrikeUsd(1n, feedDecimals)).toBe(minimum);
+    },
+  );
+
+  it.each([6, 8, 18])(
+    "accepts int192 max and rejects max plus one at %i decimals",
+    (feedDecimals) => {
+      const maximum = formatUnits(
+        PREDICTION_V2_MAX_THRESHOLD,
+        feedDecimals,
+      );
+      const aboveMaximum = formatUnits(
+        PREDICTION_V2_MAX_THRESHOLD + 1n,
+        feedDecimals,
+      );
+
+      expect(parsePredictionV2StrikeUsd(maximum, feedDecimals)).toBe(
+        PREDICTION_V2_MAX_THRESHOLD,
+      );
+      expect(parsePredictionV2StrikeUsd(aboveMaximum, feedDecimals)).toBeNull();
+    },
+  );
+
+  it("rejects non-canonical syntax and every value that viem would round", () => {
+    for (const value of [
+      "",
+      "0",
+      "-1",
+      "+1",
+      "01",
+      ".1",
+      "1.",
+      "1,000",
+      "1e3",
+      "NaN",
+      "Infinity",
+    ]) {
+      expect(parsePredictionV2StrikeUsd(value, 6), value).toBeNull();
+    }
+    for (const roundedByParseUnits of [
+      "1.0000001",
+      "1.0000009",
+      "1.2345678",
+      "0.0000009",
+    ]) {
+      expect(
+        parsePredictionV2StrikeUsd(roundedByParseUnits, 6),
+        roundedByParseUnits,
+      ).toBeNull();
+    }
+    expect(parsePredictionV2StrikeUsd(" 1.25 ", 6)).toBe(1_250_000n);
+    expect(parsePredictionV2StrikeUsd("1", 0)).toBeNull();
+    expect(parsePredictionV2StrikeUsd("1", 19)).toBeNull();
+    expect(parsePredictionV2StrikeUsd("1", 6.5)).toBeNull();
+    expect(() => formatPredictionV2StrikeUsd(0n, 8)).toThrow(TypeError);
+    expect(() => formatPredictionV2StrikeUsd(
+      PREDICTION_V2_MAX_THRESHOLD + 1n,
+      8,
+    )).toThrow(TypeError);
+  });
+
+  it.each([6, 8, 18])(
+    "round-trips every canonical boundary at %i decimals",
+    (feedDecimals) => {
+      const scale = 10n ** BigInt(feedDecimals);
+      for (const atoms of [
+        1n,
+        scale - 1n,
+        scale,
+        12_345n * scale + 6789n,
+        PREDICTION_V2_MAX_THRESHOLD,
+      ]) {
+        expect(parsePredictionV2StrikeUsd(
+          formatPredictionV2StrikeUsd(atoms, feedDecimals),
+          feedDecimals,
+        )).toBe(atoms);
+      }
+    },
+  );
+});
+
+describe("Prediction V2 market draft release binding", () => {
+  it.each([
+    [6, "1.000001", 1_000_001n],
+    [8, "1.00000001", 100_000_001n],
+    [18, "1.000000000000000001", 1_000_000_000_000_000_001n],
+  ] as const)(
+    "derives threshold atoms only from the bound %i-decimal snapshot",
+    (feedDecimals, strikeUsd, expectedAtoms) => {
+      const snapshot = snapshotWith({ feedDecimals });
+      const result = validatePredictionV2MarketDraft(
+        draft({ strikeUsd }),
+        binding(snapshot),
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("expected a valid bound market draft");
+      expect(result.market).toMatchObject({
+        selectionKey: "preset:btc",
+        onchainAssetKey: snapshot.assetKey,
+        registryRevision: snapshot.revision,
+        registrySnapshotHash: predictionV2RegistrySnapshotHash(snapshot),
+        feedDecimals,
+        thresholdAtoms: expectedAtoms,
+        strikeUsd,
+        policyValidUntil: snapshot.policy.validUntil,
+      });
+    },
+  );
+
+  it("fails closed on stale revision, Registry hash, release hash or decimals", () => {
+    const eightDecimals = snapshotWith({ feedDecimals: 8, revision: 7n });
+    const eightHash = predictionV2RegistrySnapshotHash(eightDecimals);
+    expect(validatePredictionV2MarketDraft(
+      draft({ strikeUsd: "1.00000001" }),
+      binding(eightDecimals, { releaseRegistryRevision: 8n }),
+    )).toMatchObject({ ok: false, errors: { binding: expect.any(String) } });
+    expect(validatePredictionV2MarketDraft(
+      draft({ strikeUsd: "1.00000001" }),
+      binding(eightDecimals, { registryHashSnapshotResult: HASH_11 }),
+    )).toMatchObject({ ok: false, errors: { binding: expect.any(String) } });
+    expect(validatePredictionV2MarketDraft(
+      draft({ strikeUsd: "1.00000001" }),
+      binding(eightDecimals, { releaseRegistrySnapshotHash: HASH_11 }),
+    )).toMatchObject({ ok: false, errors: { binding: expect.any(String) } });
+
+    const sixDecimals = snapshotWith({ feedDecimals: 6, revision: 7n });
+    expect(validatePredictionV2MarketDraft(
+      draft({ strikeUsd: "1.00000001" }),
+      binding(sixDecimals),
+    )).toMatchObject({ ok: false, errors: { strikeUsd: expect.any(String) } });
+    expect(validatePredictionV2MarketDraft(
+      draft({ strikeUsd: "1.000001" }),
+      {
+        ...binding(sixDecimals),
+        registryHashSnapshotResult: eightHash,
+        releaseRegistrySnapshotHash: eightHash,
+      },
+    )).toMatchObject({ ok: false, errors: { binding: expect.any(String) } });
+  });
+
+  it("binds the released snapshot identity to the explicit asset selection", () => {
+    expect(validatePredictionV2MarketDraft(
+      {
+        ...draft(),
+        asset: { mode: "preset", presetId: "eth" },
+      },
+      binding(),
+    )).toMatchObject({ ok: false, errors: { asset: expect.any(String) } });
+  });
+});
+
+describe("Prediction V2 UTC market horizon", () => {
+  it("requires strictly more than 24 hours and allows exactly 30 days", () => {
+    const atMinimum = validatePredictionV2MarketDraft(
+      draft({
+        observationTime:
+          NOW + PREDICTION_V2_MINIMUM_MARKET_DURATION_SECONDS,
+      }),
+      binding(),
+    );
+    expect(atMinimum).toMatchObject({
+      ok: false,
+      errors: { observationUtc: expect.stringContaining("more than 24 hours") },
+    });
+
+    expect(validatePredictionV2MarketDraft(
+      draft({
+        observationTime:
+          NOW + PREDICTION_V2_MINIMUM_MARKET_DURATION_SECONDS + MINUTE,
+      }),
+      binding(),
+    ).ok).toBe(true);
+    expect(validatePredictionV2MarketDraft(
+      draft({
+        observationTime:
+          NOW + PREDICTION_V2_MAXIMUM_MARKET_DURATION_SECONDS,
+      }),
+      binding(),
+    ).ok).toBe(true);
+    expect(validatePredictionV2MarketDraft(
+      draft({
+        observationTime:
+          NOW + PREDICTION_V2_MAXIMUM_MARKET_DURATION_SECONDS + MINUTE,
+      }),
+      binding(),
+    )).toMatchObject({
+      ok: false,
+      errors: { observationUtc: expect.stringContaining("no more than 30 days") },
+    });
+  });
+
+  it("never creates past the bound Oracle policy validUntil", () => {
+    const observationTime = NOW + 2n * DAY;
+    const expiringBefore = snapshotWith({
+      validUntil: observationTime - MINUTE,
+    });
+    const expiringAt = snapshotWith({ validUntil: observationTime });
+
+    expect(validatePredictionV2MarketDraft(
+      draft({ observationTime }),
+      binding(expiringBefore),
+    )).toMatchObject({
+      ok: false,
+      errors: { observationUtc: expect.stringContaining("expires") },
+    });
+    expect(validatePredictionV2MarketDraft(
+      draft({ observationTime }),
+      binding(expiringAt),
+    ).ok).toBe(true);
+  });
+
+  it("parses only real minute-precision UTC timestamps inside uint32", () => {
+    expect(parsePredictionV2ObservationUtc("2027-01-17T08:00")).toBe(
+      NOW + 2n * DAY,
+    );
+    expect(parsePredictionV2ObservationUtc("2026-02-30T08:00")).toBeNull();
+    expect(parsePredictionV2ObservationUtc("2027-01-17 08:00")).toBeNull();
+    expect(parsePredictionV2ObservationUtc("2107-01-01T00:00")).toBeNull();
+  });
+});
+
+describe("Prediction V2 informational price formatting", () => {
+  it("never presents a positive tiny price as $0.00", () => {
+    for (const value of [
+      0.0000001234,
+      1e-12,
+      1e-18,
+      1e-19,
+      Number.MIN_VALUE,
+    ]) {
+      expect(formatPredictionAssetUsdV2(value, "price"), String(value))
+        .not.toBe("$0.00");
+    }
+    expect(formatPredictionAssetUsdV2(0.0000001234, "price")).toBe(
+      "$0.0000001234",
+    );
+    expect(formatPredictionAssetUsdV2(1e-19, "price")).toBe(
+      "<$0.000000000000000001",
+    );
+    expect(formatPredictionAssetUsdV2(0, "price")).toBe("$0.00");
+  });
+});

--- a/tests/prediction-v2-release-binding.test.ts
+++ b/tests/prediction-v2-release-binding.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  getPredictionV2ReleaseBinding,
+  parsePredictionV2ReleaseBinding,
+} from "../lib/prediction-v2/release-binding.server";
+
+const disabledBinding = {
+  schemaVersion: 1,
+  releaseVersion: "prediction-v2",
+  status: "disabled",
+} as const;
+
+describe("Prediction V2 release binding", () => {
+  it("loads an immutable dormant binding with no deployment identity", () => {
+    const binding = getPredictionV2ReleaseBinding();
+
+    expect(binding).toEqual(disabledBinding);
+    expect(Object.isFrozen(binding)).toBe(true);
+    expect(binding).not.toHaveProperty("addresses");
+    expect(binding).not.toHaveProperty("deployment");
+    expect(binding).not.toHaveProperty("attestation");
+  });
+
+  it("accepts only the exact disabled V1 schema and copies the input", () => {
+    const input: Record<string, unknown> = { ...disabledBinding };
+    const parsed = parsePredictionV2ReleaseBinding(input);
+
+    input.status = "enabled";
+    expect(parsed).toEqual(disabledBinding);
+    expect(Object.isFrozen(parsed)).toBe(true);
+  });
+
+  it.each([
+    ["draft status", { ...disabledBinding, status: "draft" }],
+    ["enabled status", { ...disabledBinding, status: "enabled" }],
+    ["missing status", {
+      schemaVersion: 1,
+      releaseVersion: "prediction-v2",
+    }],
+    ["wrong schema", { ...disabledBinding, schemaVersion: 2 }],
+    ["wrong release", { ...disabledBinding, releaseVersion: "prediction-v1" }],
+    ["address injection", {
+      ...disabledBinding,
+      addresses: { factory: "0x1111111111111111111111111111111111111111" },
+    }],
+    ["environment indirection", {
+      ...disabledBinding,
+      factoryAddressEnv: "PREDICTION_V2_FACTORY_ADDRESS",
+    }],
+  ])("rejects %s", (_label, value) => {
+    expect(() => parsePredictionV2ReleaseBinding(value)).toThrow(
+      "Invalid Prediction V2 release binding",
+    );
+  });
+
+  it("rejects activation-shaped data even when it claims an attestation", () => {
+    const fakeActivatedBinding = {
+      ...disabledBinding,
+      status: "enabled",
+      deployment: {
+        chainId: 4_663,
+        factory: "0x1111111111111111111111111111111111111111",
+      },
+      attestation: {
+        signer: "self-declared",
+        signature: `0x${"11".repeat(64)}`,
+      },
+    };
+
+    expect(() => parsePredictionV2ReleaseBinding(fakeActivatedBinding)).toThrow(
+      "Invalid Prediction V2 release binding",
+    );
+  });
+
+  it("rejects arrays and records with a nonstandard prototype", () => {
+    expect(() => parsePredictionV2ReleaseBinding([disabledBinding])).toThrow(
+      "Invalid Prediction V2 release binding",
+    );
+    expect(() => parsePredictionV2ReleaseBinding(
+      Object.assign(Object.create(null), disabledBinding),
+    )).toThrow("Invalid Prediction V2 release binding");
+  });
+
+  it("rejects hidden or symbol-keyed additions", () => {
+    const hidden = { ...disabledBinding };
+    Object.defineProperty(hidden, "deployment", { value: null });
+    const symbolKeyed = {
+      ...disabledBinding,
+      [Symbol("deployment")]: null,
+    };
+
+    expect(() => parsePredictionV2ReleaseBinding(hidden)).toThrow(
+      "Invalid Prediction V2 release binding",
+    );
+    expect(() => parsePredictionV2ReleaseBinding(symbolKeyed)).toThrow(
+      "Invalid Prediction V2 release binding",
+    );
+  });
+});

--- a/tests/prediction-v2-transactions.test.ts
+++ b/tests/prediction-v2-transactions.test.ts
@@ -14,6 +14,7 @@ import {
   PREDICTION_V2_VAULT_ABI,
 } from "../lib/prediction-v2/abi";
 import { predictionV2RegistrySnapshotHash } from "../lib/prediction-v2/codec";
+import { predictionV2YesProbabilityBps } from "../lib/prediction-v2/accounting";
 import {
   bindPredictionV2BuyCapacityPreflight,
   bindPredictionV2BuyQuote,
@@ -26,12 +27,19 @@ import {
   encodePredictionV2VaultExposureControllerCall,
   preparePredictionV2BuyWithPermit,
   preparePredictionV2CreateWithPermit,
+  preparePredictionV2FinalizeAndRedeemWithChainlinkRounds,
+  preparePredictionV2FinalizeResolved,
+  preparePredictionV2FinalizeUnavailable,
+  preparePredictionV2FinalizeUnproven,
   preparePredictionV2FinalizeWithChainlinkRounds,
+  preparePredictionV2Redeem,
+  preparePredictionV2RequestUnprovenFallback,
   preparePredictionV2SellWithPermit,
 } from "../lib/prediction-v2/transactions";
 import {
   ADDRESS_1,
   ADDRESS_2,
+  ADDRESS_4,
   BTC_ASSET_KEY,
   BTC_IDENTITY,
   BUY_QUOTE,
@@ -40,6 +48,7 @@ import {
   NOW,
   POOL_KEY,
   SELL_QUOTE,
+  boundPredictionV2MarketState,
   registrySnapshot,
 } from "./prediction-v2-fixtures";
 
@@ -58,24 +67,58 @@ function permit(value: bigint) {
   };
 }
 
-function boundBuyQuote() {
+function boundBuyQuote(
+  quote = BUY_QUOTE,
+  marketState = boundPredictionV2MarketState(),
+) {
+  const quoteCall = encodePredictionV2BuyQuoteCall({
+    vault: ADDRESS_1,
+    poolKey: POOL_KEY,
+    buyYes: true,
+    requestedCollateralAtoms: quote.requestedCollateralAtoms,
+    sqrtPriceLimitX96: SQRT_PRICE_LIMIT,
+  });
   return bindPredictionV2BuyQuote({
     chainId: 4_663,
     quoter: ADDRESS_2,
     vault: ADDRESS_1,
     poolKey: POOL_KEY,
     buyYes: true,
-    requestedCollateralAtoms: BUY_QUOTE.requestedCollateralAtoms,
+    requestedCollateralAtoms: quote.requestedCollateralAtoms,
     sqrtPriceLimitX96: SQRT_PRICE_LIMIT,
     observedBlockNumber: QUOTE_BLOCK,
     observedBlockHash: HASH_11,
-    quote: BUY_QUOTE,
+    marketState,
+    quoteCall: { to: ADDRESS_2, data: quoteCall },
+    quoteResult: encodeFunctionResult({
+      abi: PREDICTION_V2_QUOTER_ABI,
+      functionName: "quoteBuy",
+      result: quote,
+    }),
   });
+}
+
+function sqrtPriceForYesProbabilityBps(targetProbabilityBps: number) {
+  let low = 1n << 96n;
+  let high = 2n << 96n;
+  while (low < high) {
+    const middle = (low + high) / 2n;
+    if (predictionV2YesProbabilityBps(middle, true) < targetProbabilityBps) {
+      low = middle + 1n;
+    } else {
+      high = middle;
+    }
+  }
+  if (predictionV2YesProbabilityBps(low, true) !== targetProbabilityBps) {
+    throw new Error("Missing exact test probability.");
+  }
+  return low;
 }
 
 function buyIntent() {
   return {
     quoter: ADDRESS_2,
+    poolManager: ADDRESS_4,
     vault: ADDRESS_1,
     poolKey: POOL_KEY,
     buyYes: true,
@@ -111,26 +154,41 @@ function buyCapacityPreflight() {
 }
 
 function boundSellQuote() {
+  const marketState = boundPredictionV2MarketState();
+  const quoteCall = encodePredictionV2SellQuoteCall({
+    vault: ADDRESS_1,
+    poolKey: POOL_KEY,
+    sellYes: true,
+    outcomeAtoms: SELL_QUOTE.outcomeInAtoms,
+    sqrtPriceLimitX96: SQRT_PRICE_LIMIT,
+  });
   return bindPredictionV2SellQuote({
     chainId: 4_663,
     quoter: ADDRESS_2,
     vault: ADDRESS_1,
     poolKey: POOL_KEY,
-    sellYes: false,
+    sellYes: true,
     outcomeAtoms: SELL_QUOTE.outcomeInAtoms,
     sqrtPriceLimitX96: SQRT_PRICE_LIMIT,
     observedBlockNumber: QUOTE_BLOCK,
     observedBlockHash: HASH_11,
-    quote: SELL_QUOTE,
+    marketState,
+    quoteCall: { to: ADDRESS_2, data: quoteCall },
+    quoteResult: encodeFunctionResult({
+      abi: PREDICTION_V2_QUOTER_ABI,
+      functionName: "quoteSellOptimal",
+      result: SELL_QUOTE,
+    }),
   });
 }
 
 function sellIntent() {
   return {
     quoter: ADDRESS_2,
+    poolManager: ADDRESS_4,
     vault: ADDRESS_1,
     poolKey: POOL_KEY,
-    sellYes: false,
+    sellYes: true,
     outcomeAtoms: SELL_QUOTE.outcomeInAtoms,
     sqrtPriceLimitX96: SQRT_PRICE_LIMIT,
   } as const;
@@ -167,6 +225,151 @@ describe("Protocol V2 prepared transactions", () => {
     expect(sell.args?.[3]).toBe(100_000n);
   });
 
+  it("binds quote provenance to the exact Quoter target, calldata, result, and block", () => {
+    const buy = boundBuyQuote();
+    expect(buy.quote).toEqual(BUY_QUOTE);
+    expect(buy.quoteCall.to).toBe(ADDRESS_2);
+    expect(buy.quoteResult).not.toBe("0x");
+
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      quoteCall: { ...buy.quoteCall, to: ADDRESS_1 },
+    })).toThrow("buy quote call binding");
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      buyYes: false,
+    })).toThrow("buy quote call binding");
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      poolKey: { ...buy.poolKey, currency0: ADDRESS_2, currency1: ADDRESS_1 },
+    })).toThrow("buy quote/market-state binding");
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      quoteResult: "0x1234",
+    })).toThrow("buy quote result");
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      quoteResult: `${buy.quoteResult}00`,
+    })).toThrow("buy quote result canonicality");
+
+    const sell = boundSellQuote();
+    expect(() => bindPredictionV2SellQuote({
+      ...sell,
+      sqrtPriceLimitX96: sell.sqrtPriceLimitX96 + 1n,
+    })).toThrow("sell quote call binding");
+  });
+
+  it("binds Vault token roles and raw slot0 evidence to the quote's exact block", () => {
+    const buy = boundBuyQuote();
+    const state = buy.marketState;
+    expect(state).toMatchObject({
+      chainId: 4_663,
+      vault: ADDRESS_1,
+      poolManager: ADDRESS_4,
+      checkpointTradingHealthy: true,
+      yesToken: POOL_KEY.currency0,
+      noToken: POOL_KEY.currency1,
+      currentSqrtPriceX96: 1n << 96n,
+      observedBlockNumber: QUOTE_BLOCK,
+      observedBlockHash: HASH_11,
+    });
+    expect(state.yesTokenResult).not.toBe("0x");
+    expect(state.noTokenResult).not.toBe("0x");
+    expect(state.checkpointResult).not.toBe("0x");
+    expect(state.checkpointTradingHealthResult).not.toBe("0x");
+    expect(state.slot0Result).not.toBe("0x");
+
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      marketState: {
+        ...state,
+        checkpointTradingHealthCall: {
+          ...state.checkpointTradingHealthCall,
+          to: ADDRESS_2,
+        },
+      },
+    })).toThrow("checkpoint trading-health call binding");
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      marketState: {
+        ...state,
+        checkpointTradingHealthResult: `0x${"0".repeat(63)}2`,
+      },
+    })).toThrow("checkpoint trading-health result");
+
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      marketState: {
+        ...state,
+        yesToken: state.noToken,
+        noToken: state.yesToken,
+      },
+    })).toThrow("decoded market-state binding");
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      marketState: {
+        ...state,
+        yesTokenCall: { ...state.yesTokenCall, data: state.noTokenCall.data },
+      },
+    })).toThrow("outcome-token call binding");
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      marketState: {
+        ...state,
+        yesTokenResult: `0x01${state.yesTokenResult.slice(4)}`,
+      },
+    })).toThrow("Vault yesToken result");
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      marketState: {
+        ...state,
+        noTokenResult: `${state.noTokenResult}00`,
+      },
+    })).toThrow("Vault noToken result");
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      marketState: {
+        ...state,
+        slot0Call: { ...state.slot0Call, to: ADDRESS_2 },
+      },
+    })).toThrow("slot0 call binding");
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      marketState: {
+        ...state,
+        currentSqrtPriceX96: state.currentSqrtPriceX96 + 1n,
+      },
+    })).toThrow("decoded market-state binding");
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      marketState: {
+        ...state,
+        slot0Result: `${state.slot0Result}00`,
+      },
+    })).toThrow("slot0 result");
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      marketState: {
+        ...state,
+        slot0Result: `0x01${state.slot0Result.slice(4)}`,
+      },
+    })).toThrow("slot0 reserved bits");
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      marketState: {
+        ...state,
+        observedBlockNumber: QUOTE_BLOCK + 1n,
+      },
+    })).toThrow("quote/market-state binding");
+    expect(() => bindPredictionV2BuyQuote({
+      ...buy,
+      marketState: {
+        ...state,
+        observedBlockHash: HASH_22,
+      },
+    })).toThrow("quote/market-state binding");
+  });
+
   it("binds the same-block capacity preflight to the full requested split notional", () => {
     const getterResult = encodeFunctionResult({
       abi: PREDICTION_V2_VAULT_ABI,
@@ -178,6 +381,11 @@ describe("Protocol V2 prepared transactions", () => {
       data: encodePredictionV2VaultExposureControllerCall(),
     }).functionName).toBe("exposureController");
     expect(decodePredictionV2VaultExposureController(getterResult)).toBe(ADDRESS_2);
+    expect(() => decodePredictionV2VaultExposureController(`${getterResult}00`))
+      .toThrow("exposure controller result");
+    expect(() => decodePredictionV2VaultExposureController(
+      `0x01${getterResult.slice(4)}`,
+    )).toThrow("exposure controller result");
 
     const capacityCall = decodeFunctionData({
       abi: PREDICTION_V2_EXPOSURE_CONTROLLER_ABI,
@@ -269,6 +477,7 @@ describe("Protocol V2 prepared transactions", () => {
       slippageBps: 50,
       tradeDeadline: TRADE_DEADLINE,
       permit: permit(BUY_QUOTE.maximumPaymentAtoms),
+      explicitlyConfirmedHighPriceImpact: true,
       nowUnixSeconds: NOW,
     });
     const decoded = decodeFunctionData({
@@ -284,6 +493,7 @@ describe("Protocol V2 prepared transactions", () => {
       deadline: TRADE_DEADLINE,
     });
     expect(decoded.args?.[3]).toBe(PERMIT_DEADLINE);
+    expect(prepared.chainId).toBe(4_663);
     expect(prepared.value).toBe(0n);
 
     expect(() => preparePredictionV2BuyWithPermit({
@@ -295,9 +505,53 @@ describe("Protocol V2 prepared transactions", () => {
       maximumQuoteAgeBlocks: 2,
       slippageBps: 50,
       tradeDeadline: TRADE_DEADLINE,
+      permit: permit(BUY_QUOTE.maximumPaymentAtoms),
+      explicitlyConfirmedHighPriceImpact: false,
+      nowUnixSeconds: NOW,
+    })).toThrow("explicit price-impact confirmation");
+
+    expect(() => preparePredictionV2BuyWithPermit({
+      router: ADDRESS_2,
+      boundQuote: boundBuyQuote(),
+      capacityPreflight: buyCapacityPreflight(),
+      intent: buyIntent(),
+      latestConfirmedBlockNumber: QUOTE_BLOCK + 1n,
+      maximumQuoteAgeBlocks: 2,
+      slippageBps: 50,
+      tradeDeadline: TRADE_DEADLINE,
       permit: permit(BUY_QUOTE.requestedCollateralAtoms),
+      explicitlyConfirmedHighPriceImpact: true,
       nowUnixSeconds: NOW,
     })).toThrow("permit amount");
+  });
+
+  it("executes the prepare gate at exact 499/500 probability-point bps", () => {
+    const quoteAt = (magnitude: 499 | 500) => ({
+      ...BUY_QUOTE,
+      swap: {
+        ...BUY_QUOTE.swap,
+        sqrtPriceX96After: sqrtPriceForYesProbabilityBps(5_000 + magnitude),
+      },
+    } as const);
+    const prepareAt = (magnitude: 499 | 500, confirmed: boolean) => {
+      const quote = boundBuyQuote(quoteAt(magnitude));
+      return preparePredictionV2BuyWithPermit({
+        router: ADDRESS_2,
+        boundQuote: quote,
+        capacityPreflight: buyCapacityPreflight(),
+        intent: buyIntent(),
+        latestConfirmedBlockNumber: QUOTE_BLOCK + 1n,
+        maximumQuoteAgeBlocks: 2,
+        slippageBps: 50,
+        tradeDeadline: TRADE_DEADLINE,
+        permit: permit(quote.quote.maximumPaymentAtoms),
+        explicitlyConfirmedHighPriceImpact: confirmed,
+        nowUnixSeconds: NOW,
+      });
+    };
+    expect(() => prepareAt(499, false)).not.toThrow();
+    expect(() => prepareAt(500, false)).toThrow("explicit price-impact confirmation");
+    expect(() => prepareAt(500, true)).not.toThrow();
   });
 
   it("uses net, never gross, sell collateral for the minimum and exact outcome permit", () => {
@@ -310,6 +564,7 @@ describe("Protocol V2 prepared transactions", () => {
       slippageBps: 100,
       tradeDeadline: TRADE_DEADLINE,
       permit: permit(SELL_QUOTE.outcomeInAtoms),
+      explicitlyConfirmedHighPriceImpact: true,
       nowUnixSeconds: NOW,
     });
     const decoded = decodeFunctionData({
@@ -318,7 +573,7 @@ describe("Protocol V2 prepared transactions", () => {
     });
     expect(decoded.functionName).toBe("sellOutcomeWithPermit");
     expect(decoded.args?.[2]).toEqual({
-      sellYes: false,
+      sellYes: true,
       outcomeAtoms: 100_000n,
       swapAtoms: 48_000n,
       minCollateralAtoms: 514_285n,
@@ -335,8 +590,51 @@ describe("Protocol V2 prepared transactions", () => {
       slippageBps: 100,
       tradeDeadline: TRADE_DEADLINE,
       permit: permit(SELL_QUOTE.outcomeInAtoms - 1n),
+      explicitlyConfirmedHighPriceImpact: true,
       nowUnixSeconds: NOW,
     })).toThrow("permit amount");
+  });
+
+  it("refuses to prepare either trade while the bound checkpoint is unhealthy", () => {
+    const unhealthyState = boundPredictionV2MarketState({ checkpointTradingHealthy: false });
+    expect(() => preparePredictionV2BuyWithPermit({
+      router: ADDRESS_2,
+      boundQuote: boundBuyQuote(BUY_QUOTE, unhealthyState),
+      capacityPreflight: buyCapacityPreflight(),
+      intent: buyIntent(),
+      latestConfirmedBlockNumber: QUOTE_BLOCK + 1n,
+      maximumQuoteAgeBlocks: 2,
+      slippageBps: 50,
+      tradeDeadline: TRADE_DEADLINE,
+      permit: permit(BUY_QUOTE.maximumPaymentAtoms),
+      explicitlyConfirmedHighPriceImpact: true,
+      nowUnixSeconds: NOW,
+    })).toThrow("checkpoint trading health");
+
+    const sellQuoteCall = encodePredictionV2SellQuoteCall({
+      vault: ADDRESS_1,
+      poolKey: POOL_KEY,
+      sellYes: true,
+      outcomeAtoms: SELL_QUOTE.outcomeInAtoms,
+      sqrtPriceLimitX96: SQRT_PRICE_LIMIT,
+    });
+    const unhealthySellQuote = bindPredictionV2SellQuote({
+      ...boundSellQuote(),
+      marketState: unhealthyState,
+      quoteCall: { to: ADDRESS_2, data: sellQuoteCall },
+    });
+    expect(() => preparePredictionV2SellWithPermit({
+      router: ADDRESS_2,
+      boundQuote: unhealthySellQuote,
+      intent: sellIntent(),
+      latestConfirmedBlockNumber: QUOTE_BLOCK + 1n,
+      maximumQuoteAgeBlocks: 2,
+      slippageBps: 100,
+      tradeDeadline: TRADE_DEADLINE,
+      permit: permit(SELL_QUOTE.outcomeInAtoms),
+      explicitlyConfirmedHighPriceImpact: true,
+      nowUnixSeconds: NOW,
+    })).toThrow("checkpoint trading health");
   });
 
   it("creates only a canonically selected identity with active exact Registry snapshot", () => {
@@ -352,6 +650,8 @@ describe("Protocol V2 prepared transactions", () => {
       registrySnapshot: snapshot,
       registryHashSnapshotResult: snapshotHash,
       factoryActiveSnapshotHash: snapshotHash,
+      factoryActiveMarketId: HASH_22,
+      factoryActiveRegistryRevision: snapshot.revision,
       releaseRegistrySnapshotHash: snapshotHash,
       observationTime,
       threshold,
@@ -366,11 +666,13 @@ describe("Protocol V2 prepared transactions", () => {
     expect(decoded.args?.[0]).toEqual(BTC_IDENTITY);
     expect(decoded.args?.[1]).toBe(Number(observationTime));
     expect(decoded.args?.[2]).toBe(threshold);
+    expect(decoded.args?.[3]).toBe(HASH_22);
     expect(prepared).toMatchObject({
       selectionKey: "preset:btc",
       onchainAssetKey: BTC_ASSET_KEY,
       registryRevision: 1n,
       registrySnapshotHash: snapshotHash,
+      expectedMarketId: HASH_22,
       value: 0n,
     });
 
@@ -382,6 +684,8 @@ describe("Protocol V2 prepared transactions", () => {
       registrySnapshot: registrySnapshot(),
       registryHashSnapshotResult: snapshotHash,
       factoryActiveSnapshotHash: snapshotHash,
+      factoryActiveMarketId: HASH_22,
+      factoryActiveRegistryRevision: snapshot.revision,
       releaseRegistrySnapshotHash: snapshotHash,
       observationTime,
       threshold,
@@ -396,6 +700,8 @@ describe("Protocol V2 prepared transactions", () => {
       registrySnapshot: registrySnapshot(false),
       registryHashSnapshotResult: snapshotHash,
       factoryActiveSnapshotHash: snapshotHash,
+      factoryActiveMarketId: HASH_22,
+      factoryActiveRegistryRevision: snapshot.revision,
       releaseRegistrySnapshotHash: snapshotHash,
       observationTime,
       threshold,
@@ -410,7 +716,41 @@ describe("Protocol V2 prepared transactions", () => {
       registrySnapshot: snapshot,
       registryHashSnapshotResult: snapshotHash,
       factoryActiveSnapshotHash: snapshotHash,
+      factoryActiveMarketId: HASH_22,
+      factoryActiveRegistryRevision: snapshot.revision,
       releaseRegistrySnapshotHash: HASH_11,
+      observationTime,
+      threshold,
+      permit: permit(2_000_000n),
+      nowUnixSeconds: NOW,
+    })).toThrow("snapshot hash binding");
+    expect(() => preparePredictionV2CreateWithPermit({
+      factory: ADDRESS_2,
+      selection: { mode: "preset", presetId: "btc" },
+      identity: BTC_IDENTITY,
+      onchainAssetKey: BTC_ASSET_KEY,
+      registrySnapshot: snapshot,
+      registryHashSnapshotResult: snapshotHash,
+      factoryActiveSnapshotHash: snapshotHash,
+      factoryActiveMarketId: `0x${"0".repeat(64)}`,
+      factoryActiveRegistryRevision: snapshot.revision,
+      releaseRegistrySnapshotHash: snapshotHash,
+      observationTime,
+      threshold,
+      permit: permit(2_000_000n),
+      nowUnixSeconds: NOW,
+    })).toThrow("active market id");
+    expect(() => preparePredictionV2CreateWithPermit({
+      factory: ADDRESS_2,
+      selection: { mode: "preset", presetId: "btc" },
+      identity: BTC_IDENTITY,
+      onchainAssetKey: BTC_ASSET_KEY,
+      registrySnapshot: snapshot,
+      registryHashSnapshotResult: snapshotHash,
+      factoryActiveSnapshotHash: snapshotHash,
+      factoryActiveMarketId: HASH_22,
+      factoryActiveRegistryRevision: snapshot.revision + 1n,
+      releaseRegistrySnapshotHash: snapshotHash,
       observationTime,
       threshold,
       permit: permit(2_000_000n),
@@ -419,19 +759,21 @@ describe("Protocol V2 prepared transactions", () => {
   });
 
   it("encodes finalize(bytes) with one exact adjacent uint80 round proof and zero value", () => {
+    const beforeRoundId = (1n << 64n) | 123n;
+    const afterRoundId = (1n << 64n) | 124n;
     const proof = encodePredictionV2ChainlinkRoundProof({
-      beforeRoundId: 123n,
-      afterRoundId: 124n,
+      beforeRoundId,
+      afterRoundId,
     });
     expect(proof).toHaveLength(2 + 64 * 2);
     expect(decodeAbiParameters(
       parseAbiParameters("uint80 beforeRoundId, uint80 afterRoundId"),
       proof,
-    )).toEqual([123n, 124n]);
+    )).toEqual([beforeRoundId, afterRoundId]);
     const prepared = preparePredictionV2FinalizeWithChainlinkRounds({
       vault: ADDRESS_1,
-      beforeRoundId: 123n,
-      afterRoundId: 124n,
+      beforeRoundId,
+      afterRoundId,
     });
     const decoded = decodeFunctionData({
       abi: PREDICTION_V2_VAULT_ABI,
@@ -441,13 +783,78 @@ describe("Protocol V2 prepared transactions", () => {
     expect(decoded.args).toEqual([proof]);
     expect(prepared.value).toBe(0n);
     expect(() => encodePredictionV2ChainlinkRoundProof({
-      beforeRoundId: 123n,
-      afterRoundId: 125n,
+      beforeRoundId,
+      afterRoundId: afterRoundId + 1n,
+    })).toThrow("round proof");
+    expect(() => encodePredictionV2ChainlinkRoundProof({
+      beforeRoundId,
+      afterRoundId: (2n << 64n) | 1n,
     })).toThrow("round proof");
     expect(() => encodePredictionV2ChainlinkRoundProof({
       beforeRoundId: 0n,
       afterRoundId: 1n,
     })).toThrow("round proof");
+  });
+
+  it("encodes every terminal fallback and redemption path without hidden value", () => {
+    const noArgPreparers = [
+      [preparePredictionV2FinalizeUnavailable, "finalizeUnavailable"],
+      [preparePredictionV2RequestUnprovenFallback, "requestUnprovenFallback"],
+      [preparePredictionV2FinalizeUnproven, "finalizeUnproven"],
+      [preparePredictionV2FinalizeResolved, "finalizeResolved"],
+    ] as const;
+    for (const [prepare, functionName] of noArgPreparers) {
+      const transaction = prepare(ADDRESS_1);
+      expect(transaction).toMatchObject({ chainId: 4_663, to: ADDRESS_1, value: 0n });
+      expect(decodeFunctionData({
+        abi: PREDICTION_V2_VAULT_ABI,
+        data: transaction.data,
+      })).toMatchObject({ functionName, args: undefined });
+    }
+
+    const redeem = preparePredictionV2Redeem({
+      vault: ADDRESS_1,
+      yesAtoms: 12n,
+      noAtoms: 34n,
+      recipient: ADDRESS_2,
+    });
+    expect(decodeFunctionData({
+      abi: PREDICTION_V2_VAULT_ABI,
+      data: redeem.data,
+    })).toMatchObject({
+      functionName: "redeem",
+      args: [12n, 34n, ADDRESS_2],
+    });
+    expect(() => preparePredictionV2Redeem({
+      vault: ADDRESS_1,
+      yesAtoms: 0n,
+      noAtoms: 0n,
+      recipient: ADDRESS_2,
+    })).toThrow("redemption amount");
+  });
+
+  it("encodes an atomic Chainlink finalize and redeem with the exact claim amounts", () => {
+    const beforeRoundId = (1n << 64n) | 999n;
+    const afterRoundId = (1n << 64n) | 1_000n;
+    const transaction = preparePredictionV2FinalizeAndRedeemWithChainlinkRounds({
+      vault: ADDRESS_1,
+      beforeRoundId,
+      afterRoundId,
+      yesAtoms: 50n,
+      noAtoms: 25n,
+      recipient: ADDRESS_2,
+    });
+    const decoded = decodeFunctionData({
+      abi: PREDICTION_V2_VAULT_ABI,
+      data: transaction.data,
+    });
+    expect(decoded.functionName).toBe("finalizeAndRedeem");
+    expect(decoded.args?.slice(1)).toEqual([50n, 25n, ADDRESS_2]);
+    expect(decodeAbiParameters(
+      parseAbiParameters("uint80 beforeRoundId, uint80 afterRoundId"),
+      decoded.args?.[0] as `0x${string}`,
+    )).toEqual([beforeRoundId, afterRoundId]);
+    expect(transaction).toMatchObject({ chainId: 4_663, to: ADDRESS_1, value: 0n });
   });
 
   it("rejects stale deadlines, non-exact pool bindings and unsafe slippage before encoding", () => {
@@ -461,6 +868,7 @@ describe("Protocol V2 prepared transactions", () => {
       slippageBps: 50,
       tradeDeadline: TRADE_DEADLINE,
       permit: permit(BUY_QUOTE.maximumPaymentAtoms),
+      explicitlyConfirmedHighPriceImpact: true,
       nowUnixSeconds: NOW,
     })).toThrow("pool LP fee binding");
     expect(() => preparePredictionV2BuyWithPermit({
@@ -473,6 +881,7 @@ describe("Protocol V2 prepared transactions", () => {
       slippageBps: 0,
       tradeDeadline: TRADE_DEADLINE,
       permit: permit(BUY_QUOTE.maximumPaymentAtoms),
+      explicitlyConfirmedHighPriceImpact: true,
       nowUnixSeconds: NOW,
     })).toThrow("slippage");
     expect(() => preparePredictionV2BuyWithPermit({
@@ -485,6 +894,7 @@ describe("Protocol V2 prepared transactions", () => {
       slippageBps: 50,
       tradeDeadline: NOW,
       permit: permit(BUY_QUOTE.maximumPaymentAtoms),
+      explicitlyConfirmedHighPriceImpact: true,
       nowUnixSeconds: NOW,
     })).toThrow("trade deadline");
   });
@@ -499,11 +909,16 @@ describe("Protocol V2 prepared transactions", () => {
       slippageBps: 50,
       tradeDeadline: TRADE_DEADLINE,
       permit: permit(BUY_QUOTE.maximumPaymentAtoms),
+      explicitlyConfirmedHighPriceImpact: true,
       nowUnixSeconds: NOW,
     } as const;
     expect(() => preparePredictionV2BuyWithPermit({
       ...common,
       intent: { ...buyIntent(), vault: ADDRESS_2 },
+    })).toThrow("intent binding");
+    expect(() => preparePredictionV2BuyWithPermit({
+      ...common,
+      intent: { ...buyIntent(), poolManager: ADDRESS_2 },
     })).toThrow("intent binding");
     expect(() => preparePredictionV2BuyWithPermit({
       ...common,
@@ -521,6 +936,16 @@ describe("Protocol V2 prepared transactions", () => {
       ...common,
       intent: buyIntent(),
       latestConfirmedBlockNumber: QUOTE_BLOCK + 3n,
+    })).toThrow("quote freshness");
+    expect(() => preparePredictionV2BuyWithPermit({
+      ...common,
+      intent: buyIntent(),
+      maximumQuoteAgeBlocks: -1,
+    })).toThrow("quote freshness");
+    expect(() => preparePredictionV2BuyWithPermit({
+      ...common,
+      intent: buyIntent(),
+      maximumQuoteAgeBlocks: 0.5,
     })).toThrow("quote freshness");
     expect(() => preparePredictionV2BuyWithPermit({
       ...common,

--- a/tests/prediction-v2-transactions.test.ts
+++ b/tests/prediction-v2-transactions.test.ts
@@ -1,0 +1,534 @@
+import { describe, expect, it } from "vitest";
+import {
+  decodeAbiParameters,
+  decodeFunctionData,
+  encodeFunctionResult,
+  parseAbiParameters,
+} from "viem";
+
+import {
+  PREDICTION_V2_EXECUTION_ROUTER_ABI,
+  PREDICTION_V2_EXPOSURE_CONTROLLER_ABI,
+  PREDICTION_V2_FACTORY_ABI,
+  PREDICTION_V2_QUOTER_ABI,
+  PREDICTION_V2_VAULT_ABI,
+} from "../lib/prediction-v2/abi";
+import { predictionV2RegistrySnapshotHash } from "../lib/prediction-v2/codec";
+import {
+  bindPredictionV2BuyCapacityPreflight,
+  bindPredictionV2BuyQuote,
+  bindPredictionV2SellQuote,
+  decodePredictionV2VaultExposureController,
+  encodePredictionV2BuyQuoteCall,
+  encodePredictionV2ChainlinkRoundProof,
+  encodePredictionV2RequireIncreaseCapacityCall,
+  encodePredictionV2SellQuoteCall,
+  encodePredictionV2VaultExposureControllerCall,
+  preparePredictionV2BuyWithPermit,
+  preparePredictionV2CreateWithPermit,
+  preparePredictionV2FinalizeWithChainlinkRounds,
+  preparePredictionV2SellWithPermit,
+} from "../lib/prediction-v2/transactions";
+import {
+  ADDRESS_1,
+  ADDRESS_2,
+  BTC_ASSET_KEY,
+  BTC_IDENTITY,
+  BUY_QUOTE,
+  HASH_11,
+  HASH_22,
+  NOW,
+  POOL_KEY,
+  SELL_QUOTE,
+  registrySnapshot,
+} from "./prediction-v2-fixtures";
+
+const TRADE_DEADLINE = NOW + 600n;
+const PERMIT_DEADLINE = NOW + 900n;
+const SQRT_PRICE_LIMIT = 4_295_128_740n;
+const QUOTE_BLOCK = 10_000n;
+
+function permit(value: bigint) {
+  return {
+    value,
+    deadline: PERMIT_DEADLINE,
+    v: 27 as const,
+    r: HASH_11,
+    s: HASH_22,
+  };
+}
+
+function boundBuyQuote() {
+  return bindPredictionV2BuyQuote({
+    chainId: 4_663,
+    quoter: ADDRESS_2,
+    vault: ADDRESS_1,
+    poolKey: POOL_KEY,
+    buyYes: true,
+    requestedCollateralAtoms: BUY_QUOTE.requestedCollateralAtoms,
+    sqrtPriceLimitX96: SQRT_PRICE_LIMIT,
+    observedBlockNumber: QUOTE_BLOCK,
+    observedBlockHash: HASH_11,
+    quote: BUY_QUOTE,
+  });
+}
+
+function buyIntent() {
+  return {
+    quoter: ADDRESS_2,
+    vault: ADDRESS_1,
+    poolKey: POOL_KEY,
+    buyYes: true,
+    requestedCollateralAtoms: BUY_QUOTE.requestedCollateralAtoms,
+    sqrtPriceLimitX96: SQRT_PRICE_LIMIT,
+  } as const;
+}
+
+function buyCapacityPreflight() {
+  const boundQuote = boundBuyQuote();
+  return bindPredictionV2BuyCapacityPreflight({
+    boundQuote,
+    observedBlockNumber: boundQuote.observedBlockNumber,
+    observedBlockHash: boundQuote.observedBlockHash,
+    vaultExposureControllerCall: {
+      to: boundQuote.vault,
+      data: encodePredictionV2VaultExposureControllerCall(),
+    },
+    vaultExposureControllerResult: encodeFunctionResult({
+      abi: PREDICTION_V2_VAULT_ABI,
+      functionName: "exposureController",
+      result: ADDRESS_2,
+    }),
+    capacityCall: {
+      to: ADDRESS_2,
+      data: encodePredictionV2RequireIncreaseCapacityCall({
+        vault: boundQuote.vault,
+        delta: boundQuote.requestedCollateralAtoms,
+      }),
+    },
+    capacityResult: "0x",
+  });
+}
+
+function boundSellQuote() {
+  return bindPredictionV2SellQuote({
+    chainId: 4_663,
+    quoter: ADDRESS_2,
+    vault: ADDRESS_1,
+    poolKey: POOL_KEY,
+    sellYes: false,
+    outcomeAtoms: SELL_QUOTE.outcomeInAtoms,
+    sqrtPriceLimitX96: SQRT_PRICE_LIMIT,
+    observedBlockNumber: QUOTE_BLOCK,
+    observedBlockHash: HASH_11,
+    quote: SELL_QUOTE,
+  });
+}
+
+function sellIntent() {
+  return {
+    quoter: ADDRESS_2,
+    vault: ADDRESS_1,
+    poolKey: POOL_KEY,
+    sellYes: false,
+    outcomeAtoms: SELL_QUOTE.outcomeInAtoms,
+    sqrtPriceLimitX96: SQRT_PRICE_LIMIT,
+  } as const;
+}
+
+describe("Protocol V2 prepared transactions", () => {
+  it("encodes the exact V2 buy and sell quote calls", () => {
+    const buy = decodeFunctionData({
+      abi: PREDICTION_V2_QUOTER_ABI,
+      data: encodePredictionV2BuyQuoteCall({
+        vault: ADDRESS_1,
+        poolKey: POOL_KEY,
+        buyYes: true,
+        requestedCollateralAtoms: 1_000_000n,
+        sqrtPriceLimitX96: SQRT_PRICE_LIMIT,
+      }),
+    });
+    expect(buy.functionName).toBe("quoteBuy");
+    expect(buy.args?.[2]).toBe(true);
+    expect(buy.args?.[3]).toBe(1_000_000n);
+
+    const sell = decodeFunctionData({
+      abi: PREDICTION_V2_QUOTER_ABI,
+      data: encodePredictionV2SellQuoteCall({
+        vault: ADDRESS_1,
+        poolKey: POOL_KEY,
+        sellYes: false,
+        outcomeAtoms: 100_000n,
+        sqrtPriceLimitX96: SQRT_PRICE_LIMIT,
+      }),
+    });
+    expect(sell.functionName).toBe("quoteSellOptimal");
+    expect(sell.args?.[2]).toBe(false);
+    expect(sell.args?.[3]).toBe(100_000n);
+  });
+
+  it("binds the same-block capacity preflight to the full requested split notional", () => {
+    const getterResult = encodeFunctionResult({
+      abi: PREDICTION_V2_VAULT_ABI,
+      functionName: "exposureController",
+      result: ADDRESS_2,
+    });
+    expect(decodeFunctionData({
+      abi: PREDICTION_V2_VAULT_ABI,
+      data: encodePredictionV2VaultExposureControllerCall(),
+    }).functionName).toBe("exposureController");
+    expect(decodePredictionV2VaultExposureController(getterResult)).toBe(ADDRESS_2);
+
+    const capacityCall = decodeFunctionData({
+      abi: PREDICTION_V2_EXPOSURE_CONTROLLER_ABI,
+      data: encodePredictionV2RequireIncreaseCapacityCall({
+        vault: ADDRESS_1,
+        delta: BUY_QUOTE.requestedCollateralAtoms,
+      }),
+    });
+    expect(capacityCall.functionName).toBe("requireIncreaseCapacity");
+    expect(capacityCall.args).toEqual([
+      ADDRESS_1,
+      BUY_QUOTE.requestedCollateralAtoms,
+    ]);
+    expect(capacityCall.args?.[1]).not.toBe(BUY_QUOTE.executedCollateralAtoms);
+
+    expect(buyCapacityPreflight()).toMatchObject({
+      chainId: 4_663,
+      exposureController: ADDRESS_2,
+      vault: ADDRESS_1,
+      delta: BUY_QUOTE.requestedCollateralAtoms,
+      observedBlockNumber: QUOTE_BLOCK,
+      observedBlockHash: HASH_11,
+      capacityResult: "0x",
+    });
+    expect(() => bindPredictionV2BuyCapacityPreflight({
+      boundQuote: boundBuyQuote(),
+      observedBlockNumber: QUOTE_BLOCK + 1n,
+      observedBlockHash: HASH_11,
+      vaultExposureControllerCall: {
+        to: ADDRESS_1,
+        data: encodePredictionV2VaultExposureControllerCall(),
+      },
+      vaultExposureControllerResult: getterResult,
+      capacityCall: {
+        to: ADDRESS_2,
+        data: encodePredictionV2RequireIncreaseCapacityCall({
+          vault: ADDRESS_1,
+          delta: BUY_QUOTE.requestedCollateralAtoms,
+        }),
+      },
+      capacityResult: "0x",
+    })).toThrow("capacity/quote block binding");
+    expect(() => bindPredictionV2BuyCapacityPreflight({
+      boundQuote: boundBuyQuote(),
+      observedBlockNumber: QUOTE_BLOCK,
+      observedBlockHash: HASH_11,
+      vaultExposureControllerCall: {
+        to: ADDRESS_1,
+        data: encodePredictionV2VaultExposureControllerCall(),
+      },
+      vaultExposureControllerResult: getterResult,
+      capacityCall: {
+        to: ADDRESS_2,
+        data: encodePredictionV2RequireIncreaseCapacityCall({
+          vault: ADDRESS_1,
+          delta: BUY_QUOTE.requestedCollateralAtoms,
+        }),
+      },
+      capacityResult: "0x00",
+    })).toThrow("capacity result");
+    expect(() => bindPredictionV2BuyCapacityPreflight({
+      boundQuote: boundBuyQuote(),
+      observedBlockNumber: QUOTE_BLOCK,
+      observedBlockHash: HASH_11,
+      vaultExposureControllerCall: {
+        to: ADDRESS_1,
+        data: encodePredictionV2VaultExposureControllerCall(),
+      },
+      vaultExposureControllerResult: getterResult,
+      capacityCall: {
+        to: ADDRESS_2,
+        data: encodePredictionV2RequireIncreaseCapacityCall({
+          vault: ADDRESS_1,
+          delta: BUY_QUOTE.executedCollateralAtoms,
+        }),
+      },
+      capacityResult: "0x",
+    })).toThrow("capacity call binding");
+  });
+
+  it("binds the buy permit to requested collateral plus its maximum 10 bps fee", () => {
+    const prepared = preparePredictionV2BuyWithPermit({
+      router: ADDRESS_2,
+      boundQuote: boundBuyQuote(),
+      capacityPreflight: buyCapacityPreflight(),
+      intent: buyIntent(),
+      latestConfirmedBlockNumber: QUOTE_BLOCK + 1n,
+      maximumQuoteAgeBlocks: 2,
+      slippageBps: 50,
+      tradeDeadline: TRADE_DEADLINE,
+      permit: permit(BUY_QUOTE.maximumPaymentAtoms),
+      nowUnixSeconds: NOW,
+    });
+    const decoded = decodeFunctionData({
+      abi: PREDICTION_V2_EXECUTION_ROUTER_ABI,
+      data: prepared.data,
+    });
+    expect(decoded.functionName).toBe("buyOutcomeWithPermit");
+    expect(decoded.args?.[2]).toEqual({
+      buyYes: true,
+      collateralAtoms: 1_000_000n,
+      minOutcomeAtoms: 189_050n,
+      sqrtPriceLimitX96: 4_295_128_740n,
+      deadline: TRADE_DEADLINE,
+    });
+    expect(decoded.args?.[3]).toBe(PERMIT_DEADLINE);
+    expect(prepared.value).toBe(0n);
+
+    expect(() => preparePredictionV2BuyWithPermit({
+      router: ADDRESS_2,
+      boundQuote: boundBuyQuote(),
+      capacityPreflight: buyCapacityPreflight(),
+      intent: buyIntent(),
+      latestConfirmedBlockNumber: QUOTE_BLOCK + 1n,
+      maximumQuoteAgeBlocks: 2,
+      slippageBps: 50,
+      tradeDeadline: TRADE_DEADLINE,
+      permit: permit(BUY_QUOTE.requestedCollateralAtoms),
+      nowUnixSeconds: NOW,
+    })).toThrow("permit amount");
+  });
+
+  it("uses net, never gross, sell collateral for the minimum and exact outcome permit", () => {
+    const prepared = preparePredictionV2SellWithPermit({
+      router: ADDRESS_2,
+      boundQuote: boundSellQuote(),
+      intent: sellIntent(),
+      latestConfirmedBlockNumber: QUOTE_BLOCK + 1n,
+      maximumQuoteAgeBlocks: 2,
+      slippageBps: 100,
+      tradeDeadline: TRADE_DEADLINE,
+      permit: permit(SELL_QUOTE.outcomeInAtoms),
+      nowUnixSeconds: NOW,
+    });
+    const decoded = decodeFunctionData({
+      abi: PREDICTION_V2_EXECUTION_ROUTER_ABI,
+      data: prepared.data,
+    });
+    expect(decoded.functionName).toBe("sellOutcomeWithPermit");
+    expect(decoded.args?.[2]).toEqual({
+      sellYes: false,
+      outcomeAtoms: 100_000n,
+      swapAtoms: 48_000n,
+      minCollateralAtoms: 514_285n,
+      sqrtPriceLimitX96: 4_295_128_740n,
+      deadline: TRADE_DEADLINE,
+    });
+    expect(decoded.args?.[2]).not.toMatchObject({ minCollateralAtoms: 514_800n });
+    expect(() => preparePredictionV2SellWithPermit({
+      router: ADDRESS_2,
+      boundQuote: boundSellQuote(),
+      intent: sellIntent(),
+      latestConfirmedBlockNumber: QUOTE_BLOCK + 1n,
+      maximumQuoteAgeBlocks: 2,
+      slippageBps: 100,
+      tradeDeadline: TRADE_DEADLINE,
+      permit: permit(SELL_QUOTE.outcomeInAtoms - 1n),
+      nowUnixSeconds: NOW,
+    })).toThrow("permit amount");
+  });
+
+  it("creates only a canonically selected identity with active exact Registry snapshot", () => {
+    const observationTime = NOW + 2n * 24n * 60n * 60n;
+    const threshold = 60_000n * 100_000_000n;
+    const snapshot = registrySnapshot();
+    const snapshotHash = predictionV2RegistrySnapshotHash(snapshot);
+    const prepared = preparePredictionV2CreateWithPermit({
+      factory: ADDRESS_2,
+      selection: { mode: "preset", presetId: "btc" },
+      identity: BTC_IDENTITY,
+      onchainAssetKey: BTC_ASSET_KEY,
+      registrySnapshot: snapshot,
+      registryHashSnapshotResult: snapshotHash,
+      factoryActiveSnapshotHash: snapshotHash,
+      releaseRegistrySnapshotHash: snapshotHash,
+      observationTime,
+      threshold,
+      permit: permit(2_000_000n),
+      nowUnixSeconds: NOW,
+    });
+    const decoded = decodeFunctionData({
+      abi: PREDICTION_V2_FACTORY_ABI,
+      data: prepared.data,
+    });
+    expect(decoded.functionName).toBe("createMarketWithPermit");
+    expect(decoded.args?.[0]).toEqual(BTC_IDENTITY);
+    expect(decoded.args?.[1]).toBe(Number(observationTime));
+    expect(decoded.args?.[2]).toBe(threshold);
+    expect(prepared).toMatchObject({
+      selectionKey: "preset:btc",
+      onchainAssetKey: BTC_ASSET_KEY,
+      registryRevision: 1n,
+      registrySnapshotHash: snapshotHash,
+      value: 0n,
+    });
+
+    expect(() => preparePredictionV2CreateWithPermit({
+      factory: ADDRESS_2,
+      selection: { mode: "preset", presetId: "btc" },
+      identity: BTC_IDENTITY,
+      onchainAssetKey: HASH_11,
+      registrySnapshot: registrySnapshot(),
+      registryHashSnapshotResult: snapshotHash,
+      factoryActiveSnapshotHash: snapshotHash,
+      releaseRegistrySnapshotHash: snapshotHash,
+      observationTime,
+      threshold,
+      permit: permit(2_000_000n),
+      nowUnixSeconds: NOW,
+    })).toThrow("asset key binding");
+    expect(() => preparePredictionV2CreateWithPermit({
+      factory: ADDRESS_2,
+      selection: { mode: "preset", presetId: "btc" },
+      identity: BTC_IDENTITY,
+      onchainAssetKey: BTC_ASSET_KEY,
+      registrySnapshot: registrySnapshot(false),
+      registryHashSnapshotResult: snapshotHash,
+      factoryActiveSnapshotHash: snapshotHash,
+      releaseRegistrySnapshotHash: snapshotHash,
+      observationTime,
+      threshold,
+      permit: permit(2_000_000n),
+      nowUnixSeconds: NOW,
+    })).toThrow("registry snapshot binding");
+    expect(() => preparePredictionV2CreateWithPermit({
+      factory: ADDRESS_2,
+      selection: { mode: "preset", presetId: "btc" },
+      identity: BTC_IDENTITY,
+      onchainAssetKey: BTC_ASSET_KEY,
+      registrySnapshot: snapshot,
+      registryHashSnapshotResult: snapshotHash,
+      factoryActiveSnapshotHash: snapshotHash,
+      releaseRegistrySnapshotHash: HASH_11,
+      observationTime,
+      threshold,
+      permit: permit(2_000_000n),
+      nowUnixSeconds: NOW,
+    })).toThrow("snapshot hash binding");
+  });
+
+  it("encodes finalize(bytes) with one exact adjacent uint80 round proof and zero value", () => {
+    const proof = encodePredictionV2ChainlinkRoundProof({
+      beforeRoundId: 123n,
+      afterRoundId: 124n,
+    });
+    expect(proof).toHaveLength(2 + 64 * 2);
+    expect(decodeAbiParameters(
+      parseAbiParameters("uint80 beforeRoundId, uint80 afterRoundId"),
+      proof,
+    )).toEqual([123n, 124n]);
+    const prepared = preparePredictionV2FinalizeWithChainlinkRounds({
+      vault: ADDRESS_1,
+      beforeRoundId: 123n,
+      afterRoundId: 124n,
+    });
+    const decoded = decodeFunctionData({
+      abi: PREDICTION_V2_VAULT_ABI,
+      data: prepared.data,
+    });
+    expect(decoded.functionName).toBe("finalize");
+    expect(decoded.args).toEqual([proof]);
+    expect(prepared.value).toBe(0n);
+    expect(() => encodePredictionV2ChainlinkRoundProof({
+      beforeRoundId: 123n,
+      afterRoundId: 125n,
+    })).toThrow("round proof");
+    expect(() => encodePredictionV2ChainlinkRoundProof({
+      beforeRoundId: 0n,
+      afterRoundId: 1n,
+    })).toThrow("round proof");
+  });
+
+  it("rejects stale deadlines, non-exact pool bindings and unsafe slippage before encoding", () => {
+    expect(() => preparePredictionV2BuyWithPermit({
+      router: ADDRESS_2,
+      boundQuote: boundBuyQuote(),
+      capacityPreflight: buyCapacityPreflight(),
+      intent: { ...buyIntent(), poolKey: { ...POOL_KEY, fee: 201 } },
+      latestConfirmedBlockNumber: QUOTE_BLOCK + 1n,
+      maximumQuoteAgeBlocks: 2,
+      slippageBps: 50,
+      tradeDeadline: TRADE_DEADLINE,
+      permit: permit(BUY_QUOTE.maximumPaymentAtoms),
+      nowUnixSeconds: NOW,
+    })).toThrow("pool LP fee binding");
+    expect(() => preparePredictionV2BuyWithPermit({
+      router: ADDRESS_2,
+      boundQuote: boundBuyQuote(),
+      capacityPreflight: buyCapacityPreflight(),
+      intent: buyIntent(),
+      latestConfirmedBlockNumber: QUOTE_BLOCK + 1n,
+      maximumQuoteAgeBlocks: 2,
+      slippageBps: 0,
+      tradeDeadline: TRADE_DEADLINE,
+      permit: permit(BUY_QUOTE.maximumPaymentAtoms),
+      nowUnixSeconds: NOW,
+    })).toThrow("slippage");
+    expect(() => preparePredictionV2BuyWithPermit({
+      router: ADDRESS_2,
+      boundQuote: boundBuyQuote(),
+      capacityPreflight: buyCapacityPreflight(),
+      intent: buyIntent(),
+      latestConfirmedBlockNumber: QUOTE_BLOCK + 1n,
+      maximumQuoteAgeBlocks: 2,
+      slippageBps: 50,
+      tradeDeadline: NOW,
+      permit: permit(BUY_QUOTE.maximumPaymentAtoms),
+      nowUnixSeconds: NOW,
+    })).toThrow("trade deadline");
+  });
+
+  it("rejects cross-market, side, limit, amount and stale bound-quote mixups", () => {
+    const common = {
+      router: ADDRESS_2,
+      boundQuote: boundBuyQuote(),
+      capacityPreflight: buyCapacityPreflight(),
+      latestConfirmedBlockNumber: QUOTE_BLOCK + 1n,
+      maximumQuoteAgeBlocks: 2,
+      slippageBps: 50,
+      tradeDeadline: TRADE_DEADLINE,
+      permit: permit(BUY_QUOTE.maximumPaymentAtoms),
+      nowUnixSeconds: NOW,
+    } as const;
+    expect(() => preparePredictionV2BuyWithPermit({
+      ...common,
+      intent: { ...buyIntent(), vault: ADDRESS_2 },
+    })).toThrow("intent binding");
+    expect(() => preparePredictionV2BuyWithPermit({
+      ...common,
+      intent: { ...buyIntent(), buyYes: false },
+    })).toThrow("intent binding");
+    expect(() => preparePredictionV2BuyWithPermit({
+      ...common,
+      intent: { ...buyIntent(), sqrtPriceLimitX96: SQRT_PRICE_LIMIT + 1n },
+    })).toThrow("intent binding");
+    expect(() => preparePredictionV2BuyWithPermit({
+      ...common,
+      intent: { ...buyIntent(), requestedCollateralAtoms: 2_000_000n },
+    })).toThrow("intent binding");
+    expect(() => preparePredictionV2BuyWithPermit({
+      ...common,
+      intent: buyIntent(),
+      latestConfirmedBlockNumber: QUOTE_BLOCK + 3n,
+    })).toThrow("quote freshness");
+    expect(() => preparePredictionV2BuyWithPermit({
+      ...common,
+      capacityPreflight: {
+        ...buyCapacityPreflight(),
+        delta: BUY_QUOTE.executedCollateralAtoms,
+      },
+      intent: buyIntent(),
+    })).toThrow("capacity preflight binding");
+  });
+});


### PR DESCRIPTION
## What changed

- adds canonical BTC, ETH, SOL and BNB presets plus explicit Ethereum, Base, BNB Chain, Robinhood Chain and Solana asset identities
- adds strict V2 market-draft, ABI, accounting, quote and transaction preparation primitives
- binds trade preparation to raw same-block Quoter, Vault, checkpoint-health and PoolManager slot0 evidence
- adds display-only CoinGecko and DexScreener discovery behind a committed disabled-only release binding
- links public product docs to the separately versioned Prediction Markets repository

## Verification

- 86 focused V2 tests passed
- targeted ESLint passed
- TypeScript passed
- production build passed
- independent release-scope review found no remaining Critical, High or Medium issue after the wording correction

## Release boundary

This PR is a dormant, fail-closed V2 foundation. Both discovery routes return 404 before provider import while the binding is disabled. It does not change the live BTC V1 flow, import the selector into a production page, touch Gates, Indexer, Envio or Dune, or claim arbitrary-token settlement readiness. Activation requires a separately reviewed onchain release, exact registry and oracle bindings, RPC orchestration and wallet/browser E2E.