### PR TITLE
fix(release): gate component-aware custom sources

### DIFF
--- a/scripts/smoke-static-dexscreener-public-apis.mjs
+++ b/scripts/smoke-static-dexscreener-public-apis.mjs
@@ -301,9 +301,29 @@ function exactCatalogSnapshot(response) {
   const generatedAt = catalog?.lastIndexedAt;
   const launchIdentity = response.body?.dataQuality?.launchIdentity;
   const customStatus = catalog?.completeness?.custom;
-  const launchSource = customStatus === "current"
-    ? `${source}+registry.custom-launched`
-    : source;
+  const registryCustomStatus = catalog?.completeness?.registryCustom;
+  const routerCustomStatus = catalog?.completeness?.routerCustom;
+  const launchSource = [
+    source,
+    ...(registryCustomStatus === "current"
+      ? ["registry.custom-launched"]
+      : []),
+    ...(routerCustomStatus === "current"
+      ? ["canonical-launch-stamp-router"]
+      : []),
+  ].join("+");
+  const expectedCustomStatus =
+    registryCustomStatus === "current" && routerCustomStatus === "current"
+      ? "current"
+      : "unavailable";
+  const expectedIncluded = [
+    "classic-v3",
+    "official-main-token",
+    "registry.custom-launched",
+    ...(routerCustomStatus === "current"
+      ? ["canonical-launch-stamp-router"]
+      : []),
+  ];
   if (!(
     CATALOG_SOURCES.has(source) &&
     CATALOG_STATUSES.has(catalog?.status) &&
@@ -313,12 +333,11 @@ function exactCatalogSnapshot(response) {
     catalog.launchSource === launchSource &&
     ["current", "last-known-good"].includes(catalog.completeness?.classic) &&
     catalog.completeness?.stock === "excluded" &&
-    ["current", "unavailable"].includes(customStatus) &&
-    JSON.stringify(catalog.scope?.included) === JSON.stringify([
-      "classic-v3",
-      "official-main-token",
-      "registry.custom-launched",
-    ]) &&
+    customStatus === expectedCustomStatus &&
+    ["current", "unavailable"].includes(registryCustomStatus) &&
+    ["current", "unavailable"].includes(routerCustomStatus) &&
+    JSON.stringify(catalog.scope?.included) ===
+      JSON.stringify(expectedIncluded) &&
     JSON.stringify(catalog.scope?.excluded) === JSON.stringify([
       "classic-v1",
       "classic-v2",

--- a/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
+++ b/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
@@ -111,6 +111,8 @@ function catalog() {
       classic: "last-known-good",
       stock: "excluded",
       custom: "unavailable",
+      registryCustom: "unavailable",
+      routerCustom: "unavailable",
     },
     scope: {
       included: [
@@ -749,7 +751,7 @@ test("staged smoke rejects health output containing provider secrets", async () 
   );
 });
 
-test("staged smoke accepts one custom-current composite catalog", async () => {
+test("staged smoke accepts Registry-current and Router-unavailable catalog", async () => {
   const project = customProject();
   const result = await runStagedStaticDexscreenerSmokeV1({
     environment: {
@@ -774,15 +776,18 @@ test("staged smoke accepts one custom-current composite catalog", async () => {
             catalog: {
               ...body.catalog,
               launchSource: "envio-classic-v3+registry.custom-launched",
-              completeness: { ...body.catalog.completeness, custom: "current" },
+              completeness: {
+                ...body.catalog.completeness,
+                registryCustom: "current",
+              },
               identityCommitment: `sha256:${"de".repeat(32)}`,
             },
             dataQuality: {
               ...body.dataQuality,
               launchIdentity: {
                 ...body.dataQuality.launchIdentity,
-                status: "current",
-                custom: "current",
+                status: "partial",
+                custom: "unavailable",
               },
             },
           };
@@ -795,7 +800,10 @@ test("staged smoke accepts one custom-current composite catalog", async () => {
             catalog: {
               ...body.catalog,
               launchSource: "envio-classic-v3+registry.custom-launched",
-              completeness: { ...body.catalog.completeness, custom: "current" },
+              completeness: {
+                ...body.catalog.completeness,
+                registryCustom: "current",
+              },
               identityCommitment: `sha256:${"de".repeat(32)}`,
             },
           };


### PR DESCRIPTION
## Summary
- derive staged Explore launch-source truth from `registryCustom` and `routerCustom` independently
- retain aggregate `custom=current` only when both components are current
- bind the expected public scope to Router availability
- cover the live Registry-current / Router-unavailable state

## Verification
- `node --test scripts/test/smoke-static-dexscreener-public-apis.test.mjs` (23/23)
- `git diff --check`
- exact staged readback: Registry current, Router unavailable, aggregate custom unavailable, launch source `envio-classic-v3+registry.custom-launched`

## Release context
The staged product response is correct. The smoke still derived `launchSource` from the old aggregate Custom status and therefore rejected the already supported component-aware state.