### PR TITLE
Add release-dark Prediction V2 creation foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,16 @@ NEXT_PUBLIC_PROGRAMMABLE_PREDICTION_QUOTER_ADDRESS=
 NEXT_PUBLIC_PROGRAMMABLE_PREDICTION_QUOTER_RUNTIME_CODE_HASH=
 NEXT_PUBLIC_PROGRAMMABLE_PREDICTION_SECONDARY_RPC_URL=
 
+# Optional future Prediction V2 server-only identity reads. Configure every
+# required URL before enabling arbitrary-token discovery; missing or mismatched
+# RPC identity keeps discovery inconclusive. Values must be credential-free in
+# this committed example and use HTTPS in deployed environments.
+PROGRAMMABLE_PREDICTION_V2_ETHEREUM_RPC_URL=
+PROGRAMMABLE_PREDICTION_V2_BASE_RPC_URL=
+PROGRAMMABLE_PREDICTION_V2_BNB_RPC_URL=
+PROGRAMMABLE_PREDICTION_V2_ROBINHOOD_RPC_URL=
+PROGRAMMABLE_PREDICTION_V2_SOLANA_RPC_URL=
+
 # Required by server routes that verify Privy access tokens.
 PRIVY_APP_SECRET=
 

--- a/app/api/prediction/asset-auto-discovery/route.ts
+++ b/app/api/prediction/asset-auto-discovery/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { isPredictionV2ReleaseEnabled } from
+  "@/lib/prediction-v2/release-binding.server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 5;
+
+const QUERY_PARAMETERS = new Set(["locator"]);
+const AVAILABLE_CACHE_CONTROL =
+  "public, max-age=0, s-maxage=15, stale-while-revalidate=30";
+
+function responseHeaders(cacheable: boolean) {
+  return {
+    "Cache-Control": cacheable ? AVAILABLE_CACHE_CONTROL : "no-store",
+    "X-Content-Type-Options": "nosniff",
+  };
+}
+
+function discoveryResultHeaders(
+  cacheable: boolean,
+  enrichmentSource: unknown,
+) {
+  return {
+    ...responseHeaders(cacheable),
+    "X-Programmable-Identity-Source": "onchain-rpc",
+    "X-Programmable-Read-Purpose": "informational-only",
+    ...(enrichmentSource === "dexscreener"
+      ? { "X-Programmable-Market-Provider": "dexscreener" }
+      : {}),
+  };
+}
+
+function invalidQuery() {
+  return NextResponse.json(
+    { error: "Enter one exact token address" },
+    { status: 400, headers: responseHeaders(false) },
+  );
+}
+
+function unavailableRelease() {
+  return NextResponse.json(
+    { error: "Not found" },
+    {
+      status: 404,
+      headers: {
+        "Cache-Control": "no-store",
+        "X-Content-Type-Options": "nosniff",
+      },
+    },
+  );
+}
+
+export async function GET(request: NextRequest) {
+  // Keep a disabled release entirely dark: do not inspect the query and do not
+  // load or contact the external discovery provider before this check passes.
+  let releaseEnabled = false;
+  try {
+    releaseEnabled = isPredictionV2ReleaseEnabled();
+  } catch {
+    return unavailableRelease();
+  }
+  if (!releaseEnabled) {
+    return unavailableRelease();
+  }
+
+  const search = request.nextUrl.searchParams;
+  if (
+    [...search.keys()].some((key) => !QUERY_PARAMETERS.has(key)) ||
+    search.getAll("locator").length !== 1
+  ) {
+    return invalidQuery();
+  }
+  const locator = search.get("locator")?.trim() ?? "";
+  if (locator.length === 0 || locator.length > 128) return invalidQuery();
+
+  const { readControlledPredictionAssetAutoDiscoveryV2 } = await import(
+    "@/lib/market-data/prediction-asset-auto-discovery-request-control-v2.server"
+  );
+  const controlled = await readControlledPredictionAssetAutoDiscoveryV2(locator, {
+    signal: request.signal,
+  });
+  if (controlled.status === "rate-limited") {
+    return NextResponse.json(
+      { error: "Too many token lookups. Try again shortly." },
+      {
+        status: 429,
+        headers: {
+          ...responseHeaders(false),
+          "Retry-After": String(controlled.retryAfterSeconds),
+        },
+      },
+    );
+  }
+  const result = controlled.result;
+  const status = result.status === "invalid"
+    ? 400
+    : result.status === "not-found"
+      ? 404
+      : result.status === "inconclusive"
+        ? 503
+        : 200;
+  const cacheable = result.status === "unique" || result.status === "ambiguous";
+
+  return NextResponse.json(result, {
+    status,
+    headers: {
+      ...(result.status === "invalid"
+        ? responseHeaders(false)
+        : discoveryResultHeaders(cacheable, result.source)),
+      ...(status === 503 ? { "Retry-After": "5" } : {}),
+    },
+  });
+}

--- a/app/api/prediction/asset-logo/[asset]/route.ts
+++ b/app/api/prediction/asset-logo/[asset]/route.ts
@@ -1,0 +1,304 @@
+import { createHash } from "node:crypto";
+
+import { NextResponse } from "next/server";
+import sharp from "sharp";
+
+import { isPredictionV2ReleaseEnabled } from
+  "@/lib/prediction-v2/release-binding.server";
+import { verifyTokenImageWebpV1 } from
+  "@/lib/server/token-image-webp-v1";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 10;
+
+const DEXSCREENER_IMAGE_ORIGIN = "https://cdn.dexscreener.com";
+const ASSET_ID_PATTERN = /^[0-9a-f]{64}$/u;
+const MAXIMUM_SOURCE_BYTES = 4_000_000;
+const MAXIMUM_SOURCE_PIXELS = 16_000_000;
+const FETCH_TIMEOUT_MS = 5_000;
+export const PREDICTION_ASSET_LOGO_MAXIMUM_CONCURRENT_TRANSFORMS_V2 = 2;
+export const PREDICTION_ASSET_LOGO_NEGATIVE_CACHE_TTL_MS_V2 = 5_000;
+export const PREDICTION_ASSET_LOGO_MAXIMUM_NEGATIVE_CACHE_ENTRIES_V2 = 256;
+export const PREDICTION_ASSET_LOGO_RUNTIME_CONTROL_SCOPE_V2 =
+  "single-runtime-only" as const;
+export const PREDICTION_ASSET_LOGO_SHARED_LIMITS_REQUIRED_FOR_ACTIVATION_V2 =
+  true as const;
+export const PREDICTION_ASSET_LOGO_KNOWN_ASSET_AUTHORIZATION_REQUIRED_FOR_ACTIVATION_V2 =
+  true as const;
+const ACCEPTED_SOURCE_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+
+type PredictionAssetLogoRouteDependenciesV2 = Readonly<{
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  nowMs?: () => number;
+  maximumConcurrentTransforms?: number;
+  negativeCacheTtlMs?: number;
+  maximumNegativeCacheEntries?: number;
+}>;
+
+function errorResponse(status: number, retryAfterSeconds?: number) {
+  return NextResponse.json(
+    { error: "Asset image is unavailable" },
+    {
+      status,
+      headers: {
+        "Cache-Control": "no-store",
+        "X-Content-Type-Options": "nosniff",
+        ...(retryAfterSeconds === undefined
+          ? {}
+          : { "Retry-After": String(retryAfterSeconds) }),
+      },
+    },
+  );
+}
+
+export function createPredictionAssetLogoHandlerV2(
+  dependencies: PredictionAssetLogoRouteDependenciesV2 = {},
+) {
+  const fetchImpl = dependencies.fetchImpl ?? fetch;
+  const nowMs = dependencies.nowMs ?? Date.now;
+  const timeoutMs = boundedInteger(
+    dependencies.timeoutMs,
+    FETCH_TIMEOUT_MS,
+    1,
+    30_000,
+    "timeoutMs",
+  );
+  const maximumConcurrentTransforms = boundedInteger(
+    dependencies.maximumConcurrentTransforms,
+    PREDICTION_ASSET_LOGO_MAXIMUM_CONCURRENT_TRANSFORMS_V2,
+    1,
+    16,
+    "maximumConcurrentTransforms",
+  );
+  const negativeCacheTtlMs = boundedInteger(
+    dependencies.negativeCacheTtlMs,
+    PREDICTION_ASSET_LOGO_NEGATIVE_CACHE_TTL_MS_V2,
+    1,
+    60_000,
+    "negativeCacheTtlMs",
+  );
+  const maximumNegativeCacheEntries = boundedInteger(
+    dependencies.maximumNegativeCacheEntries,
+    PREDICTION_ASSET_LOGO_MAXIMUM_NEGATIVE_CACHE_ENTRIES_V2,
+    1,
+    2_048,
+    "maximumNegativeCacheEntries",
+  );
+  const negativeCache = new Map<string, number>();
+  let activeTransforms = 0;
+
+  return async function predictionAssetLogo(
+    asset: string,
+    requestSignal?: AbortSignal,
+  ): Promise<Response> {
+    if (!ASSET_ID_PATTERN.test(asset)) return errorResponse(400);
+    if (requestSignal?.aborted) return errorResponse(502);
+    if (hasFreshNegativeEntry(negativeCache, asset, checkedNow(nowMs))) {
+      return errorResponse(502);
+    }
+    // This zero-queue bulkhead bounds one Node runtime only. It deliberately
+    // does not claim edge, distributed or per-client abuse protection.
+    if (activeTransforms >= maximumConcurrentTransforms) {
+      return errorResponse(503, 1);
+    }
+    activeTransforms += 1;
+
+    const source = `${DEXSCREENER_IMAGE_ORIGIN}/cms/images/${asset}` +
+      "?width=1000&height=1000&quality=95&format=auto";
+    const timeout = AbortSignal.timeout(timeoutMs);
+    const signal = requestSignal
+      ? AbortSignal.any([requestSignal, timeout])
+      : timeout;
+
+    const unavailable = () => {
+      if (!requestSignal?.aborted) {
+        const failureAtMs = checkedNow(nowMs);
+        writeBoundedNegativeCache(
+          negativeCache,
+          asset,
+          failureAtMs + negativeCacheTtlMs,
+          maximumNegativeCacheEntries,
+          failureAtMs,
+        );
+      }
+      return errorResponse(502);
+    };
+
+    try {
+      if (hasFreshNegativeEntry(negativeCache, asset, checkedNow(nowMs))) {
+        return errorResponse(502);
+      }
+      // The asset identifier cannot select a host or path prefix. Redirects
+      // remain disabled so this can never become an arbitrary URL proxy.
+      const upstream = await fetchImpl(source, {
+        cache: "force-cache",
+        credentials: "omit",
+        headers: { Accept: "image/webp,image/png,image/jpeg" },
+        method: "GET",
+        redirect: "error",
+        signal,
+      });
+      const contentType = upstream.headers.get("content-type")
+        ?.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+      if (
+        !upstream.ok ||
+        upstream.redirected ||
+        !ACCEPTED_SOURCE_TYPES.has(contentType)
+      ) return unavailable();
+
+      const bytes = await readBoundedImageBody(upstream);
+      const image = sharp(bytes, {
+        animated: false,
+        failOn: "error",
+        limitInputPixels: MAXIMUM_SOURCE_PIXELS,
+        sequentialRead: true,
+      });
+      const metadata = await image.metadata();
+      if (
+        !metadata.width ||
+        !metadata.height ||
+        metadata.width * metadata.height > MAXIMUM_SOURCE_PIXELS ||
+        (metadata.pages ?? 1) !== 1 ||
+        !["jpeg", "png", "webp"].includes(metadata.format ?? "")
+      ) return unavailable();
+
+      const normalized = await image
+        .rotate()
+        .resize(1_000, 1_000, { fit: "cover", position: "centre" })
+        .webp({ effort: 4, quality: 84 })
+        .toBuffer();
+      const verified = await verifyTokenImageWebpV1(normalized);
+      if (signal.aborted) return unavailable();
+      const digest = createHash("sha256").update(verified.bytes).digest("hex");
+
+      return new Response(Uint8Array.from(verified.bytes).buffer, {
+        status: 200,
+        headers: {
+          "Cache-Control": "public, max-age=31536000, immutable",
+          "Content-Length": String(verified.bytes.byteLength),
+          "Content-Security-Policy": "default-src 'none'; sandbox",
+          "Content-Type": "image/webp",
+          ETag: `\"sha256-${digest}\"`,
+          "X-Content-Type-Options": "nosniff",
+          "X-Programmable-Image-Source": "dexscreener",
+        },
+      });
+    } catch {
+      return unavailable();
+    } finally {
+      activeTransforms -= 1;
+    }
+  };
+}
+
+function hasFreshNegativeEntry(
+  cache: Map<string, number>,
+  asset: string,
+  nowMs: number,
+) {
+  const expiresAtMs = cache.get(asset);
+  if (expiresAtMs === undefined) return false;
+  if (expiresAtMs <= nowMs) {
+    cache.delete(asset);
+    return false;
+  }
+  return true;
+}
+
+function writeBoundedNegativeCache(
+  cache: Map<string, number>,
+  asset: string,
+  expiresAtMs: number,
+  maximumEntries: number,
+  nowMs: number,
+) {
+  for (const [candidate, expiry] of cache) {
+    if (expiry <= nowMs) cache.delete(candidate);
+  }
+  cache.delete(asset);
+  while (cache.size >= maximumEntries) {
+    const oldest = cache.keys().next().value as string | undefined;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+  cache.set(asset, expiresAtMs);
+}
+
+function checkedNow(nowMs: () => number) {
+  const value = nowMs();
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError("nowMs must return a non-negative safe integer");
+  }
+  return value;
+}
+
+function boundedInteger(
+  candidate: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+  label: string,
+) {
+  const value = candidate ?? fallback;
+  if (!Number.isInteger(value) || value < minimum || value > maximum) {
+    throw new RangeError(`${label} must be an integer from ${minimum} to ${maximum}`);
+  }
+  return value;
+}
+
+async function readBoundedImageBody(response: Response) {
+  const declared = response.headers.get("content-length");
+  if (
+    declared !== null &&
+    (!/^(?:0|[1-9][0-9]*)$/u.test(declared) ||
+      BigInt(declared) > BigInt(MAXIMUM_SOURCE_BYTES))
+  ) throw new TypeError("asset image is too large");
+  if (!response.body) throw new TypeError("asset image is empty");
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      total += next.value.byteLength;
+      if (total > MAXIMUM_SOURCE_BYTES) {
+        void reader.cancel().catch(() => undefined);
+        throw new TypeError("asset image is too large");
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  if (total === 0) throw new TypeError("asset image is empty");
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+const handler = createPredictionAssetLogoHandlerV2();
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ asset: string }> },
+) {
+  try {
+    if (!isPredictionV2ReleaseEnabled()) return errorResponse(404);
+  } catch {
+    return errorResponse(404);
+  }
+  const { asset } = await context.params;
+  return handler(asset, request.signal);
+}

--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -33,6 +33,27 @@ const LOCAL_PREVIEW_STAGES = new Set<CustomLaunchStageV1>([
   "wallet",
   "registry",
 ]);
+const PREDICTION_V2_LOCAL_PREVIEW_STATES = new Set([
+  "address",
+  "asset",
+  "prediction",
+  "review",
+  "ambiguous",
+  "error",
+] as const);
+const PREDICTION_V2_LOCAL_PREVIEW_FIXTURES = new Set([
+  "base",
+  "solana",
+] as const);
+
+type PredictionV2LocalPreviewState =
+  | "address"
+  | "asset"
+  | "prediction"
+  | "review"
+  | "ambiguous"
+  | "error";
+type PredictionV2LocalPreviewFixture = "base" | "solana";
 
 function loadLaunchForm() {
   return import("@/components/launch-builder");
@@ -60,6 +81,15 @@ const LazyDevelopmentCustomLaunchPreview = process.env.NODE_ENV === "development
   ? lazy(async () => {
       const previewModule = await import("@/components/custom-launch-local-preview");
       return { default: previewModule.CustomLaunchLocalPreview };
+    })
+  : null;
+
+const LazyDevelopmentPredictionV2Preview = process.env.NODE_ENV === "development"
+  ? lazy(async () => {
+      const previewModule = await import(
+        "@/components/prediction-market-v2-local-preview"
+      );
+      return { default: previewModule.PredictionMarketV2LocalPreview };
     })
   : null;
 
@@ -125,6 +155,35 @@ export function LaunchExperience(props: LaunchExperienceProps) {
 function DevelopmentLaunchPreviewRoute(props: LaunchExperienceProps) {
   const searchParams = useSearchParams();
   const previewCandidate = searchParams.get("localPreview");
+  if (
+    previewCandidate === "prediction-v2" &&
+    LazyDevelopmentPredictionV2Preview !== null
+  ) {
+    const stateCandidate = searchParams.get("predictionState");
+    const fixtureCandidate = searchParams.get("fixture");
+    const initialState = stateCandidate &&
+      PREDICTION_V2_LOCAL_PREVIEW_STATES.has(
+        stateCandidate as PredictionV2LocalPreviewState,
+      )
+      ? stateCandidate as PredictionV2LocalPreviewState
+      : "address";
+    const fixture = fixtureCandidate &&
+      PREDICTION_V2_LOCAL_PREVIEW_FIXTURES.has(
+        fixtureCandidate as PredictionV2LocalPreviewFixture,
+      )
+      ? fixtureCandidate as PredictionV2LocalPreviewFixture
+      : "base";
+
+    return (
+      <Suspense fallback={<LaunchFormLoading title="Create a prediction" onBack={() => undefined} />}>
+        <LazyDevelopmentPredictionV2Preview
+          fixture={fixture}
+          initialState={initialState}
+          onBack={() => window.location.assign("/launch")}
+        />
+      </Suspense>
+    );
+  }
   const localPreviewStage = previewCandidate
     && LOCAL_PREVIEW_STAGES.has(previewCandidate as CustomLaunchStageV1)
     ? previewCandidate as CustomLaunchStageV1

--- a/components/prediction-market-asset-card-v2.module.css
+++ b/components/prediction-market-asset-card-v2.module.css
@@ -1,0 +1,343 @@
+.card {
+  background: var(--webde-surface, #171717);
+  border: 1px solid var(--webde-line, rgb(255 255 255 / 11%));
+  border-radius: var(--webde-radius-card, 17px);
+  color: var(--webde-ink, #f7f3ed);
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+  position: relative;
+  transition:
+    background-color 180ms var(--webde-ease, ease),
+    border-color 180ms var(--webde-ease, ease),
+    box-shadow 180ms var(--webde-ease, ease),
+    transform 160ms var(--webde-ease, ease);
+  width: 100%;
+}
+
+.hitArea {
+  color: inherit;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-width: 0;
+  outline: 0;
+}
+
+.art {
+  aspect-ratio: 2.42 / 1;
+  background: #090909;
+  border-bottom: 1px solid var(--webde-line, rgb(255 255 255 / 11%));
+  contain: paint;
+  line-height: 0;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+}
+
+.image {
+  background: #090909;
+  display: block;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  transition: transform 240ms var(--webde-ease, ease);
+  width: 100%;
+}
+
+.body {
+  flex: 1 1 auto;
+  min-height: 154px;
+  min-width: 0;
+  padding: 18px 18px 15px;
+}
+
+.heading {
+  align-items: baseline;
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+}
+
+.heading :is(h2, h3) {
+  color: var(--webde-ink, #f7f3ed);
+  font-size: 22px;
+  font-weight: 580;
+  letter-spacing: -0.03em;
+  line-height: 1.14;
+  margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.heading > span {
+  color: var(--webde-dim, #858585);
+  flex: none;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.condition {
+  color: var(--webde-ink, #f7f3ed);
+  font-size: 15px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 580;
+  letter-spacing: -0.012em;
+  line-height: 1.35;
+  margin: 13px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.secondaryIntent {
+  color: var(--webde-dim, #858585);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 520;
+  line-height: 1.4;
+  margin: 6px 0 0;
+}
+
+.facts {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  margin: 19px 0 0;
+}
+
+.facts > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.facts dt {
+  color: var(--webde-dim, #858585);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.facts dd {
+  color: var(--webde-muted, #b9b9b9);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 560;
+  line-height: 1.3;
+  margin: 0;
+  min-width: 0;
+}
+
+.facts > div:last-child:not(:first-child) {
+  text-align: right;
+}
+
+.meta {
+  align-items: center;
+  border-top: 1px solid var(--webde-line, rgb(255 255 255 / 11%));
+  display: flex;
+  gap: 8px;
+  min-height: 48px;
+  min-width: 0;
+  padding: 1px 8px 1px 14px;
+}
+
+.metaFacts {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  margin: 0;
+  min-width: 0;
+}
+
+.metaFacts > div {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.metaFacts dt {
+  color: var(--webde-dim, #858585);
+  font-size: 9px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.metaFacts dd {
+  color: var(--webde-muted, #b9b9b9);
+  font-size: 11px;
+  font-weight: 550;
+  line-height: 1.1;
+  margin: 0;
+  max-width: 15ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.socials {
+  align-items: center;
+  display: flex;
+  gap: 0;
+  margin-inline-start: auto;
+  min-height: 44px;
+}
+
+.socialLink {
+  align-items: center;
+  background: transparent;
+  border-radius: 7px;
+  color: var(--webde-dim, #858585);
+  display: inline-flex;
+  flex: none;
+  height: 44px;
+  justify-content: center;
+  outline: 0;
+  transition:
+    background-color 160ms var(--webde-ease, ease),
+    color 160ms var(--webde-ease, ease),
+    transform 140ms var(--webde-ease, ease);
+  width: 44px;
+}
+
+.socialLink svg {
+  display: block;
+  height: 16px;
+  width: 16px;
+}
+
+.hitArea:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--webde-ink, #f7f3ed);
+}
+
+.socialLink:focus-visible {
+  background: var(--webde-control, #242424);
+  outline: 2px solid var(--webde-ink, #f7f3ed);
+  outline-offset: 2px;
+}
+
+.socialLink:active {
+  transform: scale(0.96);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .card:has(a.hitArea):hover {
+    background: var(--webde-surface-raised, #1d1d1d);
+    border-color: #505050;
+    box-shadow: 0 18px 48px rgb(0 0 0 / 30%);
+    transform: translate3d(0, -2px, 0);
+  }
+
+  .card:has(a.hitArea):hover .image {
+    transform: scale(1.012);
+  }
+
+  .socialLink:hover {
+    background: var(--webde-control, #242424);
+    color: var(--webde-ink, #f7f3ed);
+  }
+}
+
+@media (max-width: 700px) {
+  .art {
+    aspect-ratio: 1.7 / 1;
+  }
+
+  .body {
+    min-height: 140px;
+    padding: 14px 12px 12px;
+  }
+
+  .heading :is(h2, h3) {
+    font-size: 17px;
+  }
+
+  .heading > span {
+    font-size: 10px;
+  }
+
+  .condition {
+    font-size: 13px;
+    margin-top: 10px;
+  }
+
+  .secondaryIntent {
+    font-size: 10px;
+  }
+
+  .facts {
+    gap: 8px;
+    grid-template-columns: minmax(0, 1fr);
+    margin-top: 13px;
+  }
+
+  .facts > div:last-child:not(:first-child) {
+    text-align: left;
+  }
+
+  .facts dt {
+    font-size: 10px;
+  }
+
+  .facts dd {
+    font-size: 11px;
+  }
+
+  .meta {
+    flex-wrap: wrap;
+    min-height: 76px;
+    padding: 0 4px 0 10px;
+  }
+
+  .metaFacts {
+    gap: 8px;
+  }
+
+  .metaFacts dd {
+    font-size: 10px;
+  }
+
+  .socials {
+    margin-inline-start: auto;
+  }
+}
+
+@media (max-width: 360px) {
+  .meta {
+    align-content: center;
+  }
+
+  .socials {
+    flex-basis: 100%;
+    justify-content: flex-start;
+    margin-inline-start: -8px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card,
+  .image,
+  .socialLink {
+    transition-duration: 1ms;
+  }
+
+  .card:has(a.hitArea):hover,
+  .card:has(a.hitArea):hover .image {
+    transform: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .card {
+    border-color: CanvasText;
+  }
+
+  .hitArea:focus-visible,
+  .socialLink:focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
+}

--- a/components/prediction-market-asset-card-v2.tsx
+++ b/components/prediction-market-asset-card-v2.tsx
@@ -1,0 +1,708 @@
+"use client";
+
+import Link from "next/link";
+
+import { XBrandIcon } from "@/components/brand-icons";
+import { WebsiteLinkIcon } from "@/components/website-link-icon";
+import { applyTokenImageFallback } from "@/lib/token-image";
+import { predictionAssetCardImageV2 } from "@/lib/prediction-v2/asset-logo-v2";
+import type {
+  PredictionV2CreateReview,
+  PredictionV2CreateSourceNetwork,
+} from "@/lib/prediction-v2/create-flow-v2";
+import type { PredictionMarketCapCreationIntentV2 } from
+  "@/lib/prediction-v2/market-presentation-v2";
+import type { PublicPredictionMarketViewV2 } from
+  "@/lib/prediction-v2/public-market-view-v2";
+import type {
+  PredictionTokenProfileLinkV2,
+  PredictionTokenProfileV2,
+} from "@/lib/prediction-v2/token-profile-v2";
+
+import styles from "./prediction-market-asset-card-v2.module.css";
+
+const SOCIAL_ORDER = Object.freeze({
+  website: 0,
+  x: 1,
+  telegram: 2,
+} as const satisfies Readonly<Record<PredictionTokenProfileLinkV2["kind"], number>>);
+
+const CHAIN_BINDINGS = Object.freeze({
+  ethereum: Object.freeze({ reference: "1", label: "Ethereum" }),
+  base: Object.freeze({ reference: "8453", label: "Base" }),
+  bnb: Object.freeze({ reference: "56", label: "BNB Chain" }),
+  robinhood: Object.freeze({ reference: "4663", label: "Robinhood Chain" }),
+  solana: Object.freeze({ reference: "mainnet-beta", label: "Solana" }),
+} as const satisfies Readonly<Record<
+  PredictionV2CreateSourceNetwork,
+  Readonly<{ reference: string; label: string }>
+>>);
+
+const LIFECYCLE_LABELS = Object.freeze({
+  open: "Open",
+  paused: "Trading paused",
+  closed: "Closed",
+  "resolved-yes": "Resolved YES",
+  "resolved-no": "Resolved NO",
+  "resolved-invalid": "Invalid",
+  unavailable: "Unavailable",
+} as const);
+
+const X_HOSTS = new Set(["x.com", "www.x.com", "twitter.com", "www.twitter.com"]);
+const TELEGRAM_HOSTS = new Set([
+  "t.me",
+  "www.t.me",
+  "telegram.me",
+  "www.telegram.me",
+]);
+const PRIVATE_HOST_SUFFIXES = Object.freeze([
+  ".localhost",
+  ".local",
+  ".internal",
+  ".lan",
+  ".home",
+  ".arpa",
+  ".test",
+  ".invalid",
+  ".example",
+]);
+const PUBLIC_MARKET_ID_PATTERN = /^0x[0-9a-f]{64}$/u;
+const ZERO_MARKET_ID = `0x${"0".repeat(64)}`;
+const OWNED_ARTWORK_PATTERN = /^\/media\/prediction\/sha256-[0-9a-f]{64}\.webp$/u;
+const BUNDLED_ARTWORK_PATTERN =
+  /^\/brand\/programmable-token-fallback-0[1-6]-(?:dawn|moon|sun|mint|lavender|dusk)\.webp$/u;
+const EXACT_UTC_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/u;
+const PREDICTION_V2_SETTLEMENT_CHAIN_ID = "4663" as const;
+const CANONICAL_BLOCK_NUMBER_PATTERN = /^[1-9][0-9]{0,19}$/u;
+const BLOCK_HASH_PATTERN = /^0x[0-9a-f]{64}$/u;
+const ZERO_BLOCK_HASH = `0x${"0".repeat(64)}`;
+const MAX_UINT64 = (1n << 64n) - 1n;
+
+export type PredictionMarketAssetCardLifecycleV2 =
+  keyof typeof LIFECYCLE_LABELS;
+
+export type PredictionMarketAssetCardProbabilityV2 =
+  | Readonly<{ status: "available"; yesProbabilityBps: number }>
+  | Readonly<{ status: "unavailable" }>;
+
+export type PredictionMarketAssetCardHeadingLevelV2 = "h2" | "h3";
+
+export type PredictionMarketAssetCardSnapshotV2 = Readonly<{
+  settlementChainId:
+    PublicPredictionMarketViewV2["attestedProjection"]["settlementChainId"];
+  confirmedBlockNumber:
+    PublicPredictionMarketViewV2["attestedProjection"]["confirmedBlockNumber"];
+  confirmedBlockHash:
+    PublicPredictionMarketViewV2["attestedProjection"]["confirmedBlockHash"];
+}>;
+
+/**
+ * One market- and block-bound runtime observation. Lifecycle and probability
+ * cannot be supplied independently, so they can never be paired with another
+ * card without failing the binding below.
+ */
+export type PredictionMarketAssetCardStateV2 = Readonly<{
+  schemaVersion: 2;
+  marketKey: PublicPredictionMarketViewV2["marketKey"];
+  marketId: PublicPredictionMarketViewV2["marketId"];
+  snapshot: PredictionMarketAssetCardSnapshotV2;
+  lifecycle: PredictionMarketAssetCardLifecycleV2;
+  probability: PredictionMarketAssetCardProbabilityV2;
+}>;
+
+/**
+ * Public cards accept only the content-hash-verified presentation DTO plus
+ * one identity- and snapshot-bound runtime state. Discovery profiles and
+ * create reviews belong exclusively to the preview wrapper below.
+ */
+export type PredictionMarketAssetCardV2Props = Readonly<{
+  market: PublicPredictionMarketViewV2;
+  cardState: PredictionMarketAssetCardStateV2;
+  headingLevel?: PredictionMarketAssetCardHeadingLevelV2;
+  imageLoading?: "eager" | "lazy";
+  className?: string;
+}>;
+
+export type PredictionMarketAssetPreviewCardV2Props = Readonly<{
+  profile: PredictionTokenProfileV2;
+  review: PredictionV2CreateReview;
+  headingLevel?: PredictionMarketAssetCardHeadingLevelV2;
+  imageLoading?: "eager" | "lazy";
+  className?: string;
+}>;
+
+type PredictionMarketAssetCardArtworkV2 = Readonly<{
+  source: string;
+  fallback: string;
+  sourceKind: "bundled-fallback" | "owned-provider-snapshot" | "preview-proxy";
+}>;
+
+type PredictionMarketCapDisplayIntentV2 = Pick<
+  PredictionMarketCapCreationIntentV2,
+  | "kind"
+  | "settlementRole"
+  | "comparator"
+  | "targetUsd"
+  | "template"
+  | "percentChange"
+  | "equivalentPriceStrikeUsd"
+>;
+
+type PredictionMarketAssetCardRenderModelV2 = Readonly<{
+  name: string;
+  symbol: string;
+  chainLabel: string;
+  condition: string;
+  secondaryIntent: string | null;
+  resultTime: string;
+  artwork: PredictionMarketAssetCardArtworkV2;
+  links: readonly PredictionTokenProfileLinkV2[];
+  href: `/markets/v2/0x${string}` | null;
+  status: string;
+  probability: string;
+  profileBound?: boolean;
+  runtimeBinding: "bound" | "unavailable" | "preview";
+  snapshotBlock?: string;
+}>;
+
+export function predictionAssetConditionLabelV2(
+  market: PublicPredictionMarketViewV2,
+) {
+  return priceConditionLabel(market.condition.strikeUsd);
+}
+
+export function predictionAssetResultTimeLabelV2(
+  market: PublicPredictionMarketViewV2,
+) {
+  return formatResultTime(market.condition.observationUtc);
+}
+
+export function bindPredictionMarketAssetCardStateV2(
+  market: PublicPredictionMarketViewV2,
+  value: unknown,
+): PredictionMarketAssetCardStateV2 | null {
+  if (!exactRecordKeys(value, [
+    "schemaVersion",
+    "marketKey",
+    "marketId",
+    "snapshot",
+    "lifecycle",
+    "probability",
+  ])) return null;
+  if (
+    value.schemaVersion !== 2 ||
+    value.marketKey !== market.marketKey ||
+    value.marketId !== market.marketId ||
+    predictionMarketAssetCardHrefV2(market) === null ||
+    typeof value.lifecycle !== "string" ||
+    !Object.hasOwn(LIFECYCLE_LABELS, value.lifecycle)
+  ) return null;
+  const snapshot = normalizeCardSnapshot(value.snapshot);
+  const projectedSnapshot = publicMarketSnapshotIdentityV2(market);
+  const probability = normalizeCardProbability(value.probability);
+  if (
+    !snapshot ||
+    !projectedSnapshot ||
+    !probability ||
+    snapshot.settlementChainId !== projectedSnapshot.settlementChainId ||
+    snapshot.confirmedBlockNumber !== projectedSnapshot.confirmedBlockNumber ||
+    snapshot.confirmedBlockHash !== projectedSnapshot.confirmedBlockHash
+  ) return null;
+  return Object.freeze({
+    schemaVersion: 2,
+    marketKey: market.marketKey,
+    marketId: market.marketId,
+    snapshot,
+    lifecycle: value.lifecycle as PredictionMarketAssetCardLifecycleV2,
+    probability,
+  });
+}
+
+export function predictionMarketAssetCardHrefV2(
+  market: PublicPredictionMarketViewV2,
+): `/markets/v2/0x${string}` | null {
+  return PUBLIC_MARKET_ID_PATTERN.test(market.marketId) &&
+      market.marketId !== ZERO_MARKET_ID
+    ? `/markets/v2/${market.marketId}`
+    : null;
+}
+
+function exactRecordKeys(
+  value: unknown,
+  keys: readonly string[],
+): value is Record<string, unknown> {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    Object.getPrototypeOf(value) !== Object.prototype
+  ) return false;
+  const ownKeys = Reflect.ownKeys(value);
+  return ownKeys.length === keys.length &&
+    ownKeys.every((key) => typeof key === "string" && keys.includes(key)) &&
+    keys.every((key) => Object.hasOwn(value, key));
+}
+
+function normalizeCardSnapshot(
+  value: unknown,
+): PredictionMarketAssetCardSnapshotV2 | null {
+  if (!exactRecordKeys(value, [
+    "settlementChainId",
+    "confirmedBlockNumber",
+    "confirmedBlockHash",
+  ])) {
+    return null;
+  }
+  if (
+    value.settlementChainId !== PREDICTION_V2_SETTLEMENT_CHAIN_ID ||
+    typeof value.confirmedBlockNumber !== "string" ||
+    !CANONICAL_BLOCK_NUMBER_PATTERN.test(value.confirmedBlockNumber) ||
+    BigInt(value.confirmedBlockNumber) > MAX_UINT64 ||
+    typeof value.confirmedBlockHash !== "string" ||
+    !BLOCK_HASH_PATTERN.test(value.confirmedBlockHash) ||
+    value.confirmedBlockHash === ZERO_BLOCK_HASH
+  ) return null;
+  return Object.freeze({
+    settlementChainId: PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+    confirmedBlockNumber: value.confirmedBlockNumber,
+    confirmedBlockHash: value.confirmedBlockHash as
+      PredictionMarketAssetCardSnapshotV2["confirmedBlockHash"],
+  });
+}
+
+function publicMarketSnapshotIdentityV2(
+  market: PublicPredictionMarketViewV2,
+): PredictionMarketAssetCardSnapshotV2 | null {
+  const projection = (market as Readonly<{ attestedProjection?: unknown }>)
+    .attestedProjection;
+  if (
+    typeof projection !== "object" ||
+    projection === null ||
+    Array.isArray(projection)
+  ) return null;
+  const candidate = projection as Record<string, unknown>;
+  return normalizeCardSnapshot({
+    settlementChainId: candidate.settlementChainId,
+    confirmedBlockNumber: candidate.confirmedBlockNumber,
+    confirmedBlockHash: candidate.confirmedBlockHash,
+  });
+}
+
+function normalizeCardProbability(
+  value: unknown,
+): PredictionMarketAssetCardProbabilityV2 | null {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value)
+  ) return null;
+  const available = "status" in value && value.status === "available";
+  if (!exactRecordKeys(
+    value,
+    available ? ["status", "yesProbabilityBps"] : ["status"],
+  )) return null;
+  if (value.status === "unavailable") {
+    return Object.freeze({ status: "unavailable" as const });
+  }
+  if (
+    value.status !== "available" ||
+    typeof value.yesProbabilityBps !== "number" ||
+    !Number.isInteger(value.yesProbabilityBps) ||
+    value.yesProbabilityBps < 0 ||
+    value.yesProbabilityBps > 10_000
+  ) return null;
+  return Object.freeze({
+    status: "available" as const,
+    yesProbabilityBps: value.yesProbabilityBps,
+  });
+}
+
+function priceConditionLabel(strikeUsd: string) {
+  return `Price ≥ ${formatCanonicalUsd(strikeUsd)}`;
+}
+
+function formatCanonicalUsd(value: string) {
+  const match = /^(0|[1-9]\d*)(?:\.(\d+))?$/u.exec(value);
+  if (!match) return `$${value}`;
+  const integer = match[1].replace(/\B(?=(\d{3})+(?!\d))/gu, ",");
+  return `$${integer}${match[2] ? `.${match[2]}` : ""}`;
+}
+
+function formatPercentChange(value: string) {
+  if (value.startsWith("-")) return `−${value.slice(1)}%`;
+  if (value === "0") return "0%";
+  return `+${value}%`;
+}
+
+function formatResultTime(value: string) {
+  if (!EXACT_UTC_PATTERN.test(value)) return value;
+  const milliseconds = Date.parse(value);
+  if (
+    !Number.isSafeInteger(milliseconds) ||
+    new Date(milliseconds).toISOString().replace(".000Z", "Z") !== value
+  ) return value;
+  const date = new Date(milliseconds);
+  const day = new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+  const time = new Intl.DateTimeFormat("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+    timeZone: "UTC",
+  }).format(date);
+  return `${day} · ${time} UTC`;
+}
+
+function secondaryIntentLabel(
+  intent: PredictionMarketCapDisplayIntentV2 | null,
+) {
+  if (!intent) return null;
+  const change = intent.template === "percent-change" && intent.percentChange
+    ? ` · ${formatPercentChange(intent.percentChange)} from start`
+    : "";
+  return `Market-cap intent · ≥ ${formatCanonicalUsd(intent.targetUsd)}${change} · Price settles`;
+}
+
+function normalizeIdentityAddress(
+  chain: PredictionV2CreateSourceNetwork,
+  address: string,
+) {
+  return chain === "solana" ? address : address.toLowerCase();
+}
+
+function isProfileBoundToReview(
+  profile: PredictionTokenProfileV2,
+  review: PredictionV2CreateReview,
+) {
+  const chain = CHAIN_BINDINGS[review.asset.sourceNetwork];
+  return profile.chain.id === review.asset.sourceNetwork &&
+    profile.chain.reference === chain.reference &&
+    profile.chain.label === chain.label &&
+    profile.name === review.assetName &&
+    profile.symbol === review.assetSymbol &&
+    normalizeIdentityAddress(profile.chain.id, profile.address) ===
+      normalizeIdentityAddress(review.asset.sourceNetwork, review.asset.address);
+}
+
+function safeSocialLink(link: PredictionTokenProfileLinkV2) {
+  try {
+    const parsed = new URL(link.url);
+    if (
+      parsed.protocol !== "https:" ||
+      parsed.username ||
+      parsed.password ||
+      parsed.port
+    ) return null;
+    const hostname = parsed.hostname.toLowerCase();
+    if (
+      !hostname.includes(".") ||
+      hostname.endsWith(".") ||
+      hostname.includes(":") ||
+      /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/u.test(hostname) ||
+      PRIVATE_HOST_SUFFIXES.some((suffix) => hostname.endsWith(suffix))
+    ) return null;
+    if (link.kind === "x" && !X_HOSTS.has(hostname)) return null;
+    if (link.kind === "telegram" && !TELEGRAM_HOSTS.has(hostname)) return null;
+    return Object.freeze({ kind: link.kind, url: parsed.toString() });
+  } catch {
+    return null;
+  }
+}
+
+function safeProfileLinks(
+  links: readonly PredictionTokenProfileLinkV2[],
+  identityBound = true,
+) {
+  if (!identityBound) return [];
+  const byKind = new Map<
+    PredictionTokenProfileLinkV2["kind"],
+    PredictionTokenProfileLinkV2
+  >();
+  for (const link of links) {
+    const safe = safeSocialLink(link);
+    if (safe && !byKind.has(safe.kind)) byKind.set(safe.kind, safe);
+  }
+  return [...byKind.values()].sort(
+    (left, right) => SOCIAL_ORDER[left.kind] - SOCIAL_ORDER[right.kind],
+  );
+}
+
+function safePublicArtwork(market: PublicPredictionMarketViewV2) {
+  const fallback = predictionAssetCardImageV2({
+    chainId: market.asset.sourceNetwork,
+    address: market.asset.address,
+  }).source;
+  const valid = market.artwork.kind === "owned-provider-snapshot"
+    ? OWNED_ARTWORK_PATTERN.test(market.artwork.url)
+    : market.artwork.kind === "bundled-fallback" &&
+      BUNDLED_ARTWORK_PATTERN.test(market.artwork.url);
+  return Object.freeze({
+    source: valid ? market.artwork.url : fallback,
+    fallback,
+    sourceKind: valid ? market.artwork.kind : "bundled-fallback",
+  } satisfies PredictionMarketAssetCardArtworkV2);
+}
+
+function probabilityLabel(state: PredictionMarketAssetCardProbabilityV2) {
+  if (
+    state.status !== "available" ||
+    !Number.isInteger(state.yesProbabilityBps) ||
+    state.yesProbabilityBps < 0 ||
+    state.yesProbabilityBps > 10_000
+  ) return "Not available";
+  const percent = state.yesProbabilityBps / 100;
+  return `${new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  }).format(percent)}%`;
+}
+
+function socialLabel(kind: PredictionTokenProfileLinkV2["kind"]) {
+  if (kind === "website") return "Website";
+  if (kind === "telegram") return "Telegram";
+  return "X";
+}
+
+function TelegramBrandIcon() {
+  return (
+    <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+      <path
+        fill="currentColor"
+        d="M22.8 3.2 19.5 20.1c-.25 1.2-.91 1.5-1.85.94l-5.03-3.71-2.43 2.34c-.27.27-.5.5-1.02.5l.36-5.13 9.34-8.44c.41-.36-.09-.56-.63-.2L6.7 13.67l-4.98-1.56c-1.08-.34-1.1-1.08.23-1.6L21.36 3c.9-.33 1.69.2 1.44 1.2Z"
+      />
+    </svg>
+  );
+}
+
+function SocialIcon({ kind }: Readonly<{ kind: PredictionTokenProfileLinkV2["kind"] }>) {
+  if (kind === "website") return <WebsiteLinkIcon />;
+  if (kind === "telegram") return <TelegramBrandIcon />;
+  return <XBrandIcon />;
+}
+
+function PredictionMarketAssetCardFrameV2({
+  model,
+  headingLevel,
+  imageLoading,
+  className,
+  variant,
+}: Readonly<{
+  model: PredictionMarketAssetCardRenderModelV2;
+  headingLevel: PredictionMarketAssetCardHeadingLevelV2;
+  imageLoading: "eager" | "lazy";
+  className?: string;
+  variant: "public" | "preview";
+}>) {
+  const Heading = headingLevel === "h2" ? "h2" : "h3";
+  const primaryContent = (
+    <>
+      <div className={styles.art}>
+        {/* Artwork is either owned, bundled, or routed through the fixed preview proxy. */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          alt=""
+          className={styles.image}
+          decoding="async"
+          draggable={false}
+          height={300}
+          loading={imageLoading}
+          onError={(event) => {
+            applyTokenImageFallback(event.currentTarget, model.artwork.fallback);
+          }}
+          referrerPolicy="no-referrer"
+          src={model.artwork.source}
+          width={726}
+        />
+      </div>
+
+      <div className={styles.body}>
+        <header className={styles.heading}>
+          <Heading title={model.name}>{model.name}</Heading>
+          {model.symbol ? <span>${model.symbol}</span> : null}
+        </header>
+        <p className={styles.condition} title={model.condition}>
+          {model.condition}
+        </p>
+        {model.secondaryIntent ? (
+          <p className={styles.secondaryIntent}>{model.secondaryIntent}</p>
+        ) : null}
+        <dl className={styles.facts}>
+          <div>
+            <dt>Result time</dt>
+            <dd>{model.resultTime}</dd>
+          </div>
+          <div>
+            <dt>Probability</dt>
+            <dd>{model.probability}</dd>
+          </div>
+        </dl>
+      </div>
+    </>
+  );
+
+  return (
+    <article
+      className={`${styles.card}${className ? ` ${className}` : ""}`}
+      data-artwork-source={model.artwork.sourceKind}
+      data-prediction-asset-card-v2={variant === "public" ? "" : undefined}
+      data-prediction-asset-preview-card-v2={variant === "preview" ? "" : undefined}
+      data-profile-bound={model.profileBound === undefined
+        ? undefined
+        : model.profileBound ? "true" : "false"}
+      data-runtime-binding={model.runtimeBinding}
+      data-snapshot-block={model.snapshotBlock}
+    >
+      {model.href ? (
+        <Link
+          aria-label={`Open ${model.name} prediction: ${model.condition}; result at ${model.resultTime}`}
+          className={styles.hitArea}
+          href={model.href}
+        >
+          {primaryContent}
+        </Link>
+      ) : (
+        <div className={styles.hitArea}>{primaryContent}</div>
+      )}
+
+      <footer className={styles.meta}>
+        <dl aria-label="Market summary" className={styles.metaFacts}>
+          <div>
+            <dt>Status</dt>
+            <dd>{model.status}</dd>
+          </div>
+          <div>
+            <dt>Source chain</dt>
+            <dd>{model.chainLabel}</dd>
+          </div>
+        </dl>
+        {model.links.length > 0 ? (
+          <nav aria-label={`${model.name} links`} className={styles.socials}>
+            {model.links.map((link) => {
+              const label = socialLabel(link.kind);
+              return (
+                <a
+                  aria-label={`${model.name} ${label} (opens in a new tab)`}
+                  className={styles.socialLink}
+                  href={link.url}
+                  key={link.kind}
+                  rel="noopener noreferrer nofollow ugc"
+                  target="_blank"
+                  title={label}
+                >
+                  <SocialIcon kind={link.kind} />
+                </a>
+              );
+            })}
+          </nav>
+        ) : null}
+      </footer>
+    </article>
+  );
+}
+
+export function PredictionMarketAssetCardV2({
+  market,
+  cardState,
+  headingLevel = "h3",
+  imageLoading = "lazy",
+  className,
+}: PredictionMarketAssetCardV2Props) {
+  const boundState = bindPredictionMarketAssetCardStateV2(market, cardState);
+  const model = Object.freeze({
+    name: market.asset.name,
+    symbol: market.asset.symbol,
+    chainLabel: market.asset.chainLabel,
+    condition: predictionAssetConditionLabelV2(market),
+    secondaryIntent: secondaryIntentLabel(market.creationIntent),
+    resultTime: predictionAssetResultTimeLabelV2(market),
+    artwork: safePublicArtwork(market),
+    links: Object.freeze(safeProfileLinks(market.links)),
+    href: boundState ? predictionMarketAssetCardHrefV2(market) : null,
+    status: boundState
+      ? LIFECYCLE_LABELS[boundState.lifecycle]
+      : LIFECYCLE_LABELS.unavailable,
+    probability: boundState
+      ? probabilityLabel(boundState.probability)
+      : "Not available",
+    runtimeBinding: boundState ? "bound" : "unavailable",
+    snapshotBlock: boundState?.snapshot.confirmedBlockNumber,
+  } satisfies PredictionMarketAssetCardRenderModelV2);
+  return (
+    <PredictionMarketAssetCardFrameV2
+      className={className}
+      headingLevel={headingLevel}
+      imageLoading={imageLoading}
+      model={model}
+      variant="public"
+    />
+  );
+}
+
+/**
+ * Create-only adapter. It may consume discovery metadata, but it produces no
+ * public route and keeps the canonical price predicate visually primary.
+ */
+export function PredictionMarketAssetPreviewCardV2({
+  profile,
+  review,
+  headingLevel = "h3",
+  imageLoading = "lazy",
+  className,
+}: PredictionMarketAssetPreviewCardV2Props) {
+  const profileBound = isProfileBoundToReview(profile, review);
+  const fallback = predictionAssetCardImageV2({
+    chainId: review.asset.sourceNetwork,
+    address: review.asset.address,
+  }).source;
+  const cardImage = predictionAssetCardImageV2({
+    chainId: review.asset.sourceNetwork,
+    address: review.asset.address,
+    logoUrl: profileBound ? profile.logoUrl : undefined,
+  });
+  const previewIntent = review.selectedMetric === "market-cap"
+    ? Object.freeze({
+      kind: "market-cap-equivalent" as const,
+      settlementRole: "secondary-non-settlement" as const,
+      comparator: "greater-than-or-equal" as const,
+      targetUsd: review.metricTargetUsd,
+      template: review.template,
+      percentChange: review.percentChange,
+      equivalentPriceStrikeUsd: review.protocolPredicate.strikeUsd,
+    })
+    : null;
+  const model = Object.freeze({
+    name: review.assetName,
+    symbol: review.assetSymbol,
+    chainLabel: CHAIN_BINDINGS[review.asset.sourceNetwork].label,
+    condition: priceConditionLabel(review.protocolPredicate.strikeUsd),
+    secondaryIntent: secondaryIntentLabel(previewIntent),
+    resultTime: formatResultTime(review.protocolPredicate.observationUtc),
+    artwork: Object.freeze({
+      source: cardImage.source,
+      fallback,
+      sourceKind: cardImage.usesProviderLogo
+        ? "preview-proxy" as const
+        : "bundled-fallback" as const,
+    }),
+    links: Object.freeze(safeProfileLinks(profile.links ?? [], profileBound)),
+    href: null,
+    status: "Preview",
+    probability: "Not available",
+    profileBound,
+    runtimeBinding: "preview",
+  } satisfies PredictionMarketAssetCardRenderModelV2);
+  return (
+    <PredictionMarketAssetCardFrameV2
+      className={className}
+      headingLevel={headingLevel}
+      imageLoading={imageLoading}
+      model={model}
+      variant="preview"
+    />
+  );
+}

--- a/components/prediction-market-create-flow-v2.module.css
+++ b/components/prediction-market-create-flow-v2.module.css
@@ -1,0 +1,834 @@
+.root {
+  color: var(--webde-ink);
+  margin-inline: auto;
+  max-width: 820px;
+  padding: clamp(32px, 6vw, 72px) 0 80px;
+  width: 100%;
+}
+
+.intro {
+  margin: 0 auto 28px;
+  max-width: 620px;
+  text-align: center;
+}
+
+.kicker {
+  color: var(--webde-muted);
+  font-size: 14px;
+  font-weight: 620;
+  line-height: 1.4;
+  margin: 0 0 9px;
+}
+
+.title {
+  color: var(--webde-ink);
+  font-size: clamp(38px, 6vw, 58px);
+  font-weight: 540;
+  letter-spacing: -0.052em;
+  line-height: 0.98;
+  margin: 0;
+  text-wrap: balance;
+}
+
+.root .intro h1.title:focus-visible {
+  outline: 0;
+  text-decoration: underline;
+  text-decoration-color: var(--focus);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 0.15em;
+}
+
+.subtitle {
+  color: var(--webde-muted);
+  font-size: 16px;
+  line-height: 1.55;
+  margin: 16px auto 0;
+  max-width: 52ch;
+  text-wrap: pretty;
+}
+
+.surface {
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-card);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.addressForm,
+.profile,
+.prediction,
+.review {
+  min-width: 0;
+  padding: clamp(24px, 4vw, 40px);
+}
+
+.addressForm {
+  min-height: 208px;
+}
+
+.field {
+  display: grid;
+  gap: 9px;
+  min-width: 0;
+}
+
+.fieldLabel,
+.group legend {
+  color: var(--webde-ink);
+  font-size: 15px;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.addressInputRow {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.input {
+  background: var(--webde-control);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-ink);
+  font: inherit;
+  font-size: 16px;
+  min-height: 56px;
+  min-width: 0;
+  padding: 0 15px;
+  transition:
+    background-color 160ms var(--webde-ease),
+    border-color 160ms var(--webde-ease);
+  width: 100%;
+}
+
+.input::placeholder {
+  color: var(--webde-dim);
+}
+
+.input[aria-invalid="true"] {
+  border-color: color-mix(in srgb, var(--danger) 76%, var(--webde-line));
+}
+
+.primaryButton,
+.previewButton {
+  align-items: center;
+  border-radius: var(--webde-radius-control);
+  display: inline-flex;
+  font: inherit;
+  font-size: 15px;
+  font-weight: 680;
+  gap: 9px;
+  justify-content: center;
+  min-height: 56px;
+  padding: 0 22px;
+}
+
+.primaryButton {
+  background: var(--webde-ink);
+  border: 1px solid var(--webde-ink);
+  color: var(--webde-canvas);
+  cursor: pointer;
+  transition:
+    background-color 160ms var(--webde-ease),
+    border-color 160ms var(--webde-ease),
+    transform 120ms var(--webde-ease);
+}
+
+.status,
+.fieldFeedback,
+.inlineHint {
+  color: var(--webde-muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.status {
+  min-height: 20px;
+  padding-top: 9px;
+}
+
+.error {
+  color: var(--danger);
+  font-size: 14px;
+  line-height: 1.45;
+  margin: 2px 0 0;
+}
+
+.eligibilityNotice {
+  border-top: 1px solid var(--webde-line);
+  color: var(--webde-muted);
+  margin-top: 22px;
+  padding-top: 20px;
+}
+
+.inlineNotice {
+  border-top: 1px solid var(--webde-line);
+  color: var(--webde-muted);
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 24px 0 0;
+  padding-top: 20px;
+}
+
+.eligibilityNotice strong {
+  color: var(--webde-ink);
+  display: block;
+  font-size: 15px;
+  font-weight: 650;
+}
+
+.eligibilityNotice ul {
+  display: grid;
+  font-size: 14px;
+  gap: 4px;
+  line-height: 1.45;
+  margin: 8px 0 0;
+  padding-left: 19px;
+}
+
+.spinner {
+  animation: spin 800ms linear infinite;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  height: 16px;
+  width: 16px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+.ambiguous {
+  border-top: 1px solid var(--webde-line);
+  margin-top: 20px;
+  padding-top: 24px;
+}
+
+.ambiguousHeader h2 {
+  color: var(--webde-ink);
+  font-size: 22px;
+  font-weight: 590;
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.ambiguousHeader p {
+  color: var(--webde-muted);
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 6px 0 0;
+}
+
+.candidateList {
+  border-bottom: 1px solid var(--webde-line);
+  margin-top: 18px;
+}
+
+.candidateButton {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-top: 1px solid var(--webde-line);
+  color: var(--webde-ink);
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  gap: 16px;
+  justify-content: space-between;
+  min-height: 68px;
+  padding: 10px 4px;
+  text-align: left;
+  width: 100%;
+}
+
+.candidateMain {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.candidateMain strong {
+  font-size: 16px;
+  font-weight: 650;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.candidateMain span,
+.candidateMeta {
+  color: var(--webde-muted);
+  font-size: 14px;
+}
+
+.candidateMeta {
+  flex: 0 0 auto;
+}
+
+.profile {
+  animation: profile-reveal 420ms var(--webde-ease) both;
+}
+
+@keyframes profile-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.profileHeader {
+  align-items: center;
+  display: grid;
+  gap: 18px;
+  grid-template-columns: 72px minmax(0, 1fr) auto;
+}
+
+.tokenVisual,
+.tokenLogo,
+.tokenFallback {
+  border-radius: 50%;
+  height: 72px;
+  width: 72px;
+}
+
+.tokenVisual {
+  background: var(--webde-control);
+  border: 1px solid var(--webde-line);
+  overflow: hidden;
+}
+
+.tokenLogo {
+  display: block;
+  object-fit: cover;
+}
+
+.tokenFallback {
+  align-items: center;
+  color: var(--webde-ink);
+  display: flex;
+  font-size: 26px;
+  font-weight: 620;
+  justify-content: center;
+}
+
+.identity {
+  min-width: 0;
+}
+
+.chain {
+  color: var(--webde-muted);
+  display: block;
+  font-size: 14px;
+  font-weight: 590;
+  line-height: 1.35;
+  margin-bottom: 3px;
+}
+
+.tokenName {
+  color: var(--webde-ink);
+  font-size: clamp(26px, 4vw, 36px);
+  font-weight: 560;
+  letter-spacing: -0.038em;
+  line-height: 1.08;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.tokenSymbol {
+  color: var(--webde-muted);
+  font-size: 0.54em;
+  font-weight: 570;
+  letter-spacing: -0.01em;
+  margin-left: 10px;
+  vertical-align: 0.12em;
+}
+
+.addressLink {
+  align-items: center;
+  color: var(--webde-muted);
+  display: inline-flex;
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 13px;
+  gap: 5px;
+  margin-top: 8px;
+  min-height: 44px;
+  padding-inline: 2px;
+  text-decoration: none;
+}
+
+.changeButton,
+.backButton {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: var(--webde-muted);
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 620;
+  gap: 7px;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 4px;
+}
+
+.stats {
+  border-bottom: 1px solid var(--webde-line);
+  border-top: 1px solid var(--webde-line);
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  margin: 30px 0 0;
+}
+
+.stats > div {
+  min-width: 0;
+  padding: 18px 12px;
+}
+
+.stats > div:first-child {
+  padding-left: 0;
+}
+
+.stats > div:last-child {
+  padding-right: 0;
+}
+
+.stats > div + div {
+  border-left: 1px solid var(--webde-line);
+}
+
+.stats dt,
+.reviewDetails dt {
+  color: var(--webde-muted);
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.stats dd,
+.reviewDetails dd {
+  color: var(--webde-ink);
+  font-size: 17px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 640;
+  line-height: 1.25;
+  margin: 6px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.socialLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 22px;
+  margin-top: 22px;
+}
+
+.socialLink {
+  align-items: center;
+  color: var(--webde-ink);
+  display: inline-flex;
+  font-size: 14px;
+  font-weight: 620;
+  gap: 5px;
+  min-height: 44px;
+  min-width: 44px;
+  padding-inline: 6px;
+  text-decoration: none;
+}
+
+.previewBack {
+  min-height: 44px;
+}
+
+.profileActions {
+  border-top: 1px solid var(--webde-line);
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 24px;
+  padding-top: 24px;
+}
+
+.profileActions .primaryButton {
+  min-width: 188px;
+}
+
+.sectionHeader {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 28px;
+}
+
+.group {
+  border: 0;
+  margin: 0;
+  min-width: 0;
+  padding: 0;
+}
+
+.group + .group {
+  border-top: 1px solid var(--webde-line);
+  margin-top: 26px;
+  padding-top: 26px;
+}
+
+.group legend {
+  margin-bottom: 11px;
+  padding: 0;
+}
+
+.segmented {
+  background: var(--webde-control);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  display: grid;
+  gap: 4px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  padding: 4px;
+}
+
+.templateSwitch {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.segment {
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--webde-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 620;
+  line-height: 1.25;
+  min-height: 48px;
+  padding: 8px 12px;
+  transition:
+    background-color 150ms var(--webde-ease),
+    color 150ms var(--webde-ease),
+    transform 120ms var(--webde-ease);
+}
+
+.segment[data-active="true"] {
+  background: var(--webde-ink);
+  color: var(--webde-canvas);
+}
+
+.segment:disabled {
+  color: var(--webde-dim);
+  cursor: not-allowed;
+  opacity: 0.64;
+}
+
+.inlineHint {
+  margin: 9px 0 0;
+}
+
+.predictionFields {
+  border-top: 1px solid var(--webde-line);
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
+  margin-top: 26px;
+  padding-top: 26px;
+}
+
+.adornedInput {
+  position: relative;
+}
+
+.adornedInput .input {
+  padding-left: 34px;
+}
+
+.adornedInput[data-adornment="end"] .input {
+  padding-left: 15px;
+  padding-right: 38px;
+}
+
+.adornment {
+  color: var(--webde-muted);
+  font-size: 16px;
+  font-weight: 650;
+  left: 15px;
+  pointer-events: none;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+}
+
+.adornedInput[data-adornment="end"] .adornment {
+  left: auto;
+  right: 15px;
+}
+
+.fieldFeedback {
+  min-height: 20px;
+}
+
+.review {
+  column-gap: 32px;
+  display: grid;
+  grid-template-columns: minmax(0, 430px) minmax(240px, 1fr);
+  position: relative;
+}
+
+.review > .backButton,
+.reviewActions {
+  grid-column: 1 / -1;
+}
+
+.review > .backButton {
+  justify-self: start;
+}
+
+.reviewCard {
+  grid-column: 1;
+  max-width: 430px;
+  margin-top: 20px;
+  width: 100%;
+}
+
+.rule {
+  border-bottom: 1px solid var(--webde-line);
+  border-top: 1px solid var(--webde-line);
+  display: grid;
+  gap: 18px;
+  align-content: start;
+  grid-column: 2;
+  grid-template-columns: minmax(0, 1fr);
+  margin-top: 20px;
+  padding: 22px 0;
+}
+
+.ruleLabel {
+  color: var(--webde-muted);
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.45;
+}
+
+.ruleText {
+  color: var(--webde-ink);
+  font-size: 17px;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.ruleText strong {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+}
+
+.reviewDetails {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 24px 0 0;
+}
+
+.reviewActions {
+  border-top: 1px solid var(--webde-line);
+  margin-top: 26px;
+  padding-top: 24px;
+}
+
+.previewButton {
+  background: var(--webde-control);
+  border: 1px solid var(--webde-line);
+  color: var(--webde-muted);
+  cursor: not-allowed;
+  width: 100%;
+}
+
+.primaryButton:focus-visible,
+.previewButton:focus-visible,
+.input:focus-visible,
+.candidateButton:focus-visible,
+.addressLink:focus-visible,
+.changeButton:focus-visible,
+.backButton:focus-visible,
+.socialLink:focus-visible,
+.segment:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 3px;
+}
+
+.primaryButton:active,
+.candidateButton:active,
+.segment:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.primaryButton:disabled {
+  background: var(--webde-control);
+  border-color: var(--webde-line);
+  color: var(--webde-dim);
+  cursor: not-allowed;
+  transform: none;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .primaryButton:not(:disabled):hover {
+    background: #e7e7e4;
+    border-color: #e7e7e4;
+  }
+
+  .candidateButton:hover,
+  .segment:not([data-active="true"]):not(:disabled):hover {
+    background: var(--webde-surface-raised);
+    color: var(--webde-ink);
+  }
+
+  .addressLink:hover,
+  .changeButton:hover,
+  .backButton:hover,
+  .socialLink:hover {
+    color: var(--webde-ink);
+  }
+}
+
+@media (forced-colors: active) {
+  .root .intro h1.title:focus-visible {
+    outline: 2px solid CanvasText;
+    outline-offset: 5px;
+    text-decoration: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .root {
+    padding-top: 28px;
+  }
+
+  .profileHeader {
+    grid-template-columns: 64px minmax(0, 1fr);
+  }
+
+  .tokenVisual,
+  .tokenLogo,
+  .tokenFallback {
+    height: 64px;
+    width: 64px;
+  }
+
+  .changeButton {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+
+  .stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .stats > div,
+  .stats > div:first-child,
+  .stats > div:last-child {
+    border-bottom: 1px solid var(--webde-line);
+    padding: 16px;
+  }
+
+  .stats > div:nth-child(odd) {
+    border-left: 0;
+    padding-left: 0;
+  }
+
+  .stats > div:nth-child(even) {
+    border-left: 1px solid var(--webde-line);
+    padding-right: 0;
+  }
+
+  .stats > div:last-child:nth-child(odd) {
+    border-bottom: 0;
+    grid-column: 1 / -1;
+  }
+
+  .templateSwitch {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .predictionFields {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 520px) {
+  .intro {
+    margin-bottom: 22px;
+  }
+
+  .addressForm,
+  .profile,
+  .prediction,
+  .review {
+    padding: 22px;
+  }
+
+  .addressInputRow {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .addressInputRow .primaryButton,
+  .profileActions .primaryButton {
+    width: 100%;
+  }
+
+  .profileActions {
+    display: block;
+  }
+
+  .segmented {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .rule {
+    gap: 8px;
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 780px) {
+  .review {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .reviewCard,
+  .rule {
+    grid-column: 1;
+  }
+
+  .reviewCard {
+    justify-self: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .profile,
+  .spinner {
+    animation-duration: 0.01ms;
+  }
+
+  .primaryButton,
+  .input,
+  .segment {
+    transition-duration: 0.01ms;
+  }
+}
+
+@media (forced-colors: active) {
+  .primaryButton,
+  .segment[data-active="true"] {
+    border: 1px solid ButtonText;
+  }
+}

--- a/components/prediction-market-create-flow-v2.tsx
+++ b/components/prediction-market-create-flow-v2.tsx
@@ -1,0 +1,1319 @@
+"use client";
+
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
+
+import { PredictionMarketAssetPreviewCardV2 } from
+  "@/components/prediction-market-asset-card-v2";
+import styles from "@/components/prediction-market-create-flow-v2.module.css";
+import { applyTokenImageFallback } from "@/lib/token-image";
+import { predictionAssetCardImageV2 } from
+  "@/lib/prediction-v2/asset-logo-v2";
+import {
+  parsePredictionAssetAutoDiscoveryV2,
+  type PredictionAssetAutoDiscoveryClientCandidateV2,
+  type PredictionAssetAutoDiscoveryClientResultV2,
+} from "@/lib/prediction-v2/asset-auto-discovery-v2";
+import {
+  evaluatePredictionAssetDiscoveryEligibilityV2,
+  type PredictionAssetDiscoveryReasonCodeV2,
+  type PredictionAssetMarketCapSupplyEvidenceV2,
+} from "@/lib/prediction-v2/asset-eligibility-v2";
+import {
+  PREDICTION_V2_MAXIMUM_MARKET_DURATION_SECONDS,
+  PREDICTION_V2_MINIMUM_MARKET_DURATION_SECONDS,
+  PREDICTION_V2_PROTOCOL_PRICE_DECIMALS,
+  PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+  buildPredictionV2CreateReview,
+  predictionV2ExactUtcToUnixSeconds,
+  type PredictionV2CreationReferenceSnapshot,
+  type PredictionV2CreateMetric,
+  type PredictionV2CreateValidationErrors,
+  type PredictionV2DetectedAsset,
+  type PredictionV2EnabledCreateTemplate,
+  type PredictionV2ReferenceMetricSnapshot,
+  type PredictionV2ReferenceSupplySnapshot,
+} from "@/lib/prediction-v2/create-flow-v2";
+
+const AUTO_DISCOVERY_ENDPOINT = "/api/prediction/asset-auto-discovery";
+const MAX_UINT256 = (1n << 256n) - 1n;
+
+type CreateFlowViewV2 = "address" | "asset" | "prediction" | "review";
+
+export type PredictionMarketCreateFlowV2Discovery = (
+  locator: string,
+  signal: AbortSignal,
+) => Promise<unknown>;
+
+export type PredictionMarketCreateFlowV2InitialPrediction = Readonly<{
+  metric?: PredictionV2CreateMetric;
+  template?: PredictionV2EnabledCreateTemplate;
+  targetUsd?: string;
+  percentChange?: string;
+  observationUtc?: string;
+  priceDecimals?: typeof PREDICTION_V2_PROTOCOL_PRICE_DECIMALS;
+}>;
+
+export type PredictionMarketCreateFlowV2Props = Readonly<{
+  /** Deterministic seed data for local previews and static render tests. */
+  discoverToken?: PredictionMarketCreateFlowV2Discovery;
+  initialLocator?: string;
+  initialDiscoveryResult?: PredictionAssetAutoDiscoveryClientResultV2 | null;
+  initialMarketCapSupplyEvidence?: PredictionAssetMarketCapSupplyEvidenceV2 | null;
+  initialCreationSnapshot?: PredictionV2CreationReferenceSnapshot | null;
+  initialReferenceMetricSnapshot?: PredictionV2ReferenceMetricSnapshot | null;
+  initialReferenceSupplySnapshot?: PredictionV2ReferenceSupplySnapshot | null;
+  /** Prevents a supply snapshot from being reused for a different detected token. */
+  initialReferenceSupplySelectionKey?: string;
+  initialPrediction?: PredictionMarketCreateFlowV2InitialPrediction;
+  initialView?: CreateFlowViewV2;
+}>;
+
+type SearchState = "idle" | "loading";
+
+async function fetchPredictionAssetAutoDiscoveryV2(
+  locator: string,
+  signal: AbortSignal,
+) {
+  const response = await fetch(
+    `${AUTO_DISCOVERY_ENDPOINT}?locator=${encodeURIComponent(locator)}`,
+    {
+      cache: "no-store",
+      headers: { accept: "application/json" },
+      signal,
+    },
+  );
+  return response.json() as Promise<unknown>;
+}
+
+function firstCandidate(
+  result: PredictionAssetAutoDiscoveryClientResultV2 | null | undefined,
+) {
+  return result?.status === "unique" ? result.candidate : null;
+}
+
+function initialViewFor(
+  requested: CreateFlowViewV2 | undefined,
+  candidate: PredictionAssetAutoDiscoveryClientCandidateV2 | null,
+): CreateFlowViewV2 {
+  if (!candidate) return "address";
+  return requested ?? "asset";
+}
+
+function shortAddress(address: string) {
+  return address.length <= 15
+    ? address
+    : `${address.slice(0, 7)}…${address.slice(-5)}`;
+}
+
+function candidateDisplayName(
+  candidate: PredictionAssetAutoDiscoveryClientCandidateV2,
+) {
+  return candidate.profile.name ?? `${candidate.profile.chain.label} token`;
+}
+
+function candidateDisplaySymbol(
+  candidate: PredictionAssetAutoDiscoveryClientCandidateV2,
+) {
+  return candidate.profile.symbol ?? shortAddress(candidate.profile.address);
+}
+
+function candidateFallbackGlyph(
+  candidate: PredictionAssetAutoDiscoveryClientCandidateV2,
+) {
+  const source = candidate.profile.symbol ??
+    candidate.profile.name ??
+    candidate.profile.chain.label;
+  return Array.from(source)[0]?.toUpperCase() ?? "T";
+}
+
+function formatUsd(value: number | undefined, mode: "price" | "compact") {
+  if (value === undefined || !Number.isFinite(value) || value < 0) return "—";
+  if (mode === "compact" && value >= 1_000) {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      notation: "compact",
+      maximumFractionDigits: value >= 1_000_000 ? 1 : 2,
+    }).format(value);
+  }
+  if (value === 0) return "$0";
+  if (value < 0.01) {
+    return `$${value.toLocaleString("en-US", {
+      maximumSignificantDigits: 6,
+      useGrouping: false,
+    })}`;
+  }
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: value < 1 ? 6 : 2,
+  }).format(value);
+}
+
+function formatUsdText(value: string) {
+  const match = /^(0|[1-9]\d*)(?:\.(\d+))?$/u.exec(value);
+  if (!match) return `$${value}`;
+  const integer = match[1].replace(/\B(?=(\d{3})+(?!\d))/gu, ",");
+  return `$${integer}${match[2] ? `.${match[2]}` : ""}`;
+}
+
+function formatAge(seconds: number | undefined) {
+  if (seconds === undefined || !Number.isFinite(seconds) || seconds < 0) {
+    return "—";
+  }
+  if (seconds < 3_600) return `${Math.max(1, Math.floor(seconds / 60))} min`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3_600)} hr`;
+  const days = Math.floor(seconds / 86_400);
+  if (days < 60) return `${days} day${days === 1 ? "" : "s"}`;
+  if (days < 730) return `${Math.floor(days / 30)} mo`;
+  return `${Math.floor(days / 365)} yr`;
+}
+
+function exactUtcFromInput(value: string) {
+  const normalized = value.trim();
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/u.test(normalized)) {
+    return `${normalized}:00Z`;
+  }
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/u.test(normalized)) {
+    return `${normalized}Z`;
+  }
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/u.test(normalized)) {
+    return normalized;
+  }
+  return "";
+}
+
+function dateTimeInputFromUtc(value: string | undefined) {
+  if (!value) return "";
+  const exact = exactUtcFromInput(value);
+  return exact && predictionV2ExactUtcToUnixSeconds(exact)
+    ? exact.slice(0, 16)
+    : "";
+}
+
+function formatDeadline(value: string) {
+  const unixSeconds = predictionV2ExactUtcToUnixSeconds(value);
+  if (!unixSeconds) return value;
+  const date = new Date(Number(unixSeconds) * 1_000);
+  const day = new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+  const time = new Intl.DateTimeFormat("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+    timeZone: "UTC",
+  }).format(date);
+  return `${day}, ${time} UTC`;
+}
+
+function dateTimeInputFromUnixSeconds(value: bigint) {
+  const milliseconds = Number(value) * 1_000;
+  if (!Number.isSafeInteger(milliseconds)) return "";
+  return new Date(milliseconds).toISOString().slice(0, 16);
+}
+
+type EvidenceSnapshotBase = Readonly<{
+  sourceNetwork: string;
+  address: string;
+  capturedAtUtc: string;
+  snapshotReference: string;
+  evidenceDigest: string;
+  verificationStatus: string;
+}>;
+
+function evidenceSnapshotMatchesCandidate(
+  snapshot: EvidenceSnapshotBase | null | undefined,
+  candidate: PredictionAssetAutoDiscoveryClientCandidateV2,
+) {
+  if (
+    !snapshot ||
+    snapshot.sourceNetwork !== candidate.selection.sourceNetwork ||
+    snapshot.address !== candidate.profile.address ||
+    snapshot.verificationStatus !== "verified" ||
+    !predictionV2ExactUtcToUnixSeconds(snapshot.capturedAtUtc) ||
+    !/^0x[0-9a-f]{64}$/u.test(snapshot.evidenceDigest) ||
+    /^0x0{64}$/u.test(snapshot.evidenceDigest)
+  ) return false;
+  const position = snapshot.snapshotReference.split(":").at(-1);
+  const prefix = candidate.selection.sourceNetwork === "solana"
+    ? "solana:slot:"
+    : `eip155:${candidate.profile.chain.reference}:block:`;
+  return Boolean(
+    position &&
+    /^(?:0|[1-9]\d{0,19})$/u.test(position) &&
+    snapshot.snapshotReference === `${prefix}${position}`,
+  );
+}
+
+function isValidCreationSnapshot(
+  snapshot: PredictionV2CreationReferenceSnapshot | null | undefined,
+): snapshot is PredictionV2CreationReferenceSnapshot {
+  if (
+    !snapshot ||
+    snapshot.settlementChainId !== PREDICTION_V2_SETTLEMENT_CHAIN_ID ||
+    snapshot.verificationStatus !== "verified" ||
+    !predictionV2ExactUtcToUnixSeconds(snapshot.capturedAtUtc) ||
+    !/^0x[0-9a-f]{64}$/u.test(snapshot.evidenceDigest) ||
+    /^0x0{64}$/u.test(snapshot.evidenceDigest)
+  ) return false;
+  const prefix = `eip155:${PREDICTION_V2_SETTLEMENT_CHAIN_ID}:block:`;
+  if (!snapshot.snapshotReference.startsWith(prefix)) return false;
+  const position = snapshot.snapshotReference.slice(prefix.length);
+  return /^(?:0|[1-9]\d{0,19})$/u.test(position);
+}
+
+function isBoundSupplySnapshot(
+  snapshot: PredictionV2ReferenceSupplySnapshot | null | undefined,
+  candidate: PredictionAssetAutoDiscoveryClientCandidateV2,
+  creationSnapshot: PredictionV2CreationReferenceSnapshot | null,
+): snapshot is PredictionV2ReferenceSupplySnapshot {
+  if (
+    !snapshot ||
+    !creationSnapshot ||
+    !evidenceSnapshotMatchesCandidate(snapshot, candidate) ||
+    snapshot.supplyDefinition !== "fixed-supply-fully-circulating" ||
+    !/^[1-9]\d*$/u.test(snapshot.fixedSupplyAtoms) ||
+    !Number.isInteger(snapshot.tokenDecimals) ||
+    snapshot.tokenDecimals < 0 ||
+    snapshot.tokenDecimals > 255 ||
+    snapshot.capturedAtUtc !== creationSnapshot.capturedAtUtc
+  ) return false;
+  try {
+    const supply = BigInt(snapshot.fixedSupplyAtoms);
+    return supply > 0n && supply <= MAX_UINT256;
+  } catch {
+    return false;
+  }
+}
+
+function isBoundMetricSnapshot(
+  snapshot: PredictionV2ReferenceMetricSnapshot | null | undefined,
+  candidate: PredictionAssetAutoDiscoveryClientCandidateV2,
+  creationSnapshot: PredictionV2CreationReferenceSnapshot | null,
+  metric: PredictionV2CreateMetric,
+): snapshot is PredictionV2ReferenceMetricSnapshot {
+  if (!snapshot || !creationSnapshot) return false;
+  return Boolean(
+    evidenceSnapshotMatchesCandidate(snapshot, candidate) &&
+    snapshot.metric === metric &&
+    /^(?:0|[1-9]\d*)(?:\.\d+)?$/u.test(snapshot.valueUsd) &&
+    snapshot.valueUsd.length <= 96 &&
+    Number.isFinite(Number(snapshot.valueUsd)) &&
+    Number(snapshot.valueUsd) > 0 &&
+    snapshot.capturedAtUtc === creationSnapshot.capturedAtUtc,
+  );
+}
+
+function detectedAssetFromCandidate(
+  candidate: PredictionAssetAutoDiscoveryClientCandidateV2,
+  supplySnapshot: PredictionV2ReferenceSupplySnapshot | null,
+): PredictionV2DetectedAsset {
+  return {
+    identity: {
+      sourceNetwork: candidate.selection.sourceNetwork,
+      address: candidate.profile.address,
+    },
+    name: candidateDisplayName(candidate),
+    symbol: candidateDisplaySymbol(candidate),
+    referenceSupplySnapshot: supplySnapshot,
+  };
+}
+
+function searchErrorFor(result: PredictionAssetAutoDiscoveryClientResultV2) {
+  if (result.status === "invalid") {
+    return "Enter a valid token address.";
+  }
+  if (result.status === "not-found") {
+    return "No supported token was found for this address.";
+  }
+  if (result.status === "inconclusive") {
+    return "The chain could not be confirmed. Try again.";
+  }
+  return null;
+}
+
+function marketDataReasonText(reason: PredictionAssetDiscoveryReasonCodeV2) {
+  switch (reason) {
+    case "price-unavailable":
+    case "price-not-positive":
+      return "A current USD price is unavailable.";
+    case "pool-age-unavailable":
+      return "Pool age is unavailable.";
+    case "pool-too-new":
+      return "The pool must be at least 24 hours old.";
+    case "liquidity-unavailable":
+      return "Liquidity data is unavailable.";
+    case "liquidity-below-minimum":
+      return "The token needs at least $50K in liquidity.";
+    case "volume-24h-unavailable":
+      return "24-hour volume is unavailable.";
+    case "volume-24h-below-minimum":
+      return "The token needs at least $25K in 24-hour volume.";
+  }
+}
+
+function withoutPredictionErrors(
+  current: PredictionV2CreateValidationErrors,
+  keys: readonly (keyof PredictionV2CreateValidationErrors)[],
+) {
+  const next = { ...current };
+  for (const key of keys) delete next[key];
+  return next;
+}
+
+function observationErrorText(error: string | undefined) {
+  return error === "Enter an exact UTC time including seconds and Z."
+    ? "Choose a result time in UTC."
+    : error;
+}
+
+const PREDICTION_CHOICE_ERROR_KEYS = Object.freeze([
+  "metric",
+  "template",
+  "targetUsd",
+  "percentChange",
+  "referenceMetricSnapshot",
+  "referenceSupplySnapshot",
+  "precision",
+  "protocolPredicate",
+] as const satisfies readonly (keyof PredictionV2CreateValidationErrors)[]);
+
+const TARGET_FIELD_ERROR_KEYS = Object.freeze([
+  "targetUsd",
+  "percentChange",
+  "referenceMetricSnapshot",
+  "precision",
+  "protocolPredicate",
+] as const satisfies readonly (keyof PredictionV2CreateValidationErrors)[]);
+
+export function PredictionMarketCreateFlowV2({
+  discoverToken = fetchPredictionAssetAutoDiscoveryV2,
+  initialLocator,
+  initialDiscoveryResult = null,
+  initialMarketCapSupplyEvidence = null,
+  initialCreationSnapshot = null,
+  initialReferenceMetricSnapshot = null,
+  initialReferenceSupplySnapshot = null,
+  initialReferenceSupplySelectionKey,
+  initialPrediction,
+  initialView,
+}: PredictionMarketCreateFlowV2Props) {
+  const generatedId = useId();
+  const addressId = `${generatedId}-address`;
+  const addressErrorId = `${generatedId}-address-error`;
+  const targetId = `${generatedId}-target`;
+  const targetErrorId = `${generatedId}-target-error`;
+  const timeId = `${generatedId}-time`;
+  const timeErrorId = `${generatedId}-time-error`;
+
+  const seededCandidate = firstCandidate(initialDiscoveryResult);
+  const seededSupplyKey = initialReferenceSupplySelectionKey ?? null;
+  const seededMetric = initialPrediction?.metric ?? "price";
+  const seededCreationSnapshot = seededCandidate &&
+      isValidCreationSnapshot(initialCreationSnapshot)
+    ? initialCreationSnapshot
+    : null;
+  const seededPercentageAvailable = Boolean(
+    seededCandidate &&
+    isBoundMetricSnapshot(
+      initialReferenceMetricSnapshot,
+      seededCandidate,
+      seededCreationSnapshot,
+      seededMetric,
+    ),
+  );
+
+  const [view, setView] = useState<CreateFlowViewV2>(() =>
+    initialViewFor(initialView, seededCandidate)
+  );
+  const [locator, setLocator] = useState(
+    initialLocator ?? initialDiscoveryResult?.locator ?? "",
+  );
+  const [discoveryResult, setDiscoveryResult] =
+    useState<PredictionAssetAutoDiscoveryClientResultV2 | null>(
+      initialDiscoveryResult,
+    );
+  const [candidate, setCandidate] =
+    useState<PredictionAssetAutoDiscoveryClientCandidateV2 | null>(
+      seededCandidate,
+    );
+  const [searchState, setSearchState] = useState<SearchState>("idle");
+  const [searchError, setSearchError] = useState<string | null>(() =>
+    initialDiscoveryResult ? searchErrorFor(initialDiscoveryResult) : null
+  );
+  const [assetError, setAssetError] = useState<string | null>(null);
+  const [metric, setMetric] = useState<PredictionV2CreateMetric>(
+    seededMetric,
+  );
+  const [template, setTemplate] = useState<PredictionV2EnabledCreateTemplate>(
+    initialPrediction?.template === "percent-change" && seededPercentageAvailable
+      ? "percent-change"
+      : "target",
+  );
+  const [targetUsd, setTargetUsd] = useState(initialPrediction?.targetUsd ?? "");
+  const [percentChange, setPercentChange] = useState(
+    initialPrediction?.percentChange ?? "",
+  );
+  const [observationInput, setObservationInput] = useState(
+    dateTimeInputFromUtc(initialPrediction?.observationUtc),
+  );
+  const [predictionErrors, setPredictionErrors] =
+    useState<PredictionV2CreateValidationErrors>({});
+
+  const requestIdRef = useRef(0);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const stepTitleRef = useRef<HTMLHeadingElement | null>(null);
+  const addressInputRef = useRef<HTMLInputElement | null>(null);
+  const choosePredictionButtonRef = useRef<HTMLButtonElement | null>(null);
+  const reviewPredictionButtonRef = useRef<HTMLButtonElement | null>(null);
+  const targetInputRef = useRef<HTMLInputElement | null>(null);
+  const timeInputRef = useRef<HTMLInputElement | null>(null);
+  const assetErrorRef = useRef<HTMLParagraphElement | null>(null);
+  const predictionFormErrorRef = useRef<HTMLParagraphElement | null>(null);
+
+  useEffect(() => () => {
+    requestIdRef.current += 1;
+    abortControllerRef.current?.abort();
+  }, []);
+
+  const creationSnapshot = useMemo(() => {
+    if (!candidate || !isValidCreationSnapshot(initialCreationSnapshot)) {
+      return null;
+    }
+    return initialCreationSnapshot;
+  }, [candidate, initialCreationSnapshot]);
+
+  const supplySnapshot = useMemo(() => {
+    if (
+      !candidate ||
+      (seededSupplyKey !== null && candidate.selectionKey !== seededSupplyKey) ||
+      !isBoundSupplySnapshot(
+        initialReferenceSupplySnapshot,
+        candidate,
+        creationSnapshot,
+      )
+    ) return null;
+    return initialReferenceSupplySnapshot;
+  }, [
+    candidate,
+    creationSnapshot,
+    initialReferenceSupplySnapshot,
+    seededSupplyKey,
+  ]);
+
+  const referenceMetricSnapshot = useMemo(() => {
+    if (
+      !candidate ||
+      !isBoundMetricSnapshot(
+        initialReferenceMetricSnapshot,
+        candidate,
+        creationSnapshot,
+        metric,
+      )
+    ) return null;
+    return initialReferenceMetricSnapshot;
+  }, [
+    candidate,
+    creationSnapshot,
+    initialReferenceMetricSnapshot,
+    metric,
+  ]);
+
+  const detectedAsset = useMemo(() =>
+    candidate ? detectedAssetFromCandidate(candidate, supplySnapshot) : null,
+  [candidate, supplySnapshot]);
+
+  const marketDataQuality = useMemo(() => {
+    if (!candidate || !discoveryResult) return null;
+    const observedAtMs = Date.parse(discoveryResult.observedAt);
+    if (!Number.isSafeInteger(observedAtMs) || observedAtMs < 0) return null;
+    return evaluatePredictionAssetDiscoveryEligibilityV2({
+      profile: candidate.profile,
+      observedAtMs,
+      volume24hUsd: candidate.pair?.volume24hUsd ?? null,
+      marketCapSupplyEvidence: initialMarketCapSupplyEvidence,
+    });
+  }, [candidate, discoveryResult, initialMarketCapSupplyEvidence]);
+  const marketDataReasons = marketDataQuality?.reasonCodes.map(
+    marketDataReasonText,
+  ) ?? ["Current market data is unavailable."];
+  const hasCompleteMarketData = marketDataQuality?.status === "eligible";
+  const marketCapAvailable = Boolean(supplySnapshot);
+  const percentageAvailable = Boolean(referenceMetricSnapshot);
+  const predictionReady = Boolean(creationSnapshot && detectedAsset);
+  const assetReadinessId = `${generatedId}-asset-readiness`;
+  const searchStatus = searchState === "loading"
+    ? "Checking supported chains…"
+    : discoveryResult?.status === "ambiguous"
+      ? `${discoveryResult.candidates.length} matching tokens found. Choose a chain.`
+      : "";
+
+  const referenceMetricUsd = referenceMetricSnapshot?.valueUsd ?? null;
+  const observationBounds = useMemo(() => {
+    const creationUnixText = creationSnapshot
+      ? predictionV2ExactUtcToUnixSeconds(creationSnapshot.capturedAtUtc)
+      : null;
+    if (!creationUnixText) return null;
+    const creationUnix = BigInt(creationUnixText);
+    const firstValidSecond = creationUnix +
+      PREDICTION_V2_MINIMUM_MARKET_DURATION_SECONDS + 1n;
+    const firstValidMinute =
+      ((firstValidSecond + 59n) / 60n) * 60n;
+    const lastValidSecond = creationUnix +
+      PREDICTION_V2_MAXIMUM_MARKET_DURATION_SECONDS;
+    const lastValidMinute = (lastValidSecond / 60n) * 60n;
+    return {
+      min: dateTimeInputFromUnixSeconds(firstValidMinute),
+      max: dateTimeInputFromUnixSeconds(lastValidMinute),
+    };
+  }, [creationSnapshot]);
+
+  const prediction = useMemo(() => {
+    if (!creationSnapshot) return null;
+    const common = {
+      metric,
+      observationUtc: exactUtcFromInput(observationInput),
+      creationSnapshot,
+      priceDecimals: PREDICTION_V2_PROTOCOL_PRICE_DECIMALS,
+    } as const;
+    if (template === "target") return { ...common, template, targetUsd };
+    return referenceMetricSnapshot
+      ? { ...common, template, percentChange, referenceMetricSnapshot }
+      : null;
+  }, [
+    creationSnapshot,
+    metric,
+    observationInput,
+    percentChange,
+    referenceMetricSnapshot,
+    targetUsd,
+    template,
+  ]);
+
+  const reviewResult = useMemo(() =>
+    detectedAsset && prediction
+      ? buildPredictionV2CreateReview(detectedAsset, prediction)
+      : null,
+  [detectedAsset, prediction]);
+  const assetImage = useMemo(() => candidate
+    ? predictionAssetCardImageV2({
+      chainId: candidate.profile.chain.id,
+      address: candidate.profile.address,
+      logoUrl: candidate.profile.logoUrl,
+    })
+    : null,
+  [candidate]);
+  const renderedView = view === "review" && reviewResult?.ok !== true
+    ? "prediction"
+    : view;
+
+  function cancelPendingRequest() {
+    requestIdRef.current += 1;
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+    setSearchState("idle");
+  }
+
+  function focusStepTitle() {
+    window.setTimeout(() => stepTitleRef.current?.focus(), 0);
+  }
+
+  function focusAfterTransition(target: { current: HTMLElement | null }) {
+    window.setTimeout(() => target.current?.focus(), 0);
+  }
+
+  function changeLocator(value: string) {
+    cancelPendingRequest();
+    setLocator(value);
+    setDiscoveryResult(null);
+    setCandidate(null);
+    setSearchError(null);
+  }
+
+  function chooseCandidate(
+    nextCandidate: PredictionAssetAutoDiscoveryClientCandidateV2,
+  ) {
+    setCandidate(nextCandidate);
+    setAssetError(null);
+    setPredictionErrors({});
+    setMetric("price");
+    setTemplate("target");
+    setTargetUsd("");
+    setPercentChange("");
+    setView("asset");
+    focusStepTitle();
+  }
+
+  async function findToken(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (searchState === "loading") return;
+    const submittedLocator = locator.trim();
+    if (!submittedLocator) {
+      setSearchError("Enter a token address.");
+      addressInputRef.current?.focus();
+      return;
+    }
+
+    cancelPendingRequest();
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+    setSearchState("loading");
+    setSearchError(null);
+    setDiscoveryResult(null);
+    setCandidate(null);
+
+    try {
+      const body = await discoverToken(submittedLocator, controller.signal);
+      const parsed = parsePredictionAssetAutoDiscoveryV2(
+        body,
+        submittedLocator,
+      );
+      if (requestId !== requestIdRef.current || controller.signal.aborted) return;
+      if (!parsed) throw new Error("invalid discovery response");
+
+      setDiscoveryResult(parsed);
+      setLocator(parsed.locator ?? submittedLocator);
+      const resultError = searchErrorFor(parsed);
+      setSearchError(resultError);
+      if (parsed.status === "unique") chooseCandidate(parsed.candidate);
+      if (resultError) addressInputRef.current?.focus();
+    } catch (error) {
+      if (
+        requestId !== requestIdRef.current ||
+        controller.signal.aborted ||
+        (error instanceof DOMException && error.name === "AbortError")
+      ) return;
+      setSearchError("Token lookup failed. Check your connection and try again.");
+      addressInputRef.current?.focus();
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setSearchState("idle");
+        abortControllerRef.current = null;
+      }
+    }
+  }
+
+  function changeToken() {
+    cancelPendingRequest();
+    setView("address");
+    setCandidate(null);
+    setDiscoveryResult(null);
+    setSearchError(null);
+    setAssetError(null);
+    setPredictionErrors({});
+    window.setTimeout(() => addressInputRef.current?.focus(), 0);
+  }
+
+  function continueToPrediction() {
+    if (!detectedAsset) {
+      setAssetError("Choose a detected token before continuing.");
+      focusAfterTransition(assetErrorRef);
+      return;
+    }
+    if (!creationSnapshot) {
+      setAssetError("This token isn’t ready for predictions yet.");
+      focusAfterTransition(assetErrorRef);
+      return;
+    }
+    setAssetError(null);
+    setView("prediction");
+    focusStepTitle();
+  }
+
+  function reviewPrediction(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!reviewResult || !reviewResult.ok) {
+      const errors = reviewResult?.errors ?? (!detectedAsset
+        ? { asset: "Choose a detected token before continuing." }
+        : !creationSnapshot
+          ? { creationSnapshot: "A verified market reference is not available." }
+          : template === "percent-change" && !referenceMetricSnapshot
+            ? {
+                referenceMetricSnapshot:
+                  "A verified starting value is not available.",
+              }
+            : { protocolPredicate: "This prediction cannot be reviewed." });
+      setPredictionErrors(errors);
+      if (
+        errors.targetUsd ||
+        errors.percentChange ||
+        errors.referenceMetricSnapshot ||
+        errors.precision ||
+        errors.protocolPredicate
+      ) {
+        targetInputRef.current?.focus();
+      } else if (errors.observationUtc) {
+        timeInputRef.current?.focus();
+      } else {
+        focusAfterTransition(predictionFormErrorRef);
+      }
+      return;
+    }
+    setPredictionErrors({});
+    setView("review");
+    focusStepTitle();
+  }
+
+  return (
+    <section
+      aria-labelledby={`${generatedId}-title`}
+      className={styles.root}
+      data-prediction-create-v2=""
+      data-view={renderedView}
+    >
+      <header className={styles.intro}>
+        <p className={styles.kicker}>Create prediction</p>
+        <h1
+          className={styles.title}
+          id={`${generatedId}-title`}
+          ref={stepTitleRef}
+          tabIndex={-1}
+        >
+          {renderedView === "address" ? "Find a token" :
+            renderedView === "asset" ? "Token found" :
+              renderedView === "prediction" ? "Set the prediction" :
+                "Review the market"}
+        </h1>
+        <p className={styles.subtitle}>
+          {renderedView === "address"
+            ? "Paste a token address. We’ll find the chain and market data."
+            : renderedView === "asset"
+              ? "Check the token before choosing what the market predicts."
+              : renderedView === "prediction"
+                ? "Choose one measurable outcome and an exact UTC time."
+                : "Check the token, target and result time."}
+        </p>
+      </header>
+
+      <div className={styles.surface}>
+        {renderedView === "address" ? (
+          <form className={styles.addressForm} onSubmit={findToken} noValidate>
+            <div className={styles.field}>
+              <label className={styles.fieldLabel} htmlFor={addressId}>
+                Token address
+              </label>
+              <span className={styles.addressInputRow}>
+                <input
+                  aria-describedby={searchError ? addressErrorId : undefined}
+                  aria-invalid={searchError ? true : undefined}
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  className={styles.input}
+                  id={addressId}
+                  maxLength={128}
+                  name="tokenAddress"
+                  onChange={(event) => changeLocator(event.target.value)}
+                  placeholder="Paste token address"
+                  ref={addressInputRef}
+                  spellCheck={false}
+                  type="text"
+                  value={locator}
+                />
+                <button
+                  aria-busy={searchState === "loading"}
+                  className={styles.primaryButton}
+                  disabled={searchState === "loading"}
+                  type="submit"
+                >
+                  {searchState === "loading" ? (
+                    <>
+                      <span aria-hidden="true" className={styles.spinner} />
+                      Finding token
+                    </>
+                  ) : "Find token"}
+                </button>
+              </span>
+            </div>
+
+            <div
+              aria-atomic="true"
+              aria-live="polite"
+              className={styles.status}
+              role="status"
+            >
+              {searchStatus}
+            </div>
+            {searchError ? (
+              <p className={styles.error} id={addressErrorId} role="alert">
+                {searchError}
+              </p>
+            ) : null}
+
+            {discoveryResult?.status === "ambiguous" ? (
+              <div className={styles.ambiguous}>
+                <div className={styles.ambiguousHeader}>
+                  <h2>Choose the matching token</h2>
+                  <p>This address is active on more than one chain.</p>
+                </div>
+                <div className={styles.candidateList}>
+                  {discoveryResult.candidates.map((option) => (
+                    <button
+                      className={styles.candidateButton}
+                      key={option.selectionKey}
+                      onClick={() => chooseCandidate(option)}
+                      type="button"
+                    >
+                      <span className={styles.candidateMain}>
+                        <strong>{candidateDisplayName(option)}</strong>
+                        <span>{candidateDisplaySymbol(option)}</span>
+                      </span>
+                      <span className={styles.candidateMeta}>
+                        {option.profile.chain.label}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </form>
+        ) : null}
+
+        {renderedView === "asset" && candidate ? (
+          <article className={styles.profile} aria-label="Detected token">
+            <div className={styles.profileHeader}>
+              <div className={styles.tokenVisual}>
+                {assetImage ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    alt={assetImage.usesProviderLogo
+                      ? `${candidateDisplayName(candidate)} logo`
+                      : ""}
+                    className={styles.tokenLogo}
+                    height={72}
+                    onError={(event) => {
+                      applyTokenImageFallback(
+                        event.currentTarget,
+                        predictionAssetCardImageV2({
+                          chainId: candidate.profile.chain.id,
+                          address: candidate.profile.address,
+                        }).source,
+                      );
+                    }}
+                    referrerPolicy="no-referrer"
+                    src={assetImage.source}
+                    width={72}
+                  />
+                ) : (
+                  <span aria-hidden="true" className={styles.tokenFallback}>
+                    {candidateFallbackGlyph(candidate)}
+                  </span>
+                )}
+              </div>
+
+              <div className={styles.identity}>
+                <span className={styles.chain}>{candidate.profile.chain.label}</span>
+                <h2 className={styles.tokenName}>
+                  {candidateDisplayName(candidate)}
+                  <span className={styles.tokenSymbol}>
+                    {candidateDisplaySymbol(candidate)}
+                  </span>
+                </h2>
+                <a
+                  aria-label={`${shortAddress(candidate.profile.address)} · View on ${candidate.profile.chain.label} explorer (opens in a new tab)`}
+                  className={styles.addressLink}
+                  href={candidate.profile.explorerUrl}
+                  rel="noreferrer noopener"
+                  target="_blank"
+                >
+                  {shortAddress(candidate.profile.address)}
+                  <span aria-hidden="true">↗</span>
+                </a>
+              </div>
+
+              <button className={styles.changeButton} onClick={changeToken} type="button">
+                Change token
+              </button>
+            </div>
+
+            <dl className={styles.stats} aria-label="Current token data">
+              <div>
+                <dt>Price</dt>
+                <dd>{formatUsd(candidate.profile.priceUsd, "price")}</dd>
+              </div>
+              <div>
+                <dt>Market cap</dt>
+                <dd>{formatUsd(candidate.profile.marketCapUsd, "compact")}</dd>
+              </div>
+              <div>
+                <dt>FDV</dt>
+                <dd>{formatUsd(candidate.profile.fdvUsd, "compact")}</dd>
+              </div>
+              <div>
+                <dt>Liquidity</dt>
+                <dd>{formatUsd(candidate.profile.liquidityUsd, "compact")}</dd>
+              </div>
+              <div>
+                <dt>Age</dt>
+                <dd>{formatAge(candidate.profile.age?.seconds)}</dd>
+              </div>
+            </dl>
+
+            {candidate.profile.links?.length ? (
+              <nav
+                aria-label={`${candidateDisplaySymbol(candidate)} links`}
+                className={styles.socialLinks}
+              >
+                {candidate.profile.links.map((link) => (
+                  <a
+                    className={styles.socialLink}
+                    href={link.url}
+                    key={link.kind}
+                    rel="noopener noreferrer nofollow ugc"
+                    target="_blank"
+                  >
+                    {link.kind === "website" ? "Website" :
+                      link.kind === "x" ? "X" : "Telegram"}
+                    <span aria-hidden="true">↗</span>
+                  </a>
+                ))}
+              </nav>
+            ) : null}
+
+            {!hasCompleteMarketData ? (
+              <div className={styles.eligibilityNotice} role="status">
+                <strong>Market data incomplete</strong>
+                <ul>
+                  {marketDataReasons.map((reason) => <li key={reason}>{reason}</li>)}
+                </ul>
+              </div>
+            ) : null}
+
+            {!predictionReady ? (
+              <p className={styles.inlineNotice} id={assetReadinessId} role="status">
+                This token isn’t ready for predictions yet.
+              </p>
+            ) : null}
+
+            {assetError ? (
+              <p
+                className={styles.error}
+                ref={assetErrorRef}
+                role="alert"
+                tabIndex={-1}
+              >
+                {assetError}
+              </p>
+            ) : null}
+
+            <div className={styles.profileActions}>
+              <button
+                aria-describedby={!predictionReady
+                  ? assetReadinessId
+                  : undefined}
+                className={styles.primaryButton}
+                disabled={!predictionReady}
+                onClick={continueToPrediction}
+                ref={choosePredictionButtonRef}
+                type="button"
+              >
+                Continue with {candidate.profile.chain.label}
+              </button>
+            </div>
+          </article>
+        ) : null}
+
+        {renderedView === "prediction" && candidate ? (
+          <form className={styles.prediction} onSubmit={reviewPrediction} noValidate>
+            <div className={styles.sectionHeader}>
+              <button
+                className={styles.backButton}
+                onClick={() => {
+                  setView("asset");
+                  focusAfterTransition(choosePredictionButtonRef);
+                }}
+                type="button"
+              >
+                <span aria-hidden="true">←</span>
+                {candidateDisplaySymbol(candidate)}
+              </button>
+            </div>
+
+            <fieldset className={styles.group}>
+              <legend>Measure</legend>
+              <div className={styles.segmented}>
+                <button
+                  aria-pressed={metric === "market-cap"}
+                  className={styles.segment}
+                  data-active={metric === "market-cap"}
+                  disabled={!marketCapAvailable}
+                  onClick={() => {
+                    setMetric("market-cap");
+                    setTemplate("target");
+                    setPredictionErrors((current) => withoutPredictionErrors(
+                      current,
+                      PREDICTION_CHOICE_ERROR_KEYS,
+                    ));
+                  }}
+                  type="button"
+                >
+                  Market cap
+                </button>
+                <button
+                  aria-pressed={metric === "price"}
+                  className={styles.segment}
+                  data-active={metric === "price"}
+                  onClick={() => {
+                    setMetric("price");
+                    setTemplate("target");
+                    setPredictionErrors((current) => withoutPredictionErrors(
+                      current,
+                      PREDICTION_CHOICE_ERROR_KEYS,
+                    ));
+                  }}
+                  type="button"
+                >
+                  Price
+                </button>
+              </div>
+              {!marketCapAvailable ? (
+                <p className={styles.inlineHint}>
+                  Market cap isn’t available for this token yet.
+                </p>
+              ) : null}
+            </fieldset>
+
+            <fieldset className={styles.group}>
+              <legend>Prediction</legend>
+              <div className={`${styles.segmented} ${styles.templateSwitch}`}>
+                <button
+                  aria-pressed={template === "target"}
+                  className={styles.segment}
+                  data-active={template === "target"}
+                  onClick={() => {
+                    setTemplate("target");
+                    setPredictionErrors((current) => withoutPredictionErrors(
+                      current,
+                      PREDICTION_CHOICE_ERROR_KEYS,
+                    ));
+                  }}
+                  type="button"
+                >
+                  Target
+                </button>
+                <button
+                  aria-describedby={!percentageAvailable
+                    ? `${generatedId}-percentage-note`
+                    : undefined}
+                  aria-pressed={template === "percent-change"}
+                  className={styles.segment}
+                  data-active={template === "percent-change"}
+                  disabled={!percentageAvailable}
+                  onClick={() => {
+                    setTemplate("percent-change");
+                    setPredictionErrors((current) => withoutPredictionErrors(
+                      current,
+                      PREDICTION_CHOICE_ERROR_KEYS,
+                    ));
+                  }}
+                  type="button"
+                >
+                  Percentage change
+                </button>
+                <button
+                  aria-describedby={`${generatedId}-reach-note`}
+                  className={`${styles.segment} ${styles.segmentDisabled}`}
+                  disabled
+                  type="button"
+                >
+                  Reach before deadline
+                </button>
+              </div>
+              <p className={styles.inlineHint}>
+                {!percentageAvailable ? (
+                  <span id={`${generatedId}-percentage-note`}>
+                    Percentage change needs a verified starting value.{" "}
+                  </span>
+                ) : null}
+                <span id={`${generatedId}-reach-note`}>
+                  Reach markets are coming later.
+                </span>
+              </p>
+            </fieldset>
+
+            <div className={styles.predictionFields}>
+              <div className={styles.field}>
+                <label className={styles.fieldLabel} htmlFor={targetId}>
+                  {template === "target"
+                    ? metric === "market-cap" ? "Target market cap" : "Target price"
+                    : "Change"}
+                </label>
+                <span
+                  className={styles.adornedInput}
+                  data-adornment={template === "target" ? "start" : "end"}
+                >
+                  <span aria-hidden="true" className={styles.adornment}>
+                    {template === "target" ? "$" : "%"}
+                  </span>
+                  <input
+                    aria-describedby={targetErrorId}
+                    aria-invalid={Boolean(
+                      predictionErrors.targetUsd ||
+                      predictionErrors.percentChange ||
+                      predictionErrors.referenceMetricSnapshot ||
+                      predictionErrors.precision ||
+                      predictionErrors.protocolPredicate,
+                    )}
+                    autoComplete="off"
+                    className={styles.input}
+                    id={targetId}
+                    inputMode="decimal"
+                    name={template === "target" ? "targetUsd" : "percentChange"}
+                    onChange={(event) => {
+                      if (template === "target") setTargetUsd(event.target.value);
+                      else setPercentChange(event.target.value);
+                      setPredictionErrors((current) => withoutPredictionErrors(
+                        current,
+                        TARGET_FIELD_ERROR_KEYS,
+                      ));
+                    }}
+                    placeholder={template === "target" ? "1000000" : "25"}
+                    ref={targetInputRef}
+                    spellCheck={false}
+                    type="text"
+                    value={template === "target" ? targetUsd : percentChange}
+                  />
+                </span>
+                <span className={styles.fieldFeedback} id={targetErrorId}>
+                  {predictionErrors.targetUsd ??
+                    predictionErrors.percentChange ??
+                    predictionErrors.referenceMetricSnapshot ??
+                    predictionErrors.precision ??
+                    predictionErrors.protocolPredicate ??
+                    (template === "percent-change" && referenceMetricUsd
+                      ? `Measured from ${formatUsdText(referenceMetricUsd)}`
+                      : "")}
+                </span>
+              </div>
+
+              <div className={styles.field}>
+                <label className={styles.fieldLabel} htmlFor={timeId}>
+                  Result time (UTC)
+                </label>
+                <input
+                  aria-describedby={timeErrorId}
+                  aria-invalid={Boolean(predictionErrors.observationUtc)}
+                  className={styles.input}
+                  id={timeId}
+                  max={observationBounds?.max}
+                  min={observationBounds?.min}
+                  name="observationUtc"
+                  onChange={(event) => {
+                    setObservationInput(event.target.value);
+                    setPredictionErrors((current) => withoutPredictionErrors(
+                      current,
+                      ["observationUtc"],
+                    ));
+                  }}
+                  ref={timeInputRef}
+                  step={60}
+                  type="datetime-local"
+                  value={observationInput}
+                />
+                <span className={styles.fieldFeedback} id={timeErrorId}>
+                  {observationErrorText(predictionErrors.observationUtc) ??
+                    "Exact to the minute, shown in UTC."}
+                </span>
+              </div>
+            </div>
+
+            {!creationSnapshot ? (
+              <p className={styles.inlineNotice} role="status">
+                This token isn’t ready for predictions yet.
+              </p>
+            ) : null}
+
+            {predictionErrors.referenceSupplySnapshot ||
+                predictionErrors.creationSnapshot ||
+                predictionErrors.metric ||
+                predictionErrors.template ||
+                predictionErrors.priceDecimals ||
+                predictionErrors.asset ? (
+              <p
+                className={styles.error}
+                ref={predictionFormErrorRef}
+                role="alert"
+                tabIndex={-1}
+              >
+                {predictionErrors.referenceSupplySnapshot ??
+                  predictionErrors.creationSnapshot ??
+                  predictionErrors.metric ??
+                  predictionErrors.template ??
+                  predictionErrors.priceDecimals ??
+                  predictionErrors.asset}
+              </p>
+            ) : null}
+
+            <div className={styles.profileActions}>
+              <button
+                className={styles.primaryButton}
+                ref={reviewPredictionButtonRef}
+                type="submit"
+              >
+                Review prediction
+              </button>
+            </div>
+          </form>
+        ) : null}
+
+        {renderedView === "review" && reviewResult?.ok ? (
+          <div className={styles.review}>
+            <button
+              className={styles.backButton}
+              onClick={() => {
+                setView("prediction");
+                focusAfterTransition(reviewPredictionButtonRef);
+              }}
+              type="button"
+            >
+              <span aria-hidden="true">←</span>
+              Edit prediction
+            </button>
+
+            {candidate ? (
+              <div className={styles.reviewCard}>
+                <PredictionMarketAssetPreviewCardV2
+                  imageLoading="eager"
+                  profile={candidate.profile}
+                  review={reviewResult.review}
+                />
+              </div>
+            ) : null}
+
+            <div className={styles.rule}>
+              <span className={styles.ruleLabel}>YES resolves if</span>
+              <p className={styles.ruleText}>
+                The USD price is at least{" "}
+                <strong>{formatUsdText(
+                  reviewResult.review.protocolPredicate.strikeUsd,
+                )}</strong>{" "}
+                at {formatDeadline(
+                  reviewResult.review.protocolPredicate.observationUtc,
+                )}.
+              </p>
+            </div>
+
+            <div className={styles.reviewActions}>
+              <button className={styles.previewButton} disabled type="button">
+                Preview only
+              </button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/components/prediction-market-v2-local-preview.tsx
+++ b/components/prediction-market-v2-local-preview.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+
+import styles from "@/components/prediction-market-create-flow-v2.module.css";
+import {
+  PredictionMarketCreateFlowV2,
+  type PredictionMarketCreateFlowV2Discovery,
+} from "@/components/prediction-market-create-flow-v2";
+import {
+  parsePredictionAssetAutoDiscoveryV2,
+  type PredictionAssetAutoDiscoveryClientResultV2,
+} from "@/lib/prediction-v2/asset-auto-discovery-v2";
+import type { PredictionAssetMarketCapSupplyEvidenceV2 } from "@/lib/prediction-v2/asset-eligibility-v2";
+import type {
+  PredictionV2CreationReferenceSnapshot,
+  PredictionV2ReferenceMetricSnapshot,
+  PredictionV2ReferenceSupplySnapshot,
+} from "@/lib/prediction-v2/create-flow-v2";
+
+const LOCAL_PREVIEW_BUNDLE_SENTINEL =
+  "programmable-prediction-v2-local-preview-v1";
+const OBSERVED_AT = "2026-08-23T18:00:00.000Z";
+const CAPTURED_AT = "2026-08-23T18:00:00Z";
+const RESULT_AT = "2026-08-30T18:00:00Z";
+const EVIDENCE_DIGEST = `0x${"12".repeat(32)}`;
+const BASE_TOKEN_ADDRESS = `0x${"ab".repeat(20)}`;
+const EVM_PAIR_ADDRESS = `0x${"cd".repeat(20)}`;
+const SOLANA_FIXTURE_LOCATOR =
+  "4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw";
+const SOLANA_PAIR_ADDRESS = "JEJUoGfGEPTZ1XTwN39dYdFxYxDiDaSKVNy5qYWJmZt3";
+
+export type PredictionV2LocalPreviewState =
+  | "address"
+  | "asset"
+  | "prediction"
+  | "review"
+  | "ambiguous"
+  | "error";
+
+export type PredictionV2LocalPreviewFixture = "base" | "solana";
+
+type FixtureDefinition = Readonly<{
+  locator: string;
+  selectionKey: string;
+  sourceNetwork: "base" | "solana";
+  chainReference: "8453" | "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d";
+  providerChainId: "base" | "solana";
+  namespace: "evm" | "solana";
+  pairAddress: string;
+  dexId: "uniswap" | "raydium";
+  name: string;
+  symbol: string;
+  priceUsd: number;
+  marketCapUsd: number;
+  fdvUsd: number;
+  liquidityUsd: number;
+  volume24hUsd: number;
+  pairCreatedAt: number;
+  fixedSupplyAtoms: string;
+  tokenDecimals: number;
+  chainPosition: string;
+  snapshotReference: string;
+  targetMarketCapUsd: string;
+  referenceMarketCapUsd: string;
+}>;
+
+const FIXTURES = Object.freeze({
+  base: Object.freeze({
+    locator: BASE_TOKEN_ADDRESS,
+    selectionKey: `evm:8453:${BASE_TOKEN_ADDRESS}`,
+    sourceNetwork: "base",
+    chainReference: "8453",
+    providerChainId: "base",
+    namespace: "evm",
+    pairAddress: EVM_PAIR_ADDRESS,
+    dexId: "uniswap",
+    name: "Base Test Token",
+    symbol: "BTST",
+    priceUsd: 0.008,
+    marketCapUsd: 8_000_000,
+    fdvUsd: 8_000_000,
+    liquidityUsd: 420_000,
+    volume24hUsd: 180_000,
+    pairCreatedAt: Date.parse("2026-08-20T18:00:00.000Z"),
+    fixedSupplyAtoms: "1000000000000000000000000000",
+    tokenDecimals: 18,
+    chainPosition: "34900000",
+    snapshotReference: "eip155:8453:block:34900000",
+    targetMarketCapUsd: "10000000",
+    referenceMarketCapUsd: "8000000",
+  }),
+  solana: Object.freeze({
+    locator: SOLANA_FIXTURE_LOCATOR,
+    selectionKey:
+      `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d:${SOLANA_FIXTURE_LOCATOR}`,
+    sourceNetwork: "solana",
+    chainReference: "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+    providerChainId: "solana",
+    namespace: "solana",
+    pairAddress: SOLANA_PAIR_ADDRESS,
+    dexId: "raydium",
+    name: "Solana Test Token",
+    symbol: "STST",
+    priceUsd: 0.25,
+    marketCapUsd: 250_000_000,
+    fdvUsd: 250_000_000,
+    liquidityUsd: 1_250_000,
+    volume24hUsd: 830_000,
+    pairCreatedAt: Date.parse("2026-08-18T18:00:00.000Z"),
+    fixedSupplyAtoms: "1000000000000000",
+    tokenDecimals: 6,
+    chainPosition: "290000000",
+    snapshotReference: "solana:slot:290000000",
+    targetMarketCapUsd: "300000000",
+    referenceMarketCapUsd: "250000000",
+  }),
+} as const satisfies Readonly<Record<PredictionV2LocalPreviewFixture, FixtureDefinition>>);
+
+function rawCandidate(fixture: FixtureDefinition) {
+  return {
+    selectionKey: fixture.selectionKey,
+    selection: {
+      mode: "custom",
+      sourceNetwork: fixture.sourceNetwork,
+      assetLocator: fixture.locator,
+    },
+    namespace: fixture.namespace,
+    chainReference: fixture.chainReference,
+    providerChainId: fixture.providerChainId,
+    provenance: {
+      identity: { source: "onchain-rpc" },
+      enrichment: { source: "dexscreener" },
+    },
+    token: {
+      address: fixture.locator,
+      name: fixture.name,
+      symbol: fixture.symbol,
+    },
+    currentPriceUsd: fixture.priceUsd,
+    marketCapUsd: fixture.marketCapUsd,
+    fdvUsd: fixture.fdvUsd,
+    matchingPairCount: 2,
+    pair: {
+      dexId: fixture.dexId,
+      pairAddress: fixture.pairAddress,
+      matchedSide: "base",
+      liquidityUsd: fixture.liquidityUsd,
+      volume24hUsd: fixture.volume24hUsd,
+      pairCreatedAt: fixture.pairCreatedAt,
+    },
+    links: {
+      imageUrl: null,
+      websites: [{ label: "Website", url: "https://programmable.market" }],
+      socials: [{ type: "twitter", url: "https://x.com/0xprogrammable" }],
+    },
+  };
+}
+
+function rawUniqueResult(fixture: FixtureDefinition) {
+  return {
+    schemaVersion: 2,
+    locator: fixture.locator,
+    source: "dexscreener",
+    observedAt: OBSERVED_AT,
+    usage: "informational-only",
+    status: "unique",
+    candidate: rawCandidate(fixture),
+  };
+}
+
+const RAW_RESULTS = Object.freeze({
+  base: Object.freeze(rawUniqueResult(FIXTURES.base)),
+  solana: Object.freeze(rawUniqueResult(FIXTURES.solana)),
+});
+
+const RAW_AMBIGUOUS_RESULT = Object.freeze({
+  schemaVersion: 2,
+  locator: BASE_TOKEN_ADDRESS,
+  source: "dexscreener",
+  observedAt: OBSERVED_AT,
+  usage: "informational-only",
+  status: "ambiguous",
+  candidates: [
+    {
+      ...rawCandidate(FIXTURES.base),
+      selectionKey: `evm:1:${BASE_TOKEN_ADDRESS}`,
+      selection: {
+        mode: "custom",
+        sourceNetwork: "ethereum",
+        assetLocator: BASE_TOKEN_ADDRESS,
+      },
+      chainReference: "1",
+      providerChainId: "ethereum",
+    },
+    rawCandidate(FIXTURES.base),
+  ],
+});
+
+const RAW_INVALID_RESULT = Object.freeze({
+  schemaVersion: 2,
+  locator: null,
+  source: null,
+  observedAt: OBSERVED_AT,
+  usage: "informational-only",
+  status: "invalid",
+  reason: "invalid-locator",
+});
+
+function parsedFixture(value: unknown, expectedLocator: string) {
+  const result = parsePredictionAssetAutoDiscoveryV2(value, expectedLocator);
+  if (!result) throw new Error("Invalid Prediction V2 local preview fixture");
+  return result;
+}
+
+const PARSED_RESULTS = Object.freeze({
+  base: parsedFixture(RAW_RESULTS.base, BASE_TOKEN_ADDRESS),
+  solana: parsedFixture(RAW_RESULTS.solana, SOLANA_FIXTURE_LOCATOR),
+  ambiguous: parsedFixture(RAW_AMBIGUOUS_RESULT, BASE_TOKEN_ADDRESS),
+  error: parsedFixture(RAW_INVALID_RESULT, "not-a-token-address"),
+});
+
+export function createPredictionV2LocalPreviewDiscovery(
+  fixtureName: PredictionV2LocalPreviewFixture,
+): PredictionMarketCreateFlowV2Discovery {
+  const fixture = FIXTURES[fixtureName];
+  return async (locator, signal) => {
+    if (signal.aborted) {
+      const error = new Error("Local preview lookup aborted");
+      error.name = "AbortError";
+      throw error;
+    }
+    return locator.trim() === fixture.locator
+      ? RAW_RESULTS[fixtureName]
+      : RAW_INVALID_RESULT;
+  };
+}
+
+function creationSnapshot(): PredictionV2CreationReferenceSnapshot {
+  return {
+    settlementChainId: "4663",
+    capturedAtUtc: CAPTURED_AT,
+    snapshotReference: "eip155:4663:block:8000000",
+    evidenceDigest: EVIDENCE_DIGEST,
+    verificationStatus: "verified",
+  };
+}
+
+function referenceMetricSnapshot(
+  fixture: FixtureDefinition,
+): PredictionV2ReferenceMetricSnapshot {
+  return {
+    metric: "market-cap",
+    valueUsd: fixture.referenceMarketCapUsd,
+    sourceNetwork: fixture.sourceNetwork,
+    address: fixture.locator,
+    capturedAtUtc: CAPTURED_AT,
+    snapshotReference: fixture.snapshotReference,
+    evidenceDigest: EVIDENCE_DIGEST,
+    verificationStatus: "verified",
+  };
+}
+
+function referenceSupplySnapshot(
+  fixture: FixtureDefinition,
+): PredictionV2ReferenceSupplySnapshot {
+  return {
+    sourceNetwork: fixture.sourceNetwork,
+    address: fixture.locator,
+    fixedSupplyAtoms: fixture.fixedSupplyAtoms,
+    tokenDecimals: fixture.tokenDecimals,
+    capturedAtUtc: CAPTURED_AT,
+    snapshotReference: fixture.snapshotReference,
+    evidenceDigest: EVIDENCE_DIGEST,
+    verificationStatus: "verified",
+    supplyDefinition: "fixed-supply-fully-circulating",
+  };
+}
+
+function marketCapSupplyEvidence(
+  fixture: FixtureDefinition,
+): PredictionAssetMarketCapSupplyEvidenceV2 {
+  return {
+    schemaVersion: 2,
+    kind: "fixed-supply-fully-circulating",
+    chainReference: fixture.chainReference,
+    tokenAddress: fixture.locator,
+    supplyBaseUnits: fixture.fixedSupplyAtoms,
+    decimals: fixture.tokenDecimals,
+    immutable: true,
+    verification: {
+      status: "verified",
+      method: "verified-fixed-supply-fully-circulating",
+      chainStateReference: fixture.chainPosition,
+      evidenceDigest: EVIDENCE_DIGEST,
+    },
+  };
+}
+
+function initialDiscoveryResult(
+  state: PredictionV2LocalPreviewState,
+  fixtureName: PredictionV2LocalPreviewFixture,
+): PredictionAssetAutoDiscoveryClientResultV2 | null {
+  if (state === "address") return null;
+  if (state === "ambiguous") return PARSED_RESULTS.ambiguous;
+  if (state === "error") return PARSED_RESULTS.error;
+  return PARSED_RESULTS[fixtureName];
+}
+
+export function PredictionMarketV2LocalPreview({
+  fixture: fixtureName,
+  initialState,
+  onBack,
+}: Readonly<{
+  fixture: PredictionV2LocalPreviewFixture;
+  initialState: PredictionV2LocalPreviewState;
+  onBack: () => void;
+}>) {
+  const fixture = FIXTURES[fixtureName];
+  const visibleView = initialState === "asset" ||
+      initialState === "prediction" || initialState === "review"
+    ? initialState
+    : "address";
+
+  return (
+    <div
+      className="launch-page page-width"
+      data-local-preview={LOCAL_PREVIEW_BUNDLE_SENTINEL}
+      data-prediction-v2-fixture={fixtureName}
+      data-prediction-v2-state={initialState}
+    >
+      <header className="launch-page-heading">
+        <button
+          className={`launch-model-back ${styles.previewBack}`}
+          onClick={onBack}
+          type="button"
+        >
+          <ArrowLeft aria-hidden="true" size={15} />
+          Back
+        </button>
+      </header>
+
+      <PredictionMarketCreateFlowV2
+        discoverToken={createPredictionV2LocalPreviewDiscovery(fixtureName)}
+        initialCreationSnapshot={creationSnapshot()}
+        initialDiscoveryResult={initialDiscoveryResult(initialState, fixtureName)}
+        initialLocator={
+          initialState === "error" ? "not-an-address" :
+            initialState === "ambiguous" ? BASE_TOKEN_ADDRESS : fixture.locator
+        }
+        initialMarketCapSupplyEvidence={marketCapSupplyEvidence(fixture)}
+        initialPrediction={{
+          metric: "market-cap",
+          template: "target",
+          targetUsd: fixture.targetMarketCapUsd,
+          observationUtc: RESULT_AT,
+          priceDecimals: 8,
+        }}
+        initialReferenceMetricSnapshot={referenceMetricSnapshot(fixture)}
+        initialReferenceSupplySelectionKey={fixture.selectionKey}
+        initialReferenceSupplySnapshot={referenceSupplySnapshot(fixture)}
+        initialView={visibleView}
+      />
+    </div>
+  );
+}

--- a/lib/market-data/prediction-asset-auto-discovery-request-control-v2.server.ts
+++ b/lib/market-data/prediction-asset-auto-discovery-request-control-v2.server.ts
@@ -1,0 +1,311 @@
+import "server-only";
+
+import {
+  normalizePredictionAssetLocatorV2,
+  readPredictionAssetAutoDiscoveryV2,
+  type PredictionAssetAutoDiscoveryReaderV2,
+  type PredictionAssetAutoDiscoveryResultV2,
+} from "./prediction-asset-auto-discovery-v2.server";
+
+// Budget units are outbound DEX provider calls, not user requests. A full
+// initial bucket plus one minute of refill is at most 144 + 144 = 288 calls,
+// below the provider's 300/minute ceiling inside a single runtime.
+export const PREDICTION_ASSET_DISCOVERY_GLOBAL_BUDGET_CAPACITY_V2 = 144;
+export const PREDICTION_ASSET_DISCOVERY_GLOBAL_BUDGET_INTERVAL_MS_V2 = 60_000;
+export const PREDICTION_ASSET_DISCOVERY_POSITIVE_CACHE_TTL_MS_V2 = 15_000;
+export const PREDICTION_ASSET_DISCOVERY_NEGATIVE_CACHE_TTL_MS_V2 = 5_000;
+export const PREDICTION_ASSET_DISCOVERY_MAXIMUM_CONCURRENT_READS_V2 = 2;
+export const PREDICTION_ASSET_DISCOVERY_CONTROL_SCOPE_V2 =
+  "single-runtime-only" as const;
+export const PREDICTION_ASSET_DISCOVERY_SHARED_LIMITS_REQUIRED_FOR_ACTIVATION_V2 =
+  true as const;
+
+const DEFAULT_MAXIMUM_CACHE_ENTRIES = 512;
+const EVM_DEX_CALL_COST = 4;
+const SOLANA_DEX_CALL_COST = 1;
+
+type CacheEntry = Readonly<{
+  expiresAtMs: number;
+  result: PredictionAssetAutoDiscoveryResultV2;
+}>;
+
+type InFlightEntry = Readonly<{
+  controller: AbortController;
+  promise: Promise<PredictionAssetAutoDiscoveryResultV2>;
+  waiters: { count: number };
+}>;
+
+export type PredictionAssetAutoDiscoveryRequestControlResultV2 =
+  | Readonly<{
+    status: "ok";
+    result: PredictionAssetAutoDiscoveryResultV2;
+    source: "cache" | "coalesced" | "reader";
+  }>
+  | Readonly<{
+    status: "rate-limited";
+    retryAfterSeconds: number;
+  }>;
+
+export type PredictionAssetAutoDiscoveryRequestControllerOptionsV2 = Readonly<{
+  reader?: PredictionAssetAutoDiscoveryReaderV2;
+  nowMs?: () => number;
+  budgetCapacity?: number;
+  budgetIntervalMs?: number;
+  positiveCacheTtlMs?: number;
+  negativeCacheTtlMs?: number;
+  maximumCacheEntries?: number;
+  maximumConcurrentReads?: number;
+}>;
+
+export type PredictionAssetAutoDiscoveryRequestControllerV2 = Readonly<{
+  read(
+    locator: string,
+    options?: Readonly<{ signal?: AbortSignal }>,
+  ): Promise<PredictionAssetAutoDiscoveryRequestControlResultV2>;
+}>;
+
+/**
+ * Per-runtime request control. It bounds one server process without pretending
+ * to be a distributed quota. Activation also requires an edge per-client limit
+ * and a shared outbound provider-call budget across every runtime.
+ */
+export function createPredictionAssetAutoDiscoveryRequestControllerV2(
+  options: PredictionAssetAutoDiscoveryRequestControllerOptionsV2 = {},
+): PredictionAssetAutoDiscoveryRequestControllerV2 {
+  const reader = options.reader ?? Object.freeze({
+    read: readPredictionAssetAutoDiscoveryV2,
+  });
+  const nowMs = options.nowMs ?? Date.now;
+  const budgetCapacity = boundedInteger(
+    options.budgetCapacity,
+    PREDICTION_ASSET_DISCOVERY_GLOBAL_BUDGET_CAPACITY_V2,
+    EVM_DEX_CALL_COST,
+    1_000,
+    "budgetCapacity",
+  );
+  const budgetIntervalMs = boundedInteger(
+    options.budgetIntervalMs,
+    PREDICTION_ASSET_DISCOVERY_GLOBAL_BUDGET_INTERVAL_MS_V2,
+    1,
+    3_600_000,
+    "budgetIntervalMs",
+  );
+  const positiveCacheTtlMs = boundedInteger(
+    options.positiveCacheTtlMs,
+    PREDICTION_ASSET_DISCOVERY_POSITIVE_CACHE_TTL_MS_V2,
+    1,
+    60_000,
+    "positiveCacheTtlMs",
+  );
+  const negativeCacheTtlMs = boundedInteger(
+    options.negativeCacheTtlMs,
+    PREDICTION_ASSET_DISCOVERY_NEGATIVE_CACHE_TTL_MS_V2,
+    1,
+    60_000,
+    "negativeCacheTtlMs",
+  );
+  const maximumCacheEntries = boundedInteger(
+    options.maximumCacheEntries,
+    DEFAULT_MAXIMUM_CACHE_ENTRIES,
+    1,
+    10_000,
+    "maximumCacheEntries",
+  );
+  const maximumConcurrentReads = boundedInteger(
+    options.maximumConcurrentReads,
+    PREDICTION_ASSET_DISCOVERY_MAXIMUM_CONCURRENT_READS_V2,
+    1,
+    32,
+    "maximumConcurrentReads",
+  );
+  const cache = new Map<string, CacheEntry>();
+  const inFlight = new Map<string, InFlightEntry>();
+  let availableBudget = budgetCapacity;
+  let budgetUpdatedAtMs = checkedNow(nowMs);
+  let activeReads = 0;
+
+  return Object.freeze({
+    async read(locator, readOptions = {}) {
+      const normalized = normalizePredictionAssetLocatorV2(locator);
+      if (normalized === null) {
+        return Object.freeze({
+          status: "ok" as const,
+          source: "reader" as const,
+          result: await reader.read(locator, readOptions),
+        });
+      }
+
+      const currentTimeMs = checkedNow(nowMs);
+      const cached = cache.get(normalized.locator);
+      if (cached && cached.expiresAtMs > currentTimeMs) {
+        return Object.freeze({
+          status: "ok" as const,
+          source: "cache" as const,
+          result: cached.result,
+        });
+      }
+      if (cached) cache.delete(normalized.locator);
+
+      const existing = inFlight.get(normalized.locator);
+      if (existing && !existing.controller.signal.aborted) {
+        return Object.freeze({
+          status: "ok" as const,
+          source: "coalesced" as const,
+          result: await waitForEntry(existing, readOptions.signal),
+        });
+      }
+      if (existing) inFlight.delete(normalized.locator);
+
+      const elapsedMs = Math.max(0, currentTimeMs - budgetUpdatedAtMs);
+      const requestCost = normalized.namespace === "evm"
+        ? EVM_DEX_CALL_COST
+        : SOLANA_DEX_CALL_COST;
+      availableBudget = Math.min(
+        budgetCapacity,
+        availableBudget + elapsedMs * budgetCapacity / budgetIntervalMs,
+      );
+      budgetUpdatedAtMs = currentTimeMs;
+      if (availableBudget < requestCost) {
+        const waitMs = (requestCost - availableBudget) * budgetIntervalMs /
+          budgetCapacity;
+        return Object.freeze({
+          status: "rate-limited" as const,
+          retryAfterSeconds: Math.max(1, Math.ceil(waitMs / 1_000)),
+        });
+      }
+      // Zero-queue per-runtime bulkhead. Coalesced callers above share the
+      // existing slot; a distinct discovery must retry rather than waiting
+      // inside the route's bounded execution window. This is not distributed.
+      if (activeReads >= maximumConcurrentReads) {
+        return Object.freeze({
+          status: "rate-limited" as const,
+          retryAfterSeconds: 1,
+        });
+      }
+      activeReads += 1;
+      availableBudget -= requestCost;
+
+      const controller = new AbortController();
+      const waiters = { count: 0 };
+      const promise = Promise.resolve()
+        .then(() => reader.read(normalized.locator, {
+          signal: controller.signal,
+        }))
+        .then((result) => {
+          const ttlMs = cacheTtl(result, positiveCacheTtlMs, negativeCacheTtlMs);
+          if (ttlMs !== null && !controller.signal.aborted) {
+            writeBoundedCache(
+              cache,
+              normalized.locator,
+              { result, expiresAtMs: checkedNow(nowMs) + ttlMs },
+              maximumCacheEntries,
+              checkedNow(nowMs),
+            );
+          }
+          return result;
+        })
+        .finally(() => {
+          activeReads -= 1;
+          if (inFlight.get(normalized.locator)?.promise === promise) {
+            inFlight.delete(normalized.locator);
+          }
+        });
+      const entry = Object.freeze({ controller, promise, waiters });
+      inFlight.set(normalized.locator, entry);
+
+      return Object.freeze({
+        status: "ok" as const,
+        source: "reader" as const,
+        result: await waitForEntry(entry, readOptions.signal),
+      });
+    },
+  });
+}
+
+async function waitForEntry(
+  entry: InFlightEntry,
+  signal: AbortSignal | undefined,
+) {
+  entry.waiters.count += 1;
+  let active = true;
+  const release = () => {
+    if (!active) return;
+    active = false;
+    entry.waiters.count -= 1;
+    if (entry.waiters.count === 0 && signal?.aborted) {
+      entry.controller.abort();
+    }
+  };
+  const onAbort = () => release();
+  signal?.addEventListener("abort", onAbort, { once: true });
+  if (signal?.aborted) release();
+  try {
+    return await entry.promise;
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+    release();
+  }
+}
+
+function cacheTtl(
+  result: PredictionAssetAutoDiscoveryResultV2,
+  positiveCacheTtlMs: number,
+  negativeCacheTtlMs: number,
+) {
+  if (result.status === "unique" || result.status === "ambiguous") {
+    return positiveCacheTtlMs;
+  }
+  return result.status === "not-found" ? negativeCacheTtlMs : null;
+}
+
+function writeBoundedCache(
+  cache: Map<string, CacheEntry>,
+  key: string,
+  value: CacheEntry,
+  maximumEntries: number,
+  nowMs: number,
+) {
+  for (const [candidateKey, entry] of cache) {
+    if (entry.expiresAtMs <= nowMs) cache.delete(candidateKey);
+  }
+  cache.delete(key);
+  while (cache.size >= maximumEntries) {
+    const oldest = cache.keys().next().value as string | undefined;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+  cache.set(key, value);
+}
+
+function checkedNow(nowMs: () => number) {
+  const value = nowMs();
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError("nowMs must return a non-negative safe integer");
+  }
+  return value;
+}
+
+function boundedInteger(
+  candidate: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+  label: string,
+) {
+  const value = candidate ?? fallback;
+  if (!Number.isInteger(value) || value < minimum || value > maximum) {
+    throw new RangeError(`${label} must be an integer from ${minimum} to ${maximum}`);
+  }
+  return value;
+}
+
+const runtimeGlobal = globalThis as typeof globalThis & {
+  __programmablePredictionAssetDiscoveryControllerV2?:
+    PredictionAssetAutoDiscoveryRequestControllerV2;
+};
+const defaultRequestController =
+  runtimeGlobal.__programmablePredictionAssetDiscoveryControllerV2 ??=
+    createPredictionAssetAutoDiscoveryRequestControllerV2();
+
+export const readControlledPredictionAssetAutoDiscoveryV2 =
+  defaultRequestController.read;

--- a/lib/market-data/prediction-asset-auto-discovery-v2.server.ts
+++ b/lib/market-data/prediction-asset-auto-discovery-v2.server.ts
@@ -1,0 +1,1229 @@
+import "server-only";
+
+import {
+  createPredictionAssetIdentityVerifierV2,
+  type PredictionAssetIdentityFailureReasonV2,
+  type PredictionAssetIdentityProbeV2,
+  type PredictionAssetIdentityVerifierV2,
+} from "./prediction-asset-identity-verification-v2.server";
+
+const DEXSCREENER_TOKEN_PAIRS_ENDPOINT =
+  "https://api.dexscreener.com/token-pairs/v1" as const;
+const DEFAULT_TIMEOUT_MS = 3_000;
+const DEFAULT_MAXIMUM_RESPONSE_BYTES = 512_000;
+const DEFAULT_MAXIMUM_ROWS = 256;
+const MAXIMUM_LINK_ROWS = 32;
+const MAXIMUM_RETURNED_LINKS = 8;
+const ZERO_EVM_ADDRESS = `0x${"0".repeat(40)}`;
+const UNSAFE_DISPLAY_TEXT_PATTERN =
+  /[<>\u0000-\u001f\u007f-\u009f\u200b-\u200f\u202a-\u202e\u2066-\u2069\ufeff]/u;
+const IDENTITY_FAILURE_REASONS = new Set([
+  "identity-unconfigured",
+  "identity-unavailable",
+  "identity-invalid",
+] as const satisfies readonly PredictionAssetIdentityFailureReasonV2[]);
+const PRIVATE_HOST_SUFFIXES = Object.freeze([
+  ".localhost",
+  ".local",
+  ".internal",
+  ".lan",
+  ".home",
+  ".arpa",
+  ".test",
+  ".invalid",
+  ".example",
+]);
+
+export const PREDICTION_ASSET_AUTO_DISCOVERY_IDENTITY_SOURCE_V2 =
+  "onchain-rpc" as const;
+export const PREDICTION_ASSET_AUTO_DISCOVERY_ENRICHMENT_SOURCE_V2 =
+  "dexscreener" as const;
+/** @deprecated Use the enrichment source constant for new code. */
+export const PREDICTION_ASSET_AUTO_DISCOVERY_SOURCE_V2 =
+  PREDICTION_ASSET_AUTO_DISCOVERY_ENRICHMENT_SOURCE_V2;
+export const PREDICTION_ASSET_AUTO_DISCOVERY_USAGE_V2 =
+  "informational-only" as const;
+
+export type PredictionAssetAutoDiscoverySourceNetworkV2 =
+  | "ethereum"
+  | "base"
+  | "bnb"
+  | "robinhood"
+  | "solana";
+
+export type PredictionAssetAutoDiscoveryProbeFailureReasonV2 =
+  | "aborted"
+  | "timeout"
+  | "rate-limited"
+  | "provider-unavailable"
+  | "response-too-large"
+  | "response-invalid"
+  | "identity-unconfigured"
+  | "identity-unavailable"
+  | "identity-invalid"
+  | "identity-mismatch"
+  | "market-data-missing";
+
+export type PredictionAssetAutoDiscoveryCandidateV2 = Readonly<{
+  selectionKey: string;
+  selection: Readonly<{
+    mode: "custom";
+    sourceNetwork: PredictionAssetAutoDiscoverySourceNetworkV2;
+    assetLocator: string;
+  }>;
+  namespace: "evm" | "solana";
+  chainReference: string;
+  providerChainId: string;
+  provenance: Readonly<{
+    identity: Readonly<{
+      source: typeof PREDICTION_ASSET_AUTO_DISCOVERY_IDENTITY_SOURCE_V2;
+    }>;
+    enrichment: Readonly<{
+      source: typeof PREDICTION_ASSET_AUTO_DISCOVERY_ENRICHMENT_SOURCE_V2;
+    }> | null;
+  }>;
+  token: Readonly<{
+    address: string;
+    name: string | null;
+    symbol: string | null;
+  }>;
+  currentPriceUsd: number | null;
+  /** Provider-reported display data. It is not circulating-supply evidence. */
+  marketCapUsd: number | null;
+  fdvUsd: number | null;
+  matchingPairCount: number;
+  pair: Readonly<{
+    dexId: string;
+    pairAddress: string;
+    matchedSide: "base" | "quote";
+    liquidityUsd: number | null;
+    volume24hUsd: number | null;
+    pairCreatedAt: number | null;
+  }> | null;
+  links: Readonly<{
+    imageUrl: string | null;
+    websites: readonly Readonly<{
+      label: string | null;
+      url: string;
+    }>[];
+    socials: readonly Readonly<{
+      type: string | null;
+      url: string;
+    }>[];
+  }>;
+}>;
+
+type PredictionAssetAutoDiscoveryResultBaseV2 = Readonly<{
+  schemaVersion: 2;
+  locator: string | null;
+  /** Successful optional market-data enrichment, never identity authority. */
+  source: typeof PREDICTION_ASSET_AUTO_DISCOVERY_ENRICHMENT_SOURCE_V2 | null;
+  observedAt: string;
+  usage: typeof PREDICTION_ASSET_AUTO_DISCOVERY_USAGE_V2;
+}>;
+
+export type PredictionAssetAutoDiscoveryUniqueV2 =
+  PredictionAssetAutoDiscoveryResultBaseV2 & Readonly<{
+    status: "unique";
+    candidate: PredictionAssetAutoDiscoveryCandidateV2;
+  }>;
+
+export type PredictionAssetAutoDiscoveryAmbiguousV2 =
+  PredictionAssetAutoDiscoveryResultBaseV2 & Readonly<{
+    status: "ambiguous";
+    candidates: readonly PredictionAssetAutoDiscoveryCandidateV2[];
+  }>;
+
+export type PredictionAssetAutoDiscoveryInconclusiveV2 =
+  PredictionAssetAutoDiscoveryResultBaseV2 & Readonly<{
+    status: "inconclusive";
+    candidates: readonly PredictionAssetAutoDiscoveryCandidateV2[];
+    failures: readonly Readonly<{
+      sourceNetwork: PredictionAssetAutoDiscoverySourceNetworkV2;
+      reason: PredictionAssetAutoDiscoveryProbeFailureReasonV2;
+    }>[];
+  }>;
+
+export type PredictionAssetAutoDiscoveryNotFoundV2 =
+  PredictionAssetAutoDiscoveryResultBaseV2 & Readonly<{
+    status: "not-found";
+  }>;
+
+export type PredictionAssetAutoDiscoveryInvalidV2 =
+  PredictionAssetAutoDiscoveryResultBaseV2 & Readonly<{
+    status: "invalid";
+    reason: "invalid-locator";
+  }>;
+
+export type PredictionAssetAutoDiscoveryResultV2 =
+  | PredictionAssetAutoDiscoveryUniqueV2
+  | PredictionAssetAutoDiscoveryAmbiguousV2
+  | PredictionAssetAutoDiscoveryInconclusiveV2
+  | PredictionAssetAutoDiscoveryNotFoundV2
+  | PredictionAssetAutoDiscoveryInvalidV2;
+
+export type PredictionAssetAutoDiscoveryReaderOptionsV2 = Readonly<{
+  fetchImpl?: typeof fetch;
+  identityVerifier?: PredictionAssetIdentityVerifierV2;
+  now?: () => Date;
+  timeoutMs?: number;
+  maximumResponseBytes?: number;
+  maximumRows?: number;
+}>;
+
+export type PredictionAssetAutoDiscoveryReadOptionsV2 = Readonly<{
+  signal?: AbortSignal;
+}>;
+
+export type PredictionAssetAutoDiscoveryReaderV2 = Readonly<{
+  read(
+    locator: string,
+    options?: PredictionAssetAutoDiscoveryReadOptionsV2,
+  ): Promise<PredictionAssetAutoDiscoveryResultV2>;
+}>;
+
+type ProbeBinding = Readonly<{
+  sourceNetwork: PredictionAssetAutoDiscoverySourceNetworkV2;
+  namespace: "evm" | "solana";
+  chainReference: string;
+  providerChainId: string;
+}>;
+
+type NormalizedLocator = Readonly<{
+  locator: string;
+  namespace: "evm" | "solana";
+}>;
+
+type EnrichedProbeCandidate = Omit<
+  PredictionAssetAutoDiscoveryCandidateV2,
+  "provenance"
+>;
+
+type PairCandidate = Omit<
+  EnrichedProbeCandidate,
+  "matchingPairCount" | "pair"
+> & Readonly<{
+  pair: NonNullable<PredictionAssetAutoDiscoveryCandidateV2["pair"]>;
+}>;
+
+type ProbeOutcome =
+  | Readonly<{
+    status: "found";
+    candidate: EnrichedProbeCandidate;
+  }>
+  | Readonly<{ status: "not-found" }>
+  | Readonly<{
+    status: "failed";
+    reason: PredictionAssetAutoDiscoveryProbeFailureReasonV2;
+  }>;
+
+const EVM_PROBE_BINDINGS = Object.freeze([
+  Object.freeze({
+    sourceNetwork: "ethereum",
+    namespace: "evm",
+    chainReference: "1",
+    providerChainId: "ethereum",
+  }),
+  Object.freeze({
+    sourceNetwork: "base",
+    namespace: "evm",
+    chainReference: "8453",
+    providerChainId: "base",
+  }),
+  Object.freeze({
+    sourceNetwork: "bnb",
+    namespace: "evm",
+    chainReference: "56",
+    providerChainId: "bsc",
+  }),
+  Object.freeze({
+    sourceNetwork: "robinhood",
+    namespace: "evm",
+    chainReference: "4663",
+    providerChainId: "robinhood",
+  }),
+] as const satisfies readonly ProbeBinding[]);
+
+const SOLANA_PROBE_BINDING = Object.freeze({
+  sourceNetwork: "solana",
+  namespace: "solana",
+  chainReference: "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+  providerChainId: "solana",
+} as const satisfies ProbeBinding);
+
+class PredictionAssetAutoDiscoveryReadError extends Error {
+  constructor(
+    readonly reason: PredictionAssetAutoDiscoveryProbeFailureReasonV2,
+  ) {
+    super(`Prediction asset auto-discovery failed: ${reason}`);
+    this.name = "PredictionAssetAutoDiscoveryReadError";
+  }
+}
+
+export function createPredictionAssetAutoDiscoveryReaderV2(
+  options: PredictionAssetAutoDiscoveryReaderOptionsV2 = {},
+): PredictionAssetAutoDiscoveryReaderV2 {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const identityVerifier = options.identityVerifier ??
+    createPredictionAssetIdentityVerifierV2();
+  const now = options.now ?? (() => new Date());
+  const timeoutMs = boundedInteger(
+    options.timeoutMs,
+    DEFAULT_TIMEOUT_MS,
+    1,
+    30_000,
+    "timeoutMs",
+  );
+  const maximumResponseBytes = boundedInteger(
+    options.maximumResponseBytes,
+    DEFAULT_MAXIMUM_RESPONSE_BYTES,
+    2,
+    2_000_000,
+    "maximumResponseBytes",
+  );
+  const maximumRows = boundedInteger(
+    options.maximumRows,
+    DEFAULT_MAXIMUM_ROWS,
+    1,
+    1_000,
+    "maximumRows",
+  );
+
+  return Object.freeze({
+    async read(locator, readOptions = {}) {
+      const observedAt = now().toISOString();
+      const normalized = normalizePredictionAssetLocatorV2(locator);
+      const base = {
+        schemaVersion: 2 as const,
+        locator: normalized?.locator ?? null,
+        observedAt,
+        usage: PREDICTION_ASSET_AUTO_DISCOVERY_USAGE_V2,
+      };
+      if (normalized === null) {
+        return {
+          ...base,
+          source: null,
+          status: "invalid",
+          reason: "invalid-locator",
+        };
+      }
+
+      const bindings = normalized.namespace === "evm"
+        ? EVM_PROBE_BINDINGS
+        : [SOLANA_PROBE_BINDING];
+      const outcomesPromise = readOptions.signal?.aborted
+        ? bindings.map<ProbeOutcome>(() => ({
+          status: "failed",
+          reason: "aborted",
+        }))
+        : Promise.all(bindings.map((binding) => probeBinding({
+          binding,
+          locator: normalized.locator,
+          fetchImpl,
+          timeoutMs,
+          maximumResponseBytes,
+          maximumRows,
+          signal: readOptions.signal,
+        })));
+      const identityPromise = Promise.resolve()
+        .then(() => identityVerifier.verify(normalized.locator, {
+          signal: readOptions.signal,
+        }))
+        .catch(() => bindings.map<PredictionAssetIdentityProbeV2>((binding) => ({
+          sourceNetwork: binding.sourceNetwork,
+          status: "failed",
+          reason: "identity-unavailable",
+        })));
+      const [outcomes, rawIdentityProbes] = await Promise.all([
+        outcomesPromise,
+        identityPromise,
+      ]);
+      const identityProbes = normalizeIdentityProbes(bindings, rawIdentityProbes);
+
+      const candidates: PredictionAssetAutoDiscoveryCandidateV2[] = [];
+      const dexOutcomes = new Map<
+        PredictionAssetAutoDiscoverySourceNetworkV2,
+        ProbeOutcome
+      >();
+      for (let index = 0; index < outcomes.length; index += 1) {
+        const outcome = outcomes[index];
+        const binding = bindings[index];
+        if (!outcome || !binding) continue;
+        dexOutcomes.set(binding.sourceNetwork, outcome);
+      }
+
+      const failures: PredictionAssetAutoDiscoveryInconclusiveV2["failures"][number][] = [];
+      for (const binding of bindings) {
+        const identity = identityProbes.get(binding.sourceNetwork);
+        const dex = dexOutcomes.get(binding.sourceNetwork);
+        if (!identity) {
+          failures.push({
+            sourceNetwork: binding.sourceNetwork,
+            reason: "identity-invalid",
+          });
+          continue;
+        }
+        if (identity.status === "failed") {
+          failures.push({
+            sourceNetwork: binding.sourceNetwork,
+            reason: identity.reason,
+          });
+          continue;
+        }
+        if (identity.status === "verified-token") {
+          // Token identity is established independently of DEX indexing. A
+          // missing, stale or unavailable enrichment provider must never hide
+          // an otherwise exact onchain identity.
+          candidates.push(dex?.status === "found"
+            ? verifiedEnrichedCandidate(dex.candidate)
+            : identityOnlyCandidate(binding, normalized.locator));
+          continue;
+        }
+        if (dex?.status === "found") {
+          // A pool index is not proof that an address is a token on this chain.
+          failures.push({
+            sourceNetwork: binding.sourceNetwork,
+            reason: "identity-mismatch",
+          });
+        }
+      }
+
+      // Identity verification, not pool-index presence, decides whether an EVM
+      // address belongs to one or more supported chains. An unresolved identity
+      // probe or a provider/identity conflict remains explicitly inconclusive.
+      if (failures.length > 0) {
+        return {
+          ...base,
+          source: enrichmentSourceForCandidates(candidates),
+          status: "inconclusive",
+          candidates,
+          failures,
+        };
+      }
+      if (candidates.length === 0) {
+        return { ...base, source: null, status: "not-found" };
+      }
+      const source = enrichmentSourceForCandidates(candidates);
+      if (candidates.length === 1) {
+        return { ...base, source, status: "unique", candidate: candidates[0] };
+      }
+      return { ...base, source, status: "ambiguous", candidates };
+    },
+  });
+}
+
+function verifiedEnrichedCandidate(
+  candidate: EnrichedProbeCandidate,
+): PredictionAssetAutoDiscoveryCandidateV2 {
+  return {
+    ...candidate,
+    provenance: {
+      identity: {
+        source: PREDICTION_ASSET_AUTO_DISCOVERY_IDENTITY_SOURCE_V2,
+      },
+      enrichment: {
+        source: PREDICTION_ASSET_AUTO_DISCOVERY_ENRICHMENT_SOURCE_V2,
+      },
+    },
+  };
+}
+
+function enrichmentSourceForCandidates(
+  candidates: readonly PredictionAssetAutoDiscoveryCandidateV2[],
+) {
+  return candidates.some(({ provenance }) => provenance.enrichment !== null)
+    ? PREDICTION_ASSET_AUTO_DISCOVERY_ENRICHMENT_SOURCE_V2
+    : null;
+}
+
+function identityOnlyCandidate(
+  binding: ProbeBinding,
+  locator: string,
+): PredictionAssetAutoDiscoveryCandidateV2 {
+  const canonicalLocator = canonicalIdentifier(locator, binding.namespace);
+  return {
+    selectionKey: binding.namespace === "evm"
+      ? `evm:${binding.chainReference}:${canonicalLocator}`
+      : `solana:${binding.chainReference}:${canonicalLocator}`,
+    selection: {
+      mode: "custom",
+      sourceNetwork: binding.sourceNetwork,
+      assetLocator: canonicalLocator,
+    },
+    namespace: binding.namespace,
+    chainReference: binding.chainReference,
+    providerChainId: binding.providerChainId,
+    provenance: {
+      identity: {
+        source: PREDICTION_ASSET_AUTO_DISCOVERY_IDENTITY_SOURCE_V2,
+      },
+      enrichment: null,
+    },
+    token: {
+      address: canonicalLocator,
+      name: null,
+      symbol: null,
+    },
+    currentPriceUsd: null,
+    marketCapUsd: null,
+    fdvUsd: null,
+    matchingPairCount: 0,
+    pair: null,
+    links: { imageUrl: null, websites: [], socials: [] },
+  };
+}
+
+function normalizeIdentityProbes(
+  bindings: readonly ProbeBinding[],
+  probes: unknown,
+) {
+  const expected = new Set(bindings.map(({ sourceNetwork }) => sourceNetwork));
+  const normalized = new Map<
+    PredictionAssetAutoDiscoverySourceNetworkV2,
+    PredictionAssetIdentityProbeV2
+  >();
+  try {
+    if (!Array.isArray(probes) || probes.length !== bindings.length) {
+      return normalized;
+    }
+    for (const rawProbe of probes) {
+      const values = exactPlainDataValues(rawProbe);
+      if (values === null) return new Map();
+      const sourceNetwork = values.get("sourceNetwork");
+      const status = values.get("status");
+      if (
+        typeof sourceNetwork !== "string" ||
+        !expected.has(sourceNetwork as PredictionAssetAutoDiscoverySourceNetworkV2) ||
+        normalized.has(sourceNetwork as PredictionAssetAutoDiscoverySourceNetworkV2)
+      ) {
+        return new Map();
+      }
+      if (status === "verified-token" || status === "not-token") {
+        if (!hasExactKeys(values, ["sourceNetwork", "status"])) return new Map();
+        normalized.set(
+          sourceNetwork as PredictionAssetAutoDiscoverySourceNetworkV2,
+          {
+            sourceNetwork: sourceNetwork as PredictionAssetAutoDiscoverySourceNetworkV2,
+            status,
+          },
+        );
+        continue;
+      }
+      const reason = values.get("reason");
+      if (
+        status !== "failed" ||
+        !hasExactKeys(values, ["sourceNetwork", "status", "reason"]) ||
+        typeof reason !== "string" ||
+        !IDENTITY_FAILURE_REASONS.has(
+          reason as PredictionAssetIdentityFailureReasonV2,
+        )
+      ) {
+        return new Map();
+      }
+      normalized.set(
+        sourceNetwork as PredictionAssetAutoDiscoverySourceNetworkV2,
+        {
+          sourceNetwork: sourceNetwork as PredictionAssetAutoDiscoverySourceNetworkV2,
+          status: "failed",
+          reason: reason as PredictionAssetIdentityFailureReasonV2,
+        },
+      );
+    }
+  } catch {
+    return new Map();
+  }
+  if (normalized.size !== bindings.length) {
+    return new Map<
+      PredictionAssetAutoDiscoverySourceNetworkV2,
+      PredictionAssetIdentityProbeV2
+    >();
+  }
+  return normalized;
+}
+
+function exactPlainDataValues(value: unknown): ReadonlyMap<string, unknown> | null {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    Object.getPrototypeOf(value) !== Object.prototype
+  ) return null;
+  const keys = Reflect.ownKeys(value);
+  if (keys.some((key) => typeof key !== "string")) return null;
+  const values = new Map<string, unknown>();
+  for (const key of keys as string[]) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor || !("value" in descriptor)) return null;
+    values.set(key, descriptor.value);
+  }
+  return values;
+}
+
+function hasExactKeys(
+  value: ReadonlyMap<string, unknown>,
+  expected: readonly string[],
+) {
+  return value.size === expected.length &&
+    expected.every((key) => value.has(key));
+}
+
+async function probeBinding(input: Readonly<{
+  binding: ProbeBinding;
+  locator: string;
+  fetchImpl: typeof fetch;
+  timeoutMs: number;
+  maximumResponseBytes: number;
+  maximumRows: number;
+  signal?: AbortSignal;
+}>): Promise<ProbeOutcome> {
+  try {
+    const payload = await requestDexscreenerPairs(input);
+    const candidate = parseProbeCandidate(
+      payload,
+      input.binding,
+      input.locator,
+      input.maximumRows,
+    );
+    return candidate === null
+      ? { status: "not-found" }
+      : { status: "found", candidate };
+  } catch (error) {
+    return {
+      status: "failed",
+      reason: error instanceof PredictionAssetAutoDiscoveryReadError
+        ? error.reason
+        : "provider-unavailable",
+    };
+  }
+}
+
+async function requestDexscreenerPairs(input: Readonly<{
+  binding: ProbeBinding;
+  locator: string;
+  fetchImpl: typeof fetch;
+  timeoutMs: number;
+  maximumResponseBytes: number;
+  signal?: AbortSignal;
+}>): Promise<unknown> {
+  if (input.signal?.aborted) {
+    throw new PredictionAssetAutoDiscoveryReadError("aborted");
+  }
+  const controller = new AbortController();
+  let rejectDeadline!: (error: PredictionAssetAutoDiscoveryReadError) => void;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    rejectDeadline = reject;
+  });
+  let deadlineSettled = false;
+  const abortWith = (reason: "aborted" | "timeout") => {
+    if (deadlineSettled) return;
+    deadlineSettled = true;
+    controller.abort();
+    rejectDeadline(new PredictionAssetAutoDiscoveryReadError(reason));
+  };
+  const abortFromCaller = () => abortWith("aborted");
+  const timer = setTimeout(() => abortWith("timeout"), input.timeoutMs);
+  input.signal?.addEventListener("abort", abortFromCaller, { once: true });
+
+  try {
+    const url = `${DEXSCREENER_TOKEN_PAIRS_ENDPOINT}/${
+      encodeURIComponent(input.binding.providerChainId)
+    }/${encodeURIComponent(input.locator)}`;
+    const response = await Promise.race([
+      input.fetchImpl(url, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        cache: "no-store",
+        redirect: "error",
+        signal: controller.signal,
+      }),
+      deadline,
+    ]);
+
+    if (response.status === 429) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionAssetAutoDiscoveryReadError("rate-limited");
+    }
+    if (!response.ok) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionAssetAutoDiscoveryReadError("provider-unavailable");
+    }
+    const contentType = response.headers.get("content-type");
+    if (!contentType?.toLowerCase().startsWith("application/json")) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionAssetAutoDiscoveryReadError("response-invalid");
+    }
+
+    const body = await readBoundedResponseBody(
+      response,
+      input.maximumResponseBytes,
+      deadline,
+      controller,
+    );
+    try {
+      return JSON.parse(body) as unknown;
+    } catch {
+      throw new PredictionAssetAutoDiscoveryReadError("response-invalid");
+    }
+  } finally {
+    deadlineSettled = true;
+    clearTimeout(timer);
+    input.signal?.removeEventListener("abort", abortFromCaller);
+  }
+}
+
+async function readBoundedResponseBody(
+  response: Response,
+  maximumBytes: number,
+  deadline: Promise<never>,
+  controller: AbortController,
+): Promise<string> {
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null) {
+    if (!/^(?:0|[1-9][0-9]*)$/u.test(declaredLength)) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionAssetAutoDiscoveryReadError("response-invalid");
+    }
+    if (BigInt(declaredLength) > BigInt(maximumBytes)) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionAssetAutoDiscoveryReadError("response-too-large");
+    }
+  }
+
+  if (response.body === null || response.body === undefined) {
+    const body = await Promise.race([response.text(), deadline]);
+    if (new TextEncoder().encode(body).byteLength > maximumBytes) {
+      controller.abort();
+      throw new PredictionAssetAutoDiscoveryReadError("response-too-large");
+    }
+    return body;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const next = await Promise.race([reader.read(), deadline]);
+      if (next.done) break;
+      if (!(next.value instanceof Uint8Array)) {
+        throw new PredictionAssetAutoDiscoveryReadError("response-invalid");
+      }
+      totalBytes += next.value.byteLength;
+      if (totalBytes > maximumBytes) {
+        controller.abort();
+        void reader.cancel().catch(() => undefined);
+        throw new PredictionAssetAutoDiscoveryReadError("response-too-large");
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // The request AbortController owns a body read that outlives its caller.
+    }
+  }
+
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new PredictionAssetAutoDiscoveryReadError("response-invalid");
+  }
+}
+
+function abortUnreadResponse(
+  response: Response,
+  controller: AbortController,
+) {
+  controller.abort();
+  if (response.body !== null && response.body !== undefined) {
+    void response.body.cancel().catch(() => undefined);
+  }
+}
+
+function parseProbeCandidate(
+  payload: unknown,
+  binding: ProbeBinding,
+  locator: string,
+  maximumRows: number,
+): EnrichedProbeCandidate | null {
+  if (!Array.isArray(payload) || payload.length > maximumRows) {
+    throw new PredictionAssetAutoDiscoveryReadError("response-invalid");
+  }
+
+  const pairs: PairCandidate[] = [];
+  for (const row of payload) {
+    if (!isPotentialExactPairRow(row, binding, locator)) continue;
+    const parsed = parseExactPairRow(row, binding, locator);
+    if (parsed !== null) pairs.push(parsed);
+  }
+
+  if (pairs.length === 0) return null;
+  const selected = [...pairs].sort(comparePairCandidates)[0];
+  if (!selected) return null;
+  return { ...selected, matchingPairCount: pairs.length };
+}
+
+function isPotentialExactPairRow(
+  candidate: unknown,
+  binding: ProbeBinding,
+  locator: string,
+) {
+  if (!isPlainRecord(candidate) || candidate.chainId !== binding.providerChainId) {
+    return false;
+  }
+  const baseAddress = isPlainRecord(candidate.baseToken) &&
+      typeof candidate.baseToken.address === "string"
+    ? candidate.baseToken.address
+    : null;
+  const quoteAddress = isPlainRecord(candidate.quoteToken) &&
+      typeof candidate.quoteToken.address === "string"
+    ? candidate.quoteToken.address
+    : null;
+  return Boolean(
+    baseAddress && sameLocator(baseAddress, locator, binding.namespace) ||
+      quoteAddress && sameLocator(quoteAddress, locator, binding.namespace),
+  );
+}
+
+function parseExactPairRow(
+  row: Record<string, unknown>,
+  binding: ProbeBinding,
+  locator: string,
+): PairCandidate | null {
+  try {
+    const chainId = requiredBoundedString(row.chainId, 64);
+    if (chainId !== binding.providerChainId) return null;
+    const baseToken = requiredToken(row.baseToken, binding.namespace);
+    const quoteToken = requiredToken(row.quoteToken, binding.namespace);
+    const baseMatches = sameLocator(baseToken.address, locator, binding.namespace);
+    const quoteMatches = sameLocator(quoteToken.address, locator, binding.namespace);
+    if (!baseMatches && !quoteMatches) return null;
+
+    const matchedSide = baseMatches ? "base" as const : "quote" as const;
+    const matchedToken = baseMatches ? baseToken : quoteToken;
+    const priceUsd = optionalPositiveDecimal(row.priceUsd);
+    const priceNative = optionalPositiveDecimal(row.priceNative);
+    const currentPriceUsd = matchedSide === "base"
+      ? priceUsd
+      : dividePositive(priceUsd, priceNative);
+    // DEX Screener's field is display-only provider data. Its presence does
+    // not establish a circulating-supply definition or settlement evidence.
+    const marketCapUsd = matchedSide === "base"
+      ? optionalNonNegativeNumber(row.marketCap)
+      : null;
+    const fdvUsd = matchedSide === "base"
+      ? optionalNonNegativeNumber(row.fdv)
+      : null;
+    const liquidityUsd = optionalNestedNonNegativeNumber(
+      row.liquidity,
+      "usd",
+    );
+    const volume24hUsd = optionalNestedNonNegativeNumber(row.volume, "h24");
+    const pairCreatedAt = optionalNonNegativeSafeInteger(row.pairCreatedAt);
+    // DEX Screener's pair `info` describes the listed/base token. When the
+    // requested asset is the quote token, reusing it would attach the other
+    // token's artwork and socials to the requested CA. Keep that enrichment
+    // empty unless the requested identity is the base side of the exact pair.
+    const links = matchedSide === "base"
+      ? parseLinksSafely(row.info)
+      : { imageUrl: null, websites: [], socials: [] };
+    const canonicalLocator = canonicalIdentifier(locator, binding.namespace);
+
+    return {
+      selectionKey: binding.namespace === "evm"
+        ? `evm:${binding.chainReference}:${canonicalLocator}`
+        : `solana:${binding.chainReference}:${canonicalLocator}`,
+      selection: {
+        mode: "custom",
+        sourceNetwork: binding.sourceNetwork,
+        assetLocator: canonicalLocator,
+      },
+      namespace: binding.namespace,
+      chainReference: binding.chainReference,
+      providerChainId: binding.providerChainId,
+      token: {
+        address: canonicalIdentifier(matchedToken.address, binding.namespace),
+        name: matchedToken.name,
+        symbol: matchedToken.symbol,
+      },
+      currentPriceUsd,
+      marketCapUsd,
+      fdvUsd,
+      pair: {
+        dexId: requiredBoundedString(row.dexId, 64).toLowerCase(),
+        pairAddress: canonicalIdentifier(
+          requiredBoundedString(row.pairAddress, 128),
+          binding.namespace,
+        ),
+        matchedSide,
+        liquidityUsd,
+        volume24hUsd,
+        pairCreatedAt,
+      },
+      links,
+    };
+  } catch {
+    // A malformed provider row is not identity evidence and must not poison a
+    // later exact row or the independently verified identity-only candidate.
+    return null;
+  }
+}
+
+function requiredToken(candidate: unknown, namespace: "evm" | "solana") {
+  if (!isPlainRecord(candidate)) {
+    throw new PredictionAssetAutoDiscoveryReadError("response-invalid");
+  }
+  const address = requiredBoundedString(candidate.address, 128);
+  if (
+    namespace === "evm"
+      ? !isEvmLocator(address)
+      : !isSolanaLocator(address)
+  ) {
+    throw new PredictionAssetAutoDiscoveryReadError("response-invalid");
+  }
+  return {
+    address,
+    name: optionalDisplayText(candidate.name, 80, true),
+    symbol: optionalDisplayText(candidate.symbol, 24, false),
+  };
+}
+
+function parseLinks(candidate: unknown): PredictionAssetAutoDiscoveryCandidateV2["links"] {
+  if (candidate === undefined || candidate === null) {
+    return { imageUrl: null, websites: [], socials: [] };
+  }
+  if (!isPlainRecord(candidate)) {
+    throw new PredictionAssetAutoDiscoveryReadError("response-invalid");
+  }
+  const imageUrl = safeHttpUrl(candidate.imageUrl);
+  const websites = parseLinkRows(candidate.websites, "website");
+  const socials = parseLinkRows(candidate.socials, "social");
+  return { imageUrl, websites, socials };
+}
+
+function parseLinksSafely(
+  candidate: unknown,
+): PredictionAssetAutoDiscoveryCandidateV2["links"] {
+  try {
+    return parseLinks(candidate);
+  } catch {
+    return { imageUrl: null, websites: [], socials: [] };
+  }
+}
+
+function parseLinkRows(
+  candidate: unknown,
+  kind: "website",
+): PredictionAssetAutoDiscoveryCandidateV2["links"]["websites"];
+function parseLinkRows(
+  candidate: unknown,
+  kind: "social",
+): PredictionAssetAutoDiscoveryCandidateV2["links"]["socials"];
+function parseLinkRows(
+  candidate: unknown,
+  kind: "website" | "social",
+): PredictionAssetAutoDiscoveryCandidateV2["links"]["websites"] |
+  PredictionAssetAutoDiscoveryCandidateV2["links"]["socials"] {
+  if (candidate === undefined || candidate === null) return [];
+  if (!Array.isArray(candidate) || candidate.length > MAXIMUM_LINK_ROWS) {
+    throw new PredictionAssetAutoDiscoveryReadError("response-invalid");
+  }
+  const rows: { descriptor: string | null; url: string }[] = [];
+  const seen = new Set<string>();
+  for (const row of candidate) {
+    if (!isPlainRecord(row)) continue;
+    const url = safeHttpUrl(row.url);
+    if (url === null || seen.has(url)) continue;
+    seen.add(url);
+    rows.push({
+      descriptor: optionalDisplayText(
+        kind === "website" ? row.label : row.type,
+        64,
+        true,
+      ),
+      url,
+    });
+  }
+  rows.sort((first, second) => {
+    const url = compareText(first.url, second.url);
+    if (url !== 0) return url;
+    return compareText(first.descriptor ?? "", second.descriptor ?? "");
+  });
+  const selected = rows.slice(0, MAXIMUM_RETURNED_LINKS);
+  if (kind === "website") {
+    return selected.map((row) => ({
+      label: row.descriptor,
+      url: row.url,
+    }));
+  }
+  return selected.map((row) => ({
+    type: row.descriptor?.toLowerCase() ?? null,
+    url: row.url,
+  }));
+}
+
+export function normalizePredictionAssetLocatorV2(
+  candidate: unknown,
+): NormalizedLocator | null {
+  if (typeof candidate !== "string") return null;
+  const locator = candidate.trim();
+  if (isEvmLocator(locator)) {
+    return { locator: locator.toLowerCase(), namespace: "evm" };
+  }
+  if (isSolanaLocator(locator)) {
+    return { locator, namespace: "solana" };
+  }
+  return null;
+}
+
+function isEvmLocator(candidate: string) {
+  return /^0x[0-9a-fA-F]{40}$/u.test(candidate) &&
+    candidate.toLowerCase() !== ZERO_EVM_ADDRESS;
+}
+
+function isSolanaLocator(candidate: string) {
+  if (candidate.length < 32 || candidate.length > 44) return false;
+  const bytes: number[] = [0];
+  for (const character of candidate) {
+    const value = BASE58_VALUE_BY_CHARACTER.get(character);
+    if (value === undefined) return false;
+    let carry = value;
+    for (let index = 0; index < bytes.length; index += 1) {
+      const next = bytes[index]! * 58 + carry;
+      bytes[index] = next & 0xff;
+      carry = next >> 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+    if (bytes.length > 32) return false;
+  }
+  let leadingZeroes = 0;
+  while (candidate[leadingZeroes] === "1") leadingZeroes += 1;
+  const significantBytes = bytes.length === 1 && bytes[0] === 0
+    ? 0
+    : bytes.length;
+  return significantBytes + leadingZeroes === 32 && significantBytes > 0;
+}
+
+const BASE58_VALUE_BY_CHARACTER = new Map(
+  [..."123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"]
+    .map((character, index) => [character, index] as const),
+);
+
+function sameLocator(
+  candidate: string,
+  locator: string,
+  namespace: "evm" | "solana",
+) {
+  return namespace === "evm"
+    ? candidate.toLowerCase() === locator
+    : candidate === locator;
+}
+
+function canonicalIdentifier(
+  candidate: string,
+  namespace: "evm" | "solana",
+) {
+  return namespace === "evm" ? candidate.toLowerCase() : candidate;
+}
+
+function requiredBoundedString(candidate: unknown, maximumLength: number) {
+  if (
+    typeof candidate !== "string" ||
+    candidate.length === 0 ||
+    candidate.length > maximumLength ||
+    /[\u0000-\u001f\u007f-\u009f]/u.test(candidate)
+  ) {
+    throw new PredictionAssetAutoDiscoveryReadError("response-invalid");
+  }
+  return candidate;
+}
+
+function optionalDisplayText(
+  candidate: unknown,
+  maximumLength: number,
+  allowWhitespace: boolean,
+) {
+  if (candidate === undefined || candidate === null) return null;
+  if (typeof candidate !== "string") return null;
+  const normalized = candidate.normalize("NFC").trim();
+  if (!normalized || UNSAFE_DISPLAY_TEXT_PATTERN.test(normalized)) return null;
+  const text = allowWhitespace ? normalized.replace(/\s+/gu, " ") : normalized;
+  if (
+    (!allowWhitespace && /\s/u.test(text)) ||
+    Array.from(text).length > maximumLength ||
+    new TextEncoder().encode(text).length > maximumLength * 4
+  ) return null;
+  return text;
+}
+
+function optionalPositiveDecimal(candidate: unknown) {
+  if (candidate === undefined || candidate === null) return null;
+  if (
+    typeof candidate !== "string" ||
+    candidate.length > 128 ||
+    !/^(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$/u.test(candidate)
+  ) {
+    throw new PredictionAssetAutoDiscoveryReadError("response-invalid");
+  }
+  const value = Number(candidate);
+  if (!Number.isFinite(value)) {
+    throw new PredictionAssetAutoDiscoveryReadError("response-invalid");
+  }
+  return value > 0 ? value : null;
+}
+
+function optionalNonNegativeNumber(candidate: unknown) {
+  if (candidate === undefined || candidate === null) return null;
+  if (
+    typeof candidate !== "number" ||
+    !Number.isFinite(candidate) ||
+    candidate < 0
+  ) {
+    throw new PredictionAssetAutoDiscoveryReadError("response-invalid");
+  }
+  return candidate;
+}
+
+function optionalNonNegativeSafeInteger(candidate: unknown) {
+  if (candidate === undefined || candidate === null) return null;
+  if (!Number.isSafeInteger(candidate) || (candidate as number) < 0) {
+    throw new PredictionAssetAutoDiscoveryReadError("response-invalid");
+  }
+  return candidate as number;
+}
+
+function optionalNestedNonNegativeNumber(
+  candidate: unknown,
+  key: string,
+) {
+  if (candidate === undefined || candidate === null) return null;
+  if (!isPlainRecord(candidate)) {
+    throw new PredictionAssetAutoDiscoveryReadError("response-invalid");
+  }
+  return optionalNonNegativeNumber(candidate[key]);
+}
+
+function dividePositive(
+  numerator: number | null,
+  denominator: number | null,
+) {
+  if (numerator === null || denominator === null) return null;
+  const value = numerator / denominator;
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function safeHttpUrl(candidate: unknown) {
+  if (
+    typeof candidate !== "string" ||
+    candidate.length === 0 ||
+    candidate.length > 2_048 ||
+    /[\u0000-\u0020\u007f]/u.test(candidate)
+  ) {
+    return null;
+  }
+  try {
+    const url = new URL(candidate);
+    const hostname = url.hostname.toLowerCase();
+    if (
+      url.protocol !== "https:" ||
+      url.username.length > 0 ||
+      url.password.length > 0 ||
+      (url.port && url.port !== "443") ||
+      !isPublicWebHostname(hostname)
+    ) {
+      return null;
+    }
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function isPublicWebHostname(hostname: string) {
+  if (!hostname || hostname.endsWith(".") || hostname.includes(":")) {
+    return false;
+  }
+  if (/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/u.test(hostname)) return false;
+  if (!/^[a-z0-9.-]+$/u.test(hostname) || !hostname.includes(".")) {
+    return false;
+  }
+  const labels = hostname.split(".");
+  if (labels.some((label) =>
+    !label || label.length > 63 || label.startsWith("-") || label.endsWith("-")
+  )) {
+    return false;
+  }
+  return hostname !== "localhost" &&
+    !PRIVATE_HOST_SUFFIXES.some((suffix) => hostname.endsWith(suffix));
+}
+
+function comparePairCandidates(first: PairCandidate, second: PairCandidate) {
+  const priceAvailability = Number(second.currentPriceUsd !== null) -
+    Number(first.currentPriceUsd !== null);
+  if (priceAvailability !== 0) return priceAvailability;
+  const liquidity = compareNullableNumberDescending(
+    first.pair.liquidityUsd,
+    second.pair.liquidityUsd,
+  );
+  if (liquidity !== 0) return liquidity;
+  const volume = compareNullableNumberDescending(
+    first.pair.volume24hUsd,
+    second.pair.volume24hUsd,
+  );
+  if (volume !== 0) return volume;
+  const pairAddress = compareText(
+    first.pair.pairAddress,
+    second.pair.pairAddress,
+  );
+  if (pairAddress !== 0) return pairAddress;
+  return compareText(first.pair.dexId, second.pair.dexId);
+}
+
+function compareNullableNumberDescending(
+  first: number | null,
+  second: number | null,
+) {
+  if (first === second) return 0;
+  if (first === null) return 1;
+  if (second === null) return -1;
+  return first > second ? -1 : 1;
+}
+
+function compareText(first: string, second: string) {
+  if (first === second) return 0;
+  return first < second ? -1 : 1;
+}
+
+function isPlainRecord(candidate: unknown): candidate is Record<string, unknown> {
+  return Boolean(
+    candidate && typeof candidate === "object" && !Array.isArray(candidate),
+  );
+}
+
+function boundedInteger(
+  candidate: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+  label: string,
+) {
+  const value = candidate ?? fallback;
+  if (!Number.isInteger(value) || value < minimum || value > maximum) {
+    throw new RangeError(`${label} must be an integer from ${minimum} to ${maximum}`);
+  }
+  return value;
+}
+
+export const readPredictionAssetAutoDiscoveryV2 =
+  createPredictionAssetAutoDiscoveryReaderV2().read;

--- a/lib/market-data/prediction-asset-identity-verification-v2.server.ts
+++ b/lib/market-data/prediction-asset-identity-verification-v2.server.ts
@@ -1,0 +1,784 @@
+import "server-only";
+
+const DEFAULT_TIMEOUT_MS = 3_000;
+const DEFAULT_MAXIMUM_RESPONSE_BYTES = 64_000;
+const ZERO_EVM_ADDRESS = `0x${"0".repeat(40)}`;
+const SOLANA_MAINNET_GENESIS_HASH =
+  "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d";
+const SOLANA_TOKEN_PROGRAM =
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+const SOLANA_TOKEN_2022_PROGRAM =
+  "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
+const MAXIMUM_SOLANA_SUPPLY = (1n << 64n) - 1n;
+const EVM_IDENTITY_BLOCK_TAG = "safe" as const;
+const SOLANA_IDENTITY_COMMITMENT = "finalized" as const;
+
+export type PredictionAssetIdentitySourceNetworkV2 =
+  | "ethereum"
+  | "base"
+  | "bnb"
+  | "robinhood"
+  | "solana";
+
+export type PredictionAssetIdentityFailureReasonV2 =
+  | "identity-unconfigured"
+  | "identity-unavailable"
+  | "identity-invalid";
+
+export type PredictionAssetIdentityProbeV2 =
+  | Readonly<{
+    sourceNetwork: PredictionAssetIdentitySourceNetworkV2;
+    status: "verified-token" | "not-token";
+  }>
+  | Readonly<{
+    sourceNetwork: PredictionAssetIdentitySourceNetworkV2;
+    status: "failed";
+    reason: PredictionAssetIdentityFailureReasonV2;
+  }>;
+
+export type PredictionAssetIdentityVerifyOptionsV2 = Readonly<{
+  signal?: AbortSignal;
+}>;
+
+export type PredictionAssetIdentityVerifierV2 = Readonly<{
+  verify(
+    locator: string,
+    options?: PredictionAssetIdentityVerifyOptionsV2,
+  ): Promise<readonly PredictionAssetIdentityProbeV2[]>;
+}>;
+
+export type PredictionAssetIdentityRpcUrlsV2 = Readonly<
+  Partial<Record<PredictionAssetIdentitySourceNetworkV2, string | undefined>>
+>;
+
+export type PredictionAssetIdentityVerifierOptionsV2 = Readonly<{
+  fetchImpl?: typeof fetch;
+  rpcUrls?: PredictionAssetIdentityRpcUrlsV2;
+  timeoutMs?: number;
+  maximumResponseBytes?: number;
+}>;
+
+type EvmNetworkBinding = Readonly<{
+  sourceNetwork: Exclude<PredictionAssetIdentitySourceNetworkV2, "solana">;
+  chainId: bigint;
+}>;
+
+type RpcBatchOutcome =
+  | Readonly<{ kind: "result"; value: unknown }>
+  | Readonly<{ kind: "error" }>;
+
+type EvmIdentityBlock = Readonly<{
+  number: string;
+  hash: string;
+}>;
+
+const EVM_NETWORKS = Object.freeze([
+  Object.freeze({ sourceNetwork: "ethereum", chainId: 1n }),
+  Object.freeze({ sourceNetwork: "base", chainId: 8_453n }),
+  Object.freeze({ sourceNetwork: "bnb", chainId: 56n }),
+  Object.freeze({ sourceNetwork: "robinhood", chainId: 4_663n }),
+] as const satisfies readonly EvmNetworkBinding[]);
+
+const ENVIRONMENT_VARIABLE_BY_NETWORK = Object.freeze({
+  ethereum: "PROGRAMMABLE_PREDICTION_V2_ETHEREUM_RPC_URL",
+  base: "PROGRAMMABLE_PREDICTION_V2_BASE_RPC_URL",
+  bnb: "PROGRAMMABLE_PREDICTION_V2_BNB_RPC_URL",
+  robinhood: "PROGRAMMABLE_PREDICTION_V2_ROBINHOOD_RPC_URL",
+  solana: "PROGRAMMABLE_PREDICTION_V2_SOLANA_RPC_URL",
+} as const satisfies Record<
+  PredictionAssetIdentitySourceNetworkV2,
+  string
+>);
+
+class PredictionAssetIdentityRpcError extends Error {
+  constructor(readonly reason: PredictionAssetIdentityFailureReasonV2) {
+    super(`Prediction asset identity verification failed: ${reason}`);
+    this.name = "PredictionAssetIdentityRpcError";
+  }
+}
+
+export function createPredictionAssetIdentityVerifierV2(
+  options: PredictionAssetIdentityVerifierOptionsV2 = {},
+): PredictionAssetIdentityVerifierV2 {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const rawRpcUrls = options.rpcUrls ?? readEnvironmentRpcUrls();
+  const rpcUrls = normalizeRpcUrls(rawRpcUrls);
+  const timeoutMs = boundedInteger(
+    options.timeoutMs,
+    DEFAULT_TIMEOUT_MS,
+    1,
+    30_000,
+    "timeoutMs",
+  );
+  const maximumResponseBytes = boundedInteger(
+    options.maximumResponseBytes,
+    DEFAULT_MAXIMUM_RESPONSE_BYTES,
+    1,
+    1_000_000,
+    "maximumResponseBytes",
+  );
+
+  return Object.freeze({
+    async verify(locator, verifyOptions = {}) {
+      const normalized = normalizeLocator(locator);
+      if (normalized?.namespace === "evm") {
+        if (verifyOptions.signal?.aborted) {
+          return EVM_NETWORKS.map(({ sourceNetwork }) => failedProbe(
+            sourceNetwork,
+            "identity-unavailable",
+          ));
+        }
+        return Promise.all(EVM_NETWORKS.map((binding) => verifyEvmNetwork({
+          binding,
+          locator: normalized.locator,
+          rpcUrl: rpcUrls[binding.sourceNetwork],
+          fetchImpl,
+          timeoutMs,
+          maximumResponseBytes,
+          signal: verifyOptions.signal,
+        })));
+      }
+
+      if (normalized?.namespace === "solana") {
+        if (verifyOptions.signal?.aborted) {
+          return [failedProbe("solana", "identity-unavailable")];
+        }
+        return [await verifySolana({
+          locator: normalized.locator,
+          rpcUrl: rpcUrls.solana,
+          fetchImpl,
+          timeoutMs,
+          maximumResponseBytes,
+          signal: verifyOptions.signal,
+        })];
+      }
+
+      const invalidNetworks = locator.trim().toLowerCase().startsWith("0x")
+        ? EVM_NETWORKS.map(({ sourceNetwork }) => sourceNetwork)
+        : ["solana" as const];
+      return invalidNetworks.map((sourceNetwork) =>
+        failedProbe(sourceNetwork, "identity-invalid")
+      );
+    },
+  });
+}
+
+async function verifyEvmNetwork(input: Readonly<{
+  binding: EvmNetworkBinding;
+  locator: string;
+  rpcUrl: string | null;
+  fetchImpl: typeof fetch;
+  timeoutMs: number;
+  maximumResponseBytes: number;
+  signal?: AbortSignal;
+}>): Promise<PredictionAssetIdentityProbeV2> {
+  if (input.rpcUrl === null) {
+    return failedProbe(input.binding.sourceNetwork, "identity-unconfigured");
+  }
+
+  try {
+    const probeSignal = probeDeadlineSignal(input.signal, input.timeoutMs);
+    const anchorPayload = await requestJsonRpcBatch({
+      rpcUrl: input.rpcUrl,
+      fetchImpl: input.fetchImpl,
+      timeoutMs: input.timeoutMs,
+      maximumResponseBytes: input.maximumResponseBytes,
+      signal: probeSignal,
+      requests: [
+        { jsonrpc: "2.0", id: 1, method: "eth_chainId", params: [] },
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "eth_getBlockByNumber",
+          params: [EVM_IDENTITY_BLOCK_TAG, false],
+        },
+      ],
+      expectedIds: [1, 2],
+    });
+
+    const chainId = canonicalEvmQuantity(rpcResult(anchorPayload, 1));
+    if (
+      chainId === null ||
+      BigInt(chainId) !== input.binding.chainId
+    ) {
+      return failedProbe(input.binding.sourceNetwork, "identity-invalid");
+    }
+    const anchoredBlock = evmIdentityBlock(rpcResult(anchorPayload, 2));
+
+    // Resolve every identity field against one exact safe block number, then
+    // re-read that block in the same batch. This prevents a moving `latest`
+    // view or a replaced block from mixing code, decimals and supply states.
+    const identityPayload = await requestJsonRpcBatch({
+      rpcUrl: input.rpcUrl,
+      fetchImpl: input.fetchImpl,
+      timeoutMs: input.timeoutMs,
+      maximumResponseBytes: input.maximumResponseBytes,
+      signal: probeSignal,
+      requests: [
+        {
+          jsonrpc: "2.0",
+          id: 3,
+          method: "eth_getBlockByNumber",
+          params: [anchoredBlock.number, false],
+        },
+        {
+          jsonrpc: "2.0",
+          id: 4,
+          method: "eth_getCode",
+          params: [input.locator, anchoredBlock.number],
+        },
+        {
+          jsonrpc: "2.0",
+          id: 5,
+          method: "eth_call",
+          params: [
+            { to: input.locator, data: "0x313ce567" },
+            anchoredBlock.number,
+          ],
+        },
+        {
+          jsonrpc: "2.0",
+          id: 6,
+          method: "eth_call",
+          params: [
+            { to: input.locator, data: "0x18160ddd" },
+            anchoredBlock.number,
+          ],
+        },
+      ],
+      expectedIds: [3, 4, 5, 6],
+    });
+    const confirmedBlock = evmIdentityBlock(rpcResult(identityPayload, 3));
+    if (!sameEvmIdentityBlock(anchoredBlock, confirmedBlock)) {
+      return failedProbe(input.binding.sourceNetwork, "identity-invalid");
+    }
+
+    const code = rpcResult(identityPayload, 4);
+    if (code === "0x") {
+      return {
+        sourceNetwork: input.binding.sourceNetwork,
+        status: "not-token",
+      };
+    }
+    if (
+      typeof code !== "string" ||
+      !/^0x(?:[0-9a-fA-F]{2})+$/u.test(code)
+    ) {
+      return failedProbe(input.binding.sourceNetwork, "identity-invalid");
+    }
+
+    const decimals = abiWord(rpcResult(identityPayload, 5));
+    const totalSupply = abiWord(rpcResult(identityPayload, 6));
+    if (decimals === null || decimals > 255n || totalSupply === null) {
+      return failedProbe(input.binding.sourceNetwork, "identity-invalid");
+    }
+    return {
+      sourceNetwork: input.binding.sourceNetwork,
+      status: "verified-token",
+    };
+  } catch (error) {
+    return failedProbe(
+      input.binding.sourceNetwork,
+      identityFailureReason(error),
+    );
+  }
+}
+
+async function verifySolana(input: Readonly<{
+  locator: string;
+  rpcUrl: string | null;
+  fetchImpl: typeof fetch;
+  timeoutMs: number;
+  maximumResponseBytes: number;
+  signal?: AbortSignal;
+}>): Promise<PredictionAssetIdentityProbeV2> {
+  if (input.rpcUrl === null) {
+    return failedProbe("solana", "identity-unconfigured");
+  }
+
+  try {
+    const probeSignal = probeDeadlineSignal(input.signal, input.timeoutMs);
+    const anchorPayload = await requestJsonRpcBatch({
+      rpcUrl: input.rpcUrl,
+      fetchImpl: input.fetchImpl,
+      timeoutMs: input.timeoutMs,
+      maximumResponseBytes: input.maximumResponseBytes,
+      signal: probeSignal,
+      requests: [
+        { jsonrpc: "2.0", id: 1, method: "getGenesisHash", params: [] },
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "getSlot",
+          params: [{ commitment: SOLANA_IDENTITY_COMMITMENT }],
+        },
+      ],
+      expectedIds: [1, 2],
+    });
+
+    if (rpcResult(anchorPayload, 1) !== SOLANA_MAINNET_GENESIS_HASH) {
+      return failedProbe("solana", "identity-invalid");
+    }
+    const finalizedSlot = solanaSlot(rpcResult(anchorPayload, 2));
+
+    const accountPayload = await requestJsonRpcBatch({
+      rpcUrl: input.rpcUrl,
+      fetchImpl: input.fetchImpl,
+      timeoutMs: input.timeoutMs,
+      maximumResponseBytes: input.maximumResponseBytes,
+      signal: probeSignal,
+      requests: [
+        {
+          jsonrpc: "2.0",
+          id: 3,
+          method: "getAccountInfo",
+          params: [input.locator, {
+            encoding: "jsonParsed",
+            commitment: SOLANA_IDENTITY_COMMITMENT,
+            minContextSlot: finalizedSlot,
+          }],
+        },
+      ],
+      expectedIds: [3],
+    });
+
+    const accountResponse = rpcResult(accountPayload, 3);
+    if (
+      !isPlainRecord(accountResponse) ||
+      !isPlainRecord(accountResponse.context) ||
+      !("value" in accountResponse) ||
+      solanaSlot(accountResponse.context.slot) < finalizedSlot
+    ) {
+      return failedProbe("solana", "identity-invalid");
+    }
+    if (accountResponse.value === null) {
+      return { sourceNetwork: "solana", status: "not-token" };
+    }
+    if (!isPlainRecord(accountResponse.value)) {
+      return failedProbe("solana", "identity-invalid");
+    }
+
+    const owner = accountResponse.value.owner;
+    if (owner !== SOLANA_TOKEN_PROGRAM && owner !== SOLANA_TOKEN_2022_PROGRAM) {
+      return { sourceNetwork: "solana", status: "not-token" };
+    }
+    if (accountResponse.value.executable !== false) {
+      return failedProbe("solana", "identity-invalid");
+    }
+
+    const data = accountResponse.value.data;
+    if (!isPlainRecord(data) || !isPlainRecord(data.parsed)) {
+      return failedProbe("solana", "identity-invalid");
+    }
+    if (data.parsed.type !== "mint" || !isPlainRecord(data.parsed.info)) {
+      return failedProbe("solana", "identity-invalid");
+    }
+    const { decimals, supply } = data.parsed.info;
+    if (
+      typeof decimals !== "number" ||
+      !Number.isSafeInteger(decimals) ||
+      decimals < 0 ||
+      decimals > 255 ||
+      typeof supply !== "string" ||
+      !/^(?:0|[1-9][0-9]*)$/u.test(supply) ||
+      supply.length > 20 ||
+      BigInt(supply) > MAXIMUM_SOLANA_SUPPLY
+    ) {
+      return failedProbe("solana", "identity-invalid");
+    }
+
+    return { sourceNetwork: "solana", status: "verified-token" };
+  } catch (error) {
+    return failedProbe("solana", identityFailureReason(error));
+  }
+}
+
+function probeDeadlineSignal(
+  callerSignal: AbortSignal | undefined,
+  timeoutMs: number,
+) {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  return callerSignal
+    ? AbortSignal.any([callerSignal, timeoutSignal])
+    : timeoutSignal;
+}
+
+function evmIdentityBlock(value: unknown): EvmIdentityBlock {
+  if (!isPlainRecord(value)) {
+    throw new PredictionAssetIdentityRpcError("identity-invalid");
+  }
+  const number = canonicalEvmQuantity(value.number);
+  const hash = typeof value.hash === "string" &&
+      /^0x[0-9a-fA-F]{64}$/u.test(value.hash) &&
+      !/^0x0{64}$/u.test(value.hash.toLowerCase())
+    ? value.hash.toLowerCase()
+    : null;
+  if (number === null || hash === null) {
+    throw new PredictionAssetIdentityRpcError("identity-invalid");
+  }
+  return Object.freeze({ number, hash });
+}
+
+function canonicalEvmQuantity(value: unknown): string | null {
+  if (
+    typeof value !== "string" ||
+    !/^0x(?:0|[1-9a-fA-F][0-9a-fA-F]{0,15})$/u.test(value)
+  ) return null;
+  return `0x${BigInt(value).toString(16)}`;
+}
+
+function sameEvmIdentityBlock(
+  first: EvmIdentityBlock,
+  second: EvmIdentityBlock,
+) {
+  return first.number === second.number && first.hash === second.hash;
+}
+
+function solanaSlot(value: unknown): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new PredictionAssetIdentityRpcError("identity-invalid");
+  }
+  return value as number;
+}
+
+async function requestJsonRpcBatch(input: Readonly<{
+  rpcUrl: string;
+  fetchImpl: typeof fetch;
+  timeoutMs: number;
+  maximumResponseBytes: number;
+  signal?: AbortSignal;
+  requests: readonly Readonly<{
+    jsonrpc: "2.0";
+    id: number;
+    method: string;
+    params: readonly unknown[];
+  }>[];
+  expectedIds: readonly number[];
+}>): Promise<ReadonlyMap<number, RpcBatchOutcome>> {
+  if (input.signal?.aborted) {
+    throw new PredictionAssetIdentityRpcError("identity-unavailable");
+  }
+
+  const controller = new AbortController();
+  let rejectDeadline!: (error: PredictionAssetIdentityRpcError) => void;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    rejectDeadline = reject;
+  });
+  let deadlineSettled = false;
+  const abortRequest = () => {
+    if (deadlineSettled) return;
+    deadlineSettled = true;
+    controller.abort();
+    rejectDeadline(
+      new PredictionAssetIdentityRpcError("identity-unavailable"),
+    );
+  };
+  const timer = setTimeout(abortRequest, input.timeoutMs);
+  input.signal?.addEventListener("abort", abortRequest, { once: true });
+
+  try {
+    let response: Response;
+    try {
+      response = await Promise.race([
+        input.fetchImpl(input.rpcUrl, {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(input.requests),
+          cache: "no-store",
+          redirect: "error",
+          signal: controller.signal,
+        }),
+        deadline,
+      ]);
+    } catch (error) {
+      if (error instanceof PredictionAssetIdentityRpcError) throw error;
+      throw new PredictionAssetIdentityRpcError("identity-unavailable");
+    }
+    if (!(response instanceof Response)) {
+      throw new PredictionAssetIdentityRpcError("identity-invalid");
+    }
+    if (!response.ok) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionAssetIdentityRpcError("identity-unavailable");
+    }
+    const contentType = response.headers.get("content-type")?.toLowerCase();
+    if (
+      contentType === undefined ||
+      !/^application\/(?:[a-z0-9!#$&^_.+-]+\+)?json(?:\s*;|$)/u.test(contentType)
+    ) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionAssetIdentityRpcError("identity-invalid");
+    }
+    const body = await readBoundedResponseBody(
+      response,
+      input.maximumResponseBytes,
+      deadline,
+      controller,
+    );
+    let value: unknown;
+    try {
+      value = JSON.parse(body) as unknown;
+    } catch {
+      throw new PredictionAssetIdentityRpcError("identity-invalid");
+    }
+    return parseRpcBatch(value, input.expectedIds);
+  } finally {
+    deadlineSettled = true;
+    clearTimeout(timer);
+    input.signal?.removeEventListener("abort", abortRequest);
+  }
+}
+
+async function readBoundedResponseBody(
+  response: Response,
+  maximumBytes: number,
+  deadline: Promise<never>,
+  controller: AbortController,
+): Promise<string> {
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null) {
+    if (!/^(?:0|[1-9][0-9]*)$/u.test(declaredLength)) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionAssetIdentityRpcError("identity-invalid");
+    }
+    if (BigInt(declaredLength) > BigInt(maximumBytes)) {
+      abortUnreadResponse(response, controller);
+      throw new PredictionAssetIdentityRpcError("identity-invalid");
+    }
+  }
+
+  if (response.body === null) {
+    throw new PredictionAssetIdentityRpcError("identity-invalid");
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const next = await Promise.race([reader.read(), deadline]);
+      if (next.done) break;
+      if (!(next.value instanceof Uint8Array)) {
+        throw new PredictionAssetIdentityRpcError("identity-invalid");
+      }
+      totalBytes += next.value.byteLength;
+      if (totalBytes > maximumBytes) {
+        controller.abort();
+        void reader.cancel().catch(() => undefined);
+        throw new PredictionAssetIdentityRpcError("identity-invalid");
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // The request controller owns a body read that outlives this verifier.
+    }
+  }
+
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new PredictionAssetIdentityRpcError("identity-invalid");
+  }
+}
+
+function parseRpcBatch(
+  value: unknown,
+  expectedIds: readonly number[],
+): ReadonlyMap<number, RpcBatchOutcome> {
+  if (!Array.isArray(value) || value.length !== expectedIds.length) {
+    throw new PredictionAssetIdentityRpcError("identity-invalid");
+  }
+  const expected = new Set(expectedIds);
+  const results = new Map<number, RpcBatchOutcome>();
+  for (const row of value) {
+    if (
+      !isPlainRecord(row) ||
+      row.jsonrpc !== "2.0" ||
+      typeof row.id !== "number" ||
+      !Number.isSafeInteger(row.id) ||
+      !expected.has(row.id) ||
+      results.has(row.id)
+    ) {
+      throw new PredictionAssetIdentityRpcError("identity-invalid");
+    }
+    const hasResult = Object.hasOwn(row, "result");
+    const hasError = Object.hasOwn(row, "error");
+    if (hasResult === hasError) {
+      throw new PredictionAssetIdentityRpcError("identity-invalid");
+    }
+    if (hasError) {
+      if (!isPlainRecord(row.error)) {
+        throw new PredictionAssetIdentityRpcError("identity-invalid");
+      }
+      results.set(row.id, { kind: "error" });
+    } else {
+      results.set(row.id, { kind: "result", value: row.result });
+    }
+  }
+  return results;
+}
+
+function rpcResult(
+  results: ReadonlyMap<number, RpcBatchOutcome>,
+  id: number,
+): unknown {
+  const outcome = results.get(id);
+  if (outcome?.kind !== "result") {
+    throw new PredictionAssetIdentityRpcError("identity-invalid");
+  }
+  return outcome.value;
+}
+
+function abiWord(value: unknown): bigint | null {
+  if (typeof value !== "string" || !/^0x[0-9a-fA-F]{64}$/u.test(value)) {
+    return null;
+  }
+  return BigInt(value);
+}
+
+function failedProbe(
+  sourceNetwork: PredictionAssetIdentitySourceNetworkV2,
+  reason: PredictionAssetIdentityFailureReasonV2,
+): PredictionAssetIdentityProbeV2 {
+  return { sourceNetwork, status: "failed", reason };
+}
+
+function identityFailureReason(
+  error: unknown,
+): PredictionAssetIdentityFailureReasonV2 {
+  return error instanceof PredictionAssetIdentityRpcError
+    ? error.reason
+    : "identity-unavailable";
+}
+
+function readEnvironmentRpcUrls(): PredictionAssetIdentityRpcUrlsV2 {
+  return Object.freeze(Object.fromEntries(
+    Object.entries(ENVIRONMENT_VARIABLE_BY_NETWORK).map(
+      ([sourceNetwork, variable]) => [sourceNetwork, process.env[variable]],
+    ),
+  ) as Partial<Record<PredictionAssetIdentitySourceNetworkV2, string>>);
+}
+
+function normalizeRpcUrls(
+  values: PredictionAssetIdentityRpcUrlsV2,
+): Readonly<Record<PredictionAssetIdentitySourceNetworkV2, string | null>> {
+  return Object.freeze({
+    ethereum: normalizeRpcUrl(values.ethereum),
+    base: normalizeRpcUrl(values.base),
+    bnb: normalizeRpcUrl(values.bnb),
+    robinhood: normalizeRpcUrl(values.robinhood),
+    solana: normalizeRpcUrl(values.solana),
+  });
+}
+
+function normalizeRpcUrl(value: unknown): string | null {
+  if (typeof value !== "string" || value.length === 0 || value.length > 2_048) {
+    return null;
+  }
+  try {
+    const url = new URL(value);
+    if (
+      url.protocol !== "https:" ||
+      url.username !== "" ||
+      url.password !== "" ||
+      url.hash !== "" ||
+      url.hostname === ""
+    ) {
+      return null;
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeLocator(locator: unknown):
+  | Readonly<{ namespace: "evm" | "solana"; locator: string }>
+  | null {
+  if (typeof locator !== "string") return null;
+  const trimmed = locator.trim();
+  const evm = trimmed.toLowerCase();
+  if (/^0x[0-9a-f]{40}$/u.test(evm) && evm !== ZERO_EVM_ADDRESS) {
+    return { namespace: "evm", locator: evm };
+  }
+  const solanaBytes = decodeBase58(trimmed);
+  if (
+    solanaBytes?.byteLength === 32 &&
+    solanaBytes.some((value) => value !== 0)
+  ) {
+    return { namespace: "solana", locator: trimmed };
+  }
+  return null;
+}
+
+function decodeBase58(value: string): Uint8Array | null {
+  const alphabet =
+    "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+  if (value.length === 0 || value.length > 64) return null;
+  let number = 0n;
+  for (const character of value) {
+    const digit = alphabet.indexOf(character);
+    if (digit < 0) return null;
+    number = number * 58n + BigInt(digit);
+  }
+  const tail: number[] = [];
+  while (number > 0n) {
+    tail.push(Number(number & 0xffn));
+    number >>= 8n;
+  }
+  tail.reverse();
+  let leadingZeroCount = 0;
+  while (value[leadingZeroCount] === "1") leadingZeroCount += 1;
+  return Uint8Array.from([
+    ...new Array<number>(leadingZeroCount).fill(0),
+    ...tail,
+  ]);
+}
+
+function abortUnreadResponse(
+  response: Response,
+  controller: AbortController,
+) {
+  controller.abort();
+  if (response.body !== null) {
+    void response.body.cancel().catch(() => undefined);
+  }
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function boundedInteger(
+  value: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+  label: string,
+) {
+  const candidate = value ?? fallback;
+  if (
+    !Number.isSafeInteger(candidate) ||
+    candidate < minimum ||
+    candidate > maximum
+  ) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return candidate;
+}

--- a/lib/prediction-v2/asset-auto-discovery-v2.ts
+++ b/lib/prediction-v2/asset-auto-discovery-v2.ts
@@ -1,0 +1,822 @@
+import {
+  normalizePredictionTokenProfileV2,
+  type PredictionTokenProfileV2,
+} from "./token-profile-v2";
+
+export const PREDICTION_ASSET_AUTO_DISCOVERY_IDENTITY_SOURCE_V2 =
+  "onchain-rpc" as const;
+export const PREDICTION_ASSET_AUTO_DISCOVERY_ENRICHMENT_SOURCE_V2 =
+  "dexscreener" as const;
+/** @deprecated Use the enrichment source constant for new code. */
+export const PREDICTION_ASSET_AUTO_DISCOVERY_SOURCE_V2 =
+  PREDICTION_ASSET_AUTO_DISCOVERY_ENRICHMENT_SOURCE_V2;
+export const PREDICTION_ASSET_AUTO_DISCOVERY_USAGE_V2 =
+  "informational-only" as const;
+
+export type PredictionAssetAutoDiscoveryNetworkV2 =
+  | "ethereum"
+  | "base"
+  | "bnb"
+  | "robinhood"
+  | "solana";
+
+export type PredictionAssetAutoDiscoveryFailureReasonV2 =
+  | "aborted"
+  | "timeout"
+  | "rate-limited"
+  | "provider-unavailable"
+  | "response-too-large"
+  | "response-invalid"
+  | "identity-unconfigured"
+  | "identity-unavailable"
+  | "identity-invalid"
+  | "identity-mismatch"
+  | "market-data-missing";
+
+export type PredictionAssetAutoDiscoveryClientPairV2 = Readonly<{
+  dexId: string;
+  pairAddress: string;
+  matchedSide: "base" | "quote";
+  liquidityUsd: number | null;
+  volume24hUsd: number | null;
+  pairCreatedAt: number | null;
+}>;
+
+export type PredictionAssetAutoDiscoveryClientCandidateV2 = Readonly<{
+  selectionKey: string;
+  selection: Readonly<{
+    mode: "custom";
+    sourceNetwork: PredictionAssetAutoDiscoveryNetworkV2;
+    assetLocator: string;
+  }>;
+  namespace: "evm" | "solana";
+  chainReference: string;
+  providerChainId: string;
+  provenance: Readonly<{
+    identity: Readonly<{
+      source: typeof PREDICTION_ASSET_AUTO_DISCOVERY_IDENTITY_SOURCE_V2;
+    }>;
+    enrichment: Readonly<{
+      source: typeof PREDICTION_ASSET_AUTO_DISCOVERY_ENRICHMENT_SOURCE_V2;
+    }> | null;
+  }>;
+  currentPriceUsd: number | null;
+  marketCapUsd: number | null;
+  fdvUsd: number | null;
+  matchingPairCount: number;
+  pair: PredictionAssetAutoDiscoveryClientPairV2 | null;
+  /** Verified identity plus optional display-only provider enrichment. */
+  profile: PredictionTokenProfileV2;
+}>;
+
+export type PredictionAssetAutoDiscoveryClientFailureV2 = Readonly<{
+  sourceNetwork: PredictionAssetAutoDiscoveryNetworkV2;
+  reason: PredictionAssetAutoDiscoveryFailureReasonV2;
+}>;
+
+type PredictionAssetAutoDiscoveryClientBaseV2 = Readonly<{
+  schemaVersion: 2;
+  locator: string | null;
+  /** Successful optional market-data enrichment, never identity authority. */
+  source: typeof PREDICTION_ASSET_AUTO_DISCOVERY_ENRICHMENT_SOURCE_V2 | null;
+  observedAt: string;
+  usage: typeof PREDICTION_ASSET_AUTO_DISCOVERY_USAGE_V2;
+}>;
+
+export type PredictionAssetAutoDiscoveryClientResultV2 =
+  | (PredictionAssetAutoDiscoveryClientBaseV2 & Readonly<{
+    status: "unique";
+    locator: string;
+    candidate: PredictionAssetAutoDiscoveryClientCandidateV2;
+  }>)
+  | (PredictionAssetAutoDiscoveryClientBaseV2 & Readonly<{
+    status: "ambiguous";
+    locator: string;
+    candidates: readonly PredictionAssetAutoDiscoveryClientCandidateV2[];
+  }>)
+  | (PredictionAssetAutoDiscoveryClientBaseV2 & Readonly<{
+    status: "inconclusive";
+    locator: string;
+    candidates: readonly PredictionAssetAutoDiscoveryClientCandidateV2[];
+    failures: readonly PredictionAssetAutoDiscoveryClientFailureV2[];
+  }>)
+  | (PredictionAssetAutoDiscoveryClientBaseV2 & Readonly<{
+    status: "not-found";
+    locator: string;
+  }>)
+  | (PredictionAssetAutoDiscoveryClientBaseV2 & Readonly<{
+    status: "invalid";
+    locator: null;
+    reason: "invalid-locator";
+  }>);
+
+type NamespaceV2 = "evm" | "solana";
+
+type NetworkBindingV2 = Readonly<{
+  sourceNetwork: PredictionAssetAutoDiscoveryNetworkV2;
+  namespace: NamespaceV2;
+  chainReference: string;
+  providerChainId: string;
+}>;
+
+const NETWORK_BINDINGS_V2 = Object.freeze([
+  Object.freeze({
+    sourceNetwork: "ethereum",
+    namespace: "evm",
+    chainReference: "1",
+    providerChainId: "ethereum",
+  }),
+  Object.freeze({
+    sourceNetwork: "base",
+    namespace: "evm",
+    chainReference: "8453",
+    providerChainId: "base",
+  }),
+  Object.freeze({
+    sourceNetwork: "bnb",
+    namespace: "evm",
+    chainReference: "56",
+    providerChainId: "bsc",
+  }),
+  Object.freeze({
+    sourceNetwork: "robinhood",
+    namespace: "evm",
+    chainReference: "4663",
+    providerChainId: "robinhood",
+  }),
+  Object.freeze({
+    sourceNetwork: "solana",
+    namespace: "solana",
+    chainReference: "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+    providerChainId: "solana",
+  }),
+] as const satisfies readonly NetworkBindingV2[]);
+
+const FAILURE_REASONS_V2 = new Set<PredictionAssetAutoDiscoveryFailureReasonV2>([
+  "aborted",
+  "timeout",
+  "rate-limited",
+  "provider-unavailable",
+  "response-too-large",
+  "response-invalid",
+  "identity-unconfigured",
+  "identity-unavailable",
+  "identity-invalid",
+  "identity-mismatch",
+  "market-data-missing",
+]);
+const EVM_ADDRESS_V2 = /^0x[0-9a-f]{40}$/u;
+const ZERO_EVM_ADDRESS_V2 = `0x${"0".repeat(40)}`;
+const BASE58_ALPHABET_V2 =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const BASE58_INDEX_V2 = new Map(
+  [...BASE58_ALPHABET_V2].map((character, index) => [character, index] as const),
+);
+const DEX_ID_V2 = /^[a-z0-9][a-z0-9._-]{0,63}$/u;
+const MAX_CANDIDATES_V2 = 4;
+const MAX_FAILURES_V2 = 4;
+const MAX_LINKS_PER_KIND_V2 = 8;
+const MAX_MATCHING_PAIRS_V2 = 256;
+const MAX_URL_LENGTH_V2 = 2_048;
+const MAX_USD_VALUE_V2 = 1e18;
+
+const BASE_KEYS_V2 = Object.freeze([
+  "schemaVersion",
+  "locator",
+  "source",
+  "observedAt",
+  "usage",
+  "status",
+] as const);
+
+/** Stable UI identity; it is not the protocol AssetRegistry key. */
+export function predictionAutoDiscoveryCandidateKeyV2(
+  candidate: PredictionAssetAutoDiscoveryClientCandidateV2,
+) {
+  return `${candidate.profile.chain.id}:${candidate.profile.address}`;
+}
+
+/**
+ * Parse the public discovery response into a client-safe, display-only DTO.
+ * Unknown, conflicting or widened response shapes fail closed.
+ */
+export function parsePredictionAssetAutoDiscoveryV2(
+  value: unknown,
+  expectedLocator: string,
+): PredictionAssetAutoDiscoveryClientResultV2 | null {
+  try {
+    return parseResult(value, normalizeExpectedLocator(expectedLocator));
+  } catch {
+    return null;
+  }
+}
+
+function parseResult(
+  value: unknown,
+  expectedLocator: string | null,
+): PredictionAssetAutoDiscoveryClientResultV2 | null {
+  const record = exactRecord(value, BASE_KEYS_V2, [
+    "candidate",
+    "candidates",
+    "failures",
+    "reason",
+  ]);
+  if (
+    !record ||
+    record.schemaVersion !== 2 ||
+    record.usage !== PREDICTION_ASSET_AUTO_DISCOVERY_USAGE_V2
+  ) return null;
+  const source = parseEnrichmentSource(record.source);
+  if (source === undefined) return null;
+
+  const observedAtMs = canonicalInstantMs(record.observedAt);
+  if (observedAtMs === null) return null;
+  const observedAt = record.observedAt as string;
+  const status = record.status;
+  const shared = Object.freeze({
+    schemaVersion: 2 as const,
+    source,
+    observedAt,
+    usage: PREDICTION_ASSET_AUTO_DISCOVERY_USAGE_V2,
+  });
+
+  if (status === "invalid") {
+    if (
+      expectedLocator !== null ||
+      !hasExactKeys(record, [...BASE_KEYS_V2, "reason"]) ||
+      record.locator !== null ||
+      record.reason !== "invalid-locator" ||
+      source !== null
+    ) return null;
+    return Object.freeze({
+      ...shared,
+      locator: null,
+      status: "invalid" as const,
+      reason: "invalid-locator" as const,
+    });
+  }
+
+  const normalizedLocator = canonicalLocator(record.locator);
+  if (
+    expectedLocator === null ||
+    normalizedLocator === null ||
+    normalizedLocator !== record.locator ||
+    normalizedLocator !== expectedLocator
+  ) {
+    return null;
+  }
+
+  if (status === "not-found") {
+    if (!hasExactKeys(record, BASE_KEYS_V2) || source !== null) return null;
+    return Object.freeze({
+      ...shared,
+      locator: normalizedLocator,
+      status: "not-found" as const,
+    });
+  }
+
+  if (status === "unique") {
+    if (!hasExactKeys(record, [...BASE_KEYS_V2, "candidate"])) return null;
+    const candidate = parseCandidate(
+      record.candidate,
+      normalizedLocator,
+      observedAtMs,
+    );
+    if (
+      candidate === null ||
+      source !== enrichmentSourceForCandidates([candidate])
+    ) return null;
+    return Object.freeze({
+      ...shared,
+      locator: normalizedLocator,
+      status: "unique" as const,
+      candidate,
+    });
+  }
+
+  if (status === "ambiguous") {
+    if (!hasExactKeys(record, [...BASE_KEYS_V2, "candidates"])) return null;
+    const candidates = parseCandidates(
+      record.candidates,
+      normalizedLocator,
+      observedAtMs,
+      2,
+    );
+    if (
+      candidates === null ||
+      locatorNamespace(normalizedLocator) !== "evm" ||
+      source !== enrichmentSourceForCandidates(candidates)
+    ) {
+      return null;
+    }
+    return Object.freeze({
+      ...shared,
+      locator: normalizedLocator,
+      status: "ambiguous" as const,
+      candidates,
+    });
+  }
+
+  if (status === "inconclusive") {
+    if (
+      !hasExactKeys(record, [...BASE_KEYS_V2, "candidates", "failures"])
+    ) return null;
+    const candidates = parseCandidates(
+      record.candidates,
+      normalizedLocator,
+      observedAtMs,
+      0,
+    );
+    const failures = parseFailures(record.failures, normalizedLocator);
+    if (
+      candidates === null ||
+      failures === null ||
+      source !== enrichmentSourceForCandidates(candidates)
+    ) return null;
+    const occupiedNetworks = new Set(
+      candidates.map(({ selection }) => selection.sourceNetwork),
+    );
+    if (failures.some(({ sourceNetwork }) => occupiedNetworks.has(sourceNetwork))) {
+      return null;
+    }
+    return Object.freeze({
+      ...shared,
+      locator: normalizedLocator,
+      status: "inconclusive" as const,
+      candidates,
+      failures,
+    });
+  }
+
+  return null;
+}
+
+function parseCandidates(
+  value: unknown,
+  locator: string,
+  observedAtMs: number,
+  minimumLength: 0 | 2,
+): readonly PredictionAssetAutoDiscoveryClientCandidateV2[] | null {
+  if (
+    !Array.isArray(value) ||
+    value.length < minimumLength ||
+    value.length > maximumOutcomes(locator, MAX_CANDIDATES_V2)
+  ) return null;
+
+  const candidates: PredictionAssetAutoDiscoveryClientCandidateV2[] = [];
+  const keys = new Set<string>();
+  const networks = new Set<PredictionAssetAutoDiscoveryNetworkV2>();
+  for (const rawCandidate of value) {
+    const candidate = parseCandidate(rawCandidate, locator, observedAtMs);
+    if (candidate === null) return null;
+    const key = predictionAutoDiscoveryCandidateKeyV2(candidate);
+    if (
+      keys.has(key) ||
+      networks.has(candidate.selection.sourceNetwork)
+    ) return null;
+    keys.add(key);
+    networks.add(candidate.selection.sourceNetwork);
+    candidates.push(candidate);
+  }
+  return Object.freeze(candidates);
+}
+
+function parseCandidate(
+  value: unknown,
+  locator: string,
+  observedAtMs: number,
+): PredictionAssetAutoDiscoveryClientCandidateV2 | null {
+  const candidate = exactRecord(value, [
+    "selectionKey",
+    "selection",
+    "namespace",
+    "chainReference",
+    "providerChainId",
+    "provenance",
+    "token",
+    "currentPriceUsd",
+    "marketCapUsd",
+    "fdvUsd",
+    "matchingPairCount",
+    "pair",
+    "links",
+  ]);
+  if (!candidate) return null;
+
+  const selection = exactRecord(candidate.selection, [
+    "mode",
+    "sourceNetwork",
+    "assetLocator",
+  ]);
+  if (
+    !selection ||
+    selection.mode !== "custom" ||
+    typeof selection.sourceNetwork !== "string"
+  ) return null;
+  const binding = networkBinding(selection.sourceNetwork);
+  if (!binding) return null;
+  if (
+    candidate.namespace !== binding.namespace ||
+    candidate.chainReference !== binding.chainReference ||
+    candidate.providerChainId !== binding.providerChainId ||
+    selection.assetLocator !== locator ||
+    locatorNamespace(locator) !== binding.namespace
+  ) return null;
+
+  const expectedSelectionKey =
+    `${binding.namespace}:${binding.chainReference}:${locator}`;
+  if (candidate.selectionKey !== expectedSelectionKey) return null;
+
+  const provenance = parseProvenance(candidate.provenance);
+  if (provenance === null) return null;
+
+  const token = exactRecord(candidate.token, ["address", "name", "symbol"]);
+  if (
+    !token ||
+    token.address !== locator ||
+    !nullableBoundedString(token.name, 128) ||
+    !nullableBoundedString(token.symbol, 32)
+  ) return null;
+
+  const currentPriceUsd = nullableUsd(candidate.currentPriceUsd, false);
+  const marketCapUsd = nullableUsd(candidate.marketCapUsd, true);
+  const fdvUsd = nullableUsd(candidate.fdvUsd, true);
+  if (
+    currentPriceUsd === undefined ||
+    marketCapUsd === undefined ||
+    fdvUsd === undefined ||
+    !Number.isSafeInteger(candidate.matchingPairCount) ||
+    (candidate.matchingPairCount as number) < 0 ||
+    (candidate.matchingPairCount as number) > MAX_MATCHING_PAIRS_V2
+  ) return null;
+
+  const pair = candidate.pair === null ? null : parsePair(candidate.pair, binding);
+  const links = parseLinks(candidate.links);
+  if (candidate.pair !== null && pair === null || links === null) return null;
+  if ((pair === null) !== (provenance.enrichment === null)) return null;
+  if (pair === null) {
+    if (
+      candidate.matchingPairCount !== 0 ||
+      token.name !== null ||
+      token.symbol !== null ||
+      currentPriceUsd !== null ||
+      marketCapUsd !== null ||
+      fdvUsd !== null ||
+      !linksAreEmpty(links)
+    ) return null;
+  } else if (candidate.matchingPairCount === 0) {
+    return null;
+  }
+  if (
+    pair?.matchedSide === "quote" &&
+    (marketCapUsd !== null || fdvUsd !== null)
+  ) return null;
+
+  const profile = normalizePredictionTokenProfileV2({
+    chain: binding.sourceNetwork,
+    address: token.address,
+    name: token.name,
+    symbol: token.symbol,
+    imageUrl: links.imageUrl,
+    websites: links.websites,
+    socials: links.socials,
+    priceUsd: currentPriceUsd,
+    marketCapUsd,
+    fdvUsd,
+    liquidityUsd: pair?.liquidityUsd,
+    pairCreatedAtMs: pair?.pairCreatedAt,
+  }, observedAtMs);
+  if (
+    profile === null ||
+    profile.chain.id !== binding.sourceNetwork ||
+    profile.address !== locator
+  ) return null;
+
+  return Object.freeze({
+    selectionKey: expectedSelectionKey,
+    selection: Object.freeze({
+      mode: "custom" as const,
+      sourceNetwork: binding.sourceNetwork,
+      assetLocator: locator,
+    }),
+    namespace: binding.namespace,
+    chainReference: binding.chainReference,
+    providerChainId: binding.providerChainId,
+    provenance,
+    currentPriceUsd,
+    marketCapUsd,
+    fdvUsd,
+    matchingPairCount: candidate.matchingPairCount as number,
+    pair,
+    profile,
+  });
+}
+
+function parseProvenance(
+  value: unknown,
+): PredictionAssetAutoDiscoveryClientCandidateV2["provenance"] | null {
+  const provenance = exactRecord(value, ["identity", "enrichment"]);
+  const identity = exactRecord(provenance?.identity, ["source"]);
+  if (
+    !provenance ||
+    !identity ||
+    identity.source !== PREDICTION_ASSET_AUTO_DISCOVERY_IDENTITY_SOURCE_V2
+  ) return null;
+
+  let enrichment: Readonly<{
+    source: typeof PREDICTION_ASSET_AUTO_DISCOVERY_ENRICHMENT_SOURCE_V2;
+  }> | null = null;
+  if (provenance.enrichment !== null) {
+    const candidate = exactRecord(provenance.enrichment, ["source"]);
+    if (
+      !candidate ||
+      candidate.source !== PREDICTION_ASSET_AUTO_DISCOVERY_ENRICHMENT_SOURCE_V2
+    ) return null;
+    enrichment = Object.freeze({
+      source: PREDICTION_ASSET_AUTO_DISCOVERY_ENRICHMENT_SOURCE_V2,
+    });
+  }
+
+  return Object.freeze({
+    identity: Object.freeze({
+      source: PREDICTION_ASSET_AUTO_DISCOVERY_IDENTITY_SOURCE_V2,
+    }),
+    enrichment,
+  });
+}
+
+function enrichmentSourceForCandidates(
+  candidates: readonly PredictionAssetAutoDiscoveryClientCandidateV2[],
+) {
+  return candidates.some(({ provenance }) => provenance.enrichment !== null)
+    ? PREDICTION_ASSET_AUTO_DISCOVERY_ENRICHMENT_SOURCE_V2
+    : null;
+}
+
+function parseEnrichmentSource(value: unknown) {
+  if (value === null) return null;
+  return value === PREDICTION_ASSET_AUTO_DISCOVERY_ENRICHMENT_SOURCE_V2
+    ? PREDICTION_ASSET_AUTO_DISCOVERY_ENRICHMENT_SOURCE_V2
+    : undefined;
+}
+
+function parsePair(
+  value: unknown,
+  binding: NetworkBindingV2,
+): PredictionAssetAutoDiscoveryClientPairV2 | null {
+  const pair = exactRecord(value, [
+    "dexId",
+    "pairAddress",
+    "matchedSide",
+    "liquidityUsd",
+    "volume24hUsd",
+    "pairCreatedAt",
+  ]);
+  if (
+    !pair ||
+    typeof pair.dexId !== "string" ||
+    !DEX_ID_V2.test(pair.dexId) ||
+    pair.matchedSide !== "base" && pair.matchedSide !== "quote"
+  ) return null;
+  const pairAddress = canonicalLocator(pair.pairAddress);
+  if (
+    pairAddress === null ||
+    pairAddress !== pair.pairAddress ||
+    locatorNamespace(pairAddress) !== binding.namespace
+  ) return null;
+  const liquidityUsd = nullableUsd(pair.liquidityUsd, true);
+  const volume24hUsd = nullableUsd(pair.volume24hUsd, true);
+  const pairCreatedAt = nullableTimestampMs(pair.pairCreatedAt);
+  if (
+    liquidityUsd === undefined ||
+    volume24hUsd === undefined ||
+    pairCreatedAt === undefined
+  ) return null;
+
+  return Object.freeze({
+    dexId: pair.dexId,
+    pairAddress,
+    matchedSide: pair.matchedSide,
+    liquidityUsd,
+    volume24hUsd,
+    pairCreatedAt,
+  });
+}
+
+type ParsedLinksV2 = Readonly<{
+  imageUrl: string | null;
+  websites: readonly Readonly<{ label: string | null; url: string }>[];
+  socials: readonly Readonly<{ type: string | null; url: string }>[];
+}>;
+
+function parseLinks(value: unknown): ParsedLinksV2 | null {
+  const links = exactRecord(value, ["imageUrl", "websites", "socials"]);
+  if (!links || !nullableBoundedString(links.imageUrl, MAX_URL_LENGTH_V2)) {
+    return null;
+  }
+  const websites = parseLinkRows(links.websites, "label");
+  const socials = parseLinkRows(links.socials, "type");
+  if (websites === null || socials === null) return null;
+  return Object.freeze({
+    imageUrl: links.imageUrl as string | null,
+    websites,
+    socials,
+  });
+}
+
+function linksAreEmpty(links: ParsedLinksV2) {
+  return links.imageUrl === null &&
+    links.websites.length === 0 &&
+    links.socials.length === 0;
+}
+
+function parseLinkRows<Key extends "label" | "type">(
+  value: unknown,
+  descriptorKey: Key,
+): readonly Readonly<{ url: string } & Record<Key, string | null>>[] | null {
+  if (!Array.isArray(value) || value.length > MAX_LINKS_PER_KIND_V2) return null;
+  const rows: Readonly<{ url: string } & Record<Key, string | null>>[] = [];
+  const urls = new Set<string>();
+  for (const rawRow of value) {
+    const row = exactRecord(rawRow, [descriptorKey, "url"]);
+    if (
+      !row ||
+      !nullableBoundedString(row[descriptorKey], 64) ||
+      typeof row.url !== "string" ||
+      row.url.length === 0 ||
+      row.url.length > MAX_URL_LENGTH_V2 ||
+      new TextEncoder().encode(row.url).length > MAX_URL_LENGTH_V2 ||
+      urls.has(row.url)
+    ) return null;
+    urls.add(row.url);
+    rows.push(Object.freeze({
+      [descriptorKey]: row[descriptorKey] as string | null,
+      url: row.url,
+    }) as Readonly<{ url: string } & Record<Key, string | null>>);
+  }
+  return Object.freeze(rows);
+}
+
+function parseFailures(
+  value: unknown,
+  locator: string,
+): readonly PredictionAssetAutoDiscoveryClientFailureV2[] | null {
+  const maximum = maximumOutcomes(locator, MAX_FAILURES_V2);
+  if (!Array.isArray(value) || value.length < 1 || value.length > maximum) {
+    return null;
+  }
+  const namespace = locatorNamespace(locator);
+  const networks = new Set<PredictionAssetAutoDiscoveryNetworkV2>();
+  const failures: PredictionAssetAutoDiscoveryClientFailureV2[] = [];
+  for (const rawFailure of value) {
+    const failure = exactRecord(rawFailure, ["sourceNetwork", "reason"]);
+    if (
+      !failure ||
+      typeof failure.sourceNetwork !== "string" ||
+      typeof failure.reason !== "string" ||
+      !FAILURE_REASONS_V2.has(
+        failure.reason as PredictionAssetAutoDiscoveryFailureReasonV2,
+      )
+    ) return null;
+    const binding = networkBinding(failure.sourceNetwork);
+    if (
+      !binding ||
+      binding.namespace !== namespace ||
+      networks.has(binding.sourceNetwork)
+    ) return null;
+    networks.add(binding.sourceNetwork);
+    failures.push(Object.freeze({
+      sourceNetwork: binding.sourceNetwork,
+      reason: failure.reason as PredictionAssetAutoDiscoveryFailureReasonV2,
+    }));
+  }
+  return Object.freeze(failures);
+}
+
+function maximumOutcomes(locator: string, limit: number) {
+  return locatorNamespace(locator) === "evm" ? limit : 1;
+}
+
+function networkBinding(value: string): NetworkBindingV2 | null {
+  return NETWORK_BINDINGS_V2.find(({ sourceNetwork }) => sourceNetwork === value)
+    ?? null;
+}
+
+function canonicalLocator(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  if (EVM_ADDRESS_V2.test(value) && value !== ZERO_EVM_ADDRESS_V2) return value;
+  return isCanonicalSolanaAddress(value) ? value : null;
+}
+
+function normalizeExpectedLocator(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  const normalizedEvm = trimmed.toLowerCase();
+  if (
+    EVM_ADDRESS_V2.test(normalizedEvm) &&
+    normalizedEvm !== ZERO_EVM_ADDRESS_V2
+  ) return normalizedEvm;
+  return isCanonicalSolanaAddress(trimmed) ? trimmed : null;
+}
+
+function locatorNamespace(value: string): NamespaceV2 {
+  return value.startsWith("0x") ? "evm" : "solana";
+}
+
+function isCanonicalSolanaAddress(value: string) {
+  if (value.length < 32 || value.length > 44) return false;
+  const littleEndian = [0];
+  for (const character of value) {
+    const alphabetIndex = BASE58_INDEX_V2.get(character);
+    if (alphabetIndex === undefined) return false;
+    let carry = alphabetIndex;
+    for (let index = 0; index < littleEndian.length; index += 1) {
+      carry += littleEndian[index]! * 58;
+      littleEndian[index] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      littleEndian.push(carry & 0xff);
+      carry >>= 8;
+    }
+    if (littleEndian.length > 32) return false;
+  }
+  let leadingZeroes = 0;
+  while (leadingZeroes < value.length && value[leadingZeroes] === "1") {
+    leadingZeroes += 1;
+  }
+  const significantBytes = littleEndian.length === 1 && littleEndian[0] === 0
+    ? 0
+    : littleEndian.length;
+  return significantBytes + leadingZeroes === 32 && significantBytes > 0;
+}
+
+function canonicalInstantMs(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const parsed = Date.parse(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 &&
+      new Date(parsed).toISOString() === value
+    ? parsed
+    : null;
+}
+
+function nullableUsd(
+  value: unknown,
+  allowZero: boolean,
+): number | null | undefined {
+  if (value === null) return null;
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    value > MAX_USD_VALUE_V2 ||
+    (allowZero ? value < 0 : value <= 0)
+  ) return undefined;
+  return value;
+}
+
+function nullableTimestampMs(value: unknown): number | null | undefined {
+  if (value === null) return null;
+  return Number.isSafeInteger(value) && (value as number) >= 0 &&
+      Number.isFinite(new Date(value as number).getTime())
+    ? value as number
+    : undefined;
+}
+
+function nullableBoundedString(value: unknown, maximumLength: number) {
+  return value === null || (
+    typeof value === "string" &&
+    value.length <= maximumLength &&
+    new TextEncoder().encode(value).length <= maximumLength * 4
+  );
+}
+
+function exactRecord(
+  value: unknown,
+  requiredKeys: readonly string[],
+  allowedAdditionalKeys: readonly string[] = [],
+): Record<string, unknown> | null {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    Object.getPrototypeOf(value) !== Object.prototype
+  ) return null;
+  const record = value as Record<string, unknown>;
+  const ownKeys = Reflect.ownKeys(record);
+  if (ownKeys.some((key) => typeof key !== "string")) return null;
+  const allowed = new Set([...requiredKeys, ...allowedAdditionalKeys]);
+  if (
+    requiredKeys.some((key) => !Object.hasOwn(record, key)) ||
+    ownKeys.some((key) => !allowed.has(key as string))
+  ) return null;
+  return record;
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  expectedKeys: readonly string[],
+) {
+  const ownKeys = Reflect.ownKeys(value);
+  return ownKeys.length === expectedKeys.length &&
+    expectedKeys.every((key) => Object.hasOwn(value, key));
+}

--- a/lib/prediction-v2/asset-eligibility-v2.ts
+++ b/lib/prediction-v2/asset-eligibility-v2.ts
@@ -1,0 +1,304 @@
+import type { PredictionTokenProfileV2 } from "./token-profile-v2";
+
+export const PREDICTION_ASSET_DISCOVERY_THRESHOLDS_V2 = Object.freeze({
+  minimumPoolAgeSeconds: 24 * 60 * 60,
+  minimumLiquidityUsd: 50_000,
+  minimumVolume24hUsd: 25_000,
+});
+
+export const PREDICTION_ASSET_DISCOVERY_SCOPE_V2 =
+  "discovery-quality-only" as const;
+
+export const PREDICTION_ASSET_DISCOVERY_REASON_CODES_V2 = Object.freeze([
+  "price-unavailable",
+  "price-not-positive",
+  "pool-age-unavailable",
+  "pool-too-new",
+  "liquidity-unavailable",
+  "liquidity-below-minimum",
+  "volume-24h-unavailable",
+  "volume-24h-below-minimum",
+] as const);
+
+export type PredictionAssetDiscoveryReasonCodeV2 =
+  (typeof PREDICTION_ASSET_DISCOVERY_REASON_CODES_V2)[number];
+
+export type PredictionAssetDiscoveryStatusV2 =
+  | "eligible"
+  | "ineligible"
+  | "unknown";
+
+export type PredictionAssetMarketCapSupplyEvidenceV2 = Readonly<{
+  schemaVersion: 2;
+  kind:
+    | "immutable-circulating-supply"
+    | "fixed-supply-fully-circulating";
+  chainReference: string;
+  tokenAddress: string;
+  supplyBaseUnits: string;
+  decimals: number;
+  immutable: true;
+  /** Authenticated upstream evidence; this display gate validates its binding. */
+  verification: Readonly<{
+    status: "verified";
+    method:
+      | "verified-immutable-circulating-supply"
+      | "verified-fixed-supply-fully-circulating";
+    chainStateReference: string;
+    evidenceDigest: string;
+  }>;
+}>;
+
+export type PredictionAssetDiscoveryEvidenceV2 = Readonly<{
+  /** Already normalized, client-safe token discovery data. */
+  profile: PredictionTokenProfileV2;
+  /** Timestamp at which the price, liquidity and rolling volume were observed. */
+  observedAtMs: number;
+  /** Missing provider data stays unknown; an explicit zero remains a known zero. */
+  volume24hUsd?: number | null;
+  marketCapSupplyEvidence?: PredictionAssetMarketCapSupplyEvidenceV2 | null;
+}>;
+
+export type PredictionAssetMetricAvailabilityReasonCodeV2 =
+  | "price-unavailable"
+  | "price-not-positive"
+  | "market-cap-unavailable"
+  | "market-cap-fixed-supply-required"
+  | "market-cap-supply-evidence-unavailable"
+  | "market-cap-supply-evidence-invalid";
+
+export type PredictionAssetMetricAvailabilityV2 = Readonly<{
+  available: boolean;
+  reasonCodes: readonly PredictionAssetMetricAvailabilityReasonCodeV2[];
+}>;
+
+export type PredictionAssetDiscoveryEligibilityV2 = Readonly<{
+  schemaVersion: 2;
+  scope: typeof PREDICTION_ASSET_DISCOVERY_SCOPE_V2;
+  status: PredictionAssetDiscoveryStatusV2;
+  observedAt: string;
+  reasonCodes: readonly PredictionAssetDiscoveryReasonCodeV2[];
+  thresholds: typeof PREDICTION_ASSET_DISCOVERY_THRESHOLDS_V2;
+  observed: Readonly<{
+    priceUsd: number | null;
+    poolAgeSeconds: number | null;
+    liquidityUsd: number | null;
+    volume24hUsd: number | null;
+  }>;
+  metrics: Readonly<{
+    price: PredictionAssetMetricAvailabilityV2;
+    marketCap: PredictionAssetMetricAvailabilityV2;
+  }>;
+}>;
+
+const KNOWN_INELIGIBILITY_REASONS = new Set<
+  PredictionAssetDiscoveryReasonCodeV2
+>([
+  "price-not-positive",
+  "pool-too-new",
+  "liquidity-below-minimum",
+  "volume-24h-below-minimum",
+]);
+
+const CANONICAL_POSITIVE_INTEGER = /^[1-9][0-9]{0,77}$/u;
+
+/**
+ * Evaluate only the beta discovery-quality gate. This result does not establish
+ * oracle coverage, settlement eligibility, token safety or release availability.
+ */
+export function evaluatePredictionAssetDiscoveryEligibilityV2(
+  evidence: PredictionAssetDiscoveryEvidenceV2,
+): PredictionAssetDiscoveryEligibilityV2 {
+  const observedAtMs = requireObservedAtMs(evidence.observedAtMs);
+  const priceUsd = nonNegativeFiniteNumberOrNull(evidence.profile.priceUsd);
+  const poolAgeSeconds = poolAgeSecondsAt(
+    evidence.profile,
+    observedAtMs,
+  );
+  const liquidityUsd = nonNegativeFiniteNumberOrNull(
+    evidence.profile.liquidityUsd,
+  );
+  const volume24hUsd = nonNegativeFiniteNumberOrNull(evidence.volume24hUsd);
+  const reasonCodes: PredictionAssetDiscoveryReasonCodeV2[] = [];
+
+  if (priceUsd === null) {
+    reasonCodes.push("price-unavailable");
+  } else if (priceUsd === 0) {
+    reasonCodes.push("price-not-positive");
+  }
+
+  if (poolAgeSeconds === null) {
+    reasonCodes.push("pool-age-unavailable");
+  } else if (
+    poolAgeSeconds <
+      PREDICTION_ASSET_DISCOVERY_THRESHOLDS_V2.minimumPoolAgeSeconds
+  ) {
+    reasonCodes.push("pool-too-new");
+  }
+
+  if (liquidityUsd === null) {
+    reasonCodes.push("liquidity-unavailable");
+  } else if (
+    liquidityUsd <
+      PREDICTION_ASSET_DISCOVERY_THRESHOLDS_V2.minimumLiquidityUsd
+  ) {
+    reasonCodes.push("liquidity-below-minimum");
+  }
+
+  if (volume24hUsd === null) {
+    reasonCodes.push("volume-24h-unavailable");
+  } else if (
+    volume24hUsd <
+      PREDICTION_ASSET_DISCOVERY_THRESHOLDS_V2.minimumVolume24hUsd
+  ) {
+    reasonCodes.push("volume-24h-below-minimum");
+  }
+
+  const marketCapReasonCodes = marketCapMetricReasonCodes(
+    evidence.profile,
+    evidence.marketCapSupplyEvidence,
+  );
+  const frozenReasonCodes = Object.freeze(reasonCodes);
+  const frozenMarketCapReasonCodes = Object.freeze(marketCapReasonCodes);
+  const frozenPriceReasonCodes = Object.freeze(
+    priceUsd === null
+      ? ["price-unavailable" as const]
+      : priceUsd === 0
+        ? ["price-not-positive" as const]
+        : [],
+  );
+
+  return Object.freeze({
+    schemaVersion: 2 as const,
+    scope: PREDICTION_ASSET_DISCOVERY_SCOPE_V2,
+    status: discoveryStatus(reasonCodes),
+    observedAt: new Date(observedAtMs).toISOString(),
+    reasonCodes: frozenReasonCodes,
+    thresholds: PREDICTION_ASSET_DISCOVERY_THRESHOLDS_V2,
+    observed: Object.freeze({
+      priceUsd,
+      poolAgeSeconds,
+      liquidityUsd,
+      volume24hUsd,
+    }),
+    metrics: Object.freeze({
+      price: Object.freeze({
+        available: priceUsd !== null && priceUsd > 0,
+        reasonCodes: frozenPriceReasonCodes,
+      }),
+      marketCap: Object.freeze({
+        available: marketCapReasonCodes.length === 0,
+        reasonCodes: frozenMarketCapReasonCodes,
+      }),
+    }),
+  });
+}
+
+function requireObservedAtMs(value: number): number {
+  if (
+    !Number.isSafeInteger(value) ||
+    value < 0 ||
+    !Number.isFinite(new Date(value).getTime())
+  ) {
+    throw new TypeError("observedAtMs must be a non-negative safe integer");
+  }
+  return value;
+}
+
+function positiveFiniteNumberOrNull(value: number | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : null;
+}
+
+function nonNegativeFiniteNumberOrNull(
+  value: number | null | undefined,
+): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : null;
+}
+
+function poolAgeSecondsAt(
+  profile: PredictionTokenProfileV2,
+  observedAtMs: number,
+): number | null {
+  if (!profile.age) return null;
+  const pairCreatedAtMs = Date.parse(profile.age.pairCreatedAt);
+  if (
+    !Number.isSafeInteger(pairCreatedAtMs) ||
+    new Date(pairCreatedAtMs).toISOString() !== profile.age.pairCreatedAt ||
+    pairCreatedAtMs > observedAtMs
+  ) {
+    return null;
+  }
+  return Math.floor((observedAtMs - pairCreatedAtMs) / 1_000);
+}
+
+function discoveryStatus(
+  reasonCodes: readonly PredictionAssetDiscoveryReasonCodeV2[],
+): PredictionAssetDiscoveryStatusV2 {
+  if (reasonCodes.some((code) => KNOWN_INELIGIBILITY_REASONS.has(code))) {
+    return "ineligible";
+  }
+  return reasonCodes.length === 0 ? "eligible" : "unknown";
+}
+
+function marketCapMetricReasonCodes(
+  profile: PredictionTokenProfileV2,
+  evidence: PredictionAssetMarketCapSupplyEvidenceV2 | null | undefined,
+): PredictionAssetMetricAvailabilityReasonCodeV2[] {
+  const reasonCodes: PredictionAssetMetricAvailabilityReasonCodeV2[] = [];
+  if (positiveFiniteNumberOrNull(profile.marketCapUsd) === null) {
+    reasonCodes.push("market-cap-unavailable");
+  }
+  if (evidence === null || evidence === undefined) {
+    reasonCodes.push("market-cap-supply-evidence-unavailable");
+  } else if (!validMarketCapSupplyEvidence(profile, evidence)) {
+    reasonCodes.push("market-cap-supply-evidence-invalid");
+  } else if (evidence.kind !== "fixed-supply-fully-circulating") {
+    reasonCodes.push("market-cap-fixed-supply-required");
+  }
+  return reasonCodes;
+}
+
+function validMarketCapSupplyEvidence(
+  profile: PredictionTokenProfileV2,
+  evidence: unknown,
+): boolean {
+  if (!isRecord(evidence)) return false;
+  const verification = isRecord(evidence.verification)
+    ? evidence.verification
+    : null;
+  const expectedVerificationMethod = evidence.kind ===
+      "immutable-circulating-supply"
+    ? "verified-immutable-circulating-supply"
+    : "verified-fixed-supply-fully-circulating";
+  return evidence.schemaVersion === 2 &&
+    (evidence.kind === "immutable-circulating-supply" ||
+      evidence.kind === "fixed-supply-fully-circulating") &&
+    evidence.chainReference === profile.chain.reference &&
+    evidence.tokenAddress === profile.address &&
+    evidence.immutable === true &&
+    typeof evidence.supplyBaseUnits === "string" &&
+    CANONICAL_POSITIVE_INTEGER.test(evidence.supplyBaseUnits) &&
+    Number.isSafeInteger(evidence.decimals) &&
+    typeof evidence.decimals === "number" &&
+    evidence.decimals >= 0 &&
+    evidence.decimals <= 255 &&
+    verification?.status === "verified" &&
+    verification.method === expectedVerificationMethod &&
+    canonicalChainStateReference(verification.chainStateReference) &&
+    typeof verification.evidenceDigest === "string" &&
+    /^0x[0-9a-f]{64}$/u.test(verification.evidenceDigest) &&
+    !/^0x0{64}$/u.test(verification.evidenceDigest);
+}
+
+function canonicalChainStateReference(value: unknown): value is string {
+  return typeof value === "string" &&
+    /^(?:0|[1-9][0-9]{0,19}|0x[0-9a-f]{64})$/u.test(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/lib/prediction-v2/asset-logo-v2.ts
+++ b/lib/prediction-v2/asset-logo-v2.ts
@@ -1,0 +1,75 @@
+const DEXSCREENER_IMAGE_HOST_V2 = "cdn.dexscreener.com";
+const DEXSCREENER_IMAGE_PATH_V2 = /^\/cms\/images\/([0-9a-f]{64})$/u;
+
+const PREDICTION_ASSET_FALLBACKS_V2 = Object.freeze([
+  "/brand/programmable-token-fallback-01-dawn.webp",
+  "/brand/programmable-token-fallback-02-moon.webp",
+  "/brand/programmable-token-fallback-03-sun.webp",
+  "/brand/programmable-token-fallback-04-mint.webp",
+  "/brand/programmable-token-fallback-05-lavender.webp",
+  "/brand/programmable-token-fallback-06-dusk.webp",
+] as const);
+
+export type PredictionAssetCardImageV2 = Readonly<{
+  source: string;
+  usesProviderLogo: boolean;
+}>;
+
+/**
+ * Reduce a DEX Screener image URL to its immutable CDN asset identifier. The
+ * browser never receives or loads the provider URL directly; the internal
+ * image route reconstructs one fixed upstream origin from this identifier.
+ */
+export function predictionDexscreenerLogoAssetIdV2(
+  value: string | null | undefined,
+): string | null {
+  if (!value) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.hostname !== DEXSCREENER_IMAGE_HOST_V2 ||
+    parsed.port !== "" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.hash !== ""
+  ) return null;
+  return DEXSCREENER_IMAGE_PATH_V2.exec(parsed.pathname)?.[1] ?? null;
+}
+
+export function predictionAssetFallbackImageV2(
+  chainId: string,
+  address: string,
+) {
+  // FNV-1a is deliberately used only for stable visual distribution. It is
+  // not an identity or integrity digest.
+  let hash = 0x811c9dc5;
+  for (const character of `${chainId}:${address}`.toLowerCase()) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return PREDICTION_ASSET_FALLBACKS_V2[
+    hash % PREDICTION_ASSET_FALLBACKS_V2.length
+  ];
+}
+
+export function predictionAssetCardImageV2(input: Readonly<{
+  chainId: string;
+  address: string;
+  logoUrl?: string | null;
+}>): PredictionAssetCardImageV2 {
+  const assetId = predictionDexscreenerLogoAssetIdV2(input.logoUrl);
+  return assetId
+    ? Object.freeze({
+      source: `/api/prediction/asset-logo/${assetId}`,
+      usesProviderLogo: true,
+    })
+    : Object.freeze({
+      source: predictionAssetFallbackImageV2(input.chainId, input.address),
+      usesProviderLogo: false,
+    });
+}

--- a/lib/prediction-v2/create-flow-v2.ts
+++ b/lib/prediction-v2/create-flow-v2.ts
@@ -1,0 +1,1074 @@
+/**
+ * Pure, JSON-safe data model for the progressive Prediction V2 create flow.
+ *
+ * This module deliberately models neither asset discovery nor settlement
+ * eligibility. Discovery supplies an exact chain + token-address identity;
+ * the released Registry/Oracle path must independently decide whether that
+ * identity can be used to create a live market.
+ */
+
+export const PREDICTION_V2_CREATE_STEPS = Object.freeze([
+  "address",
+  "asset",
+  "prediction",
+  "review",
+] as const);
+
+export type PredictionV2CreateStep =
+  (typeof PREDICTION_V2_CREATE_STEPS)[number];
+
+export const PREDICTION_V2_CREATE_SOURCE_NETWORKS = Object.freeze([
+  { id: "ethereum", label: "Ethereum", namespace: "evm", chainReference: "1" },
+  { id: "base", label: "Base", namespace: "evm", chainReference: "8453" },
+  { id: "bnb", label: "BNB Chain", namespace: "evm", chainReference: "56" },
+  {
+    id: "robinhood",
+    label: "Robinhood Chain",
+    namespace: "evm",
+    chainReference: "4663",
+  },
+  {
+    id: "solana",
+    label: "Solana",
+    namespace: "solana",
+    chainReference: "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+  },
+] as const);
+
+export type PredictionV2CreateSourceNetwork =
+  (typeof PREDICTION_V2_CREATE_SOURCE_NETWORKS)[number]["id"];
+
+export const PREDICTION_V2_CREATE_METRICS = Object.freeze([
+  { id: "price", label: "Price" },
+  { id: "market-cap", label: "Market cap" },
+] as const);
+
+export type PredictionV2CreateMetric =
+  (typeof PREDICTION_V2_CREATE_METRICS)[number]["id"];
+
+export const PREDICTION_V2_CREATE_TEMPLATES = Object.freeze([
+  { id: "target", label: "Target", enabled: true },
+  { id: "percent-change", label: "Percentage change", enabled: true },
+  {
+    id: "reach",
+    label: "Reach before deadline",
+    enabled: false,
+    reason: "Requires an independently released continuous-observation policy.",
+  },
+] as const);
+
+export type PredictionV2CreateTemplate =
+  (typeof PREDICTION_V2_CREATE_TEMPLATES)[number]["id"];
+export type PredictionV2EnabledCreateTemplate = Exclude<
+  PredictionV2CreateTemplate,
+  "reach"
+>;
+
+export const PREDICTION_V2_CREATE_COMPARATOR =
+  "greater-than-or-equal" as const;
+export const PREDICTION_V2_CREATE_QUOTE_CURRENCY = "USD" as const;
+export const PREDICTION_V2_CREATE_TIMEZONE = "UTC" as const;
+export const PREDICTION_V2_CREATE_SETTLEMENT_ELIGIBILITY =
+  "not-evaluated" as const;
+export const PREDICTION_V2_PROTOCOL_PRICE_DECIMALS = 8 as const;
+export const PREDICTION_V2_VERIFIED_SNAPSHOT_STATUS = "verified" as const;
+export const PREDICTION_V2_SETTLEMENT_CHAIN_ID = "4663" as const;
+export const PREDICTION_V2_MINIMUM_MARKET_DURATION_SECONDS = 24n * 60n * 60n;
+export const PREDICTION_V2_MAXIMUM_MARKET_DURATION_SECONDS =
+  30n * 24n * 60n * 60n;
+
+export type PredictionV2DetectedAssetIdentity = Readonly<{
+  sourceNetwork: PredictionV2CreateSourceNetwork;
+  /** Lowercase 20-byte address on EVM networks; canonical base58 on Solana. */
+  address: string;
+}>;
+
+/**
+ * Immutable, provider-authenticated point in source-chain state used when the
+ * creator builds the draft. It is evidence for the review, not a claim that
+ * the current onchain economic key commits to this object.
+ */
+export type PredictionV2CreationReferenceSnapshot = Readonly<{
+  settlementChainId: typeof PREDICTION_V2_SETTLEMENT_CHAIN_ID;
+  capturedAtUtc: string;
+  snapshotReference: string;
+  evidenceDigest: string;
+  verificationStatus: typeof PREDICTION_V2_VERIFIED_SNAPSHOT_STATUS;
+}>;
+
+/**
+ * A supply observation bound to an immutable external snapshot reference.
+ * Integer values stay decimal strings so the object remains JSON/UI safe.
+ */
+export type PredictionV2ReferenceSupplySnapshot = Readonly<{
+  sourceNetwork: PredictionV2CreateSourceNetwork;
+  address: string;
+  /** Verified supply that cannot mint, burn, rebase or otherwise change. */
+  fixedSupplyAtoms: string;
+  tokenDecimals: number;
+  capturedAtUtc: string;
+  snapshotReference: string;
+  evidenceDigest: string;
+  verificationStatus: typeof PREDICTION_V2_VERIFIED_SNAPSHOT_STATUS;
+  supplyDefinition: "fixed-supply-fully-circulating";
+}>;
+
+/**
+ * Verified source-asset metric baseline cross-attested to the exact settlement
+ * creation time. Its source reference remains distinct from the settlement
+ * chain reference.
+ */
+export type PredictionV2ReferenceMetricSnapshot = Readonly<{
+  metric: PredictionV2CreateMetric;
+  valueUsd: string;
+  sourceNetwork: PredictionV2CreateSourceNetwork;
+  address: string;
+  capturedAtUtc: string;
+  snapshotReference: string;
+  evidenceDigest: string;
+  verificationStatus: typeof PREDICTION_V2_VERIFIED_SNAPSHOT_STATUS;
+}>;
+
+export type PredictionV2DetectedAsset = Readonly<{
+  identity: PredictionV2DetectedAssetIdentity;
+  name: string;
+  symbol: string;
+  referenceSupplySnapshot: PredictionV2ReferenceSupplySnapshot | null;
+}>;
+
+type PredictionV2CreatePredictionBase = Readonly<{
+  metric: PredictionV2CreateMetric;
+  observationUtc: string;
+  /** Exact immutable reference point that must precede the result deadline. */
+  creationSnapshot: PredictionV2CreationReferenceSnapshot;
+  /** Current Prediction V2 contracts settle normalized USD prices at 1e8. */
+  priceDecimals: typeof PREDICTION_V2_PROTOCOL_PRICE_DECIMALS;
+}>;
+
+export type PredictionV2TargetPrediction =
+  PredictionV2CreatePredictionBase & Readonly<{
+    template: "target";
+    targetUsd: string;
+  }>;
+
+export type PredictionV2PercentChangePrediction =
+  PredictionV2CreatePredictionBase & Readonly<{
+    template: "percent-change";
+    percentChange: string;
+    /** Identity-bound, verified baseline; raw discovery numbers are not valid. */
+    referenceMetricSnapshot: PredictionV2ReferenceMetricSnapshot;
+  }>;
+
+export type PredictionV2ReachPrediction =
+  PredictionV2CreatePredictionBase & Readonly<{
+    template: "reach";
+    targetUsd: string;
+  }>;
+
+export type PredictionV2CreatePrediction =
+  | PredictionV2TargetPrediction
+  | PredictionV2PercentChangePrediction
+  | PredictionV2ReachPrediction;
+
+export type PredictionV2CreateFlowState =
+  | Readonly<{
+    schemaVersion: 2;
+    step: "address";
+    addressInput: string;
+  }>
+  | Readonly<{
+    schemaVersion: 2;
+    step: "asset";
+    addressInput: string;
+    asset: PredictionV2DetectedAsset;
+  }>
+  | Readonly<{
+    schemaVersion: 2;
+    step: "prediction";
+    addressInput: string;
+    asset: PredictionV2DetectedAsset;
+    prediction: PredictionV2CreatePrediction | null;
+  }>
+  | Readonly<{
+    schemaVersion: 2;
+    step: "review";
+    addressInput: string;
+    asset: PredictionV2DetectedAsset;
+    prediction: PredictionV2TargetPrediction | PredictionV2PercentChangePrediction;
+    review: PredictionV2CreateReview;
+  }>;
+
+export type PredictionV2CreateReview = Readonly<{
+  schemaVersion: 2;
+  asset: PredictionV2DetectedAssetIdentity;
+  assetName: string;
+  assetSymbol: string;
+  selectedMetric: PredictionV2CreateMetric;
+  template: PredictionV2EnabledCreateTemplate;
+  metricTargetUsd: string;
+  inputTargetUsd: string | null;
+  percentChange: string | null;
+  referenceMetricUsd: string | null;
+  creationSnapshot: PredictionV2CreationReferenceSnapshot;
+  referenceMetricSnapshot: PredictionV2ReferenceMetricSnapshot | null;
+  referenceSupplySnapshot: PredictionV2ReferenceSupplySnapshot | null;
+  protocolPredicate: Readonly<{
+    metric: "usd-price";
+    comparator: typeof PREDICTION_V2_CREATE_COMPARATOR;
+    quoteCurrency: typeof PREDICTION_V2_CREATE_QUOTE_CURRENCY;
+    strikeUsd: string;
+    strikeAtoms: string;
+    priceDecimals: typeof PREDICTION_V2_PROTOCOL_PRICE_DECIMALS;
+    observationUtc: string;
+    observationUnixSeconds: string;
+    timezone: typeof PREDICTION_V2_CREATE_TIMEZONE;
+    /**
+     * Immutable review evidence used to derive the absolute predicate. The
+     * canonical onchain predicate remains the USD strike and result time above.
+     */
+    evidenceBinding: Readonly<{
+      creationSnapshot: PredictionV2CreationReferenceSnapshot;
+      referenceMetricSnapshot: PredictionV2ReferenceMetricSnapshot | null;
+      referenceSupplySnapshot: PredictionV2ReferenceSupplySnapshot | null;
+    }>;
+  }>;
+  /** This pure create model never asserts Registry/Oracle release readiness. */
+  settlementEligibility: typeof PREDICTION_V2_CREATE_SETTLEMENT_ELIGIBILITY;
+}>;
+
+export type PredictionV2CreateValidationErrors = Readonly<{
+  asset?: string;
+  metric?: string;
+  template?: string;
+  targetUsd?: string;
+  percentChange?: string;
+  referenceMetricSnapshot?: string;
+  creationSnapshot?: string;
+  referenceSupplySnapshot?: string;
+  observationUtc?: string;
+  priceDecimals?: string;
+  precision?: string;
+  protocolPredicate?: string;
+}>;
+
+export type PredictionV2CreateReviewResult =
+  | Readonly<{ ok: true; review: PredictionV2CreateReview }>
+  | Readonly<{ ok: false; errors: PredictionV2CreateValidationErrors }>;
+
+type ParsedDecimal = Readonly<{
+  coefficient: bigint;
+  scale: number;
+}>;
+
+const EVM_NETWORKS = new Set<PredictionV2CreateSourceNetwork>([
+  "ethereum",
+  "base",
+  "bnb",
+  "robinhood",
+]);
+const SUPPORTED_NETWORKS = new Set<PredictionV2CreateSourceNetwork>(
+  PREDICTION_V2_CREATE_SOURCE_NETWORKS.map(({ id }) => id),
+);
+const EVM_ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/u;
+const SOLANA_BASE58_PATTERN = /^[1-9A-HJ-NP-Za-km-z]+$/u;
+const SOLANA_BASE58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const UNSIGNED_DECIMAL_PATTERN = /^(?:0|[1-9]\d*)(?:\.(\d+))?$/u;
+const SIGNED_DECIMAL_PATTERN = /^(-?)(?:0|[1-9]\d*)(?:\.(\d+))?$/u;
+const EXACT_UTC_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})Z$/u;
+const CANONICAL_POSITIVE_INTEGER_PATTERN = /^[1-9]\d*$/u;
+const MAX_DECIMAL_TEXT_LENGTH = 96;
+const MAX_DECIMAL_SCALE = 36;
+const MAX_TOKEN_DECIMALS = 255;
+const MAX_UINT32 = (1n << 32n) - 1n;
+const MAX_UINT64 = (1n << 64n) - 1n;
+const MAX_UINT256 = (1n << 256n) - 1n;
+const MAX_PROTOCOL_THRESHOLD = (1n << 191n) - 1n;
+const CANONICAL_CHAIN_POSITION_PATTERN = /^(?:0|[1-9]\d{0,19})$/u;
+const CANONICAL_EVIDENCE_DIGEST_PATTERN = /^0x[0-9a-f]{64}$/u;
+const ZERO_EVIDENCE_DIGEST = `0x${"0".repeat(64)}`;
+
+const EVM_CHAIN_REFERENCE_BY_NETWORK = Object.freeze({
+  ethereum: "1",
+  base: "8453",
+  bnb: "56",
+  robinhood: "4663",
+} as const satisfies Readonly<Record<
+  Exclude<PredictionV2CreateSourceNetwork, "solana">,
+  string
+>>);
+
+function powerOfTen(exponent: number) {
+  if (!Number.isInteger(exponent) || exponent < 0 || exponent > 512) {
+    throw new RangeError("Unsupported decimal scale");
+  }
+  return 10n ** BigInt(exponent);
+}
+
+function normalizeDecimal(coefficient: bigint, scale: number): ParsedDecimal {
+  let normalizedCoefficient = coefficient;
+  let normalizedScale = scale;
+  while (normalizedScale > 0 && normalizedCoefficient % 10n === 0n) {
+    normalizedCoefficient /= 10n;
+    normalizedScale -= 1;
+  }
+  return { coefficient: normalizedCoefficient, scale: normalizedScale };
+}
+
+function parseUnsignedDecimal(value: unknown): ParsedDecimal | null {
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  if (text.length === 0 || text.length > MAX_DECIMAL_TEXT_LENGTH) return null;
+  const match = UNSIGNED_DECIMAL_PATTERN.exec(text);
+  if (!match) return null;
+  const fractionLength = match[1]?.length ?? 0;
+  if (fractionLength > MAX_DECIMAL_SCALE) return null;
+  const coefficient = BigInt(text.replace(".", ""));
+  return normalizeDecimal(coefficient, fractionLength);
+}
+
+function parseSignedDecimal(value: unknown): ParsedDecimal | null {
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  if (text.length === 0 || text.length > MAX_DECIMAL_TEXT_LENGTH) return null;
+  const match = SIGNED_DECIMAL_PATTERN.exec(text);
+  if (!match) return null;
+  const fractionLength = match[2]?.length ?? 0;
+  if (fractionLength > MAX_DECIMAL_SCALE) return null;
+  const unsignedText = text.replace(/^-|\./gu, "");
+  const unsignedCoefficient = BigInt(unsignedText);
+  const coefficient = match[1] === "-" ? -unsignedCoefficient : unsignedCoefficient;
+  return normalizeDecimal(coefficient, fractionLength);
+}
+
+function formatDecimal(value: ParsedDecimal) {
+  const normalized = normalizeDecimal(value.coefficient, value.scale);
+  const negative = normalized.coefficient < 0n;
+  const digits = (negative ? -normalized.coefficient : normalized.coefficient)
+    .toString();
+  if (normalized.scale === 0) return `${negative ? "-" : ""}${digits}`;
+  const padded = digits.padStart(normalized.scale + 1, "0");
+  const split = padded.length - normalized.scale;
+  return `${negative ? "-" : ""}${padded.slice(0, split)}.${padded.slice(split)}`;
+}
+
+function decimalToAtomsExact(value: ParsedDecimal, decimals: number) {
+  if (value.coefficient < 0n) return null;
+  if (value.scale <= decimals) {
+    return value.coefficient * powerOfTen(decimals - value.scale);
+  }
+  const divisor = powerOfTen(value.scale - decimals);
+  return value.coefficient % divisor === 0n
+    ? value.coefficient / divisor
+    : null;
+}
+
+function atomsToDecimal(atoms: bigint, decimals: number) {
+  return formatDecimal({ coefficient: atoms, scale: decimals });
+}
+
+function decodeBase58Bytes(value: string): Uint8Array | null {
+  if (!value || !SOLANA_BASE58_PATTERN.test(value)) return null;
+  const littleEndian = [0];
+  for (const character of value) {
+    const alphabetIndex = SOLANA_BASE58_ALPHABET.indexOf(character);
+    if (alphabetIndex < 0) return null;
+    let carry = alphabetIndex;
+    for (let index = 0; index < littleEndian.length; index += 1) {
+      carry += littleEndian[index] * 58;
+      littleEndian[index] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      littleEndian.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+
+  let leadingZeroCount = 0;
+  while (leadingZeroCount < value.length && value[leadingZeroCount] === "1") {
+    leadingZeroCount += 1;
+  }
+  const decodedLength = littleEndian.length + leadingZeroCount -
+    (littleEndian.length === 1 && littleEndian[0] === 0 ? 1 : 0);
+  const decoded = new Uint8Array(decodedLength);
+  for (let index = 0; index < littleEndian.length; index += 1) {
+    const target = decoded.length - 1 - index;
+    if (target >= leadingZeroCount) decoded[target] = littleEndian[index];
+  }
+  return decoded;
+}
+
+function isSupportedNetwork(
+  value: unknown,
+): value is PredictionV2CreateSourceNetwork {
+  return typeof value === "string" &&
+    SUPPORTED_NETWORKS.has(value as PredictionV2CreateSourceNetwork);
+}
+
+export function normalizePredictionV2DetectedAssetIdentity(
+  value: unknown,
+): PredictionV2DetectedAssetIdentity | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const candidate = value as Record<string, unknown>;
+  if (!isSupportedNetwork(candidate.sourceNetwork) ||
+    typeof candidate.address !== "string") return null;
+  const address = candidate.address.trim();
+  if (EVM_NETWORKS.has(candidate.sourceNetwork)) {
+    if (!EVM_ADDRESS_PATTERN.test(address) || /^0x0{40}$/iu.test(address)) {
+      return null;
+    }
+    return { sourceNetwork: candidate.sourceNetwork, address: address.toLowerCase() };
+  }
+  const decoded = decodeBase58Bytes(address);
+  return decoded?.length === 32 && decoded.some((byte) => byte !== 0)
+    ? { sourceNetwork: "solana", address }
+    : null;
+}
+
+function canonicalSnapshotReferenceForIdentity(
+  identity: PredictionV2DetectedAssetIdentity,
+  value: unknown,
+) {
+  if (typeof value !== "string" || value !== value.trim()) return null;
+  const separatorIndex = value.lastIndexOf(":");
+  if (separatorIndex < 0) return null;
+  const position = value.slice(separatorIndex + 1);
+  if (!CANONICAL_CHAIN_POSITION_PATTERN.test(position) ||
+    BigInt(position) > MAX_UINT64) return null;
+  const expectedPrefix = identity.sourceNetwork === "solana"
+    ? "solana:slot:"
+    : `eip155:${EVM_CHAIN_REFERENCE_BY_NETWORK[identity.sourceNetwork]}:block:`;
+  return value === `${expectedPrefix}${position}` ? value : null;
+}
+
+function canonicalSettlementSnapshotReference(value: unknown) {
+  if (typeof value !== "string" || value !== value.trim()) return null;
+  const prefix = `eip155:${PREDICTION_V2_SETTLEMENT_CHAIN_ID}:block:`;
+  if (!value.startsWith(prefix)) return null;
+  const position = value.slice(prefix.length);
+  return CANONICAL_CHAIN_POSITION_PATTERN.test(position) &&
+      BigInt(position) <= MAX_UINT64
+    ? value
+    : null;
+}
+
+function canonicalEvidenceDigest(value: unknown) {
+  return typeof value === "string" &&
+      CANONICAL_EVIDENCE_DIGEST_PATTERN.test(value) &&
+      value !== ZERO_EVIDENCE_DIGEST
+    ? value
+    : null;
+}
+
+function normalizedSnapshotIdentity(
+  sourceNetwork: unknown,
+  address: unknown,
+  expectedIdentity: PredictionV2DetectedAssetIdentity | null = null,
+) {
+  const identity = normalizePredictionV2DetectedAssetIdentity({
+    sourceNetwork,
+    address,
+  });
+  if (!identity || address !== identity.address) return null;
+  if (expectedIdentity && (
+    identity.sourceNetwork !== expectedIdentity.sourceNetwork ||
+    identity.address !== expectedIdentity.address
+  )) return null;
+  return identity;
+}
+
+/** Parse an exact `YYYY-MM-DDTHH:mm:ssZ` UTC value into JSON-safe Unix seconds. */
+export function predictionV2ExactUtcToUnixSeconds(
+  value: unknown,
+): string | null {
+  if (typeof value !== "string") return null;
+  const match = EXACT_UTC_PATTERN.exec(value);
+  if (!match) return null;
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  if (year < 1970) return null;
+  const milliseconds = Date.UTC(year, month - 1, day, hour, minute, second, 0);
+  if (!Number.isFinite(milliseconds)) return null;
+  const parsed = new Date(milliseconds);
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day ||
+    parsed.getUTCHours() !== hour ||
+    parsed.getUTCMinutes() !== minute ||
+    parsed.getUTCSeconds() !== second
+  ) return null;
+  const unixSeconds = BigInt(milliseconds / 1_000);
+  return unixSeconds <= MAX_UINT32 ? unixSeconds.toString() : null;
+}
+
+/** Exact decimal-to-atoms helper. It never uses Number for protocol values. */
+export function parsePredictionV2DecimalAtoms(
+  value: string,
+  decimals: number,
+): bigint | null {
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > MAX_TOKEN_DECIMALS) {
+    return null;
+  }
+  const parsed = parseUnsignedDecimal(value);
+  return parsed ? decimalToAtomsExact(parsed, decimals) : null;
+}
+
+export function formatPredictionV2DecimalAtoms(
+  atoms: bigint,
+  decimals: number,
+) {
+  if (atoms < 0n || !Number.isInteger(decimals) ||
+    decimals < 0 || decimals > MAX_TOKEN_DECIMALS) {
+    throw new TypeError("Invalid decimal atoms");
+  }
+  return atomsToDecimal(atoms, decimals);
+}
+
+type PriceStrikeDerivation =
+  | Readonly<{
+    ok: true;
+    strikeAtoms: string;
+    strikeUsd: string;
+  }>
+  | Readonly<{
+    ok: false;
+    reason: "invalid" | "precision" | "unsupported";
+  }>;
+
+function deriveExactMarketCapPriceStrike(
+  target: ParsedDecimal,
+  supplySnapshot: PredictionV2ReferenceSupplySnapshot,
+  priceDecimals: number,
+): PriceStrikeDerivation {
+  const snapshotIdentity = normalizedSnapshotIdentity(
+    supplySnapshot?.sourceNetwork,
+    supplySnapshot?.address,
+  );
+  if (
+    target.coefficient <= 0n ||
+    priceDecimals !== PREDICTION_V2_PROTOCOL_PRICE_DECIMALS ||
+    !snapshotIdentity ||
+    supplySnapshot.supplyDefinition !== "fixed-supply-fully-circulating" ||
+    supplySnapshot.verificationStatus !== PREDICTION_V2_VERIFIED_SNAPSHOT_STATUS ||
+    !canonicalSnapshotReferenceForIdentity(
+      snapshotIdentity,
+      supplySnapshot.snapshotReference,
+    ) ||
+    !canonicalEvidenceDigest(supplySnapshot.evidenceDigest) ||
+    !predictionV2ExactUtcToUnixSeconds(supplySnapshot.capturedAtUtc) ||
+    typeof supplySnapshot.fixedSupplyAtoms !== "string" ||
+    !CANONICAL_POSITIVE_INTEGER_PATTERN.test(
+      supplySnapshot.fixedSupplyAtoms,
+    )
+  ) {
+    return { ok: false, reason: "invalid" };
+  }
+  const fixedSupplyAtoms = BigInt(
+    supplySnapshot.fixedSupplyAtoms,
+  );
+  if (fixedSupplyAtoms <= 0n || fixedSupplyAtoms > MAX_UINT256 ||
+    !Number.isInteger(supplySnapshot.tokenDecimals) ||
+    supplySnapshot.tokenDecimals < 0 ||
+    supplySnapshot.tokenDecimals > MAX_TOKEN_DECIMALS) {
+    return { ok: false, reason: "invalid" };
+  }
+
+  const numerator = target.coefficient * powerOfTen(
+    supplySnapshot.tokenDecimals + priceDecimals,
+  );
+  const denominator = powerOfTen(target.scale) * fixedSupplyAtoms;
+  if (numerator % denominator !== 0n) {
+    return { ok: false, reason: "precision" };
+  }
+  const strikeAtoms = numerator / denominator;
+  if (strikeAtoms <= 0n || strikeAtoms > MAX_PROTOCOL_THRESHOLD) {
+    return { ok: false, reason: "unsupported" };
+  }
+  return {
+    ok: true,
+    strikeAtoms: strikeAtoms.toString(),
+    strikeUsd: atomsToDecimal(strikeAtoms, priceDecimals),
+  };
+}
+
+/**
+ * Converts a USD market-cap threshold only when its frozen-supply price is
+ * exactly representable by the current 8-decimal protocol predicate. Mutable
+ * circulating-supply snapshots are deliberately unsupported.
+ */
+export function predictionV2MarketCapTargetToPriceStrike(
+  targetMarketCapUsd: string,
+  supplySnapshot: PredictionV2ReferenceSupplySnapshot,
+  priceDecimals: number,
+): Readonly<{ strikeAtoms: string; strikeUsd: string }> | null {
+  const target = parseUnsignedDecimal(targetMarketCapUsd);
+  if (!target) return null;
+  const result = deriveExactMarketCapPriceStrike(
+    target,
+    supplySnapshot,
+    priceDecimals,
+  );
+  return result.ok
+    ? { strikeAtoms: result.strikeAtoms, strikeUsd: result.strikeUsd }
+    : null;
+}
+
+function percentageTarget(
+  reference: ParsedDecimal,
+  percent: ParsedDecimal,
+): Readonly<{ target: ParsedDecimal; normalizedPercent: string }> | null {
+  if (reference.coefficient <= 0n || percent.coefficient <= 0n) return null;
+  const percentScale = powerOfTen(percent.scale);
+  const multiplier = 100n * percentScale + percent.coefficient;
+  return {
+    target: normalizeDecimal(
+      reference.coefficient * multiplier,
+      reference.scale + percent.scale + 2,
+    ),
+    normalizedPercent: formatDecimal(percent),
+  };
+}
+
+function validateDetectedAsset(
+  asset: PredictionV2DetectedAsset,
+): Readonly<{
+  asset: PredictionV2DetectedAsset | null;
+  error?: string;
+}> {
+  const identity = normalizePredictionV2DetectedAssetIdentity(asset?.identity);
+  const name = typeof asset?.name === "string" ? asset.name.trim() : "";
+  const symbol = typeof asset?.symbol === "string" ? asset.symbol.trim() : "";
+  if (!identity || !name || name.length > 160 || !symbol || symbol.length > 32) {
+    return { asset: null, error: "Use a valid detected token identity." };
+  }
+  return {
+    asset: {
+      identity,
+      name,
+      symbol,
+      referenceSupplySnapshot: asset.referenceSupplySnapshot ?? null,
+    },
+  };
+}
+
+type NormalizedEvidenceSnapshotBase = Readonly<{
+  identity: PredictionV2DetectedAssetIdentity;
+  capturedAtUtc: string;
+  capturedUnixSeconds: string;
+  snapshotReference: string;
+  evidenceDigest: string;
+}>;
+
+function normalizeEvidenceSnapshotBase(
+  snapshot: unknown,
+  expectedIdentity: PredictionV2DetectedAssetIdentity,
+): NormalizedEvidenceSnapshotBase | null {
+  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) {
+    return null;
+  }
+  const candidate = snapshot as Record<string, unknown>;
+  const identity = normalizedSnapshotIdentity(
+    candidate.sourceNetwork,
+    candidate.address,
+    expectedIdentity,
+  );
+  if (!identity ||
+    candidate.verificationStatus !== PREDICTION_V2_VERIFIED_SNAPSHOT_STATUS) {
+    return null;
+  }
+  const capturedUnixSeconds = predictionV2ExactUtcToUnixSeconds(
+    candidate.capturedAtUtc,
+  );
+  const snapshotReference = canonicalSnapshotReferenceForIdentity(
+    identity,
+    candidate.snapshotReference,
+  );
+  const evidenceDigest = canonicalEvidenceDigest(candidate.evidenceDigest);
+  if (!capturedUnixSeconds || typeof candidate.capturedAtUtc !== "string" ||
+    !snapshotReference || !evidenceDigest) return null;
+  return {
+    identity,
+    capturedAtUtc: candidate.capturedAtUtc,
+    capturedUnixSeconds,
+    snapshotReference,
+    evidenceDigest,
+  };
+}
+
+function validateCreationSnapshot(
+  snapshot: PredictionV2CreationReferenceSnapshot,
+): Readonly<{
+  snapshot: PredictionV2CreationReferenceSnapshot | null;
+  capturedUnixSeconds: string | null;
+  error?: string;
+}> {
+  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) {
+    return {
+      snapshot: null,
+      capturedUnixSeconds: null,
+      error: "Use a verified immutable Robinhood Chain creation snapshot.",
+    };
+  }
+  const candidate = snapshot as Record<string, unknown>;
+  const capturedUnixSeconds = predictionV2ExactUtcToUnixSeconds(
+    candidate.capturedAtUtc,
+  );
+  const snapshotReference = canonicalSettlementSnapshotReference(
+    candidate.snapshotReference,
+  );
+  const evidenceDigest = canonicalEvidenceDigest(candidate.evidenceDigest);
+  if (candidate.settlementChainId !== PREDICTION_V2_SETTLEMENT_CHAIN_ID ||
+    candidate.verificationStatus !== PREDICTION_V2_VERIFIED_SNAPSHOT_STATUS ||
+    !capturedUnixSeconds || typeof candidate.capturedAtUtc !== "string" ||
+    !snapshotReference || !evidenceDigest) {
+    return {
+      snapshot: null,
+      capturedUnixSeconds: null,
+      error: "Use a verified immutable Robinhood Chain creation snapshot.",
+    };
+  }
+  return {
+    snapshot: {
+      settlementChainId: PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+      capturedAtUtc: candidate.capturedAtUtc,
+      snapshotReference,
+      evidenceDigest,
+      verificationStatus: PREDICTION_V2_VERIFIED_SNAPSHOT_STATUS,
+    },
+    capturedUnixSeconds,
+  };
+}
+
+function validateReferenceMetricSnapshot(
+  snapshot: PredictionV2ReferenceMetricSnapshot,
+  expectedIdentity: PredictionV2DetectedAssetIdentity,
+  expectedMetric: PredictionV2CreateMetric,
+  creationSnapshot: PredictionV2CreationReferenceSnapshot | null,
+): Readonly<{
+  snapshot: PredictionV2ReferenceMetricSnapshot | null;
+  value: ParsedDecimal | null;
+  error?: string;
+}> {
+  const base = normalizeEvidenceSnapshotBase(snapshot, expectedIdentity);
+  const value = parseUnsignedDecimal(snapshot?.valueUsd);
+  // Exact timestamp equality is the V2 cross-attestation rule. Source and
+  // settlement references intentionally remain different and are both kept.
+  if (!base || snapshot?.metric !== expectedMetric || !value ||
+    value.coefficient <= 0n || !creationSnapshot ||
+    base.capturedAtUtc !== creationSnapshot.capturedAtUtc) {
+    return {
+      snapshot: null,
+      value: null,
+      error:
+        "Percentage change requires a verified metric baseline from the exact creation snapshot.",
+    };
+  }
+  return {
+    snapshot: {
+      metric: expectedMetric,
+      valueUsd: formatDecimal(value),
+      sourceNetwork: base.identity.sourceNetwork,
+      address: base.identity.address,
+      capturedAtUtc: base.capturedAtUtc,
+      snapshotReference: base.snapshotReference,
+      evidenceDigest: base.evidenceDigest,
+      verificationStatus: PREDICTION_V2_VERIFIED_SNAPSHOT_STATUS,
+    },
+    value,
+  };
+}
+
+function validateSupplySnapshot(
+  snapshot: PredictionV2ReferenceSupplySnapshot | null,
+  expectedIdentity: PredictionV2DetectedAssetIdentity,
+  creationSnapshot: PredictionV2CreationReferenceSnapshot | null,
+): Readonly<{
+  snapshot: PredictionV2ReferenceSupplySnapshot | null;
+  error?: string;
+}> {
+  if (!snapshot) {
+    return {
+      snapshot: null,
+      error:
+        "Market-cap markets require verified fixed, fully circulating supply.",
+    };
+  }
+  const base = normalizeEvidenceSnapshotBase(snapshot, expectedIdentity);
+  // Exact timestamp equality cross-attests the immutable source-supply proof
+  // to creation without conflating its source block with the settlement block.
+  if (!base || snapshot.supplyDefinition !== "fixed-supply-fully-circulating" ||
+    typeof snapshot.fixedSupplyAtoms !== "string" ||
+    !CANONICAL_POSITIVE_INTEGER_PATTERN.test(
+      snapshot.fixedSupplyAtoms,
+    ) || !creationSnapshot ||
+    base.capturedAtUtc !== creationSnapshot.capturedAtUtc) {
+    return {
+      snapshot: null,
+      error:
+        "Fixed, fully circulating supply must be verified for this token at the exact creation snapshot.",
+    };
+  }
+  const supply = BigInt(snapshot.fixedSupplyAtoms);
+  if (supply <= 0n || supply > MAX_UINT256) {
+    return { snapshot: null, error: "The fixed supply must be positive." };
+  }
+  if (!Number.isInteger(snapshot.tokenDecimals) || snapshot.tokenDecimals < 0 ||
+    snapshot.tokenDecimals > MAX_TOKEN_DECIMALS) {
+    return { snapshot: null, error: "The reference supply decimals are invalid." };
+  }
+  return {
+    snapshot: {
+      sourceNetwork: base.identity.sourceNetwork,
+      address: base.identity.address,
+      fixedSupplyAtoms: supply.toString(),
+      tokenDecimals: snapshot.tokenDecimals,
+      capturedAtUtc: base.capturedAtUtc,
+      snapshotReference: base.snapshotReference,
+      evidenceDigest: base.evidenceDigest,
+      verificationStatus: PREDICTION_V2_VERIFIED_SNAPSHOT_STATUS,
+      supplyDefinition: "fixed-supply-fully-circulating",
+    },
+  };
+}
+
+export function buildPredictionV2CreateReview(
+  assetInput: PredictionV2DetectedAsset,
+  prediction: PredictionV2CreatePrediction,
+): PredictionV2CreateReviewResult {
+  const errors: {
+    asset?: string;
+    metric?: string;
+    template?: string;
+    targetUsd?: string;
+    percentChange?: string;
+    referenceMetricSnapshot?: string;
+    creationSnapshot?: string;
+    referenceSupplySnapshot?: string;
+    observationUtc?: string;
+    priceDecimals?: string;
+    precision?: string;
+    protocolPredicate?: string;
+  } = {};
+  if (!prediction || typeof prediction !== "object") {
+    return {
+      ok: false,
+      errors: {
+        metric: "Choose a supported metric.",
+        template: "Choose a supported prediction type.",
+      },
+    };
+  }
+  const detected = validateDetectedAsset(assetInput);
+  if (detected.error) errors.asset = detected.error;
+
+  const metric = prediction.metric === "price" || prediction.metric === "market-cap"
+    ? prediction.metric
+    : null;
+  if (!metric) errors.metric = "Choose Price or Market cap.";
+  const template = prediction.template === "target" ||
+      prediction.template === "percent-change" || prediction.template === "reach"
+    ? prediction.template
+    : null;
+  if (!template) {
+    errors.template = "Choose a supported prediction type.";
+  } else if (template === "reach") {
+    errors.template = "Reach-before-deadline markets are not enabled yet.";
+  }
+
+  let creationSnapshot: PredictionV2CreationReferenceSnapshot | null = null;
+  let creationUnixSeconds: string | null = null;
+  if (detected.asset) {
+    const creation = validateCreationSnapshot(
+      prediction.creationSnapshot,
+    );
+    if (creation.error) errors.creationSnapshot = creation.error;
+    creationSnapshot = creation.snapshot;
+    creationUnixSeconds = creation.capturedUnixSeconds;
+  }
+
+  const observationUnixSeconds = predictionV2ExactUtcToUnixSeconds(
+    prediction.observationUtc,
+  );
+  if (!observationUnixSeconds) {
+    errors.observationUtc = "Enter an exact UTC time including seconds and Z.";
+  } else if (creationUnixSeconds) {
+    const observation = BigInt(observationUnixSeconds);
+    const creation = BigInt(creationUnixSeconds);
+    if (observation <=
+      creation + PREDICTION_V2_MINIMUM_MARKET_DURATION_SECONDS) {
+      errors.observationUtc =
+        "The result time must be more than 24 hours after the creation snapshot.";
+    } else if (observation >
+      creation + PREDICTION_V2_MAXIMUM_MARKET_DURATION_SECONDS) {
+      errors.observationUtc =
+        "The result time must be no more than 30 days after the creation snapshot.";
+    }
+  }
+  if (prediction.priceDecimals !== PREDICTION_V2_PROTOCOL_PRICE_DECIMALS) {
+    errors.priceDecimals =
+      `Prediction V2 requires exactly ${PREDICTION_V2_PROTOCOL_PRICE_DECIMALS} price decimals.`;
+  }
+
+  let metricTarget: ParsedDecimal | null = null;
+  let normalizedPercent: string | null = null;
+  let referenceMetricUsd: string | null = null;
+  let referenceMetricSnapshot: PredictionV2ReferenceMetricSnapshot | null = null;
+  let inputTargetUsd: string | null = null;
+  if (prediction.template === "target" || prediction.template === "reach") {
+    const parsedTarget = parseUnsignedDecimal(prediction.targetUsd);
+    if (!parsedTarget || parsedTarget.coefficient <= 0n) {
+      errors.targetUsd = "Enter a positive USD target as a decimal value.";
+    } else {
+      metricTarget = parsedTarget;
+      inputTargetUsd = formatDecimal(parsedTarget);
+    }
+  } else if (prediction.template === "percent-change" && metric && detected.asset) {
+    const reference = validateReferenceMetricSnapshot(
+      prediction.referenceMetricSnapshot,
+      detected.asset.identity,
+      metric,
+      creationSnapshot,
+    );
+    if (reference.error) errors.referenceMetricSnapshot = reference.error;
+    referenceMetricSnapshot = reference.snapshot;
+    if (reference.value) referenceMetricUsd = formatDecimal(reference.value);
+
+    const parsedPercent = parseSignedDecimal(prediction.percentChange);
+    if (!parsedPercent) {
+      errors.percentChange = "Enter a percentage as a decimal value.";
+    } else if (parsedPercent.coefficient <= 0n) {
+      errors.percentChange =
+        "Prediction V2 supports only a positive upward percentage threshold.";
+    }
+    const derived = reference.value && parsedPercent && parsedPercent.coefficient > 0n
+      ? percentageTarget(reference.value, parsedPercent)
+      : null;
+    if (derived) {
+      metricTarget = derived.target;
+      normalizedPercent = derived.normalizedPercent;
+    }
+  }
+
+  let supplySnapshot: PredictionV2ReferenceSupplySnapshot | null = null;
+  if (metric === "market-cap" && detected.asset) {
+    const supply = validateSupplySnapshot(
+      assetInput?.referenceSupplySnapshot ?? null,
+      detected.asset.identity,
+      creationSnapshot,
+    );
+    if (supply.error) errors.referenceSupplySnapshot = supply.error;
+    supplySnapshot = supply.snapshot;
+  }
+
+  let priceStrike: Readonly<{ strikeAtoms: string; strikeUsd: string }> | null = null;
+  if (metricTarget && !errors.priceDecimals) {
+    if (metric === "price") {
+      const strikeAtoms = decimalToAtomsExact(
+        metricTarget,
+        PREDICTION_V2_PROTOCOL_PRICE_DECIMALS,
+      );
+      if (strikeAtoms === null) {
+        errors.precision =
+          "The exact target cannot be represented by the 8-decimal protocol price.";
+      } else if (strikeAtoms <= 0n || strikeAtoms > MAX_PROTOCOL_THRESHOLD) {
+        errors.protocolPredicate = "The resulting price threshold is unsupported.";
+      } else {
+        priceStrike = {
+          strikeAtoms: strikeAtoms.toString(),
+          strikeUsd: atomsToDecimal(
+            strikeAtoms,
+            PREDICTION_V2_PROTOCOL_PRICE_DECIMALS,
+          ),
+        };
+      }
+    } else if (metric === "market-cap" && supplySnapshot) {
+      const derived = deriveExactMarketCapPriceStrike(
+        metricTarget,
+        supplySnapshot,
+        PREDICTION_V2_PROTOCOL_PRICE_DECIMALS,
+      );
+      if (!derived.ok && derived.reason === "precision") {
+        errors.precision =
+          "The exact market-cap target cannot be represented by the 8-decimal protocol price.";
+      } else if (!derived.ok) {
+        errors.protocolPredicate =
+          "The market-cap target cannot produce a valid price threshold.";
+      } else {
+        priceStrike = {
+          strikeAtoms: derived.strikeAtoms,
+          strikeUsd: derived.strikeUsd,
+        };
+      }
+    }
+  }
+
+  const enabledTemplate = template === "target" || template === "percent-change"
+    ? template
+    : null;
+  if (Object.keys(errors).length > 0 || !detected.asset || !metric ||
+    !enabledTemplate || !metricTarget || !priceStrike || !observationUnixSeconds ||
+    !creationSnapshot) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    review: {
+      schemaVersion: 2,
+      asset: detected.asset.identity,
+      assetName: detected.asset.name,
+      assetSymbol: detected.asset.symbol,
+      selectedMetric: metric,
+      template: enabledTemplate,
+      metricTargetUsd: formatDecimal(metricTarget),
+      inputTargetUsd,
+      percentChange: normalizedPercent,
+      referenceMetricUsd,
+      creationSnapshot,
+      referenceMetricSnapshot,
+      referenceSupplySnapshot: supplySnapshot,
+      protocolPredicate: {
+        metric: "usd-price",
+        comparator: PREDICTION_V2_CREATE_COMPARATOR,
+        quoteCurrency: PREDICTION_V2_CREATE_QUOTE_CURRENCY,
+        strikeUsd: priceStrike.strikeUsd,
+        strikeAtoms: priceStrike.strikeAtoms,
+        priceDecimals: PREDICTION_V2_PROTOCOL_PRICE_DECIMALS,
+        observationUtc: prediction.observationUtc,
+        observationUnixSeconds,
+        timezone: PREDICTION_V2_CREATE_TIMEZONE,
+        evidenceBinding: {
+          creationSnapshot,
+          referenceMetricSnapshot,
+          referenceSupplySnapshot: supplySnapshot,
+        },
+      },
+      settlementEligibility: PREDICTION_V2_CREATE_SETTLEMENT_ELIGIBILITY,
+    },
+  };
+}
+
+export function nextPredictionV2CreateStep(
+  step: PredictionV2CreateStep,
+): PredictionV2CreateStep {
+  const index = PREDICTION_V2_CREATE_STEPS.indexOf(step);
+  return PREDICTION_V2_CREATE_STEPS[Math.min(
+    Math.max(index, 0) + 1,
+    PREDICTION_V2_CREATE_STEPS.length - 1,
+  )];
+}
+
+export function previousPredictionV2CreateStep(
+  step: PredictionV2CreateStep,
+): PredictionV2CreateStep {
+  const index = PREDICTION_V2_CREATE_STEPS.indexOf(step);
+  return PREDICTION_V2_CREATE_STEPS[Math.max(index - 1, 0)];
+}

--- a/lib/prediction-v2/market-presentation-v2.ts
+++ b/lib/prediction-v2/market-presentation-v2.ts
@@ -1,0 +1,1367 @@
+import { isAddress, sha256, stringToHex } from "viem";
+
+import {
+  predictionAssetIdentityCandidatesV2,
+  predictionOnchainAssetKeyV2,
+  type PredictionAssetIdentityV2,
+  type PredictionBytes32V2,
+} from "../prediction-market-assets-v2";
+import {
+  PREDICTION_ASSET_AUTO_DISCOVERY_SOURCE_V2,
+  PREDICTION_ASSET_AUTO_DISCOVERY_USAGE_V2,
+  type PredictionAssetAutoDiscoveryClientCandidateV2,
+  type PredictionAssetAutoDiscoveryClientResultV2,
+  type PredictionAssetAutoDiscoveryNetworkV2,
+} from "./asset-auto-discovery-v2";
+import {
+  predictionAssetFallbackImageV2,
+  predictionDexscreenerLogoAssetIdV2,
+} from "./asset-logo-v2";
+import { assertCanonicalPredictionV2Identity } from "./codec";
+import {
+  PREDICTION_V2_CREATE_COMPARATOR,
+  PREDICTION_V2_CREATE_QUOTE_CURRENCY,
+  PREDICTION_V2_CREATE_SETTLEMENT_ELIGIBILITY,
+  PREDICTION_V2_CREATE_SOURCE_NETWORKS,
+  PREDICTION_V2_CREATE_TIMEZONE,
+  PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+  buildPredictionV2CreateReview,
+  type PredictionV2CreatePrediction,
+  type PredictionV2CreationReferenceSnapshot,
+  type PredictionV2CreateReview,
+  type PredictionV2DetectedAsset,
+  type PredictionV2ReferenceMetricSnapshot,
+  type PredictionV2ReferenceSupplySnapshot,
+} from "./create-flow-v2";
+import {
+  PREDICTION_TOKEN_PROFILE_CHAINS_V2,
+  normalizePredictionTokenProfileV2,
+  type PredictionTokenProfileLinkV2,
+} from "./token-profile-v2";
+
+export const PREDICTION_MARKET_PRESENTATION_SCHEMA_V2 = 2 as const;
+export const PREDICTION_MARKET_PRESENTATION_RECORD_KIND_V2 =
+  "prediction-market-presentation" as const;
+export const PREDICTION_MARKET_PRESENTATION_STORAGE_MODEL_V2 =
+  "append-only-revision" as const;
+export const PREDICTION_MARKET_PRESENTATION_HASH_DOMAIN_V2 =
+  "programmable.prediction-market-presentation.v2" as const;
+export const PREDICTION_MARKET_PRESENTATION_USAGE_V2 =
+  "display-only" as const;
+
+export type PredictionPresentationSha256V2 = `sha256:${string}`;
+export type PredictionMarketKeyV2 =
+  `eip155:4663:${string}:${PredictionBytes32V2}`;
+
+export type PredictionMarketEconomicBindingV2 = Readonly<{
+  settlementChainId: typeof PREDICTION_V2_SETTLEMENT_CHAIN_ID;
+  factoryAddress: string;
+  economicKey: PredictionBytes32V2;
+  vaultAddress: string;
+  checkpointAddress: string;
+  poolId: PredictionBytes32V2;
+  marketId: PredictionBytes32V2;
+  assetIdentity: PredictionAssetIdentityV2;
+  onchainAssetKey: PredictionBytes32V2;
+  registryRevision: string;
+  registrySnapshotHash: PredictionBytes32V2;
+  resolutionPolicyHash: PredictionBytes32V2;
+  policyValidUntil: string;
+  snapshotAssetCapAtoms: string;
+  observationUnixSeconds: string;
+  thresholdAtoms: string;
+  priceDecimals: 8;
+  observedBlockNumber: string;
+  observedBlockHash: PredictionBytes32V2;
+}>;
+
+export type PredictionMarketPresentationRevisionLinkV2 = Readonly<{
+  sequence: string;
+  previousPresentationRevisionHash: PredictionPresentationSha256V2 | null;
+}>;
+
+export type PredictionMarketOwnedArtworkV2 = Readonly<{
+  kind: "bundled-fallback" | "owned-provider-snapshot";
+  url: string;
+  digest: PredictionPresentationSha256V2;
+  contentType: "image/webp";
+  sourceAssetId: string | null;
+}>;
+
+export type PredictionMarketPresentationConditionV2 = Readonly<{
+  kind: "usd-price-at-utc";
+  metric: "usd-price";
+  comparator: typeof PREDICTION_V2_CREATE_COMPARATOR;
+  quoteCurrency: typeof PREDICTION_V2_CREATE_QUOTE_CURRENCY;
+  strikeUsd: string;
+  strikeAtoms: string;
+  priceDecimals: 8;
+  observationUtc: string;
+  observationUnixSeconds: string;
+  timezone: typeof PREDICTION_V2_CREATE_TIMEZONE;
+}>;
+
+export type PredictionMarketCapCreationIntentV2 = Readonly<{
+  kind: "market-cap-equivalent";
+  settlementRole: "secondary-non-settlement";
+  comparator: typeof PREDICTION_V2_CREATE_COMPARATOR;
+  targetUsd: string;
+  template: "target" | "percent-change";
+  percentChange: string | null;
+  equivalentPriceStrikeUsd: string;
+  /**
+   * Immutable inputs needed to independently rebuild the creation-time
+   * market-cap conversion. None of these values participate in settlement.
+   */
+  evidence: Readonly<{
+    creationSnapshot: PredictionV2CreationReferenceSnapshot;
+    referenceSupplySnapshot: PredictionV2ReferenceSupplySnapshot;
+    referenceMetricSnapshot: PredictionV2ReferenceMetricSnapshot | null;
+  }>;
+}>;
+
+export type PredictionMarketPresentationRecordV2 = Readonly<{
+  schemaVersion: typeof PREDICTION_MARKET_PRESENTATION_SCHEMA_V2;
+  recordKind: typeof PREDICTION_MARKET_PRESENTATION_RECORD_KIND_V2;
+  storageModel: typeof PREDICTION_MARKET_PRESENTATION_STORAGE_MODEL_V2;
+  revision: PredictionMarketPresentationRevisionLinkV2;
+  marketKey: PredictionMarketKeyV2;
+  onchain: PredictionMarketEconomicBindingV2;
+  asset: Readonly<{
+    selectionKey: string;
+    sourceNetwork: PredictionAssetAutoDiscoveryNetworkV2;
+    namespace: "evm" | "solana";
+    chainReference: string;
+    chainLabel: string;
+    address: string;
+    name: string;
+    symbol: string;
+    explorerUrl: string;
+  }>;
+  condition: PredictionMarketPresentationConditionV2;
+  creationIntent: PredictionMarketCapCreationIntentV2 | null;
+  provider: Readonly<{
+    id: typeof PREDICTION_ASSET_AUTO_DISCOVERY_SOURCE_V2;
+    usage: typeof PREDICTION_ASSET_AUTO_DISCOVERY_USAGE_V2;
+    providerChainId: string;
+    observedAt: string;
+    pair: Readonly<{
+      dexId: string;
+      pairAddress: string;
+    }> | null;
+    imageAssetId: string | null;
+  }>;
+  display: Readonly<{
+    usage: typeof PREDICTION_MARKET_PRESENTATION_USAGE_V2;
+    links: readonly PredictionTokenProfileLinkV2[];
+    artwork: PredictionMarketOwnedArtworkV2;
+  }>;
+  presentationRevisionHash: PredictionPresentationSha256V2;
+}>;
+
+export type BuildPredictionMarketPresentationRecordV2Input = Readonly<{
+  /** Parsed envelope; its observedAt is the only accepted observation time. */
+  discovery: PredictionAssetAutoDiscoveryClientResultV2;
+  candidateSelectionKey: string;
+  review: PredictionV2CreateReview;
+  /** Same-block, confirmed Factory/Registry projection supplied by the caller. */
+  economicBinding: PredictionMarketEconomicBindingV2;
+  revision: PredictionMarketPresentationRevisionLinkV2;
+  /** Already persisted owned bytes, or an exact bundled fallback. */
+  artwork: PredictionMarketOwnedArtworkV2;
+}>;
+
+export type UnsignedPredictionMarketPresentationRecordV2 = Omit<
+  PredictionMarketPresentationRecordV2,
+  "presentationRevisionHash"
+>;
+
+const PROVIDER_CHAIN_IDS = Object.freeze({
+  ethereum: "ethereum",
+  base: "base",
+  bnb: "bsc",
+  robinhood: "robinhood",
+  solana: "solana",
+} as const satisfies Readonly<
+  Record<PredictionAssetAutoDiscoveryNetworkV2, string>
+>);
+const BYTES32_PATTERN = /^0x[0-9a-f]{64}$/u;
+const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+const UINT_PATTERN = /^(?:0|[1-9][0-9]*)$/u;
+const DEX_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/u;
+const IMAGE_ASSET_ID_PATTERN = /^[0-9a-f]{64}$/u;
+const OWNED_PROVIDER_ARTWORK_PATTERN =
+  /^\/media\/prediction\/sha256-([0-9a-f]{64})\.webp$/u;
+const MAX_UINT32 = (1n << 32n) - 1n;
+const MAX_UINT64 = (1n << 64n) - 1n;
+const MAX_UINT256 = (1n << 256n) - 1n;
+const MAX_INT192 = (1n << 191n) - 1n;
+
+const BUNDLED_FALLBACK_DIGESTS = Object.freeze({
+  "/brand/programmable-token-fallback-01-dawn.webp":
+    "sha256:222e019abc81ed856ad138a9db9ec686f8168e8e22e748a0b9f710f802752910",
+  "/brand/programmable-token-fallback-02-moon.webp":
+    "sha256:010570a9e8c50b252dc4d40c3c7f6e4cf73d3c1959e14deabb5c9463a3c48b61",
+  "/brand/programmable-token-fallback-03-sun.webp":
+    "sha256:7359a51ffe252e33bab08f79af5a8b3076cfcc2ce1ac3de4d502aec2408bb733",
+  "/brand/programmable-token-fallback-04-mint.webp":
+    "sha256:bdc2c0544aab662c033eb3d938be9fa9e43449a7eb97eb9795eaff9b9cccd39b",
+  "/brand/programmable-token-fallback-05-lavender.webp":
+    "sha256:5e6c28c1edd33a23e9c905dce7303383e725a5f13dd549f78a57ee63b82149c6",
+  "/brand/programmable-token-fallback-06-dusk.webp":
+    "sha256:1092abc51da5e97cd25bc4a9b26b0db08a369d36de60100f5b47c594c8ddb2eb",
+} as const satisfies Readonly<Record<string, PredictionPresentationSha256V2>>);
+
+/**
+ * Pure source model. It neither persists data nor authenticates RPC. A caller
+ * must bind Factory/Registry reads at one confirmed block, then append this
+ * record with compare-and-swap.
+ */
+export function buildPredictionMarketPresentationRecordV2(
+  input: BuildPredictionMarketPresentationRecordV2Input,
+): PredictionMarketPresentationRecordV2 | null {
+  try {
+    const candidate = candidateFromDiscoveryEnvelope(
+      input.discovery,
+      input.candidateSelectionKey,
+    );
+    if (!candidate) return null;
+    const observedAt = input.discovery.observedAt;
+    const observedAtMs = canonicalInstantMs(observedAt);
+    if (observedAtMs === null) return null;
+    const review = rebuildCanonicalReview(input.review);
+    const onchain = normalizeEconomicBinding(input.economicBinding);
+    const revision = normalizeRevision(input.revision);
+    if (!review || !onchain || !revision) return null;
+
+    const sourceNetwork = candidate.selection.sourceNetwork;
+    const network = PREDICTION_V2_CREATE_SOURCE_NETWORKS.find(
+      ({ id }) => id === sourceNetwork,
+    );
+    const profileChain = PREDICTION_TOKEN_PROFILE_CHAINS_V2.find(
+      ({ id }) => id === sourceNetwork,
+    );
+    if (!network || !profileChain) return null;
+    const address = review.asset.address;
+    const expectedSelectionKey =
+      `${network.namespace}:${network.chainReference}:${address}`;
+    if (!candidateMatchesBindings(
+      candidate,
+      expectedSelectionKey,
+      address,
+      network,
+      profileChain,
+    )) return null;
+
+    const identityCandidates = predictionAssetIdentityCandidatesV2({
+      mode: "custom",
+      sourceNetwork,
+      assetLocator: address,
+    });
+    if (!identityCandidates.some((identity) =>
+      sameAssetIdentity(identity, onchain.assetIdentity)
+    )) return null;
+    if (
+      onchain.onchainAssetKey !== predictionOnchainAssetKeyV2(
+        onchain.assetIdentity,
+      ) ||
+      review.protocolPredicate.observationUnixSeconds !==
+        onchain.observationUnixSeconds ||
+      review.protocolPredicate.strikeAtoms !== onchain.thresholdAtoms ||
+      review.protocolPredicate.priceDecimals !== onchain.priceDecimals
+    ) return null;
+
+    const displayProfile = normalizeDisplayProfile(
+      candidate,
+      sourceNetwork,
+      address,
+      observedAtMs,
+    );
+    if (
+      !displayProfile ||
+      displayProfile.name !== review.assetName ||
+      displayProfile.symbol !== review.assetSymbol ||
+      candidate.profile.explorerUrl !== displayProfile.explorerUrl
+    ) return null;
+    const imageAssetId = predictionDexscreenerLogoAssetIdV2(
+      displayProfile.logoUrl,
+    );
+    const artwork = normalizeOwnedArtwork(
+      input.artwork,
+      sourceNetwork,
+      address,
+      imageAssetId,
+    );
+    if (!artwork) return null;
+
+    const marketKey = predictionMarketKeyV2(onchain);
+    const condition = Object.freeze({
+      kind: "usd-price-at-utc" as const,
+      metric: "usd-price" as const,
+      comparator: PREDICTION_V2_CREATE_COMPARATOR,
+      quoteCurrency: PREDICTION_V2_CREATE_QUOTE_CURRENCY,
+      strikeUsd: review.protocolPredicate.strikeUsd,
+      strikeAtoms: onchain.thresholdAtoms,
+      priceDecimals: onchain.priceDecimals,
+      observationUtc: review.protocolPredicate.observationUtc,
+      observationUnixSeconds: onchain.observationUnixSeconds,
+      timezone: PREDICTION_V2_CREATE_TIMEZONE,
+    });
+    const links = Object.freeze((displayProfile.links ?? []).map((link) =>
+      Object.freeze({ kind: link.kind, url: link.url })
+    ));
+    const unsigned = Object.freeze({
+      schemaVersion: PREDICTION_MARKET_PRESENTATION_SCHEMA_V2,
+      recordKind: PREDICTION_MARKET_PRESENTATION_RECORD_KIND_V2,
+      storageModel: PREDICTION_MARKET_PRESENTATION_STORAGE_MODEL_V2,
+      revision,
+      marketKey,
+      onchain,
+      asset: Object.freeze({
+        selectionKey: expectedSelectionKey,
+        sourceNetwork,
+        namespace: network.namespace,
+        chainReference: network.chainReference,
+        chainLabel: profileChain.label,
+        address,
+        name: review.assetName,
+        symbol: review.assetSymbol,
+        explorerUrl: displayProfile.explorerUrl,
+      }),
+      condition,
+      creationIntent: marketCapCreationIntent(review),
+      provider: Object.freeze({
+        id: PREDICTION_ASSET_AUTO_DISCOVERY_SOURCE_V2,
+        usage: PREDICTION_ASSET_AUTO_DISCOVERY_USAGE_V2,
+        providerChainId: candidate.providerChainId,
+        observedAt,
+        pair: candidate.pair
+          ? Object.freeze({
+            dexId: candidate.pair.dexId,
+            pairAddress: candidate.pair.pairAddress,
+          })
+          : null,
+        imageAssetId,
+      }),
+      display: Object.freeze({
+        usage: PREDICTION_MARKET_PRESENTATION_USAGE_V2,
+        links,
+        artwork,
+      }),
+    } satisfies UnsignedPredictionMarketPresentationRecordV2);
+    return parsePredictionMarketPresentationRecordV2({
+      ...unsigned,
+      presentationRevisionHash:
+        predictionMarketPresentationRevisionHashV2(unsigned),
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parses one immutable revision. This proves internal content integrity only:
+ * it authenticates neither the author nor onchain truth and must never feed a
+ * public card without the separately verified projection context. Only an
+ * external append-only store can prove prior-revision existence and reject
+ * forks.
+ */
+export function parsePredictionMarketPresentationRecordV2(
+  value: unknown,
+): PredictionMarketPresentationRecordV2 | null {
+  try {
+    const record = exactRecord(value, [
+      "schemaVersion",
+      "recordKind",
+      "storageModel",
+      "revision",
+      "marketKey",
+      "onchain",
+      "asset",
+      "condition",
+      "creationIntent",
+      "provider",
+      "display",
+      "presentationRevisionHash",
+    ]);
+    if (
+      !record ||
+      record.schemaVersion !== PREDICTION_MARKET_PRESENTATION_SCHEMA_V2 ||
+      record.recordKind !== PREDICTION_MARKET_PRESENTATION_RECORD_KIND_V2 ||
+      record.storageModel !== PREDICTION_MARKET_PRESENTATION_STORAGE_MODEL_V2
+    ) return null;
+    const revision = normalizeRevision(record.revision);
+    const onchain = normalizeEconomicBinding(record.onchain);
+    const asset = normalizeStoredAsset(record.asset, onchain);
+    const provider = normalizeStoredProvider(record.provider, asset);
+    const condition = normalizeStoredCondition(record.condition, onchain);
+    const creationIntent = normalizeCreationIntent(
+      record.creationIntent,
+      condition,
+      asset,
+    );
+    const display = normalizeStoredDisplay(
+      record.display,
+      asset,
+      provider,
+    );
+    if (
+      !revision ||
+      !onchain ||
+      !asset ||
+      !provider ||
+      !condition ||
+      creationIntent === undefined ||
+      !display
+    ) return null;
+    const marketKey = predictionMarketKeyV2(onchain);
+    if (record.marketKey !== marketKey) return null;
+    const unsigned = Object.freeze({
+      schemaVersion: PREDICTION_MARKET_PRESENTATION_SCHEMA_V2,
+      recordKind: PREDICTION_MARKET_PRESENTATION_RECORD_KIND_V2,
+      storageModel: PREDICTION_MARKET_PRESENTATION_STORAGE_MODEL_V2,
+      revision,
+      marketKey,
+      onchain,
+      asset,
+      condition,
+      creationIntent,
+      provider,
+      display,
+    } satisfies UnsignedPredictionMarketPresentationRecordV2);
+    const revisionHash = canonicalSha256(record.presentationRevisionHash);
+    if (
+      !revisionHash ||
+      revisionHash !== predictionMarketPresentationRevisionHashV2(unsigned)
+    ) return null;
+    return Object.freeze({
+      ...unsigned,
+      presentationRevisionHash: revisionHash,
+    });
+  } catch {
+    return null;
+  }
+}
+
+export function predictionMarketPresentationRevisionHashV2(
+  record: UnsignedPredictionMarketPresentationRecordV2,
+): PredictionPresentationSha256V2 {
+  const digest = sha256(stringToHex(
+    `${PREDICTION_MARKET_PRESENTATION_HASH_DOMAIN_V2}\0${canonicalJson(record)}`,
+  ));
+  return `sha256:${digest.slice(2)}`;
+}
+
+export function predictionMarketKeyV2(
+  binding: Pick<
+    PredictionMarketEconomicBindingV2,
+    "settlementChainId" | "factoryAddress" | "economicKey"
+  >,
+): PredictionMarketKeyV2 {
+  const factory = canonicalAddress(binding.factoryAddress);
+  const economicKey = canonicalBytes32(binding.economicKey);
+  if (
+    binding.settlementChainId !== PREDICTION_V2_SETTLEMENT_CHAIN_ID ||
+    !factory ||
+    !economicKey
+  ) throw new TypeError("Invalid Prediction market economic identity");
+  return `eip155:${PREDICTION_V2_SETTLEMENT_CHAIN_ID}:${factory}:${economicKey}`;
+}
+
+export function predictionMarketBundledFallbackArtworkV2(
+  chainId: string,
+  address: string,
+): PredictionMarketOwnedArtworkV2 {
+  const url = predictionAssetFallbackImageV2(chainId, address);
+  const digest = BUNDLED_FALLBACK_DIGESTS[
+    url as keyof typeof BUNDLED_FALLBACK_DIGESTS
+  ];
+  if (!digest) throw new TypeError("Unknown bundled Prediction artwork");
+  return Object.freeze({
+    kind: "bundled-fallback" as const,
+    url,
+    digest,
+    contentType: "image/webp" as const,
+    sourceAssetId: null,
+  });
+}
+
+function candidateFromDiscoveryEnvelope(
+  discovery: PredictionAssetAutoDiscoveryClientResultV2,
+  selectionKey: string,
+): PredictionAssetAutoDiscoveryClientCandidateV2 | null {
+  if (
+    !discovery ||
+    discovery.schemaVersion !== 2 ||
+    discovery.source !== PREDICTION_ASSET_AUTO_DISCOVERY_SOURCE_V2 ||
+    discovery.usage !== PREDICTION_ASSET_AUTO_DISCOVERY_USAGE_V2 ||
+    canonicalInstantMs(discovery.observedAt) === null
+  ) return null;
+  const candidates = discovery.status === "unique"
+    ? [discovery.candidate]
+    : discovery.status === "ambiguous"
+      ? discovery.candidates
+      : [];
+  const matches = candidates.filter((candidate) =>
+    candidate.selectionKey === selectionKey
+  );
+  if (matches.length !== 1 || discovery.locator !== matches[0]?.profile.address) {
+    return null;
+  }
+  return matches[0] ?? null;
+}
+
+function candidateMatchesBindings(
+  candidate: PredictionAssetAutoDiscoveryClientCandidateV2,
+  expectedSelectionKey: string,
+  address: string,
+  network: (typeof PREDICTION_V2_CREATE_SOURCE_NETWORKS)[number],
+  profileChain: (typeof PREDICTION_TOKEN_PROFILE_CHAINS_V2)[number],
+) {
+  return candidate.selection.mode === "custom" &&
+    candidate.selection.assetLocator === address &&
+    candidate.selectionKey === expectedSelectionKey &&
+    candidate.namespace === network.namespace &&
+    candidate.chainReference === network.chainReference &&
+    candidate.providerChainId ===
+      PROVIDER_CHAIN_IDS[candidate.selection.sourceNetwork] &&
+    candidate.profile.schemaVersion === 2 &&
+    candidate.profile.chain.id === candidate.selection.sourceNetwork &&
+    candidate.profile.chain.reference === profileChain.reference &&
+    candidate.profile.chain.label === profileChain.label &&
+    candidate.profile.address === address;
+}
+
+function normalizeDisplayProfile(
+  candidate: PredictionAssetAutoDiscoveryClientCandidateV2,
+  sourceNetwork: PredictionAssetAutoDiscoveryNetworkV2,
+  address: string,
+  observedAtMs: number,
+) {
+  return normalizePredictionTokenProfileV2({
+    chain: sourceNetwork,
+    address,
+    name: candidate.profile.name,
+    symbol: candidate.profile.symbol,
+    logoUrl: candidate.profile.logoUrl,
+    website: profileLink(candidate.profile.links, "website"),
+    x: profileLink(candidate.profile.links, "x"),
+    telegram: profileLink(candidate.profile.links, "telegram"),
+  }, observedAtMs);
+}
+
+function normalizeEconomicBinding(
+  value: unknown,
+): PredictionMarketEconomicBindingV2 | null {
+  const binding = exactRecord(value, [
+    "settlementChainId",
+    "factoryAddress",
+    "economicKey",
+    "vaultAddress",
+    "checkpointAddress",
+    "poolId",
+    "marketId",
+    "assetIdentity",
+    "onchainAssetKey",
+    "registryRevision",
+    "registrySnapshotHash",
+    "resolutionPolicyHash",
+    "policyValidUntil",
+    "snapshotAssetCapAtoms",
+    "observationUnixSeconds",
+    "thresholdAtoms",
+    "priceDecimals",
+    "observedBlockNumber",
+    "observedBlockHash",
+  ]);
+  if (
+    !binding ||
+    binding.settlementChainId !== PREDICTION_V2_SETTLEMENT_CHAIN_ID ||
+    binding.priceDecimals !== 8
+  ) return null;
+  const factoryAddress = canonicalAddress(binding.factoryAddress);
+  const economicKey = canonicalBytes32(binding.economicKey);
+  const vaultAddress = canonicalAddress(binding.vaultAddress);
+  const checkpointAddress = canonicalAddress(binding.checkpointAddress);
+  const poolId = canonicalBytes32(binding.poolId);
+  const marketId = canonicalBytes32(binding.marketId);
+  const onchainAssetKey = canonicalBytes32(binding.onchainAssetKey);
+  const registrySnapshotHash = canonicalBytes32(binding.registrySnapshotHash);
+  const resolutionPolicyHash = canonicalBytes32(binding.resolutionPolicyHash);
+  const observedBlockHash = canonicalBytes32(binding.observedBlockHash);
+  const registryRevision = canonicalUint(binding.registryRevision, 1n, MAX_UINT64);
+  const policyValidUntil = canonicalUint(
+    binding.policyValidUntil,
+    1n,
+    MAX_UINT64,
+  );
+  const snapshotAssetCapAtoms = canonicalUint(
+    binding.snapshotAssetCapAtoms,
+    1n,
+    MAX_UINT256,
+  );
+  const observationUnixSeconds = canonicalUint(
+    binding.observationUnixSeconds,
+    1n,
+    MAX_UINT32,
+  );
+  const thresholdAtoms = canonicalUint(binding.thresholdAtoms, 1n, MAX_INT192);
+  const observedBlockNumber = canonicalUint(
+    binding.observedBlockNumber,
+    1n,
+    MAX_UINT64,
+  );
+  const assetIdentity = assertCanonicalPredictionV2Identity(
+    binding.assetIdentity,
+  );
+  if (
+    !factoryAddress ||
+    !economicKey ||
+    !vaultAddress ||
+    !checkpointAddress ||
+    !poolId ||
+    !marketId ||
+    !onchainAssetKey ||
+    !registrySnapshotHash ||
+    !resolutionPolicyHash ||
+    !observedBlockHash ||
+    !registryRevision ||
+    !policyValidUntil ||
+    !snapshotAssetCapAtoms ||
+    !observationUnixSeconds ||
+    !thresholdAtoms ||
+    !observedBlockNumber ||
+    BigInt(observationUnixSeconds) > BigInt(policyValidUntil) ||
+    onchainAssetKey !== predictionOnchainAssetKeyV2(assetIdentity)
+  ) return null;
+  return Object.freeze({
+    settlementChainId: PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+    factoryAddress,
+    economicKey,
+    vaultAddress,
+    checkpointAddress,
+    poolId,
+    marketId,
+    assetIdentity: Object.freeze(assetIdentity),
+    onchainAssetKey,
+    registryRevision,
+    registrySnapshotHash,
+    resolutionPolicyHash,
+    policyValidUntil,
+    snapshotAssetCapAtoms,
+    observationUnixSeconds,
+    thresholdAtoms,
+    priceDecimals: 8,
+    observedBlockNumber,
+    observedBlockHash,
+  });
+}
+
+function normalizeRevision(
+  value: unknown,
+): PredictionMarketPresentationRevisionLinkV2 | null {
+  const revision = exactRecord(value, [
+    "sequence",
+    "previousPresentationRevisionHash",
+  ]);
+  if (!revision) return null;
+  const sequence = canonicalUint(revision.sequence, 1n, MAX_UINT64);
+  if (!sequence) return null;
+  const previous = revision.previousPresentationRevisionHash === null
+    ? null
+    : canonicalSha256(revision.previousPresentationRevisionHash);
+  if (
+    (sequence === "1" && previous !== null) ||
+    (sequence !== "1" && previous === null)
+  ) return null;
+  return Object.freeze({
+    sequence,
+    previousPresentationRevisionHash: previous,
+  });
+}
+
+function normalizeOwnedArtwork(
+  value: unknown,
+  chainId: string,
+  address: string,
+  expectedProviderAssetId: string | null,
+): PredictionMarketOwnedArtworkV2 | null {
+  const artwork = exactRecord(value, [
+    "kind",
+    "url",
+    "digest",
+    "contentType",
+    "sourceAssetId",
+  ]);
+  if (!artwork || artwork.contentType !== "image/webp") return null;
+  const digest = canonicalSha256(artwork.digest);
+  if (!digest || typeof artwork.url !== "string") return null;
+  if (artwork.kind === "bundled-fallback") {
+    const expectedUrl = predictionAssetFallbackImageV2(chainId, address);
+    const expectedDigest = BUNDLED_FALLBACK_DIGESTS[
+      expectedUrl as keyof typeof BUNDLED_FALLBACK_DIGESTS
+    ];
+    if (
+      artwork.url !== expectedUrl ||
+      artwork.sourceAssetId !== null ||
+      digest !== expectedDigest
+    ) return null;
+    return Object.freeze({
+      kind: "bundled-fallback",
+      url: expectedUrl,
+      digest,
+      contentType: "image/webp",
+      sourceAssetId: null,
+    });
+  }
+  const pathDigest = OWNED_PROVIDER_ARTWORK_PATTERN.exec(artwork.url)?.[1];
+  if (
+    artwork.kind !== "owned-provider-snapshot" ||
+    typeof artwork.sourceAssetId !== "string" ||
+    artwork.sourceAssetId !== expectedProviderAssetId ||
+    !IMAGE_ASSET_ID_PATTERN.test(artwork.sourceAssetId) ||
+    !pathDigest ||
+    digest !== `sha256:${pathDigest}`
+  ) return null;
+  return Object.freeze({
+    kind: "owned-provider-snapshot",
+    url: artwork.url,
+    digest,
+    contentType: "image/webp",
+    sourceAssetId: artwork.sourceAssetId,
+  });
+}
+
+function rebuildCanonicalReview(
+  review: PredictionV2CreateReview,
+): PredictionV2CreateReview | null {
+  if (
+    review.schemaVersion !== 2 ||
+    review.settlementEligibility !==
+      PREDICTION_V2_CREATE_SETTLEMENT_ELIGIBILITY
+  ) return null;
+  const asset: PredictionV2DetectedAsset = {
+    identity: review.asset,
+    name: review.assetName,
+    symbol: review.assetSymbol,
+    referenceSupplySnapshot: review.referenceSupplySnapshot,
+  };
+  const common = {
+    metric: review.selectedMetric,
+    observationUtc: review.protocolPredicate.observationUtc,
+    creationSnapshot: review.creationSnapshot,
+    priceDecimals: review.protocolPredicate.priceDecimals,
+  } as const;
+  let prediction: PredictionV2CreatePrediction;
+  if (review.template === "target" && review.inputTargetUsd !== null) {
+    prediction = {
+      ...common,
+      template: "target",
+      targetUsd: review.inputTargetUsd,
+    };
+  } else if (
+    review.template === "percent-change" &&
+    review.percentChange !== null &&
+    review.referenceMetricSnapshot !== null
+  ) {
+    prediction = {
+      ...common,
+      template: "percent-change",
+      percentChange: review.percentChange,
+      referenceMetricSnapshot: review.referenceMetricSnapshot,
+    };
+  } else {
+    return null;
+  }
+  const rebuilt = buildPredictionV2CreateReview(asset, prediction);
+  return rebuilt.ok && equalJsonValue(rebuilt.review, review)
+    ? rebuilt.review
+    : null;
+}
+
+function marketCapCreationIntent(
+  review: PredictionV2CreateReview,
+): PredictionMarketCapCreationIntentV2 | null {
+  if (review.selectedMetric !== "market-cap") return null;
+  if (
+    !review.referenceSupplySnapshot ||
+    (review.template === "percent-change" && !review.referenceMetricSnapshot)
+  ) {
+    throw new TypeError("Market-cap intent is missing immutable evidence");
+  }
+  return Object.freeze({
+    kind: "market-cap-equivalent",
+    settlementRole: "secondary-non-settlement",
+    comparator: PREDICTION_V2_CREATE_COMPARATOR,
+    targetUsd: review.metricTargetUsd,
+    template: review.template,
+    percentChange: review.percentChange,
+    equivalentPriceStrikeUsd: review.protocolPredicate.strikeUsd,
+    evidence: Object.freeze({
+      creationSnapshot: Object.freeze({ ...review.creationSnapshot }),
+      referenceSupplySnapshot: Object.freeze({
+        ...review.referenceSupplySnapshot,
+      }),
+      referenceMetricSnapshot: review.referenceMetricSnapshot
+        ? Object.freeze({ ...review.referenceMetricSnapshot })
+        : null,
+    }),
+  });
+}
+
+function normalizeStoredAsset(
+  value: unknown,
+  onchain: PredictionMarketEconomicBindingV2 | null,
+): PredictionMarketPresentationRecordV2["asset"] | null {
+  if (!onchain) return null;
+  const asset = exactRecord(value, [
+    "selectionKey",
+    "sourceNetwork",
+    "namespace",
+    "chainReference",
+    "chainLabel",
+    "address",
+    "name",
+    "symbol",
+    "explorerUrl",
+  ]);
+  if (!asset || typeof asset.sourceNetwork !== "string") return null;
+  const network = PREDICTION_V2_CREATE_SOURCE_NETWORKS.find(
+    ({ id }) => id === asset.sourceNetwork,
+  );
+  const profileChain = PREDICTION_TOKEN_PROFILE_CHAINS_V2.find(
+    ({ id }) => id === asset.sourceNetwork,
+  );
+  if (!network || !profileChain) return null;
+  const profile = normalizePredictionTokenProfileV2({
+    chain: asset.sourceNetwork,
+    address: asset.address,
+    name: asset.name,
+    symbol: asset.symbol,
+  }, 0);
+  if (
+    !profile?.name ||
+    !profile.symbol ||
+    asset.namespace !== network.namespace ||
+    asset.chainReference !== network.chainReference ||
+    asset.chainLabel !== profileChain.label ||
+    asset.explorerUrl !== profile.explorerUrl
+  ) return null;
+  const selectionKey = `${network.namespace}:${network.chainReference}:` +
+    profile.address;
+  if (asset.selectionKey !== selectionKey) return null;
+  const identities = predictionAssetIdentityCandidatesV2({
+    mode: "custom",
+    sourceNetwork: network.id,
+    assetLocator: profile.address,
+  });
+  if (!identities.some((identity) =>
+    sameAssetIdentity(identity, onchain.assetIdentity)
+  )) return null;
+  return Object.freeze({
+    selectionKey,
+    sourceNetwork: network.id,
+    namespace: network.namespace,
+    chainReference: network.chainReference,
+    chainLabel: profileChain.label,
+    address: profile.address,
+    name: profile.name,
+    symbol: profile.symbol,
+    explorerUrl: profile.explorerUrl,
+  });
+}
+
+function normalizeStoredProvider(
+  value: unknown,
+  asset: PredictionMarketPresentationRecordV2["asset"] | null,
+): PredictionMarketPresentationRecordV2["provider"] | null {
+  if (!asset) return null;
+  const provider = exactRecord(value, [
+    "id",
+    "usage",
+    "providerChainId",
+    "observedAt",
+    "pair",
+    "imageAssetId",
+  ]);
+  const pair = provider?.pair === null
+    ? null
+    : exactRecord(provider?.pair, ["dexId", "pairAddress"]);
+  if (
+    !provider ||
+    provider.id !== PREDICTION_ASSET_AUTO_DISCOVERY_SOURCE_V2 ||
+    provider.usage !== PREDICTION_ASSET_AUTO_DISCOVERY_USAGE_V2 ||
+    provider.providerChainId !== PROVIDER_CHAIN_IDS[asset.sourceNetwork] ||
+    canonicalInstantMs(provider.observedAt) === null ||
+    (pair !== null && (
+      typeof pair.dexId !== "string" ||
+      !DEX_ID_PATTERN.test(pair.dexId)
+    ))
+  ) return null;
+  const pairProfile = pair === null
+    ? null
+    : normalizePredictionTokenProfileV2({
+      chain: asset.sourceNetwork,
+      address: pair.pairAddress,
+    }, 0);
+  if (pair !== null && !pairProfile) return null;
+  const imageAssetId = provider.imageAssetId === null
+    ? null
+    : typeof provider.imageAssetId === "string" &&
+        IMAGE_ASSET_ID_PATTERN.test(provider.imageAssetId)
+      ? provider.imageAssetId
+      : undefined;
+  if (imageAssetId === undefined) return null;
+  return Object.freeze({
+    id: PREDICTION_ASSET_AUTO_DISCOVERY_SOURCE_V2,
+    usage: PREDICTION_ASSET_AUTO_DISCOVERY_USAGE_V2,
+    providerChainId: PROVIDER_CHAIN_IDS[asset.sourceNetwork],
+    observedAt: provider.observedAt as string,
+    pair: pair && pairProfile
+      ? Object.freeze({
+        dexId: pair.dexId as string,
+        pairAddress: pairProfile.address,
+      })
+      : null,
+    imageAssetId,
+  });
+}
+
+function normalizeStoredCondition(
+  value: unknown,
+  onchain: PredictionMarketEconomicBindingV2 | null,
+): PredictionMarketPresentationConditionV2 | null {
+  if (!onchain) return null;
+  const condition = exactRecord(value, [
+    "kind",
+    "metric",
+    "comparator",
+    "quoteCurrency",
+    "strikeUsd",
+    "strikeAtoms",
+    "priceDecimals",
+    "observationUtc",
+    "observationUnixSeconds",
+    "timezone",
+  ]);
+  if (
+    !condition ||
+    condition.kind !== "usd-price-at-utc" ||
+    condition.metric !== "usd-price" ||
+    condition.comparator !== PREDICTION_V2_CREATE_COMPARATOR ||
+    condition.quoteCurrency !== PREDICTION_V2_CREATE_QUOTE_CURRENCY ||
+    condition.priceDecimals !== onchain.priceDecimals ||
+    condition.timezone !== PREDICTION_V2_CREATE_TIMEZONE ||
+    condition.strikeAtoms !== onchain.thresholdAtoms ||
+    condition.observationUnixSeconds !== onchain.observationUnixSeconds ||
+    typeof condition.strikeUsd !== "string" ||
+    typeof condition.observationUtc !== "string"
+  ) return null;
+  const expectedStrike = formatAtoms(
+    BigInt(onchain.thresholdAtoms),
+    10n ** BigInt(onchain.priceDecimals),
+    onchain.priceDecimals,
+  );
+  const exactUtc = exactUtcFromUnixSeconds(onchain.observationUnixSeconds);
+  if (condition.strikeUsd !== expectedStrike || condition.observationUtc !== exactUtc) {
+    return null;
+  }
+  return Object.freeze({
+    kind: "usd-price-at-utc",
+    metric: "usd-price",
+    comparator: PREDICTION_V2_CREATE_COMPARATOR,
+    quoteCurrency: PREDICTION_V2_CREATE_QUOTE_CURRENCY,
+    strikeUsd: expectedStrike,
+    strikeAtoms: onchain.thresholdAtoms,
+    priceDecimals: 8,
+    observationUtc: exactUtc,
+    observationUnixSeconds: onchain.observationUnixSeconds,
+    timezone: PREDICTION_V2_CREATE_TIMEZONE,
+  });
+}
+
+function normalizeCreationIntent(
+  value: unknown,
+  condition: PredictionMarketPresentationConditionV2 | null,
+  asset: PredictionMarketPresentationRecordV2["asset"] | null,
+): PredictionMarketCapCreationIntentV2 | null | undefined {
+  if (!condition || !asset) return undefined;
+  if (value === null) return null;
+  const intent = exactRecord(value, [
+    "kind",
+    "settlementRole",
+    "comparator",
+    "targetUsd",
+    "template",
+    "percentChange",
+    "equivalentPriceStrikeUsd",
+    "evidence",
+  ]);
+  if (
+    !intent ||
+    intent.kind !== "market-cap-equivalent" ||
+    intent.settlementRole !== "secondary-non-settlement" ||
+    intent.comparator !== PREDICTION_V2_CREATE_COMPARATOR ||
+    intent.template !== "target" && intent.template !== "percent-change" ||
+    !canonicalPositiveDecimal(intent.targetUsd) ||
+    intent.equivalentPriceStrikeUsd !== condition.strikeUsd
+  ) return undefined;
+  const percentChange = intent.percentChange === null
+    ? null
+    : canonicalSignedNonzeroDecimal(intent.percentChange);
+  if (
+    (intent.template === "target" && percentChange !== null) ||
+    (intent.template === "percent-change" && percentChange === null)
+  ) return undefined;
+  const evidence = normalizeMarketCapEvidence(
+    intent.evidence,
+    asset,
+    intent.template,
+  );
+  if (!evidence) return undefined;
+  const prediction: PredictionV2CreatePrediction = intent.template === "target"
+    ? {
+      metric: "market-cap",
+      template: "target",
+      targetUsd: intent.targetUsd as string,
+      observationUtc: condition.observationUtc,
+      creationSnapshot: evidence.creationSnapshot,
+      priceDecimals: condition.priceDecimals,
+    }
+    : {
+      metric: "market-cap",
+      template: "percent-change",
+      percentChange: percentChange as string,
+      referenceMetricSnapshot: evidence.referenceMetricSnapshot as
+        PredictionV2ReferenceMetricSnapshot,
+      observationUtc: condition.observationUtc,
+      creationSnapshot: evidence.creationSnapshot,
+      priceDecimals: condition.priceDecimals,
+    };
+  const rebuilt = buildPredictionV2CreateReview({
+    identity: {
+      sourceNetwork: asset.sourceNetwork,
+      address: asset.address,
+    },
+    name: asset.name,
+    symbol: asset.symbol,
+    referenceSupplySnapshot: evidence.referenceSupplySnapshot,
+  }, prediction);
+  if (
+    !rebuilt.ok ||
+    rebuilt.review.selectedMetric !== "market-cap" ||
+    rebuilt.review.template !== intent.template ||
+    rebuilt.review.metricTargetUsd !== intent.targetUsd ||
+    rebuilt.review.percentChange !== percentChange ||
+    rebuilt.review.protocolPredicate.strikeUsd !== condition.strikeUsd ||
+    rebuilt.review.protocolPredicate.strikeAtoms !== condition.strikeAtoms ||
+    !equalJsonValue(rebuilt.review.creationSnapshot, evidence.creationSnapshot) ||
+    !equalJsonValue(
+      rebuilt.review.referenceSupplySnapshot,
+      evidence.referenceSupplySnapshot,
+    ) ||
+    !equalJsonValue(
+      rebuilt.review.referenceMetricSnapshot,
+      evidence.referenceMetricSnapshot,
+    )
+  ) return undefined;
+  return Object.freeze({
+    kind: "market-cap-equivalent",
+    settlementRole: "secondary-non-settlement",
+    comparator: PREDICTION_V2_CREATE_COMPARATOR,
+    targetUsd: intent.targetUsd as string,
+    template: intent.template,
+    percentChange,
+    equivalentPriceStrikeUsd: condition.strikeUsd,
+    evidence,
+  });
+}
+
+function normalizeMarketCapEvidence(
+  value: unknown,
+  asset: PredictionMarketPresentationRecordV2["asset"],
+  template: "target" | "percent-change",
+): PredictionMarketCapCreationIntentV2["evidence"] | null {
+  const evidence = exactRecord(value, [
+    "creationSnapshot",
+    "referenceSupplySnapshot",
+    "referenceMetricSnapshot",
+  ]);
+  if (!evidence) return null;
+  const creationSnapshot = exactRecord(evidence.creationSnapshot, [
+    "settlementChainId",
+    "capturedAtUtc",
+    "snapshotReference",
+    "evidenceDigest",
+    "verificationStatus",
+  ]);
+  const referenceSupplySnapshot = exactRecord(
+    evidence.referenceSupplySnapshot,
+    [
+      "sourceNetwork",
+      "address",
+      "fixedSupplyAtoms",
+      "tokenDecimals",
+      "capturedAtUtc",
+      "snapshotReference",
+      "evidenceDigest",
+      "verificationStatus",
+      "supplyDefinition",
+    ],
+  );
+  const referenceMetricSnapshot = evidence.referenceMetricSnapshot === null
+    ? null
+    : exactRecord(evidence.referenceMetricSnapshot, [
+      "metric",
+      "valueUsd",
+      "sourceNetwork",
+      "address",
+      "capturedAtUtc",
+      "snapshotReference",
+      "evidenceDigest",
+      "verificationStatus",
+    ]);
+  if (
+    !creationSnapshot ||
+    !referenceSupplySnapshot ||
+    (template === "target" && referenceMetricSnapshot !== null) ||
+    (template === "percent-change" && referenceMetricSnapshot === null)
+  ) return null;
+  return Object.freeze({
+    creationSnapshot: Object.freeze({
+      settlementChainId: creationSnapshot.settlementChainId,
+      capturedAtUtc: creationSnapshot.capturedAtUtc,
+      snapshotReference: creationSnapshot.snapshotReference,
+      evidenceDigest: creationSnapshot.evidenceDigest,
+      verificationStatus: creationSnapshot.verificationStatus,
+    }) as PredictionV2CreationReferenceSnapshot,
+    referenceSupplySnapshot: Object.freeze({
+      sourceNetwork: referenceSupplySnapshot.sourceNetwork,
+      address: referenceSupplySnapshot.address,
+      fixedSupplyAtoms: referenceSupplySnapshot.fixedSupplyAtoms,
+      tokenDecimals: referenceSupplySnapshot.tokenDecimals,
+      capturedAtUtc: referenceSupplySnapshot.capturedAtUtc,
+      snapshotReference: referenceSupplySnapshot.snapshotReference,
+      evidenceDigest: referenceSupplySnapshot.evidenceDigest,
+      verificationStatus: referenceSupplySnapshot.verificationStatus,
+      supplyDefinition: referenceSupplySnapshot.supplyDefinition,
+    }) as PredictionV2ReferenceSupplySnapshot,
+    referenceMetricSnapshot: referenceMetricSnapshot
+      ? Object.freeze({
+        metric: referenceMetricSnapshot.metric,
+        valueUsd: referenceMetricSnapshot.valueUsd,
+        sourceNetwork: referenceMetricSnapshot.sourceNetwork,
+        address: referenceMetricSnapshot.address,
+        capturedAtUtc: referenceMetricSnapshot.capturedAtUtc,
+        snapshotReference: referenceMetricSnapshot.snapshotReference,
+        evidenceDigest: referenceMetricSnapshot.evidenceDigest,
+        verificationStatus: referenceMetricSnapshot.verificationStatus,
+      }) as PredictionV2ReferenceMetricSnapshot
+      : null,
+  });
+}
+
+function normalizeStoredDisplay(
+  value: unknown,
+  asset: PredictionMarketPresentationRecordV2["asset"] | null,
+  provider: PredictionMarketPresentationRecordV2["provider"] | null,
+): PredictionMarketPresentationRecordV2["display"] | null {
+  if (!asset || !provider) return null;
+  const display = exactRecord(value, ["usage", "links", "artwork"]);
+  if (
+    !display ||
+    display.usage !== PREDICTION_MARKET_PRESENTATION_USAGE_V2 ||
+    !Array.isArray(display.links) ||
+    display.links.length > 3
+  ) return null;
+  const linksByKind = new Map<string, unknown>();
+  for (const link of display.links) {
+    const row = exactRecord(link, ["kind", "url"]);
+    if (!row || typeof row.kind !== "string" || linksByKind.has(row.kind)) {
+      return null;
+    }
+    linksByKind.set(row.kind, row.url);
+  }
+  const profile = normalizePredictionTokenProfileV2({
+    chain: asset.sourceNetwork,
+    address: asset.address,
+    name: asset.name,
+    symbol: asset.symbol,
+    website: linksByKind.get("website"),
+    x: linksByKind.get("x"),
+    telegram: linksByKind.get("telegram"),
+  }, Date.parse(provider.observedAt));
+  if (!profile) return null;
+  const links = Object.freeze((profile.links ?? []).map((link) =>
+    Object.freeze({ kind: link.kind, url: link.url })
+  ));
+  if (!equalJsonValue(links, display.links)) return null;
+  const artwork = normalizeOwnedArtwork(
+    display.artwork,
+    asset.sourceNetwork,
+    asset.address,
+    provider.imageAssetId,
+  );
+  return artwork
+    ? Object.freeze({
+      usage: PREDICTION_MARKET_PRESENTATION_USAGE_V2,
+      links,
+      artwork,
+    })
+    : null;
+}
+
+function profileLink(
+  links: readonly PredictionTokenProfileLinkV2[] | undefined,
+  kind: PredictionTokenProfileLinkV2["kind"],
+) {
+  if (!Array.isArray(links)) return undefined;
+  const link = links.find((candidate) =>
+    candidate &&
+    typeof candidate === "object" &&
+    candidate.kind === kind &&
+    typeof candidate.url === "string"
+  );
+  return link?.url;
+}
+
+function exactRecord(
+  value: unknown,
+  keys: readonly string[],
+): Record<string, unknown> | null {
+  if (!isPlainRecord(value)) return null;
+  const actual = Reflect.ownKeys(value);
+  return actual.length === keys.length &&
+      actual.every((key) => typeof key === "string" && keys.includes(key)) &&
+      keys.every((key) => Object.hasOwn(value, key))
+    ? value
+    : null;
+}
+
+function canonicalAddress(value: unknown): string | null {
+  if (typeof value !== "string" || !isAddress(value, { strict: false })) {
+    return null;
+  }
+  const normalized = value.toLowerCase();
+  return normalized === `0x${"0".repeat(40)}` ? null : normalized;
+}
+
+function canonicalBytes32(value: unknown): PredictionBytes32V2 | null {
+  return typeof value === "string" &&
+      BYTES32_PATTERN.test(value) &&
+      value !== `0x${"0".repeat(64)}`
+    ? value as PredictionBytes32V2
+    : null;
+}
+
+function canonicalSha256(
+  value: unknown,
+): PredictionPresentationSha256V2 | null {
+  return typeof value === "string" && SHA256_PATTERN.test(value)
+    ? value as PredictionPresentationSha256V2
+    : null;
+}
+
+function canonicalUint(
+  value: unknown,
+  minimum: bigint,
+  maximum: bigint,
+): string | null {
+  if (typeof value !== "string" || !UINT_PATTERN.test(value)) return null;
+  const number = BigInt(value);
+  return number >= minimum && number <= maximum ? number.toString() : null;
+}
+
+function canonicalInstantMs(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const parsed = Date.parse(value);
+  return Number.isSafeInteger(parsed) &&
+      parsed >= 0 &&
+      new Date(parsed).toISOString() === value
+    ? parsed
+    : null;
+}
+
+function canonicalPositiveDecimal(value: unknown): string | null {
+  if (
+    typeof value !== "string" ||
+    value.length > 96 ||
+    !/^(?:0|[1-9][0-9]*)(?:\.[0-9]*[1-9])?$/u.test(value) ||
+    !/[1-9]/u.test(value)
+  ) return null;
+  return value;
+}
+
+function canonicalSignedNonzeroDecimal(value: unknown): string | null {
+  if (
+    typeof value !== "string" ||
+    value.length > 97 ||
+    !/^-?(?:0|[1-9][0-9]*)(?:\.[0-9]*[1-9])?$/u.test(value) ||
+    !/[1-9]/u.test(value)
+  ) return null;
+  return value;
+}
+
+function exactUtcFromUnixSeconds(value: string) {
+  return new Date(Number(BigInt(value)) * 1_000).toISOString()
+    .replace(".000Z", "Z");
+}
+
+function formatAtoms(atoms: bigint, scale: bigint, decimals: number) {
+  const whole = atoms / scale;
+  const fraction = (atoms % scale).toString().padStart(decimals, "0")
+    .replace(/0+$/u, "");
+  return fraction ? `${whole}.${fraction}` : whole.toString();
+}
+
+function sameAssetIdentity(
+  left: PredictionAssetIdentityV2,
+  right: PredictionAssetIdentityV2,
+) {
+  return left.sourceNamespace === right.sourceNamespace &&
+    left.sourceChain === right.sourceChain &&
+    left.assetIdentifier === right.assetIdentifier &&
+    left.assetStandard === right.assetStandard;
+}
+
+function equalJsonValue(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((item, index) => equalJsonValue(item, right[index]));
+  }
+  if (!isPlainRecord(left) || !isPlainRecord(right)) return false;
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+  return leftKeys.length === rightKeys.length &&
+    leftKeys.every((key, index) =>
+      key === rightKeys[index] && equalJsonValue(left[key], right[key])
+    );
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "string" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError("Non-finite JSON number");
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+  }
+  if (!isPlainRecord(value)) throw new TypeError("Non-canonical JSON value");
+  return `{${Object.keys(value).sort().map((key) =>
+    `${JSON.stringify(key)}:${canonicalJson(value[key])}`
+  ).join(",")}}`;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype;
+}

--- a/lib/prediction-v2/public-market-view-v2.ts
+++ b/lib/prediction-v2/public-market-view-v2.ts
@@ -1,0 +1,553 @@
+import { isAddress, verifyMessage, type Hex } from "viem";
+
+import type { PredictionBytes32V2 } from "../prediction-market-assets-v2";
+import { PREDICTION_V2_SETTLEMENT_CHAIN_ID } from "./create-flow-v2";
+import {
+  parsePredictionMarketPresentationRecordV2,
+  type PredictionMarketCapCreationIntentV2,
+  type PredictionMarketKeyV2,
+  type PredictionMarketOwnedArtworkV2,
+  type PredictionMarketPresentationConditionV2,
+  type PredictionPresentationSha256V2,
+} from "./market-presentation-v2";
+import type { PredictionTokenProfileLinkV2 } from "./token-profile-v2";
+
+export const PREDICTION_MARKET_PROJECTION_CONTEXT_SCHEMA_V2 = 2 as const;
+export const PREDICTION_MARKET_PROJECTION_CONTEXT_KIND_V2 =
+  "prediction-market-attested-projection" as const;
+export const PREDICTION_MARKET_PROJECTION_ATTESTATION_SCHEME_V2 =
+  "eip191-eoa" as const;
+export const PREDICTION_MARKET_PROJECTION_ATTESTATION_DOMAIN_V2 =
+  "programmable.prediction-market-projection.v2" as const;
+
+export type PredictionMarketCanonicalReleaseV2 = Readonly<{
+  schemaVersion: 2;
+  releaseId: string;
+  settlementChainId: typeof PREDICTION_V2_SETTLEMENT_CHAIN_ID;
+  factoryAddress: string;
+  factoryRuntimeCodeHash: PredictionBytes32V2;
+  projectionAttestorAddress: string;
+}>;
+
+export type UnsignedPredictionMarketAttestedProjectionContextV2 = Readonly<{
+  schemaVersion: typeof PREDICTION_MARKET_PROJECTION_CONTEXT_SCHEMA_V2;
+  contextKind: typeof PREDICTION_MARKET_PROJECTION_CONTEXT_KIND_V2;
+  releaseId: string;
+  settlementChainId: typeof PREDICTION_V2_SETTLEMENT_CHAIN_ID;
+  factoryAddress: string;
+  factoryRuntimeCodeHash: PredictionBytes32V2;
+  presentationRevisionHash: PredictionPresentationSha256V2;
+  readMarket: Readonly<{
+    marketKey: PredictionMarketKeyV2;
+    economicKey: PredictionBytes32V2;
+    vaultAddress: string;
+    checkpointAddress: string;
+    poolId: PredictionBytes32V2;
+    marketId: PredictionBytes32V2;
+    onchainAssetKey: PredictionBytes32V2;
+    registryRevision: string;
+    registrySnapshotHash: PredictionBytes32V2;
+    resolutionPolicyHash: PredictionBytes32V2;
+    policyValidUntil: string;
+    snapshotAssetCapAtoms: string;
+    observationUnixSeconds: string;
+    thresholdAtoms: string;
+    priceDecimals: 8;
+  }>;
+  confirmedBlock: Readonly<{
+    number: string;
+    hash: PredictionBytes32V2;
+  }>;
+}>;
+
+export type PredictionMarketAttestedProjectionContextV2 =
+  UnsignedPredictionMarketAttestedProjectionContextV2 & Readonly<{
+    attestation: Readonly<{
+      scheme: typeof PREDICTION_MARKET_PROJECTION_ATTESTATION_SCHEME_V2;
+      signerAddress: string;
+      signature: Hex;
+    }>;
+  }>;
+
+/**
+ * The only validated Prediction V2 card/profile input. A content-addressed
+ * presentation record is necessary but not sufficient: this DTO is emitted
+ * only after an external release attestor has signed the exact revision,
+ * Factory read and confirmed block under an application-pinned release root.
+ */
+export type PublicPredictionMarketViewV2 = Readonly<{
+  schemaVersion: 2;
+  marketKey: PredictionMarketKeyV2;
+  marketId: PredictionBytes32V2;
+  asset: Readonly<{
+    sourceNetwork: "ethereum" | "base" | "bnb" | "robinhood" | "solana";
+    chainLabel: string;
+    address: string;
+    name: string;
+    symbol: string;
+    explorerUrl: string;
+  }>;
+  condition: PredictionMarketPresentationConditionV2;
+  creationIntent: PredictionMarketCapCreationIntentV2 | null;
+  artwork: PredictionMarketOwnedArtworkV2;
+  links: readonly PredictionTokenProfileLinkV2[];
+  presentation: Readonly<{
+    revision: string;
+    revisionHash: PredictionPresentationSha256V2;
+    observedAt: string;
+  }>;
+  attestedProjection: Readonly<{
+    releaseId: string;
+    settlementChainId: typeof PREDICTION_V2_SETTLEMENT_CHAIN_ID;
+    factoryAddress: string;
+    factoryRuntimeCodeHash: PredictionBytes32V2;
+    economicKey: PredictionBytes32V2;
+    onchainAssetKey: PredictionBytes32V2;
+    registryRevision: string;
+    registrySnapshotHash: PredictionBytes32V2;
+    confirmedBlockNumber: string;
+    confirmedBlockHash: PredictionBytes32V2;
+    attestorAddress: string;
+  }>;
+}>;
+
+/**
+ * Canonical EIP-191 payload for the separately operated projection attestor.
+ * This function validates shape only; signing it is an external privileged
+ * operation and does not by itself make a public view.
+ */
+export function predictionMarketProjectionAttestationMessageV2(
+  value: unknown,
+): string | null {
+  const context = normalizeUnsignedProjectionContext(value);
+  return context
+    ? `${PREDICTION_MARKET_PROJECTION_ATTESTATION_DOMAIN_V2}\0${canonicalJson(context)}`
+    : null;
+}
+
+/**
+ * Authenticates and normalizes an immutable projection context against a
+ * canonical release root. `canonicalReleaseValue` must come from application-
+ * owned, reviewed configuration, never from a request or stored presentation.
+ */
+export async function parsePredictionMarketAttestedProjectionContextV2(
+  value: unknown,
+  canonicalReleaseValue: unknown,
+): Promise<PredictionMarketAttestedProjectionContextV2 | null> {
+  try {
+    const release = normalizeCanonicalRelease(canonicalReleaseValue);
+    const context = exactRecord(value, [
+      "schemaVersion",
+      "contextKind",
+      "releaseId",
+      "settlementChainId",
+      "factoryAddress",
+      "factoryRuntimeCodeHash",
+      "presentationRevisionHash",
+      "readMarket",
+      "confirmedBlock",
+      "attestation",
+    ]);
+    if (!release || !context) return null;
+    const unsigned = normalizeUnsignedProjectionContext({
+      schemaVersion: context.schemaVersion,
+      contextKind: context.contextKind,
+      releaseId: context.releaseId,
+      settlementChainId: context.settlementChainId,
+      factoryAddress: context.factoryAddress,
+      factoryRuntimeCodeHash: context.factoryRuntimeCodeHash,
+      presentationRevisionHash: context.presentationRevisionHash,
+      readMarket: context.readMarket,
+      confirmedBlock: context.confirmedBlock,
+    });
+    const attestation = exactRecord(context.attestation, [
+      "scheme",
+      "signerAddress",
+      "signature",
+    ]);
+    if (!unsigned || !attestation) return null;
+    const signerAddress = canonicalAddress(attestation.signerAddress);
+    const signature = canonicalSignature(attestation.signature);
+    if (
+      unsigned.releaseId !== release.releaseId ||
+      unsigned.settlementChainId !== release.settlementChainId ||
+      unsigned.factoryAddress !== release.factoryAddress ||
+      unsigned.factoryRuntimeCodeHash !== release.factoryRuntimeCodeHash ||
+      attestation.scheme !==
+        PREDICTION_MARKET_PROJECTION_ATTESTATION_SCHEME_V2 ||
+      signerAddress !== release.projectionAttestorAddress ||
+      !signature
+    ) return null;
+    const message = predictionMarketProjectionAttestationMessageV2(unsigned);
+    if (!message || !await verifyMessage({
+      address: release.projectionAttestorAddress as `0x${string}`,
+      message,
+      signature,
+    })) return null;
+    return Object.freeze({
+      ...unsigned,
+      attestation: Object.freeze({
+        scheme: PREDICTION_MARKET_PROJECTION_ATTESTATION_SCHEME_V2,
+        signerAddress: release.projectionAttestorAddress,
+        signature,
+      }),
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Projects a public view only when both independent boundaries hold:
+ * presentation integrity and a release-pinned signature over the exact
+ * Factory read, block and presentation revision.
+ */
+export async function publicPredictionMarketViewV2FromAttestedProjection(
+  recordValue: unknown,
+  projectionContextValue: unknown,
+  canonicalReleaseValue: unknown,
+): Promise<PublicPredictionMarketViewV2 | null> {
+  const record = parsePredictionMarketPresentationRecordV2(recordValue);
+  const context = await parsePredictionMarketAttestedProjectionContextV2(
+    projectionContextValue,
+    canonicalReleaseValue,
+  );
+  if (!record || !context || !projectionMatchesRecord(context, record)) {
+    return null;
+  }
+  return Object.freeze({
+    schemaVersion: 2 as const,
+    marketKey: record.marketKey,
+    marketId: record.onchain.marketId,
+    asset: Object.freeze({
+      sourceNetwork: record.asset.sourceNetwork,
+      chainLabel: record.asset.chainLabel,
+      address: record.asset.address,
+      name: record.asset.name,
+      symbol: record.asset.symbol,
+      explorerUrl: record.asset.explorerUrl,
+    }),
+    condition: record.condition,
+    creationIntent: record.creationIntent,
+    artwork: record.display.artwork,
+    links: record.display.links,
+    presentation: Object.freeze({
+      revision: record.revision.sequence,
+      revisionHash: record.presentationRevisionHash,
+      observedAt: record.provider.observedAt,
+    }),
+    attestedProjection: Object.freeze({
+      releaseId: context.releaseId,
+      settlementChainId: context.settlementChainId,
+      factoryAddress: context.factoryAddress,
+      factoryRuntimeCodeHash: context.factoryRuntimeCodeHash,
+      economicKey: context.readMarket.economicKey,
+      onchainAssetKey: context.readMarket.onchainAssetKey,
+      registryRevision: context.readMarket.registryRevision,
+      registrySnapshotHash: context.readMarket.registrySnapshotHash,
+      confirmedBlockNumber: context.confirmedBlock.number,
+      confirmedBlockHash: context.confirmedBlock.hash,
+      attestorAddress: context.attestation.signerAddress,
+    }),
+  });
+}
+
+function projectionMatchesRecord(
+  context: PredictionMarketAttestedProjectionContextV2,
+  record: NonNullable<ReturnType<
+    typeof parsePredictionMarketPresentationRecordV2
+  >>,
+) {
+  return context.presentationRevisionHash === record.presentationRevisionHash &&
+    context.settlementChainId === record.onchain.settlementChainId &&
+    context.factoryAddress === record.onchain.factoryAddress &&
+    context.readMarket.marketKey === record.marketKey &&
+    context.readMarket.economicKey === record.onchain.economicKey &&
+    context.readMarket.vaultAddress === record.onchain.vaultAddress &&
+    context.readMarket.checkpointAddress === record.onchain.checkpointAddress &&
+    context.readMarket.poolId === record.onchain.poolId &&
+    context.readMarket.marketId === record.onchain.marketId &&
+    context.readMarket.onchainAssetKey === record.onchain.onchainAssetKey &&
+    context.readMarket.registryRevision === record.onchain.registryRevision &&
+    context.readMarket.registrySnapshotHash ===
+      record.onchain.registrySnapshotHash &&
+    context.readMarket.resolutionPolicyHash ===
+      record.onchain.resolutionPolicyHash &&
+    context.readMarket.policyValidUntil === record.onchain.policyValidUntil &&
+    context.readMarket.snapshotAssetCapAtoms ===
+      record.onchain.snapshotAssetCapAtoms &&
+    context.readMarket.observationUnixSeconds ===
+      record.onchain.observationUnixSeconds &&
+    context.readMarket.thresholdAtoms === record.onchain.thresholdAtoms &&
+    context.readMarket.priceDecimals === record.onchain.priceDecimals &&
+    context.confirmedBlock.number === record.onchain.observedBlockNumber &&
+    context.confirmedBlock.hash === record.onchain.observedBlockHash;
+}
+
+function normalizeCanonicalRelease(
+  value: unknown,
+): PredictionMarketCanonicalReleaseV2 | null {
+  const release = exactRecord(value, [
+    "schemaVersion",
+    "releaseId",
+    "settlementChainId",
+    "factoryAddress",
+    "factoryRuntimeCodeHash",
+    "projectionAttestorAddress",
+  ]);
+  if (
+    !release ||
+    release.schemaVersion !== 2 ||
+    release.settlementChainId !== PREDICTION_V2_SETTLEMENT_CHAIN_ID ||
+    !canonicalReleaseId(release.releaseId)
+  ) return null;
+  const factoryAddress = canonicalAddress(release.factoryAddress);
+  const factoryRuntimeCodeHash = canonicalBytes32(
+    release.factoryRuntimeCodeHash,
+  );
+  const projectionAttestorAddress = canonicalAddress(
+    release.projectionAttestorAddress,
+  );
+  if (!factoryAddress || !factoryRuntimeCodeHash || !projectionAttestorAddress) {
+    return null;
+  }
+  return Object.freeze({
+    schemaVersion: 2,
+    releaseId: release.releaseId as string,
+    settlementChainId: PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+    factoryAddress,
+    factoryRuntimeCodeHash,
+    projectionAttestorAddress,
+  });
+}
+
+function normalizeUnsignedProjectionContext(
+  value: unknown,
+): UnsignedPredictionMarketAttestedProjectionContextV2 | null {
+  const context = exactRecord(value, [
+    "schemaVersion",
+    "contextKind",
+    "releaseId",
+    "settlementChainId",
+    "factoryAddress",
+    "factoryRuntimeCodeHash",
+    "presentationRevisionHash",
+    "readMarket",
+    "confirmedBlock",
+  ]);
+  if (
+    !context ||
+    context.schemaVersion !== PREDICTION_MARKET_PROJECTION_CONTEXT_SCHEMA_V2 ||
+    context.contextKind !== PREDICTION_MARKET_PROJECTION_CONTEXT_KIND_V2 ||
+    context.settlementChainId !== PREDICTION_V2_SETTLEMENT_CHAIN_ID ||
+    !canonicalReleaseId(context.releaseId)
+  ) return null;
+  const factoryAddress = canonicalAddress(context.factoryAddress);
+  const factoryRuntimeCodeHash = canonicalBytes32(
+    context.factoryRuntimeCodeHash,
+  );
+  const presentationRevisionHash = canonicalSha256(
+    context.presentationRevisionHash,
+  );
+  const readMarket = exactRecord(context.readMarket, [
+    "marketKey",
+    "economicKey",
+    "vaultAddress",
+    "checkpointAddress",
+    "poolId",
+    "marketId",
+    "onchainAssetKey",
+    "registryRevision",
+    "registrySnapshotHash",
+    "resolutionPolicyHash",
+    "policyValidUntil",
+    "snapshotAssetCapAtoms",
+    "observationUnixSeconds",
+    "thresholdAtoms",
+    "priceDecimals",
+  ]);
+  const confirmedBlock = exactRecord(context.confirmedBlock, [
+    "number",
+    "hash",
+  ]);
+  if (
+    !factoryAddress ||
+    !factoryRuntimeCodeHash ||
+    !presentationRevisionHash ||
+    !readMarket ||
+    !confirmedBlock ||
+    readMarket.priceDecimals !== 8
+  ) return null;
+  const economicKey = canonicalBytes32(readMarket.economicKey);
+  const vaultAddress = canonicalAddress(readMarket.vaultAddress);
+  const checkpointAddress = canonicalAddress(readMarket.checkpointAddress);
+  const poolId = canonicalBytes32(readMarket.poolId);
+  const marketId = canonicalBytes32(readMarket.marketId);
+  const onchainAssetKey = canonicalBytes32(readMarket.onchainAssetKey);
+  const registrySnapshotHash = canonicalBytes32(
+    readMarket.registrySnapshotHash,
+  );
+  const resolutionPolicyHash = canonicalBytes32(
+    readMarket.resolutionPolicyHash,
+  );
+  const registryRevision = canonicalUint(readMarket.registryRevision, 1n);
+  const policyValidUntil = canonicalUint(readMarket.policyValidUntil, 1n);
+  const snapshotAssetCapAtoms = canonicalUint(
+    readMarket.snapshotAssetCapAtoms,
+    1n,
+    (1n << 256n) - 1n,
+  );
+  const observationUnixSeconds = canonicalUint(
+    readMarket.observationUnixSeconds,
+    1n,
+    (1n << 32n) - 1n,
+  );
+  const thresholdAtoms = canonicalUint(
+    readMarket.thresholdAtoms,
+    1n,
+    (1n << 191n) - 1n,
+  );
+  const confirmedBlockNumber = canonicalUint(confirmedBlock.number, 1n);
+  const confirmedBlockHash = canonicalBytes32(confirmedBlock.hash);
+  const marketKey = typeof readMarket.marketKey === "string" &&
+      readMarket.marketKey ===
+        `eip155:${PREDICTION_V2_SETTLEMENT_CHAIN_ID}:${factoryAddress}:${economicKey}`
+    ? readMarket.marketKey as PredictionMarketKeyV2
+    : null;
+  if (
+    !economicKey ||
+    !vaultAddress ||
+    !checkpointAddress ||
+    !poolId ||
+    !marketId ||
+    !onchainAssetKey ||
+    !registrySnapshotHash ||
+    !resolutionPolicyHash ||
+    !registryRevision ||
+    !policyValidUntil ||
+    !snapshotAssetCapAtoms ||
+    !observationUnixSeconds ||
+    !thresholdAtoms ||
+    !confirmedBlockNumber ||
+    !confirmedBlockHash ||
+    !marketKey ||
+    BigInt(observationUnixSeconds) > BigInt(policyValidUntil)
+  ) return null;
+  return Object.freeze({
+    schemaVersion: PREDICTION_MARKET_PROJECTION_CONTEXT_SCHEMA_V2,
+    contextKind: PREDICTION_MARKET_PROJECTION_CONTEXT_KIND_V2,
+    releaseId: context.releaseId as string,
+    settlementChainId: PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+    factoryAddress,
+    factoryRuntimeCodeHash,
+    presentationRevisionHash,
+    readMarket: Object.freeze({
+      marketKey,
+      economicKey,
+      vaultAddress,
+      checkpointAddress,
+      poolId,
+      marketId,
+      onchainAssetKey,
+      registryRevision,
+      registrySnapshotHash,
+      resolutionPolicyHash,
+      policyValidUntil,
+      snapshotAssetCapAtoms,
+      observationUnixSeconds,
+      thresholdAtoms,
+      priceDecimals: 8 as const,
+    }),
+    confirmedBlock: Object.freeze({
+      number: confirmedBlockNumber,
+      hash: confirmedBlockHash,
+    }),
+  });
+}
+
+function exactRecord(
+  value: unknown,
+  keys: readonly string[],
+): Record<string, unknown> | null {
+  if (!isPlainRecord(value)) return null;
+  const actual = Reflect.ownKeys(value);
+  return actual.length === keys.length &&
+      actual.every((key) => typeof key === "string" && keys.includes(key)) &&
+      keys.every((key) => Object.hasOwn(value, key))
+    ? value
+    : null;
+}
+
+function canonicalReleaseId(value: unknown): string | null {
+  return typeof value === "string" &&
+      /^[a-z0-9][a-z0-9._-]{0,95}$/u.test(value)
+    ? value
+    : null;
+}
+
+function canonicalAddress(value: unknown): string | null {
+  if (typeof value !== "string" || !isAddress(value, { strict: false })) {
+    return null;
+  }
+  const normalized = value.toLowerCase();
+  return normalized === `0x${"0".repeat(40)}` ? null : normalized;
+}
+
+function canonicalBytes32(value: unknown): PredictionBytes32V2 | null {
+  return typeof value === "string" &&
+      /^0x[0-9a-f]{64}$/u.test(value) &&
+      value !== `0x${"0".repeat(64)}`
+    ? value as PredictionBytes32V2
+    : null;
+}
+
+function canonicalSha256(
+  value: unknown,
+): PredictionPresentationSha256V2 | null {
+  return typeof value === "string" && /^sha256:[0-9a-f]{64}$/u.test(value)
+    ? value as PredictionPresentationSha256V2
+    : null;
+}
+
+function canonicalSignature(value: unknown): Hex | null {
+  return typeof value === "string" && /^0x[0-9a-f]{130}$/u.test(value)
+    ? value as Hex
+    : null;
+}
+
+function canonicalUint(
+  value: unknown,
+  minimum: bigint,
+  maximum = (1n << 64n) - 1n,
+): string | null {
+  if (typeof value !== "string" || !/^(?:0|[1-9][0-9]*)$/u.test(value)) {
+    return null;
+  }
+  const number = BigInt(value);
+  return number >= minimum && number <= maximum ? number.toString() : null;
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "string" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError("Non-finite JSON number");
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+  }
+  if (!isPlainRecord(value)) throw new TypeError("Non-canonical JSON value");
+  return `{${Object.keys(value).sort().map((key) =>
+    `${JSON.stringify(key)}:${canonicalJson(value[key])}`
+  ).join(",")}}`;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype;
+}

--- a/lib/prediction-v2/read-model-v2.server.ts
+++ b/lib/prediction-v2/read-model-v2.server.ts
@@ -1,0 +1,1433 @@
+import "server-only";
+
+import {
+  decodeFunctionResult,
+  encodeFunctionData,
+  getAddress,
+  type Abi,
+  type Address,
+  type Hex,
+} from "viem";
+
+import {
+  predictionOnchainAssetKeyV2,
+  type PredictionAssetIdentityV2,
+  type PredictionBytes32V2,
+} from "../prediction-market-assets-v2";
+import {
+  PREDICTION_V2_ASSET_REGISTRY_ABI,
+  PREDICTION_V2_CHECKPOINT_ABI,
+  PREDICTION_V2_FACTORY_ABI,
+  PREDICTION_V2_POOL_MANAGER_STATE_ABI,
+  PREDICTION_V2_VAULT_ABI,
+  type PredictionV2PoolKey,
+  type PredictionV2RegistrySnapshot,
+} from "./abi";
+import {
+  bindPredictionV2MarketState,
+  predictionV2PoolId,
+  predictionV2PoolStateSlot,
+  predictionV2YesProbabilityBps,
+} from "./accounting";
+import {
+  decodePredictionV2MarketRecord,
+  decodePredictionV2RegistrySnapshot,
+  predictionV2RegistrySnapshotHash,
+} from "./codec";
+
+const PREDICTION_V2_CHAIN_ID = 4_663 as const;
+const PREDICTION_V2_MAXIMUM_PAGE_SIZE = 24;
+const PREDICTION_V2_MARKET_BATCH_SIZE = 4;
+const PREDICTION_V2_MAXIMUM_DUAL_CALLS_IN_FLIGHT = 8;
+const PREDICTION_V2_CUTOFF_BEFORE_OBSERVATION_SECONDS = 60n;
+const PREDICTION_V2_PRICE_DECIMALS = 8n;
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const ZERO_BYTES32 = `0x${"00".repeat(32)}`;
+const HEX_PATTERN = /^0x(?:[0-9a-fA-F]{2})*$/u;
+const BYTES32_PATTERN = /^0x[0-9a-fA-F]{64}$/u;
+
+/**
+ * Exact LifecycleHookV2 read closure from canonical V2 source commit
+ * 2a6297b34a30aff3b945156d0dce94ff979861fd.
+ */
+export const PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI = [
+  {
+    type: "function",
+    name: "factory",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "authorizedRouter",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "poolManager",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "lifecycle",
+    stateMutability: "view",
+    inputs: [{ name: "poolId", type: "bytes32" }],
+    outputs: [
+      { name: "cutoff", type: "uint64" },
+      { name: "registeredBlock", type: "uint64" },
+      { name: "checkpoint", type: "address" },
+      { name: "initialized", type: "bool" },
+    ],
+  },
+] as const satisfies Abi;
+
+/**
+ * Exact Router-facing Factory read from canonical V2 source commit
+ * 2a6297b34a30aff3b945156d0dce94ff979861fd.
+ */
+export const PREDICTION_V2_FACTORY_CANONICAL_READ_ABI = [
+  {
+    type: "function",
+    name: "isCanonicalVault",
+    stateMutability: "view",
+    inputs: [
+      { name: "vault", type: "address" },
+      { name: "poolId", type: "bytes32" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+] as const satisfies Abi;
+
+/**
+ * Exact ExecutionRouterV2 read closure from canonical V2 source commit
+ * 2a6297b34a30aff3b945156d0dce94ff979861fd.
+ */
+export const PREDICTION_V2_EXECUTION_ROUTER_READ_ABI = [
+  {
+    type: "function",
+    name: "factory",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "manager",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "collateral",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+] as const satisfies Abi;
+
+export type PredictionV2SafeBlock = Readonly<{
+  number: bigint;
+  hash: PredictionBytes32V2;
+  parentHash: PredictionBytes32V2;
+  timestamp: bigint;
+}>;
+
+export type PredictionV2ReadCall = Readonly<{
+  to: Address;
+  data: Hex;
+  blockNumber: bigint;
+  blockHash: PredictionBytes32V2;
+  requireCanonical: true;
+  signal?: AbortSignal;
+}>;
+
+/**
+ * A reader may return this only for a deterministic EVM execution revert. RPC
+ * transport, timeout, malformed-response, and provider errors must reject the
+ * promise so they remain global fail-closed failures.
+ */
+export type PredictionV2RpcCallRevert = Readonly<{
+  status: "reverted";
+  data: Hex;
+}>;
+
+/**
+ * Provider-neutral, server-only boundary. Each implementation must obtain its
+ * safe block independently; the read model accepts state only after the two
+ * readers agree on the complete block identity and every raw eth_call result.
+ * `call` must use the request's EIP-1898 `{ blockHash, requireCanonical }`
+ * reference; `blockNumber` is retained only for diagnostics and assertions.
+ */
+export type PredictionV2RpcReader = Readonly<{
+  readerId: string;
+  getChainId(signal?: AbortSignal): Promise<number>;
+  getSafeBlock(signal?: AbortSignal): Promise<PredictionV2SafeBlock>;
+  getBlock(
+    blockNumber: bigint,
+    signal?: AbortSignal,
+  ): Promise<PredictionV2SafeBlock | null>;
+  call(request: PredictionV2ReadCall): Promise<Hex | PredictionV2RpcCallRevert>;
+}>;
+
+export type PredictionV2ReadBinding = Readonly<{
+  factory: Address;
+  assetRegistry: Address;
+  poolManager: Address;
+  hook: Address;
+  collateral: Address;
+  router: Address;
+  deploymentBlock: bigint;
+}>;
+
+export type PredictionV2ReadCursor = Readonly<{
+  schemaVersion: 2;
+  blockNumber: bigint;
+  blockHash: PredictionBytes32V2;
+  marketCount: bigint;
+  nextExclusiveIndex: bigint;
+}>;
+
+export type PredictionV2ProtocolState =
+  | "OPEN"
+  | "FINAL_YES"
+  | "FINAL_NO"
+  | "FINAL_INVALID";
+
+export type PredictionV2CheckpointStatus = "AWAITING" | "FINAL" | "INVALID";
+
+export type PredictionV2TradingPhase = "OPEN" | "CLOSED" | "FINAL";
+
+export type PredictionV2TradabilityReason =
+  | "tradable"
+  | "market-final"
+  | "cutoff-reached"
+  | "checkpoint-unhealthy";
+
+export type PredictionV2Lifecycle = Readonly<{
+  protocolState: PredictionV2ProtocolState;
+  checkpointStatus: PredictionV2CheckpointStatus;
+  tradingPhase: PredictionV2TradingPhase;
+  tradable: boolean;
+  tradabilityReason: PredictionV2TradabilityReason;
+  checkpointTradingHealthy: boolean;
+  resolvedPrice: bigint;
+}>;
+
+export type PredictionV2ReadMarket = Readonly<{
+  economicKey: PredictionBytes32V2;
+  marketId: PredictionBytes32V2;
+  assetKey: PredictionBytes32V2;
+  registryRevision: bigint;
+  registrySnapshotHash: PredictionBytes32V2;
+  resolutionPolicyHash: PredictionBytes32V2;
+  policyValidUntil: bigint;
+  snapshotAssetCap: bigint;
+  vault: Address;
+  checkpoint: Address;
+  yesToken: Address;
+  noToken: Address;
+  poolId: PredictionBytes32V2;
+  poolKey: PredictionV2PoolKey;
+  asset: Readonly<{
+    identity: PredictionAssetIdentityV2;
+    displaySymbol: string;
+  }>;
+  predicate: Readonly<{
+    comparator: "greater-than-or-equal";
+    threshold: bigint;
+    observationTime: bigint;
+    priceDecimals: number;
+  }>;
+  lifecycle: PredictionV2Lifecycle;
+  deadlines: Readonly<{
+    cutoff: bigint;
+    resolutionDeadline: bigint;
+    hardResolutionDeadline: bigint;
+    fallbackRequestedAt: bigint;
+    fallbackChallengeDeadline: bigint;
+  }>;
+  poolState: Readonly<{
+    sqrtPriceX96: bigint;
+    tick: number;
+    poolManagerProtocolFee: number;
+    lpFee: number;
+    yesProbabilityBps: number;
+  }>;
+  accountedLiability: bigint;
+}>;
+
+export type PredictionV2QuarantinedMarket = Readonly<{
+  index: bigint;
+  economicKey: PredictionBytes32V2;
+  code: "invalid-market-wiring";
+}>;
+
+export type PredictionV2DirectoryRead = Readonly<{
+  schemaVersion: 2;
+  chainId: typeof PREDICTION_V2_CHAIN_ID;
+  snapshot: PredictionV2SafeBlock;
+  marketCount: bigint;
+  markets: readonly PredictionV2ReadMarket[];
+  quarantined: readonly PredictionV2QuarantinedMarket[];
+  nextCursor: PredictionV2ReadCursor | null;
+}>;
+
+type NormalizedBinding = PredictionV2ReadBinding;
+
+class PredictionV2ReadModelError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PredictionV2ReadModelError";
+  }
+}
+
+class PredictionV2MarketWiringError extends Error {
+  constructor() {
+    super("Prediction V2 market wiring is invalid");
+    this.name = "PredictionV2MarketWiringError";
+  }
+}
+
+class PredictionV2DeterministicCallRevert extends Error {
+  constructor() {
+    super("Prediction V2 contract read reverted deterministically");
+    this.name = "PredictionV2DeterministicCallRevert";
+  }
+}
+
+class PredictionV2DualCallLimiter {
+  readonly #waiters: Array<() => void> = [];
+  #active = 0;
+
+  async run<Value>(operation: () => Promise<Value>, signal?: AbortSignal): Promise<Value> {
+    signal?.throwIfAborted();
+    if (this.#active >= PREDICTION_V2_MAXIMUM_DUAL_CALLS_IN_FLIGHT) {
+      await new Promise<void>((resolve) => this.#waiters.push(resolve));
+    } else {
+      this.#active += 1;
+    }
+    try {
+      signal?.throwIfAborted();
+      return await operation();
+    } finally {
+      const next = this.#waiters.shift();
+      if (next) next();
+      else this.#active -= 1;
+    }
+  }
+}
+
+function fail(message: string): never {
+  throw new PredictionV2ReadModelError(message);
+}
+
+function invalidMarket(): never {
+  throw new PredictionV2MarketWiringError();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonzeroAddress(value: unknown, label: string): Address {
+  if (typeof value !== "string") return fail(`${label} is invalid`);
+  let address: Address;
+  try {
+    address = getAddress(value);
+  } catch {
+    return fail(`${label} is invalid`);
+  }
+  if (address.toLowerCase() === ZERO_ADDRESS) return fail(`${label} is zero`);
+  return address;
+}
+
+function nonzeroBytes32(value: unknown, label: string): PredictionBytes32V2 {
+  if (
+    typeof value !== "string" ||
+    !BYTES32_PATTERN.test(value) ||
+    value.toLowerCase() === ZERO_BYTES32
+  ) return fail(`${label} is invalid`);
+  return value.toLowerCase() as PredictionBytes32V2;
+}
+
+function exactHex(value: unknown, label: string): Hex {
+  if (typeof value !== "string" || !HEX_PATTERN.test(value)) {
+    return fail(`${label} is not canonical hex`);
+  }
+  return value.toLowerCase() as Hex;
+}
+
+type NormalizedCallOutcome =
+  | Readonly<{ status: "success"; data: Hex }>
+  | Readonly<{ status: "reverted"; data: Hex }>;
+
+function normalizeCallOutcome(value: unknown, label: string): NormalizedCallOutcome {
+  if (typeof value === "string") {
+    return Object.freeze({ status: "success", data: exactHex(value, label) });
+  }
+  const ownKeys = isRecord(value) ? Reflect.ownKeys(value) : [];
+  if (
+    !isRecord(value) ||
+    ownKeys.some((key) => typeof key !== "string") ||
+    (ownKeys as string[]).sort().join(",") !== "data,status" ||
+    value.status !== "reverted"
+  ) return fail(`${label} is invalid`);
+  return Object.freeze({
+    status: "reverted",
+    data: exactHex(value.data, `${label} revert data`),
+  });
+}
+
+function sameAddress(left: Address, right: Address) {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function sameBytes32(left: string, right: string) {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function normalizeBinding(binding: PredictionV2ReadBinding): NormalizedBinding {
+  if (!isRecord(binding) || binding.deploymentBlock < 1n) {
+    return fail("Prediction V2 read binding is invalid");
+  }
+  return Object.freeze({
+    factory: nonzeroAddress(binding.factory, "Factory"),
+    assetRegistry: nonzeroAddress(binding.assetRegistry, "Asset Registry"),
+    poolManager: nonzeroAddress(binding.poolManager, "PoolManager"),
+    hook: nonzeroAddress(binding.hook, "Hook"),
+    collateral: nonzeroAddress(binding.collateral, "collateral"),
+    router: nonzeroAddress(binding.router, "Router"),
+    deploymentBlock: binding.deploymentBlock,
+  });
+}
+
+function normalizeBlock(value: PredictionV2SafeBlock, label: string): PredictionV2SafeBlock {
+  if (!isRecord(value) || value.number < 1n || value.timestamp < 0n) {
+    return fail(`${label} block is invalid`);
+  }
+  return Object.freeze({
+    number: value.number,
+    hash: nonzeroBytes32(value.hash, `${label} block hash`),
+    parentHash: nonzeroBytes32(value.parentHash, `${label} parent hash`),
+    timestamp: value.timestamp,
+  });
+}
+
+function assertSameBlock(
+  primary: PredictionV2SafeBlock,
+  secondary: PredictionV2SafeBlock,
+) {
+  if (!sameBlockIdentity(primary, secondary)) {
+    fail("Prediction V2 RPCs disagree about the safe block");
+  }
+}
+
+function sameBlockIdentity(
+  primary: PredictionV2SafeBlock,
+  secondary: PredictionV2SafeBlock,
+) {
+  return !(
+    primary.number !== secondary.number ||
+    !sameBytes32(primary.hash, secondary.hash) ||
+    !sameBytes32(primary.parentHash, secondary.parentHash) ||
+    primary.timestamp !== secondary.timestamp
+  );
+}
+
+function normalizeCursor(value: PredictionV2ReadCursor): PredictionV2ReadCursor {
+  const ownKeys = isRecord(value) ? Reflect.ownKeys(value) : [];
+  if (
+    !isRecord(value) ||
+    ownKeys.some((key) => typeof key !== "string") ||
+    (ownKeys as string[]).sort().join(",") !==
+      "blockHash,blockNumber,marketCount,nextExclusiveIndex,schemaVersion" ||
+    value.schemaVersion !== 2 ||
+    value.blockNumber < 1n ||
+    value.marketCount < 0n ||
+    value.nextExclusiveIndex < 0n ||
+    value.nextExclusiveIndex > value.marketCount
+  ) return fail("Prediction V2 cursor is invalid");
+  return Object.freeze({
+    schemaVersion: 2,
+    blockNumber: value.blockNumber,
+    blockHash: nonzeroBytes32(value.blockHash, "cursor block hash"),
+    marketCount: value.marketCount,
+    nextExclusiveIndex: value.nextExclusiveIndex,
+  });
+}
+
+export function predictionV2PageIndices(input: Readonly<{
+  marketCount: bigint;
+  limit: number;
+  nextExclusiveIndex?: bigint;
+}>) {
+  if (input.marketCount < 0n) return fail("Prediction V2 market count is invalid");
+  if (
+    !Number.isInteger(input.limit) ||
+    input.limit < 1 ||
+    input.limit > PREDICTION_V2_MAXIMUM_PAGE_SIZE
+  ) return fail("Prediction V2 page size must be between 1 and 24");
+  const upperBound = input.nextExclusiveIndex ?? input.marketCount;
+  if (upperBound < 0n || upperBound > input.marketCount) {
+    return fail("Prediction V2 page cursor is outside the Factory range");
+  }
+  const pageSize = Number(
+    upperBound < BigInt(input.limit) ? upperBound : BigInt(input.limit),
+  );
+  const indices = Array.from(
+    { length: pageSize },
+    (_, index) => upperBound - 1n - BigInt(index),
+  );
+  const nextExclusiveIndex = upperBound - BigInt(pageSize);
+  return Object.freeze({
+    indices: Object.freeze(indices),
+    nextExclusiveIndex,
+  });
+}
+
+function encodeCall(
+  abi: Abi,
+  functionName: string,
+  args?: readonly unknown[],
+): Hex {
+  return encodeFunctionData({
+    abi,
+    functionName: functionName as never,
+    ...(args ? { args: args as never } : {}),
+  });
+}
+
+function decodeResult(
+  abi: Abi,
+  functionName: string,
+  data: Hex,
+): unknown {
+  return decodeFunctionResult({
+    abi,
+    functionName: functionName as never,
+    data,
+  });
+}
+
+function decodeAddressResult(abi: Abi, functionName: string, data: Hex): Address {
+  return nonzeroAddress(decodeResult(abi, functionName, data), `${functionName} result`);
+}
+
+function decodeBytes32Result(
+  abi: Abi,
+  functionName: string,
+  data: Hex,
+): PredictionBytes32V2 {
+  return nonzeroBytes32(decodeResult(abi, functionName, data), `${functionName} result`);
+}
+
+function decodeUnsignedResult(abi: Abi, functionName: string, data: Hex): bigint {
+  const value = decodeResult(abi, functionName, data);
+  if (
+    (typeof value !== "number" && typeof value !== "bigint") ||
+    (typeof value === "number" && (!Number.isSafeInteger(value) || value < 0)) ||
+    (typeof value === "bigint" && value < 0n)
+  ) return fail(`${functionName} result is invalid`);
+  return BigInt(value);
+}
+
+function decodeSignedResult(abi: Abi, functionName: string, data: Hex): bigint {
+  const value = decodeResult(abi, functionName, data);
+  if (
+    (typeof value !== "number" && typeof value !== "bigint") ||
+    (typeof value === "number" && !Number.isSafeInteger(value))
+  ) return fail(`${functionName} result is invalid`);
+  return BigInt(value);
+}
+
+function decodeBooleanResult(abi: Abi, functionName: string, data: Hex): boolean {
+  const value = decodeResult(abi, functionName, data);
+  if (typeof value !== "boolean") return fail(`${functionName} result is invalid`);
+  return value;
+}
+
+function exactTuple(
+  value: unknown,
+  fields: readonly string[],
+  label: string,
+): Record<string, unknown> {
+  if (Array.isArray(value)) {
+    if (value.length !== fields.length) return fail(`${label} result is invalid`);
+    return Object.fromEntries(fields.map((field, index) => [field, value[index]]));
+  }
+  if (!isRecord(value)) return fail(`${label} result is invalid`);
+  const keys = Reflect.ownKeys(value);
+  if (
+    keys.some((key) => typeof key !== "string") ||
+    (keys as string[]).sort().join(",") !== [...fields].sort().join(",")
+  ) return fail(`${label} result is invalid`);
+  return value;
+}
+
+function unsignedValue(value: unknown, label: string): bigint {
+  if (
+    (typeof value !== "number" && typeof value !== "bigint") ||
+    (typeof value === "number" && (!Number.isSafeInteger(value) || value < 0)) ||
+    (typeof value === "bigint" && value < 0n)
+  ) return fail(`${label} is invalid`);
+  return BigInt(value);
+}
+
+function decodeHookLifecycle(data: Hex) {
+  const value = exactTuple(
+    decodeResult(PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI, "lifecycle", data),
+    ["cutoff", "registeredBlock", "checkpoint", "initialized"],
+    "LifecycleHook lifecycle",
+  );
+  if (typeof value.initialized !== "boolean") {
+    return fail("LifecycleHook initialized result is invalid");
+  }
+  return Object.freeze({
+    cutoff: unsignedValue(value.cutoff, "LifecycleHook cutoff"),
+    registeredBlock: unsignedValue(
+      value.registeredBlock,
+      "LifecycleHook registered block",
+    ),
+    checkpoint: nonzeroAddress(value.checkpoint, "LifecycleHook checkpoint"),
+    initialized: value.initialized,
+  });
+}
+
+function decodePoolKey(data: Hex): PredictionV2PoolKey {
+  const value = decodeResult(PREDICTION_V2_FACTORY_ABI, "getPoolKey", data);
+  if (!isRecord(value)) return fail("PoolKey result is invalid");
+  const fee = value.fee;
+  const tickSpacing = value.tickSpacing;
+  if (
+    typeof fee !== "number" ||
+    !Number.isInteger(fee) ||
+    typeof tickSpacing !== "number" ||
+    !Number.isInteger(tickSpacing)
+  ) return fail("PoolKey result is invalid");
+  return Object.freeze({
+    currency0: nonzeroAddress(value.currency0, "PoolKey currency0"),
+    currency1: nonzeroAddress(value.currency1, "PoolKey currency1"),
+    fee,
+    tickSpacing,
+    hooks: nonzeroAddress(value.hooks, "PoolKey hook"),
+  });
+}
+
+function decodeSlot0(data: Hex) {
+  const word = decodeResult(PREDICTION_V2_POOL_MANAGER_STATE_ABI, "extsload", data);
+  const canonical = nonzeroBytes32(word, "PoolManager slot0");
+  const packed = BigInt(canonical);
+  if (packed >> 232n !== 0n) return fail("PoolManager slot0 reserved bits are set");
+  const sqrtPriceX96 = packed & ((1n << 160n) - 1n);
+  const unsignedTick = Number((packed >> 160n) & 0xff_ffffn);
+  const tick = unsignedTick >= 0x80_0000
+    ? unsignedTick - 0x100_0000
+    : unsignedTick;
+  return Object.freeze({
+    sqrtPriceX96,
+    tick,
+    poolManagerProtocolFee: Number((packed >> 184n) & 0xff_ffffn),
+    lpFee: Number((packed >> 208n) & 0xff_ffffn),
+  });
+}
+
+function protocolState(value: bigint): PredictionV2ProtocolState {
+  const states = ["OPEN", "FINAL_YES", "FINAL_NO", "FINAL_INVALID"] as const;
+  if (value < 0n || value >= BigInt(states.length)) return invalidMarket();
+  return states[Number(value)];
+}
+
+function checkpointStatus(value: bigint): PredictionV2CheckpointStatus {
+  const statuses = ["AWAITING", "FINAL", "INVALID"] as const;
+  if (value < 0n || value >= BigInt(statuses.length)) return invalidMarket();
+  return statuses[Number(value)];
+}
+
+function lifecycle(input: Readonly<{
+  state: bigint;
+  checkpointStatus: bigint;
+  checkpointTradingHealthy: boolean;
+  resolvedPrice: bigint;
+  threshold: bigint;
+  cutoff: bigint;
+  observationTime: bigint;
+  blockTimestamp: bigint;
+}>): PredictionV2Lifecycle {
+  const state = protocolState(input.state);
+  const status = checkpointStatus(input.checkpointStatus);
+  if (state !== "OPEN" && input.blockTimestamp < input.cutoff) invalidMarket();
+  if (status !== "AWAITING" && input.checkpointTradingHealthy) invalidMarket();
+  if (status !== "FINAL" && input.resolvedPrice !== 0n) invalidMarket();
+  if (status !== "AWAITING" && input.blockTimestamp <= input.observationTime) invalidMarket();
+  if (
+    (state === "FINAL_YES" &&
+      (status !== "FINAL" || input.resolvedPrice < input.threshold)) ||
+    (state === "FINAL_NO" &&
+      (status !== "FINAL" || input.resolvedPrice <= 0n ||
+        input.resolvedPrice >= input.threshold)) ||
+    (state === "FINAL_INVALID" &&
+      status !== "INVALID" && (status !== "FINAL" || input.resolvedPrice > 0n))
+  ) invalidMarket();
+
+  if (state !== "OPEN") {
+    return Object.freeze({
+      protocolState: state,
+      checkpointStatus: status,
+      tradingPhase: "FINAL",
+      tradable: false,
+      tradabilityReason: "market-final",
+      checkpointTradingHealthy: input.checkpointTradingHealthy,
+      resolvedPrice: input.resolvedPrice,
+    });
+  }
+  if (input.blockTimestamp >= input.cutoff) {
+    return Object.freeze({
+      protocolState: state,
+      checkpointStatus: status,
+      tradingPhase: "CLOSED",
+      tradable: false,
+      tradabilityReason: "cutoff-reached",
+      checkpointTradingHealthy: input.checkpointTradingHealthy,
+      resolvedPrice: input.resolvedPrice,
+    });
+  }
+  if (!input.checkpointTradingHealthy) {
+    return Object.freeze({
+      protocolState: state,
+      checkpointStatus: status,
+      tradingPhase: "OPEN",
+      tradable: false,
+      tradabilityReason: "checkpoint-unhealthy",
+      checkpointTradingHealthy: input.checkpointTradingHealthy,
+      resolvedPrice: input.resolvedPrice,
+    });
+  }
+  return Object.freeze({
+    protocolState: state,
+    checkpointStatus: status,
+    tradingPhase: "OPEN",
+    tradable: true,
+    tradabilityReason: "tradable",
+    checkpointTradingHealthy: true,
+    resolvedPrice: input.resolvedPrice,
+  });
+}
+
+async function sameRawCall(input: Readonly<{
+  readers: readonly [PredictionV2RpcReader, PredictionV2RpcReader];
+  limiter: PredictionV2DualCallLimiter;
+  to: Address;
+  data: Hex;
+  blockNumber: bigint;
+  blockHash: PredictionBytes32V2;
+  signal?: AbortSignal;
+}>): Promise<Hex> {
+  input.signal?.throwIfAborted();
+  const request = Object.freeze({
+    to: input.to,
+    data: input.data,
+    blockNumber: input.blockNumber,
+    blockHash: input.blockHash,
+    requireCanonical: true as const,
+    ...(input.signal ? { signal: input.signal } : {}),
+  });
+  const [primaryValue, secondaryValue] = await input.limiter.run(
+    () => Promise.all([
+      input.readers[0].call(request),
+      input.readers[1].call(request),
+    ]),
+    input.signal,
+  );
+  const primary = normalizeCallOutcome(primaryValue, "primary RPC result");
+  const secondary = normalizeCallOutcome(secondaryValue, "secondary RPC result");
+  if (primary.status !== secondary.status || primary.data !== secondary.data) {
+    fail("Prediction V2 RPCs disagree about contract state");
+  }
+  if (primary.status === "reverted") throw new PredictionV2DeterministicCallRevert();
+  return primary.data;
+}
+
+function readFunction(input: Readonly<{
+  readers: readonly [PredictionV2RpcReader, PredictionV2RpcReader];
+  limiter: PredictionV2DualCallLimiter;
+  to: Address;
+  abi: Abi;
+  functionName: string;
+  args?: readonly unknown[];
+  blockNumber: bigint;
+  blockHash: PredictionBytes32V2;
+  signal?: AbortSignal;
+}>) {
+  return sameRawCall({
+    readers: input.readers,
+    limiter: input.limiter,
+    to: input.to,
+    data: encodeCall(input.abi, input.functionName, input.args),
+    blockNumber: input.blockNumber,
+    blockHash: input.blockHash,
+    ...(input.signal ? { signal: input.signal } : {}),
+  });
+}
+
+async function resolveSnapshot(input: Readonly<{
+  readers: readonly [PredictionV2RpcReader, PredictionV2RpcReader];
+  binding: NormalizedBinding;
+  cursor?: PredictionV2ReadCursor;
+  signal?: AbortSignal;
+}>) {
+  const [primaryChainId, secondaryChainId, primarySafe, secondarySafe] =
+    await Promise.all([
+      input.readers[0].getChainId(input.signal),
+      input.readers[1].getChainId(input.signal),
+      input.readers[0].getSafeBlock(input.signal),
+      input.readers[1].getSafeBlock(input.signal),
+    ]);
+  if (
+    primaryChainId !== PREDICTION_V2_CHAIN_ID ||
+    secondaryChainId !== PREDICTION_V2_CHAIN_ID
+  ) fail("A Prediction V2 RPC is not serving Robinhood Chain");
+  const safePrimary = normalizeBlock(primarySafe, "primary safe");
+  const safeSecondary = normalizeBlock(secondarySafe, "secondary safe");
+  assertSameBlock(safePrimary, safeSecondary);
+  if (safePrimary.number < input.binding.deploymentBlock) {
+    fail("Prediction V2 safe block predates the release deployment");
+  }
+  if (!input.cursor) return safePrimary;
+  if (input.cursor.blockNumber > safePrimary.number) {
+    fail("Prediction V2 cursor is newer than the safe block");
+  }
+  const [primaryHistorical, secondaryHistorical] = await Promise.all([
+    input.readers[0].getBlock(input.cursor.blockNumber, input.signal),
+    input.readers[1].getBlock(input.cursor.blockNumber, input.signal),
+  ]);
+  if (!primaryHistorical || !secondaryHistorical) {
+    return fail("Prediction V2 cursor block is unavailable");
+  }
+  const historicalPrimary = normalizeBlock(primaryHistorical, "primary cursor");
+  const historicalSecondary = normalizeBlock(secondaryHistorical, "secondary cursor");
+  assertSameBlock(historicalPrimary, historicalSecondary);
+  if (!sameBytes32(historicalPrimary.hash, input.cursor.blockHash)) {
+    fail("Prediction V2 cursor block was replaced");
+  }
+  return historicalPrimary;
+}
+
+async function revalidateSnapshot(input: Readonly<{
+  readers: readonly [PredictionV2RpcReader, PredictionV2RpcReader];
+  block: PredictionV2SafeBlock;
+  signal?: AbortSignal;
+}>) {
+  input.signal?.throwIfAborted();
+  const [primaryCurrent, secondaryCurrent] = await Promise.all([
+    input.readers[0].getBlock(input.block.number, input.signal),
+    input.readers[1].getBlock(input.block.number, input.signal),
+  ]);
+  if (!primaryCurrent || !secondaryCurrent) {
+    return fail("Prediction V2 snapshot block disappeared during read");
+  }
+  const primary = normalizeBlock(primaryCurrent, "primary final snapshot");
+  const secondary = normalizeBlock(secondaryCurrent, "secondary final snapshot");
+  assertSameBlock(primary, secondary);
+  if (!sameBlockIdentity(input.block, primary)) {
+    fail("Prediction V2 snapshot block changed during read");
+  }
+}
+
+async function mapInBatches<Input, Output>(
+  values: readonly Input[],
+  mapper: (value: Input) => Promise<Output>,
+): Promise<Output[]> {
+  const output: Output[] = [];
+  for (let index = 0; index < values.length; index += PREDICTION_V2_MARKET_BATCH_SIZE) {
+    output.push(...await Promise.all(
+      values.slice(index, index + PREDICTION_V2_MARKET_BATCH_SIZE).map(mapper),
+    ));
+  }
+  return output;
+}
+
+async function readVerifiedMarket(input: Readonly<{
+  readers: readonly [PredictionV2RpcReader, PredictionV2RpcReader];
+  limiter: PredictionV2DualCallLimiter;
+  binding: NormalizedBinding;
+  economicKey: PredictionBytes32V2;
+  block: PredictionV2SafeBlock;
+  signal?: AbortSignal;
+}>): Promise<PredictionV2ReadMarket> {
+  const call = (
+    to: Address,
+    abi: Abi,
+    functionName: string,
+    args?: readonly unknown[],
+  ) => readFunction({
+    readers: input.readers,
+    limiter: input.limiter,
+    to,
+    abi,
+    functionName,
+    ...(args ? { args } : {}),
+    blockNumber: input.block.number,
+    blockHash: input.block.hash,
+    ...(input.signal ? { signal: input.signal } : {}),
+  });
+
+  const [marketResult, poolKeyResult] = await Promise.all([
+    call(input.binding.factory, PREDICTION_V2_FACTORY_ABI, "markets", [input.economicKey]),
+    call(input.binding.factory, PREDICTION_V2_FACTORY_ABI, "getPoolKey", [input.economicKey]),
+  ]);
+
+  let market;
+  let poolKey: PredictionV2PoolKey;
+  try {
+    market = decodePredictionV2MarketRecord(marketResult);
+    poolKey = decodePoolKey(poolKeyResult);
+    if (!market) invalidMarket();
+  } catch {
+    return invalidMarket();
+  }
+
+  const vault = market.vault;
+  const checkpoint = market.checkpoint;
+  const slot0CallData = encodeCall(PREDICTION_V2_POOL_MANAGER_STATE_ABI, "extsload", [
+    predictionV2PoolStateSlot(poolKey),
+  ]);
+  const [
+    registrySnapshotResult,
+    vaultCollateralResult,
+    vaultCheckpointResult,
+    vaultFactoryResult,
+    vaultRouterResult,
+    yesTokenResult,
+    noTokenResult,
+    cutoffResult,
+    thresholdResult,
+    vaultEconomicKeyResult,
+    vaultMarketIdResult,
+    vaultAssetKeyResult,
+    vaultRegistryRevisionResult,
+    vaultRegistrySnapshotHashResult,
+    vaultPolicyHashResult,
+    vaultStateResult,
+    accountedLiabilityResult,
+    canonicalPoolIdResult,
+    checkpointStatusResult,
+    resolvedPriceResult,
+    observationTimeResult,
+    resolutionDeadlineResult,
+    hardResolutionDeadlineResult,
+    fallbackRequestedAtResult,
+    fallbackChallengeDeadlineResult,
+    checkpointPolicyHashResult,
+    priceDecimalsResult,
+    checkpointHealthResult,
+    hookLifecycleResult,
+    canonicalVaultResult,
+    slot0Result,
+  ] = await Promise.all([
+    call(input.binding.assetRegistry, PREDICTION_V2_ASSET_REGISTRY_ABI, "getSnapshot", [
+      market.assetKey,
+      market.registryRevision,
+    ]),
+    call(vault, PREDICTION_V2_VAULT_ABI, "collateral"),
+    call(vault, PREDICTION_V2_VAULT_ABI, "checkpoint"),
+    call(vault, PREDICTION_V2_VAULT_ABI, "factory"),
+    call(vault, PREDICTION_V2_VAULT_ABI, "router"),
+    call(vault, PREDICTION_V2_VAULT_ABI, "yesToken"),
+    call(vault, PREDICTION_V2_VAULT_ABI, "noToken"),
+    call(vault, PREDICTION_V2_VAULT_ABI, "cutoff"),
+    call(vault, PREDICTION_V2_VAULT_ABI, "threshold"),
+    call(vault, PREDICTION_V2_VAULT_ABI, "economicKey"),
+    call(vault, PREDICTION_V2_VAULT_ABI, "marketId"),
+    call(vault, PREDICTION_V2_VAULT_ABI, "assetKey"),
+    call(vault, PREDICTION_V2_VAULT_ABI, "registryRevision"),
+    call(vault, PREDICTION_V2_VAULT_ABI, "registrySnapshotHash"),
+    call(vault, PREDICTION_V2_VAULT_ABI, "oraclePolicyHash"),
+    call(vault, PREDICTION_V2_VAULT_ABI, "state"),
+    call(vault, PREDICTION_V2_VAULT_ABI, "accountedLiability"),
+    call(vault, PREDICTION_V2_VAULT_ABI, "canonicalPoolId"),
+    call(checkpoint, PREDICTION_V2_CHECKPOINT_ABI, "status"),
+    call(checkpoint, PREDICTION_V2_CHECKPOINT_ABI, "resolvedPrice"),
+    call(checkpoint, PREDICTION_V2_CHECKPOINT_ABI, "observationTime"),
+    call(checkpoint, PREDICTION_V2_CHECKPOINT_ABI, "resolutionDeadline"),
+    call(checkpoint, PREDICTION_V2_CHECKPOINT_ABI, "hardResolutionDeadline"),
+    call(checkpoint, PREDICTION_V2_CHECKPOINT_ABI, "fallbackRequestedAt"),
+    call(checkpoint, PREDICTION_V2_CHECKPOINT_ABI, "fallbackChallengeDeadline"),
+    call(checkpoint, PREDICTION_V2_CHECKPOINT_ABI, "policyHash"),
+    call(checkpoint, PREDICTION_V2_CHECKPOINT_ABI, "priceDecimals"),
+    call(checkpoint, PREDICTION_V2_CHECKPOINT_ABI, "isTradingHealthy"),
+    call(
+      input.binding.hook,
+      PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI,
+      "lifecycle",
+      [market.poolId],
+    ),
+    call(
+      input.binding.factory,
+      PREDICTION_V2_FACTORY_CANONICAL_READ_ABI,
+      "isCanonicalVault",
+      [vault, market.poolId],
+    ),
+    sameRawCall({
+      readers: input.readers,
+      limiter: input.limiter,
+      to: input.binding.poolManager,
+      data: slot0CallData,
+      blockNumber: input.block.number,
+      blockHash: input.block.hash,
+      ...(input.signal ? { signal: input.signal } : {}),
+    }),
+  ]);
+
+  let snapshot: PredictionV2RegistrySnapshot;
+  let collateral: Address;
+  let vaultCheckpoint: Address;
+  let vaultFactory: Address;
+  let router: Address;
+  let yesToken: Address;
+  let noToken: Address;
+  let cutoff: bigint;
+  let threshold: bigint;
+  let vaultEconomicKey: PredictionBytes32V2;
+  let vaultMarketId: PredictionBytes32V2;
+  let vaultAssetKey: PredictionBytes32V2;
+  let vaultRegistryRevision: bigint;
+  let vaultRegistrySnapshotHash: PredictionBytes32V2;
+  let vaultPolicyHash: PredictionBytes32V2;
+  let rawState: bigint;
+  let accountedLiability: bigint;
+  let canonicalPoolId: PredictionBytes32V2;
+  let rawCheckpointStatus: bigint;
+  let resolvedPrice: bigint;
+  let observationTime: bigint;
+  let resolutionDeadline: bigint;
+  let hardResolutionDeadline: bigint;
+  let fallbackRequestedAt: bigint;
+  let fallbackChallengeDeadline: bigint;
+  let checkpointPolicyHash: PredictionBytes32V2;
+  let priceDecimals: bigint;
+  let checkpointTradingHealthy: boolean;
+  let hookLifecycle: ReturnType<typeof decodeHookLifecycle>;
+  let canonicalVault: boolean;
+  let slot0: ReturnType<typeof decodeSlot0>;
+  try {
+    snapshot = decodePredictionV2RegistrySnapshot(registrySnapshotResult, "getSnapshot");
+    collateral = decodeAddressResult(PREDICTION_V2_VAULT_ABI, "collateral", vaultCollateralResult);
+    vaultCheckpoint = decodeAddressResult(PREDICTION_V2_VAULT_ABI, "checkpoint", vaultCheckpointResult);
+    vaultFactory = decodeAddressResult(PREDICTION_V2_VAULT_ABI, "factory", vaultFactoryResult);
+    router = decodeAddressResult(PREDICTION_V2_VAULT_ABI, "router", vaultRouterResult);
+    yesToken = decodeAddressResult(PREDICTION_V2_VAULT_ABI, "yesToken", yesTokenResult);
+    noToken = decodeAddressResult(PREDICTION_V2_VAULT_ABI, "noToken", noTokenResult);
+    cutoff = decodeUnsignedResult(PREDICTION_V2_VAULT_ABI, "cutoff", cutoffResult);
+    threshold = decodeSignedResult(PREDICTION_V2_VAULT_ABI, "threshold", thresholdResult);
+    vaultEconomicKey = decodeBytes32Result(PREDICTION_V2_VAULT_ABI, "economicKey", vaultEconomicKeyResult);
+    vaultMarketId = decodeBytes32Result(PREDICTION_V2_VAULT_ABI, "marketId", vaultMarketIdResult);
+    vaultAssetKey = decodeBytes32Result(PREDICTION_V2_VAULT_ABI, "assetKey", vaultAssetKeyResult);
+    vaultRegistryRevision = decodeUnsignedResult(PREDICTION_V2_VAULT_ABI, "registryRevision", vaultRegistryRevisionResult);
+    vaultRegistrySnapshotHash = decodeBytes32Result(PREDICTION_V2_VAULT_ABI, "registrySnapshotHash", vaultRegistrySnapshotHashResult);
+    vaultPolicyHash = decodeBytes32Result(PREDICTION_V2_VAULT_ABI, "oraclePolicyHash", vaultPolicyHashResult);
+    rawState = decodeUnsignedResult(PREDICTION_V2_VAULT_ABI, "state", vaultStateResult);
+    accountedLiability = decodeUnsignedResult(PREDICTION_V2_VAULT_ABI, "accountedLiability", accountedLiabilityResult);
+    canonicalPoolId = decodeBytes32Result(PREDICTION_V2_VAULT_ABI, "canonicalPoolId", canonicalPoolIdResult);
+    rawCheckpointStatus = decodeUnsignedResult(PREDICTION_V2_CHECKPOINT_ABI, "status", checkpointStatusResult);
+    resolvedPrice = decodeSignedResult(PREDICTION_V2_CHECKPOINT_ABI, "resolvedPrice", resolvedPriceResult);
+    observationTime = decodeUnsignedResult(PREDICTION_V2_CHECKPOINT_ABI, "observationTime", observationTimeResult);
+    resolutionDeadline = decodeUnsignedResult(PREDICTION_V2_CHECKPOINT_ABI, "resolutionDeadline", resolutionDeadlineResult);
+    hardResolutionDeadline = decodeUnsignedResult(PREDICTION_V2_CHECKPOINT_ABI, "hardResolutionDeadline", hardResolutionDeadlineResult);
+    fallbackRequestedAt = decodeUnsignedResult(PREDICTION_V2_CHECKPOINT_ABI, "fallbackRequestedAt", fallbackRequestedAtResult);
+    fallbackChallengeDeadline = decodeUnsignedResult(PREDICTION_V2_CHECKPOINT_ABI, "fallbackChallengeDeadline", fallbackChallengeDeadlineResult);
+    checkpointPolicyHash = decodeBytes32Result(PREDICTION_V2_CHECKPOINT_ABI, "policyHash", checkpointPolicyHashResult);
+    priceDecimals = decodeUnsignedResult(PREDICTION_V2_CHECKPOINT_ABI, "priceDecimals", priceDecimalsResult);
+    checkpointTradingHealthy = decodeBooleanResult(PREDICTION_V2_CHECKPOINT_ABI, "isTradingHealthy", checkpointHealthResult);
+    hookLifecycle = decodeHookLifecycle(hookLifecycleResult);
+    canonicalVault = decodeBooleanResult(
+      PREDICTION_V2_FACTORY_CANONICAL_READ_ABI,
+      "isCanonicalVault",
+      canonicalVaultResult,
+    );
+    slot0 = decodeSlot0(slot0Result);
+  } catch {
+    return invalidMarket();
+  }
+
+  const localAssetKey = predictionOnchainAssetKeyV2(snapshot.identity);
+  const localSnapshotHash = predictionV2RegistrySnapshotHash(snapshot);
+  const localPoolId = predictionV2PoolId(poolKey);
+  if (
+    !sameAddress(collateral, input.binding.collateral) ||
+    !sameAddress(vaultCheckpoint, checkpoint) ||
+    !sameAddress(vaultFactory, input.binding.factory) ||
+    !sameAddress(router, input.binding.router) ||
+    !sameAddress(poolKey.hooks, input.binding.hook) ||
+    !sameBytes32(vaultEconomicKey, input.economicKey) ||
+    !sameBytes32(vaultMarketId, market.marketId) ||
+    !sameBytes32(vaultAssetKey, market.assetKey) ||
+    vaultRegistryRevision !== market.registryRevision ||
+    !sameBytes32(vaultRegistrySnapshotHash, market.registrySnapshotHash) ||
+    !sameBytes32(vaultPolicyHash, market.resolutionPolicyHash) ||
+    !sameBytes32(checkpointPolicyHash, market.resolutionPolicyHash) ||
+    !sameBytes32(snapshot.assetKey, market.assetKey) ||
+    snapshot.revision !== market.registryRevision ||
+    !sameBytes32(localAssetKey, market.assetKey) ||
+    !sameBytes32(snapshot.policy.checkpointKind, market.resolutionPolicyHash) ||
+    !sameBytes32(localSnapshotHash, market.registrySnapshotHash) ||
+    !sameBytes32(localPoolId, market.poolId) ||
+    !sameBytes32(canonicalPoolId, market.poolId) ||
+    hookLifecycle.cutoff !== cutoff ||
+    !sameAddress(hookLifecycle.checkpoint, checkpoint) ||
+    !hookLifecycle.initialized ||
+    hookLifecycle.registeredBlock < input.binding.deploymentBlock ||
+    hookLifecycle.registeredBlock > input.block.number ||
+    !canonicalVault ||
+    market.policyValidUntil !== snapshot.policy.validUntil ||
+    market.snapshotAssetCap !== snapshot.policy.maxOpenInterestAtoms ||
+    !snapshot.policy.active ||
+    threshold <= 0n ||
+    cutoff + PREDICTION_V2_CUTOFF_BEFORE_OBSERVATION_SECONDS !== observationTime ||
+    observationTime > market.policyValidUntil ||
+    resolutionDeadline < observationTime ||
+    hardResolutionDeadline < resolutionDeadline ||
+    priceDecimals !== PREDICTION_V2_PRICE_DECIMALS ||
+    priceDecimals !== BigInt(snapshot.policy.feedDecimals) ||
+    (fallbackRequestedAt === 0n) !== (fallbackChallengeDeadline === 0n) ||
+    (fallbackRequestedAt > 0n && fallbackChallengeDeadline < fallbackRequestedAt)
+  ) invalidMarket();
+
+  const [registryHashResult, economicKeyResult] = await Promise.all([
+    call(input.binding.assetRegistry, PREDICTION_V2_ASSET_REGISTRY_ABI, "hashSnapshot", [snapshot]),
+    call(input.binding.factory, PREDICTION_V2_FACTORY_ABI, "economicEventKey", [
+      market.assetKey,
+      Number(observationTime),
+      threshold,
+    ]),
+  ]);
+  let registryHash: PredictionBytes32V2;
+  let derivedEconomicKey: PredictionBytes32V2;
+  try {
+    registryHash = decodeBytes32Result(PREDICTION_V2_ASSET_REGISTRY_ABI, "hashSnapshot", registryHashResult);
+    derivedEconomicKey = decodeBytes32Result(PREDICTION_V2_FACTORY_ABI, "economicEventKey", economicKeyResult);
+  } catch {
+    return invalidMarket();
+  }
+  if (
+    !sameBytes32(registryHash, localSnapshotHash) ||
+    !sameBytes32(derivedEconomicKey, input.economicKey)
+  ) invalidMarket();
+
+  let marketState;
+  try {
+    marketState = bindPredictionV2MarketState({
+      chainId: PREDICTION_V2_CHAIN_ID,
+      vault,
+      poolManager: input.binding.poolManager,
+      poolKey,
+      poolId: market.poolId,
+      poolStateSlot: predictionV2PoolStateSlot(poolKey),
+      checkpoint,
+      checkpointTradingHealthy,
+      yesToken,
+      noToken,
+      currentSqrtPriceX96: slot0.sqrtPriceX96,
+      currentTick: slot0.tick,
+      poolManagerProtocolFee: slot0.poolManagerProtocolFee,
+      lpFee: slot0.lpFee,
+      observedBlockNumber: input.block.number,
+      observedBlockHash: input.block.hash,
+      checkpointCall: Object.freeze({
+        to: vault,
+        data: encodeCall(PREDICTION_V2_VAULT_ABI, "checkpoint"),
+      }),
+      checkpointResult: vaultCheckpointResult,
+      checkpointTradingHealthCall: Object.freeze({
+        to: checkpoint,
+        data: encodeCall(PREDICTION_V2_CHECKPOINT_ABI, "isTradingHealthy"),
+      }),
+      checkpointTradingHealthResult: checkpointHealthResult,
+      yesTokenCall: Object.freeze({
+        to: vault,
+        data: encodeCall(PREDICTION_V2_VAULT_ABI, "yesToken"),
+      }),
+      yesTokenResult,
+      noTokenCall: Object.freeze({
+        to: vault,
+        data: encodeCall(PREDICTION_V2_VAULT_ABI, "noToken"),
+      }),
+      noTokenResult,
+      slot0Call: Object.freeze({
+        to: input.binding.poolManager,
+        data: slot0CallData,
+      }),
+      slot0Result,
+    });
+  } catch {
+    return invalidMarket();
+  }
+
+  const marketLifecycle = lifecycle({
+    state: rawState,
+    checkpointStatus: rawCheckpointStatus,
+    checkpointTradingHealthy,
+    resolvedPrice,
+    threshold,
+    cutoff,
+    observationTime,
+    blockTimestamp: input.block.timestamp,
+  });
+  const yesIsCurrency0 = sameAddress(poolKey.currency0, yesToken);
+  return Object.freeze({
+    economicKey: input.economicKey,
+    marketId: market.marketId,
+    assetKey: market.assetKey,
+    registryRevision: market.registryRevision,
+    registrySnapshotHash: market.registrySnapshotHash,
+    resolutionPolicyHash: market.resolutionPolicyHash,
+    policyValidUntil: market.policyValidUntil,
+    snapshotAssetCap: market.snapshotAssetCap,
+    vault,
+    checkpoint,
+    yesToken,
+    noToken,
+    poolId: market.poolId,
+    poolKey,
+    asset: Object.freeze({
+      identity: snapshot.identity,
+      displaySymbol: snapshot.displaySymbol,
+    }),
+    predicate: Object.freeze({
+      comparator: "greater-than-or-equal" as const,
+      threshold,
+      observationTime,
+      priceDecimals: Number(priceDecimals),
+    }),
+    lifecycle: marketLifecycle,
+    deadlines: Object.freeze({
+      cutoff,
+      resolutionDeadline,
+      hardResolutionDeadline,
+      fallbackRequestedAt,
+      fallbackChallengeDeadline,
+    }),
+    poolState: Object.freeze({
+      sqrtPriceX96: marketState.currentSqrtPriceX96,
+      tick: marketState.currentTick,
+      poolManagerProtocolFee: marketState.poolManagerProtocolFee,
+      lpFee: marketState.lpFee,
+      yesProbabilityBps: predictionV2YesProbabilityBps(
+        marketState.currentSqrtPriceX96,
+        yesIsCurrency0,
+      ),
+    }),
+    accountedLiability,
+  });
+}
+
+export async function readPredictionV2Directory(input: Readonly<{
+  readers: readonly [PredictionV2RpcReader, PredictionV2RpcReader];
+  binding: PredictionV2ReadBinding;
+  limit?: number;
+  cursor?: PredictionV2ReadCursor | null;
+  signal?: AbortSignal;
+}>): Promise<PredictionV2DirectoryRead> {
+  if (
+    input.readers.length !== 2 ||
+    input.readers[0] === input.readers[1] ||
+    typeof input.readers[0].readerId !== "string" ||
+    typeof input.readers[1].readerId !== "string" ||
+    input.readers[0].readerId.trim().length === 0 ||
+    input.readers[1].readerId.trim().length === 0 ||
+    input.readers[0].readerId === input.readers[1].readerId
+  ) fail("Prediction V2 requires two distinct RPC readers");
+  const binding = normalizeBinding(input.binding);
+  const cursor = input.cursor ? normalizeCursor(input.cursor) : undefined;
+  const limit = input.limit ?? PREDICTION_V2_MAXIMUM_PAGE_SIZE;
+  const block = await resolveSnapshot({
+    readers: input.readers,
+    binding,
+    ...(cursor ? { cursor } : {}),
+    ...(input.signal ? { signal: input.signal } : {}),
+  });
+  const limiter = new PredictionV2DualCallLimiter();
+
+  const readFactory = (functionName: string, args?: readonly unknown[]) =>
+    readFunction({
+      readers: input.readers,
+      limiter,
+      to: binding.factory,
+      abi: PREDICTION_V2_FACTORY_ABI,
+      functionName,
+      ...(args ? { args } : {}),
+      blockNumber: block.number,
+      blockHash: block.hash,
+      ...(input.signal ? { signal: input.signal } : {}),
+    });
+  const readBound = (to: Address, abi: Abi, functionName: string) => readFunction({
+    readers: input.readers,
+    limiter,
+    to,
+    abi,
+    functionName,
+    blockNumber: block.number,
+    blockHash: block.hash,
+    ...(input.signal ? { signal: input.signal } : {}),
+  });
+  const [
+    assetRegistryResult,
+    managerResult,
+    marketCountResult,
+    hookFactoryResult,
+    hookRouterResult,
+    hookManagerResult,
+    routerFactoryResult,
+    routerManagerResult,
+    routerCollateralResult,
+  ] = await Promise.all([
+    readFactory("assetRegistry"),
+    readFactory("manager"),
+    readFactory("marketCount"),
+    readBound(binding.hook, PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI, "factory"),
+    readBound(
+      binding.hook,
+      PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI,
+      "authorizedRouter",
+    ),
+    readBound(binding.hook, PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI, "poolManager"),
+    readBound(binding.router, PREDICTION_V2_EXECUTION_ROUTER_READ_ABI, "factory"),
+    readBound(binding.router, PREDICTION_V2_EXECUTION_ROUTER_READ_ABI, "manager"),
+    readBound(binding.router, PREDICTION_V2_EXECUTION_ROUTER_READ_ABI, "collateral"),
+  ]);
+  const assetRegistry = decodeAddressResult(
+    PREDICTION_V2_FACTORY_ABI,
+    "assetRegistry",
+    assetRegistryResult,
+  );
+  const manager = decodeAddressResult(PREDICTION_V2_FACTORY_ABI, "manager", managerResult);
+  const marketCount = decodeUnsignedResult(
+    PREDICTION_V2_FACTORY_ABI,
+    "marketCount",
+    marketCountResult,
+  );
+  const hookFactory = decodeAddressResult(
+    PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI,
+    "factory",
+    hookFactoryResult,
+  );
+  const hookRouter = decodeAddressResult(
+    PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI,
+    "authorizedRouter",
+    hookRouterResult,
+  );
+  const hookManager = decodeAddressResult(
+    PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI,
+    "poolManager",
+    hookManagerResult,
+  );
+  const routerFactory = decodeAddressResult(
+    PREDICTION_V2_EXECUTION_ROUTER_READ_ABI,
+    "factory",
+    routerFactoryResult,
+  );
+  const routerManager = decodeAddressResult(
+    PREDICTION_V2_EXECUTION_ROUTER_READ_ABI,
+    "manager",
+    routerManagerResult,
+  );
+  const routerCollateral = decodeAddressResult(
+    PREDICTION_V2_EXECUTION_ROUTER_READ_ABI,
+    "collateral",
+    routerCollateralResult,
+  );
+  if (
+    !sameAddress(assetRegistry, binding.assetRegistry) ||
+    !sameAddress(manager, binding.poolManager) ||
+    !sameAddress(hookFactory, binding.factory) ||
+    !sameAddress(hookRouter, binding.router) ||
+    !sameAddress(hookManager, binding.poolManager) ||
+    !sameAddress(routerFactory, binding.factory) ||
+    !sameAddress(routerManager, binding.poolManager) ||
+    !sameAddress(routerCollateral, binding.collateral)
+  ) fail("Prediction V2 release endpoints do not match the read binding");
+  if (cursor && cursor.marketCount !== marketCount) {
+    fail("Prediction V2 cursor market count changed");
+  }
+
+  const page = predictionV2PageIndices({
+    marketCount,
+    limit,
+    ...(cursor ? { nextExclusiveIndex: cursor.nextExclusiveIndex } : {}),
+  });
+  const indexedKeys = await mapInBatches(page.indices, async (index) => {
+    const result = await readFactory("marketKeyAt", [index]);
+    return Object.freeze({
+      index,
+      economicKey: decodeBytes32Result(
+        PREDICTION_V2_FACTORY_ABI,
+        "marketKeyAt",
+        result,
+      ),
+    });
+  });
+  if (new Set(indexedKeys.map(({ economicKey }) => economicKey)).size !== indexedKeys.length) {
+    fail("Prediction V2 Factory returned duplicate market keys");
+  }
+
+  const rows = await mapInBatches(indexedKeys, async ({ index, economicKey }) => {
+    try {
+      return Object.freeze({
+        status: "verified" as const,
+        market: await readVerifiedMarket({
+          readers: input.readers,
+          limiter,
+          binding,
+          economicKey,
+          block,
+          ...(input.signal ? { signal: input.signal } : {}),
+        }),
+      });
+    } catch (error) {
+      if (
+        !(error instanceof PredictionV2MarketWiringError) &&
+        !(error instanceof PredictionV2DeterministicCallRevert)
+      ) throw error;
+      return Object.freeze({
+        status: "quarantined" as const,
+        failure: Object.freeze({
+          index,
+          economicKey,
+          code: "invalid-market-wiring" as const,
+        }),
+      });
+    }
+  });
+  await revalidateSnapshot({
+    readers: input.readers,
+    block,
+    ...(input.signal ? { signal: input.signal } : {}),
+  });
+  const markets = rows.flatMap((row) => row.status === "verified" ? [row.market] : []);
+  const quarantined = rows.flatMap((row) =>
+    row.status === "quarantined" ? [row.failure] : []
+  );
+  const nextCursor = page.nextExclusiveIndex > 0n
+    ? Object.freeze({
+      schemaVersion: 2 as const,
+      blockNumber: block.number,
+      blockHash: nonzeroBytes32(block.hash, "snapshot block hash"),
+      marketCount,
+      nextExclusiveIndex: page.nextExclusiveIndex,
+    })
+    : null;
+  return Object.freeze({
+    schemaVersion: 2,
+    chainId: PREDICTION_V2_CHAIN_ID,
+    snapshot: block,
+    marketCount,
+    markets: Object.freeze(markets),
+    quarantined: Object.freeze(quarantined),
+    nextCursor,
+  });
+}

--- a/lib/prediction-v2/release-binding.server.ts
+++ b/lib/prediction-v2/release-binding.server.ts
@@ -74,3 +74,17 @@ export function getPredictionV2ReleaseBinding(): PredictionV2ReleaseBinding {
   cachedReleaseBinding ??= parsePredictionV2ReleaseBinding(releaseBindingJson);
   return cachedReleaseBinding;
 }
+
+/**
+ * V1 has no activation schema, so it can never authorize a public V2 route.
+ * Activation must replace this guard with a separately reviewed exact parser
+ * bound to the deployed contracts and its attestation trust root.
+ */
+export function isPredictionV2ReleaseEnabled(): boolean {
+  try {
+    void getPredictionV2ReleaseBinding();
+  } catch {
+    return false;
+  }
+  return false;
+}

--- a/lib/prediction-v2/token-profile-v2.ts
+++ b/lib/prediction-v2/token-profile-v2.ts
@@ -1,0 +1,432 @@
+export const PREDICTION_TOKEN_PROFILE_CHAINS_V2 = Object.freeze([
+  Object.freeze({
+    id: "ethereum",
+    reference: "1",
+    label: "Ethereum",
+    namespace: "evm",
+    explorerOrigin: "https://etherscan.io",
+  }),
+  Object.freeze({
+    id: "base",
+    reference: "8453",
+    label: "Base",
+    namespace: "evm",
+    explorerOrigin: "https://basescan.org",
+  }),
+  Object.freeze({
+    id: "bnb",
+    reference: "56",
+    label: "BNB Chain",
+    namespace: "evm",
+    explorerOrigin: "https://bscscan.com",
+  }),
+  Object.freeze({
+    id: "robinhood",
+    reference: "4663",
+    label: "Robinhood Chain",
+    namespace: "evm",
+    explorerOrigin: "https://robinhoodchain.blockscout.com",
+  }),
+  Object.freeze({
+    id: "solana",
+    reference: "mainnet-beta",
+    label: "Solana",
+    namespace: "solana",
+    explorerOrigin: "https://solscan.io",
+  }),
+] as const);
+
+export type PredictionTokenProfileChainIdV2 =
+  (typeof PREDICTION_TOKEN_PROFILE_CHAINS_V2)[number]["id"];
+
+export type PredictionTokenProfileChainV2 = Readonly<{
+  id: PredictionTokenProfileChainIdV2;
+  reference: string;
+  label: string;
+}>;
+
+export type PredictionTokenProfileLinkV2 = Readonly<{
+  kind: "website" | "x" | "telegram";
+  url: string;
+}>;
+
+export type PredictionTokenProfileAgeV2 = Readonly<{
+  pairCreatedAt: string;
+  seconds: number;
+}>;
+
+export type PredictionTokenProfileV2 = Readonly<{
+  schemaVersion: 2;
+  chain: PredictionTokenProfileChainV2;
+  address: string;
+  explorerUrl: string;
+  name?: string;
+  symbol?: string;
+  logoUrl?: string;
+  links?: readonly PredictionTokenProfileLinkV2[];
+  priceUsd?: number;
+  /** Provider-reported display value; not circulating-supply evidence. */
+  marketCapUsd?: number;
+  /** Provider-reported fully diluted valuation. Never labeled as market cap. */
+  fdvUsd?: number;
+  liquidityUsd?: number;
+  age?: PredictionTokenProfileAgeV2;
+}>;
+
+/**
+ * Deliberately provider-neutral, untrusted input. Discovery readers should map
+ * their response into this shape before anything reaches the UI or API.
+ */
+export type PredictionTokenProfileCandidateV2 = Readonly<{
+  chain: unknown;
+  address: unknown;
+  name?: unknown;
+  symbol?: unknown;
+  logoUrl?: unknown;
+  imageUrl?: unknown;
+  website?: unknown;
+  websites?: unknown;
+  x?: unknown;
+  twitter?: unknown;
+  telegram?: unknown;
+  socials?: unknown;
+  priceUsd?: unknown;
+  marketCapUsd?: unknown;
+  fdvUsd?: unknown;
+  liquidityUsd?: unknown;
+  pairCreatedAtMs?: unknown;
+  pairCreatedAt?: unknown;
+}>;
+
+const CHAIN_ALIASES = Object.freeze({
+  ethereum: "ethereum",
+  eth: "ethereum",
+  "1": "ethereum",
+  base: "base",
+  "8453": "base",
+  bnb: "bnb",
+  bsc: "bnb",
+  "bnb-chain": "bnb",
+  "56": "bnb",
+  robinhood: "robinhood",
+  "robinhood-chain": "robinhood",
+  "4663": "robinhood",
+  solana: "solana",
+  "mainnet-beta": "solana",
+} as const satisfies Record<string, PredictionTokenProfileChainIdV2>);
+
+const EVM_ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/u;
+const ZERO_EVM_ADDRESS = `0x${"0".repeat(40)}`;
+const BASE58_PATTERN = /^[1-9A-HJ-NP-Za-km-z]+$/u;
+const BASE58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const UNSAFE_TEXT_PATTERN =
+  /[<>\u0000-\u001f\u007f-\u009f\u200b-\u200f\u202a-\u202e\u2066-\u2069\ufeff]/u;
+const UNSAFE_URL_INPUT_PATTERN = /[\u0000-\u0020\u007f]/u;
+const DECIMAL_PATTERN = /^(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?$/u;
+const MAX_URL_BYTES = 2_048;
+const MAX_LINK_CANDIDATES = 16;
+const MAX_TOTAL_LINK_CANDIDATES = 64;
+const MAX_USD_VALUE = 1e18;
+
+const X_HOSTS = new Set(["x.com", "www.x.com", "twitter.com", "www.twitter.com"]);
+const TELEGRAM_HOSTS = new Set([
+  "t.me",
+  "www.t.me",
+  "telegram.me",
+  "www.telegram.me",
+]);
+const PRIVATE_HOST_SUFFIXES = Object.freeze([
+  ".localhost",
+  ".local",
+  ".internal",
+  ".lan",
+  ".home",
+  ".arpa",
+  ".test",
+  ".invalid",
+  ".example",
+]);
+
+type ResolvedChain = (typeof PREDICTION_TOKEN_PROFILE_CHAINS_V2)[number];
+type SafeUrl = Readonly<{ parsed: URL; canonical: string }>;
+
+export function normalizePredictionTokenProfileV2(
+  candidate: unknown,
+  observedAtMs: number,
+): PredictionTokenProfileV2 | null {
+  if (!isRecord(candidate)) return null;
+  if (!Number.isSafeInteger(observedAtMs) || observedAtMs < 0 ||
+    !Number.isFinite(new Date(observedAtMs).getTime())) {
+    throw new TypeError("observedAtMs must be a non-negative safe integer");
+  }
+
+  const chain = resolveChain(candidate.chain);
+  if (!chain) return null;
+  const address = normalizeAddress(chain, candidate.address);
+  if (!address) return null;
+
+  const name = safeText(candidate.name, 80, true);
+  const symbol = safeText(candidate.symbol, 24, false);
+  const logoUrl = safeHttpsUrl(candidate.logoUrl)?.canonical ??
+    safeHttpsUrl(candidate.imageUrl)?.canonical;
+  const links = normalizeLinks(candidate);
+  const priceUsd = safeUsd(candidate.priceUsd, false);
+  const marketCapUsd = safeUsd(candidate.marketCapUsd, false);
+  const fdvUsd = safeUsd(candidate.fdvUsd, false);
+  const liquidityUsd = safeUsd(candidate.liquidityUsd, true);
+  const age = normalizeAge(
+    candidate.pairCreatedAtMs ?? candidate.pairCreatedAt,
+    observedAtMs,
+  );
+
+  return Object.freeze({
+    schemaVersion: 2,
+    chain: Object.freeze({
+      id: chain.id,
+      reference: chain.reference,
+      label: chain.label,
+    }),
+    address,
+    explorerUrl: `${chain.explorerOrigin}/token/${address}`,
+    ...(name ? { name } : {}),
+    ...(symbol ? { symbol } : {}),
+    ...(logoUrl ? { logoUrl } : {}),
+    ...(links.length > 0 ? { links: Object.freeze(links) } : {}),
+    ...(priceUsd !== null ? { priceUsd } : {}),
+    ...(marketCapUsd !== null ? { marketCapUsd } : {}),
+    ...(fdvUsd !== null ? { fdvUsd } : {}),
+    ...(liquidityUsd !== null ? { liquidityUsd } : {}),
+    ...(age ? { age } : {}),
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function resolveChain(value: unknown): ResolvedChain | null {
+  const key = typeof value === "number"
+    ? Number.isSafeInteger(value) ? String(value) : ""
+    : typeof value === "string" ? value.trim().toLowerCase() : "";
+  const id = CHAIN_ALIASES[key as keyof typeof CHAIN_ALIASES];
+  return id
+    ? PREDICTION_TOKEN_PROFILE_CHAINS_V2.find((chain) => chain.id === id) ?? null
+    : null;
+}
+
+function normalizeAddress(chain: ResolvedChain, value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const address = value.trim();
+  if (chain.namespace === "evm") {
+    if (!EVM_ADDRESS_PATTERN.test(address)) return null;
+    const canonical = address.toLowerCase();
+    return canonical === ZERO_EVM_ADDRESS ? null : canonical;
+  }
+  const decoded = decodeBase58(address);
+  if (!decoded || decoded.length !== 32 || decoded.every((byte) => byte === 0)) {
+    return null;
+  }
+  return address;
+}
+
+function decodeBase58(value: string): Uint8Array | null {
+  if (!value || value.length > 64 || !BASE58_PATTERN.test(value)) return null;
+  const littleEndian = [0];
+  for (const character of value) {
+    const alphabetIndex = BASE58_ALPHABET.indexOf(character);
+    if (alphabetIndex < 0) return null;
+    let carry = alphabetIndex;
+    for (let index = 0; index < littleEndian.length; index += 1) {
+      carry += littleEndian[index] * 58;
+      littleEndian[index] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      littleEndian.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+
+  let leadingZeroes = 0;
+  while (leadingZeroes < value.length && value[leadingZeroes] === "1") {
+    leadingZeroes += 1;
+  }
+  const payloadLength = littleEndian.length === 1 && littleEndian[0] === 0
+    ? 0
+    : littleEndian.length;
+  const decoded = new Uint8Array(leadingZeroes + payloadLength);
+  for (let index = 0; index < payloadLength; index += 1) {
+    decoded[decoded.length - 1 - index] = littleEndian[index];
+  }
+  return decoded;
+}
+
+function safeText(
+  value: unknown,
+  maximumCharacters: number,
+  allowWhitespace: boolean,
+): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.normalize("NFC").trim();
+  if (!normalized || UNSAFE_TEXT_PATTERN.test(normalized)) return null;
+  const text = allowWhitespace ? normalized.replace(/\s+/gu, " ") : normalized;
+  if ((!allowWhitespace && /\s/u.test(text)) ||
+    Array.from(text).length > maximumCharacters ||
+    new TextEncoder().encode(text).length > maximumCharacters * 4) {
+    return null;
+  }
+  return text;
+}
+
+function safeHttpsUrl(value: unknown): SafeUrl | null {
+  if (typeof value !== "string") return null;
+  const raw = value.trim();
+  if (!raw || raw.length > MAX_URL_BYTES ||
+    new TextEncoder().encode(raw).length > MAX_URL_BYTES ||
+    UNSAFE_URL_INPUT_PATTERN.test(raw)) {
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  const hostname = parsed.hostname.toLowerCase();
+  if (parsed.protocol !== "https:" || parsed.username || parsed.password ||
+    (parsed.port && parsed.port !== "443") || !isPublicHostname(hostname)) {
+    return null;
+  }
+  parsed.hash = "";
+  return Object.freeze({ parsed, canonical: parsed.toString() });
+}
+
+function isPublicHostname(hostname: string): boolean {
+  if (!hostname || hostname.endsWith(".") || hostname.includes(":")) return false;
+  if (/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/u.test(hostname)) return false;
+  if (!/^[a-z0-9.-]+$/u.test(hostname) || !hostname.includes(".")) return false;
+  const labels = hostname.split(".");
+  if (labels.some((label) => !label || label.length > 63 ||
+    label.startsWith("-") || label.endsWith("-"))) {
+    return false;
+  }
+  return hostname !== "localhost" &&
+    !PRIVATE_HOST_SUFFIXES.some((suffix) => hostname.endsWith(suffix));
+}
+
+function normalizeLinks(
+  candidate: Record<string, unknown>,
+): PredictionTokenProfileLinkV2[] {
+  const byKind = new Map<PredictionTokenProfileLinkV2["kind"], string>();
+  const seenUrls = new Set<string>();
+  const candidates = [
+    ...linkCandidates(candidate.website),
+    ...linkCandidates(candidate.websites),
+    ...linkCandidates(candidate.x),
+    ...linkCandidates(candidate.twitter),
+    ...linkCandidates(candidate.telegram),
+    ...linkCandidates(candidate.socials),
+  ].slice(0, MAX_TOTAL_LINK_CANDIDATES);
+
+  for (const value of candidates) {
+    const safe = safeHttpsUrl(value);
+    if (!safe) continue;
+    const socialKind = socialKindForHostname(safe.parsed.hostname.toLowerCase());
+    const kind = socialKind ?? "website";
+    if (!socialKind && !isWebsiteCandidate(value, candidate)) continue;
+
+    const canonical = socialKind
+      ? canonicalSocialUrl(safe.parsed, socialKind)
+      : safe.canonical;
+    if (!canonical || seenUrls.has(canonical) || byKind.has(kind)) continue;
+    seenUrls.add(canonical);
+    byKind.set(kind, canonical);
+  }
+
+  return (["website", "x", "telegram"] as const).flatMap((kind) => {
+    const url = byKind.get(kind);
+    return url ? [Object.freeze({ kind, url })] : [];
+  });
+}
+
+function linkCandidates(value: unknown): string[] {
+  const entries = Array.isArray(value) ? value.slice(0, MAX_LINK_CANDIDATES) : [value];
+  return entries.flatMap((entry) => {
+    if (typeof entry === "string") return [entry];
+    if (!isRecord(entry)) return [];
+    return typeof entry.url === "string" ? [entry.url] : [];
+  });
+}
+
+function isWebsiteCandidate(
+  value: string,
+  candidate: Record<string, unknown>,
+): boolean {
+  return linkCandidates(candidate.website).includes(value) ||
+    linkCandidates(candidate.websites).includes(value);
+}
+
+function socialKindForHostname(
+  hostname: string,
+): "x" | "telegram" | null {
+  if (X_HOSTS.has(hostname)) return "x";
+  if (TELEGRAM_HOSTS.has(hostname)) return "telegram";
+  return null;
+}
+
+function canonicalSocialUrl(
+  source: URL,
+  kind: "x" | "telegram",
+): string | null {
+  if (source.pathname === "/") return null;
+  const parsed = new URL(source.toString());
+  parsed.hostname = kind === "x" ? "x.com" : "t.me";
+  parsed.port = "";
+  parsed.search = "";
+  parsed.hash = "";
+  return parsed.toString();
+}
+
+function safeUsd(value: unknown, allowZero: boolean): number | null {
+  const numeric = typeof value === "number"
+    ? value
+    : typeof value === "string" && DECIMAL_PATTERN.test(value.trim())
+      ? Number(value.trim())
+      : Number.NaN;
+  if (!Number.isFinite(numeric) || numeric > MAX_USD_VALUE ||
+    (allowZero ? numeric < 0 : numeric <= 0)) {
+    return null;
+  }
+  return numeric;
+}
+
+function normalizeAge(
+  value: unknown,
+  observedAtMs: number,
+): PredictionTokenProfileAgeV2 | null {
+  const createdAtMs = timestampMs(value);
+  if (createdAtMs === null || createdAtMs > observedAtMs) return null;
+  return Object.freeze({
+    pairCreatedAt: new Date(createdAtMs).toISOString(),
+    seconds: Math.floor((observedAtMs - createdAtMs) / 1_000),
+  });
+}
+
+function timestampMs(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 &&
+      Number.isFinite(new Date(value).getTime()) ? value : null;
+  }
+  if (typeof value !== "string") return null;
+  if (/^(?:0|[1-9][0-9]{0,15})$/u.test(value)) {
+    const numeric = Number(value);
+    return Number.isSafeInteger(numeric) &&
+      Number.isFinite(new Date(numeric).getTime()) ? numeric : null;
+  }
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString() === value
+    ? parsed.getTime()
+    : null;
+}

--- a/scripts/test/verify-custom-launch-production-bundle.test.mjs
+++ b/scripts/test/verify-custom-launch-production-bundle.test.mjs
@@ -30,6 +30,7 @@ test("accepts a production bundle without development-only launch seeds", () => 
 test("rejects a local seed in source maps and non-JavaScript production artifacts", () => {
   for (const [path, marker] of [
     [".next/static/chunks/leak.js.map", "programmable-custom-launch-local-preview-v1"],
+    [".next/static/chunks/prediction-leak.js.map", "programmable-prediction-v2-local-preview-v1"],
     [".next/server/app/leak.rsc", "Local seed"],
   ]) {
     const root = bundleFixture();
@@ -37,7 +38,7 @@ test("rejects a local seed in source maps and non-JavaScript production artifact
       writeFileSync(join(root, path), marker, "utf8");
       assert.throws(
         () => verifyCustomLaunchProductionBundle(root),
-        /Development-only Custom Launch preview leaked into production/u,
+        /Development-only launch preview leaked into production/u,
       );
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/scripts/verify-custom-launch-production-bundle.mjs
+++ b/scripts/verify-custom-launch-production-bundle.mjs
@@ -4,6 +4,7 @@ import { join, relative, resolve } from "node:path";
 const PRODUCTION_BUNDLE_ROOTS = [".next/static", ".next/server"];
 const DEVELOPMENT_ONLY_MARKERS = [
   "programmable-custom-launch-local-preview-v1",
+  "programmable-prediction-v2-local-preview-v1",
   "example-labs/approved-module",
   "local-interface-preview",
   "Local seed",
@@ -39,7 +40,7 @@ export function verifyCustomLaunchProductionBundle(root = process.cwd()) {
     }
   }
   if (findings.length > 0) {
-    throw new Error(`Development-only Custom Launch preview leaked into production:\n${findings.join("\n")}`);
+    throw new Error(`Development-only launch preview leaked into production:\n${findings.join("\n")}`);
   }
   return Object.freeze({
     schemaVersion: "programmable.custom-launch-production-bundle-scan.v1",

--- a/tests/prediction-asset-auto-discovery-request-control-v2.test.ts
+++ b/tests/prediction-asset-auto-discovery-request-control-v2.test.ts
@@ -1,0 +1,427 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  PREDICTION_ASSET_DISCOVERY_CONTROL_SCOPE_V2,
+  PREDICTION_ASSET_DISCOVERY_SHARED_LIMITS_REQUIRED_FOR_ACTIVATION_V2,
+  createPredictionAssetAutoDiscoveryRequestControllerV2,
+} from "../lib/market-data/prediction-asset-auto-discovery-request-control-v2.server";
+import type {
+  PredictionAssetAutoDiscoveryResultV2,
+} from "../lib/market-data/prediction-asset-auto-discovery-v2.server";
+
+const OBSERVED_AT = "2026-08-23T18:00:00.000Z";
+const EVM_A = `0x${"ab".repeat(20)}`;
+const EVM_B = `0x${"cd".repeat(20)}`;
+const EVM_C = `0x${"ef".repeat(20)}`;
+const SOLANA_LOCATORS = Object.freeze([
+  "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  "So11111111111111111111111111111111111111112",
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+  "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
+]);
+
+function indexedEvmAddress(index: number) {
+  return `0x${index.toString(16).padStart(40, "0")}`;
+}
+
+function result(
+  locator: string,
+  status: "not-found" | "inconclusive" = "not-found",
+): PredictionAssetAutoDiscoveryResultV2 {
+  const base = {
+    schemaVersion: 2 as const,
+    locator,
+    source: null,
+    observedAt: OBSERVED_AT,
+    usage: "informational-only" as const,
+  };
+  return status === "not-found"
+    ? { ...base, status }
+    : {
+      ...base,
+      status,
+      candidates: [],
+      failures: [{ sourceNetwork: "base", reason: "identity-unavailable" }],
+    };
+}
+
+function uniqueResult(locator: string): PredictionAssetAutoDiscoveryResultV2 {
+  return {
+    schemaVersion: 2,
+    locator,
+    source: "dexscreener",
+    observedAt: OBSERVED_AT,
+    usage: "informational-only",
+    status: "unique",
+    candidate: {
+      selectionKey: `evm:8453:${locator}`,
+      selection: { mode: "custom", sourceNetwork: "base", assetLocator: locator },
+      namespace: "evm",
+      chainReference: "8453",
+      providerChainId: "base",
+      provenance: {
+        identity: { source: "onchain-rpc" },
+        enrichment: { source: "dexscreener" },
+      },
+      token: { address: locator, name: "Example", symbol: "EXM" },
+      currentPriceUsd: 1,
+      marketCapUsd: null,
+      fdvUsd: null,
+      matchingPairCount: 1,
+      pair: {
+        dexId: "uniswap",
+        pairAddress: `0x${"12".repeat(20)}`,
+        matchedSide: "base",
+        liquidityUsd: 100_000,
+        volume24hUsd: 50_000,
+        pairCreatedAt: 1_700_000_000_000,
+      },
+      links: { imageUrl: null, websites: [], socials: [] },
+    },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((next, fail) => {
+    resolve = next;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("prediction asset auto-discovery request control V2", () => {
+  it("keeps its bulkhead explicitly per-runtime and activation-gated", () => {
+    expect(PREDICTION_ASSET_DISCOVERY_CONTROL_SCOPE_V2)
+      .toBe("single-runtime-only");
+    expect(PREDICTION_ASSET_DISCOVERY_SHARED_LIMITS_REQUIRED_FOR_ACTIVATION_V2)
+      .toBe(true);
+  });
+
+  it("coalesces normalized EVM locators before spending another budget unit", async () => {
+    const pending = deferred<PredictionAssetAutoDiscoveryResultV2>();
+    const read = vi.fn(async () => pending.promise);
+    const controller = createPredictionAssetAutoDiscoveryRequestControllerV2({
+      reader: { read },
+      budgetCapacity: 4,
+      budgetIntervalMs: 60_000,
+      nowMs: () => 1_000,
+    });
+
+    const first = controller.read(`  0x${"AB".repeat(20)}  `);
+    const second = controller.read(EVM_A);
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(1));
+    pending.resolve(result(EVM_A));
+
+    await expect(first).resolves.toMatchObject({ status: "ok", source: "reader" });
+    await expect(second).resolves.toMatchObject({
+      status: "ok",
+      source: "coalesced",
+    });
+    expect(read).toHaveBeenCalledWith(EVM_A, {
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("uses a short negative cache but never caches inconclusive reads", async () => {
+    let now = 10_000;
+    const read = vi.fn(async (locator: string) => result(locator));
+    const controller = createPredictionAssetAutoDiscoveryRequestControllerV2({
+      reader: { read },
+      budgetCapacity: 20,
+      budgetIntervalMs: 60_000,
+      positiveCacheTtlMs: 100,
+      negativeCacheTtlMs: 50,
+      nowMs: () => now,
+    });
+
+    await expect(controller.read(EVM_A)).resolves.toMatchObject({ source: "reader" });
+    await expect(controller.read(EVM_A)).resolves.toMatchObject({ source: "cache" });
+    now += 51;
+    await expect(controller.read(EVM_A)).resolves.toMatchObject({ source: "reader" });
+    expect(read).toHaveBeenCalledTimes(2);
+
+    read.mockImplementation(async (locator: string) => result(locator, "inconclusive"));
+    await controller.read(EVM_B);
+    await controller.read(EVM_B);
+    expect(read).toHaveBeenCalledTimes(4);
+  });
+
+  it("uses a separately bounded positive cache", async () => {
+    let now = 15_000;
+    const read = vi.fn(async (locator: string) => uniqueResult(locator));
+    const controller = createPredictionAssetAutoDiscoveryRequestControllerV2({
+      reader: { read },
+      budgetCapacity: 10,
+      budgetIntervalMs: 60_000,
+      positiveCacheTtlMs: 100,
+      negativeCacheTtlMs: 50,
+      nowMs: () => now,
+    });
+
+    await expect(controller.read(EVM_A)).resolves.toMatchObject({ source: "reader" });
+    await expect(controller.read(EVM_A)).resolves.toMatchObject({ source: "cache" });
+    now += 101;
+    await expect(controller.read(EVM_A)).resolves.toMatchObject({ source: "reader" });
+    expect(read).toHaveBeenCalledTimes(2);
+  });
+
+  it("enforces a bounded refillable global budget and returns a retry delay", async () => {
+    let now = 20_000;
+    const read = vi.fn(async (locator: string) => result(locator));
+    const controller = createPredictionAssetAutoDiscoveryRequestControllerV2({
+      reader: { read },
+      budgetCapacity: 8,
+      budgetIntervalMs: 1_000,
+      nowMs: () => now,
+    });
+
+    await expect(controller.read(EVM_A)).resolves.toMatchObject({ status: "ok" });
+    await expect(controller.read(EVM_B)).resolves.toMatchObject({ status: "ok" });
+    await expect(controller.read(EVM_C)).resolves.toEqual({
+      status: "rate-limited",
+      retryAfterSeconds: 1,
+    });
+    expect(read).toHaveBeenCalledTimes(2);
+
+    now += 500;
+    await expect(controller.read(EVM_C)).resolves.toMatchObject({ status: "ok" });
+    expect(read).toHaveBeenCalledTimes(3);
+  });
+
+  it("charges four DEX calls for EVM discovery and one for Solana", async () => {
+    const read = vi.fn(async (locator: string) => result(locator));
+    const evmController = createPredictionAssetAutoDiscoveryRequestControllerV2({
+      reader: { read },
+      budgetCapacity: 4,
+      budgetIntervalMs: 60_000,
+      nowMs: () => 25_000,
+    });
+
+    await expect(evmController.read(EVM_A)).resolves.toMatchObject({ status: "ok" });
+    await expect(evmController.read(EVM_B)).resolves.toMatchObject({
+      status: "rate-limited",
+    });
+
+    const solanaController = createPredictionAssetAutoDiscoveryRequestControllerV2({
+      reader: { read },
+      budgetCapacity: 4,
+      budgetIntervalMs: 60_000,
+      nowMs: () => 25_000,
+    });
+    for (const locator of SOLANA_LOCATORS.slice(0, 4)) {
+      await expect(solanaController.read(locator)).resolves.toMatchObject({
+        status: "ok",
+      });
+    }
+    await expect(solanaController.read(SOLANA_LOCATORS[4]!)).resolves
+      .toMatchObject({ status: "rate-limited" });
+    expect(read).toHaveBeenCalledTimes(5);
+  });
+
+  it("keeps a full burst plus one minute of refill below 300 DEX calls", async () => {
+    let now = 50_000;
+    const read = vi.fn(async (locator: string) => result(locator));
+    const controller = createPredictionAssetAutoDiscoveryRequestControllerV2({
+      reader: { read },
+      nowMs: () => now,
+    });
+
+    for (let index = 1; index <= 36; index += 1) {
+      await expect(controller.read(indexedEvmAddress(index))).resolves
+        .toMatchObject({ status: "ok" });
+    }
+    await expect(controller.read(indexedEvmAddress(37))).resolves
+      .toMatchObject({ status: "rate-limited" });
+
+    now += 60_000;
+    for (let index = 37; index <= 72; index += 1) {
+      await expect(controller.read(indexedEvmAddress(index))).resolves
+        .toMatchObject({ status: "ok" });
+    }
+    await expect(controller.read(indexedEvmAddress(73))).resolves
+      .toMatchObject({ status: "rate-limited" });
+
+    const outboundDexCalls = read.mock.calls.length * 4;
+    expect(outboundDexCalls).toBe(288);
+    expect(outboundDexCalls).toBeLessThan(300);
+  });
+
+  it("bounds distinct active reads without queueing or charging a rejected read", async () => {
+    const pendingA = deferred<PredictionAssetAutoDiscoveryResultV2>();
+    const pendingB = deferred<PredictionAssetAutoDiscoveryResultV2>();
+    const pendingC = deferred<PredictionAssetAutoDiscoveryResultV2>();
+    const pending = new Map([
+      [EVM_A, pendingA],
+      [EVM_B, pendingB],
+      [EVM_C, pendingC],
+    ]);
+    const read = vi.fn(async (locator: string) => pending.get(locator)!.promise);
+    const controller = createPredictionAssetAutoDiscoveryRequestControllerV2({
+      reader: { read },
+      budgetCapacity: 12,
+      budgetIntervalMs: 60_000,
+      maximumConcurrentReads: 2,
+      nowMs: () => 27_000,
+    });
+
+    const first = controller.read(EVM_A);
+    const second = controller.read(EVM_B);
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(2));
+    await expect(controller.read(EVM_C)).resolves.toEqual({
+      status: "rate-limited",
+      retryAfterSeconds: 1,
+    });
+    expect(read).toHaveBeenCalledTimes(2);
+
+    const coalesced = controller.read(EVM_A);
+    expect(read).toHaveBeenCalledTimes(2);
+    pendingA.resolve(result(EVM_A));
+    await expect(first).resolves.toMatchObject({ source: "reader" });
+    await expect(coalesced).resolves.toMatchObject({ source: "coalesced" });
+
+    const third = controller.read(EVM_C);
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(3));
+    pendingB.resolve(result(EVM_B));
+    pendingC.resolve(result(EVM_C));
+    await expect(second).resolves.toMatchObject({ status: "ok" });
+    await expect(third).resolves.toMatchObject({ status: "ok" });
+  });
+
+  it("holds a permit after subscriber abort until an abort-ignoring reader settles", async () => {
+    const pendingA = deferred<PredictionAssetAutoDiscoveryResultV2>();
+    const pendingB = deferred<PredictionAssetAutoDiscoveryResultV2>();
+    let readerSignal: AbortSignal | undefined;
+    const read = vi.fn(async (
+      locator: string,
+      options?: Readonly<{ signal?: AbortSignal }>,
+    ) => {
+      if (locator === EVM_A) {
+        readerSignal = options?.signal;
+        return pendingA.promise;
+      }
+      return pendingB.promise;
+    });
+    const controller = createPredictionAssetAutoDiscoveryRequestControllerV2({
+      reader: { read },
+      budgetCapacity: 8,
+      budgetIntervalMs: 60_000,
+      maximumConcurrentReads: 1,
+      nowMs: () => 28_000,
+    });
+    const caller = new AbortController();
+    const first = controller.read(EVM_A, { signal: caller.signal });
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(1));
+    caller.abort();
+    expect(readerSignal?.aborted).toBe(true);
+
+    await expect(controller.read(EVM_B)).resolves.toEqual({
+      status: "rate-limited",
+      retryAfterSeconds: 1,
+    });
+    pendingA.resolve(result(EVM_A, "inconclusive"));
+    await expect(first).resolves.toMatchObject({ status: "ok" });
+
+    const second = controller.read(EVM_B);
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(2));
+    pendingB.resolve(result(EVM_B));
+    await expect(second).resolves.toMatchObject({ status: "ok" });
+  });
+
+  it("releases a permit when the reader rejects", async () => {
+    const pendingA = deferred<PredictionAssetAutoDiscoveryResultV2>();
+    const pendingB = deferred<PredictionAssetAutoDiscoveryResultV2>();
+    const read = vi.fn(async (locator: string) =>
+      locator === EVM_A ? pendingA.promise : pendingB.promise
+    );
+    const controller = createPredictionAssetAutoDiscoveryRequestControllerV2({
+      reader: { read },
+      budgetCapacity: 8,
+      budgetIntervalMs: 60_000,
+      maximumConcurrentReads: 1,
+      nowMs: () => 29_000,
+    });
+
+    const first = controller.read(EVM_A);
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(1));
+    pendingA.reject(new Error("reader failed"));
+    await expect(first).rejects.toThrow("reader failed");
+
+    const second = controller.read(EVM_B);
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(2));
+    pendingB.resolve(result(EVM_B));
+    await expect(second).resolves.toMatchObject({ status: "ok" });
+  });
+
+  it.each([0, 33, 1.5])(
+    "rejects invalid maximum concurrency %s",
+    (maximumConcurrentReads) => {
+      expect(() => createPredictionAssetAutoDiscoveryRequestControllerV2({
+        maximumConcurrentReads,
+      })).toThrow(/maximumConcurrentReads/u);
+    },
+  );
+
+  it("does not let one cancelled subscriber abort a shared read", async () => {
+    const completed = deferred<PredictionAssetAutoDiscoveryResultV2>();
+    let sharedSignal: AbortSignal | undefined;
+    const read = vi.fn(async (
+      _locator: string,
+      options?: Readonly<{ signal?: AbortSignal }>,
+    ) => {
+      sharedSignal = options?.signal;
+      return completed.promise;
+    });
+    const controller = createPredictionAssetAutoDiscoveryRequestControllerV2({
+      reader: { read },
+      nowMs: () => 30_000,
+    });
+    const firstAbort = new AbortController();
+    const secondAbort = new AbortController();
+
+    const first = controller.read(EVM_A, { signal: firstAbort.signal });
+    const second = controller.read(EVM_A, { signal: secondAbort.signal });
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(1));
+    firstAbort.abort();
+    expect(sharedSignal?.aborted).toBe(false);
+    completed.resolve(result(EVM_A));
+
+    await expect(first).resolves.toMatchObject({ status: "ok" });
+    await expect(second).resolves.toMatchObject({ status: "ok" });
+  });
+
+  it("aborts the shared reader after every subscriber cancels", async () => {
+    let sharedSignal: AbortSignal | undefined;
+    const read = vi.fn(async (
+      locator: string,
+      options?: Readonly<{ signal?: AbortSignal }>,
+    ) => {
+      sharedSignal = options?.signal;
+      await new Promise<void>((resolve) => {
+        options?.signal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      return result(locator, "inconclusive");
+    });
+    const controller = createPredictionAssetAutoDiscoveryRequestControllerV2({
+      reader: { read },
+      nowMs: () => 40_000,
+    });
+    const firstAbort = new AbortController();
+    const secondAbort = new AbortController();
+
+    const first = controller.read(EVM_A, { signal: firstAbort.signal });
+    const second = controller.read(EVM_A, { signal: secondAbort.signal });
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(1));
+    firstAbort.abort();
+    expect(sharedSignal?.aborted).toBe(false);
+    secondAbort.abort();
+
+    await expect(first).resolves.toMatchObject({ status: "ok" });
+    await expect(second).resolves.toMatchObject({ status: "ok" });
+    expect(sharedSignal?.aborted).toBe(true);
+  });
+});

--- a/tests/prediction-asset-auto-discovery-route.test.ts
+++ b/tests/prediction-asset-auto-discovery-route.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  releaseEnabled: false,
+  releaseError: false,
+  loaded: vi.fn(),
+  read: vi.fn(),
+}));
+
+vi.mock("../lib/prediction-v2/release-binding.server", () => ({
+  isPredictionV2ReleaseEnabled: () => {
+    if (mocks.releaseError) throw new Error("invalid release binding");
+    return mocks.releaseEnabled;
+  },
+}));
+
+vi.mock(
+  "../lib/market-data/prediction-asset-auto-discovery-request-control-v2.server",
+  () => {
+    mocks.loaded();
+    return { readControlledPredictionAssetAutoDiscoveryV2: mocks.read };
+  },
+);
+
+import { NextRequest } from "next/server";
+
+import { GET } from "../app/api/prediction/asset-auto-discovery/route";
+
+const EVM_ADDRESS = `0x${"ab".repeat(20)}`;
+
+function request(query: string) {
+  return new NextRequest(
+    `http://localhost/api/prediction/asset-auto-discovery?${query}`,
+  );
+}
+
+function result(status: string) {
+  return {
+    schemaVersion: 2,
+    locator: EVM_ADDRESS,
+    status,
+    source: status === "unique" || status === "ambiguous"
+      ? "dexscreener"
+      : null,
+    observedAt: "2026-08-23T18:00:00.000Z",
+    usage: "informational-only",
+  };
+}
+
+describe("Prediction V2 asset auto-discovery route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.releaseEnabled = false;
+    mocks.releaseError = false;
+  });
+
+  it("keeps a malformed release binding dark", async () => {
+    mocks.releaseError = true;
+
+    const response = await GET(request(`locator=${EVM_ADDRESS}`));
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(mocks.loaded).not.toHaveBeenCalled();
+    expect(mocks.read).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "",
+    `locator=${EVM_ADDRESS}`,
+    `locator=${EVM_ADDRESS}&extra=true`,
+  ] as const)("returns a dark, non-cacheable 404 before inspecting query %s", async (
+    query,
+  ) => {
+    const response = await GET(request(query));
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("x-programmable-market-provider")).toBeNull();
+    await expect(response.json()).resolves.toEqual({ error: "Not found" });
+    expect(mocks.loaded).not.toHaveBeenCalled();
+    expect(mocks.read).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "",
+    `locator=${EVM_ADDRESS}&locator=${EVM_ADDRESS}`,
+    `locator=${EVM_ADDRESS}&network=base`,
+    `locator=${"a".repeat(129)}`,
+  ])("rejects an invalid enabled query before loading the provider: %s", async (
+    query,
+  ) => {
+    mocks.releaseEnabled = true;
+
+    const response = await GET(request(query));
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("x-programmable-identity-source")).toBeNull();
+    expect(response.headers.get("x-programmable-market-provider")).toBeNull();
+    expect(response.headers.get("x-programmable-read-purpose")).toBeNull();
+    await expect(response.json()).resolves.toEqual({
+      error: "Enter one exact token address",
+    });
+    expect(mocks.loaded).not.toHaveBeenCalled();
+    expect(mocks.read).not.toHaveBeenCalled();
+  });
+
+  it("returns a cacheable informational unique result and forwards cancellation", async () => {
+    mocks.releaseEnabled = true;
+    mocks.read.mockResolvedValueOnce({
+      status: "ok",
+      source: "reader",
+      result: {
+        ...result("unique"),
+        candidate: { selection: { sourceNetwork: "base" } },
+      },
+    });
+    const input = request(`locator=%20${EVM_ADDRESS}%20`);
+
+    const response = await GET(input);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toContain("s-maxage=15");
+    expect(response.headers.get("x-programmable-market-provider"))
+      .toBe("dexscreener");
+    expect(response.headers.get("x-programmable-identity-source"))
+      .toBe("onchain-rpc");
+    expect(response.headers.get("x-programmable-read-purpose"))
+      .toBe("informational-only");
+    expect(mocks.read).toHaveBeenCalledWith(EVM_ADDRESS, {
+      signal: input.signal,
+    });
+    await expect(response.json()).resolves.toMatchObject({ status: "unique" });
+  });
+
+  it("attributes an identity-only result to RPC without inventing DEX enrichment", async () => {
+    mocks.releaseEnabled = true;
+    mocks.read.mockResolvedValueOnce({
+      status: "ok",
+      source: "reader",
+      result: {
+        ...result("unique"),
+        source: null,
+        candidate: { selection: { sourceNetwork: "base" } },
+      },
+    });
+
+    const response = await GET(request(`locator=${EVM_ADDRESS}`));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-programmable-identity-source"))
+      .toBe("onchain-rpc");
+    expect(response.headers.get("x-programmable-market-provider")).toBeNull();
+    expect(response.headers.get("x-programmable-read-purpose"))
+      .toBe("informational-only");
+  });
+
+  it.each([
+    ["ambiguous", 200, false],
+    ["invalid", 400, false],
+    ["not-found", 404, false],
+    ["inconclusive", 503, true],
+  ] as const)("maps %s to HTTP %i", async (
+    discoveryStatus,
+    expectedStatus,
+    retryable,
+  ) => {
+    mocks.releaseEnabled = true;
+    mocks.read.mockResolvedValueOnce({
+      status: "ok",
+      source: "reader",
+      result: result(discoveryStatus),
+    });
+
+    const response = await GET(request(`locator=${EVM_ADDRESS}`));
+
+    expect(response.status).toBe(expectedStatus);
+    expect(response.headers.get("retry-after")).toBe(retryable ? "5" : null);
+    expect(response.headers.get("cache-control")).toBe(
+      discoveryStatus === "ambiguous"
+        ? "public, max-age=0, s-maxage=15, stale-while-revalidate=30"
+        : "no-store",
+    );
+    expect(response.headers.get("x-programmable-identity-source")).toBe(
+      discoveryStatus === "invalid" ? null : "onchain-rpc",
+    );
+    expect(response.headers.get("x-programmable-market-provider")).toBe(
+      discoveryStatus === "ambiguous" ? "dexscreener" : null,
+    );
+  });
+
+  it("maps the local provider budget to a non-cacheable HTTP 429", async () => {
+    mocks.releaseEnabled = true;
+    mocks.read.mockResolvedValueOnce({
+      status: "rate-limited",
+      retryAfterSeconds: 7,
+    });
+
+    const response = await GET(request(`locator=${EVM_ADDRESS}`));
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("retry-after")).toBe("7");
+    expect(response.headers.get("x-programmable-identity-source")).toBeNull();
+    expect(response.headers.get("x-programmable-market-provider")).toBeNull();
+    expect(response.headers.get("x-programmable-read-purpose")).toBeNull();
+    await expect(response.json()).resolves.toEqual({
+      error: "Too many token lookups. Try again shortly.",
+    });
+  });
+});

--- a/tests/prediction-asset-auto-discovery-v2.test.ts
+++ b/tests/prediction-asset-auto-discovery-v2.test.ts
@@ -1,0 +1,875 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  createPredictionAssetAutoDiscoveryReaderV2,
+  type PredictionAssetAutoDiscoveryReaderOptionsV2,
+} from "../lib/market-data/prediction-asset-auto-discovery-v2.server";
+
+const OBSERVED_AT = "2026-08-23T18:00:00.000Z";
+const EVM_ADDRESS = `0x${"Ab".repeat(20)}`;
+const CANONICAL_EVM_ADDRESS = EVM_ADDRESS.toLowerCase();
+const OTHER_EVM_ADDRESS = `0x${"cd".repeat(20)}`;
+const SOLANA_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const OTHER_SOLANA_MINT = "So11111111111111111111111111111111111111112";
+const EVM_NETWORKS = ["ethereum", "base", "bnb", "robinhood"] as const;
+
+function identityVerifier(
+  verified: readonly (typeof EVM_NETWORKS)[number][] | readonly ["solana"] = [],
+  failed: Partial<Record<
+    (typeof EVM_NETWORKS)[number] | "solana",
+    "identity-unconfigured" | "identity-unavailable" | "identity-invalid"
+  >> = {},
+) {
+  const verifiedNetworks = new Set<string>(verified);
+  return Object.freeze({
+    verify: vi.fn(async (locator: string) => {
+      const networks = locator.startsWith("0x") ? EVM_NETWORKS : ["solana"] as const;
+      return networks.map((sourceNetwork) => {
+        const reason = failed[sourceNetwork];
+        if (reason) return { sourceNetwork, status: "failed" as const, reason };
+        return verifiedNetworks.has(sourceNetwork)
+          ? { sourceNetwork, status: "verified-token" as const }
+          : { sourceNetwork, status: "not-token" as const };
+      });
+    }),
+  });
+}
+
+function injectedIdentityVerifier(probes: unknown) {
+  return {
+    verify: vi.fn(async () => probes),
+  } as unknown as NonNullable<
+    PredictionAssetAutoDiscoveryReaderOptionsV2["identityVerifier"]
+  >;
+}
+
+type PairInput = Readonly<{
+  chainId: string;
+  locator: string;
+  namespace?: "evm" | "solana";
+  matchedSide?: "base" | "quote";
+  pairAddress?: string;
+  dexId?: string;
+  priceUsd?: string | null;
+  priceNative?: string | null;
+  liquidityUsd?: number | null;
+  volume24hUsd?: number | null;
+  marketCap?: number | null;
+  fdv?: number | null;
+  pairCreatedAt?: number | null;
+  tokenName?: string;
+  tokenSymbol?: string;
+  info?: unknown;
+}>;
+
+function pair(input: PairInput) {
+  const namespace = input.namespace ?? "evm";
+  const other = namespace === "evm" ? OTHER_EVM_ADDRESS : OTHER_SOLANA_MINT;
+  const matchedToken = {
+    address: input.locator,
+    name: input.tokenName ?? "Example Token",
+    symbol: input.tokenSymbol ?? "EXM",
+  };
+  const otherToken = { address: other, name: "USD Coin", symbol: "USDC" };
+  return {
+    chainId: input.chainId,
+    dexId: input.dexId ?? "uniswap",
+    pairAddress: input.pairAddress ?? `0x${"ef".repeat(20)}`,
+    baseToken: input.matchedSide === "quote" ? otherToken : matchedToken,
+    quoteToken: input.matchedSide === "quote" ? matchedToken : otherToken,
+    priceUsd: input.priceUsd === undefined ? "1.25" : input.priceUsd,
+    priceNative: input.priceNative === undefined ? "2.5" : input.priceNative,
+    liquidity: input.liquidityUsd === undefined
+      ? { usd: 75_000 }
+      : input.liquidityUsd === null
+        ? null
+        : { usd: input.liquidityUsd },
+    volume: input.volume24hUsd === undefined
+      ? { h24: 50_000 }
+      : input.volume24hUsd === null
+        ? null
+        : { h24: input.volume24hUsd },
+    marketCap: input.marketCap === undefined ? 2_000_000 : input.marketCap,
+    fdv: input.fdv === undefined ? 2_500_000 : input.fdv,
+    pairCreatedAt: input.pairCreatedAt === undefined
+      ? 1_700_000_000_000
+      : input.pairCreatedAt,
+    info: input.info,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200, headers?: HeadersInit) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      ...headers,
+    },
+  });
+}
+
+function reader(
+  fetchImpl: typeof fetch,
+  overrides: Partial<
+    Parameters<typeof createPredictionAssetAutoDiscoveryReaderV2>[0]
+  > = {},
+) {
+  return createPredictionAssetAutoDiscoveryReaderV2({
+    fetchImpl,
+    identityVerifier: identityVerifier(),
+    now: () => new Date(OBSERVED_AT),
+    timeoutMs: 100,
+    maximumResponseBytes: 512_000,
+    maximumRows: 256,
+    ...overrides,
+  });
+}
+
+function providerChainId(url: URL | RequestInfo) {
+  const segments = new URL(String(url)).pathname.split("/");
+  return segments.at(-2) ?? "";
+}
+
+describe("prediction asset auto-discovery V2", () => {
+  beforeEach(() => vi.useRealTimers());
+
+  it.each([
+    "",
+    "not-an-address",
+    `0x${"ab".repeat(19)}`,
+    `0x${"0".repeat(40)}`,
+    "1111111111111111111111111111111",
+    "1".repeat(32),
+    `${SOLANA_MINT}0`,
+  ])("rejects an invalid raw locator without a provider request: %s", async (
+    locator,
+  ) => {
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await expect(reader(fetchImpl).read(locator)).resolves.toEqual({
+      schemaVersion: 2,
+      locator: null,
+      status: "invalid",
+      reason: "invalid-locator",
+      source: null,
+      observedAt: OBSERVED_AT,
+      usage: "informational-only",
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("auto-selects only after all chains verify exactly one token deployment", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
+      expect(init).toMatchObject({
+        method: "GET",
+        cache: "no-store",
+        redirect: "error",
+      });
+      const chainId = providerChainId(url);
+      return jsonResponse(chainId === "base"
+        ? [pair({ chainId, locator: CANONICAL_EVM_ADDRESS })]
+        : []);
+    });
+
+    const result = await reader(fetchImpl, {
+      identityVerifier: identityVerifier(["base"]),
+    }).read(`  ${EVM_ADDRESS}  `);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(fetchImpl.mock.calls.map(([url]) => String(url))).toEqual([
+      `https://api.dexscreener.com/token-pairs/v1/ethereum/${CANONICAL_EVM_ADDRESS}`,
+      `https://api.dexscreener.com/token-pairs/v1/base/${CANONICAL_EVM_ADDRESS}`,
+      `https://api.dexscreener.com/token-pairs/v1/bsc/${CANONICAL_EVM_ADDRESS}`,
+      `https://api.dexscreener.com/token-pairs/v1/robinhood/${CANONICAL_EVM_ADDRESS}`,
+    ]);
+    expect(result).toMatchObject({
+      schemaVersion: 2,
+      locator: CANONICAL_EVM_ADDRESS,
+      status: "unique",
+      source: "dexscreener",
+      observedAt: OBSERVED_AT,
+      usage: "informational-only",
+      candidate: {
+        selectionKey: `evm:8453:${CANONICAL_EVM_ADDRESS}`,
+        selection: {
+          mode: "custom",
+          sourceNetwork: "base",
+          assetLocator: CANONICAL_EVM_ADDRESS,
+        },
+        namespace: "evm",
+        chainReference: "8453",
+        providerChainId: "base",
+        provenance: {
+          identity: { source: "onchain-rpc" },
+          enrichment: { source: "dexscreener" },
+        },
+        currentPriceUsd: 1.25,
+        marketCapUsd: 2_000_000,
+        fdvUsd: 2_500_000,
+        matchingPairCount: 1,
+      },
+    });
+    expect(result).not.toHaveProperty("settlementEligible");
+    expect(result.status === "unique" && result.candidate)
+      .not.toHaveProperty("settlementEligible");
+  });
+
+  it("returns inconclusive instead of a false unique result when any identity probe fails", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url) => {
+      const chainId = providerChainId(url);
+      if (chainId === "base") {
+        return jsonResponse([pair({
+          chainId,
+          locator: CANONICAL_EVM_ADDRESS,
+        })]);
+      }
+      return jsonResponse([]);
+    });
+
+    const result = await reader(fetchImpl, {
+      identityVerifier: identityVerifier(["base"], {
+        robinhood: "identity-unavailable",
+      }),
+    }).read(EVM_ADDRESS);
+
+    expect(result).toMatchObject({
+      status: "inconclusive",
+      candidates: [{ selection: { sourceNetwork: "base" } }],
+      failures: [{
+        sourceNetwork: "robinhood",
+        reason: "identity-unavailable",
+      }],
+    });
+  });
+
+  it("keeps a verified identity candidate when DEX enrichment is unavailable", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => jsonResponse({}, 503));
+
+    const result = await reader(fetchImpl, {
+      identityVerifier: identityVerifier(["base"]),
+    }).read(EVM_ADDRESS);
+
+    expect(result).toMatchObject({
+      status: "unique",
+      source: null,
+      candidate: {
+        selectionKey: `evm:8453:${CANONICAL_EVM_ADDRESS}`,
+        selection: { sourceNetwork: "base" },
+        token: {
+          address: CANONICAL_EVM_ADDRESS,
+          name: null,
+          symbol: null,
+        },
+        currentPriceUsd: null,
+        marketCapUsd: null,
+        fdvUsd: null,
+        matchingPairCount: 0,
+        pair: null,
+        provenance: {
+          identity: { source: "onchain-rpc" },
+          enrichment: null,
+        },
+        links: { imageUrl: null, websites: [], socials: [] },
+      },
+    });
+    expect(result).not.toHaveProperty("failures");
+  });
+
+  it("keeps a verified identity candidate but stays inconclusive for another unresolved chain", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => jsonResponse({}, 503));
+
+    const result = await reader(fetchImpl, {
+      identityVerifier: identityVerifier(["base"], {
+        robinhood: "identity-unavailable",
+      }),
+    }).read(EVM_ADDRESS);
+
+    expect(result).toMatchObject({
+      status: "inconclusive",
+      source: null,
+      candidates: [{
+        selection: { sourceNetwork: "base" },
+        matchingPairCount: 0,
+        pair: null,
+        provenance: {
+          identity: { source: "onchain-rpc" },
+          enrichment: null,
+        },
+      }],
+      failures: [{
+        sourceNetwork: "robinhood",
+        reason: "identity-unavailable",
+      }],
+    });
+  });
+
+  it("never mistakes one indexed EVM pool for chain identity", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url) => {
+      const chainId = providerChainId(url);
+      return jsonResponse(chainId === "base"
+        ? [pair({ chainId, locator: CANONICAL_EVM_ADDRESS })]
+        : []);
+    });
+
+    const result = await reader(fetchImpl, {
+      identityVerifier: identityVerifier(["ethereum"]),
+    }).read(EVM_ADDRESS);
+
+    expect(result).toMatchObject({
+      status: "inconclusive",
+      candidates: [{
+        selection: { sourceNetwork: "ethereum" },
+        matchingPairCount: 0,
+        pair: null,
+      }],
+      failures: [{ sourceNetwork: "base", reason: "identity-mismatch" }],
+    });
+  });
+
+  it.each([
+    ["non-array set", null],
+    ["unknown status", [
+      { sourceNetwork: "ethereum", status: "unknown" },
+      { sourceNetwork: "base", status: "verified-token" },
+      { sourceNetwork: "bnb", status: "not-token" },
+      { sourceNetwork: "robinhood", status: "not-token" },
+    ]],
+    ["invalid failure reason", [
+      { sourceNetwork: "ethereum", status: "failed", reason: "timeout" },
+      { sourceNetwork: "base", status: "verified-token" },
+      { sourceNetwork: "bnb", status: "not-token" },
+      { sourceNetwork: "robinhood", status: "not-token" },
+    ]],
+    ["unknown network", [
+      { sourceNetwork: "polygon", status: "not-token" },
+      { sourceNetwork: "base", status: "verified-token" },
+      { sourceNetwork: "bnb", status: "not-token" },
+      { sourceNetwork: "robinhood", status: "not-token" },
+    ]],
+    ["null row", [
+      null,
+      { sourceNetwork: "base", status: "verified-token" },
+      { sourceNetwork: "bnb", status: "not-token" },
+      { sourceNetwork: "robinhood", status: "not-token" },
+    ]],
+    ["duplicate network", [
+      { sourceNetwork: "ethereum", status: "not-token" },
+      { sourceNetwork: "base", status: "verified-token" },
+      { sourceNetwork: "bnb", status: "not-token" },
+      { sourceNetwork: "ethereum", status: "not-token" },
+    ]],
+    ["missing row", [
+      { sourceNetwork: "ethereum", status: "not-token" },
+      { sourceNetwork: "base", status: "verified-token" },
+      { sourceNetwork: "bnb", status: "not-token" },
+    ]],
+    ["extra key", [
+      { sourceNetwork: "ethereum", status: "not-token", extra: true },
+      { sourceNetwork: "base", status: "verified-token" },
+      { sourceNetwork: "bnb", status: "not-token" },
+      { sourceNetwork: "robinhood", status: "not-token" },
+    ]],
+    ["non-plain row", [
+      Object.assign(Object.create(null), {
+        sourceNetwork: "ethereum",
+        status: "not-token",
+      }),
+      { sourceNetwork: "base", status: "verified-token" },
+      { sourceNetwork: "bnb", status: "not-token" },
+      { sourceNetwork: "robinhood", status: "not-token" },
+    ]],
+  ])("fails closed for a malformed injected identity set: %s", async (
+    _label,
+    probes,
+  ) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url) => {
+      const chainId = providerChainId(url);
+      return jsonResponse(chainId === "base"
+        ? [pair({ chainId, locator: CANONICAL_EVM_ADDRESS })]
+        : []);
+    });
+
+    const result = await reader(fetchImpl, {
+      identityVerifier: injectedIdentityVerifier(probes),
+    }).read(EVM_ADDRESS);
+
+    expect(result).toMatchObject({
+      status: "inconclusive",
+      candidates: [],
+      failures: EVM_NETWORKS.map((sourceNetwork) => ({
+        sourceNetwork,
+        reason: "identity-invalid",
+      })),
+    });
+  });
+
+  it("contains throwing verifier getters as an inconclusive result", async () => {
+    const throwing = {
+      sourceNetwork: "ethereum",
+      get status(): never {
+        throw new Error("malicious getter");
+      },
+    };
+    const fetchImpl = vi.fn<typeof fetch>(async (url) => {
+      const chainId = providerChainId(url);
+      return jsonResponse(chainId === "base"
+        ? [pair({ chainId, locator: CANONICAL_EVM_ADDRESS })]
+        : []);
+    });
+
+    await expect(reader(fetchImpl, {
+      identityVerifier: injectedIdentityVerifier([
+        throwing,
+        { sourceNetwork: "base", status: "verified-token" },
+        { sourceNetwork: "bnb", status: "not-token" },
+        { sourceNetwork: "robinhood", status: "not-token" },
+      ]),
+    }).read(EVM_ADDRESS)).resolves.toMatchObject({
+      status: "inconclusive",
+      candidates: [],
+      failures: EVM_NETWORKS.map((sourceNetwork) => ({
+        sourceNetwork,
+        reason: "identity-invalid",
+      })),
+    });
+  });
+
+  it("contains a verifier array with a throwing length trap", async () => {
+    const probes = new Proxy([
+      { sourceNetwork: "ethereum", status: "not-token" },
+      { sourceNetwork: "base", status: "verified-token" },
+      { sourceNetwork: "bnb", status: "not-token" },
+      { sourceNetwork: "robinhood", status: "not-token" },
+    ], {
+      get(target, property, receiver) {
+        if (property === "length") throw new Error("malicious length trap");
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const fetchImpl = vi.fn<typeof fetch>(async (url) => {
+      const chainId = providerChainId(url);
+      return jsonResponse(chainId === "base"
+        ? [pair({ chainId, locator: CANONICAL_EVM_ADDRESS })]
+        : []);
+    });
+
+    await expect(reader(fetchImpl, {
+      identityVerifier: injectedIdentityVerifier(probes),
+    }).read(EVM_ADDRESS)).resolves.toMatchObject({
+      status: "inconclusive",
+      candidates: [],
+      failures: EVM_NETWORKS.map((sourceNetwork) => ({
+        sourceNetwork,
+        reason: "identity-invalid",
+      })),
+    });
+  });
+
+  it("returns every verified deployment even when one has no DEX enrichment", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url) => {
+      const chainId = providerChainId(url);
+      return jsonResponse(chainId === "base"
+        ? [pair({ chainId, locator: CANONICAL_EVM_ADDRESS })]
+        : []);
+    });
+
+    const result = await reader(fetchImpl, {
+      identityVerifier: identityVerifier(["ethereum", "base"]),
+    }).read(EVM_ADDRESS);
+
+    expect(result).toMatchObject({
+      status: "ambiguous",
+      source: "dexscreener",
+      candidates: [
+        {
+          selection: { sourceNetwork: "ethereum" },
+          matchingPairCount: 0,
+          pair: null,
+          provenance: { enrichment: null },
+        },
+        {
+          selection: { sourceNetwork: "base" },
+          matchingPairCount: 1,
+          provenance: { enrichment: { source: "dexscreener" } },
+        },
+      ],
+    });
+  });
+
+  it("ignores DEX outages on chains proven not to contain the token", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url) => {
+      const chainId = providerChainId(url);
+      if (chainId === "base") {
+        return jsonResponse([pair({
+          chainId,
+          locator: CANONICAL_EVM_ADDRESS,
+        })]);
+      }
+      if (chainId === "robinhood") return jsonResponse({}, 500);
+      return jsonResponse([]);
+    });
+
+    await expect(reader(fetchImpl, {
+      identityVerifier: identityVerifier(["base"]),
+    }).read(EVM_ADDRESS)).resolves.toMatchObject({
+      status: "unique",
+      candidate: { selection: { sourceNetwork: "base" } },
+    });
+  });
+
+  it("returns deterministic ambiguity when the address has pairs on multiple EVM chains", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url) => {
+      const chainId = providerChainId(url);
+      return jsonResponse(chainId === "ethereum" || chainId === "bsc"
+        ? [pair({ chainId, locator: CANONICAL_EVM_ADDRESS })]
+        : []);
+    });
+
+    const result = await reader(fetchImpl, {
+      identityVerifier: identityVerifier(["ethereum", "bnb"]),
+    }).read(EVM_ADDRESS);
+
+    expect(result).toMatchObject({
+      status: "ambiguous",
+      candidates: [
+        { selection: { sourceNetwork: "ethereum" }, chainReference: "1" },
+        { selection: { sourceNetwork: "bnb" }, chainReference: "56" },
+      ],
+    });
+  });
+
+  it("returns not-found only after every EVM provider probe definitively returns no exact pair", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => jsonResponse([]));
+
+    await expect(reader(fetchImpl).read(EVM_ADDRESS)).resolves.toMatchObject({
+      locator: CANONICAL_EVM_ADDRESS,
+      status: "not-found",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+  });
+
+  it("recognizes a 32-byte Solana address and probes only Solana", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url) => {
+      expect(String(url)).toBe(
+        `https://api.dexscreener.com/token-pairs/v1/solana/${SOLANA_MINT}`,
+      );
+      return jsonResponse([pair({
+        chainId: "solana",
+        locator: SOLANA_MINT,
+        namespace: "solana",
+        pairAddress: OTHER_SOLANA_MINT,
+      })]);
+    });
+
+    await expect(reader(fetchImpl, {
+      identityVerifier: identityVerifier(["solana"]),
+    }).read(SOLANA_MINT)).resolves.toMatchObject({
+      locator: SOLANA_MINT,
+      status: "unique",
+      candidate: {
+        namespace: "solana",
+        selectionKey:
+          `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d:${SOLANA_MINT}`,
+        selection: { sourceNetwork: "solana", assetLocator: SOLANA_MINT },
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("counts an exact quote-side match but derives the quote price instead of using the base price", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url) => {
+      const chainId = providerChainId(url);
+      return jsonResponse(chainId === "base"
+        ? [pair({
+          chainId,
+          locator: CANONICAL_EVM_ADDRESS,
+          matchedSide: "quote",
+          priceUsd: "2",
+          priceNative: "4",
+          marketCap: 99_000_000,
+          fdv: 100_000_000,
+          info: {
+            imageUrl: "https://cdn.example.com/wrong-base-token.png",
+            websites: [{
+              label: "Wrong base token",
+              url: "https://wrong-base-token.example.org",
+            }],
+            socials: [{
+              type: "twitter",
+              url: "https://x.com/wrong_base_token",
+            }],
+          },
+        })]
+        : []);
+    });
+
+    const result = await reader(fetchImpl, {
+      identityVerifier: identityVerifier(["base"]),
+    }).read(EVM_ADDRESS);
+
+    expect(result).toMatchObject({
+      status: "unique",
+      candidate: {
+        currentPriceUsd: 0.5,
+        marketCapUsd: null,
+        fdvUsd: null,
+        matchingPairCount: 1,
+        pair: { matchedSide: "quote" },
+        links: { imageUrl: null, websites: [], socials: [] },
+      },
+    });
+  });
+
+  it("never substitutes an unorientable quote-side price", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url) => {
+      const chainId = providerChainId(url);
+      return jsonResponse(chainId === "ethereum"
+        ? [pair({
+          chainId,
+          locator: CANONICAL_EVM_ADDRESS,
+          matchedSide: "quote",
+          priceUsd: "2",
+          priceNative: null,
+        })]
+        : []);
+    });
+
+    await expect(reader(fetchImpl, {
+      identityVerifier: identityVerifier(["ethereum"]),
+    }).read(EVM_ADDRESS)).resolves.toMatchObject({
+      status: "unique",
+      candidate: {
+        currentPriceUsd: null,
+        marketCapUsd: null,
+        fdvUsd: null,
+        pair: { matchedSide: "quote" },
+      },
+    });
+  });
+
+  it("selects the deepest priced pair deterministically and sanitizes provider metadata and links", async () => {
+    const shallowPair = pair({
+      chainId: "base",
+      locator: CANONICAL_EVM_ADDRESS,
+      pairAddress: `0x${"11".repeat(20)}`,
+      liquidityUsd: 10,
+      priceUsd: "9",
+    });
+    const deepPair = pair({
+      chainId: "base",
+      locator: CANONICAL_EVM_ADDRESS,
+      pairAddress: `0x${"22".repeat(20)}`,
+      liquidityUsd: 100_000,
+      volume24hUsd: 25_000,
+      pairCreatedAt: 1_650_000_000_000,
+      priceUsd: "3",
+      tokenName: "  Example\n Coin  ",
+      tokenSymbol: " EXM ",
+      info: {
+        imageUrl: "https://cdn.example.com/token.png#fragment",
+        websites: [
+          { label: "Site", url: "https://example.com" },
+          { label: "Duplicate", url: "https://example.com/" },
+          { label: "Unsafe", url: "javascript:alert(1)" },
+          { label: "Insecure", url: "http://unsafe.example.com" },
+          { label: "Private", url: "https://127.0.0.1/token" },
+        ],
+        socials: [
+          { type: "Twitter", url: "https://x.com/example" },
+          { type: "Telegram", url: "https://t.me/example" },
+          { type: "Bad", url: "https://user:secret@example.com" },
+        ],
+      },
+    });
+    const fetchImpl = vi.fn<typeof fetch>(async (url) => {
+      const chainId = providerChainId(url);
+      return jsonResponse(chainId === "base"
+        ? [shallowPair, deepPair]
+        : []);
+    });
+
+    const result = await reader(fetchImpl, {
+      identityVerifier: identityVerifier(["base"]),
+    }).read(EVM_ADDRESS);
+
+    expect(result).toMatchObject({
+      status: "unique",
+      candidate: {
+        token: { name: null, symbol: "EXM" },
+        currentPriceUsd: 3,
+        matchingPairCount: 2,
+        pair: {
+          pairAddress: `0x${"22".repeat(20)}`,
+          liquidityUsd: 100_000,
+          volume24hUsd: 25_000,
+          pairCreatedAt: 1_650_000_000_000,
+        },
+        links: {
+          imageUrl: "https://cdn.example.com/token.png",
+          websites: [{ label: "Site", url: "https://example.com/" }],
+          socials: [
+            { type: "telegram", url: "https://t.me/example" },
+            { type: "twitter", url: "https://x.com/example" },
+          ],
+        },
+      },
+    });
+  });
+
+  it("ignores malformed foreign rows and preserves a later valid exact match", async () => {
+    const valid = pair({
+      chainId: "base",
+      locator: CANONICAL_EVM_ADDRESS,
+      info: { websites: "malformed optional enrichment" },
+    });
+    const malformedExact = {
+      ...pair({ chainId: "base", locator: CANONICAL_EVM_ADDRESS }),
+      dexId: 7,
+    };
+    const fetchImpl = vi.fn<typeof fetch>(async (url) => {
+      const chainId = providerChainId(url);
+      return jsonResponse(chainId === "base"
+        ? [
+            null,
+            {
+              chainId: "base",
+              baseToken: { address: OTHER_EVM_ADDRESS },
+              quoteToken: null,
+              dexId: null,
+            },
+            { chainId: 7, baseToken: null, quoteToken: null },
+            malformedExact,
+            valid,
+          ]
+        : []);
+    });
+
+    const result = await reader(fetchImpl, {
+      identityVerifier: identityVerifier(["base"]),
+    }).read(EVM_ADDRESS);
+
+    expect(result).toMatchObject({
+      status: "unique",
+      candidate: {
+        selection: { sourceNetwork: "base" },
+        matchingPairCount: 1,
+        pair: { dexId: "uniswap" },
+        links: { imageUrl: null, websites: [], socials: [] },
+      },
+    });
+  });
+
+  it("drops HTML, bidi and control-bearing display text at the server boundary", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url) => {
+      const chainId = providerChainId(url);
+      return jsonResponse(chainId === "base"
+        ? [pair({
+          chainId,
+          locator: CANONICAL_EVM_ADDRESS,
+          tokenName: "<b>spoof</b>",
+          tokenSymbol: "YES\u202eNO",
+          info: {
+            websites: [{
+              label: "Site\u0000hidden",
+              url: "https://example.com",
+            }],
+            socials: [{
+              type: "x\u2066spoof",
+              url: "https://x.com/example",
+            }],
+          },
+        })]
+        : []);
+    });
+
+    await expect(reader(fetchImpl, {
+      identityVerifier: identityVerifier(["base"]),
+    }).read(EVM_ADDRESS)).resolves.toMatchObject({
+      status: "unique",
+      candidate: {
+        token: { name: null, symbol: null },
+        links: {
+          websites: [{ label: null, url: "https://example.com/" }],
+          socials: [{ type: null, url: "https://x.com/example" }],
+        },
+      },
+    });
+  });
+
+  it("keeps verified Solana identity through invalid or unavailable DEX responses", async () => {
+    const malformedRows = Array.from({ length: 3 }, () => ({}));
+    const scenarios = [
+      vi.fn<typeof fetch>(async () => jsonResponse({}, 404)),
+      vi.fn<typeof fetch>(async () => jsonResponse(malformedRows)),
+      vi.fn<typeof fetch>(async () => jsonResponse([], 200, {
+        "content-length": "999999",
+      })),
+    ];
+
+    for (const fetchImpl of scenarios) {
+      const result = await reader(fetchImpl, {
+        identityVerifier: identityVerifier(["solana"]),
+        maximumResponseBytes: 1_000,
+        maximumRows: 2,
+      }).read(SOLANA_MINT);
+      expect(result).toMatchObject({
+        status: "unique",
+        candidate: {
+          selection: { sourceNetwork: "solana" },
+          matchingPairCount: 0,
+          pair: null,
+        },
+      });
+    }
+  });
+
+  it("bounds providers that ignore AbortSignal", async () => {
+    vi.useFakeTimers();
+    const signals: AbortSignal[] = [];
+    const fetchImpl = vi.fn<typeof fetch>((_url, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return new Promise<Response>(() => undefined);
+    });
+    const pending = reader(fetchImpl, {
+      identityVerifier: identityVerifier(EVM_NETWORKS),
+      timeoutMs: 100,
+    }).read(EVM_ADDRESS);
+
+    await vi.advanceTimersByTimeAsync(101);
+
+    await expect(pending).resolves.toMatchObject({
+      status: "ambiguous",
+      candidates: EVM_NETWORKS.map((sourceNetwork) => ({
+        selection: { sourceNetwork },
+        matchingPairCount: 0,
+        pair: null,
+      })),
+    });
+    expect(signals).toHaveLength(4);
+    expect(signals.every((signal) => signal.aborted)).toBe(true);
+  });
+
+  it("does not start provider reads when the caller is already aborted", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await reader(fetchImpl, {
+      identityVerifier: identityVerifier(EVM_NETWORKS),
+    }).read(EVM_ADDRESS, {
+      signal: controller.signal,
+    });
+
+    expect(result).toMatchObject({
+      status: "ambiguous",
+      candidates: EVM_NETWORKS.map((sourceNetwork) => ({
+        selection: { sourceNetwork },
+        matchingPairCount: 0,
+        pair: null,
+      })),
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/tests/prediction-asset-identity-verification-v2.test.ts
+++ b/tests/prediction-asset-identity-verification-v2.test.ts
@@ -1,0 +1,658 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  createPredictionAssetIdentityVerifierV2,
+  type PredictionAssetIdentityRpcUrlsV2,
+} from "../lib/market-data/prediction-asset-identity-verification-v2.server";
+
+const EVM_ADDRESS = `0x${"ab".repeat(20)}`;
+const SOLANA_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const SOLANA_MAINNET_GENESIS_HASH =
+  "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d";
+const SOLANA_TOKEN_PROGRAM =
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+const SOLANA_TOKEN_2022_PROGRAM =
+  "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
+const EVM_SAFE_BLOCK_NUMBER = "0x1234";
+const EVM_SAFE_BLOCK_HASH = `0x${"12".repeat(32)}`;
+const SOLANA_FINALIZED_SLOT = 123;
+const SOLANA_ACCOUNT_CONTEXT_SLOT = 124;
+
+const RPC_URLS = Object.freeze({
+  ethereum: "https://ethereum.rpc.example/v2/key",
+  base: "https://base.rpc.example/v2/key",
+  bnb: "https://bnb.rpc.example/v2/key",
+  robinhood: "https://robinhood.rpc.example/v2/key",
+  solana: "https://solana.rpc.example/v2/key",
+} as const satisfies PredictionAssetIdentityRpcUrlsV2);
+
+const EVM_CHAIN_ID_BY_HOST = Object.freeze({
+  "ethereum.rpc.example": "0x1",
+  "base.rpc.example": "0x2105",
+  "bnb.rpc.example": "0x38",
+  "robinhood.rpc.example": "0x1237",
+} as const);
+
+function jsonResponse(
+  body: unknown,
+  status = 200,
+  contentType = "application/json; charset=utf-8",
+) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": contentType },
+  });
+}
+
+function rpcResult(id: number, result: unknown) {
+  return { jsonrpc: "2.0", id, result };
+}
+
+function rpcError(id: number) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    error: { code: -32_000, message: "execution reverted" },
+  };
+}
+
+function abiWord(value: bigint | number) {
+  return `0x${BigInt(value).toString(16).padStart(64, "0")}`;
+}
+
+type EvmResponseOverrides = Readonly<{
+  anchorBlock?: unknown;
+  confirmedBlock?: unknown;
+  code?: unknown;
+  decimals?: unknown;
+  decimalsError?: boolean;
+  totalSupply?: unknown;
+}>;
+
+function evmBlock(
+  number = EVM_SAFE_BLOCK_NUMBER,
+  hash = EVM_SAFE_BLOCK_HASH,
+) {
+  return { number, hash };
+}
+
+function evmResponse(
+  chainId: string,
+  request: readonly Readonly<{ id: number; method: string }>[],
+  overrides: EvmResponseOverrides = {},
+) {
+  if (request[0]?.method === "eth_chainId") {
+    return [
+      rpcResult(1, chainId),
+      rpcResult(2, overrides.anchorBlock ?? evmBlock()),
+    ];
+  }
+  if (request[0]?.method === "eth_getBlockByNumber") {
+    return [
+      rpcResult(3, overrides.confirmedBlock ?? evmBlock()),
+      rpcResult(4, overrides.code ?? "0x60006000"),
+      overrides.decimalsError
+        ? rpcError(5)
+        : rpcResult(5, overrides.decimals ?? abiWord(18)),
+      rpcResult(6, overrides.totalSupply ?? abiWord(1_000_000)),
+    ];
+  }
+  throw new Error(`Unexpected EVM request: ${request[0]?.method ?? "empty"}`);
+}
+
+function solanaAnchorBatch(input: Readonly<{
+  genesisHash?: string;
+  finalizedSlot?: unknown;
+}> = {}) {
+  return [
+    rpcResult(1, input.genesisHash ?? SOLANA_MAINNET_GENESIS_HASH),
+    rpcResult(2, input.finalizedSlot ?? SOLANA_FINALIZED_SLOT),
+  ];
+}
+
+function solanaAccountBatch(input: Readonly<{
+  account?: unknown;
+  contextSlot?: unknown;
+}> = {}) {
+  return [rpcResult(3, {
+    context: {
+      slot: input.contextSlot ?? SOLANA_ACCOUNT_CONTEXT_SLOT,
+    },
+    value: input.account === undefined
+      ? solanaMintAccount(SOLANA_TOKEN_PROGRAM)
+      : input.account,
+  })];
+}
+
+type SolanaResponseOverrides = Readonly<{
+  genesisHash?: string;
+  finalizedSlot?: unknown;
+  account?: unknown;
+  contextSlot?: unknown;
+}>;
+
+function solanaResponse(
+  request: readonly Readonly<{ method: string }>[],
+  overrides: SolanaResponseOverrides = {},
+) {
+  if (request[0]?.method === "getGenesisHash") {
+    return solanaAnchorBatch(overrides);
+  }
+  if (request[0]?.method === "getAccountInfo") {
+    return solanaAccountBatch(overrides);
+  }
+  throw new Error(`Unexpected Solana request: ${request[0]?.method ?? "empty"}`);
+}
+
+function solanaMintAccount(owner: string, type = "mint") {
+  return {
+    data: {
+      program: "spl-token",
+      parsed: {
+        type,
+        info: { decimals: 6, supply: "1000000000" },
+      },
+      space: 82,
+    },
+    executable: false,
+    lamports: 1_461_600,
+    owner,
+  };
+}
+
+function networkForUrl(url: URL | RequestInfo) {
+  const hostname = new URL(String(url)).hostname;
+  if (!(hostname in EVM_CHAIN_ID_BY_HOST)) {
+    throw new Error(`Unexpected EVM RPC hostname: ${hostname}`);
+  }
+  return hostname as keyof typeof EVM_CHAIN_ID_BY_HOST;
+}
+
+function createVerifier(
+  fetchImpl: typeof fetch,
+  overrides: Readonly<{
+    rpcUrls?: PredictionAssetIdentityRpcUrlsV2;
+    timeoutMs?: number;
+    maximumResponseBytes?: number;
+  }> = {},
+) {
+  return createPredictionAssetIdentityVerifierV2({
+    fetchImpl,
+    rpcUrls: overrides.rpcUrls ?? RPC_URLS,
+    timeoutMs: overrides.timeoutMs ?? 100,
+    maximumResponseBytes: overrides.maximumResponseBytes ?? 64_000,
+  });
+}
+
+describe("prediction asset identity verification V2", () => {
+  it("fails closed without configured RPC URLs and makes no request", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const verifier = createVerifier(fetchImpl, { rpcUrls: {} });
+
+    await expect(verifier.verify(EVM_ADDRESS)).resolves.toEqual([
+      { sourceNetwork: "ethereum", status: "failed", reason: "identity-unconfigured" },
+      { sourceNetwork: "base", status: "failed", reason: "identity-unconfigured" },
+      { sourceNetwork: "bnb", status: "failed", reason: "identity-unconfigured" },
+      { sourceNetwork: "robinhood", status: "failed", reason: "identity-unconfigured" },
+    ]);
+    await expect(verifier.verify(SOLANA_MINT)).resolves.toEqual([
+      { sourceNetwork: "solana", status: "failed", reason: "identity-unconfigured" },
+    ]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-HTTPS and credential-bearing RPC configuration", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const verifier = createVerifier(fetchImpl, {
+      rpcUrls: {
+        ethereum: "http://ethereum.rpc.example",
+        base: "https://user:password@base.rpc.example",
+        bnb: "not a URL",
+        robinhood: "https://robinhood.rpc.example/#fragment",
+      },
+    });
+
+    const results = await verifier.verify(EVM_ADDRESS);
+
+    expect(results).toHaveLength(4);
+    expect(results.every((result) =>
+      result.status === "failed" && result.reason === "identity-unconfigured"
+    )).toBe(true);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("pins all four EVM probes to one exact safe block per network", async () => {
+    const anchorReleases = new Map<string, (response: Response) => void>();
+    const fetchImpl = vi.fn<typeof fetch>((url, init) => {
+      const hostname = networkForUrl(url);
+      expect(init).toMatchObject({
+        method: "POST",
+        cache: "no-store",
+        redirect: "error",
+      });
+      expect(init?.headers).toEqual({
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      });
+      const request = JSON.parse(String(init?.body)) as {
+        id: number;
+        method: string;
+        params: readonly unknown[];
+      }[];
+      expect(JSON.stringify(request)).not.toContain("latest");
+      if (request[0]?.method === "eth_chainId") {
+        expect(request).toEqual([
+          { jsonrpc: "2.0", id: 1, method: "eth_chainId", params: [] },
+          {
+            jsonrpc: "2.0",
+            id: 2,
+            method: "eth_getBlockByNumber",
+            params: ["safe", false],
+          },
+        ]);
+        return new Promise<Response>((resolve) => {
+          anchorReleases.set(hostname, resolve);
+        });
+      }
+      expect(request).toEqual([
+        {
+          jsonrpc: "2.0",
+          id: 3,
+          method: "eth_getBlockByNumber",
+          params: [EVM_SAFE_BLOCK_NUMBER, false],
+        },
+        {
+          jsonrpc: "2.0",
+          id: 4,
+          method: "eth_getCode",
+          params: [EVM_ADDRESS, EVM_SAFE_BLOCK_NUMBER],
+        },
+        {
+          jsonrpc: "2.0",
+          id: 5,
+          method: "eth_call",
+          params: [
+            { to: EVM_ADDRESS, data: "0x313ce567" },
+            EVM_SAFE_BLOCK_NUMBER,
+          ],
+        },
+        {
+          jsonrpc: "2.0",
+          id: 6,
+          method: "eth_call",
+          params: [
+            { to: EVM_ADDRESS, data: "0x18160ddd" },
+            EVM_SAFE_BLOCK_NUMBER,
+          ],
+        },
+      ]);
+      return Promise.resolve(jsonResponse(evmResponse(
+        EVM_CHAIN_ID_BY_HOST[hostname],
+        request,
+      )));
+    });
+
+    const pending = createVerifier(fetchImpl).verify(EVM_ADDRESS.toUpperCase());
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(4));
+    expect([...anchorReleases.keys()]).toEqual([
+      "ethereum.rpc.example",
+      "base.rpc.example",
+      "bnb.rpc.example",
+      "robinhood.rpc.example",
+    ]);
+    for (const [hostname, release] of anchorReleases) {
+      release(jsonResponse(evmResponse(
+        EVM_CHAIN_ID_BY_HOST[hostname as keyof typeof EVM_CHAIN_ID_BY_HOST],
+        [{ id: 1, method: "eth_chainId" }],
+      )));
+    }
+
+    await expect(pending).resolves.toEqual([
+      { sourceNetwork: "ethereum", status: "verified-token" },
+      { sourceNetwork: "base", status: "verified-token" },
+      { sourceNetwork: "bnb", status: "verified-token" },
+      { sourceNetwork: "robinhood", status: "verified-token" },
+    ]);
+    expect(fetchImpl).toHaveBeenCalledTimes(8);
+  });
+
+  it("fails the affected probe on a mismatched EVM chain id", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
+      const hostname = networkForUrl(url);
+      const chainId = hostname === "base.rpc.example"
+        ? "0x1"
+        : EVM_CHAIN_ID_BY_HOST[hostname];
+      const request = JSON.parse(String(init?.body)) as {
+        id: number;
+        method: string;
+      }[];
+      return jsonResponse(evmResponse(chainId, request));
+    });
+
+    const results = await createVerifier(fetchImpl).verify(EVM_ADDRESS);
+
+    expect(results[1]).toEqual({
+      sourceNetwork: "base",
+      status: "failed",
+      reason: "identity-invalid",
+    });
+    expect(results.filter(({ status }) => status === "verified-token"))
+      .toHaveLength(3);
+  });
+
+  it.each([
+    {
+      label: "replaced safe block hash",
+      overrides: {
+        confirmedBlock: evmBlock(
+          EVM_SAFE_BLOCK_NUMBER,
+          `0x${"34".repeat(32)}`,
+        ),
+      },
+    },
+    {
+      label: "replaced safe block number",
+      overrides: {
+        confirmedBlock: evmBlock("0x1235", EVM_SAFE_BLOCK_HASH),
+      },
+    },
+    {
+      label: "noncanonical safe block number",
+      overrides: { anchorBlock: evmBlock("0x01234") },
+    },
+  ] satisfies readonly Readonly<{
+    label: string;
+    overrides: EvmResponseOverrides;
+  }>[])("fails closed on a $label", async ({ overrides }) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
+      const hostname = networkForUrl(url);
+      const request = JSON.parse(String(init?.body)) as {
+        id: number;
+        method: string;
+      }[];
+      return jsonResponse(evmResponse(
+        EVM_CHAIN_ID_BY_HOST[hostname],
+        request,
+        hostname === "base.rpc.example" ? overrides : {},
+      ));
+    });
+
+    const results = await createVerifier(fetchImpl).verify(EVM_ADDRESS);
+
+    expect(results[1]).toEqual({
+      sourceNetwork: "base",
+      status: "failed",
+      reason: "identity-invalid",
+    });
+  });
+
+  it("classifies empty bytecode as not-token even when contract calls revert", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
+      const hostname = networkForUrl(url);
+      const request = JSON.parse(String(init?.body)) as {
+        id: number;
+        method: string;
+      }[];
+      return jsonResponse(evmResponse(
+        EVM_CHAIN_ID_BY_HOST[hostname],
+        request,
+        hostname === "ethereum.rpc.example"
+          ? { code: "0x", decimalsError: true }
+          : {},
+      ));
+    });
+
+    const results = await createVerifier(fetchImpl).verify(EVM_ADDRESS);
+
+    expect(results[0]).toEqual({
+      sourceNetwork: "ethereum",
+      status: "not-token",
+    });
+  });
+
+  it.each([
+    {
+      name: "a reverted decimals probe",
+      overrides: { decimalsError: true },
+    },
+    {
+      name: "a malformed totalSupply word",
+      overrides: { totalSupply: "0x01" },
+    },
+    {
+      name: "decimals outside uint8",
+      overrides: { decimals: abiWord(256) },
+    },
+  ] satisfies readonly Readonly<{
+    name: string;
+    overrides: EvmResponseOverrides;
+  }>[]) ("fails closed on $name", async ({ overrides }) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
+      const hostname = networkForUrl(url);
+      const request = JSON.parse(String(init?.body)) as {
+        id: number;
+        method: string;
+      }[];
+      return jsonResponse(evmResponse(
+        EVM_CHAIN_ID_BY_HOST[hostname],
+        request,
+        hostname === "base.rpc.example" ? overrides : {},
+      ));
+    });
+
+    const results = await createVerifier(fetchImpl).verify(EVM_ADDRESS);
+
+    expect(results[1]).toEqual({
+      sourceNetwork: "base",
+      status: "failed",
+      reason: "identity-invalid",
+    });
+  });
+
+  it.each([
+    ["Token", SOLANA_TOKEN_PROGRAM],
+    ["Token-2022", SOLANA_TOKEN_2022_PROGRAM],
+  ])("verifies a Solana %s mint on mainnet", async (_label, owner) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => {
+      const request = JSON.parse(String(init?.body)) as {
+        id: number;
+        method: string;
+        params: readonly unknown[];
+      }[];
+      if (request[0]?.method === "getGenesisHash") {
+        expect(request).toEqual([
+          { jsonrpc: "2.0", id: 1, method: "getGenesisHash", params: [] },
+          {
+            jsonrpc: "2.0",
+            id: 2,
+            method: "getSlot",
+            params: [{ commitment: "finalized" }],
+          },
+        ]);
+      } else {
+        expect(request).toEqual([{
+          jsonrpc: "2.0",
+          id: 3,
+          method: "getAccountInfo",
+          params: [SOLANA_MINT, {
+            encoding: "jsonParsed",
+            commitment: "finalized",
+            minContextSlot: SOLANA_FINALIZED_SLOT,
+          }],
+        }]);
+      }
+      return jsonResponse(solanaResponse(request, {
+        account: solanaMintAccount(owner),
+      }));
+    });
+
+    await expect(createVerifier(fetchImpl).verify(SOLANA_MINT)).resolves
+      .toEqual([{ sourceNetwork: "solana", status: "verified-token" }]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toBe(RPC_URLS.solana);
+    expect(String(fetchImpl.mock.calls[1]?.[0])).toBe(RPC_URLS.solana);
+  });
+
+  it.each([
+    ["a missing account", null],
+    ["a non-token account", solanaMintAccount("11111111111111111111111111111111")],
+  ])("classifies %s as not-token", async (_label, account) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => {
+      const request = JSON.parse(String(init?.body)) as {
+        method: string;
+      }[];
+      return jsonResponse(solanaResponse(request, { account }));
+    });
+
+    await expect(createVerifier(fetchImpl).verify(SOLANA_MINT)).resolves
+      .toEqual([{ sourceNetwork: "solana", status: "not-token" }]);
+  });
+
+  it("fails a token-owned Solana account whose parsed data is not a mint", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => {
+      const request = JSON.parse(String(init?.body)) as {
+        method: string;
+      }[];
+      return jsonResponse(solanaResponse(request, {
+        account: solanaMintAccount(SOLANA_TOKEN_PROGRAM, "account"),
+      }));
+    });
+
+    await expect(createVerifier(fetchImpl).verify(SOLANA_MINT)).resolves
+      .toEqual([{
+        sourceNetwork: "solana",
+        status: "failed",
+        reason: "identity-invalid",
+      }]);
+  });
+
+  it("fails closed when the Solana RPC is not mainnet", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => {
+      const request = JSON.parse(String(init?.body)) as {
+        method: string;
+      }[];
+      return jsonResponse(solanaResponse(request, {
+        genesisHash: "EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+        account: null,
+      }));
+    });
+
+    await expect(createVerifier(fetchImpl).verify(SOLANA_MINT)).resolves
+      .toEqual([{
+        sourceNetwork: "solana",
+        status: "failed",
+        reason: "identity-invalid",
+      }]);
+  });
+
+  it("bounds a provider that ignores the timeout signal", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(() => new Promise<Response>(() => {}));
+    const verifier = createVerifier(fetchImpl, {
+      rpcUrls: { solana: RPC_URLS.solana },
+      timeoutMs: 5,
+    });
+
+    await expect(verifier.verify(SOLANA_MINT)).resolves.toEqual([{
+      sourceNetwork: "solana",
+      status: "failed",
+      reason: "identity-unavailable",
+    }]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors an already-aborted caller without issuing requests", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const controller = new AbortController();
+    controller.abort();
+
+    const results = await createVerifier(fetchImpl).verify(EVM_ADDRESS, {
+      signal: controller.signal,
+    });
+
+    expect(results).toEqual([
+      { sourceNetwork: "ethereum", status: "failed", reason: "identity-unavailable" },
+      { sourceNetwork: "base", status: "failed", reason: "identity-unavailable" },
+      { sourceNetwork: "bnb", status: "failed", reason: "identity-unavailable" },
+      { sourceNetwork: "robinhood", status: "failed", reason: "identity-unavailable" },
+    ]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("bounds an in-flight provider when the caller aborts", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(() => new Promise<Response>(() => {}));
+    const controller = new AbortController();
+    const verifier = createVerifier(fetchImpl, {
+      rpcUrls: { solana: RPC_URLS.solana },
+    });
+
+    const pending = verifier.verify(SOLANA_MINT, { signal: controller.signal });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+    controller.abort();
+
+    await expect(pending).resolves.toEqual([{
+      sourceNetwork: "solana",
+      status: "failed",
+      reason: "identity-unavailable",
+    }]);
+  });
+
+  it.each([
+    ["a non-JSON response", () => new Response("no", {
+      headers: { "content-type": "text/plain" },
+    }), 64_000],
+    ["an oversized response", () => jsonResponse(solanaAnchorBatch()), 8],
+  ])("fails closed on %s", async (_label, response, maximumResponseBytes) => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => response());
+    const verifier = createVerifier(fetchImpl, {
+      rpcUrls: { solana: RPC_URLS.solana },
+      maximumResponseBytes,
+    });
+
+    await expect(verifier.verify(SOLANA_MINT)).resolves.toEqual([{
+      sourceNetwork: "solana",
+      status: "failed",
+      reason: "identity-invalid",
+    }]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a Solana account response older than the finalized anchor slot", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => {
+      const request = JSON.parse(String(init?.body)) as {
+        method: string;
+      }[];
+      return jsonResponse(solanaResponse(request, {
+        contextSlot: SOLANA_FINALIZED_SLOT - 1,
+      }));
+    });
+
+    await expect(createVerifier(fetchImpl).verify(SOLANA_MINT)).resolves
+      .toEqual([{
+        sourceNetwork: "solana",
+        status: "failed",
+        reason: "identity-invalid",
+      }]);
+  });
+
+  it.each([
+    ["0x1234", 4],
+    ["not-a-solana-address", 1],
+    [`0x${"0".repeat(40)}`, 4],
+    ["1".repeat(32), 1],
+  ])("rejects invalid locator %s without a request", async (
+    locator,
+    resultCount,
+  ) => {
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    const results = await createVerifier(fetchImpl).verify(locator);
+
+    expect(results).toHaveLength(resultCount);
+    expect(results.every((result) =>
+      result.status === "failed" && result.reason === "identity-invalid"
+    )).toBe(true);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/tests/prediction-market-asset-card-v2.test.tsx
+++ b/tests/prediction-market-asset-card-v2.test.tsx
@@ -1,0 +1,468 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  PredictionMarketAssetCardV2,
+  PredictionMarketAssetPreviewCardV2,
+  bindPredictionMarketAssetCardStateV2,
+  predictionAssetConditionLabelV2,
+  predictionAssetResultTimeLabelV2,
+  predictionMarketAssetCardHrefV2,
+  type PredictionMarketAssetCardStateV2,
+} from "../components/prediction-market-asset-card-v2";
+import { predictionAssetCardImageV2 } from
+  "../lib/prediction-v2/asset-logo-v2";
+import type { PredictionV2CreateReview } from
+  "../lib/prediction-v2/create-flow-v2";
+import type { PublicPredictionMarketViewV2 } from
+  "../lib/prediction-v2/public-market-view-v2";
+import type { PredictionTokenProfileV2 } from
+  "../lib/prediction-v2/token-profile-v2";
+
+const ADDRESS = `0x${"ab".repeat(20)}`;
+const OTHER_ADDRESS = `0x${"cd".repeat(20)}`;
+const MARKET_ID = `0x${"22".repeat(32)}` as `0x${string}`;
+const MARKET_KEY =
+  `eip155:4663:0x${"11".repeat(20)}:0x${"21".repeat(32)}` as const;
+const CONFIRMED_BLOCK_NUMBER = "9100020";
+const CONFIRMED_BLOCK_HASH = `0x${"24".repeat(32)}` as `0x${string}`;
+const ARTWORK_DIGEST = "33".repeat(32);
+const PROVIDER_ASSET_ID = "12".repeat(32);
+
+const PUBLIC_MARKET = Object.freeze({
+  schemaVersion: 2,
+  marketKey: MARKET_KEY,
+  marketId: MARKET_ID,
+  attestedProjection: Object.freeze({
+    releaseId: "prediction-v2-test",
+    settlementChainId: "4663",
+    factoryAddress: `0x${"11".repeat(20)}`,
+    factoryRuntimeCodeHash: `0x${"12".repeat(32)}`,
+    economicKey: `0x${"21".repeat(32)}`,
+    onchainAssetKey: `0x${"13".repeat(32)}`,
+    registryRevision: "7",
+    registrySnapshotHash: `0x${"23".repeat(32)}`,
+    confirmedBlockNumber: CONFIRMED_BLOCK_NUMBER,
+    confirmedBlockHash: CONFIRMED_BLOCK_HASH,
+    attestorAddress: `0x${"14".repeat(20)}`,
+  }),
+  asset: Object.freeze({
+    sourceNetwork: "base",
+    chainLabel: "Base",
+    address: ADDRESS,
+    name: "Example Coin",
+    symbol: "EXAMPLE",
+    explorerUrl: `https://basescan.org/token/${ADDRESS}`,
+  }),
+  condition: Object.freeze({
+    kind: "usd-price-at-utc",
+    metric: "usd-price",
+    comparator: "greater-than-or-equal",
+    quoteCurrency: "USD",
+    strikeUsd: "0.01",
+    strikeAtoms: "1000000",
+    priceDecimals: 8,
+    observationUtc: "2026-08-30T18:00:00Z",
+    observationUnixSeconds: "1788112800",
+    timezone: "UTC",
+  }),
+  creationIntent: null,
+  artwork: Object.freeze({
+    kind: "owned-provider-snapshot",
+    url: `/media/prediction/sha256-${ARTWORK_DIGEST}.webp`,
+    digest: `sha256:${ARTWORK_DIGEST}`,
+    contentType: "image/webp",
+    sourceAssetId: PROVIDER_ASSET_ID,
+  }),
+  links: Object.freeze([
+    Object.freeze({ kind: "website", url: "https://example.com/" }),
+    Object.freeze({ kind: "x", url: "https://x.com/example" }),
+    Object.freeze({ kind: "telegram", url: "https://t.me/example" }),
+  ]),
+  presentation: Object.freeze({
+    revision: "1",
+    revisionHash: `sha256:${"44".repeat(32)}`,
+    observedAt: "2026-08-23T18:00:00.000Z",
+  }),
+} as const) satisfies PublicPredictionMarketViewV2;
+
+const PUBLIC_MARKET_WITH_INTENT = Object.freeze({
+  ...PUBLIC_MARKET,
+  creationIntent: Object.freeze({
+    kind: "market-cap-equivalent",
+    settlementRole: "secondary-non-settlement",
+    comparator: "greater-than-or-equal",
+    targetUsd: "10000000",
+    template: "target",
+    percentChange: null,
+    equivalentPriceStrikeUsd: "0.01",
+    evidence: Object.freeze({
+      creationSnapshot: Object.freeze({
+        settlementChainId: "4663",
+        capturedAtUtc: "2026-08-23T18:00:00Z",
+        snapshotReference: "eip155:4663:block:9100000",
+        evidenceDigest: `0x${"15".repeat(32)}`,
+        verificationStatus: "verified",
+      }),
+      referenceSupplySnapshot: Object.freeze({
+        sourceNetwork: "base",
+        address: ADDRESS,
+        fixedSupplyAtoms: "1000000000000000000",
+        tokenDecimals: 18,
+        capturedAtUtc: "2026-08-23T18:00:00Z",
+        snapshotReference: "eip155:8453:block:35000000",
+        evidenceDigest: `0x${"16".repeat(32)}`,
+        verificationStatus: "verified",
+        supplyDefinition: "fixed-supply-fully-circulating",
+      }),
+      referenceMetricSnapshot: null,
+    }),
+  }),
+} as const) satisfies PublicPredictionMarketViewV2;
+
+const CARD_STATE = Object.freeze({
+  schemaVersion: 2,
+  marketKey: MARKET_KEY,
+  marketId: MARKET_ID,
+  snapshot: Object.freeze({
+    settlementChainId: "4663",
+    confirmedBlockNumber: CONFIRMED_BLOCK_NUMBER,
+    confirmedBlockHash: CONFIRMED_BLOCK_HASH,
+  }),
+  lifecycle: "open",
+  probability: Object.freeze({
+    status: "available",
+    yesProbabilityBps: 6_270,
+  }),
+} as const satisfies PredictionMarketAssetCardStateV2);
+
+const PROFILE = {
+  schemaVersion: 2,
+  chain: { id: "base", reference: "8453", label: "Base" },
+  address: ADDRESS,
+  explorerUrl: `https://basescan.org/token/${ADDRESS}`,
+  name: "Example Coin",
+  symbol: "EXAMPLE",
+  logoUrl: `https://cdn.dexscreener.com/cms/images/${PROVIDER_ASSET_ID}`,
+  links: PUBLIC_MARKET.links,
+} as const satisfies PredictionTokenProfileV2;
+
+const CREATION_SNAPSHOT = {
+  settlementChainId: "4663",
+  capturedAtUtc: "2026-08-23T18:00:00Z",
+  snapshotReference: "eip155:4663:block:9100000",
+  evidenceDigest: `0x${"11".repeat(32)}`,
+  verificationStatus: "verified",
+} as const;
+
+const REVIEW = {
+  schemaVersion: 2,
+  asset: { sourceNetwork: "base", address: ADDRESS },
+  assetName: "Example Coin",
+  assetSymbol: "EXAMPLE",
+  selectedMetric: "market-cap",
+  template: "target",
+  metricTargetUsd: "10000000",
+  inputTargetUsd: "10000000",
+  percentChange: null,
+  referenceMetricUsd: null,
+  creationSnapshot: CREATION_SNAPSHOT,
+  referenceMetricSnapshot: null,
+  referenceSupplySnapshot: null,
+  protocolPredicate: {
+    metric: "usd-price",
+    comparator: "greater-than-or-equal",
+    quoteCurrency: "USD",
+    strikeUsd: "0.01",
+    strikeAtoms: "1000000",
+    priceDecimals: 8,
+    observationUtc: "2026-08-30T18:00:00Z",
+    observationUnixSeconds: "1788112800",
+    timezone: "UTC",
+    evidenceBinding: {
+      creationSnapshot: CREATION_SNAPSHOT,
+      referenceMetricSnapshot: null,
+      referenceSupplySnapshot: null,
+    },
+  },
+  settlementEligibility: "not-evaluated",
+} as const satisfies PredictionV2CreateReview;
+
+type PublicCardProps = Parameters<typeof PredictionMarketAssetCardV2>[0];
+type PublicRawInputKeys = Extract<
+  keyof PublicCardProps,
+  "profile" | "review" | "href" | "status" | "lifecycle" | "probability"
+>;
+const PUBLIC_CARD_HAS_NO_RAW_INPUTS: PublicRawInputKeys extends never
+  ? true
+  : false = true;
+const PUBLIC_CARD_REQUIRES_BOUND_STATE: "cardState" extends keyof PublicCardProps
+  ? true
+  : false = true;
+
+function renderPublicCard(
+  cardState: PredictionMarketAssetCardStateV2 = CARD_STATE,
+  market: PublicPredictionMarketViewV2 = PUBLIC_MARKET_WITH_INTENT,
+) {
+  return renderToStaticMarkup(
+    <PredictionMarketAssetCardV2 cardState={cardState} market={market} />,
+  );
+}
+
+describe("PredictionMarketAssetCardV2", () => {
+  it("accepts only market- and block-bound state and keeps price primary", () => {
+    const bound = bindPredictionMarketAssetCardStateV2(
+      PUBLIC_MARKET_WITH_INTENT,
+      CARD_STATE,
+    );
+    const html = renderToStaticMarkup(
+      <PredictionMarketAssetCardV2
+        cardState={CARD_STATE}
+        headingLevel="h2"
+        market={PUBLIC_MARKET_WITH_INTENT}
+      />,
+    );
+    const conditionIndex = html.indexOf("Price ≥ $0.01");
+    const intentIndex = html.indexOf("Market-cap intent");
+    const resultTime = "Aug 30, 2026 · 18:00:00 UTC";
+
+    expect(PUBLIC_CARD_HAS_NO_RAW_INPUTS).toBe(true);
+    expect(PUBLIC_CARD_REQUIRES_BOUND_STATE).toBe(true);
+    expect(bound).not.toBeNull();
+    expect(Object.isFrozen(bound)).toBe(true);
+    expect(Object.isFrozen(bound?.snapshot)).toBe(true);
+    expect(Object.isFrozen(bound?.probability)).toBe(true);
+    expect(html).toContain('data-prediction-asset-card-v2=""');
+    expect(html).toContain('data-runtime-binding="bound"');
+    expect(html).toContain(
+      `data-snapshot-block="${CONFIRMED_BLOCK_NUMBER}"`,
+    );
+    expect(html).toContain(`<h2 title="Example Coin">Example Coin</h2>`);
+    expect(html).toContain(`href="/markets/v2/${MARKET_ID}"`);
+    expect(html).toContain(
+      `aria-label="Open Example Coin prediction: Price ≥ $0.01; result at ${resultTime}"`,
+    );
+    expect(conditionIndex).toBeGreaterThan(0);
+    expect(intentIndex).toBeGreaterThan(conditionIndex);
+    expect(html).toContain(
+      "Market-cap intent · ≥ $10,000,000 · Price settles",
+    );
+    expect(html).toContain("<dt>Result time</dt>");
+    expect(html).not.toContain("<dt>Closes</dt>");
+    expect(predictionAssetConditionLabelV2(PUBLIC_MARKET)).toBe(
+      "Price ≥ $0.01",
+    );
+    expect(predictionAssetResultTimeLabelV2(PUBLIC_MARKET)).toBe(resultTime);
+  });
+
+  it("fails closed when state carries another market id", () => {
+    const mismatched = Object.freeze({
+      ...CARD_STATE,
+      marketId: `0x${"66".repeat(32)}`,
+    }) as unknown as PredictionMarketAssetCardStateV2;
+    const html = renderPublicCard(mismatched);
+
+    expect(bindPredictionMarketAssetCardStateV2(
+      PUBLIC_MARKET_WITH_INTENT,
+      mismatched,
+    )).toBeNull();
+    expect(html).toContain('data-runtime-binding="unavailable"');
+    expect(html).not.toContain("data-snapshot-block");
+    expect(html).not.toContain("/markets/v2/");
+    expect(html).toContain("<dt>Status</dt><dd>Unavailable</dd>");
+    expect(html).toContain("<dt>Probability</dt><dd>Not available</dd>");
+    expect(html).not.toContain("62.7%");
+  });
+
+  it("rejects stale state from another market key even with a reused id", () => {
+    const stale = Object.freeze({
+      ...CARD_STATE,
+      marketKey:
+        `eip155:4663:0x${"77".repeat(20)}:0x${"78".repeat(32)}`,
+    }) as unknown as PredictionMarketAssetCardStateV2;
+    const html = renderPublicCard(stale);
+
+    expect(bindPredictionMarketAssetCardStateV2(
+      PUBLIC_MARKET_WITH_INTENT,
+      stale,
+    )).toBeNull();
+    expect(html).toContain('data-runtime-binding="unavailable"');
+    expect(html).not.toContain("/markets/v2/");
+    expect(html).not.toContain("62.7%");
+  });
+
+  it("rejects a stale or malformed confirmed-block identity", () => {
+    const staleBlock = Object.freeze({
+      ...CARD_STATE,
+      snapshot: Object.freeze({
+        ...CARD_STATE.snapshot,
+        confirmedBlockNumber: "9100019",
+      }),
+    }) as PredictionMarketAssetCardStateV2;
+    const wrongHash = Object.freeze({
+      ...CARD_STATE,
+      snapshot: Object.freeze({
+        ...CARD_STATE.snapshot,
+        confirmedBlockHash: `0x${"25".repeat(32)}`,
+      }),
+    }) as PredictionMarketAssetCardStateV2;
+    const nonCanonicalBlock = {
+      ...CARD_STATE,
+      snapshot: {
+        ...CARD_STATE.snapshot,
+        confirmedBlockNumber: "09100020",
+      },
+    };
+
+    expect(bindPredictionMarketAssetCardStateV2(
+      PUBLIC_MARKET_WITH_INTENT,
+      staleBlock,
+    )).toBeNull();
+    expect(bindPredictionMarketAssetCardStateV2(
+      PUBLIC_MARKET_WITH_INTENT,
+      wrongHash,
+    )).toBeNull();
+    expect(bindPredictionMarketAssetCardStateV2(
+      PUBLIC_MARKET_WITH_INTENT,
+      nonCanonicalBlock,
+    )).toBeNull();
+    expect(renderPublicCard(staleBlock)).toContain(
+      'data-runtime-binding="unavailable"',
+    );
+  });
+
+  it("fails closed without the view's attested snapshot identity", () => {
+    const withoutProjection = {
+      ...PUBLIC_MARKET_WITH_INTENT,
+    };
+    delete (withoutProjection as { attestedProjection?: unknown })
+      .attestedProjection;
+    const market = withoutProjection as unknown as PublicPredictionMarketViewV2;
+    const html = renderPublicCard(CARD_STATE, market);
+
+    expect(bindPredictionMarketAssetCardStateV2(market, CARD_STATE)).toBeNull();
+    expect(html).toContain('data-runtime-binding="unavailable"');
+    expect(html).not.toContain("/markets/v2/");
+    expect(html).not.toContain("62.7%");
+  });
+
+  it("uses owned decorative artwork and semantic status/source facts", () => {
+    const html = renderPublicCard();
+
+    expect(html).toContain('data-artwork-source="owned-provider-snapshot"');
+    expect(html).toContain(
+      `src="/media/prediction/sha256-${ARTWORK_DIGEST}.webp"`,
+    );
+    expect(html).toContain('alt=""');
+    expect(html).not.toContain("cdn.dexscreener.com");
+    expect(html).toContain('referrerPolicy="no-referrer"');
+    expect(html).toContain('<dl aria-label="Market summary"');
+    expect(html).toContain("<dt>Status</dt><dd>Open</dd>");
+    expect(html).toContain("<dt>Source chain</dt><dd>Base</dd>");
+    expect(html).toContain("<dt>Probability</dt><dd>62.7%</dd>");
+  });
+
+  it("derives only the strict public market path and rejects malformed ids", () => {
+    expect(predictionMarketAssetCardHrefV2(PUBLIC_MARKET)).toBe(
+      `/markets/v2/${MARKET_ID}`,
+    );
+    const malformed = {
+      ...PUBLIC_MARKET,
+      marketId: MARKET_ID.toUpperCase(),
+    } as unknown as PublicPredictionMarketViewV2;
+    expect(predictionMarketAssetCardHrefV2(malformed)).toBeNull();
+    const matchingMalformedState = {
+      ...CARD_STATE,
+      marketId: MARKET_ID.toUpperCase(),
+    } as unknown as PredictionMarketAssetCardStateV2;
+    const html = renderPublicCard(matchingMalformedState, malformed);
+
+    expect(html).not.toContain("/markets/v2/");
+    expect(html).toContain("<h3");
+    expect(html).toContain('data-runtime-binding="unavailable"');
+    expect(html).not.toContain("62.7%");
+  });
+
+  it("keeps every 44px project link outside the primary market link", () => {
+    const html = renderPublicCard();
+    const marketLinkEnd = html.indexOf("</a>");
+    const firstSocial = html.indexOf(
+      "Example Coin Website (opens in a new tab)",
+    );
+
+    expect(html).toContain('href="https://example.com/"');
+    expect(html).toContain('href="https://x.com/example"');
+    expect(html).toContain('href="https://t.me/example"');
+    expect(html).toContain('rel="noopener noreferrer nofollow ugc"');
+    expect(marketLinkEnd).toBeGreaterThan(0);
+    expect(firstSocial).toBeGreaterThan(marketLinkEnd);
+
+    const css = readFileSync(
+      join(
+        process.cwd(),
+        "components/prediction-market-asset-card-v2.module.css",
+      ),
+      "utf8",
+    );
+    expect(css).toMatch(
+      /\.socialLink\s*\{[\s\S]*?height:\s*44px;[\s\S]*?width:\s*44px;/u,
+    );
+  });
+
+  it("keeps raw discovery and review data inside the create-only preview", () => {
+    const html = renderToStaticMarkup(
+      <PredictionMarketAssetPreviewCardV2
+        headingLevel="h2"
+        imageLoading="eager"
+        profile={PROFILE}
+        review={REVIEW}
+      />,
+    );
+
+    expect(html).toContain('data-prediction-asset-preview-card-v2=""');
+    expect(html).not.toContain("data-prediction-asset-card-v2");
+    expect(html).toContain('data-profile-bound="true"');
+    expect(html).toContain('data-runtime-binding="preview"');
+    expect(html).toContain('data-artwork-source="preview-proxy"');
+    expect(html).toContain(
+      `src="/api/prediction/asset-logo/${PROVIDER_ASSET_ID}"`,
+    );
+    expect(html).not.toContain("cdn.dexscreener.com");
+    expect(html).toContain('alt=""');
+    expect(html).toContain("Price ≥ $0.01");
+    expect(html).toContain(
+      "Market-cap intent · ≥ $10,000,000 · Price settles",
+    );
+    expect(html).toContain("<dt>Result time</dt>");
+    expect(html).not.toContain("<dt>Closes</dt>");
+    expect(html).not.toContain("/markets/v2/");
+    expect(html).toContain("<dt>Status</dt><dd>Preview</dd>");
+  });
+
+  it("fails the create preview closed when the profile identity drifts", () => {
+    const unboundProfile = {
+      ...PROFILE,
+      address: OTHER_ADDRESS,
+      logoUrl: "https://attacker.example/logo.png",
+      links: [{ kind: "website", url: "https://attacker.example/" }],
+    } as const satisfies PredictionTokenProfileV2;
+    const html = renderToStaticMarkup(
+      <PredictionMarketAssetPreviewCardV2
+        profile={unboundProfile}
+        review={REVIEW}
+      />,
+    );
+    const fallback = predictionAssetCardImageV2({
+      chainId: "base",
+      address: ADDRESS,
+    }).source;
+
+    expect(html).toContain('data-profile-bound="false"');
+    expect(html).toContain('data-artwork-source="bundled-fallback"');
+    expect(html).toContain(`src="${fallback}"`);
+    expect(html).not.toContain("attacker.example");
+    expect(html).not.toContain("<nav");
+  });
+});

--- a/tests/prediction-market-create-flow-v2.test.tsx
+++ b/tests/prediction-market-create-flow-v2.test.tsx
@@ -1,0 +1,322 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { PredictionMarketCreateFlowV2 } from "../components/prediction-market-create-flow-v2";
+import type {
+  PredictionAssetAutoDiscoveryClientCandidateV2,
+  PredictionAssetAutoDiscoveryClientResultV2,
+} from "../lib/prediction-v2/asset-auto-discovery-v2";
+import type {
+  PredictionV2CreationReferenceSnapshot,
+  PredictionV2ReferenceMetricSnapshot,
+  PredictionV2ReferenceSupplySnapshot,
+} from "../lib/prediction-v2/create-flow-v2";
+
+const ADDRESS = `0x${"ab".repeat(20)}`;
+const OBSERVED_AT = "2026-08-23T18:00:00.000Z";
+
+function candidate(
+  overrides: Partial<PredictionAssetAutoDiscoveryClientCandidateV2> = {},
+): PredictionAssetAutoDiscoveryClientCandidateV2 {
+  return {
+    selectionKey: `evm:8453:${ADDRESS}`,
+    selection: {
+      mode: "custom",
+      sourceNetwork: "base",
+      assetLocator: ADDRESS,
+    },
+    namespace: "evm",
+    chainReference: "8453",
+    providerChainId: "base",
+    provenance: {
+      identity: { source: "onchain-rpc" },
+      enrichment: { source: "dexscreener" },
+    },
+    currentPriceUsd: 0.008,
+    marketCapUsd: 8_000_000,
+    fdvUsd: 9_500_000,
+    matchingPairCount: 2,
+    pair: {
+      dexId: "uniswap",
+      pairAddress: `0x${"cd".repeat(20)}`,
+      matchedSide: "base",
+      liquidityUsd: 420_000,
+      volume24hUsd: 180_000,
+      pairCreatedAt: Date.parse("2026-08-20T18:00:00.000Z"),
+    },
+    profile: {
+      schemaVersion: 2,
+      chain: { id: "base", reference: "8453", label: "Base" },
+      address: ADDRESS,
+      explorerUrl: `https://basescan.org/token/${ADDRESS}`,
+      name: "Example Coin",
+      symbol: "EXAMPLE",
+      logoUrl: "https://cdn.example.com/example.png",
+      links: [
+        { kind: "website", url: "https://example.com/" },
+        { kind: "x", url: "https://x.com/example" },
+        { kind: "telegram", url: "https://t.me/example" },
+      ],
+      priceUsd: 0.008,
+      marketCapUsd: 8_000_000,
+      fdvUsd: 9_500_000,
+      liquidityUsd: 420_000,
+      age: {
+        pairCreatedAt: "2026-08-20T18:00:00.000Z",
+        seconds: 259_200,
+      },
+    },
+    ...overrides,
+  };
+}
+
+function identityOnlyCandidate() {
+  return candidate({
+    currentPriceUsd: null,
+    marketCapUsd: null,
+    fdvUsd: null,
+    matchingPairCount: 0,
+    pair: null,
+    provenance: {
+      identity: { source: "onchain-rpc" },
+      enrichment: null,
+    },
+    profile: {
+      schemaVersion: 2,
+      chain: { id: "base", reference: "8453", label: "Base" },
+      address: ADDRESS,
+      explorerUrl: `https://basescan.org/token/${ADDRESS}`,
+    },
+  });
+}
+
+function uniqueResult(
+  token = candidate(),
+): PredictionAssetAutoDiscoveryClientResultV2 {
+  return {
+    schemaVersion: 2,
+    locator: ADDRESS,
+    source: token.provenance.enrichment?.source ?? null,
+    observedAt: OBSERVED_AT,
+    usage: "informational-only",
+    status: "unique",
+    candidate: token,
+  };
+}
+
+const SNAPSHOT_TIME = "2026-08-23T12:00:00Z";
+
+const CREATION_SNAPSHOT = {
+  settlementChainId: "4663",
+  capturedAtUtc: SNAPSHOT_TIME,
+  snapshotReference: "eip155:4663:block:9100000",
+  evidenceDigest: `0x${"11".repeat(32)}`,
+  verificationStatus: "verified",
+} as const satisfies PredictionV2CreationReferenceSnapshot;
+
+const SUPPLY_SNAPSHOT = {
+  sourceNetwork: "base",
+  address: ADDRESS,
+  fixedSupplyAtoms: "1000000000000000000000000000",
+  tokenDecimals: 18,
+  capturedAtUtc: SNAPSHOT_TIME,
+  snapshotReference: "eip155:8453:block:34900000",
+  evidenceDigest: `0x${"22".repeat(32)}`,
+  verificationStatus: "verified",
+  supplyDefinition: "fixed-supply-fully-circulating",
+} as const satisfies PredictionV2ReferenceSupplySnapshot;
+
+const PRICE_REFERENCE_SNAPSHOT = {
+  metric: "price",
+  valueUsd: "0.008",
+  sourceNetwork: "base",
+  address: ADDRESS,
+  capturedAtUtc: "2026-08-23T12:00:00Z",
+  snapshotReference: "eip155:8453:block:34900000",
+  evidenceDigest: `0x${"33".repeat(32)}`,
+  verificationStatus: "verified",
+} as const satisfies PredictionV2ReferenceMetricSnapshot;
+
+describe("PredictionMarketCreateFlowV2", () => {
+  it("starts with one token-address lookup and no chain or wallet decision", () => {
+    const html = renderToStaticMarkup(<PredictionMarketCreateFlowV2 />);
+
+    expect(html).toContain("Find a token");
+    expect(html).toContain("Token address");
+    expect(html).toContain("Find token");
+    expect(html).toContain('name="tokenAddress"');
+    expect(html).toContain('maxLength="128"');
+    expect(html).not.toContain("Choose chain");
+    expect(html).not.toContain("Solana mint");
+    expect(html).not.toContain("Contract address");
+    expect(html).not.toContain("wallet");
+    expect(html).not.toContain("<select");
+  });
+
+  it("reveals the detected token profile, market data and safe project links", () => {
+    const html = renderToStaticMarkup(
+      <PredictionMarketCreateFlowV2
+        initialDiscoveryResult={uniqueResult()}
+      />,
+    );
+
+    expect(html).toContain("Token found");
+    expect(html).toContain("Example Coin");
+    expect(html).toContain("EXAMPLE");
+    expect(html).toContain("Base");
+    expect(html).toContain("Price");
+    expect(html).toContain("Market cap");
+    expect(html).toContain("FDV");
+    expect(html).toContain("Liquidity");
+    expect(html).toContain("Age");
+    expect(html).toContain('href="https://example.com/"');
+    expect(html).toContain('href="https://x.com/example"');
+    expect(html).toContain('href="https://t.me/example"');
+    expect(html).toContain("Continue with Base");
+  });
+
+  it("shows every prediction template and enables market cap only with bound supply evidence", () => {
+    const available = renderToStaticMarkup(
+      <PredictionMarketCreateFlowV2
+        initialDiscoveryResult={uniqueResult()}
+        initialCreationSnapshot={CREATION_SNAPSHOT}
+        initialPrediction={{ metric: "market-cap" }}
+        initialReferenceSupplySnapshot={SUPPLY_SNAPSHOT}
+        initialView="prediction"
+      />,
+    );
+    expect(available).toContain("Set the prediction");
+    expect(available).toContain("Market cap");
+    expect(available).toContain("Price");
+    expect(available).toContain("Target");
+    expect(available).toContain("Percentage change");
+    expect(available).toContain("Reach before deadline");
+    expect(available).toMatch(/aria-pressed="true"[^>]*>Market cap<\/button>/u);
+    expect(available).toMatch(/disabled=""[^>]*>Reach before deadline<\/button>/u);
+
+    const unavailable = renderToStaticMarkup(
+      <PredictionMarketCreateFlowV2
+        initialDiscoveryResult={uniqueResult()}
+        initialView="prediction"
+      />,
+    );
+    expect(unavailable).toMatch(/disabled=""[^>]*>Market cap<\/button>/u);
+    expect(unavailable).toContain(
+      "Market cap isn’t available for this token yet.",
+    );
+    expect(unavailable).toMatch(/aria-pressed="true"[^>]*>Price<\/button>/u);
+  });
+
+  it("enables percentage change only with a bound verified starting value", () => {
+    const available = renderToStaticMarkup(
+      <PredictionMarketCreateFlowV2
+        initialCreationSnapshot={CREATION_SNAPSHOT}
+        initialDiscoveryResult={uniqueResult()}
+        initialReferenceMetricSnapshot={PRICE_REFERENCE_SNAPSHOT}
+        initialView="prediction"
+      />,
+    );
+
+    expect(available).not.toMatch(
+      /disabled=""[^>]*>Percentage change<\/button>/u,
+    );
+    expect(available).toContain("Reach markets are coming later.");
+  });
+
+  it("shows incomplete market data without treating DEX quality as eligibility", () => {
+    const base = candidate();
+    if (!base.pair) throw new Error("expected enriched pair fixture");
+    const lowLiquidity = candidate({
+      pair: { ...base.pair, liquidityUsd: 49_000 },
+      profile: { ...base.profile, liquidityUsd: 49_000 },
+    });
+    const html = renderToStaticMarkup(
+      <PredictionMarketCreateFlowV2
+        initialCreationSnapshot={CREATION_SNAPSHOT}
+        initialDiscoveryResult={uniqueResult(lowLiquidity)}
+      />,
+    );
+
+    expect(html).toContain("Market data incomplete");
+    expect(html).toContain("The token needs at least $50K in liquidity.");
+    expect(html).not.toMatch(
+      /<button[^>]*disabled=""[^>]*>Continue with Base<\/button>/u,
+    );
+  });
+
+  it("uses deterministic identity fallbacks when DEX enrichment is absent", () => {
+    const html = renderToStaticMarkup(
+      <PredictionMarketCreateFlowV2
+        initialCreationSnapshot={CREATION_SNAPSHOT}
+        initialDiscoveryResult={uniqueResult(identityOnlyCandidate())}
+      />,
+    );
+
+    expect(html).toContain("Base token");
+    expect(html).toContain("0xababa…babab");
+    expect(html).toContain("Market data incomplete");
+    expect(html).not.toContain("Token name and symbol are unavailable");
+    expect(html).not.toMatch(
+      /<button[^>]*disabled=""[^>]*>Continue with Base<\/button>/u,
+    );
+  });
+
+  it("carries identity fallbacks into the deterministic review", () => {
+    const html = renderToStaticMarkup(
+      <PredictionMarketCreateFlowV2
+        initialCreationSnapshot={CREATION_SNAPSHOT}
+        initialDiscoveryResult={uniqueResult(identityOnlyCandidate())}
+        initialPrediction={{
+          metric: "price",
+          template: "target",
+          targetUsd: "0.01",
+          observationUtc: "2026-09-20T18:00:00Z",
+          priceDecimals: 8,
+        }}
+        initialView="review"
+      />,
+    );
+
+    expect(html).toContain("Review the market");
+    expect(html).toContain("Base token");
+    expect(html).toContain("$0xababa…babab");
+    expect(html).toContain("Price ≥ $0.01");
+  });
+
+  it("reviews the token-style card against its authoritative absolute price rule", () => {
+    const html = renderToStaticMarkup(
+      <PredictionMarketCreateFlowV2
+        initialDiscoveryResult={uniqueResult()}
+        initialPrediction={{
+          metric: "market-cap",
+          template: "target",
+          targetUsd: "10000000",
+          observationUtc: "2026-09-20T18:00:00Z",
+          priceDecimals: 8,
+        }}
+        initialCreationSnapshot={CREATION_SNAPSHOT}
+        initialReferenceSupplySnapshot={SUPPLY_SNAPSHOT}
+        initialView="review"
+      />,
+    );
+
+    expect(html).toContain("Review the market");
+    expect(html).toContain('data-prediction-asset-preview-card-v2=""');
+    expect(html).not.toContain('data-prediction-asset-card-v2=""');
+    expect(html).toContain("Example Coin");
+    expect(html).toContain("$EXAMPLE");
+    expect(html).toContain("Price ≥ $0.01");
+    expect(html).toContain(
+      "Market-cap intent · ≥ $10,000,000 · Price settles",
+    );
+    expect(html).toContain("Result time");
+    expect(html).toContain("YES resolves if");
+    expect(html).toContain("The USD price is at least");
+    expect(html).toContain("$0.01");
+    expect(html).toContain("18:00:00 UTC");
+    expect(html).toContain("Preview only");
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Preview only<\/button>/u);
+    expect(html).not.toContain("Create market");
+    expect(html).not.toContain("cdn.example.com");
+  });
+});

--- a/tests/prediction-market-v2-local-preview.test.tsx
+++ b/tests/prediction-market-v2-local-preview.test.tsx
@@ -1,0 +1,163 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { LaunchExperience } from "../components/launch-entry";
+import {
+  PredictionMarketV2LocalPreview,
+  createPredictionV2LocalPreviewDiscovery,
+} from "../components/prediction-market-v2-local-preview";
+import { parsePredictionAssetAutoDiscoveryV2 } from "../lib/prediction-v2/asset-auto-discovery-v2";
+
+const root = process.cwd();
+const BASE_TOKEN_ADDRESS = `0x${"ab".repeat(20)}`;
+const SOLANA_FIXTURE_LOCATOR =
+  "4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw";
+
+function preview(
+  initialState: Parameters<typeof PredictionMarketV2LocalPreview>[0]["initialState"],
+  fixture: Parameters<typeof PredictionMarketV2LocalPreview>[0]["fixture"] = "base",
+) {
+  return renderToStaticMarkup(
+    <PredictionMarketV2LocalPreview
+      fixture={fixture}
+      initialState={initialState}
+      onBack={() => undefined}
+    />,
+  );
+}
+
+describe("Prediction V2 development-only local preview", () => {
+  it("keeps the non-development launch runtime on the existing BTC V1 path", () => {
+    expect(process.env.NODE_ENV).not.toBe("development");
+    const html = renderToStaticMarkup(
+      <LaunchExperience customLaunchPublicEnabled={false} />,
+    );
+
+    expect(html).toContain('data-launch-model-option="prediction"');
+    expect(html).toContain("Create a BTC prediction with YES and NO.");
+    expect(html).not.toContain("programmable-prediction-v2-local-preview-v1");
+
+    const source = readFileSync(
+      join(root, "components/launch-entry.tsx"),
+      "utf8",
+    );
+    expect(source).toContain(
+      'if (process.env.NODE_ENV !== "development") {',
+    );
+    expect(source).toMatch(
+      /const LazyDevelopmentPredictionV2Preview = process\.env\.NODE_ENV === "development"[\s\S]*?prediction-market-v2-local-preview[\s\S]*?: null;/u,
+    );
+    expect(source).toContain('previewCandidate === "prediction-v2"');
+    expect(source).toContain('searchParams.get("predictionState")');
+    expect(source).toContain('searchParams.get("fixture")');
+  });
+
+  it.each([
+    ["base", BASE_TOKEN_ADDRESS],
+    ["solana", SOLANA_FIXTURE_LOCATOR],
+  ] as const)(
+    "starts the %s fixture with only the Token address decision",
+    (fixture, address) => {
+      const html = preview("address", fixture);
+
+      expect(html).toContain(
+        'data-local-preview="programmable-prediction-v2-local-preview-v1"',
+      );
+      expect(html).toContain(`data-prediction-v2-fixture="${fixture}"`);
+      expect(html).toContain("Token address");
+      expect(html).toContain(`value="${address}"`);
+      expect(html).toContain("Find token");
+      expect(html).not.toContain("Choose chain");
+      expect(html).not.toContain("Solana mint");
+      expect(html).not.toContain("Connect wallet");
+    },
+  );
+
+  it("shows deterministic ambiguous and error states without a provider call", () => {
+    const ambiguous = preview("ambiguous");
+    expect(ambiguous).toContain("Choose the matching token");
+    expect(ambiguous).toContain("Ethereum");
+    expect(ambiguous).toContain("Base");
+
+    const error = preview("error");
+    expect(error).toContain("Enter a valid token address.");
+    expect(error).toContain('value="not-an-address"');
+  });
+
+  it.each([
+    ["base", "Base Test Token", "BTST"],
+    ["solana", "Solana Test Token", "STST"],
+  ] as const)(
+    "renders the detected %s token before prediction choices",
+    (fixture, name, symbol) => {
+      const html = preview("asset", fixture);
+
+      expect(html).toContain("Token found");
+      expect(html).toContain(name);
+      expect(html).toContain(symbol);
+      expect(html).toContain("Price");
+      expect(html).toContain("Market cap");
+      expect(html).toContain("Liquidity");
+      expect(html).toContain(`Continue with ${fixture === "base" ? "Base" : "Solana"}`);
+      expect(html).not.toContain("Prediction unavailable");
+    },
+  );
+
+  it("renders the prediction and review states from bound immutable evidence", () => {
+    const prediction = preview("prediction");
+    expect(prediction).toContain("Set the prediction");
+    expect(prediction).toContain("Market cap");
+    expect(prediction).toContain("Price");
+    expect(prediction).toContain("Target");
+    expect(prediction).toContain("Percentage change");
+    expect(prediction).toContain("Reach before deadline");
+    expect(prediction).toContain('value="10000000"');
+    expect(prediction).toContain('value="2026-08-30T18:00"');
+
+    const review = preview("review");
+    expect(review).toContain("Review the market");
+    expect(review).toContain('data-prediction-asset-preview-card-v2=""');
+    expect(review).toContain("Base Test Token");
+    expect(review).toContain("$BTST");
+    expect(review).toContain(
+      "Market-cap intent · ≥ $10,000,000 · Price settles",
+    );
+    expect(review).toContain("Aug 30, 2026 · 18:00:00 UTC");
+    expect(review).toContain("YES resolves if");
+    expect(review).toContain("$0.01");
+    expect(review).toContain("Preview only");
+    expect(review).not.toContain("Create market");
+  });
+
+  it("injects deterministic discovery and never calls fetch", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    try {
+      const discover = createPredictionV2LocalPreviewDiscovery("base");
+      const raw = await discover(BASE_TOKEN_ADDRESS, new AbortController().signal);
+      expect(parsePredictionAssetAutoDiscoveryV2(raw, BASE_TOKEN_ADDRESS)).toMatchObject({
+        status: "unique",
+        locator: BASE_TOKEN_ADDRESS,
+        candidate: {
+          selection: { sourceNetwork: "base" },
+        },
+      });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("contains no wallet, transaction, RPC or network client in the preview wrapper", () => {
+    const source = readFileSync(
+      join(root, "components/prediction-market-v2-local-preview.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain("discoverToken={createPredictionV2LocalPreviewDiscovery(fixtureName)}");
+    expect(source).not.toMatch(
+      /wallet-provider|prediction-market-chain|\bviem\b|\bwagmi\b|\bethers\b|\bfetch\s*\(|\/api\/prediction/u,
+    );
+  });
+});

--- a/tests/prediction-v2-asset-auto-discovery.test.ts
+++ b/tests/prediction-v2-asset-auto-discovery.test.ts
@@ -1,0 +1,641 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parsePredictionAssetAutoDiscoveryV2 as parseAutoDiscoveryResponse,
+  predictionAutoDiscoveryCandidateKeyV2,
+} from "../lib/prediction-v2/asset-auto-discovery-v2";
+
+const OBSERVED_AT = "2026-08-23T18:00:00.000Z";
+const EVM_ADDRESS = `0x${"ab".repeat(20)}`;
+const OTHER_EVM_ADDRESS = `0x${"ef".repeat(20)}`;
+const SOLANA_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const SOLANA_PAIR = "So11111111111111111111111111111111111111112";
+
+const NETWORKS = {
+  ethereum: {
+    namespace: "evm",
+    chainReference: "1",
+    providerChainId: "ethereum",
+    locator: EVM_ADDRESS,
+    pairAddress: OTHER_EVM_ADDRESS,
+  },
+  base: {
+    namespace: "evm",
+    chainReference: "8453",
+    providerChainId: "base",
+    locator: EVM_ADDRESS,
+    pairAddress: OTHER_EVM_ADDRESS,
+  },
+  bnb: {
+    namespace: "evm",
+    chainReference: "56",
+    providerChainId: "bsc",
+    locator: EVM_ADDRESS,
+    pairAddress: OTHER_EVM_ADDRESS,
+  },
+  robinhood: {
+    namespace: "evm",
+    chainReference: "4663",
+    providerChainId: "robinhood",
+    locator: EVM_ADDRESS,
+    pairAddress: OTHER_EVM_ADDRESS,
+  },
+  solana: {
+    namespace: "solana",
+    chainReference: "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+    providerChainId: "solana",
+    locator: SOLANA_MINT,
+    pairAddress: SOLANA_PAIR,
+  },
+} as const;
+
+type Network = keyof typeof NETWORKS;
+
+function candidate(
+  sourceNetwork: Network = "base",
+  overrides: Record<string, unknown> = {},
+) {
+  const binding = NETWORKS[sourceNetwork];
+  const locator = binding.locator;
+  return {
+    selectionKey:
+      `${binding.namespace}:${binding.chainReference}:${locator}`,
+    selection: {
+      mode: "custom",
+      sourceNetwork,
+      assetLocator: locator,
+    },
+    namespace: binding.namespace,
+    chainReference: binding.chainReference,
+    providerChainId: binding.providerChainId,
+    provenance: {
+      identity: { source: "onchain-rpc" },
+      enrichment: { source: "dexscreener" },
+    },
+    token: {
+      address: locator,
+      name: "Example Token",
+      symbol: "EXM",
+    },
+    currentPriceUsd: 0.0042,
+    marketCapUsd: 4_200_000,
+    fdvUsd: 5_000_000,
+    matchingPairCount: 2,
+    pair: {
+      dexId: "uniswap",
+      pairAddress: binding.pairAddress,
+      matchedSide: "base",
+      liquidityUsd: 120_000,
+      volume24hUsd: 75_000,
+      pairCreatedAt: Date.parse("2026-08-21T18:00:00.000Z"),
+    },
+    links: {
+      imageUrl: "https://cdn.example.com/token.png#provider",
+      websites: [{ label: "Website", url: "https://token.example.com" }],
+      socials: [
+        { type: "twitter", url: "https://twitter.com/example?s=20" },
+        { type: "telegram", url: "https://telegram.me/example?ref=provider" },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+function identityOnlyCandidate(sourceNetwork: Network = "base") {
+  const binding = NETWORKS[sourceNetwork];
+  return candidate(sourceNetwork, {
+    token: {
+      address: binding.locator,
+      name: null,
+      symbol: null,
+    },
+    currentPriceUsd: null,
+    marketCapUsd: null,
+    fdvUsd: null,
+    matchingPairCount: 0,
+    pair: null,
+    provenance: {
+      identity: { source: "onchain-rpc" },
+      enrichment: null,
+    },
+    links: { imageUrl: null, websites: [], socials: [] },
+  });
+}
+
+function base(status: string, locator: string | null = EVM_ADDRESS) {
+  return {
+    schemaVersion: 2,
+    locator,
+    source: "dexscreener",
+    observedAt: OBSERVED_AT,
+    usage: "informational-only",
+    status,
+  };
+}
+
+function unique(
+  sourceNetwork: Network = "base",
+  candidateOverrides: Record<string, unknown> = {},
+) {
+  const binding = NETWORKS[sourceNetwork];
+  return {
+    ...base("unique", binding.locator),
+    candidate: candidate(sourceNetwork, candidateOverrides),
+  };
+}
+
+/** Structural tests default to the same locator the caller submitted. */
+function parsePredictionAssetAutoDiscoveryV2(
+  value: unknown,
+  expectedLocator = expectedLocatorForFixture(value),
+) {
+  return parseAutoDiscoveryResponse(value, expectedLocator);
+}
+
+function expectedLocatorForFixture(value: unknown) {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as { locator?: unknown }).locator === "string"
+  ) return (value as { locator: string }).locator;
+  return "not-a-token-address";
+}
+
+describe("prediction V2 asset auto-discovery client contract", () => {
+  it("parses a unique result and exposes only a sanitized token profile", () => {
+    const raw = unique("base", {
+      token: {
+        address: EVM_ADDRESS,
+        name: "<img src=x onerror=alert(1)>",
+        symbol: "BAD SYMBOL",
+      },
+      links: {
+        imageUrl: "http://cdn.example.com/insecure.png",
+        websites: [
+          { label: "bad", url: "javascript:alert(1)" },
+          { label: "site", url: "https://token.example.com/docs#top" },
+        ],
+        socials: [
+          { type: "twitter", url: "https://www.x.com/example?s=20#profile" },
+          { type: "telegram", url: "https://t.me/example?ref=provider" },
+          { type: "website", url: "https://127.0.0.1/internal" },
+        ],
+      },
+    });
+
+    const parsed = parsePredictionAssetAutoDiscoveryV2(raw);
+
+    expect(parsed).toMatchObject({
+      schemaVersion: 2,
+      locator: EVM_ADDRESS,
+      source: "dexscreener",
+      observedAt: OBSERVED_AT,
+      usage: "informational-only",
+      status: "unique",
+      candidate: {
+        selectionKey: `evm:8453:${EVM_ADDRESS}`,
+        selection: {
+          mode: "custom",
+          sourceNetwork: "base",
+          assetLocator: EVM_ADDRESS,
+        },
+        namespace: "evm",
+        chainReference: "8453",
+        providerChainId: "base",
+        provenance: {
+          identity: { source: "onchain-rpc" },
+          enrichment: { source: "dexscreener" },
+        },
+        currentPriceUsd: 0.0042,
+        marketCapUsd: 4_200_000,
+        fdvUsd: 5_000_000,
+        matchingPairCount: 2,
+        profile: {
+          schemaVersion: 2,
+          chain: { id: "base", reference: "8453", label: "Base" },
+          address: EVM_ADDRESS,
+          explorerUrl: `https://basescan.org/token/${EVM_ADDRESS}`,
+          links: [
+            { kind: "website", url: "https://token.example.com/docs" },
+            { kind: "x", url: "https://x.com/example" },
+            { kind: "telegram", url: "https://t.me/example" },
+          ],
+          priceUsd: 0.0042,
+          marketCapUsd: 4_200_000,
+          fdvUsd: 5_000_000,
+          liquidityUsd: 120_000,
+          age: {
+            pairCreatedAt: "2026-08-21T18:00:00.000Z",
+            seconds: 172_800,
+          },
+        },
+      },
+    });
+    expect(parsed && parsed.status === "unique" && parsed.candidate.profile)
+      .not.toHaveProperty("name");
+    expect(parsed && parsed.status === "unique" && parsed.candidate.profile)
+      .not.toHaveProperty("symbol");
+    expect(parsed && parsed.status === "unique" && parsed.candidate.profile)
+      .not.toHaveProperty("logoUrl");
+    expect(parsed && parsed.status === "unique" && parsed.candidate)
+      .not.toHaveProperty("token");
+    expect(parsed && parsed.status === "unique" && parsed.candidate)
+      .not.toHaveProperty("links");
+    expect(parsed && parsed.status === "unique" && parsed.candidate)
+      .not.toHaveProperty("settlementEligible");
+    expect(Object.isFrozen(parsed)).toBe(true);
+  });
+
+  it("binds the response to the exact submitted locator", () => {
+    expect(parseAutoDiscoveryResponse(unique("base"), OTHER_EVM_ADDRESS))
+      .toBeNull();
+    expect(parseAutoDiscoveryResponse(
+      unique("base"),
+      `  0x${"AB".repeat(20)}  `,
+    )).toMatchObject({ status: "unique", locator: EVM_ADDRESS });
+    expect(parseAutoDiscoveryResponse(unique("solana"), SOLANA_PAIR)).toBeNull();
+  });
+
+  it("parses an exact verified identity without DEX enrichment", () => {
+    const parsed = parsePredictionAssetAutoDiscoveryV2({
+      ...base("unique"),
+      source: null,
+      candidate: identityOnlyCandidate(),
+    });
+
+    expect(parsed).toMatchObject({
+      status: "unique",
+      candidate: {
+        selection: { sourceNetwork: "base" },
+        currentPriceUsd: null,
+        marketCapUsd: null,
+        fdvUsd: null,
+        matchingPairCount: 0,
+        pair: null,
+        provenance: {
+          identity: { source: "onchain-rpc" },
+          enrichment: null,
+        },
+        profile: {
+          schemaVersion: 2,
+          chain: { id: "base", reference: "8453", label: "Base" },
+          address: EVM_ADDRESS,
+          explorerUrl: `https://basescan.org/token/${EVM_ADDRESS}`,
+        },
+      },
+    });
+    if (!parsed || parsed.status !== "unique") throw new Error("unreachable");
+    expect(parsed.candidate.profile).not.toHaveProperty("name");
+    expect(parsed.candidate.profile).not.toHaveProperty("symbol");
+    expect(parsed.candidate.profile).not.toHaveProperty("priceUsd");
+    expect(parsed.candidate.profile).not.toHaveProperty("liquidityUsd");
+  });
+
+  it.each([
+    { currentPriceUsd: 1 },
+    { marketCapUsd: 1 },
+    { fdvUsd: 1 },
+    { matchingPairCount: 1 },
+    {
+      token: {
+        address: EVM_ADDRESS,
+        name: "Provider name",
+        symbol: null,
+      },
+    },
+    {
+      links: {
+        imageUrl: "https://cdn.example.com/token.png",
+        websites: [],
+        socials: [],
+      },
+    },
+  ])("rejects identity-only candidates carrying orphaned enrichment: %#", (
+    override,
+  ) => {
+    expect(parsePredictionAssetAutoDiscoveryV2({
+      ...base("unique"),
+      source: null,
+      candidate: {
+        ...identityOnlyCandidate(),
+        ...override,
+      },
+    })).toBeNull();
+  });
+
+  it("rejects an enriched pair with a zero matching-pair count", () => {
+    expect(parsePredictionAssetAutoDiscoveryV2(unique("base", {
+      matchingPairCount: 0,
+    }))).toBeNull();
+  });
+
+  it.each([
+    { provenance: undefined },
+    {
+      provenance: {
+        identity: { source: "dexscreener" },
+        enrichment: { source: "dexscreener" },
+      },
+    },
+    {
+      provenance: {
+        identity: { source: "onchain-rpc", extra: true },
+        enrichment: { source: "dexscreener" },
+      },
+    },
+    {
+      provenance: {
+        identity: { source: "onchain-rpc" },
+        enrichment: null,
+      },
+    },
+  ])("rejects missing or conflicting enriched provenance: %#", (override) => {
+    expect(parsePredictionAssetAutoDiscoveryV2(unique("base", override)))
+      .toBeNull();
+  });
+
+  it("rejects identity-only data attributed to DEX enrichment", () => {
+    expect(parsePredictionAssetAutoDiscoveryV2({
+      ...base("unique"),
+      candidate: {
+        ...identityOnlyCandidate(),
+        provenance: {
+          identity: { source: "onchain-rpc" },
+          enrichment: { source: "dexscreener" },
+        },
+      },
+    })).toBeNull();
+  });
+
+  it("accepts an invalid response only for an invalid submitted locator", () => {
+    const invalid = {
+      ...base("invalid", null),
+      source: null,
+      reason: "invalid-locator",
+    };
+    expect(parseAutoDiscoveryResponse(invalid, "not-a-token-address"))
+      .toMatchObject({ status: "invalid", locator: null });
+    expect(parseAutoDiscoveryResponse(invalid, EVM_ADDRESS)).toBeNull();
+  });
+
+  it.each(Object.keys(NETWORKS) as Network[])(
+    "binds the exact supported mapping for %s",
+    (sourceNetwork) => {
+      const parsed = parsePredictionAssetAutoDiscoveryV2(unique(sourceNetwork));
+      const binding = NETWORKS[sourceNetwork];
+      expect(parsed).toMatchObject({
+        locator: binding.locator,
+        status: "unique",
+        candidate: {
+          selectionKey:
+            `${binding.namespace}:${binding.chainReference}:${binding.locator}`,
+          selection: { sourceNetwork, assetLocator: binding.locator },
+          namespace: binding.namespace,
+          chainReference: binding.chainReference,
+          providerChainId: binding.providerChainId,
+          profile: { chain: { id: sourceNetwork }, address: binding.locator },
+        },
+      });
+    },
+  );
+
+  it("parses ambiguous candidates and provides a stable client candidate key", () => {
+    const raw = {
+      ...base("ambiguous"),
+      candidates: [candidate("ethereum"), candidate("base")],
+    };
+    const parsed = parsePredictionAssetAutoDiscoveryV2(raw);
+
+    expect(parsed).toMatchObject({
+      status: "ambiguous",
+      candidates: [
+        { selection: { sourceNetwork: "ethereum" } },
+        { selection: { sourceNetwork: "base" } },
+      ],
+    });
+    if (!parsed || parsed.status !== "ambiguous") throw new Error("unreachable");
+    expect(parsed.candidates.map(predictionAutoDiscoveryCandidateKeyV2)).toEqual([
+      `ethereum:${EVM_ADDRESS}`,
+      `base:${EVM_ADDRESS}`,
+    ]);
+    expect(Object.isFrozen(parsed.candidates)).toBe(true);
+  });
+
+  it("rejects duplicate candidates in an ambiguous response", () => {
+    const duplicate = candidate("base");
+    expect(parsePredictionAssetAutoDiscoveryV2({
+      ...base("ambiguous"),
+      candidates: [duplicate, { ...duplicate }],
+    })).toBeNull();
+  });
+
+  it("parses an inconclusive result without treating discovery as eligibility", () => {
+    const parsed = parsePredictionAssetAutoDiscoveryV2({
+      ...base("inconclusive"),
+      candidates: [candidate("base")],
+      failures: [
+        { sourceNetwork: "ethereum", reason: "timeout" },
+        { sourceNetwork: "robinhood", reason: "rate-limited" },
+      ],
+    });
+
+    expect(parsed).toMatchObject({
+      status: "inconclusive",
+      candidates: [{ selection: { sourceNetwork: "base" } }],
+      failures: [
+        { sourceNetwork: "ethereum", reason: "timeout" },
+        { sourceNetwork: "robinhood", reason: "rate-limited" },
+      ],
+    });
+    expect(parsed).not.toHaveProperty("settlementEligible");
+  });
+
+  it.each([
+    "identity-unconfigured",
+    "identity-unavailable",
+    "identity-invalid",
+    "identity-mismatch",
+    "market-data-missing",
+  ] as const)("accepts the fail-closed discovery reason %s", (reason) => {
+    expect(parsePredictionAssetAutoDiscoveryV2({
+      ...base("inconclusive"),
+      source: null,
+      candidates: [],
+      failures: [{ sourceNetwork: "base", reason }],
+    })).toMatchObject({
+      status: "inconclusive",
+      failures: [{ sourceNetwork: "base", reason }],
+    });
+  });
+
+  it.each([
+    { failures: [] },
+    { failures: [{ sourceNetwork: "ethereum", reason: "not-a-reason" }] },
+    { failures: [
+      { sourceNetwork: "ethereum", reason: "timeout" },
+      { sourceNetwork: "ethereum", reason: "rate-limited" },
+    ] },
+    { failures: [{ sourceNetwork: "solana", reason: "timeout" }] },
+    { failures: [{ sourceNetwork: "base", reason: "timeout", extra: true }] },
+  ])("rejects an invalid failure set: %#", ({ failures }) => {
+    expect(parsePredictionAssetAutoDiscoveryV2({
+      ...base("inconclusive"),
+      candidates: [candidate("base")],
+      failures,
+    })).toBeNull();
+  });
+
+  it("rejects a failure that overlaps a returned candidate network", () => {
+    expect(parsePredictionAssetAutoDiscoveryV2({
+      ...base("inconclusive"),
+      candidates: [candidate("base")],
+      failures: [{ sourceNetwork: "base", reason: "timeout" }],
+    })).toBeNull();
+  });
+
+  it("parses exact not-found and invalid states", () => {
+    expect(parsePredictionAssetAutoDiscoveryV2({
+      ...base("not-found"),
+      source: null,
+    })).toEqual({
+      schemaVersion: 2,
+      locator: EVM_ADDRESS,
+      source: null,
+      observedAt: OBSERVED_AT,
+      usage: "informational-only",
+      status: "not-found",
+    });
+    expect(parsePredictionAssetAutoDiscoveryV2({
+      ...base("invalid", null),
+      source: null,
+      reason: "invalid-locator",
+    })).toEqual({
+      schemaVersion: 2,
+      locator: null,
+      source: null,
+      observedAt: OBSERVED_AT,
+      usage: "informational-only",
+      status: "invalid",
+      reason: "invalid-locator",
+    });
+  });
+
+  it("preserves a quote-side price without inventing market cap or FDV", () => {
+    const rawCandidate = candidate("base", {
+      marketCapUsd: null,
+      fdvUsd: null,
+      pair: {
+        ...candidate("base").pair,
+        matchedSide: "quote",
+      },
+    });
+    const parsed = parsePredictionAssetAutoDiscoveryV2({
+      ...base("unique"),
+      candidate: rawCandidate,
+    });
+
+    expect(parsed).toMatchObject({
+      status: "unique",
+      candidate: {
+        currentPriceUsd: 0.0042,
+        marketCapUsd: null,
+        fdvUsd: null,
+        pair: { matchedSide: "quote" },
+      },
+    });
+    if (!parsed || parsed.status !== "unique") throw new Error("unreachable");
+    expect(parsed.candidate.profile).not.toHaveProperty("marketCapUsd");
+    expect(parsed.candidate.profile).not.toHaveProperty("fdvUsd");
+
+    expect(parsePredictionAssetAutoDiscoveryV2({
+      ...base("unique"),
+      candidate: {
+        ...rawCandidate,
+        marketCapUsd: 4_200_000,
+      },
+    })).toBeNull();
+  });
+
+  it.each([
+    { selectionKey: `evm:1:${EVM_ADDRESS}` },
+    { chainReference: "1" },
+    { providerChainId: "bsc" },
+    { namespace: "solana" },
+    {
+      selection: {
+        mode: "custom",
+        sourceNetwork: "bnb",
+        assetLocator: EVM_ADDRESS,
+      },
+    },
+    {
+      selection: {
+        mode: "custom",
+        sourceNetwork: "base",
+        assetLocator: OTHER_EVM_ADDRESS,
+      },
+    },
+    {
+      token: {
+        address: OTHER_EVM_ADDRESS,
+        name: "Example Token",
+        symbol: "EXM",
+      },
+    },
+  ])("rejects a conflicting identity binding: %#", (override) => {
+    expect(parsePredictionAssetAutoDiscoveryV2(unique("base", override)))
+      .toBeNull();
+  });
+
+  it.each([
+    { schemaVersion: 3 },
+    { source: "other" },
+    { usage: "settlement" },
+    { observedAt: "2026-08-23T18:00:00Z" },
+    { locator: `0x${"AB".repeat(20)}` },
+  ])("rejects a malformed or widened envelope: %#", (override) => {
+    expect(parsePredictionAssetAutoDiscoveryV2({
+      ...unique("base"),
+      ...override,
+    })).toBeNull();
+  });
+
+  it("rejects unknown fields at every security-relevant boundary", () => {
+    expect(parsePredictionAssetAutoDiscoveryV2({
+      ...unique("base"),
+      settlementEligible: true,
+    })).toBeNull();
+    expect(parsePredictionAssetAutoDiscoveryV2(unique("base", {
+      settlementEligible: true,
+    }))).toBeNull();
+    expect(parsePredictionAssetAutoDiscoveryV2(unique("base", {
+      pair: { ...candidate("base").pair, extra: true },
+    }))).toBeNull();
+  });
+
+  it("bounds link arrays and rejects zero token or pair identities", () => {
+    expect(parsePredictionAssetAutoDiscoveryV2(unique("base", {
+      links: {
+        imageUrl: null,
+        websites: Array.from({ length: 9 }, (_, index) => ({
+          label: null,
+          url: `https://site-${index}.example.com`,
+        })),
+        socials: [],
+      },
+    }))).toBeNull();
+    expect(parsePredictionAssetAutoDiscoveryV2({
+      ...base("not-found", `0x${"0".repeat(40)}`),
+    })).toBeNull();
+    expect(parsePredictionAssetAutoDiscoveryV2({
+      ...base("not-found", "11111111111111111111111111111111"),
+    })).toBeNull();
+    expect(parsePredictionAssetAutoDiscoveryV2(unique("base", {
+      pair: {
+        ...candidate("base").pair,
+        pairAddress: `0x${"0".repeat(40)}`,
+      },
+    }))).toBeNull();
+  });
+});

--- a/tests/prediction-v2-asset-eligibility.test.ts
+++ b/tests/prediction-v2-asset-eligibility.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluatePredictionAssetDiscoveryEligibilityV2,
+  PREDICTION_ASSET_DISCOVERY_SCOPE_V2,
+  PREDICTION_ASSET_DISCOVERY_THRESHOLDS_V2,
+  type PredictionAssetMarketCapSupplyEvidenceV2,
+} from "../lib/prediction-v2/asset-eligibility-v2";
+import {
+  normalizePredictionTokenProfileV2,
+  type PredictionTokenProfileV2,
+} from "../lib/prediction-v2/token-profile-v2";
+
+const ADDRESS = `0x${"ab".repeat(20)}`;
+const OBSERVED_AT_MS = Date.parse("2026-08-23T18:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+function profile(
+  overrides: Readonly<Record<string, unknown>> = {},
+): PredictionTokenProfileV2 {
+  const normalized = normalizePredictionTokenProfileV2({
+    chain: "base",
+    address: ADDRESS,
+    priceUsd: 0.000_001,
+    marketCapUsd: 1_000_000,
+    fdvUsd: 9_000_000,
+    liquidityUsd: 50_000,
+    pairCreatedAtMs: OBSERVED_AT_MS - DAY_MS,
+    ...overrides,
+  }, OBSERVED_AT_MS);
+  if (!normalized) throw new Error("test profile must normalize");
+  return normalized;
+}
+
+function supplyEvidence(
+  overrides: Partial<PredictionAssetMarketCapSupplyEvidenceV2> = {},
+): PredictionAssetMarketCapSupplyEvidenceV2 {
+  return {
+    schemaVersion: 2,
+    kind: "fixed-supply-fully-circulating",
+    chainReference: "8453",
+    tokenAddress: ADDRESS,
+    supplyBaseUnits: "1000000000000000",
+    decimals: 9,
+    immutable: true,
+    verification: {
+      status: "verified",
+      method: "verified-fixed-supply-fully-circulating",
+      chainStateReference: "34567890",
+      evidenceDigest: `0x${"12".repeat(32)}`,
+    },
+    ...overrides,
+  };
+}
+
+describe("prediction asset discovery eligibility v2", () => {
+  it("passes every beta boundary and enables fixed fully-circulating market cap", () => {
+    const result = evaluatePredictionAssetDiscoveryEligibilityV2({
+      profile: profile(),
+      observedAtMs: OBSERVED_AT_MS,
+      volume24hUsd: 25_000,
+      marketCapSupplyEvidence: supplyEvidence(),
+    });
+
+    expect(result).toEqual({
+      schemaVersion: 2,
+      scope: "discovery-quality-only",
+      status: "eligible",
+      observedAt: "2026-08-23T18:00:00.000Z",
+      reasonCodes: [],
+      thresholds: {
+        minimumPoolAgeSeconds: 86_400,
+        minimumLiquidityUsd: 50_000,
+        minimumVolume24hUsd: 25_000,
+      },
+      observed: {
+        priceUsd: 0.000_001,
+        poolAgeSeconds: 86_400,
+        liquidityUsd: 50_000,
+        volume24hUsd: 25_000,
+      },
+      metrics: {
+        price: { available: true, reasonCodes: [] },
+        marketCap: { available: true, reasonCodes: [] },
+      },
+    });
+    expect(result.scope).toBe(PREDICTION_ASSET_DISCOVERY_SCOPE_V2);
+    expect(result.thresholds).toBe(PREDICTION_ASSET_DISCOVERY_THRESHOLDS_V2);
+    expect(result).not.toHaveProperty("settlementEligible");
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.reasonCodes)).toBe(true);
+    expect(Object.isFrozen(result.observed)).toBe(true);
+    expect(Object.isFrozen(result.metrics.marketCap.reasonCodes)).toBe(true);
+  });
+
+  it.each([
+    {
+      label: "pool age",
+      profile: () => profile({ pairCreatedAtMs: OBSERVED_AT_MS - DAY_MS + 1 }),
+      volume24hUsd: 25_000,
+      reason: "pool-too-new",
+    },
+    {
+      label: "liquidity",
+      profile: () => profile({ liquidityUsd: 49_999.99 }),
+      volume24hUsd: 25_000,
+      reason: "liquidity-below-minimum",
+    },
+    {
+      label: "24h volume",
+      profile: () => profile(),
+      volume24hUsd: 24_999.99,
+      reason: "volume-24h-below-minimum",
+    },
+  ])("fails one deterministic unit below the $label boundary", ({
+    profile: buildProfile,
+    volume24hUsd,
+    reason,
+  }) => {
+    const result = evaluatePredictionAssetDiscoveryEligibilityV2({
+      profile: buildProfile(),
+      observedAtMs: OBSERVED_AT_MS,
+      volume24hUsd,
+    });
+    expect(result.status).toBe("ineligible");
+    expect(result.reasonCodes).toEqual([reason]);
+  });
+
+  it("keeps missing values unknown instead of coercing them to zero", () => {
+    const result = evaluatePredictionAssetDiscoveryEligibilityV2({
+      profile: profile({
+        priceUsd: null,
+        liquidityUsd: null,
+        pairCreatedAtMs: null,
+        marketCapUsd: null,
+      }),
+      observedAtMs: OBSERVED_AT_MS,
+    });
+
+    expect(result.status).toBe("unknown");
+    expect(result.reasonCodes).toEqual([
+      "price-unavailable",
+      "pool-age-unavailable",
+      "liquidity-unavailable",
+      "volume-24h-unavailable",
+    ]);
+    expect(result.observed).toEqual({
+      priceUsd: null,
+      poolAgeSeconds: null,
+      liquidityUsd: null,
+      volume24hUsd: null,
+    });
+  });
+
+  it("treats explicit zero liquidity and volume as known ineligibility", () => {
+    const result = evaluatePredictionAssetDiscoveryEligibilityV2({
+      profile: profile({ liquidityUsd: 0 }),
+      observedAtMs: OBSERVED_AT_MS,
+      volume24hUsd: 0,
+    });
+
+    expect(result.status).toBe("ineligible");
+    expect(result.reasonCodes).toEqual([
+      "liquidity-below-minimum",
+      "volume-24h-below-minimum",
+    ]);
+    expect(result.observed.liquidityUsd).toBe(0);
+    expect(result.observed.volume24hUsd).toBe(0);
+  });
+
+  it("defensively treats an explicit zero price as known ineligibility", () => {
+    const result = evaluatePredictionAssetDiscoveryEligibilityV2({
+      profile: { ...profile(), priceUsd: 0 },
+      observedAtMs: OBSERVED_AT_MS,
+      volume24hUsd: 25_000,
+    });
+
+    expect(result.status).toBe("ineligible");
+    expect(result.reasonCodes).toEqual(["price-not-positive"]);
+    expect(result.observed.priceUsd).toBe(0);
+    expect(result.metrics.price).toEqual({
+      available: false,
+      reasonCodes: ["price-not-positive"],
+    });
+  });
+
+  it("lets a known failed check dominate unrelated unknown checks", () => {
+    const result = evaluatePredictionAssetDiscoveryEligibilityV2({
+      profile: profile({ priceUsd: null, liquidityUsd: 0 }),
+      observedAtMs: OBSERVED_AT_MS,
+      volume24hUsd: null,
+    });
+
+    expect(result.status).toBe("ineligible");
+    expect(result.reasonCodes).toEqual([
+      "price-unavailable",
+      "liquidity-below-minimum",
+      "volume-24h-unavailable",
+    ]);
+  });
+
+  it("keeps market cap unavailable until exact fixed-supply evidence exists", () => {
+    const withoutEvidence = evaluatePredictionAssetDiscoveryEligibilityV2({
+      profile: profile(),
+      observedAtMs: OBSERVED_AT_MS,
+      volume24hUsd: 25_000,
+    });
+    expect(withoutEvidence.status).toBe("eligible");
+    expect(withoutEvidence.metrics.marketCap).toEqual({
+      available: false,
+      reasonCodes: ["market-cap-supply-evidence-unavailable"],
+    });
+
+    const wrongIdentity = evaluatePredictionAssetDiscoveryEligibilityV2({
+      profile: profile(),
+      observedAtMs: OBSERVED_AT_MS,
+      volume24hUsd: 25_000,
+      marketCapSupplyEvidence: supplyEvidence({ chainReference: "1" }),
+    });
+    expect(wrongIdentity.status).toBe("eligible");
+    expect(wrongIdentity.metrics.marketCap).toEqual({
+      available: false,
+      reasonCodes: ["market-cap-supply-evidence-invalid"],
+    });
+
+    const unauthenticated = evaluatePredictionAssetDiscoveryEligibilityV2({
+      profile: profile(),
+      observedAtMs: OBSERVED_AT_MS,
+      volume24hUsd: 25_000,
+      marketCapSupplyEvidence: {
+        ...supplyEvidence(),
+        verification: {
+          ...supplyEvidence().verification,
+          evidenceDigest: "self-asserted",
+        },
+      },
+    });
+    expect(unauthenticated.metrics.marketCap).toEqual({
+      available: false,
+      reasonCodes: ["market-cap-supply-evidence-invalid"],
+    });
+  });
+
+  it("keeps a valid circulating-supply snapshot calculator-only", () => {
+    const fixedEvidence = supplyEvidence();
+    const result = evaluatePredictionAssetDiscoveryEligibilityV2({
+      profile: profile(),
+      observedAtMs: OBSERVED_AT_MS,
+      volume24hUsd: 25_000,
+      marketCapSupplyEvidence: {
+        ...fixedEvidence,
+        kind: "immutable-circulating-supply",
+        verification: {
+          ...fixedEvidence.verification,
+          method: "verified-immutable-circulating-supply",
+        },
+      },
+    });
+
+    expect(result.status).toBe("eligible");
+    expect(result.metrics.marketCap).toEqual({
+      available: false,
+      reasonCodes: ["market-cap-fixed-supply-required"],
+    });
+  });
+
+  it.each([
+    {
+      label: "token identity",
+      value: {
+        ...supplyEvidence(),
+        tokenAddress: `0x${"cd".repeat(20)}`,
+      },
+    },
+    {
+      label: "kind-bound verification method",
+      value: {
+        ...supplyEvidence(),
+        kind: "immutable-circulating-supply",
+      },
+    },
+    {
+      label: "chain state reference",
+      value: {
+        ...supplyEvidence(),
+        verification: {
+          ...supplyEvidence().verification,
+          chainStateReference: "latest",
+        },
+      },
+    },
+    {
+      label: "zero evidence digest",
+      value: {
+        ...supplyEvidence(),
+        verification: {
+          ...supplyEvidence().verification,
+          evidenceDigest: `0x${"00".repeat(32)}`,
+        },
+      },
+    },
+    {
+      label: "runtime JSON types",
+      value: {
+        ...supplyEvidence(),
+        supplyBaseUnits: [123],
+        verification: {
+          ...supplyEvidence().verification,
+          chainStateReference: [34_567_890],
+          evidenceDigest: [`0x${"12".repeat(32)}`],
+        },
+      },
+    },
+  ])("rejects supply evidence with an invalid $label binding", ({ value }) => {
+    const result = evaluatePredictionAssetDiscoveryEligibilityV2({
+      profile: profile(),
+      observedAtMs: OBSERVED_AT_MS,
+      volume24hUsd: 25_000,
+      marketCapSupplyEvidence:
+        value as unknown as PredictionAssetMarketCapSupplyEvidenceV2,
+    });
+
+    expect(result.metrics.marketCap).toEqual({
+      available: false,
+      reasonCodes: ["market-cap-supply-evidence-invalid"],
+    });
+  });
+
+  it("never relabels FDV as market cap even when fixed-supply evidence exists", () => {
+    const result = evaluatePredictionAssetDiscoveryEligibilityV2({
+      profile: profile({ marketCapUsd: null, fdvUsd: 9_000_000 }),
+      observedAtMs: OBSERVED_AT_MS,
+      volume24hUsd: 25_000,
+      marketCapSupplyEvidence: supplyEvidence({
+        kind: "fixed-supply-fully-circulating",
+        verification: {
+          ...supplyEvidence().verification,
+          method: "verified-fixed-supply-fully-circulating",
+        },
+      }),
+    });
+
+    expect(result.status).toBe("eligible");
+    expect(result.metrics.marketCap).toEqual({
+      available: false,
+      reasonCodes: ["market-cap-unavailable"],
+    });
+  });
+
+  it("recomputes age at the explicit observation time rather than trusting cached seconds", () => {
+    const sourceProfile = profile({
+      pairCreatedAtMs: OBSERVED_AT_MS - DAY_MS,
+    });
+    const staleAgeProfile = {
+      ...sourceProfile,
+      age: {
+        ...sourceProfile.age!,
+        seconds: 0,
+      },
+    };
+    const result = evaluatePredictionAssetDiscoveryEligibilityV2({
+      profile: staleAgeProfile,
+      observedAtMs: OBSERVED_AT_MS,
+      volume24hUsd: 25_000,
+    });
+
+    expect(result.status).toBe("eligible");
+    expect(result.observed.poolAgeSeconds).toBe(86_400);
+  });
+
+  it("rejects a nondeterministic observation timestamp", () => {
+    expect(() => evaluatePredictionAssetDiscoveryEligibilityV2({
+      profile: profile(),
+      observedAtMs: Number.NaN,
+      volume24hUsd: 25_000,
+    })).toThrow(TypeError);
+  });
+});

--- a/tests/prediction-v2-asset-logo.test.ts
+++ b/tests/prediction-v2-asset-logo.test.ts
@@ -1,0 +1,234 @@
+import sharp from "sharp";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  GET,
+  PREDICTION_ASSET_LOGO_KNOWN_ASSET_AUTHORIZATION_REQUIRED_FOR_ACTIVATION_V2,
+  PREDICTION_ASSET_LOGO_RUNTIME_CONTROL_SCOPE_V2,
+  PREDICTION_ASSET_LOGO_SHARED_LIMITS_REQUIRED_FOR_ACTIVATION_V2,
+  createPredictionAssetLogoHandlerV2,
+} from
+  "../app/api/prediction/asset-logo/[asset]/route";
+import {
+  predictionAssetCardImageV2,
+  predictionAssetFallbackImageV2,
+  predictionDexscreenerLogoAssetIdV2,
+} from "../lib/prediction-v2/asset-logo-v2";
+
+const ASSET = "ab".repeat(32);
+const OTHER_ASSET = "cd".repeat(32);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+describe("Prediction V2 asset logos", () => {
+  it("keeps runtime controls explicit without claiming activation safety", () => {
+    expect(PREDICTION_ASSET_LOGO_RUNTIME_CONTROL_SCOPE_V2)
+      .toBe("single-runtime-only");
+    expect(PREDICTION_ASSET_LOGO_SHARED_LIMITS_REQUIRED_FOR_ACTIVATION_V2)
+      .toBe(true);
+    expect(
+      PREDICTION_ASSET_LOGO_KNOWN_ASSET_AUTHORIZATION_REQUIRED_FOR_ACTIVATION_V2,
+    ).toBe(true);
+  });
+
+  it("keeps the public image route dark while Prediction V2 is disabled", async () => {
+    const response = await GET(
+      new Request(`https://programmable.market/api/prediction/asset-logo/${ASSET}`),
+      { params: Promise.resolve({ asset: ASSET }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("reduces only the fixed DEX Screener image origin to an internal route", () => {
+    const providerUrl =
+      `https://cdn.dexscreener.com/cms/images/${ASSET}` +
+      "?width=800&height=800&quality=95&format=auto";
+    expect(predictionDexscreenerLogoAssetIdV2(providerUrl)).toBe(ASSET);
+    expect(predictionAssetCardImageV2({
+      chainId: "base",
+      address: `0x${"12".repeat(20)}`,
+      logoUrl: providerUrl,
+    })).toEqual({
+      source: `/api/prediction/asset-logo/${ASSET}`,
+      usesProviderLogo: true,
+    });
+    expect(predictionDexscreenerLogoAssetIdV2(
+      `https://cdn.dexscreener.com.example.com/cms/images/${ASSET}`,
+    )).toBeNull();
+    expect(predictionDexscreenerLogoAssetIdV2(
+      `https://example.com/cms/images/${ASSET}`,
+    )).toBeNull();
+    expect(predictionDexscreenerLogoAssetIdV2(
+      `https://cdn.dexscreener.com/cms/images/${ASSET}/other`,
+    )).toBeNull();
+  });
+
+  it("uses a stable chain-and-address fallback for every namespace", () => {
+    const first = predictionAssetFallbackImageV2(
+      "solana",
+      "4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw",
+    );
+    expect(first).toBe(predictionAssetFallbackImageV2(
+      "solana",
+      "4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw",
+    ));
+    expect(first).toMatch(/^\/brand\/programmable-token-fallback-/u);
+    expect(predictionAssetCardImageV2({
+      chainId: "solana",
+      address: "4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw",
+      logoUrl: "https://arbitrary.example/token.png",
+    }).usesProviderLogo).toBe(false);
+  });
+
+  it("fetches one fixed upstream path and returns stripped 1000px WebP", async () => {
+    const source = await sharp({
+      create: {
+        width: 320,
+        height: 180,
+        channels: 3,
+        background: { r: 230, g: 120, b: 90 },
+      },
+    }).jpeg().toBuffer();
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(source, {
+      status: 200,
+      headers: {
+        "content-length": String(source.byteLength),
+        "content-type": "image/jpeg",
+      },
+    }));
+    const response = await createPredictionAssetLogoHandlerV2({
+      fetchImpl,
+      timeoutMs: 1_000,
+    })(ASSET);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/webp");
+    await expect(sharp(await response.arrayBuffer()).metadata()).resolves
+      .toMatchObject({ format: "webp", width: 1_000, height: 1_000 });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      `https://cdn.dexscreener.com/cms/images/${ASSET}` +
+        "?width=1000&height=1000&quality=95&format=auto",
+      expect.objectContaining({ redirect: "error", credentials: "omit" }),
+    );
+  });
+
+  it("fails closed for invalid ids, redirects, oversized and non-image data", async () => {
+    const handler = createPredictionAssetLogoHandlerV2({
+      fetchImpl: vi.fn<typeof fetch>(async () => new Response("not an image", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      })),
+    });
+    await expect(handler("../token")).resolves.toMatchObject({ status: 400 });
+    await expect(handler(ASSET)).resolves.toMatchObject({ status: 502 });
+
+    const oversized = createPredictionAssetLogoHandlerV2({
+      fetchImpl: vi.fn<typeof fetch>(async () => new Response("x", {
+        status: 200,
+        headers: {
+          "content-length": "4000001",
+          "content-type": "image/png",
+        },
+      })),
+    });
+    await expect(oversized(ASSET)).resolves.toMatchObject({ status: 502 });
+  });
+
+  it("bounds active provider and transform work without queueing", async () => {
+    const firstFetch = deferred<Response>();
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      if (fetchImpl.mock.calls.length === 1) return firstFetch.promise;
+      return new Response("not an image", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      });
+    });
+    const handler = createPredictionAssetLogoHandlerV2({
+      fetchImpl,
+      maximumConcurrentTransforms: 1,
+    });
+
+    const first = handler(ASSET);
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+    const saturated = await handler(OTHER_ASSET);
+    expect(saturated.status).toBe(503);
+    expect(saturated.headers.get("retry-after")).toBe("1");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    firstFetch.resolve(new Response("not an image", {
+      status: 200,
+      headers: { "content-type": "text/plain" },
+    }));
+    await expect(first).resolves.toMatchObject({ status: 502 });
+    await expect(handler(OTHER_ASSET)).resolves.toMatchObject({ status: 502 });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("short-caches provider and transform failures, then retries after expiry", async () => {
+    let now = 10_000;
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(
+      "not an image",
+      { status: 200, headers: { "content-type": "text/plain" } },
+    ));
+    const handler = createPredictionAssetLogoHandlerV2({
+      fetchImpl,
+      negativeCacheTtlMs: 50,
+      nowMs: () => now,
+    });
+
+    await expect(handler(ASSET)).resolves.toMatchObject({ status: 502 });
+    await expect(handler(ASSET)).resolves.toMatchObject({ status: 502 });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    now += 51;
+    await expect(handler(ASSET)).resolves.toMatchObject({ status: 502 });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds negative-cache entries and never caches caller abort or capacity", async () => {
+    const now = 20_000;
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(
+      "not an image",
+      { status: 200, headers: { "content-type": "text/plain" } },
+    ));
+    const handler = createPredictionAssetLogoHandlerV2({
+      fetchImpl,
+      maximumNegativeCacheEntries: 1,
+      negativeCacheTtlMs: 100,
+      nowMs: () => now,
+    });
+    const aborted = new AbortController();
+    aborted.abort();
+
+    await expect(handler(ASSET, aborted.signal)).resolves
+      .toMatchObject({ status: 502 });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    await handler(ASSET);
+    await handler(OTHER_ASSET);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    // The second failure evicts the first entry, so the first asset is fetched
+    // again even though its original TTL has not expired.
+    await handler(ASSET);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([0, 17, 1.5])(
+    "rejects invalid logo transform concurrency %s",
+    (maximumConcurrentTransforms) => {
+      expect(() => createPredictionAssetLogoHandlerV2({
+        maximumConcurrentTransforms,
+      })).toThrow(/maximumConcurrentTransforms/u);
+    },
+  );
+});

--- a/tests/prediction-v2-create-flow.test.ts
+++ b/tests/prediction-v2-create-flow.test.ts
@@ -1,0 +1,594 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PREDICTION_V2_CREATE_METRICS,
+  PREDICTION_V2_CREATE_SOURCE_NETWORKS,
+  PREDICTION_V2_CREATE_STEPS,
+  PREDICTION_V2_CREATE_TEMPLATES,
+  PREDICTION_V2_MAXIMUM_MARKET_DURATION_SECONDS,
+  PREDICTION_V2_MINIMUM_MARKET_DURATION_SECONDS,
+  PREDICTION_V2_PROTOCOL_PRICE_DECIMALS,
+  PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+  buildPredictionV2CreateReview,
+  formatPredictionV2DecimalAtoms,
+  nextPredictionV2CreateStep,
+  normalizePredictionV2DetectedAssetIdentity,
+  parsePredictionV2DecimalAtoms,
+  predictionV2ExactUtcToUnixSeconds,
+  predictionV2MarketCapTargetToPriceStrike,
+  previousPredictionV2CreateStep,
+  type PredictionV2CreatePrediction,
+  type PredictionV2CreationReferenceSnapshot,
+  type PredictionV2DetectedAsset,
+  type PredictionV2PercentChangePrediction,
+  type PredictionV2ReferenceMetricSnapshot,
+  type PredictionV2ReferenceSupplySnapshot,
+  type PredictionV2TargetPrediction,
+} from "../lib/prediction-v2/create-flow-v2";
+
+const EVM_ADDRESS = "0xAbCdEf0000000000000000000000000000001234";
+const NORMALIZED_EVM_ADDRESS = EVM_ADDRESS.toLowerCase();
+const OTHER_EVM_ADDRESS = "0x123456000000000000000000000000000000abcd";
+const SOLANA_ADDRESS = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const CREATION_UTC = "2026-08-23T12:00:00Z";
+const OBSERVATION_UTC = "2026-09-01T12:00:00Z";
+const BASE_REFERENCE = "eip155:8453:block:34900000";
+const SETTLEMENT_REFERENCE = "eip155:4663:block:9100000";
+const CREATION_DIGEST = `0x${"11".repeat(32)}`;
+const SUPPLY_DIGEST = `0x${"22".repeat(32)}`;
+const METRIC_DIGEST = `0x${"33".repeat(32)}`;
+
+const CREATION_SNAPSHOT = {
+  settlementChainId: PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+  capturedAtUtc: CREATION_UTC,
+  snapshotReference: SETTLEMENT_REFERENCE,
+  evidenceDigest: CREATION_DIGEST,
+  verificationStatus: "verified",
+} as const satisfies PredictionV2CreationReferenceSnapshot;
+
+const BILLION_TOKEN_FIXED_SUPPLY = {
+  sourceNetwork: "base",
+  address: NORMALIZED_EVM_ADDRESS,
+  fixedSupplyAtoms: "1000000000000000000000000000",
+  tokenDecimals: 18,
+  capturedAtUtc: CREATION_UTC,
+  snapshotReference: BASE_REFERENCE,
+  evidenceDigest: SUPPLY_DIGEST,
+  verificationStatus: "verified",
+  supplyDefinition: "fixed-supply-fully-circulating",
+} as const satisfies PredictionV2ReferenceSupplySnapshot;
+
+function metricSnapshot(
+  metric: "price" | "market-cap",
+  valueUsd: string,
+  overrides: Partial<PredictionV2ReferenceMetricSnapshot> = {},
+): PredictionV2ReferenceMetricSnapshot {
+  return {
+    metric,
+    valueUsd,
+    sourceNetwork: "base",
+    address: NORMALIZED_EVM_ADDRESS,
+    capturedAtUtc: CREATION_UTC,
+    snapshotReference: BASE_REFERENCE,
+    evidenceDigest: METRIC_DIGEST,
+    verificationStatus: "verified",
+    ...overrides,
+  };
+}
+
+function asset(
+  overrides: Partial<PredictionV2DetectedAsset> = {},
+): PredictionV2DetectedAsset {
+  return {
+    identity: { sourceNetwork: "base", address: EVM_ADDRESS },
+    name: "Example Coin",
+    symbol: "EXAMPLE",
+    referenceSupplySnapshot: BILLION_TOKEN_FIXED_SUPPLY,
+    ...overrides,
+  };
+}
+
+function target(
+  overrides: Partial<PredictionV2TargetPrediction> = {},
+): PredictionV2TargetPrediction {
+  return {
+    metric: "price",
+    template: "target",
+    targetUsd: "0.015",
+    observationUtc: OBSERVATION_UTC,
+    creationSnapshot: CREATION_SNAPSHOT,
+    priceDecimals: PREDICTION_V2_PROTOCOL_PRICE_DECIMALS,
+    ...overrides,
+  };
+}
+
+function percentChange(
+  metric: "price" | "market-cap",
+  referenceMetricUsd: string,
+  percent: string,
+  overrides: Partial<PredictionV2PercentChangePrediction> = {},
+): PredictionV2PercentChangePrediction {
+  return {
+    metric,
+    template: "percent-change",
+    percentChange: percent,
+    referenceMetricSnapshot: metricSnapshot(metric, referenceMetricUsd),
+    observationUtc: OBSERVATION_UTC,
+    creationSnapshot: CREATION_SNAPSHOT,
+    priceDecimals: PREDICTION_V2_PROTOCOL_PRICE_DECIMALS,
+    ...overrides,
+  };
+}
+
+describe("Prediction V2 progressive create-flow model", () => {
+  it("exposes the bounded flow, networks and fixed protocol constants", () => {
+    expect(PREDICTION_V2_CREATE_STEPS).toEqual([
+      "address",
+      "asset",
+      "prediction",
+      "review",
+    ]);
+    expect(PREDICTION_V2_CREATE_SOURCE_NETWORKS.map(({ id }) => id)).toEqual([
+      "ethereum",
+      "base",
+      "bnb",
+      "robinhood",
+      "solana",
+    ]);
+    expect(PREDICTION_V2_CREATE_METRICS.map(({ id }) => id)).toEqual([
+      "price",
+      "market-cap",
+    ]);
+    expect(PREDICTION_V2_PROTOCOL_PRICE_DECIMALS).toBe(8);
+    expect(PREDICTION_V2_MINIMUM_MARKET_DURATION_SECONDS).toBe(86_400n);
+    expect(PREDICTION_V2_MAXIMUM_MARKET_DURATION_SECONDS).toBe(2_592_000n);
+    expect(nextPredictionV2CreateStep("address")).toBe("asset");
+    expect(nextPredictionV2CreateStep("review")).toBe("review");
+    expect(previousPredictionV2CreateStep("review")).toBe("prediction");
+    expect(previousPredictionV2CreateStep("address")).toBe("address");
+  });
+
+  it.each(["ethereum", "base", "bnb", "robinhood"] as const)(
+    "binds a detected %s asset to its chain and canonical EVM address",
+    (sourceNetwork) => {
+      expect(normalizePredictionV2DetectedAssetIdentity({
+        sourceNetwork,
+        address: EVM_ADDRESS,
+      })).toEqual({ sourceNetwork, address: NORMALIZED_EVM_ADDRESS });
+    },
+  );
+
+  it("accepts a nonzero 32-byte Solana address and rejects cross-namespace input", () => {
+    expect(normalizePredictionV2DetectedAssetIdentity({
+      sourceNetwork: "solana",
+      address: SOLANA_ADDRESS,
+    })).toEqual({ sourceNetwork: "solana", address: SOLANA_ADDRESS });
+    expect(normalizePredictionV2DetectedAssetIdentity({
+      sourceNetwork: "base",
+      address: SOLANA_ADDRESS,
+    })).toBeNull();
+    expect(normalizePredictionV2DetectedAssetIdentity({
+      sourceNetwork: "solana",
+      address: EVM_ADDRESS,
+    })).toBeNull();
+    expect(normalizePredictionV2DetectedAssetIdentity({
+      sourceNetwork: "solana",
+      address: "1".repeat(32),
+    })).toBeNull();
+  });
+
+  it("keeps reach visible but disabled", () => {
+    expect(PREDICTION_V2_CREATE_TEMPLATES).toEqual([
+      { id: "target", label: "Target", enabled: true },
+      { id: "percent-change", label: "Percentage change", enabled: true },
+      {
+        id: "reach",
+        label: "Reach before deadline",
+        enabled: false,
+        reason: expect.stringContaining("continuous-observation"),
+      },
+    ]);
+    expect(buildPredictionV2CreateReview(asset(), {
+      ...target(),
+      template: "reach",
+      targetUsd: "0.02",
+    })).toMatchObject({
+      ok: false,
+      errors: { template: expect.stringContaining("not enabled") },
+    });
+  });
+});
+
+describe("Prediction V2 exact protocol-value derivation", () => {
+  it("builds an explicit 8-decimal >= USD-price predicate with evidence binding", () => {
+    const result = buildPredictionV2CreateReview(asset(), target());
+
+    expect(result).toEqual({
+      ok: true,
+      review: {
+        schemaVersion: 2,
+        asset: { sourceNetwork: "base", address: NORMALIZED_EVM_ADDRESS },
+        assetName: "Example Coin",
+        assetSymbol: "EXAMPLE",
+        selectedMetric: "price",
+        template: "target",
+        metricTargetUsd: "0.015",
+        inputTargetUsd: "0.015",
+        percentChange: null,
+        referenceMetricUsd: null,
+        creationSnapshot: CREATION_SNAPSHOT,
+        referenceMetricSnapshot: null,
+        referenceSupplySnapshot: null,
+        protocolPredicate: {
+          metric: "usd-price",
+          comparator: "greater-than-or-equal",
+          quoteCurrency: "USD",
+          strikeUsd: "0.015",
+          strikeAtoms: "1500000",
+          priceDecimals: 8,
+          observationUtc: OBSERVATION_UTC,
+          observationUnixSeconds: "1788264000",
+          timezone: "UTC",
+          evidenceBinding: {
+            creationSnapshot: CREATION_SNAPSHOT,
+            referenceMetricSnapshot: null,
+            referenceSupplySnapshot: null,
+          },
+        },
+        settlementEligibility: "not-evaluated",
+      },
+    });
+    if (!result.ok) throw new Error("expected valid create review");
+    expect(() => JSON.stringify(result.review)).not.toThrow();
+    expect(JSON.stringify(result.review)).not.toContain("settlementEligible");
+  });
+
+  it("derives a positive percentage threshold only from a verified baseline", () => {
+    const baseline = metricSnapshot("price", "1.25");
+    const result = buildPredictionV2CreateReview(asset(), percentChange(
+      "price",
+      "1.25",
+      "20.00",
+      { referenceMetricSnapshot: baseline },
+    ));
+
+    expect(result).toMatchObject({
+      ok: true,
+      review: {
+        selectedMetric: "price",
+        template: "percent-change",
+        metricTargetUsd: "1.5",
+        inputTargetUsd: null,
+        percentChange: "20",
+        referenceMetricUsd: "1.25",
+        referenceMetricSnapshot: baseline,
+        protocolPredicate: {
+          comparator: "greater-than-or-equal",
+          strikeUsd: "1.5",
+          strikeAtoms: "150000000",
+          evidenceBinding: { referenceMetricSnapshot: baseline },
+        },
+      },
+    });
+  });
+
+  it("converts an exact market-cap target using only fixed fully circulating supply", () => {
+    const result = buildPredictionV2CreateReview(asset(), target({
+      metric: "market-cap",
+      targetUsd: "10000000",
+    }));
+
+    expect(result).toMatchObject({
+      ok: true,
+      review: {
+        selectedMetric: "market-cap",
+        metricTargetUsd: "10000000",
+        referenceSupplySnapshot: BILLION_TOKEN_FIXED_SUPPLY,
+        protocolPredicate: {
+          metric: "usd-price",
+          comparator: "greater-than-or-equal",
+          strikeUsd: "0.01",
+          strikeAtoms: "1000000",
+          evidenceBinding: {
+            referenceSupplySnapshot: BILLION_TOKEN_FIXED_SUPPLY,
+          },
+        },
+        settlementEligibility: "not-evaluated",
+      },
+    });
+    if (!result.ok) throw new Error("expected exact market-cap review");
+    expect(result.review.creationSnapshot.snapshotReference)
+      .toBe(SETTLEMENT_REFERENCE);
+    expect(result.review.referenceSupplySnapshot?.snapshotReference)
+      .toBe(BASE_REFERENCE);
+    expect(result.review.referenceSupplySnapshot?.snapshotReference)
+      .not.toBe(result.review.creationSnapshot.snapshotReference);
+  });
+
+  it("supports an exactly representable positive market-cap percentage threshold", () => {
+    const result = buildPredictionV2CreateReview(
+      asset(),
+      percentChange("market-cap", "8000000", "25"),
+    );
+    expect(result).toMatchObject({
+      ok: true,
+      review: {
+        metricTargetUsd: "10000000",
+        protocolPredicate: { strikeUsd: "0.01", strikeAtoms: "1000000" },
+      },
+    });
+  });
+
+  it("requires exact market-cap representation instead of ceiling the target", () => {
+    const threeTokenSupply = {
+      ...BILLION_TOKEN_FIXED_SUPPLY,
+      fixedSupplyAtoms: "3",
+      tokenDecimals: 0,
+    } as const;
+    expect(predictionV2MarketCapTargetToPriceStrike(
+      "1",
+      threeTokenSupply,
+      PREDICTION_V2_PROTOCOL_PRICE_DECIMALS,
+    )).toBeNull();
+    expect(predictionV2MarketCapTargetToPriceStrike(
+      "3",
+      threeTokenSupply,
+      PREDICTION_V2_PROTOCOL_PRICE_DECIMALS,
+    )).toEqual({ strikeAtoms: "100000000", strikeUsd: "1" });
+    expect(predictionV2MarketCapTargetToPriceStrike(
+      "3",
+      threeTokenSupply,
+      18,
+    )).toBeNull();
+  });
+
+  it("round-trips exact decimal atoms without Number-based protocol math", () => {
+    expect(parsePredictionV2DecimalAtoms("123.00000001", 8)).toBe(
+      12_300_000_001n,
+    );
+    expect(formatPredictionV2DecimalAtoms(12_300_000_001n, 8)).toBe(
+      "123.00000001",
+    );
+    expect(parsePredictionV2DecimalAtoms("0.000000001", 8)).toBeNull();
+  });
+});
+
+describe("Prediction V2 fail-closed precision and direction", () => {
+  it.each(["0", "-0", "-20", "-99.99", "-100"])(
+    "rejects non-upward percentage %s under the >= predicate",
+    (percent) => {
+      expect(buildPredictionV2CreateReview(
+        asset(),
+        percentChange("price", "100", percent),
+      )).toMatchObject({
+        ok: false,
+        errors: { percentChange: expect.stringContaining("positive upward") },
+      });
+    },
+  );
+
+  it("rejects percentage precision drift instead of silently rounding upward", () => {
+    expect(buildPredictionV2CreateReview(
+      asset(),
+      percentChange("price", "0.00000001", "50"),
+    )).toMatchObject({
+      ok: false,
+      errors: { precision: expect.stringContaining("exact target") },
+    });
+  });
+
+  it("rejects amplified market-cap tick drift for high-supply tokens", () => {
+    const hugeSupply = {
+      ...BILLION_TOKEN_FIXED_SUPPLY,
+      fixedSupplyAtoms: "1000000000000000000000000000000000",
+    } as const;
+    expect(buildPredictionV2CreateReview(
+      asset({ referenceSupplySnapshot: hugeSupply }),
+      target({ metric: "market-cap", targetUsd: "100000" }),
+    )).toMatchObject({
+      ok: false,
+      errors: { precision: expect.stringContaining("exact market-cap target") },
+    });
+  });
+
+  it.each([1, 7, 9, 18])(
+    "rejects %i price decimals because the current protocol is fixed at 8",
+    (priceDecimals) => {
+      expect(buildPredictionV2CreateReview(
+        asset(),
+        { ...target(), priceDecimals } as unknown as PredictionV2CreatePrediction,
+      )).toMatchObject({
+        ok: false,
+        errors: { priceDecimals: expect.stringContaining("exactly 8") },
+      });
+    },
+  );
+
+  it("rejects a direct price target that needs more than 8 decimals", () => {
+    expect(buildPredictionV2CreateReview(
+      asset(),
+      target({ targetUsd: "0.000000001" }),
+    )).toMatchObject({
+      ok: false,
+      errors: { precision: expect.stringContaining("8-decimal") },
+    });
+  });
+});
+
+describe("Prediction V2 immutable snapshot bindings", () => {
+  it.each([
+    ["wrong chain", { settlementChainId: "8453" }],
+    ["wrong reference", { snapshotReference: "eip155:8453:block:9100000" }],
+    ["oversized block", {
+      snapshotReference: "eip155:4663:block:18446744073709551616",
+    }],
+    ["zero digest", { evidenceDigest: `0x${"0".repeat(64)}` }],
+    ["uppercase digest", { evidenceDigest: `0x${"AA".repeat(32)}` }],
+    ["unverified", { verificationStatus: "unverified" }],
+  ] as const)("rejects a %s creation snapshot", (_label, overrides) => {
+    expect(buildPredictionV2CreateReview(
+      asset(),
+      target({
+        creationSnapshot: {
+          ...CREATION_SNAPSHOT,
+          ...overrides,
+        } as unknown as PredictionV2CreationReferenceSnapshot,
+      }),
+    )).toMatchObject({
+      ok: false,
+      errors: { creationSnapshot: expect.any(String) },
+    });
+  });
+
+  it.each([
+    [null, "missing"],
+    [{ ...BILLION_TOKEN_FIXED_SUPPLY, fixedSupplyAtoms: "0" }, "zero"],
+    [{ ...BILLION_TOKEN_FIXED_SUPPLY, fixedSupplyAtoms: "01" }, "noncanonical"],
+    [{ ...BILLION_TOKEN_FIXED_SUPPLY, fixedSupplyAtoms: [123] }, "coerced array"],
+    [{ ...BILLION_TOKEN_FIXED_SUPPLY, sourceNetwork: "ethereum" }, "wrong chain"],
+    [{ ...BILLION_TOKEN_FIXED_SUPPLY, address: OTHER_EVM_ADDRESS }, "wrong token"],
+    [{ ...BILLION_TOKEN_FIXED_SUPPLY, capturedAtUtc: "2026-08-23T11:59:59Z" }, "stale"],
+    [{ ...BILLION_TOKEN_FIXED_SUPPLY, snapshotReference: "eip155:1:block:34899999" }, "wrong chain reference"],
+    [{ ...BILLION_TOKEN_FIXED_SUPPLY, evidenceDigest: `0x${"0".repeat(64)}` }, "zero digest"],
+    [{ ...BILLION_TOKEN_FIXED_SUPPLY, verificationStatus: "unverified" }, "unverified"],
+    [{
+      ...BILLION_TOKEN_FIXED_SUPPLY,
+      supplyDefinition: "circulating-at-creation",
+    }, "mutable circulating supply"],
+  ] as ReadonlyArray<readonly [unknown, string]>)(
+    "rejects %s fixed-supply evidence",
+    (snapshot, label) => {
+      const result = buildPredictionV2CreateReview(
+        asset({
+          referenceSupplySnapshot:
+            snapshot as PredictionV2ReferenceSupplySnapshot | null,
+        }),
+        target({ metric: "market-cap", targetUsd: "10000000" }),
+      );
+      expect(result, label).toMatchObject({
+        ok: false,
+        errors: { referenceSupplySnapshot: expect.any(String) },
+      });
+    },
+  );
+
+  it.each([
+    ["wrong metric", { metric: "market-cap" }],
+    ["wrong chain", { sourceNetwork: "ethereum" }],
+    ["wrong token", { address: OTHER_EVM_ADDRESS }],
+    ["stale time", { capturedAtUtc: "2026-08-23T11:59:59Z" }],
+    ["wrong reference", { snapshotReference: "eip155:1:block:34899999" }],
+    ["zero digest", { evidenceDigest: `0x${"0".repeat(64)}` }],
+    ["unverified", { verificationStatus: "unverified" }],
+  ] as const)("rejects a %s percentage baseline", (_label, overrides) => {
+    expect(buildPredictionV2CreateReview(
+      asset(),
+      percentChange("price", "1", "20", {
+        referenceMetricSnapshot: {
+          ...metricSnapshot("price", "1"),
+          ...overrides,
+        } as unknown as PredictionV2ReferenceMetricSnapshot,
+      }),
+    )).toMatchObject({
+      ok: false,
+      errors: { referenceMetricSnapshot: expect.any(String) },
+    });
+  });
+
+  it("rejects a raw, unauthenticated percentage baseline", () => {
+    const prediction = {
+      ...percentChange("price", "1", "20"),
+      referenceMetricSnapshot: undefined,
+      referenceMetricUsd: "1",
+    } as unknown as PredictionV2CreatePrediction;
+    expect(buildPredictionV2CreateReview(asset(), prediction)).toMatchObject({
+      ok: false,
+      errors: { referenceMetricSnapshot: expect.any(String) },
+    });
+  });
+});
+
+describe("Prediction V2 deadline and protocol bounds", () => {
+  it("matches the Factory's strict >24h and inclusive <=30d boundaries", () => {
+    expect(buildPredictionV2CreateReview(
+      asset(),
+      target({ observationUtc: "2026-08-24T12:00:00Z" }),
+    )).toMatchObject({
+      ok: false,
+      errors: { observationUtc: expect.stringContaining("more than 24 hours") },
+    });
+    expect(buildPredictionV2CreateReview(
+      asset(),
+      target({ observationUtc: "2026-08-24T12:00:01Z" }),
+    ).ok).toBe(true);
+    expect(buildPredictionV2CreateReview(
+      asset(),
+      target({ observationUtc: "2026-09-22T12:00:00Z" }),
+    ).ok).toBe(true);
+    expect(buildPredictionV2CreateReview(
+      asset(),
+      target({ observationUtc: "2026-09-22T12:00:01Z" }),
+    )).toMatchObject({
+      ok: false,
+      errors: { observationUtc: expect.stringContaining("no more than 30 days") },
+    });
+  });
+
+  it("rejects malformed UTC, invalid calendar dates and unsupported uint32 time", () => {
+    for (const observationUtc of [
+      "2026-09-01T12:00",
+      "2026-09-01T14:00:00+02:00",
+      "2026-02-30T18:00:00Z",
+      "2107-01-01T00:00:00Z",
+    ]) {
+      expect(predictionV2ExactUtcToUnixSeconds(observationUtc)).toBeNull();
+      expect(buildPredictionV2CreateReview(
+        asset(),
+        target({ observationUtc }),
+      )).toMatchObject({
+        ok: false,
+        errors: { observationUtc: expect.any(String) },
+      });
+    }
+    expect(predictionV2ExactUtcToUnixSeconds("2106-02-07T06:28:15Z"))
+      .toBe("4294967295");
+    expect(predictionV2ExactUtcToUnixSeconds("2106-02-07T06:28:16Z"))
+      .toBeNull();
+  });
+
+  it("rejects invalid identity, malformed decimals and unsupported runtime enums", () => {
+    expect(buildPredictionV2CreateReview(
+      asset({
+        identity: { sourceNetwork: "base", address: `0x${"0".repeat(40)}` },
+      }),
+      target(),
+    )).toMatchObject({ ok: false, errors: { asset: expect.any(String) } });
+
+    for (const targetUsd of ["0", "-1", "+1", "01", "1e3", "NaN"] as const) {
+      expect(buildPredictionV2CreateReview(
+        asset(),
+        target({ targetUsd }),
+      )).toMatchObject({ ok: false, errors: { targetUsd: expect.any(String) } });
+    }
+
+    expect(buildPredictionV2CreateReview(
+      asset(),
+      { ...target(), metric: "volume" } as unknown as PredictionV2CreatePrediction,
+    )).toMatchObject({
+      ok: false,
+      errors: { metric: expect.any(String) },
+    });
+  });
+
+  it("returns byte-for-byte deterministic JSON-safe review data", () => {
+    const first = buildPredictionV2CreateReview(asset(), target({
+      metric: "market-cap",
+      targetUsd: "10000000.00",
+    }));
+    const second = buildPredictionV2CreateReview(asset(), target({
+      metric: "market-cap",
+      targetUsd: "10000000.00",
+    }));
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+});

--- a/tests/prediction-v2-market-presentation.test.ts
+++ b/tests/prediction-v2-market-presentation.test.ts
@@ -1,0 +1,610 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  predictionAssetIdentityCandidatesV2,
+  predictionOnchainAssetKeyV2,
+} from "../lib/prediction-market-assets-v2";
+import {
+  parsePredictionAssetAutoDiscoveryV2,
+  type PredictionAssetAutoDiscoveryClientResultV2,
+} from "../lib/prediction-v2/asset-auto-discovery-v2";
+import {
+  PREDICTION_V2_PROTOCOL_PRICE_DECIMALS,
+  PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+  buildPredictionV2CreateReview,
+  type PredictionV2CreateReview,
+} from "../lib/prediction-v2/create-flow-v2";
+import {
+  buildPredictionMarketPresentationRecordV2,
+  parsePredictionMarketPresentationRecordV2,
+  predictionMarketBundledFallbackArtworkV2,
+  predictionMarketPresentationRevisionHashV2,
+  type BuildPredictionMarketPresentationRecordV2Input,
+  type PredictionMarketEconomicBindingV2,
+  type PredictionMarketOwnedArtworkV2,
+} from "../lib/prediction-v2/market-presentation-v2";
+
+const OBSERVED_AT = "2026-08-23T18:00:00.000Z";
+const CREATION_UTC = "2026-08-23T12:00:00Z";
+const OBSERVATION_UTC = "2026-09-01T12:00:00Z";
+const OBSERVATION_UNIX_SECONDS = "1788264000";
+const EVM_ADDRESS = `0x${"ab".repeat(20)}`;
+const OTHER_EVM_ADDRESS = `0x${"ef".repeat(20)}`;
+const FACTORY = `0x${"12".repeat(20)}`;
+const VAULT = `0x${"13".repeat(20)}`;
+const CHECKPOINT = `0x${"14".repeat(20)}`;
+const ECONOMIC_KEY = `0x${"21".repeat(32)}` as const;
+const MARKET_ID = `0x${"22".repeat(32)}` as const;
+const SNAPSHOT_HASH = `0x${"23".repeat(32)}` as const;
+const BLOCK_HASH = `0x${"24".repeat(32)}` as const;
+const POOL_ID = `0x${"27".repeat(32)}` as const;
+const RESOLUTION_POLICY_HASH = `0x${"28".repeat(32)}` as const;
+const DEXSCREENER_IMAGE_ID = "25".repeat(32);
+const OWNED_ARTWORK_DIGEST = "26".repeat(32);
+
+function discovery(input: Readonly<{
+  observedAt?: string;
+  source?: "dexscreener" | null;
+  candidateOverrides?: Record<string, unknown>;
+}> = {}): PredictionAssetAutoDiscoveryClientResultV2 {
+  const raw = {
+    schemaVersion: 2,
+    locator: EVM_ADDRESS,
+    source: input.source === undefined ? "dexscreener" : input.source,
+    observedAt: input.observedAt ?? OBSERVED_AT,
+    usage: "informational-only",
+    status: "unique",
+    candidate: {
+      selectionKey: `evm:8453:${EVM_ADDRESS}`,
+      selection: {
+        mode: "custom",
+        sourceNetwork: "base",
+        assetLocator: EVM_ADDRESS,
+      },
+      namespace: "evm",
+      chainReference: "8453",
+      providerChainId: "base",
+      provenance: {
+        identity: { source: "onchain-rpc" },
+        enrichment: { source: "dexscreener" },
+      },
+      token: {
+        address: EVM_ADDRESS,
+        name: "Example Coin",
+        symbol: "EXAMPLE",
+      },
+      currentPriceUsd: 0.0042,
+      marketCapUsd: 4_200_000,
+      fdvUsd: 5_000_000,
+      matchingPairCount: 2,
+      pair: {
+        dexId: "uniswap",
+        pairAddress: OTHER_EVM_ADDRESS,
+        matchedSide: "base",
+        liquidityUsd: 120_000,
+        volume24hUsd: 75_000,
+        pairCreatedAt: Date.parse("2026-08-21T18:00:00.000Z"),
+      },
+      links: {
+        imageUrl:
+          `https://cdn.dexscreener.com/cms/images/${DEXSCREENER_IMAGE_ID}`,
+        websites: [{ label: "Website", url: "https://token.example.com" }],
+        socials: [
+          { type: "twitter", url: "https://twitter.com/example?s=20" },
+          { type: "telegram", url: "https://telegram.me/example?ref=provider" },
+        ],
+      },
+      ...input.candidateOverrides,
+    },
+  };
+  const parsed = parsePredictionAssetAutoDiscoveryV2(raw, EVM_ADDRESS);
+  if (!parsed) throw new Error("expected parsed discovery envelope");
+  return parsed;
+}
+
+function review(metric: "price" | "market-cap" = "price") {
+  const creationSnapshot = {
+    settlementChainId: PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+    capturedAtUtc: CREATION_UTC,
+    snapshotReference: "eip155:4663:block:9100000",
+    evidenceDigest: `0x${"11".repeat(32)}`,
+    verificationStatus: "verified",
+  } as const;
+  const supplySnapshot = metric === "market-cap"
+    ? {
+      sourceNetwork: "base" as const,
+      address: EVM_ADDRESS,
+      fixedSupplyAtoms: "1000000000000000000000000000",
+      tokenDecimals: 18,
+      capturedAtUtc: CREATION_UTC,
+      snapshotReference: "eip155:8453:block:34900000",
+      evidenceDigest: `0x${"31".repeat(32)}`,
+      verificationStatus: "verified" as const,
+      supplyDefinition: "fixed-supply-fully-circulating" as const,
+    }
+    : null;
+  const result = buildPredictionV2CreateReview({
+    identity: { sourceNetwork: "base", address: EVM_ADDRESS },
+    name: "Example Coin",
+    symbol: "EXAMPLE",
+    referenceSupplySnapshot: supplySnapshot,
+  }, {
+    metric,
+    template: "target",
+    targetUsd: metric === "price" ? "0.015" : "10000000",
+    observationUtc: OBSERVATION_UTC,
+    creationSnapshot,
+    priceDecimals: PREDICTION_V2_PROTOCOL_PRICE_DECIMALS,
+  });
+  if (!result.ok) throw new Error("expected valid create review");
+  return result.review;
+}
+
+function percentageMarketCapReview() {
+  const creationSnapshot = {
+    settlementChainId: PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+    capturedAtUtc: CREATION_UTC,
+    snapshotReference: "eip155:4663:block:9100000",
+    evidenceDigest: `0x${"11".repeat(32)}`,
+    verificationStatus: "verified",
+  } as const;
+  const supplySnapshot = {
+    sourceNetwork: "base" as const,
+    address: EVM_ADDRESS,
+    fixedSupplyAtoms: "1000000000000000000000000000",
+    tokenDecimals: 18,
+    capturedAtUtc: CREATION_UTC,
+    snapshotReference: "eip155:8453:block:34900000",
+    evidenceDigest: `0x${"31".repeat(32)}`,
+    verificationStatus: "verified" as const,
+    supplyDefinition: "fixed-supply-fully-circulating" as const,
+  };
+  const result = buildPredictionV2CreateReview({
+    identity: { sourceNetwork: "base", address: EVM_ADDRESS },
+    name: "Example Coin",
+    symbol: "EXAMPLE",
+    referenceSupplySnapshot: supplySnapshot,
+  }, {
+    metric: "market-cap",
+    template: "percent-change",
+    percentChange: "25",
+    referenceMetricSnapshot: {
+      metric: "market-cap",
+      valueUsd: "10000000",
+      sourceNetwork: "base",
+      address: EVM_ADDRESS,
+      capturedAtUtc: CREATION_UTC,
+      snapshotReference: "eip155:8453:block:34900000",
+      evidenceDigest: `0x${"32".repeat(32)}`,
+      verificationStatus: "verified",
+    },
+    observationUtc: OBSERVATION_UTC,
+    creationSnapshot,
+    priceDecimals: PREDICTION_V2_PROTOCOL_PRICE_DECIMALS,
+  });
+  if (!result.ok) throw new Error("expected valid percentage review");
+  return result.review;
+}
+
+function economicBinding(
+  createReview: PredictionV2CreateReview,
+  overrides: Partial<PredictionMarketEconomicBindingV2> = {},
+): PredictionMarketEconomicBindingV2 {
+  const identity = predictionAssetIdentityCandidatesV2({
+    mode: "custom",
+    sourceNetwork: "base",
+    assetLocator: EVM_ADDRESS,
+  })[0];
+  if (!identity) throw new Error("expected Base identity");
+  return {
+    settlementChainId: PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+    factoryAddress: FACTORY,
+    economicKey: ECONOMIC_KEY,
+    vaultAddress: VAULT,
+    checkpointAddress: CHECKPOINT,
+    poolId: POOL_ID,
+    marketId: MARKET_ID,
+    assetIdentity: identity,
+    onchainAssetKey: predictionOnchainAssetKeyV2(identity),
+    registryRevision: "7",
+    registrySnapshotHash: SNAPSHOT_HASH,
+    resolutionPolicyHash: RESOLUTION_POLICY_HASH,
+    policyValidUntil: "1788350400",
+    snapshotAssetCapAtoms: "1000000000",
+    observationUnixSeconds: OBSERVATION_UNIX_SECONDS,
+    thresholdAtoms: createReview.protocolPredicate.strikeAtoms,
+    priceDecimals: 8,
+    observedBlockNumber: "9100020",
+    observedBlockHash: BLOCK_HASH,
+    ...overrides,
+  };
+}
+
+function recordInput(input: Readonly<{
+  discovery?: PredictionAssetAutoDiscoveryClientResultV2;
+  review?: PredictionV2CreateReview;
+  economicOverrides?: Partial<PredictionMarketEconomicBindingV2>;
+  artwork?: PredictionMarketOwnedArtworkV2;
+  sequence?: string;
+  previousHash?: `sha256:${string}` | null;
+}> = {}): BuildPredictionMarketPresentationRecordV2Input {
+  const createReview = input.review ?? review();
+  return {
+    discovery: input.discovery ?? discovery(),
+    candidateSelectionKey: `evm:8453:${EVM_ADDRESS}`,
+    review: createReview,
+    economicBinding: economicBinding(createReview, input.economicOverrides),
+    revision: {
+      sequence: input.sequence ?? "1",
+      previousPresentationRevisionHash: input.previousHash ?? null,
+    },
+    artwork: input.artwork ?? predictionMarketBundledFallbackArtworkV2(
+      "base",
+      EVM_ADDRESS,
+    ),
+  };
+}
+
+describe("Prediction V2 append-only presentation record", () => {
+  it("binds a stable market key only to canonical onchain economic identity", () => {
+    const record = buildPredictionMarketPresentationRecordV2(recordInput());
+
+    expect(record).toMatchObject({
+      schemaVersion: 2,
+      recordKind: "prediction-market-presentation",
+      storageModel: "append-only-revision",
+      revision: {
+        sequence: "1",
+        previousPresentationRevisionHash: null,
+      },
+      marketKey: `eip155:4663:${FACTORY}:${ECONOMIC_KEY}`,
+      onchain: {
+        economicKey: ECONOMIC_KEY,
+        vaultAddress: VAULT,
+        checkpointAddress: CHECKPOINT,
+        poolId: POOL_ID,
+        marketId: MARKET_ID,
+        resolutionPolicyHash: RESOLUTION_POLICY_HASH,
+        policyValidUntil: "1788350400",
+        snapshotAssetCapAtoms: "1000000000",
+        observationUnixSeconds: OBSERVATION_UNIX_SECONDS,
+        thresholdAtoms: "1500000",
+      },
+      asset: {
+        selectionKey: `evm:8453:${EVM_ADDRESS}`,
+        sourceNetwork: "base",
+        address: EVM_ADDRESS,
+        name: "Example Coin",
+        symbol: "EXAMPLE",
+      },
+      condition: {
+        kind: "usd-price-at-utc",
+        metric: "usd-price",
+        comparator: "greater-than-or-equal",
+        strikeUsd: "0.015",
+        strikeAtoms: "1500000",
+        observationUtc: OBSERVATION_UTC,
+      },
+      provider: {
+        id: "dexscreener",
+        observedAt: OBSERVED_AT,
+        imageAssetId: DEXSCREENER_IMAGE_ID,
+      },
+      display: {
+        usage: "display-only",
+        artwork: { kind: "bundled-fallback" },
+      },
+      presentationRevisionHash: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+    });
+    expect(record?.creationIntent).toBeNull();
+    expect(parsePredictionMarketPresentationRecordV2(record)).toEqual(record);
+    expect(JSON.stringify(record)).not.toContain("sourceLogoUrl");
+    expect(JSON.stringify(record)).not.toContain("currentPriceUsd");
+    expect(Object.isFrozen(record)).toBe(true);
+  });
+
+  it("changes the revision hash, but not marketKey, when display provenance changes", () => {
+    const first = buildPredictionMarketPresentationRecordV2(recordInput());
+    const second = buildPredictionMarketPresentationRecordV2(recordInput({
+      discovery: discovery({ observedAt: "2026-08-23T18:05:00.000Z" }),
+    }));
+
+    expect(first?.marketKey).toBe(second?.marketKey);
+    expect(first?.presentationRevisionHash).not.toBe(
+      second?.presentationRevisionHash,
+    );
+  });
+
+  it("ignores provider economics in both marketKey and presentation revision", () => {
+    const first = buildPredictionMarketPresentationRecordV2(recordInput());
+    const changed = buildPredictionMarketPresentationRecordV2(recordInput({
+      discovery: discovery({
+        candidateOverrides: {
+          currentPriceUsd: 999_999,
+          marketCapUsd: null,
+          fdvUsd: 1,
+        },
+      }),
+    }));
+
+    expect(changed).toEqual(first);
+  });
+
+  it("takes observedAt only from the candidate's parsed discovery envelope", () => {
+    const input = recordInput();
+    expect(input).not.toHaveProperty("observedAt");
+    expect(buildPredictionMarketPresentationRecordV2({
+      ...input,
+      candidateSelectionKey: `evm:1:${EVM_ADDRESS}`,
+    })).toBeNull();
+    expect(buildPredictionMarketPresentationRecordV2({
+      ...input,
+      discovery: {
+        ...input.discovery,
+        observedAt: "2026-08-23T18:00:00Z",
+      },
+    })).toBeNull();
+  });
+
+  it("fails closed when economic identity, asset or predicate diverges", () => {
+    const validReview = review();
+    const wrongIdentity = predictionAssetIdentityCandidatesV2({
+      mode: "custom",
+      sourceNetwork: "ethereum",
+      assetLocator: EVM_ADDRESS,
+    })[0];
+    if (!wrongIdentity) throw new Error("expected Ethereum identity");
+
+    expect(buildPredictionMarketPresentationRecordV2(recordInput({
+      review: validReview,
+      economicOverrides: {
+        assetIdentity: wrongIdentity,
+        onchainAssetKey: predictionOnchainAssetKeyV2(wrongIdentity),
+      },
+    }))).toBeNull();
+    expect(buildPredictionMarketPresentationRecordV2(recordInput({
+      economicOverrides: { thresholdAtoms: "1500001" },
+    }))).toBeNull();
+    expect(buildPredictionMarketPresentationRecordV2(recordInput({
+      economicOverrides: { observationUnixSeconds: "1788264001" },
+    }))).toBeNull();
+    expect(buildPredictionMarketPresentationRecordV2(recordInput({
+      economicOverrides: { vaultAddress: `0x${"0".repeat(40)}` },
+    }))).toBeNull();
+    expect(buildPredictionMarketPresentationRecordV2(recordInput({
+      economicOverrides: {
+        resolutionPolicyHash: `0x${"0".repeat(64)}`,
+      },
+    }))).toBeNull();
+    expect(buildPredictionMarketPresentationRecordV2(recordInput({
+      economicOverrides: { policyValidUntil: "1788263999" },
+    }))).toBeNull();
+  });
+
+  it("keeps market cap only as an explicit secondary creation intent", () => {
+    const marketCapReview = review("market-cap");
+    const record = buildPredictionMarketPresentationRecordV2(recordInput({
+      review: marketCapReview,
+    }));
+
+    expect(record?.condition).toMatchObject({
+      metric: "usd-price",
+      strikeUsd: "0.01",
+      strikeAtoms: "1000000",
+    });
+    expect(record?.creationIntent).toEqual({
+      kind: "market-cap-equivalent",
+      settlementRole: "secondary-non-settlement",
+      comparator: "greater-than-or-equal",
+      targetUsd: "10000000",
+      template: "target",
+      percentChange: null,
+      equivalentPriceStrikeUsd: "0.01",
+      evidence: {
+        creationSnapshot: marketCapReview.creationSnapshot,
+        referenceSupplySnapshot: marketCapReview.referenceSupplySnapshot,
+        referenceMetricSnapshot: null,
+      },
+    });
+  });
+
+  it("recomputes a percent market-cap intent from immutable baseline and supply evidence", () => {
+    const marketCapReview = percentageMarketCapReview();
+    const record = buildPredictionMarketPresentationRecordV2(recordInput({
+      review: marketCapReview,
+    }));
+
+    expect(record?.condition).toMatchObject({
+      metric: "usd-price",
+      strikeUsd: "0.0125",
+      strikeAtoms: "1250000",
+    });
+    expect(record?.creationIntent).toMatchObject({
+      targetUsd: "12500000",
+      template: "percent-change",
+      percentChange: "25",
+      equivalentPriceStrikeUsd: "0.0125",
+      evidence: {
+        referenceMetricSnapshot: {
+          metric: "market-cap",
+          valueUsd: "10000000",
+          snapshotReference: "eip155:8453:block:34900000",
+          evidenceDigest: `0x${"32".repeat(32)}`,
+        },
+        referenceSupplySnapshot: {
+          snapshotReference: "eip155:8453:block:34900000",
+          evidenceDigest: `0x${"31".repeat(32)}`,
+        },
+      },
+    });
+    expect(parsePredictionMarketPresentationRecordV2(record)).toEqual(record);
+  });
+
+  it("accepts only owned content-addressed artwork or exact bundled bytes", () => {
+    const ownedArtwork = {
+      kind: "owned-provider-snapshot",
+      url: `/media/prediction/sha256-${OWNED_ARTWORK_DIGEST}.webp`,
+      digest: `sha256:${OWNED_ARTWORK_DIGEST}`,
+      contentType: "image/webp",
+      sourceAssetId: DEXSCREENER_IMAGE_ID,
+    } as const satisfies PredictionMarketOwnedArtworkV2;
+    expect(buildPredictionMarketPresentationRecordV2(recordInput({
+      artwork: ownedArtwork,
+    }))?.display.artwork).toEqual(ownedArtwork);
+
+    for (const artwork of [
+      { ...ownedArtwork, url: `/api/prediction/asset-logo/${DEXSCREENER_IMAGE_ID}` },
+      { ...ownedArtwork, digest: `sha256:${"27".repeat(32)}` },
+      { ...ownedArtwork, sourceAssetId: "28".repeat(32) },
+    ] as PredictionMarketOwnedArtworkV2[]) {
+      expect(buildPredictionMarketPresentationRecordV2(recordInput({
+        artwork,
+      }))).toBeNull();
+    }
+  });
+
+  it("binds every bundled fallback digest to the checked-in artwork bytes", async () => {
+    const artworks = new Map<string, PredictionMarketOwnedArtworkV2>();
+    for (let index = 1; index <= 256 && artworks.size < 6; index += 1) {
+      const address = `0x${index.toString(16).padStart(40, "0")}`;
+      const artwork = predictionMarketBundledFallbackArtworkV2("base", address);
+      artworks.set(artwork.url, artwork);
+    }
+    expect(artworks.size).toBe(6);
+    for (const artwork of artworks.values()) {
+      const bytes = await readFile(path.join(
+        process.cwd(),
+        "public",
+        artwork.url.slice(1),
+      ));
+      expect(`sha256:${createHash("sha256").update(bytes).digest("hex")}`)
+        .toBe(artwork.digest);
+    }
+  });
+
+  it("enforces append-only revision linkage shape without pretending to persist it", () => {
+    const priorHash = `sha256:${"29".repeat(32)}` as const;
+    expect(buildPredictionMarketPresentationRecordV2(recordInput({
+      sequence: "2",
+      previousHash: priorHash,
+    }))?.revision).toEqual({
+      sequence: "2",
+      previousPresentationRevisionHash: priorHash,
+    });
+    expect(buildPredictionMarketPresentationRecordV2(recordInput({
+      sequence: "2",
+    }))).toBeNull();
+    expect(buildPredictionMarketPresentationRecordV2(recordInput({
+      previousHash: priorHash,
+    }))).toBeNull();
+  });
+
+  it("rejects a mutated persisted record whose revision hash no longer matches", () => {
+    const record = buildPredictionMarketPresentationRecordV2(recordInput());
+    if (!record) throw new Error("expected presentation record");
+    expect(parsePredictionMarketPresentationRecordV2({
+      ...record,
+      asset: { ...record.asset, name: "Forged Coin" },
+    })).toBeNull();
+    expect(parsePredictionMarketPresentationRecordV2({
+      ...record,
+      marketKey: record.marketKey.replace(ECONOMIC_KEY, MARKET_ID),
+    })).toBeNull();
+  });
+
+  it("fails closed on identity-only discovery without inventing display identity", () => {
+    const record = buildPredictionMarketPresentationRecordV2(recordInput({
+      discovery: discovery({
+        source: null,
+        candidateOverrides: {
+          provenance: {
+            identity: { source: "onchain-rpc" },
+            enrichment: null,
+          },
+          token: {
+            address: EVM_ADDRESS,
+            name: null,
+            symbol: null,
+          },
+          currentPriceUsd: null,
+          marketCapUsd: null,
+          fdvUsd: null,
+          matchingPairCount: 0,
+          pair: null,
+          links: {
+            imageUrl: null,
+            websites: [],
+            socials: [],
+          },
+        },
+      }),
+    }));
+    expect(record).toBeNull();
+  });
+
+  it("rejects rehashed market-cap intent mutations that evidence cannot reproduce", () => {
+    const source = buildPredictionMarketPresentationRecordV2(recordInput({
+      review: review("market-cap"),
+    }));
+    if (!source?.creationIntent) throw new Error("expected market-cap intent");
+    const { presentationRevisionHash: _priorHash, ...unsigned } = source;
+    expect(_priorHash).toMatch(/^sha256:[0-9a-f]{64}$/u);
+    const changedTarget = {
+      ...unsigned,
+      creationIntent: {
+        ...source.creationIntent,
+        targetUsd: "20000000",
+      },
+    };
+    expect(parsePredictionMarketPresentationRecordV2({
+      ...changedTarget,
+      presentationRevisionHash:
+        predictionMarketPresentationRevisionHashV2(changedTarget),
+    })).toBeNull();
+
+    const changedSupply = {
+      ...unsigned,
+      creationIntent: {
+        ...source.creationIntent,
+        evidence: {
+          ...source.creationIntent.evidence,
+          referenceSupplySnapshot: {
+            ...source.creationIntent.evidence.referenceSupplySnapshot,
+            fixedSupplyAtoms: "2000000000000000000000000000",
+          },
+        },
+      },
+    };
+    expect(parsePredictionMarketPresentationRecordV2({
+      ...changedSupply,
+      presentationRevisionHash:
+        predictionMarketPresentationRevisionHashV2(changedSupply),
+    })).toBeNull();
+
+    const percentSource = buildPredictionMarketPresentationRecordV2(recordInput({
+      review: percentageMarketCapReview(),
+    }));
+    if (!percentSource?.creationIntent) {
+      throw new Error("expected percentage market-cap intent");
+    }
+    const { presentationRevisionHash: _percentHash, ...percentUnsigned } =
+      percentSource;
+    expect(_percentHash).toMatch(/^sha256:[0-9a-f]{64}$/u);
+    const changedPercent = {
+      ...percentUnsigned,
+      creationIntent: {
+        ...percentSource.creationIntent,
+        percentChange: "50",
+      },
+    };
+    expect(parsePredictionMarketPresentationRecordV2({
+      ...changedPercent,
+      presentationRevisionHash:
+        predictionMarketPresentationRevisionHashV2(changedPercent),
+    })).toBeNull();
+  });
+});

--- a/tests/prediction-v2-public-market-view.test.ts
+++ b/tests/prediction-v2-public-market-view.test.ts
@@ -1,0 +1,359 @@
+import { privateKeyToAccount } from "viem/accounts";
+import { describe, expect, it } from "vitest";
+
+import {
+  predictionAssetIdentityCandidatesV2,
+  predictionOnchainAssetKeyV2,
+} from "../lib/prediction-market-assets-v2";
+import { parsePredictionAssetAutoDiscoveryV2 } from
+  "../lib/prediction-v2/asset-auto-discovery-v2";
+import {
+  PREDICTION_V2_PROTOCOL_PRICE_DECIMALS,
+  PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+  buildPredictionV2CreateReview,
+} from "../lib/prediction-v2/create-flow-v2";
+import {
+  buildPredictionMarketPresentationRecordV2,
+  parsePredictionMarketPresentationRecordV2,
+  predictionMarketBundledFallbackArtworkV2,
+  predictionMarketPresentationRevisionHashV2,
+} from "../lib/prediction-v2/market-presentation-v2";
+import {
+  PREDICTION_MARKET_PROJECTION_ATTESTATION_SCHEME_V2,
+  PREDICTION_MARKET_PROJECTION_CONTEXT_KIND_V2,
+  parsePredictionMarketAttestedProjectionContextV2,
+  predictionMarketProjectionAttestationMessageV2,
+  publicPredictionMarketViewV2FromAttestedProjection,
+  type PredictionMarketCanonicalReleaseV2,
+  type UnsignedPredictionMarketAttestedProjectionContextV2,
+} from "../lib/prediction-v2/public-market-view-v2";
+
+const ADDRESS = `0x${"ab".repeat(20)}`;
+const PAIR = `0x${"ef".repeat(20)}`;
+const FACTORY = `0x${"12".repeat(20)}`;
+const FACTORY_RUNTIME_CODE_HASH = `0x${"41".repeat(32)}` as const;
+const ATTESTOR = privateKeyToAccount(`0x${"42".repeat(32)}`);
+const ATTACKER = privateKeyToAccount(`0x${"43".repeat(32)}`);
+
+const CANONICAL_RELEASE = Object.freeze({
+  schemaVersion: 2,
+  releaseId: "prediction-v2.release-1",
+  settlementChainId: PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+  factoryAddress: FACTORY,
+  factoryRuntimeCodeHash: FACTORY_RUNTIME_CODE_HASH,
+  projectionAttestorAddress: ATTESTOR.address.toLowerCase(),
+} as const satisfies PredictionMarketCanonicalReleaseV2);
+
+function record() {
+  const observedAt = "2026-08-23T18:00:00.000Z";
+  const discovery = parsePredictionAssetAutoDiscoveryV2({
+    schemaVersion: 2,
+    locator: ADDRESS,
+    source: "dexscreener",
+    observedAt,
+    usage: "informational-only",
+    status: "unique",
+    candidate: {
+      selectionKey: `evm:8453:${ADDRESS}`,
+      selection: { mode: "custom", sourceNetwork: "base", assetLocator: ADDRESS },
+      namespace: "evm",
+      chainReference: "8453",
+      providerChainId: "base",
+      provenance: {
+        identity: { source: "onchain-rpc" },
+        enrichment: { source: "dexscreener" },
+      },
+      token: { address: ADDRESS, name: "Example Coin", symbol: "EXAMPLE" },
+      currentPriceUsd: 0.01,
+      marketCapUsd: 10_000_000,
+      fdvUsd: 10_000_000,
+      matchingPairCount: 1,
+      pair: {
+        dexId: "uniswap",
+        pairAddress: PAIR,
+        matchedSide: "base",
+        liquidityUsd: 100_000,
+        volume24hUsd: 50_000,
+        pairCreatedAt: Date.parse("2026-08-20T18:00:00.000Z"),
+      },
+      links: {
+        imageUrl: null,
+        websites: [{ label: "Website", url: "https://token.example.com" }],
+        socials: [],
+      },
+    },
+  }, ADDRESS);
+  if (!discovery) throw new Error("expected discovery");
+  const creationSnapshot = {
+    settlementChainId: PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+    capturedAtUtc: "2026-08-23T12:00:00Z",
+    snapshotReference: "eip155:4663:block:9100000",
+    evidenceDigest: `0x${"11".repeat(32)}`,
+    verificationStatus: "verified",
+  } as const;
+  const reviewed = buildPredictionV2CreateReview({
+    identity: { sourceNetwork: "base", address: ADDRESS },
+    name: "Example Coin",
+    symbol: "EXAMPLE",
+    referenceSupplySnapshot: null,
+  }, {
+    metric: "price",
+    template: "target",
+    targetUsd: "0.015",
+    observationUtc: "2026-09-01T12:00:00Z",
+    creationSnapshot,
+    priceDecimals: PREDICTION_V2_PROTOCOL_PRICE_DECIMALS,
+  });
+  if (!reviewed.ok) throw new Error("expected review");
+  const identity = predictionAssetIdentityCandidatesV2({
+    mode: "custom",
+    sourceNetwork: "base",
+    assetLocator: ADDRESS,
+  })[0];
+  if (!identity) throw new Error("expected identity");
+  return buildPredictionMarketPresentationRecordV2({
+    discovery,
+    candidateSelectionKey: `evm:8453:${ADDRESS}`,
+    review: reviewed.review,
+    economicBinding: {
+      settlementChainId: PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+      factoryAddress: FACTORY,
+      economicKey: `0x${"21".repeat(32)}`,
+      vaultAddress: `0x${"13".repeat(20)}`,
+      checkpointAddress: `0x${"14".repeat(20)}`,
+      poolId: `0x${"27".repeat(32)}`,
+      marketId: `0x${"22".repeat(32)}`,
+      assetIdentity: identity,
+      onchainAssetKey: predictionOnchainAssetKeyV2(identity),
+      registryRevision: "7",
+      registrySnapshotHash: `0x${"23".repeat(32)}`,
+      resolutionPolicyHash: `0x${"28".repeat(32)}`,
+      policyValidUntil: "1788350400",
+      snapshotAssetCapAtoms: "1000000000",
+      observationUnixSeconds: "1788264000",
+      thresholdAtoms: "1500000",
+      priceDecimals: 8,
+      observedBlockNumber: "9100020",
+      observedBlockHash: `0x${"24".repeat(32)}`,
+    },
+    revision: { sequence: "1", previousPresentationRevisionHash: null },
+    artwork: predictionMarketBundledFallbackArtworkV2("base", ADDRESS),
+  });
+}
+
+function unsignedProjection(
+  source: NonNullable<ReturnType<typeof record>>,
+): UnsignedPredictionMarketAttestedProjectionContextV2 {
+  return {
+    schemaVersion: 2,
+    contextKind: PREDICTION_MARKET_PROJECTION_CONTEXT_KIND_V2,
+    releaseId: CANONICAL_RELEASE.releaseId,
+    settlementChainId: PREDICTION_V2_SETTLEMENT_CHAIN_ID,
+    factoryAddress: FACTORY,
+    factoryRuntimeCodeHash: FACTORY_RUNTIME_CODE_HASH,
+    presentationRevisionHash: source.presentationRevisionHash,
+    readMarket: {
+      marketKey: source.marketKey,
+      economicKey: source.onchain.economicKey,
+      vaultAddress: source.onchain.vaultAddress,
+      checkpointAddress: source.onchain.checkpointAddress,
+      poolId: source.onchain.poolId,
+      marketId: source.onchain.marketId,
+      onchainAssetKey: source.onchain.onchainAssetKey,
+      registryRevision: source.onchain.registryRevision,
+      registrySnapshotHash: source.onchain.registrySnapshotHash,
+      resolutionPolicyHash: source.onchain.resolutionPolicyHash,
+      policyValidUntil: source.onchain.policyValidUntil,
+      snapshotAssetCapAtoms: source.onchain.snapshotAssetCapAtoms,
+      observationUnixSeconds: source.onchain.observationUnixSeconds,
+      thresholdAtoms: source.onchain.thresholdAtoms,
+      priceDecimals: source.onchain.priceDecimals,
+    },
+    confirmedBlock: {
+      number: source.onchain.observedBlockNumber,
+      hash: source.onchain.observedBlockHash,
+    },
+  };
+}
+
+async function signProjection(
+  unsigned: UnsignedPredictionMarketAttestedProjectionContextV2,
+  signer = ATTESTOR,
+) {
+  const message = predictionMarketProjectionAttestationMessageV2(unsigned);
+  if (!message) throw new Error("expected canonical attestation message");
+  return {
+    ...unsigned,
+    attestation: {
+      scheme: PREDICTION_MARKET_PROJECTION_ATTESTATION_SCHEME_V2,
+      signerAddress: signer.address.toLowerCase(),
+      signature: await signer.signMessage({ message }),
+    },
+  } as const;
+}
+
+describe("Public Prediction V2 market view", () => {
+  it("projects a card-safe DTO only from a release-pinned attested read", async () => {
+    const source = record();
+    if (!source) throw new Error("expected record");
+    const context = await signProjection(unsignedProjection(source));
+    const view = await publicPredictionMarketViewV2FromAttestedProjection(
+      source,
+      context,
+      CANONICAL_RELEASE,
+    );
+
+    expect(view).toMatchObject({
+      schemaVersion: 2,
+      marketKey: source.marketKey,
+      marketId: `0x${"22".repeat(32)}`,
+      asset: {
+        sourceNetwork: "base",
+        name: "Example Coin",
+        symbol: "EXAMPLE",
+      },
+      condition: {
+        metric: "usd-price",
+        strikeUsd: "0.015",
+      },
+      presentation: {
+        revision: "1",
+        revisionHash: source.presentationRevisionHash,
+        observedAt: "2026-08-23T18:00:00.000Z",
+      },
+      attestedProjection: {
+        releaseId: CANONICAL_RELEASE.releaseId,
+        settlementChainId: "4663",
+        factoryAddress: FACTORY,
+        factoryRuntimeCodeHash: FACTORY_RUNTIME_CODE_HASH,
+        confirmedBlockNumber: "9100020",
+        confirmedBlockHash: `0x${"24".repeat(32)}`,
+        attestorAddress: ATTESTOR.address.toLowerCase(),
+      },
+    });
+    expect(JSON.stringify(view)).not.toContain("providerChainId");
+    expect(JSON.stringify(view)).not.toContain("imageAssetId");
+    expect(JSON.stringify(view)).not.toContain("sourceLogoUrl");
+    expect(Object.isFrozen(view)).toBe(true);
+    expect(Object.isFrozen(view?.attestedProjection)).toBe(true);
+  });
+
+  it("treats a stored record parser as integrity-only", async () => {
+    const source = record();
+    if (!source) throw new Error("expected record");
+    expect(parsePredictionMarketPresentationRecordV2(source)).toEqual(source);
+    expect(await publicPredictionMarketViewV2FromAttestedProjection(
+      source,
+      null,
+      CANONICAL_RELEASE,
+    )).toBeNull();
+    expect(await publicPredictionMarketViewV2FromAttestedProjection(
+      source,
+      await signProjection(unsignedProjection(source)),
+      { ...CANONICAL_RELEASE, status: "enabled" },
+    )).toBeNull();
+  });
+
+  it("rejects a forged-but-rehashed presentation revision", async () => {
+    const source = record();
+    if (!source) throw new Error("expected record");
+    const context = await signProjection(unsignedProjection(source));
+    const { presentationRevisionHash: _oldHash, ...unsigned } = source;
+    expect(_oldHash).toBe(source.presentationRevisionHash);
+    const forgedUnsigned = {
+      ...unsigned,
+      asset: { ...source.asset, name: "Forged Coin" },
+    };
+    const forged = {
+      ...forgedUnsigned,
+      presentationRevisionHash:
+        predictionMarketPresentationRevisionHashV2(forgedUnsigned),
+    };
+    expect(parsePredictionMarketPresentationRecordV2(forged)).not.toBeNull();
+    expect(await publicPredictionMarketViewV2FromAttestedProjection(
+      forged,
+      context,
+      CANONICAL_RELEASE,
+    )).toBeNull();
+
+    const forgedContext = await signProjection({
+      ...unsignedProjection(source),
+      presentationRevisionHash: forged.presentationRevisionHash,
+    }, ATTACKER);
+    expect(await publicPredictionMarketViewV2FromAttestedProjection(
+      forged,
+      forgedContext,
+      CANONICAL_RELEASE,
+    )).toBeNull();
+  });
+
+  it("cross-checks the exact Factory read and confirmed block", async () => {
+    const source = record();
+    if (!source) throw new Error("expected record");
+    const wrongBlock = await signProjection({
+      ...unsignedProjection(source),
+      confirmedBlock: {
+        number: "9100021",
+        hash: `0x${"25".repeat(32)}`,
+      },
+    });
+    expect(await parsePredictionMarketAttestedProjectionContextV2(
+      wrongBlock,
+      CANONICAL_RELEASE,
+    )).not.toBeNull();
+    expect(await publicPredictionMarketViewV2FromAttestedProjection(
+      source,
+      wrongBlock,
+      CANONICAL_RELEASE,
+    )).toBeNull();
+
+    const wrongMarket = await signProjection({
+      ...unsignedProjection(source),
+      readMarket: {
+        ...unsignedProjection(source).readMarket,
+        marketId: `0x${"26".repeat(32)}`,
+      },
+    });
+    expect(await publicPredictionMarketViewV2FromAttestedProjection(
+      source,
+      wrongMarket,
+      CANONICAL_RELEASE,
+    )).toBeNull();
+
+    const wrongFactoryRecord = await signProjection({
+      ...unsignedProjection(source),
+      readMarket: {
+        ...unsignedProjection(source).readMarket,
+        vaultAddress: `0x${"15".repeat(20)}`,
+        resolutionPolicyHash: `0x${"29".repeat(32)}`,
+      },
+    });
+    expect(await publicPredictionMarketViewV2FromAttestedProjection(
+      source,
+      wrongFactoryRecord,
+      CANONICAL_RELEASE,
+    )).toBeNull();
+  });
+
+  it("rejects a valid signature outside the pinned release or factory", async () => {
+    const source = record();
+    if (!source) throw new Error("expected record");
+    const context = await signProjection(unsignedProjection(source));
+    expect(await publicPredictionMarketViewV2FromAttestedProjection(
+      source,
+      context,
+      {
+        ...CANONICAL_RELEASE,
+        releaseId: "prediction-v2.release-2",
+      },
+    )).toBeNull();
+    expect(await publicPredictionMarketViewV2FromAttestedProjection(
+      source,
+      context,
+      {
+        ...CANONICAL_RELEASE,
+        factoryAddress: `0x${"13".repeat(20)}`,
+      },
+    )).toBeNull();
+  });
+});

--- a/tests/prediction-v2-read-model.test.ts
+++ b/tests/prediction-v2-read-model.test.ts
@@ -1,0 +1,844 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  decodeFunctionData,
+  encodeFunctionResult,
+  getAddress,
+  stringToHex,
+  toHex,
+  type Abi,
+  type Address,
+  type Hex,
+} from "viem";
+
+import {
+  PREDICTION_PRESET_ASSETS_V2,
+  predictionOnchainAssetKeyV2,
+  type PredictionBytes32V2,
+} from "../lib/prediction-market-assets-v2";
+import {
+  PREDICTION_V2_ASSET_REGISTRY_ABI,
+  PREDICTION_V2_CHECKPOINT_ABI,
+  PREDICTION_V2_FACTORY_ABI,
+  PREDICTION_V2_POOL_MANAGER_STATE_ABI,
+  PREDICTION_V2_VAULT_ABI,
+  type PredictionV2OraclePolicy,
+  type PredictionV2PoolKey,
+  type PredictionV2RegistrySnapshot,
+} from "../lib/prediction-v2/abi";
+import {
+  predictionV2PoolId,
+} from "../lib/prediction-v2/accounting";
+import {
+  predictionV2RegistrySnapshotHash,
+} from "../lib/prediction-v2/codec";
+import {
+  PREDICTION_V2_EXECUTION_ROUTER_READ_ABI,
+  PREDICTION_V2_FACTORY_CANONICAL_READ_ABI,
+  PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI,
+  predictionV2PageIndices,
+  readPredictionV2Directory,
+  type PredictionV2ReadBinding,
+  type PredictionV2ReadCall,
+  type PredictionV2RpcReader,
+  type PredictionV2SafeBlock,
+} from "../lib/prediction-v2/read-model-v2.server";
+
+const address = (suffix: number) =>
+  getAddress(`0x${suffix.toString(16).padStart(40, "0")}`) as Address;
+const bytes32 = (value: bigint | number) =>
+  toHex(BigInt(value), { size: 32 }) as PredictionBytes32V2;
+
+const FACTORY = address(1);
+const REGISTRY = address(2);
+const POOL_MANAGER = address(3);
+const HOOK = address(4);
+const COLLATERAL = address(5);
+const ROUTER = address(6);
+const VAULT = address(7);
+const CHECKPOINT = address(8);
+const YES_TOKEN = address(9);
+const NO_TOKEN = address(10);
+const CHECKPOINT_ADAPTER = address(11);
+const FEED = address(12);
+const AGGREGATOR = address(13);
+
+const ECONOMIC_KEY = bytes32(101);
+const OTHER_ECONOMIC_KEY = bytes32(102);
+const MARKET_ID = bytes32(103);
+const POLICY_VALID_UNTIL = 5_000n;
+const ASSET_CAP = 20_000_000n;
+const THRESHOLD = 100_000_000n;
+const OBSERVATION_TIME = 2_000n;
+const BLOCK = Object.freeze({
+  number: 100n,
+  hash: bytes32(201),
+  parentHash: bytes32(200),
+  timestamp: 1_000n,
+}) satisfies PredictionV2SafeBlock;
+
+const binding = Object.freeze({
+  factory: FACTORY,
+  assetRegistry: REGISTRY,
+  poolManager: POOL_MANAGER,
+  hook: HOOK,
+  collateral: COLLATERAL,
+  router: ROUTER,
+  deploymentBlock: 50n,
+}) satisfies PredictionV2ReadBinding;
+
+const policy = Object.freeze({
+  checkpointKind: bytes32(301),
+  checkpointAdapter: CHECKPOINT_ADAPTER,
+  checkpointAdapterCodehash: bytes32(302),
+  feedId: bytes32(0),
+  feedAddress: FEED,
+  feedProxyCodehash: bytes32(303),
+  feedPhaseId: 1,
+  feedAggregator: AGGREGATOR,
+  feedAggregatorCodehash: bytes32(304),
+  feedDescriptionHash: bytes32(305),
+  feedDecimals: 8,
+  quoteCurrency: stringToHex("USD", { size: 32 }) as PredictionBytes32V2,
+  assetEvidenceHash: bytes32(306),
+  maxOpenInterestAtoms: ASSET_CAP,
+  validUntil: POLICY_VALID_UNTIL,
+  policyVersion: 1,
+  active: true,
+}) satisfies PredictionV2OraclePolicy;
+
+const snapshot = Object.freeze({
+  assetKey: predictionOnchainAssetKeyV2(PREDICTION_PRESET_ASSETS_V2[0].identity),
+  revision: 1n,
+  identity: PREDICTION_PRESET_ASSETS_V2[0].identity,
+  displaySymbol: "BTC",
+  policy,
+}) satisfies PredictionV2RegistrySnapshot;
+const SNAPSHOT_HASH = predictionV2RegistrySnapshotHash(snapshot);
+const POLICY_HASH = policy.checkpointKind;
+const poolKey = Object.freeze({
+  currency0: YES_TOKEN,
+  currency1: NO_TOKEN,
+  fee: 200,
+  tickSpacing: 10,
+  hooks: HOOK,
+}) satisfies PredictionV2PoolKey;
+const POOL_ID = predictionV2PoolId(poolKey);
+const SLOT0 = bytes32((200n << 208n) | (1n << 96n));
+const PREDICTION_V2_FACTORY_TEST_ABI = [
+  ...PREDICTION_V2_FACTORY_ABI,
+  ...PREDICTION_V2_FACTORY_CANONICAL_READ_ABI,
+] as const satisfies Abi;
+
+type FixtureOverrides = Readonly<Record<string, unknown>>;
+
+type FixtureCallProbe = {
+  active: number;
+  maximum: number;
+  delayMs: number;
+};
+
+type FixtureOptions = Readonly<{
+  readerId: string;
+  block?: PredictionV2SafeBlock;
+  chainId?: number;
+  marketCount?: bigint;
+  marketKeys?: readonly PredictionBytes32V2[];
+  blockReads?: readonly (PredictionV2SafeBlock | null)[];
+  overrides?: FixtureOverrides;
+  callProbe?: FixtureCallProbe;
+  deterministicRevert?: (request: PredictionV2ReadCall) => boolean;
+}>;
+
+function encodeResult(
+  abi: Abi,
+  functionName: string,
+  result: unknown,
+): Hex {
+  return encodeFunctionResult({
+    abi,
+    functionName: functionName as never,
+    result: result as never,
+  });
+}
+
+function decodedCall(abi: Abi, data: Hex) {
+  return decodeFunctionData({ abi, data }) as Readonly<{
+    functionName: string;
+    args?: readonly unknown[];
+  }>;
+}
+
+class FixtureReader implements PredictionV2RpcReader {
+  readonly readerId: string;
+  readonly calls: PredictionV2ReadCall[] = [];
+  readonly #block: PredictionV2SafeBlock;
+  readonly #chainId: number;
+  readonly #marketCount: bigint;
+  readonly #marketKeys: readonly PredictionBytes32V2[];
+  readonly #blockReads: readonly (PredictionV2SafeBlock | null)[];
+  readonly #overrides: FixtureOverrides;
+  readonly #callProbe?: FixtureCallProbe;
+  readonly #deterministicRevert?: (request: PredictionV2ReadCall) => boolean;
+  #blockReadIndex = 0;
+
+  constructor(options: FixtureOptions) {
+    this.readerId = options.readerId;
+    this.#block = options.block ?? BLOCK;
+    this.#chainId = options.chainId ?? 4_663;
+    this.#marketCount = options.marketCount ?? 1n;
+    this.#marketKeys = options.marketKeys ?? [ECONOMIC_KEY];
+    this.#blockReads = options.blockReads ?? [];
+    this.#overrides = options.overrides ?? {};
+    this.#callProbe = options.callProbe;
+    this.#deterministicRevert = options.deterministicRevert;
+  }
+
+  async getChainId() {
+    return this.#chainId;
+  }
+
+  async getSafeBlock() {
+    return this.#block;
+  }
+
+  async getBlock(blockNumber: bigint) {
+    const configured = this.#blockReads[this.#blockReadIndex];
+    this.#blockReadIndex += 1;
+    if (configured !== undefined) return configured;
+    return blockNumber === this.#block.number ? this.#block : null;
+  }
+
+  async call(request: PredictionV2ReadCall) {
+    this.calls.push(request);
+    const callProbe = this.#callProbe;
+    if (callProbe) {
+      callProbe.active += 1;
+      callProbe.maximum = Math.max(
+        callProbe.maximum,
+        callProbe.active,
+      );
+    }
+    try {
+      if (callProbe?.delayMs) {
+        await new Promise((resolve) => setTimeout(resolve, callProbe.delayMs));
+      }
+      if (this.#deterministicRevert?.(request)) {
+        return Object.freeze({ status: "reverted" as const, data: "0xdeadbeef" as Hex });
+      }
+      if (request.to.toLowerCase() === FACTORY.toLowerCase()) {
+        return this.#factory(request.data);
+      }
+      if (request.to.toLowerCase() === REGISTRY.toLowerCase()) {
+        return this.#registry(request.data);
+      }
+      if (request.to.toLowerCase() === VAULT.toLowerCase()) {
+        return this.#vault(request.data);
+      }
+      if (request.to.toLowerCase() === CHECKPOINT.toLowerCase()) {
+        return this.#checkpoint(request.data);
+      }
+      if (request.to.toLowerCase() === HOOK.toLowerCase()) {
+        return this.#hook(request.data);
+      }
+      if (request.to.toLowerCase() === ROUTER.toLowerCase()) {
+        return this.#router(request.data);
+      }
+      if (request.to.toLowerCase() === POOL_MANAGER.toLowerCase()) {
+        return this.#poolManager(request.data);
+      }
+      throw new Error("unexpected fixture target");
+    } finally {
+      if (callProbe) callProbe.active -= 1;
+    }
+  }
+
+  #value(key: string, fallback: unknown) {
+    return Object.hasOwn(this.#overrides, key) ? this.#overrides[key] : fallback;
+  }
+
+  #factory(data: Hex) {
+    const call = decodedCall(PREDICTION_V2_FACTORY_TEST_ABI, data);
+    switch (call.functionName) {
+      case "assetRegistry":
+        return encodeResult(PREDICTION_V2_FACTORY_ABI, call.functionName,
+          this.#value("factory.assetRegistry", REGISTRY));
+      case "manager":
+        return encodeResult(PREDICTION_V2_FACTORY_ABI, call.functionName,
+          this.#value("factory.manager", POOL_MANAGER));
+      case "marketCount":
+        return encodeResult(PREDICTION_V2_FACTORY_ABI, call.functionName,
+          this.#marketCount);
+      case "marketKeyAt": {
+        const index = Number(call.args?.[0]);
+        const key = this.#marketKeys[index];
+        if (!key) throw new Error("fixture market index is missing");
+        return encodeResult(PREDICTION_V2_FACTORY_ABI, call.functionName, key);
+      }
+      case "markets":
+        return encodeResult(PREDICTION_V2_FACTORY_ABI, call.functionName, [
+          this.#value("factory.vault", VAULT),
+          this.#value("factory.checkpoint", CHECKPOINT),
+          this.#value("factory.poolId", POOL_ID),
+          this.#value("factory.marketId", MARKET_ID),
+          this.#value("factory.assetKey", snapshot.assetKey),
+          this.#value("factory.registrySnapshotHash", SNAPSHOT_HASH),
+          this.#value("factory.resolutionPolicyHash", POLICY_HASH),
+          this.#value("factory.registryRevision", snapshot.revision),
+          this.#value("factory.policyValidUntil", POLICY_VALID_UNTIL),
+          this.#value("factory.snapshotAssetCap", ASSET_CAP),
+        ]);
+      case "getPoolKey":
+        return encodeResult(PREDICTION_V2_FACTORY_ABI, call.functionName,
+          this.#value("factory.poolKey", poolKey));
+      case "economicEventKey":
+        return encodeResult(PREDICTION_V2_FACTORY_ABI, call.functionName,
+          this.#value("factory.derivedEconomicKey", ECONOMIC_KEY));
+      case "isCanonicalVault":
+        return encodeResult(
+          PREDICTION_V2_FACTORY_CANONICAL_READ_ABI,
+          call.functionName,
+          this.#value("factory.isCanonicalVault", true),
+        );
+      default:
+        throw new Error(`unexpected Factory call ${call.functionName}`);
+    }
+  }
+
+  #registry(data: Hex) {
+    const call = decodedCall(PREDICTION_V2_ASSET_REGISTRY_ABI, data);
+    switch (call.functionName) {
+      case "getSnapshot":
+        return encodeResult(PREDICTION_V2_ASSET_REGISTRY_ABI, call.functionName,
+          this.#value("registry.snapshot", snapshot));
+      case "hashSnapshot":
+        return encodeResult(PREDICTION_V2_ASSET_REGISTRY_ABI, call.functionName,
+          this.#value("registry.hashSnapshot", SNAPSHOT_HASH));
+      default:
+        throw new Error(`unexpected Registry call ${call.functionName}`);
+    }
+  }
+
+  #vault(data: Hex) {
+    const call = decodedCall(PREDICTION_V2_VAULT_ABI, data);
+    const values: Readonly<Record<string, unknown>> = {
+      collateral: COLLATERAL,
+      checkpoint: CHECKPOINT,
+      factory: FACTORY,
+      router: ROUTER,
+      yesToken: YES_TOKEN,
+      noToken: NO_TOKEN,
+      cutoff: OBSERVATION_TIME - 60n,
+      threshold: THRESHOLD,
+      economicKey: ECONOMIC_KEY,
+      marketId: MARKET_ID,
+      assetKey: snapshot.assetKey,
+      registryRevision: snapshot.revision,
+      registrySnapshotHash: SNAPSHOT_HASH,
+      oraclePolicyHash: POLICY_HASH,
+      state: 0,
+      accountedLiability: 2_000_000n,
+      canonicalPoolId: POOL_ID,
+    };
+    if (!Object.hasOwn(values, call.functionName)) {
+      throw new Error(`unexpected Vault call ${call.functionName}`);
+    }
+    return encodeResult(PREDICTION_V2_VAULT_ABI, call.functionName,
+      this.#value(`vault.${call.functionName}`, values[call.functionName]));
+  }
+
+  #checkpoint(data: Hex) {
+    const call = decodedCall(PREDICTION_V2_CHECKPOINT_ABI, data);
+    const values: Readonly<Record<string, unknown>> = {
+      status: 0,
+      resolvedPrice: 0n,
+      observationTime: Number(OBSERVATION_TIME),
+      resolutionDeadline: 2_100,
+      hardResolutionDeadline: 2_200,
+      fallbackRequestedAt: 0,
+      fallbackChallengeDeadline: 0,
+      policyHash: POLICY_HASH,
+      priceDecimals: 8,
+      isTradingHealthy: true,
+    };
+    if (!Object.hasOwn(values, call.functionName)) {
+      throw new Error(`unexpected Checkpoint call ${call.functionName}`);
+    }
+    return encodeResult(PREDICTION_V2_CHECKPOINT_ABI, call.functionName,
+      this.#value(`checkpoint.${call.functionName}`, values[call.functionName]));
+  }
+
+  #hook(data: Hex) {
+    const call = decodedCall(PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI, data);
+    switch (call.functionName) {
+      case "factory":
+        return encodeResult(PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI, call.functionName,
+          this.#value("hook.factory", FACTORY));
+      case "authorizedRouter":
+        return encodeResult(PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI, call.functionName,
+          this.#value("hook.authorizedRouter", ROUTER));
+      case "poolManager":
+        return encodeResult(PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI, call.functionName,
+          this.#value("hook.poolManager", POOL_MANAGER));
+      case "lifecycle":
+        return encodeResult(PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI, call.functionName, [
+          this.#value("hook.cutoff", OBSERVATION_TIME - 60n),
+          this.#value("hook.registeredBlock", 75n),
+          this.#value("hook.checkpoint", CHECKPOINT),
+          this.#value("hook.initialized", true),
+        ]);
+      default:
+        throw new Error(`unexpected LifecycleHook call ${call.functionName}`);
+    }
+  }
+
+  #router(data: Hex) {
+    const call = decodedCall(PREDICTION_V2_EXECUTION_ROUTER_READ_ABI, data);
+    const values: Readonly<Record<string, unknown>> = {
+      factory: FACTORY,
+      manager: POOL_MANAGER,
+      collateral: COLLATERAL,
+    };
+    if (!Object.hasOwn(values, call.functionName)) {
+      throw new Error(`unexpected ExecutionRouter call ${call.functionName}`);
+    }
+    return encodeResult(
+      PREDICTION_V2_EXECUTION_ROUTER_READ_ABI,
+      call.functionName,
+      this.#value(`router.${call.functionName}`, values[call.functionName]),
+    );
+  }
+
+  #poolManager(data: Hex) {
+    const call = decodedCall(PREDICTION_V2_POOL_MANAGER_STATE_ABI, data);
+    if (call.functionName !== "extsload") throw new Error("unexpected PoolManager call");
+    return encodeResult(PREDICTION_V2_POOL_MANAGER_STATE_ABI, call.functionName,
+      this.#value("pool.slot0", SLOT0));
+  }
+}
+
+function readers(input: Readonly<{
+  primary?: Omit<FixtureOptions, "readerId">;
+  secondary?: Omit<FixtureOptions, "readerId">;
+}> = {}) {
+  return [
+    new FixtureReader({ readerId: "primary", ...input.primary }),
+    new FixtureReader({ readerId: "secondary", ...input.secondary }),
+  ] as const;
+}
+
+function deterministicMarketRevert(economicKey: PredictionBytes32V2) {
+  return (request: PredictionV2ReadCall) => {
+    if (request.to.toLowerCase() !== FACTORY.toLowerCase()) return false;
+    const call = decodedCall(PREDICTION_V2_FACTORY_TEST_ABI, request.data);
+    return call.functionName === "markets" && call.args?.[0] === economicKey;
+  };
+}
+
+describe("Prediction V2 bounded Factory read model", () => {
+  it("reads one fully cross-bound market at one agreed safe block", async () => {
+    const pair = readers();
+    const result = await readPredictionV2Directory({
+      readers: pair,
+      binding,
+      limit: 24,
+    });
+
+    expect(result).toMatchObject({
+      schemaVersion: 2,
+      chainId: 4_663,
+      snapshot: BLOCK,
+      marketCount: 1n,
+      quarantined: [],
+      nextCursor: null,
+      markets: [{
+        economicKey: ECONOMIC_KEY,
+        marketId: MARKET_ID,
+        assetKey: snapshot.assetKey,
+        vault: VAULT,
+        checkpoint: CHECKPOINT,
+        yesToken: YES_TOKEN,
+        noToken: NO_TOKEN,
+        poolId: POOL_ID,
+        asset: { displaySymbol: "BTC", identity: snapshot.identity },
+        predicate: {
+          comparator: "greater-than-or-equal",
+          threshold: THRESHOLD,
+          observationTime: OBSERVATION_TIME,
+          priceDecimals: 8,
+        },
+        lifecycle: {
+          protocolState: "OPEN",
+          checkpointStatus: "AWAITING",
+          tradingPhase: "OPEN",
+          tradable: true,
+          tradabilityReason: "tradable",
+        },
+        poolState: {
+          sqrtPriceX96: 1n << 96n,
+          tick: 0,
+          lpFee: 200,
+          yesProbabilityBps: 5_000,
+        },
+      }],
+    });
+    for (const reader of pair) {
+      expect(reader.calls.length).toBeGreaterThan(25);
+      expect(reader.calls.every(({ blockNumber }) => blockNumber === BLOCK.number))
+        .toBe(true);
+      expect(reader.calls.every(({ blockHash }) => blockHash === BLOCK.hash))
+        .toBe(true);
+      expect(reader.calls.every(({ requireCanonical }) => requireCanonical))
+        .toBe(true);
+      const hookLifecycleCall = reader.calls.find(({ to, data }) =>
+        to.toLowerCase() === HOOK.toLowerCase() &&
+        decodedCall(PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI, data).functionName === "lifecycle"
+      );
+      expect(hookLifecycleCall).toBeDefined();
+      expect(decodedCall(
+        PREDICTION_V2_LIFECYCLE_HOOK_READ_ABI,
+        hookLifecycleCall!.data,
+      ).args).toEqual([POOL_ID]);
+      const canonicalVaultCall = reader.calls.find(({ to, data }) =>
+        to.toLowerCase() === FACTORY.toLowerCase() &&
+        decodedCall(PREDICTION_V2_FACTORY_TEST_ABI, data).functionName ===
+          "isCanonicalVault"
+      );
+      expect(canonicalVaultCall).toBeDefined();
+      expect(decodedCall(
+        PREDICTION_V2_FACTORY_TEST_ABI,
+        canonicalVaultCall!.data,
+      ).args).toEqual([VAULT, POOL_ID]);
+    }
+  });
+
+  it("bounds newest-first pagination to 1..24 and emits a snapshot-bound cursor", async () => {
+    expect(predictionV2PageIndices({ marketCount: 27n, limit: 3 })).toEqual({
+      indices: [26n, 25n, 24n],
+      nextExclusiveIndex: 24n,
+    });
+    expect(() => predictionV2PageIndices({ marketCount: 1n, limit: 0 }))
+      .toThrow("between 1 and 24");
+    expect(() => predictionV2PageIndices({ marketCount: 25n, limit: 25 }))
+      .toThrow("between 1 and 24");
+
+    const pair = readers({
+      primary: { marketCount: 2n, marketKeys: [OTHER_ECONOMIC_KEY, ECONOMIC_KEY] },
+      secondary: { marketCount: 2n, marketKeys: [OTHER_ECONOMIC_KEY, ECONOMIC_KEY] },
+    });
+    const result = await readPredictionV2Directory({
+      readers: pair,
+      binding,
+      limit: 1,
+    });
+    expect(result.markets.map(({ economicKey }) => economicKey)).toEqual([ECONOMIC_KEY]);
+    expect(result.nextCursor).toEqual({
+      schemaVersion: 2,
+      blockNumber: BLOCK.number,
+      blockHash: BLOCK.hash,
+      marketCount: 2n,
+      nextExclusiveIndex: 1n,
+    });
+  });
+
+  it("rejects chain, safe-block and raw same-block RPC disagreement globally", async () => {
+    await expect(readPredictionV2Directory({
+      readers: readers({ secondary: { chainId: 1 } }),
+      binding,
+    })).rejects.toThrow("not serving Robinhood Chain");
+
+    await expect(readPredictionV2Directory({
+      readers: readers({
+        secondary: { block: { ...BLOCK, hash: bytes32(999) } },
+      }),
+      binding,
+    })).rejects.toThrow("disagree about the safe block");
+
+    await expect(readPredictionV2Directory({
+      readers: readers({
+        secondary: { overrides: { "vault.marketId": bytes32(999) } },
+      }),
+      binding,
+    })).rejects.toThrow("disagree about contract state");
+
+    await expect(readPredictionV2Directory({
+      readers: readers({
+        primary: { deterministicRevert: deterministicMarketRevert(ECONOMIC_KEY) },
+      }),
+      binding,
+    })).rejects.toThrow("disagree about contract state");
+  });
+
+  it("rejects a mid-read reorg after all hash-bound calls and before returning", async () => {
+    const replacedBlock = Object.freeze({
+      ...BLOCK,
+      hash: bytes32(901),
+      parentHash: bytes32(900),
+    });
+    const pair = readers({
+      primary: { blockReads: [replacedBlock] },
+      secondary: { blockReads: [replacedBlock] },
+    });
+
+    await expect(readPredictionV2Directory({ readers: pair, binding }))
+      .rejects.toThrow("snapshot block changed during read");
+    expect(pair[0].calls.length).toBeGreaterThan(25);
+    expect(pair[1].calls.length).toBeGreaterThan(25);
+    expect(pair[0].calls.every(({ blockHash }) => blockHash === BLOCK.hash)).toBe(true);
+    expect(pair[1].calls.every(({ blockHash }) => blockHash === BLOCK.hash)).toBe(true);
+  });
+
+  it.each([
+    ["Hook Factory", { "hook.factory": address(91) }],
+    ["Hook authorized Router", { "hook.authorizedRouter": address(92) }],
+    ["Hook PoolManager", { "hook.poolManager": address(96) }],
+    ["Router Factory", { "router.factory": address(93) }],
+    ["Router PoolManager", { "router.manager": address(94) }],
+    ["Router collateral", { "router.collateral": address(95) }],
+  ])("rejects invalid global %s wiring", async (_label, overrides) => {
+    await expect(readPredictionV2Directory({
+      readers: readers({
+        primary: { overrides },
+        secondary: { overrides },
+      }),
+      binding,
+    })).rejects.toThrow("release endpoints do not match");
+  });
+
+  it("quarantines one dual-RPC deterministic revert without hiding a healthy market", async () => {
+    const revert = deterministicMarketRevert(OTHER_ECONOMIC_KEY);
+    const options = {
+      marketCount: 2n,
+      marketKeys: [OTHER_ECONOMIC_KEY, ECONOMIC_KEY],
+      deterministicRevert: revert,
+    } as const;
+    const result = await readPredictionV2Directory({
+      readers: readers({ primary: options, secondary: options }),
+      binding,
+      limit: 2,
+    });
+
+    expect(result.markets.map(({ economicKey }) => economicKey)).toEqual([ECONOMIC_KEY]);
+    expect(result.quarantined).toEqual([{
+      index: 0n,
+      economicKey: OTHER_ECONOMIC_KEY,
+      code: "invalid-market-wiring",
+    }]);
+  });
+
+  it("caps provider concurrency across batched market reads", async () => {
+    const probe: FixtureCallProbe = { active: 0, maximum: 0, delayMs: 2 };
+    const marketKeys = [
+      bytes32(110),
+      bytes32(111),
+      bytes32(112),
+      ECONOMIC_KEY,
+    ];
+    const options = { marketCount: 4n, marketKeys, callProbe: probe } as const;
+    await readPredictionV2Directory({
+      readers: readers({ primary: options, secondary: options }),
+      binding,
+      limit: 4,
+    });
+
+    expect(probe.maximum).toBeGreaterThan(2);
+    expect(probe.maximum).toBeLessThanOrEqual(16);
+    expect(probe.active).toBe(0);
+  });
+
+  it("rejects a replaced snapshot cursor before reading Factory state", async () => {
+    const pair = readers();
+    await expect(readPredictionV2Directory({
+      readers: pair,
+      binding,
+      cursor: {
+        schemaVersion: 2,
+        blockNumber: BLOCK.number,
+        blockHash: bytes32(999),
+        marketCount: 2n,
+        nextExclusiveIndex: 1n,
+      },
+    })).rejects.toThrow("cursor block was replaced");
+    expect(pair[0].calls).toHaveLength(0);
+    expect(pair[1].calls).toHaveLength(0);
+  });
+
+  it("rejects hidden cursor fields instead of accepting an extended cursor", async () => {
+    const cursor = {
+      schemaVersion: 2 as const,
+      blockNumber: BLOCK.number,
+      blockHash: BLOCK.hash,
+      marketCount: 2n,
+      nextExclusiveIndex: 1n,
+    };
+    Object.defineProperty(cursor, "providerOverride", { value: "untrusted" });
+    await expect(readPredictionV2Directory({
+      readers: readers(),
+      binding,
+      cursor,
+    })).rejects.toThrow("cursor is invalid");
+  });
+
+  it.each([
+    ["Factory/Vault identity", { "vault.economicKey": bytes32(800) }],
+    ["Registry snapshot", { "factory.registrySnapshotHash": bytes32(801) }],
+    ["Checkpoint policy", { "checkpoint.policyHash": bytes32(802) }],
+    ["terminal checkpoint health", {
+      "checkpoint.status": 1,
+      "checkpoint.isTradingHealthy": true,
+    }],
+    ["60-second cutoff", { "vault.cutoff": OBSERVATION_TIME }],
+    ["Pool binding", {
+      "factory.poolKey": { ...poolKey, hooks: address(99) },
+    }],
+    ["LifecycleHook cutoff", { "hook.cutoff": OBSERVATION_TIME - 59n }],
+    ["LifecycleHook checkpoint", { "hook.checkpoint": address(98) }],
+    ["LifecycleHook initialization", { "hook.initialized": false }],
+    ["LifecycleHook registration block", { "hook.registeredBlock": 49n }],
+    ["Factory canonical Vault mapping", { "factory.isCanonicalVault": false }],
+  ])("quarantines one market with invalid %s wiring", async (_label, overrides) => {
+    const result = await readPredictionV2Directory({
+      readers: readers({
+        primary: { overrides },
+        secondary: { overrides },
+      }),
+      binding,
+    });
+    expect(result.markets).toEqual([]);
+    expect(result.quarantined).toEqual([{
+      index: 0n,
+      economicKey: ECONOMIC_KEY,
+      code: "invalid-market-wiring",
+    }]);
+  });
+
+  it.each([
+    [
+      "closed pending resolution",
+      { state: 0, status: 0, price: 0n, healthy: true },
+      { protocolState: "OPEN", tradingPhase: "CLOSED", tradabilityReason: "cutoff-reached" },
+    ],
+    [
+      "paused before cutoff",
+      { state: 0, status: 0, price: 0n, healthy: false },
+      { protocolState: "OPEN", tradingPhase: "OPEN", tradabilityReason: "checkpoint-unhealthy" },
+    ],
+    [
+      "final YES",
+      { state: 1, status: 1, price: THRESHOLD, healthy: false },
+      { protocolState: "FINAL_YES", tradingPhase: "FINAL", tradabilityReason: "market-final" },
+    ],
+    [
+      "final NO",
+      { state: 2, status: 1, price: THRESHOLD - 1n, healthy: false },
+      { protocolState: "FINAL_NO", tradingPhase: "FINAL", tradabilityReason: "market-final" },
+    ],
+    [
+      "final invalid",
+      { state: 3, status: 2, price: 0n, healthy: false },
+      { protocolState: "FINAL_INVALID", tradingPhase: "FINAL", tradabilityReason: "market-final" },
+    ],
+    [
+      "final invalid from a nonpositive terminal price",
+      { state: 3, status: 1, price: 0n, healthy: false },
+      { protocolState: "FINAL_INVALID", tradingPhase: "FINAL", tradabilityReason: "market-final" },
+    ],
+    [
+      "terminal checkpoint awaiting Vault consumption",
+      { state: 0, status: 1, price: THRESHOLD, healthy: false },
+      { protocolState: "OPEN", tradingPhase: "CLOSED", tradabilityReason: "cutoff-reached" },
+    ],
+  ])("derives %s only from verified chain time and lifecycle reads", async (
+    label,
+    fixture,
+    expected,
+  ) => {
+    const afterCutoff = label === "paused before cutoff"
+      ? BLOCK
+      : { ...BLOCK, timestamp: OBSERVATION_TIME + 1n };
+    const overrides = {
+      "vault.state": fixture.state,
+      "checkpoint.status": fixture.status,
+      "checkpoint.resolvedPrice": fixture.price,
+      "checkpoint.isTradingHealthy": fixture.healthy,
+    };
+    const result = await readPredictionV2Directory({
+      readers: readers({
+        primary: { block: afterCutoff, overrides },
+        secondary: { block: afterCutoff, overrides },
+      }),
+      binding,
+    });
+    expect(result.markets[0]?.lifecycle).toMatchObject({
+      ...expected,
+      tradable: false,
+    });
+  });
+
+  it.each([
+    [
+      "a terminal checkpoint before observation",
+      { state: 0, status: 1, price: THRESHOLD, healthy: false },
+      BLOCK.timestamp,
+    ],
+    [
+      "a nonzero AWAITING price",
+      { state: 0, status: 0, price: 1n, healthy: true },
+      OBSERVATION_TIME + 1n,
+    ],
+    [
+      "a nonzero INVALID price",
+      { state: 0, status: 2, price: 1n, healthy: false },
+      OBSERVATION_TIME + 1n,
+    ],
+    [
+      "a finalized Vault with an AWAITING checkpoint",
+      { state: 3, status: 0, price: 0n, healthy: false },
+      OBSERVATION_TIME + 1n,
+    ],
+  ])("quarantines %s", async (_label, fixture, timestamp) => {
+    const overrides = {
+      "vault.state": fixture.state,
+      "checkpoint.status": fixture.status,
+      "checkpoint.resolvedPrice": fixture.price,
+      "checkpoint.isTradingHealthy": fixture.healthy,
+    };
+    const block = { ...BLOCK, timestamp };
+    const result = await readPredictionV2Directory({
+      readers: readers({
+        primary: { block, overrides },
+        secondary: { block, overrides },
+      }),
+      binding,
+    });
+    expect(result.markets).toEqual([]);
+    expect(result.quarantined).toHaveLength(1);
+  });
+
+  it("uses the historical Registry revision and fails closed on cursor count drift", async () => {
+    const pair = readers();
+    await readPredictionV2Directory({ readers: pair, binding });
+    const registryCall = pair[0].calls.find(({ to, data }) => {
+      if (to.toLowerCase() !== REGISTRY.toLowerCase()) return false;
+      return decodedCall(PREDICTION_V2_ASSET_REGISTRY_ABI, data).functionName ===
+        "getSnapshot";
+    });
+    expect(registryCall).toBeDefined();
+    expect(decodedCall(PREDICTION_V2_ASSET_REGISTRY_ABI, registryCall!.data).args)
+      .toEqual([snapshot.assetKey, snapshot.revision]);
+
+    await expect(readPredictionV2Directory({
+      readers: pair,
+      binding,
+      cursor: {
+        schemaVersion: 2,
+        blockNumber: BLOCK.number,
+        blockHash: BLOCK.hash,
+        marketCount: 2n,
+        nextExclusiveIndex: 1n,
+      },
+    })).rejects.toThrow("cursor market count changed");
+  });
+});

--- a/tests/prediction-v2-release-binding.test.ts
+++ b/tests/prediction-v2-release-binding.test.ts
@@ -4,6 +4,7 @@ vi.mock("server-only", () => ({}));
 
 import {
   getPredictionV2ReleaseBinding,
+  isPredictionV2ReleaseEnabled,
   parsePredictionV2ReleaseBinding,
 } from "../lib/prediction-v2/release-binding.server";
 
@@ -22,6 +23,10 @@ describe("Prediction V2 release binding", () => {
     expect(binding).not.toHaveProperty("addresses");
     expect(binding).not.toHaveProperty("deployment");
     expect(binding).not.toHaveProperty("attestation");
+  });
+
+  it("cannot authorize a public V2 route under the disabled-only V1 schema", () => {
+    expect(isPredictionV2ReleaseEnabled()).toBe(false);
   });
 
   it("accepts only the exact disabled V1 schema and copies the input", () => {

--- a/tests/prediction-v2-token-profile.test.ts
+++ b/tests/prediction-v2-token-profile.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizePredictionTokenProfileV2,
+  PREDICTION_TOKEN_PROFILE_CHAINS_V2,
+} from "../lib/prediction-v2/token-profile-v2";
+
+const EVM_ADDRESS = `0x${"Ab".repeat(20)}`;
+const CANONICAL_EVM_ADDRESS = EVM_ADDRESS.toLowerCase();
+const SOLANA_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const OBSERVED_AT_MS = Date.parse("2026-08-23T18:00:00.000Z");
+
+describe("prediction token profile v2", () => {
+  it("normalizes a complete untrusted EVM profile without conflating market cap and FDV", () => {
+    const profile = normalizePredictionTokenProfileV2({
+      chain: 56,
+      address: `  ${EVM_ADDRESS}  `,
+      name: "  Great   Meme  ",
+      symbol: "MEME",
+      logoUrl: "data:image/png;base64,not-used",
+      imageUrl: "https://cdn.example.com/token.png#provider-fragment",
+      website: "https://meme.example.com/path",
+      websites: [
+        { label: "<b>not preserved</b>", url: "https://twitter.com/great_meme?s=20" },
+        { url: "https://meme.example.com/path" },
+      ],
+      socials: [
+        { type: "twitter", url: "https://www.x.com/great_meme#profile" },
+        { type: "telegram", url: "https://telegram.me/great_meme?ref=provider" },
+      ],
+      priceUsd: "0.00042",
+      marketCapUsd: "420000",
+      fdvUsd: "500000",
+      liquidityUsd: 120000,
+      pairCreatedAtMs: Date.parse("2026-08-21T18:00:00.000Z"),
+      explorerUrl: "https://evil.example/token/not-used",
+      description: "<script>provider HTML is not part of the DTO</script>",
+    }, OBSERVED_AT_MS);
+
+    expect(profile).toEqual({
+      schemaVersion: 2,
+      chain: { id: "bnb", reference: "56", label: "BNB Chain" },
+      address: CANONICAL_EVM_ADDRESS,
+      explorerUrl: `https://bscscan.com/token/${CANONICAL_EVM_ADDRESS}`,
+      name: "Great Meme",
+      symbol: "MEME",
+      logoUrl: "https://cdn.example.com/token.png",
+      links: [
+        { kind: "website", url: "https://meme.example.com/path" },
+        { kind: "x", url: "https://x.com/great_meme" },
+        { kind: "telegram", url: "https://t.me/great_meme" },
+      ],
+      priceUsd: 0.00042,
+      marketCapUsd: 420000,
+      fdvUsd: 500000,
+      liquidityUsd: 120000,
+      age: {
+        pairCreatedAt: "2026-08-21T18:00:00.000Z",
+        seconds: 172800,
+      },
+    });
+    expect(profile).not.toHaveProperty("description");
+    expect(profile).not.toHaveProperty("explorerUrl", "https://evil.example/token/not-used");
+  });
+
+  it("builds explorer URLs from the validated identity for every supported chain", () => {
+    const expected = {
+      ethereum: "https://etherscan.io",
+      base: "https://basescan.org",
+      bnb: "https://bscscan.com",
+      robinhood: "https://robinhoodchain.blockscout.com",
+    } as const;
+
+    for (const [chain, origin] of Object.entries(expected)) {
+      expect(normalizePredictionTokenProfileV2({
+        chain,
+        address: EVM_ADDRESS,
+      }, OBSERVED_AT_MS)?.explorerUrl).toBe(
+        `${origin}/token/${CANONICAL_EVM_ADDRESS}`,
+      );
+    }
+
+    expect(normalizePredictionTokenProfileV2({
+      chain: "solana",
+      address: SOLANA_MINT,
+    }, OBSERVED_AT_MS)).toMatchObject({
+      chain: { id: "solana", reference: "mainnet-beta", label: "Solana" },
+      address: SOLANA_MINT,
+      explorerUrl: `https://solscan.io/token/${SOLANA_MINT}`,
+    });
+    expect(PREDICTION_TOKEN_PROFILE_CHAINS_V2).toHaveLength(5);
+  });
+
+  it("rejects invalid or mismatched token identities", () => {
+    const invalid = [
+      { chain: "polygon", address: EVM_ADDRESS },
+      { chain: "base", address: "0x1234" },
+      { chain: "base", address: `0x${"0".repeat(40)}` },
+      { chain: "solana", address: EVM_ADDRESS },
+      { chain: "solana", address: "11111111111111111111111111111111" },
+      { chain: "ethereum", address: SOLANA_MINT },
+    ];
+    for (const candidate of invalid) {
+      expect(normalizePredictionTokenProfileV2(candidate, OBSERVED_AT_MS)).toBeNull();
+    }
+  });
+
+  it("keeps missing or invalid optional provider fields out of the DTO", () => {
+    const profile = normalizePredictionTokenProfileV2({
+      chain: "base",
+      address: EVM_ADDRESS,
+      name: "<img src=x onerror=alert(1)>",
+      symbol: "BAD SYMBOL",
+      logoUrl: "data:image/svg+xml,<svg onload=alert(1)>",
+      websites: [{ label: "safe-looking", url: "javascript:alert(1)" }],
+      socials: [{ type: "twitter", url: "https://not-x.example/project" }],
+      priceUsd: 0,
+      marketCapUsd: -1,
+      fdvUsd: "Infinity",
+      liquidityUsd: "not-a-number",
+      pairCreatedAtMs: 9_007_199_254_740_991,
+    }, OBSERVED_AT_MS);
+
+    expect(profile).toEqual({
+      schemaVersion: 2,
+      chain: { id: "base", reference: "8453", label: "Base" },
+      address: CANONICAL_EVM_ADDRESS,
+      explorerUrl: `https://basescan.org/token/${CANONICAL_EVM_ADDRESS}`,
+    });
+  });
+
+  it.each([
+    "http://project.example",
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "https://user:pass@project.example",
+    "https://127.0.0.1/logo.png",
+    "https://10.0.0.1/logo.png",
+    "https://[::1]/logo.png",
+    "https://localhost/logo.png",
+    "https://metadata.google.internal/logo.png",
+    "https://project.local/logo.png",
+    "https://project.example:8443/logo.png",
+  ])("rejects an unsafe HTTPS-adjacent URL: %s", (url) => {
+    const profile = normalizePredictionTokenProfileV2({
+      chain: "ethereum",
+      address: EVM_ADDRESS,
+      logoUrl: url,
+      website: url,
+    }, OBSERVED_AT_MS);
+    expect(profile).not.toHaveProperty("logoUrl");
+    expect(profile).not.toHaveProperty("links");
+  });
+
+  it("identifies social platforms by exact hostname and deduplicates aliases", () => {
+    const profile = normalizePredictionTokenProfileV2({
+      chain: "base",
+      address: EVM_ADDRESS,
+      websites: [
+        "https://x.com.evil.example.com/project",
+        "https://project.example.com",
+        "https://project.example.com/",
+        "https://twitter.com/project?s=20",
+      ],
+      x: "https://www.x.com/project#duplicate",
+      telegram: "https://www.telegram.me/project?duplicate=1",
+      socials: [
+        { type: "telegram", url: "https://t.me/project" },
+        { type: "x", url: "https://evilx.com/project" },
+      ],
+    }, OBSERVED_AT_MS);
+
+    expect(profile?.links).toEqual([
+      { kind: "website", url: "https://x.com.evil.example.com/project" },
+      { kind: "x", url: "https://x.com/project" },
+      { kind: "telegram", url: "https://t.me/project" },
+    ]);
+  });
+
+  it("never substitutes FDV for an unavailable market cap", () => {
+    const profile = normalizePredictionTokenProfileV2({
+      chain: "robinhood",
+      address: EVM_ADDRESS,
+      fdvUsd: "1000000",
+    }, OBSERVED_AT_MS);
+    expect(profile).toHaveProperty("fdvUsd", 1000000);
+    expect(profile).not.toHaveProperty("marketCapUsd");
+  });
+
+  it("is deterministic, bounded and deeply immutable for returned collections", () => {
+    const candidate = {
+      chain: "bsc",
+      address: EVM_ADDRESS,
+      name: "A".repeat(81),
+      symbol: "OK",
+      websites: Array.from({ length: 40 }, (_, index) =>
+        `https://site-${index}.example.com`),
+      pairCreatedAt: "2026-08-23T17:59:59.001Z",
+    };
+    const first = normalizePredictionTokenProfileV2(candidate, OBSERVED_AT_MS);
+    const second = normalizePredictionTokenProfileV2(candidate, OBSERVED_AT_MS);
+    expect(first).toEqual(second);
+    expect(first).not.toHaveProperty("name");
+    expect(first?.links).toHaveLength(1);
+    expect(first?.age?.seconds).toBe(0);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(Object.isFrozen(first?.chain)).toBe(true);
+    expect(Object.isFrozen(first?.links)).toBe(true);
+  });
+
+  it("requires an explicit deterministic observation timestamp", () => {
+    expect(() => normalizePredictionTokenProfileV2({
+      chain: "base",
+      address: EVM_ADDRESS,
+    }, Number.NaN)).toThrow(TypeError);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.{ts,tsx}"],
   },
 });


### PR DESCRIPTION
## Summary

- Add a release-dark Prediction V2 creation foundation for contract-address discovery across Ethereum, Base, BNB Chain, Robinhood Chain and Solana.
- Verify token identity onchain; use Dexscreener only for optional display enrichment such as artwork and socials.
- Add price and market-cap creation intent, a token-style market card, exact UTC review, a block-bound read model and attested public projection boundaries.
- Add bounded discovery/logo work, disabled release guards and a production-bundle sentinel for the development preview.

## Validation

- Prediction suites: 530/530 tests passed.
- Interface CI: 3,765 passed, 33 skipped.
- TypeScript: passed.
- ESLint: 0 errors; 26 pre-existing warnings outside this slice.
- Next production build, candidate-neutrality and bundle scan: passed.
- Desktop 1440x900 and mobile 390x844 browser QA: no overflow and 0 console errors while the server was running.
- Final independent read-only source review: no critical, high, medium or low code findings. This is not an external security audit.

## Release boundary

This PR does not activate Prediction V2 and does not switch live Prediction V1 behavior. The new APIs return 404/no-store before provider work while the disabled release binding is in force. No contract deployment, provider credential, production alias or onchain transaction is included.

Activation remains blocked on exact V2 deployment and runtime evidence, independent review and lifecycle canaries, pinned attestor/append-only operation, edge and distributed provider budgets, authorized logo asset IDs, and the public create/trade/reconciliation surfaces.