### PR TITLE
Fix Router provenance on token charts

### DIFF
--- a/app/api/explore/token/chart/route.ts
+++ b/app/api/explore/token/chart/route.ts
@@ -15,6 +15,12 @@ import type {
   MarketChartV1,
 } from "../../../../../lib/market-data/market-data-v1";
 import { isTokenChartRange } from "../../../../../lib/onchain/chart";
+import {
+  mergeRouterCustomExploreEntriesV1,
+  publicLaunchSourceV1,
+  readFinalizedRouterCustomExploreEntriesV1,
+  routerCustomEntriesAtOrBeforeBlockV1,
+} from "../../../../../lib/alchemy/router-custom-public.server";
 import { readProductionCustomExploreDirectoryV1 } from
   "../../../../../lib/server/custom-launch/explore-directory-v1";
 import { isCustomLaunchRegistryPublicReadEnabled } from
@@ -52,39 +58,74 @@ export async function GET(request: NextRequest) {
     });
     let entries = catalog.entries;
     let customStatus: "current" | "unavailable" = "unavailable";
+    let customReadFailed = false;
     if (isCustomLaunchRegistryPublicReadEnabled()) {
       let customEntries;
       try {
         customEntries = await readProductionCustomExploreDirectoryV1(request.signal);
       } catch {
         // A Custom Registry outage cannot invalidate an already committed
-        // canonical identity, but an unknown address remains indeterminate.
-        if (!entries.some((entry) =>
-          entry.tokenAddress?.toLowerCase() === address.toLowerCase()
-        )) {
-          return unavailable({
-            address,
-            range,
-            launchSource: catalog.source,
-            reason: "identity-unavailable",
-            status: 503,
-          });
-        }
+        // canonical identity. Unknown identities remain indeterminate until
+        // both Custom authorities have been read below.
+        customReadFailed = true;
       }
       if (customEntries !== undefined) {
         entries = mergeEnvioClassicV3CatalogEntriesV1(entries, customEntries);
         customStatus = "current";
       }
     }
+    let routerStatus: "current" | "unavailable" = "unavailable";
+    let routerReadFailed = false;
+    try {
+      const verifiedRouterEntries =
+        await readFinalizedRouterCustomExploreEntriesV1({
+          signal: request.signal,
+          deadlineMs: Date.now() + 8_000,
+        });
+      entries = mergeRouterCustomExploreEntriesV1(
+        entries,
+        routerCustomEntriesAtOrBeforeBlockV1(
+          verifiedRouterEntries,
+          catalog.asOfBlock,
+        ),
+      );
+      routerStatus = "current";
+    } catch {
+      console.error("Token chart Router Custom read unavailable", {
+        name: "RouterCustomReadError",
+      });
+      routerReadFailed = true;
+    }
+    const registryBoundLaunchSource = customStatus === "current"
+      ? `${catalog.source}+registry.custom-launched`
+      : catalog.source;
+    const launchSource = publicLaunchSourceV1({
+      registryCustomCurrent: customStatus === "current",
+      routerCustomCurrent: routerStatus === "current",
+    });
+    if (
+      launchSource !== registryBoundLaunchSource &&
+      launchSource !==
+        `${registryBoundLaunchSource}+canonical-launch-stamp-router`
+    ) {
+      throw new Error("Token chart launch source is not catalog-bound");
+    }
     const entry = entries.find((candidate) =>
       candidate.tokenAddress?.toLowerCase() === address.toLowerCase()
     );
     if (entry === undefined) {
+      if (customReadFailed || routerReadFailed) {
+        return unavailable({
+          address,
+          range,
+          launchSource,
+          reason: "identity-unavailable",
+          routerStatus,
+          status: 503,
+        });
+      }
       return json({ error: "Token not found" }, 404);
     }
-    const launchSource = customStatus === "current"
-      ? `${catalog.source}+registry.custom-launched`
-      : catalog.source;
     const identities = exploreEntryMarketIdentitiesV1(entry);
     if (identities.length !== 1) {
       return unavailable({
@@ -92,6 +133,7 @@ export async function GET(request: NextRequest) {
         range,
         launchSource,
         reason: "identity-unavailable",
+        routerStatus,
       });
     }
     if (range === "all" && !Number.isFinite(Date.parse(entry.launchedAt))) {
@@ -100,6 +142,7 @@ export async function GET(request: NextRequest) {
         range,
         launchSource,
         reason: "identity-unavailable",
+        routerStatus,
       });
     }
     const chart = await readBitqueryMarketChartV1({
@@ -108,7 +151,12 @@ export async function GET(request: NextRequest) {
       ...(range === "all" ? { historyStart: entry.launchedAt } : {}),
       signal: request.signal,
     });
-    return chartResponse(chart, launchSource, entry.exploreKind === "token");
+    return chartResponse(
+      chart,
+      launchSource,
+      entry.exploreKind === "token",
+      routerStatus,
+    );
   } catch (error) {
     console.error("Token chart identity read failed", {
       name: error instanceof Error ? error.name : "LaunchCatalogError",
@@ -118,6 +166,7 @@ export async function GET(request: NextRequest) {
       range,
       launchSource: "envio-classic-v3",
       reason: "market-data-unavailable",
+      routerStatus: "unavailable",
       status: 503,
     });
   }
@@ -135,6 +184,7 @@ function unavailable(input: Readonly<{
   range: "1h" | "1d" | "1w" | "all";
   launchSource: string;
   reason: MarketChartErrorV1["reason"];
+  routerStatus?: "current" | "unavailable";
   status?: 200 | 503;
 }>) {
   const status = input.status ?? 200;
@@ -157,6 +207,8 @@ function unavailable(input: Readonly<{
         "X-Programmable-Data-Quality": "unavailable",
         "X-Programmable-Launch-Source": input.launchSource,
         "X-Programmable-Read-Source": input.launchSource,
+        "X-Programmable-Router-Read-Status":
+          input.routerStatus ?? "unavailable",
         ...(status === 503 ? { "Retry-After": "5" } : {}),
       },
     },
@@ -167,6 +219,7 @@ function chartResponse(
   chart: MarketChartV1,
   launchSource: string,
   isCanonicalToken: boolean,
+  routerStatus: "current" | "unavailable",
 ) {
   const dataQuality = chart.status === "ready" ||
       chart.status === "insufficient-history"
@@ -186,6 +239,7 @@ function chartResponse(
       "X-Programmable-Data-Quality": dataQuality,
       "X-Programmable-Launch-Source": launchSource,
       "X-Programmable-Read-Source": `${launchSource}+bitquery`,
+      "X-Programmable-Router-Read-Status": routerStatus,
       "X-Programmable-Market-Provider": "bitquery",
       "X-Programmable-Market-Read-Status": chart.readStatus,
       ...(hasPriceHistory

--- a/tests/token-chart-api.test.ts
+++ b/tests/token-chart-api.test.ts
@@ -81,6 +81,7 @@ const mocks = vi.hoisted(() => ({
   mergeEntries: vi.fn(),
   customEnabled: vi.fn(),
   customDirectory: vi.fn(),
+  readRouter: vi.fn(),
   readChart: vi.fn(),
 }));
 vi.mock("../lib/market-data/envio-classic-v3-catalog.server", () => ({
@@ -96,8 +97,25 @@ vi.mock("../lib/server/custom-launch/public-readiness", () => ({
 vi.mock("../lib/server/custom-launch/explore-directory-v1", () => ({
   readProductionCustomExploreDirectoryV1: mocks.customDirectory,
 }));
+vi.mock("../lib/alchemy/router-custom-public.server", () => ({
+  readFinalizedRouterCustomExploreEntriesV1: mocks.readRouter,
+  routerCustomEntriesAtOrBeforeBlockV1: (entries: readonly unknown[]) => entries,
+  mergeRouterCustomExploreEntriesV1: (
+    existing: readonly unknown[],
+    router: readonly unknown[],
+  ) => [...existing, ...router],
+  publicLaunchSourceV1: (input: Readonly<{
+    registryCustomCurrent: boolean;
+    routerCustomCurrent: boolean;
+  }>) => [
+    "envio-classic-v3",
+    ...(input.registryCustomCurrent ? ["registry.custom-launched"] : []),
+    ...(input.routerCustomCurrent ? ["canonical-launch-stamp-router"] : []),
+  ].join("+"),
+}));
 
 import { GET } from "../app/api/explore/token/chart/route";
+import { customGraphExploreEntry } from "./launch-stamp-surface-fixture";
 
 function request(query = `address=${address}&range=1d`) {
   return new NextRequest(`http://localhost/api/explore/token/chart?${query}`);
@@ -110,6 +128,7 @@ describe("pool-bound token chart API", () => {
       source: "envio-classic-v3",
       status: "last-known-good",
       generatedAt: "2026-08-14T00:00:00.000Z",
+      asOfBlock: "25740000",
       entries: [token],
     });
     mocks.customEnabled.mockReturnValue(false);
@@ -118,6 +137,7 @@ describe("pool-bound token chart API", () => {
       ...canonical,
       ...custom,
     ]);
+    mocks.readRouter.mockResolvedValue([]);
     mocks.readChart.mockResolvedValue(chart);
   });
 
@@ -129,10 +149,13 @@ describe("pool-bound token chart API", () => {
       "public, max-age=0, s-maxage=2, stale-while-revalidate=2",
     );
     expect(response.headers.get("x-programmable-launch-source")).toBe(
-      "envio-classic-v3",
+      "envio-classic-v3+canonical-launch-stamp-router",
     );
     expect(response.headers.get("x-programmable-read-source")).toBe(
-      "envio-classic-v3+bitquery",
+      "envio-classic-v3+canonical-launch-stamp-router+bitquery",
+    );
+    expect(response.headers.get("x-programmable-router-read-status")).toBe(
+      "current",
     );
     expect(response.headers.get("x-programmable-data-quality")).toBe("current");
     expect(response.headers.get("x-programmable-market-provider")).toBe(
@@ -200,10 +223,10 @@ describe("pool-bound token chart API", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("x-programmable-launch-source")).toBe(
-      "envio-classic-v3+registry.custom-launched",
+      "envio-classic-v3+registry.custom-launched+canonical-launch-stamp-router",
     );
     expect(response.headers.get("x-programmable-read-source")).toBe(
-      "envio-classic-v3+registry.custom-launched+bitquery",
+      "envio-classic-v3+registry.custom-launched+canonical-launch-stamp-router+bitquery",
     );
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(mocks.readChart).toHaveBeenCalledWith(expect.objectContaining({
@@ -273,10 +296,10 @@ describe("pool-bound token chart API", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("x-programmable-launch-source")).toBe(
-      "envio-classic-v3",
+      "envio-classic-v3+canonical-launch-stamp-router",
     );
     expect(response.headers.get("x-programmable-read-source")).toBe(
-      "envio-classic-v3+bitquery",
+      "envio-classic-v3+canonical-launch-stamp-router+bitquery",
     );
     expect(response.headers.get("x-programmable-data-quality")).toBe(
       "unavailable",
@@ -291,6 +314,46 @@ describe("pool-bound token chart API", () => {
       status: "unavailable",
       points: [],
     });
+  });
+
+  it("binds a Router-only Custom launch to its canonical provenance", async () => {
+    mocks.catalog.mockResolvedValue({
+      source: "envio-classic-v3",
+      asOfBlock: "25740000",
+      entries: [],
+    });
+    mocks.customEnabled.mockReturnValue(true);
+    mocks.readRouter.mockResolvedValue([customGraphExploreEntry]);
+    mocks.readChart.mockResolvedValue({
+      ...chart,
+      identity: {
+        ...chart.identity,
+        tokenAddress: customGraphExploreEntry.tokenAddress,
+        poolId: customGraphExploreEntry.poolId,
+      },
+    });
+
+    const response = await GET(request(
+      `address=${customGraphExploreEntry.tokenAddress}&range=1d`,
+    ));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-programmable-launch-source")).toBe(
+      "envio-classic-v3+registry.custom-launched+canonical-launch-stamp-router",
+    );
+    expect(response.headers.get("x-programmable-read-source")).toBe(
+      "envio-classic-v3+registry.custom-launched+canonical-launch-stamp-router+bitquery",
+    );
+    expect(response.headers.get("x-programmable-router-read-status")).toBe(
+      "current",
+    );
+    expect(mocks.readChart).toHaveBeenCalledWith(expect.objectContaining({
+      identity: expect.objectContaining({
+        tokenAddress: customGraphExploreEntry.tokenAddress,
+        poolId: customGraphExploreEntry.poolId,
+      }),
+      range: "1d",
+    }));
   });
 
   it("returns 404 for an address outside the committed identity catalog", async () => {


### PR DESCRIPTION
## What
- merge finalized Router Custom identities into token chart lookups
- preserve the exact Programmable launch source on chart responses
- fail closed only when an unknown identity cannot be resolved authoritatively

## Focused verification
- `npx vitest run tests/token-chart-api.test.ts` (14/14)
- `npx eslint app/api/explore/token/chart/route.ts tests/token-chart-api.test.ts`
- `git diff --check`