### PR TITLE
fix(explore): omit null market data from public entries

### DIFF
--- a/lib/explore-financial-data.ts
+++ b/lib/explore-financial-data.ts
@@ -765,9 +765,12 @@ function canonicalTotalSupply(entry: ExploreEntry): string | null {
 export function publicExploreEntryV1(
   entry: ValuedExploreEntry,
 ): PublicValuedExploreEntry {
-  if (entry.exploreKind === "custom-project") return entry;
-
   const output = { ...entry } as Record<string, unknown>;
+  if (output.marketData === null) delete output.marketData;
+  if (entry.exploreKind === "custom-project") {
+    return output as PublicValuedExploreEntry;
+  }
+
   delete output.liveMarketStateEvidence;
   delete output.liveMarketPriceEvidence;
   for (const field of LEGACY_MARKET_CAP_FIELDS) delete output[field];

--- a/tests/explore-financial-data.test.ts
+++ b/tests/explore-financial-data.test.ts
@@ -143,6 +143,16 @@ function currentEvidenceFixture(
 }
 
 describe("Explore financial-data semantics", () => {
+  it("omits null optional market data at the public boundary", () => {
+    const entry = {
+      ...canonicalTokenExploreEntryV1(goldenToken()),
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+      marketData: null,
+    } as unknown as ValuedExploreEntry;
+
+    expect(publicExploreEntryV1(entry)).not.toHaveProperty("marketData");
+  });
+
   it("promotes trade-independent current FDV only at the dual liquidity threshold", () => {
     const { valued, liquidityEvidence } = currentEvidenceFixture();
     const current = withCurrentOnchainValuation(valued, liquidityEvidence);


### PR DESCRIPTION
## Summary
- omit invalid `marketData: null` at the public Explore boundary
- preserve the existing optional-field contract for tokens and custom projects
- add one focused regression test

## Verification
- `npx vitest run tests/explore-financial-data.test.ts` (24/24)
- `node --test scripts/test/smoke-static-dexscreener-public-apis.test.mjs` (23/23)
- `npm run typecheck`
- `git diff --check`

## Release context
The production candidate exposed Envio entries with `marketData: null` when Dexscreener had no qualified FDV. The public contract requires this optional enrichment field to be absent, and the staged Highest-FDV smoke correctly failed closed.