### PR TITLE
Fix Router index bootstrap without legacy Classic snapshot

### DIFF
--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -148,7 +148,7 @@
     },
     "runtime": {
       "path": "lib/alchemy/explore.server.ts",
-      "sha256": "06ed5879f453628d5da656a9494aab3485528249ea915de6a88888126cd40fe3"
+      "sha256": "9e05971ef410de2b368def0ea2a78c863e6dc4ebb996eec9dd45f715a41d9db8"
     },
     "store": {
       "path": "lib/alchemy/launch-registry.server.ts",

--- a/lib/alchemy/explore.server.ts
+++ b/lib/alchemy/explore.server.ts
@@ -17,7 +17,10 @@ import type {
   ReadyOnchainDeployment,
 } from "../onchain/types";
 import type { LauncherToken } from "../tokens";
-import { advanceLaunchStampRouterSlice } from "./launch-stamp.server";
+import {
+  advanceLaunchStampRouterSlice,
+  LAUNCH_STAMP_ROUTER_INITIAL_CURSOR,
+} from "./launch-stamp.server";
 import {
   readAlchemyLaunchRegistry,
   writeAlchemyLaunchRegistry,
@@ -138,11 +141,26 @@ type AlchemyRegistryRefreshOptions = Readonly<{
 
 type ReadyExploreModel = Extract<ExploreReadModel, { status: "ready" }>;
 
-function durableReadyModel(
+function durableOrRouterBootstrapModel(
   deployment: ReadyOnchainDeployment,
   read: Awaited<ReturnType<typeof readDurableExploreModel>>,
 ): ReadyExploreModel {
   if (read.status !== "ready") {
+    if (read.reason === "missing") {
+      return {
+        status: "ready",
+        tokens: [],
+        snapshot: {
+          chainId: deployment.chainId,
+          blockNumber: LAUNCH_STAMP_ROUTER_INITIAL_CURSOR.blockNumber,
+          blockHash: LAUNCH_STAMP_ROUTER_INITIAL_CURSOR.blockHash,
+          confirmations: Number(deployment.confirmations),
+        },
+        creatorClaims: [],
+        launcherFeesAccruedWei: "0",
+        launcherFeesAccruedEth: "0",
+      };
+    }
     throw new Error(
       `Durable Alchemy registry is ${read.reason}: ${read.detail}`,
     );
@@ -346,7 +364,8 @@ async function refreshAlchemyExploreRegistryOnce(
     deployment,
     Number.MAX_SAFE_INTEGER,
   );
-  const base = durableReadyModel(deployment, durable);
+  const hasDurableClassicBase = durable.status === "ready";
+  const base = durableOrRouterBootstrapModel(deployment, durable);
   const initialCursor: AlchemyLaunchCursor = {
     blockNumber: base.snapshot.blockNumber,
     blockHash: base.snapshot.blockHash,
@@ -372,11 +391,13 @@ async function refreshAlchemyExploreRegistryOnce(
       blockHash: cursor.blockHash,
     },
   };
-  const confirmed = await advanceExploreLaunchDiscovery(
-    deployment,
-    cursorModel,
-    "confirmed",
-  );
+  const confirmed = hasDurableClassicBase
+    ? await advanceExploreLaunchDiscovery(
+      deployment,
+      cursorModel,
+      "confirmed",
+    )
+    : cursorModel;
   const routerAdvance = await advanceLaunchStampRouterSlice(
     deployment,
     {
@@ -430,7 +451,8 @@ async function refreshAlchemyExploreRegistryOnce(
       console.warn("Alchemy registry persistence failed", safeAlchemyError(error));
     }
   }
-  const servedCursorModel = options.includeLatest === false
+  const servedCursorModel = options.includeLatest === false ||
+      !hasDurableClassicBase
     ? confirmed
     : await advanceExploreLaunchDiscovery(deployment, confirmed, "latest");
   const classicModel: ReadyExploreModel = {

--- a/scripts/perf/alchemy-explore-source-contracts.mjs
+++ b/scripts/perf/alchemy-explore-source-contracts.mjs
@@ -152,11 +152,14 @@ export function evaluateAlchemyExploreSourceContracts(
     "alchemy-durable-registry",
     runtimeSource.includes("readDurableExploreModel(") &&
       runtimeSource.includes("Number.MAX_SAFE_INTEGER") &&
+      runtimeSource.includes("durableOrRouterBootstrapModel(") &&
+      runtimeSource.includes('read.reason === "missing"') &&
+      runtimeSource.includes("hasDurableClassicBase") &&
       runtimeSource.includes("readAlchemyLaunchRegistry(") &&
       runtimeSource.includes("advanceExploreLaunchDiscovery(") &&
       !runtimeSource.includes("readExploreModel(") &&
       !runtimeSource.includes("readLiveExploreModel"),
-    "the request path starts from the verified durable registry and advances only its separate launch overlay",
+    "the request path preserves the verified durable Classic base when present and can independently bootstrap the bounded Router slice when that retired snapshot is absent",
   );
   check(
     "alchemy-launch-registry-cas",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -173,7 +173,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     runtime: Object.freeze({
       path: "lib/alchemy/explore.server.ts",
       sha256:
-        "06ed5879f453628d5da656a9494aab3485528249ea915de6a88888126cd40fe3",
+        "9e05971ef410de2b368def0ea2a78c863e6dc4ebb996eec9dd45f715a41d9db8",
     }),
     store: Object.freeze({
       path: "lib/alchemy/launch-registry.server.ts",
@@ -1315,7 +1315,7 @@ export function evaluateReadModelOperationsSourceContracts(
         "revalidateTag(ALCHEMY_EXPLORE_CACHE_TAG, { expire: 0 })",
       ) &&
       routerRefresherRuntime.includes(
-        'advanceExploreLaunchDiscovery(\n    deployment,\n    cursorModel,\n    "confirmed",',
+        'const confirmed = hasDurableClassicBase\n    ? await advanceExploreLaunchDiscovery(\n      deployment,\n      cursorModel,\n      "confirmed",\n    )\n    : cursorModel;',
       ) &&
       routerRefresherRuntime.includes("await writeAlchemyLaunchRegistry(") &&
       routerRefresherRuntime.includes(

--- a/tests/alchemy-launch-refresh.test.ts
+++ b/tests/alchemy-launch-refresh.test.ts
@@ -26,6 +26,11 @@ vi.mock("../lib/onchain/read-model", () => ({
 }));
 vi.mock("../lib/alchemy/launch-stamp.server", () => ({
   advanceLaunchStampRouterSlice: mocks.advanceLaunchStampRouterSlice,
+  LAUNCH_STAMP_ROUTER_INITIAL_CURSOR: {
+    blockNumber: "25717611",
+    blockHash:
+      "0x2d42bd6f5cea0a09b7a76c5ca51569ac69e677cef0498b12730d6f1f7a979a5e",
+  },
 }));
 vi.mock("../lib/alchemy/launch-registry.server", () => ({
   readAlchemyLaunchRegistry: mocks.readAlchemyLaunchRegistry,
@@ -35,7 +40,10 @@ vi.mock("../lib/alchemy/launch-registry.server", () => ({
 import { refreshAlchemyExploreRegistry } from "../lib/alchemy/explore.server";
 import { canonicalTokenExploreEntryV1 } from "../lib/explore-entry-v1";
 import type { LauncherToken } from "../lib/tokens";
-import { stampedClassicToken } from "./launch-stamp-surface-fixture";
+import {
+  customGraphToken,
+  stampedClassicToken,
+} from "./launch-stamp-surface-fixture";
 
 const deployment = {
   environment: "production",
@@ -330,6 +338,62 @@ describe("Alchemy launch overlay refresh", () => {
       "registry-etag",
     );
     expect(result.launchStampRouterBlockNumber).toBe("25717680");
+  });
+
+  it("bootstraps the Router slice without the retired Classic snapshot", async () => {
+    mocks.readDurableExploreModel.mockResolvedValue({
+      status: "unavailable",
+      reason: "missing",
+      detail: "No durable index snapshot exists",
+    });
+    mocks.advanceLaunchStampRouterSlice.mockResolvedValueOnce({
+      slice: {
+        cursor: {
+          blockNumber: "25718017",
+          blockHash: `0x${"cd".repeat(32)}`,
+        },
+        tokens: [customGraphToken],
+      },
+      scannedFromBlock: "25717612",
+      scannedToBlock: "25718017",
+      discovered: 1,
+      hydrated: 1,
+      rebuiltAfterReorg: false,
+    });
+
+    const result = await refreshAlchemyExploreRegistry({
+      includeLatest: true,
+    });
+
+    expect(mocks.readAlchemyLaunchRegistry).toHaveBeenCalledWith(
+      deployment,
+      expect.objectContaining({ blockNumber: "25717611" }),
+    );
+    expect(mocks.advanceExploreLaunchDiscovery).not.toHaveBeenCalled();
+    expect(mocks.writeAlchemyLaunchRegistry).toHaveBeenCalledWith(
+      deployment,
+      expect.objectContaining({
+        cursor: expect.objectContaining({ blockNumber: "25717611" }),
+        tokens: [],
+        launchStampRouter: expect.objectContaining({
+          cursor: expect.objectContaining({ blockNumber: "25718017" }),
+          tokens: [customGraphToken],
+        }),
+      }),
+      "registry-etag",
+    );
+    expect(result).toMatchObject({
+      baseBlockNumber: "25717611",
+      confirmedBlockNumber: "25717611",
+      servedBlockNumber: "25717611",
+      launchStampRouterBlockNumber: "25718017",
+    });
+    expect(result.model.tokens).toEqual([
+      expect.objectContaining({
+        tokenAddress: customGraphToken.tokenAddress,
+        launchDiscoverySource: "operational-launch-overlay",
+      }),
+    ]);
   });
 
   it("persists a Router cursor hash replacement even without block progress", async () => {


### PR DESCRIPTION
## What changed

- bootstrap the bounded Launch Stamp Router slice when the retired durable Classic snapshot is absent
- preserve the verified durable Classic path whenever that snapshot exists
- keep invalid or misconfigured durable storage fail-closed
- add a focused regression test for the exact production 503 precondition

## Why

Production Classic identity is already owned by Envio. Requiring a missing legacy Classic snapshot before the independent Router cursor can advance caused the protected minute cron to return 503. This removes only that obsolete dependency; Router finality, provenance validation, CAS persistence, and reorg handling are unchanged.

## Verification

- `vitest run tests/alchemy-launch-refresh.test.ts tests/alchemy-launch-refresh-cron.test.ts`
- `tsc --noEmit --pretty false`
- focused ESLint on changed files
- `alchemy-durable-registry` source-contract check passes
