### PR TITLE
Make Custom launch documentation API-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Programmable is a launch platform for Uniswap v4 products. This repository conta
 contract workspace, the public read model and the evidence that binds what the product shows to deployed code.
 
 Classic is the direct launch model for a fixed supply token, a permanently locked ETH pool and configurable creator
-rewards. Custom is the reviewed path for products that need their own hook, application logic or execution graph.
+rewards. Custom is the API-first path for products that need their own hook, application logic or execution graph.
+An authenticated request binds one deterministic bundle to the controller wallet, and the wallet separately reviews
+and signs the prepared transaction.
 Prediction Markets is a separately versioned Uniswap v4 launch model for onchain outcome markets. Its current
 capabilities, contracts and release evidence live in the public
 [`programmable-prediction-markets`](https://github.com/0xprogrammable/programmable-prediction-markets) repository.
@@ -52,7 +54,7 @@ transaction.
 | Model                  | What it creates                                                       | Access                                                    |
 | ---------------------- | --------------------------------------------------------------------- | --------------------------------------------------------- |
 | **Classic**            | A fixed supply token with configurable buy and sell transaction fees  | Open through [Create](https://programmable.market/launch) |
-| **Custom**             | A token or application with an individually reviewed hook and release | Accepted and activated revisions only                     |
+| **Custom**             | A token or application with its own deterministic hook graph          | Wallet-bound [Custom Launch API](https://programmable.market/developers/api-keys) |
 | **Prediction Markets** | Onchain outcome markets powered by Uniswap v4                         | Open through [Create](https://programmable.market/launch) |
 
 A hook is a smart contract attached to a Uniswap v4 pool. The pool calls it at defined points in a transaction, which
@@ -126,15 +128,17 @@ provider availability or onchain lifecycle completion.
 
 ## Public interfaces
 
-| Surface             | Canonical location                                                                                       |
-| ------------------- | -------------------------------------------------------------------------------------------------------- |
-| Product             | [programmable.market](https://programmable.market)                                                       |
-| Explore             | [programmable.market/explore](https://programmable.market/explore)                                       |
-| Prediction Markets  | [programmable.market/markets](https://programmable.market/markets)                                       |
-| Documentation       | [programmable.market/docs](https://programmable.market/docs)                                             |
-| Developer reference | [programmable.market/docs/developers](https://programmable.market/docs/developers)                       |
-| Service status      | [developers.programmable.family/api/v2/status](https://developers.programmable.family/api/v2/status)     |
-| Deployment manifest | [developers.programmable.family/api/v2/manifest](https://developers.programmable.family/api/v2/manifest) |
+| Surface                      | Canonical location                                                                                       |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Product                      | [programmable.market](https://programmable.market)                                                       |
+| Explore                      | [programmable.market/explore](https://programmable.market/explore)                                       |
+| Prediction Markets           | [programmable.market/markets](https://programmable.market/markets)                                       |
+| Documentation                | [programmable.market/docs](https://programmable.market/docs)                                             |
+| Custom Launch API keys       | [programmable.market/developers/api-keys](https://programmable.market/developers/api-keys)               |
+| Authenticated Custom writes  | [api.programmable.market/v1/custom-launches](https://api.programmable.market/v1/custom-launches)          |
+| Read-only developer reference | [programmable.market/docs/developers](https://programmable.market/docs/developers)                       |
+| Read-only service status     | [developers.programmable.family/api/v2/status](https://developers.programmable.family/api/v2/status)     |
+| Deployment manifest          | [developers.programmable.family/api/v2/manifest](https://developers.programmable.family/api/v2/manifest) |
 
 Ethereum contract addresses and integration data should come from the versioned manifest rather than screenshots,
 token names or third-party metadata. For Prediction Markets, use the canonical repository for the current networks,
@@ -145,9 +149,8 @@ supported market types, economics, resolution rules, contract addresses and rele
 | Repository                                                                                             | Responsibility                                                              |
 | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
 | [`hookbuilder`](https://github.com/0xprogrammable/hookbuilder)                                         | Agent Skill and local tools for building reproducible Uniswap v4 projects   |
-| [`submit-launch`](https://github.com/0xprogrammable/submit-launch)                                     | Exact-revision intake and public review records for one completed project   |
-| [`submit-template`](https://github.com/0xprogrammable/submit-template)                                 | Requirements and version binding for reusable hook templates                |
-| [`developers`](https://github.com/0xprogrammable/developers)                                           | Discovery manifests, API contracts and direct verification rules            |
+| [`launch-policy`](https://github.com/0xprogrammable/launch-policy)                                     | Versioned Custom launch requirements, policies and schemas                  |
+| [`developers`](https://github.com/0xprogrammable/developers)                                           | Read-only discovery manifests, API contracts and verification rules         |
 | [`programmable-prediction-markets`](https://github.com/0xprogrammable/programmable-prediction-markets) | Prediction market contracts, release specifications and deployment evidence |
 
 ## Release and security boundaries
@@ -155,8 +158,8 @@ supported market types, economics, resolution rules, contract addresses and rele
 `production` is the canonical full-product branch and the only source for website releases. `main` preserves public
 contract and release-evidence history. Feature branches merge through reviewed pull requests.
 
-Source verification, passing tests, a Registry record, a review result or a visible token page are not an external
-audit, a safety guarantee, proof of liquidity or launch authorization. Deployment, activation, finality and public
+Source verification, passing tests, a Registry record, a prepared action or a visible token page are not an external
+audit, a safety guarantee, proof of liquidity or wallet authorization. Deployment, activation, finality and public
 availability require separate evidence.
 
 The smart contracts in this repository have not undergone an external audit or public security contest.

--- a/app/docs/creators/earnings/page.tsx
+++ b/app/docs/creators/earnings/page.tsx
@@ -95,9 +95,8 @@ export default function CreatorEarningsDocsPage() {
           official launches that use that version.
         </p>
         <p>
-          The current template repository does not accept public applications. A
-          share accrues only when the matching template registry and payout path
-          are active for the launch.
+          Public template intake is not active. A share accrues only when the
+          matching template registry and payout path are active for the launch.
         </p>
       </section>
 
@@ -122,7 +121,7 @@ export default function CreatorEarningsDocsPage() {
           <li>Fees depend on qualifying activity and may be zero.</li>
           <li>Programmable does not promise trading volume or fixed income.</li>
           <li>
-            Review, approval, listing and program participation do not create a
+            API preparation, listing and program participation do not create a
             payment by themselves.
           </li>
           <li>

--- a/app/docs/creators/launch/page.tsx
+++ b/app/docs/creators/launch/page.tsx
@@ -108,15 +108,16 @@ export default function CreatorLaunchDocsPage() {
       <section id="submit">
         <h2>Submit the bundle</h2>
         <p>
-          Send the source descriptor and executable graph bundle to the Custom
-          Launch API with the key as a Bearer credential. The API validates the
-          declared manifest commitment, wallet binding, graph, hook permissions
-          and launch constraints before it prepares an action. It does not
-          compile or simulate the submitted project.
+          Send the source descriptor and executable graph bundle to{" "}
+          <code>https://api.programmable.market/v1/custom-launches</code> with
+          the key as a Bearer credential. The API validates the declared
+          manifest commitment, wallet binding, graph, hook permissions and
+          launch constraints before it prepares an action. It does not compile
+          or simulate the submitted project.
         </p>
         <p className={styles.inlineAction}>
-          <Link href="/docs/developers/machine-readable">
-            Read the machine-readable API guide
+          <Link href="/developers/custom-launch-api-v1.md">
+            Read the Custom Launch API guide
           </Link>
         </p>
       </section>
@@ -157,7 +158,7 @@ export default function CreatorLaunchDocsPage() {
           </li>
           <li>
             Treat a new contract version or materially changed control path as a
-            new review target.
+            new launch subject.
           </li>
         </ul>
       </section>

--- a/app/docs/creators/page.tsx
+++ b/app/docs/creators/page.tsx
@@ -9,15 +9,15 @@ import { DocsShell } from "@/components/docs-shell";
 export const metadata: Metadata = {
   title: "Creators · Programmable",
   description:
-    "Prepare a Custom launch through the API, publish reusable hook logic and understand how creators earn.",
+    "Prepare a Custom launch through the API and understand current creator paths and earnings.",
   alternates: { canonical: "/docs/creators" },
 };
 
 const sections = [
   { id: "paths", label: "Choose a creator path" },
   { id: "project", label: "Launch a project" },
-  { id: "template", label: "Publish a template" },
-  { id: "review", label: "Checks and activation" },
+  { id: "template", label: "Public templates" },
+  { id: "review", label: "Checks and wallet action" },
   { id: "earn", label: "How creators earn" },
   { id: "tools", label: "Tools and programs" },
 ] as const;
@@ -26,16 +26,16 @@ export default function CreatorsDocsPage() {
   return (
     <DocsShell
       currentPath="/docs/creators"
-      description="Prepare a Custom launch through the API, publish reusable hook logic or work with Programmable through a creator program."
+      description="Prepare a Custom launch through the API, understand the planned template policy or work with Programmable through a creator program."
       sections={sections}
       title="Create with Programmable"
     >
       <section id="paths">
         <h2>Choose a creator path</h2>
         <p>
-          A project launch and a reusable template are different products. A
-          launch creates one token and market. A template is reviewed for other
-          people to use in future launches.
+          Custom project launches are available through the API. A reusable
+          template would be a different product for other people to use in
+          future launches, and its public intake is not open.
         </p>
 
         <div className={styles.pathGrid}>
@@ -48,12 +48,11 @@ export default function CreatorsDocsPage() {
             </small>
           </Link>
           <Link className={styles.pathCard} href="/docs/creators/templates">
-            <span>Submit a Template</span>
-            <strong>Publish reusable logic</strong>
+            <span>Planned</span>
+            <strong>Understand public templates</strong>
             <small>
-              Submit a reusable hook template that other creators can use in
-              their own official launches. The repository currently does not
-              accept public template applications.
+              Read the planned versioning, attribution and fee policy. Public
+              template submissions are not active.
             </small>
           </Link>
           <a
@@ -66,8 +65,7 @@ export default function CreatorsDocsPage() {
             <strong>Build with the skill and tools</strong>
             <small>
               Use the Hook Builder skill to create a reproducible Uniswap v4
-              project before packaging it for the Custom Launch API or Submit a
-              Template.
+              project before packaging it for the Custom Launch API.
             </small>
             <span className="sr-only">Opens Hook Builder on GitHub</span>
           </a>
@@ -95,16 +93,17 @@ export default function CreatorsDocsPage() {
       </section>
 
       <section id="template">
-        <h2>Publish a template</h2>
+        <h2>Public templates are planned</h2>
         <p>
           A public template uses one 20 bps fee: 10 bps goes to the template
           creator and 10 bps goes to Programmable. The share is tied to the
           exact template version and its official payout path; no share accrues
-          before the repository, registry and recipient path are activated.
+          before the program, registry and recipient path are activated.
         </p>
         <p>
-          Submit a Template is the separate path for reusable hook logic. Do not
-          send reusable template applications through the Custom Launch API.
+          Public template intake is not active. The Custom Launch API accepts
+          one concrete project and token bundle; it does not publish reusable
+          templates.
         </p>
         <p className={styles.inlineAction}>
           <Link href="/docs/creators/templates">Read the template model</Link>
@@ -112,17 +111,17 @@ export default function CreatorsDocsPage() {
       </section>
 
       <section id="review">
-        <h2>Checks and activation</h2>
+        <h2>Checks and wallet action</h2>
         <p>
           The Custom Launch API checks one deterministic bundle and prepares an
-          exact wallet action. Template Reviewer separately checks one reusable
-          template version, its parameter range and payout identity.
+          exact wallet action. A future template program would separately bind
+          one reusable version, parameter range and payout identity.
         </p>
         <p>
-          Preparation and activation are separate. An API result does not
+          Preparation and wallet execution are separate. An API result does not
           authorize the controller wallet, sign a transaction or broadcast it.
-          The matching wallet action and release record must provide those
-          separate bindings.
+          The matching wallet action and final onchain record provide those
+          separate results.
         </p>
       </section>
 
@@ -134,8 +133,8 @@ export default function CreatorsDocsPage() {
           their separately documented payout path is active.
         </p>
         <p>
-          Revenue depends on qualifying activity. Review, publication and
-          listing do not promise volume or a fixed payment.
+          Revenue depends on qualifying activity. API preparation, publication
+          and listing do not promise volume or a fixed payment.
         </p>
         <p className={styles.inlineAction}>
           <Link href="/docs/creators/earnings">Compare creator earnings</Link>

--- a/app/docs/creators/programs/page.tsx
+++ b/app/docs/creators/programs/page.tsx
@@ -41,8 +41,9 @@ export default function CreatorProgramsDocsPage() {
           accrue a share.
         </p>
         <p>
-          Partnership support does not replace technical review or create a
-          general endorsement of every project launched from that template.
+          Partnership support does not replace applicable project checks,
+          Custom API requirements or wallet confirmation. It also does not
+          endorse every project launched from that template.
         </p>
       </section>
 

--- a/app/docs/creators/templates/page.tsx
+++ b/app/docs/creators/templates/page.tsx
@@ -1,19 +1,18 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
-import { DocsExternalLink } from "@/components/docs-external-link";
 import docsStyles from "@/components/docs-experience.module.css";
 import styles from "@/components/docs-hub.module.css";
 import {
   formatBps,
   PROGRAMMABLE_FEE_TABLE,
-  PROGRAMMABLE_PUBLIC_REPOSITORIES,
 } from "@/components/docs-public-policy";
 import { DocsShell } from "@/components/docs-shell";
 
 export const metadata: Metadata = {
-  title: "Publish a template · Programmable",
+  title: "Public templates · Programmable",
   description:
-    "Publish reusable hook logic with clear version binding, attribution and creator fees.",
+    "Understand the planned reusable hook versioning, attribution and creator fee policy.",
   alternates: { canonical: "/docs/creators/templates" },
 };
 
@@ -23,7 +22,7 @@ const sections = [
   { id: "economics", label: "Template economics" },
   { id: "version", label: "Version and attribution" },
   { id: "requirements", label: "What a template needs" },
-  { id: "next", label: "Repository reference" },
+  { id: "next", label: "Current status" },
 ] as const;
 
 export default function CreatorTemplateDocsPage() {
@@ -36,34 +35,27 @@ export default function CreatorTemplateDocsPage() {
       parentHref="/docs/creators"
       parentLabel="Creators"
       sections={sections}
-      title="Publish a template"
+      title="Public templates"
     >
       <section id="overview">
         <h2>Template model</h2>
         <p>
           A template is reusable hook logic with a defined parameter range. Each
-          version is reviewed and attributed separately so creators can see
+          version would be bound and attributed separately so creators can see
           exactly which code their launches use.
         </p>
         <p>
-          Use Submit a Template for reusable logic. A concrete token and project
-          belong in the Custom Launch API, while Hook Builder remains the skill
-          and tooling layer for creating both.
+          A concrete token and project belong in the Custom Launch API. A public
+          template would be a separately versioned product for other creators to
+          select, but that submission path is not active.
         </p>
         <div className={docsStyles.callout}>
-          <strong>Follow the Submit a Template repository.</strong>
+          <strong>Public template intake is closed.</strong>
           <p>
-            The repository is the source for the schema, examples and intake
-            rules. Its current instructions do not accept public template
-            applications. Read the repository before opening a pull request; the
-            repository controls when that changes.
+            Do not open a repository application or send a reusable template to
+            the Custom Launch API. Use the API only for one concrete project and
+            token bundle.
           </p>
-          <DocsExternalLink
-            href={PROGRAMMABLE_PUBLIC_REPOSITORIES.submitTemplate}
-            variant="chip"
-          >
-            Open Submit a Template
-          </DocsExternalLink>
         </div>
       </section>
 
@@ -94,7 +86,7 @@ export default function CreatorTemplateDocsPage() {
                 </td>
               </tr>
               <tr>
-                <th scope="row">Review target</th>
+                <th scope="row">Version target</th>
                 <td data-label="Project launch">
                   One source revision and launch configuration.
                 </td>
@@ -109,7 +101,7 @@ export default function CreatorTemplateDocsPage() {
                   Launch from the bound wallet.
                 </td>
                 <td data-label="Public template">
-                  Publish a version for future official launches.
+                  No public submission while the program is inactive.
                 </td>
               </tr>
               <tr>
@@ -118,7 +110,7 @@ export default function CreatorTemplateDocsPage() {
                   Defined by the project market.
                 </td>
                 <td data-label="Public template">
-                  10 bps from qualifying official template usage.
+                  Planned 10 bps from qualifying official template usage.
                 </td>
               </tr>
             </tbody>
@@ -176,18 +168,14 @@ export default function CreatorTemplateDocsPage() {
       </section>
 
       <section id="next">
-        <h2>Repository reference</h2>
+        <h2>Current status</h2>
         <p>
-          Submit a Template contains the schema, examples and review process for
-          this path. Use the repository as the source for current intake
-          instructions.
+          Public template submissions and fee share activation are not active.
+          For a concrete Custom project, use the current API-first launch path.
         </p>
-        <DocsExternalLink
-          href={PROGRAMMABLE_PUBLIC_REPOSITORIES.submitTemplate}
-          variant="chip"
-        >
-          Follow Submit a Template
-        </DocsExternalLink>
+        <p className={styles.inlineAction}>
+          <Link href="/developers/api-keys">Create a Custom launch API key</Link>
+        </p>
       </section>
     </DocsShell>
   );

--- a/app/docs/developers/machine-readable/page.tsx
+++ b/app/docs/developers/machine-readable/page.tsx
@@ -234,8 +234,8 @@ export default function MachineReadableDocsPage() {
             no authentication.
           </li>
           <li>
-            <code>api.programmable.market/v1/custom-launches</code> requires a
-            wallet-bound <code>pm_live_</code> Bearer key.
+            <code>https://api.programmable.market/v1/custom-launches</code>{" "}
+            requires a wallet-bound <code>pm_live_</code> Bearer key.
           </li>
           <li>
             Keys default to 90 days, are capped at 366 days and are limited to

--- a/app/docs/economics/page.tsx
+++ b/app/docs/economics/page.tsx
@@ -117,8 +117,8 @@ export default function EconomicsDocsPage() {
           <p>
             The policy describes the split; the matching release and public
             record determine whether a particular launch, template or recipient
-            can use it. Public template intake is controlled by the repository
-            instructions. Prediction Markets keeps its current economics in the{" "}
+            can use it. Public template intake is not active. Prediction Markets
+            keeps its current economics in the{" "}
             <DocsExternalLink
               href={PROGRAMMABLE_PUBLIC_REPOSITORIES.predictionMarkets}
             >
@@ -138,9 +138,9 @@ export default function EconomicsDocsPage() {
           separately documented payout path is active.
         </p>
         <p>
-          Earnings depend on actual qualifying activity. A review, listing or
-          template publication does not promise trading volume or a fixed
-          payment.
+          Earnings depend on actual qualifying activity. API preparation,
+          listing or template publication does not promise trading volume or a
+          fixed payment.
         </p>
         <p className={styles.inlineAction}>
           <Link href="/docs/creators/earnings">Read the creator guide</Link>

--- a/app/docs/launch-stamps/page.tsx
+++ b/app/docs/launch-stamps/page.tsx
@@ -720,11 +720,11 @@ export default function LaunchStampDocsPage() {
           <div>
             <dt>Not launch authorization</dt>
             <dd>
-              A Router reference does not grant launch access. Custom releases
-              use a review and activation path. Check the deployment record and{" "}
-              <Link href="/docs/trust">trust boundaries</Link> before the{" "}
+              A Router reference does not grant launch access. Custom launch
+              preparation uses a wallet-bound key and the authenticated API.
+              Read the <Link href="/docs/trust">trust boundaries</Link> and{" "}
               <Link href="/docs/creators/launch">creator launch guide</Link> for
-              the separate access rules.
+              the separate access and wallet rules.
             </dd>
           </div>
         </dl>

--- a/app/docs/models/[model]/page.tsx
+++ b/app/docs/models/[model]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
 import { DocsAddress } from "@/components/docs-address";
@@ -25,11 +26,11 @@ const classicSections = [
 
 const customSections = [
   { id: "overview", label: "What Custom is" },
-  { id: "release-scope", label: "Release-specific behavior" },
-  { id: "release-requirements", label: "Release requirements" },
+  { id: "release-scope", label: "Bundle-specific behavior" },
+  { id: "release-requirements", label: "Bundle requirements" },
   { id: "launch-information", label: "Launch information" },
   { id: "router-provenance", label: "Router provenance" },
-  { id: "project-presentation", label: "What activation does not prove" },
+  { id: "project-presentation", label: "What preparation does not prove" },
 ] as const;
 
 const stockPairedSections = [
@@ -53,7 +54,7 @@ const modelMetadata: Record<ModelSlug, { description: string; title: string }> =
     custom: {
       title: "Custom hooks",
       description:
-        "Requirements and provenance for releases that use individual Uniswap v4 hooks.",
+        "API preparation requirements and provenance for individual Uniswap v4 hook graphs.",
     },
     "prediction-markets": {
       title: "Prediction Markets",
@@ -376,7 +377,7 @@ function CustomDocs() {
       currentPath="/docs/models/custom"
       kicker="Launch model · Ethereum"
       title="Custom hooks"
-      description="Custom launches use Uniswap v4 hook logic with behavior and controls defined by each release."
+      description="Custom launches use deterministic Uniswap v4 hook graphs prepared through the wallet-bound API."
       sections={customSections}
     >
       <section id="overview">
@@ -387,9 +388,12 @@ function CustomDocs() {
           liquidity or other permitted callbacks work.
         </p>
         <p>
-          Each release defines its own review target, execution profile and
-          activation record. Use those records and the program instructions for
-          the launch path you are evaluating.
+          Each request binds one source descriptor, manifest digest, graph
+          bundle and controller wallet. The authenticated API prepares the exact
+          wallet action without signing or broadcasting it.
+        </p>
+        <p className={styles.inlineAction}>
+          <Link href="/developers/api-keys">Create a Custom launch API key</Link>
         </p>
       </section>
 
@@ -403,15 +407,15 @@ function CustomDocs() {
       </section>
 
       <section id="release-requirements">
-        <h2>Release requirements</h2>
+        <h2>Bundle requirements</h2>
         <p>
-          Before activation, a release must define the following information.
+          Before submission, a bundle must define the following information.
         </p>
         <ul className={styles.contentList}>
           <li>The allowed token and pool configuration.</li>
           <li>The fee path, reward recipients and mutable controls.</li>
           <li>Liquidity custody and every withdrawal path.</li>
-          <li>Transaction preparation, simulation and wallet validation.</li>
+          <li>Transaction construction, graph bindings and controller wallet.</li>
           <li>
             Deployment records, runtime verification and supported network.
           </li>
@@ -443,13 +447,13 @@ function CustomDocs() {
       </section>
 
       <section id="project-presentation">
-        <h2>What activation does not prove</h2>
+        <h2>What preparation does not prove</h2>
         <p>
-          Activation makes the configured release path available. It does not
-          establish current tradability, liquidity, price, pool state, support
-          in an external terminal or the behavior of an interface outside the
-          release. Project artwork, descriptions and links do not verify the
-          hook or make another launch path available.
+          A prepared action does not establish current tradability, liquidity,
+          price, pool state, audit coverage, support in an external terminal or
+          the behavior of an interface outside the submitted graph. Project
+          artwork, descriptions and links do not verify the hook or make another
+          launch path available.
         </p>
       </section>
     </DocsShell>

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -4,13 +4,12 @@ import { ArrowRight } from "lucide-react";
 
 import docsStyles from "@/components/docs-experience.module.css";
 import styles from "@/components/docs-hub.module.css";
-import { PROGRAMMABLE_PUBLIC_REPOSITORIES } from "@/components/docs-public-policy";
 import { DocsShell } from "@/components/docs-shell";
 
 export const metadata: Metadata = {
   title: "Documentation · Programmable",
   description:
-    "Understand Programmable, launch a project, publish a template or integrate verified launch data.",
+    "Understand Programmable, prepare a Custom launch through the API or integrate verified launch data.",
   alternates: { canonical: "/docs" },
 };
 
@@ -33,7 +32,7 @@ const paths = [
   },
   {
     description:
-      "Build a project, follow the review path and understand how creators earn.",
+      "Build a project, prepare it through the API and understand how creators earn.",
     href: "/docs/creators",
     label: "Create with Programmable",
     meta: "Creators",
@@ -112,8 +111,8 @@ export default function DocsIndexPage() {
           <div>
             <h3>Creators</h3>
             <p>
-              Build a concrete project or publish reusable hook logic, then
-              understand the review, attribution and fee path before launch.
+              Build a concrete project, prepare it through the Custom Launch API
+              and review the exact wallet action before launch.
             </p>
           </div>
           <div>
@@ -121,7 +120,7 @@ export default function DocsIndexPage() {
             <p>
               Use Hook Builder as the skill and tooling layer. It produces the
               reproducible project that can become a deterministic Custom
-              Launch API bundle or a reusable template submission.
+              Launch API bundle.
             </p>
           </div>
           <div>
@@ -137,8 +136,8 @@ export default function DocsIndexPage() {
       <section id="system">
         <h2>How the system fits together</h2>
         <p>
-          Programmable separates creation, review, execution and verification.
-          Each step has its own evidence and its own result.
+          Programmable separates creation, API preparation, wallet execution and
+          verification. Each step has its own evidence and its own result.
         </p>
 
         <div className={docsStyles.flow}>
@@ -163,7 +162,7 @@ export default function DocsIndexPage() {
         <p>
           Bundle checks and transaction preparation do not sign or broadcast a
           launch. The controller wallet still reviews the exact action and
-          authorizes any transaction. Public applications can then verify the
+          authorizes any transaction. Public integrations can then verify the
           resulting onchain record.
         </p>
       </section>
@@ -230,8 +229,8 @@ export default function DocsIndexPage() {
               <span>
                 <strong>Trust and verification</strong>
                 <small>
-                  Understand what review, activation and Router provenance
-                  establish.
+                  Understand what bundle checks, wallet execution and Router
+                  provenance establish.
                 </small>
               </span>
               <ArrowRight aria-hidden="true" size={17} strokeWidth={1.8} />
@@ -242,8 +241,8 @@ export default function DocsIndexPage() {
               <span>
                 <strong>Creator paths</strong>
                 <small>
-                  Choose Hook Builder, the Custom Launch API or Submit a
-                  Template.
+                  Use Hook Builder and the Custom Launch API. The public template
+                  program remains separate and is not open for submissions.
                 </small>
               </span>
               <ArrowRight aria-hidden="true" size={17} strokeWidth={1.8} />
@@ -262,21 +261,16 @@ export default function DocsIndexPage() {
             </Link>
           </li>
           <li>
-            <a
-              href={PROGRAMMABLE_PUBLIC_REPOSITORIES.submitTemplate}
-              rel="noreferrer"
-              target="_blank"
-            >
+            <Link href="/docs/creators/templates">
               <span>
-                <strong>Submit a Template</strong>
+                <strong>Public template policy</strong>
                 <small>
-                  Read the requirements; submit only when the repository accepts
-                  applications.
+                  Understand the planned versioning and fee model. Public
+                  template intake is not open.
                 </small>
               </span>
               <ArrowRight aria-hidden="true" size={17} strokeWidth={1.8} />
-              <span className="sr-only">Opens GitHub in a new tab</span>
-            </a>
+            </Link>
           </li>
         </ul>
       </section>

--- a/app/docs/trust/page.tsx
+++ b/app/docs/trust/page.tsx
@@ -8,13 +8,13 @@ import { DocsShell } from "@/components/docs-shell";
 export const metadata: Metadata = {
   title: "Trust · Programmable",
   description:
-    "Understand what source review, launch activation, wallet execution and Router provenance prove.",
+    "Understand what bundle evidence, API preparation, wallet execution and Router provenance prove.",
   alternates: { canonical: "/docs/trust" },
 };
 
 const sections = [
   { id: "layers", label: "Evidence layers" },
-  { id: "review", label: "Review and approval" },
+  { id: "review", label: "Checks and preparation" },
   { id: "router", label: "Router provenance" },
   { id: "roles", label: "Roles and controls" },
   { id: "audits", label: "Independent review" },
@@ -25,7 +25,7 @@ export default function TrustDocsPage() {
   return (
     <DocsShell
       currentPath="/docs/trust"
-      description="Programmable separates source review, launch authority, wallet execution and public onchain verification."
+      description="Programmable separates caller evidence, API preparation, wallet execution and public onchain verification."
       sections={sections}
       title="Trust"
     >
@@ -37,17 +37,17 @@ export default function TrustDocsPage() {
         </p>
         <ol className={docsStyles.steps}>
           <li>
-            <strong>Source review</strong>
+            <strong>Agent evidence</strong>
             <span>
-              Did the exact source revision and its evidence pass the published
-              review gates?
+              Which checks did the agent attest it ran for the exact graph
+              bundle?
             </span>
           </li>
           <li>
-            <strong>Launch activation</strong>
+            <strong>API preparation</strong>
             <span>
-              Is the matching execution profile active for the named revision,
-              wallet and chain?
+              Did the platform validate the declared manifest, graph, evidence
+              digests and wallet binding and return an exact action?
             </span>
           </li>
           <li>
@@ -80,29 +80,31 @@ export default function TrustDocsPage() {
       </section>
 
       <section id="review">
-        <h2>Review and approval</h2>
+        <h2>Checks and preparation</h2>
         <p>
-          A review applies to one exact source revision and evidence set. A
-          later commit is a different target, even when its project name is
-          unchanged.
+          Each Custom request binds one source descriptor, manifest digest,
+          graph bundle and set of agent evidence digests. A changed bundle is a
+          new launch subject, even when its project name is unchanged.
         </p>
         <div className={docsStyles.factGrid}>
           <div className={docsStyles.fact}>
-            <span>Accepted revision</span>
-            <strong>Passed the defined review gates</strong>
+            <span>Agent evidence</span>
+            <strong>Caller-declared digests for checks on the exact graph</strong>
           </div>
           <div className={docsStyles.fact}>
-            <span>Changes requested</span>
-            <strong>Needs a specific correction and a new review target</strong>
+            <span>Prepared</span>
+            <strong>The exact wallet action exists but is not signed</strong>
           </div>
           <div className={docsStyles.fact}>
-            <span>Pending</span>
-            <strong>Required evidence is incomplete or unavailable</strong>
+            <span>Failed</span>
+            <strong>The request did not satisfy a required binding or constraint</strong>
           </div>
         </div>
         <p>
-          Acceptance is technical readiness for the named scope. It is not an
-          external audit, endorsement, price opinion or promise that a launch
+          The platform validates shapes, digests and graph bindings. It does not
+          fetch the evidence, reproduce the build, compile or simulate the
+          project, audit it or adopt the agent&apos;s claims. A prepared result is
+          not an approval, endorsement, price opinion or promise that a launch
           will trade.
         </p>
       </section>

--- a/components/create-guide.tsx
+++ b/components/create-guide.tsx
@@ -6,11 +6,12 @@ import {
   useState,
   type MouseEvent as ReactMouseEvent,
 } from "react";
-import { Check, CircleHelp, Copy, ExternalLink, X } from "lucide-react";
+import Link from "next/link";
+import { ArrowRight, Check, CircleHelp, Copy, ExternalLink, X } from "lucide-react";
 
 import styles from "@/components/create-guide.module.css";
 
-const BUILD_PROMPT = `Build a Uniswap v4 hook for Programmable. Start from the official Hookbuilder at https://github.com/0xprogrammable/hookbuilder. The token should [describe the behavior in plain words]. Keep the project limited to that behavior, add tests, run the local checks, and explain the results. Prepare the exact GitHub revision for Programmable review. Do not deploy, sign, or submit anything without asking me first.`;
+const BUILD_PROMPT = `Build a Uniswap v4 hook for Programmable. Start from the official Hook Builder at https://github.com/0xprogrammable/hookbuilder. The token should [describe the behavior in plain words]. Keep the project limited to that behavior, add tests, run the applicable local checks, and explain the results. Follow https://programmable.market/developers/custom-launch-api-v1.md to package one deterministic source and graph bundle with the required evidence digests. Use my Programmable API key only for the authenticated request to https://api.programmable.market/v1/custom-launches. Never print the key or store it in source control. Do not sign or broadcast. Stop after the API returns the prepared wallet action so I can review it.`;
 
 type CopyState = "idle" | "copied" | "failed";
 
@@ -173,9 +174,9 @@ export function CreateGuide() {
               <div>
                 <h3>Review it locally</h3>
                 <p>
-                  Ask the coding assistant to explain the changes, run the local
-                  checks, and fix any failures. Keep the exact commit you want
-                  reviewed on GitHub.
+                  Ask the coding assistant to explain the changes, run the
+                  applicable local checks, and fix any failures. Keep the exact
+                  source and artifacts that the API bundle identifies.
                 </p>
               </div>
             </li>
@@ -185,12 +186,12 @@ export function CreateGuide() {
                 4
               </span>
               <div>
-                <h3>Submit the exact revision</h3>
+                <h3>Prepare the launch through the API</h3>
                 <p>
-                  Hookbuilder prepares the project. Submit a Launch records the
-                  exact revision for Programmable review. After review and release
-                  binding, the approved project can continue through the Custom
-                  Hook launch here.
+                  Hook Builder packages the project and required evidence. Create
+                  a wallet-bound API key, submit the deterministic bundle to the
+                  Custom Launch API, then review the prepared action in the
+                  controller wallet. The API key cannot sign or broadcast.
                 </p>
                 <div className={styles.links}>
                   <a
@@ -201,14 +202,10 @@ export function CreateGuide() {
                     Open Hookbuilder
                     <ExternalLink aria-hidden="true" size={15} strokeWidth={1.8} />
                   </a>
-                  <a
-                    href="https://github.com/0xprogrammable/submit-launch"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Open Submit a Launch
-                    <ExternalLink aria-hidden="true" size={15} strokeWidth={1.8} />
-                  </a>
+                  <Link href="/developers/api-keys">
+                    Create a Custom launch API key
+                    <ArrowRight aria-hidden="true" size={15} strokeWidth={1.8} />
+                  </Link>
                 </div>
               </div>
             </li>

--- a/components/docs-data.ts
+++ b/components/docs-data.ts
@@ -56,7 +56,7 @@ export const docsCategories = [
     relatedPaths: programmablePaths,
   },
   {
-    description: "Launch, publish and earn",
+    description: "Launch and earn",
     href: "/docs/creators",
     label: "Creators",
     relatedPaths: creatorPaths,
@@ -115,7 +115,7 @@ export const docsNavigation: readonly DocsNavigationGroup[] = [
       {
         depth: 1,
         href: "/docs/creators/templates",
-        label: "Publish a template",
+        label: "Public template policy",
       },
       { depth: 1, href: "/docs/creators/earnings", label: "Earnings" },
       { depth: 1, href: "/docs/creators/programs", label: "Programs" },
@@ -169,9 +169,9 @@ export const docsSearchItems: DocsSearchItem[] = [
     href: "/docs/creators/launch",
   },
   {
-    title: "Publish a template",
+    title: "Public template policy",
     description:
-      "Publish reusable hook logic with clear version binding and attribution.",
+      "Understand the planned version binding, attribution and fee model.",
     href: "/docs/creators/templates",
     keywords: ["template", "royalty", "fee share"],
   },
@@ -203,7 +203,7 @@ export const docsSearchItems: DocsSearchItem[] = [
   {
     title: "Trust",
     description:
-      "Understand what reviews, launch stamps and public records prove.",
+      "Understand what bundle checks, launch stamps and public records prove.",
     href: "/docs/trust",
     keywords: ["security", "audit", "approval"],
   },

--- a/components/docs-public-policy.ts
+++ b/components/docs-public-policy.ts
@@ -20,8 +20,7 @@ export const PROGRAMMABLE_PUBLIC_REPOSITORIES = {
     "https://github.com/0xprogrammable/programmable-prediction-markets",
   product: "https://github.com/0xprogrammable/programmable",
   productIssues: "https://github.com/0xprogrammable/programmable/issues",
-  submitLaunch: "https://github.com/0xprogrammable/submit-launch",
-  submitTemplate: "https://github.com/0xprogrammable/submit-template",
+  launchPolicy: "https://github.com/0xprogrammable/launch-policy",
 } as const;
 
 export const PROGRAMMABLE_PRODUCT_STATES = {
@@ -32,9 +31,9 @@ export const PROGRAMMABLE_PRODUCT_STATES = {
     lifecycle: "Live",
   },
   custom: {
-    availability: "Gated",
+    availability: "Open",
     detail:
-      "Custom releases are enabled individually after review and release binding.",
+      "Custom launch preparation uses a wallet-bound API key, and the controller wallet signs separately.",
     label: "Custom hooks",
     lifecycle: "Live",
   },

--- a/docs/public/.gitbook/STYLEGUIDE.md
+++ b/docs/public/.gitbook/STYLEGUIDE.md
@@ -4,7 +4,7 @@
 
 Programmable documentation serves token creators, hook developers, integrators, researchers and people verifying a launch. A reader should be able to understand what is public now, what an interface does, where a fact comes from and which action still belongs to a wallet or maintainer.
 
-The documentation explains the product without turning technical evidence into a marketing claim. It separates source availability, review, release activation, wallet execution, chain finality, indexing, price data and liquidity data because those states prove different things.
+The documentation explains the product without turning technical evidence into a marketing claim. It separates caller-declared source evidence, API preparation, wallet execution, chain finality, indexing, price data and liquidity data because those states prove different things.
 
 ## Voice
 
@@ -22,7 +22,7 @@ When a fact can drift, link readers to the live status endpoint, developer manif
 
 ## Product terminology
 
-Use “Programmable” with this capitalization. Use “Classic”, “Custom” and “Prediction Markets” for the documented launch models. Use “Custom project” when referring to a project submitted through the public Custom Launch intake. Use “hook” only when the technical mechanism matters, and explain it in plain English when it first appears on a reader facing page.
+Use “Programmable” with this capitalization. Use “Classic”, “Custom” and “Prediction Markets” for the documented launch models. Use “Custom project” for one concrete project and token bundle prepared through the authenticated Custom Launch API. Use “hook” only when the technical mechanism matters, and explain it in plain English when it first appears on a reader facing page.
 
 The canonical Prediction Markets repository owns current networks, supported markets, collateral and activation rules, fees and creator rewards, resolution rules, contract addresses and security or release evidence. Do not duplicate those release-specific facts in these docs; link to the canonical repository instead.
 

--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -1,17 +1,17 @@
 ---
-description: Official documentation for launching, reviewing and integrating Programmable products
+description: Official documentation for launching, verifying and integrating Programmable products
 cover: .gitbook/assets/programmable-night-garden-v2.png
 coverY: 0
 ---
 
 # Programmable
 
-Programmable is a launch platform for Uniswap v4 products. Classic turns a focused set of choices into a fixed supply token, a permanently locked ETH pool and creator rewards. Custom is the reviewed path for products that need their own hook, application logic or execution graph. Prediction Markets is the separately versioned launch model for onchain outcome markets.
+Programmable is a launch platform for Uniswap v4 products. Classic turns a focused set of choices into a fixed supply token, a permanently locked ETH pool and creator rewards. Custom is the API-first path for products that need their own hook, application logic or execution graph. Prediction Markets is the separately versioned launch model for onchain outcome markets.
 
-Classic and Prediction Markets are available from Create. A Custom project moves through public source review and an exact release binding before the named creator wallet receives an executable launch path. In every case, the wallet reviews and signs its own transaction on the required network.
+Classic and Prediction Markets are available from Create. For Custom, the controller wallet creates a scoped API key, an agent submits one deterministic bundle for checks, and the API returns a prepared action. In every case, the wallet reviews and signs its own transaction on the required network.
 
 {% hint style="info" %}
-These docs describe current public products and the evidence available for them. A successful check, accepted source revision or visible token page is not a guarantee of safety, liquidity or future value.
+These docs describe current public products and the evidence available for them. A successful check, prepared action or visible token page is not a guarantee of safety, liquidity or future value.
 {% endhint %}
 
 ## Choose a path
@@ -20,7 +20,7 @@ These docs describe current public products and the evidence available for them.
 | ---------------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | Launch a standard token      | [Create Classic](https://programmable.market/launch)                                     | Configure the token, fees, reward recipients and Initial Buy before signing one Ethereum transaction                         |
 | Create a prediction market   | [Create Prediction Market](https://programmable.market/launch)                           | Choose an available market and review the current release requirements before signing                                        |
-| Build with a custom hook     | [Programmable v4 Builder](https://github.com/0xprogrammable/hookbuilder/releases/latest) | Prepare one exact public revision, then submit it through [Submit a Launch](https://github.com/0xprogrammable/submit-launch) |
+| Build with a custom hook     | [Programmable v4 Builder](https://github.com/0xprogrammable/hookbuilder/releases/latest) | Create a [wallet-bound API key](https://programmable.market/developers/api-keys), submit one deterministic bundle to the Custom Launch API, then review the prepared wallet action |
 | Verify or integrate launches | [Developer reference](developers/README.md)                                              | Resolve current deployments from the manifest and reproduce provenance from Ethereum                                         |
 
 To inspect an existing token, begin with [Explore](https://programmable.market/explore) and use its contract address rather than only a name or ticker.
@@ -39,7 +39,7 @@ To inspect an existing token, begin with [Explore](https://programmable.market/e
 
 ## How a launch becomes public
 
-1. The creator configures a supported launch or prepares one exact reviewed Custom release.
+1. The creator configures a supported launch or prepares one exact Custom API bundle.
 2. The creator wallet checks the network, destination, calldata and value, then signs the transaction.
 3. The required network confirms the transaction and the launch reaches the required finality.
 4. The appropriate website surface publishes the canonical token, pool or prediction market identity. The developer feeds currently cover the Ethereum launch records. Optional price, chart and liquidity data remain separate.
@@ -48,8 +48,8 @@ To inspect an existing token, begin with [Explore](https://programmable.market/e
 
 Each supported launch has one or more tokens, a pool identity and a launch model. Router based Ethereum launches can also carry a launch stamp that binds the token, hook, PoolManager and pool to one canonical execution record. Historical Ethereum launches remain discoverable through the public data service even when they predate the Router. Prediction Markets has its own versioned identity and release records.
 
-Programmable keeps source review, launch authority, wallet execution, chain finality and public indexing separate. That separation is deliberate: it makes it possible to say exactly what has been proven without turning one green check into a broader claim.
+Programmable keeps caller-declared source evidence, API preparation, wallet execution, chain finality and public indexing separate. That separation is deliberate: it makes it possible to say exactly what has been proven without turning one green check into a broader claim.
 
 ## Official sources
 
-The website is [programmable.market](https://programmable.market), the public organization is [0xprogrammable](https://github.com/0xprogrammable), and the read only Ethereum developer service is [developers.programmable.family](https://developers.programmable.family). Prediction Markets source and current release details live in the [public Prediction Markets repository](https://github.com/0xprogrammable/programmable-prediction-markets). Contract addresses and integration data should come from canonical release evidence rather than copied screenshots or third party token metadata.
+The website is [programmable.market](https://programmable.market), the authenticated Custom write API is [api.programmable.market](https://api.programmable.market), and the read only Ethereum developer service is [developers.programmable.family](https://developers.programmable.family). The public organization is [0xprogrammable](https://github.com/0xprogrammable). Prediction Markets source and current release details live in the [public Prediction Markets repository](https://github.com/0xprogrammable/programmable-prediction-markets). Contract addresses and integration data should come from canonical release evidence rather than copied screenshots or third party token metadata.

--- a/docs/public/SUMMARY.md
+++ b/docs/public/SUMMARY.md
@@ -8,7 +8,7 @@
 - [Create](creators/README.md)
   - [Launch a project](creators/launch.md)
   - [Creator earnings](creators/earnings.md)
-  - [Public templates](creators/templates.md)
+  - [Public template policy](creators/templates.md)
   - [Creator programs](creators/programs.md)
 - [Fees and revenue](economics.md)
 - [V4 token](v4-token.md)

--- a/docs/public/creators/README.md
+++ b/docs/public/creators/README.md
@@ -1,5 +1,5 @@
 ---
-description: Start a Classic token or prediction market, or prepare one exact Custom project for review
+description: Start a Classic token or prediction market, or prepare one exact Custom project through the API
 ---
 
 # Create
@@ -8,7 +8,7 @@ Choose Classic when the product fits the standard token launch settings. Choose 
 
 ## Launch Classic
 
-Classic is available from [Create](https://programmable.market/launch). The launch wallet supplies token metadata, selects buy and sell transaction fees, chooses reward recipients and Initial Buy custody, then reviews one Ethereum transaction. No source repository or public review application is required for the standard model.
+Classic is available from [Create](https://programmable.market/launch). The launch wallet supplies token metadata, selects buy and sell transaction fees, chooses reward recipients and Initial Buy custody, then reviews one Ethereum transaction. The standard model does not require a source bundle or Custom Launch API key.
 
 ## Create a Prediction Market
 
@@ -16,13 +16,13 @@ Prediction Markets is available from [Create](https://programmable.market/launch
 
 ## Build a Custom project
 
-Custom work starts with the [Programmable v4 Builder](https://github.com/0xprogrammable/hookbuilder/releases/latest). The Builder can turn a plain idea or an existing public repository into a reviewable project, run its bounded checks and prepare the exact application for Submit a Launch.
+Custom work starts with the [Programmable v4 Builder](https://github.com/0xprogrammable/hookbuilder/releases/latest). The Builder can turn a plain idea or an existing public repository into a deterministic project, run the applicable checks and package the source and graph bundle required by the [Custom Launch API](https://programmable.market/developers/custom-launch-api-v1.md).
 
-The application path is public, but authority remains separate. The accepted source revision must receive a matching release binding before its named wallet can launch through the product.
+Connect the controller wallet and create a [wallet-bound API key](https://programmable.market/developers/api-keys). The authenticated write endpoint is `https://api.programmable.market/v1/custom-launches`. The API validates and prepares an exact action, but the key cannot sign or broadcast. The controller wallet reviews and confirms the action separately.
 
 ## Reusable work
 
-Reusable public templates have their own repository and fee model because one template can affect many later launches. The repository publishes the requirements, but public applications and fee share activation are not open. The current state is recorded in [Submit a Template](https://github.com/0xprogrammable/submit-template).
+Reusable public templates remain a planned product with a separate fee and versioning model because one template can affect many later launches. Public template intake and fee share activation are not open. The Custom Launch API accepts one concrete project and token bundle; it does not publish reusable templates.
 
 {% content-ref url="launch.md" %}
 [launch.md](launch.md)

--- a/docs/public/creators/earnings.md
+++ b/docs/public/creators/earnings.md
@@ -10,4 +10,4 @@ Rewards accrue in ETH and follow the recipient configuration recorded at launch.
 
 The published public template policy describes a 0.2% total transaction fee. It assigns 0.1% to the template creator and 0.1% to Programmable. That policy is not active until public template intake and the exact payout route are activated.
 
-Earnings depend on actual qualifying activity. A review, listing, template record or visible token page does not promise volume, revenue or a fixed payment.
+Earnings depend on actual qualifying activity. API preparation, listing, a template record or a visible token page does not promise volume, revenue or a fixed payment.

--- a/docs/public/creators/launch.md
+++ b/docs/public/creators/launch.md
@@ -1,27 +1,33 @@
 ---
-description: Move one exact public project from the Programmable v4 Builder through review and creator signed launch
+description: Prepare one deterministic Custom project through the authenticated API and creator signed launch
 ---
 
 # Launch a project
 
-Custom projects use a public, exact revision workflow. The project stays in its creator owned repository, while the Builder prepares a small application that identifies the source, evidence, requested route and launch wallet without copying the whole codebase into the review repository.
+Custom launch preparation is API-first. The Builder packages one deterministic source and graph bundle, the authenticated API validates its declared commitments, and the controller wallet separately reviews and signs the prepared transaction. No GitHub pull request submits the launch.
 
 ## Prepare the source
 
-Start from a public GitHub repository that contains the code, tests, deployment logic and material project information needed to understand the release. Use the latest stable [Programmable v4 Builder release](https://github.com/0xprogrammable/hookbuilder/releases/latest) rather than the moving development branch.
+Keep the contracts, tests, deployment logic and material project information needed to understand the release in one reproducible source bundle. Use the latest stable [Programmable v4 Builder release](https://github.com/0xprogrammable/hookbuilder/releases/latest) rather than the moving development branch.
 
-The Builder preserves the product intent, chooses the smallest complete architecture and runs the checks that apply to that project. It freezes the repository id, commit and tree used by the application so a later commit cannot be mistaken for the reviewed revision.
+The Builder preserves the product intent, chooses the smallest complete architecture and runs the checks that apply to that project. The source descriptor, manifest digest, graph bundle and agent evidence must all identify the same exact launch subject.
 
-## Submit the application
+## Create an API key
 
-[Submit a Launch](https://github.com/0xprogrammable/submit-launch) accepts public applications. The Builder creates the required six file draft application and checks the repository state before every GitHub write. Do not hand write the package or treat the pull request as launch approval.
+Connect the controller wallet at [Custom Launch API keys](https://programmable.market/developers/api-keys) and create a scoped key. Give the secret only to the agent or workflow that should prepare launches for that wallet. Keep it out of source control and public chats.
 
-Review evaluates the named revision and evidence. Missing evidence remains pending rather than being turned into an unsupported safety conclusion. A complete reproducible failure can block the exact revision, while a scanner label or model opinion cannot replace the published review policy.
+The key grants only `custom-launch:create` and `custom-launch:read`. It is not a wallet key and cannot sign or broadcast a transaction.
+
+## Submit the bundle
+
+Send one closed request to `https://api.programmable.market/v1/custom-launches` with the API key as a Bearer credential and a stable idempotency key. Follow the [Custom Launch API V1 guide](https://programmable.market/developers/custom-launch-api-v1.md) for the exact schema, graph limits, evidence fields and response states.
+
+The platform validates the manifest digest, graph constraints, required agent evidence and permit binding. It does not compile the source, reproduce the build, audit the project or adopt the agent's claims as a safety conclusion.
 
 ## Launch from the bound wallet
 
-An accepted revision still needs an active release binding. When that binding exists, the named wallet opens the launch experience, checks the network, transaction destination, calldata and value, then signs the transaction itself. A submitted transaction becomes a completed launch only after it succeeds, reaches the required finality and agrees with the public launch record.
+When the request is prepared, the controller wallet checks the network, transaction destination, calldata and value, then signs the transaction itself. A submitted transaction becomes a completed launch only after it succeeds, reaches the required finality and agrees with the public Router record.
 
 ## Keep the record useful
 
-After launch, share the contract address rather than only a name or ticker. Material source changes, permission changes or a new deployed version should be disclosed as a new review target. An old accepted revision does not silently cover new bytes.
+After launch, share the contract address rather than only a name or ticker. Material source changes, permission changes or a new deployed version create a new launch subject. An earlier prepared bundle does not silently cover new bytes.

--- a/docs/public/creators/programs.md
+++ b/docs/public/creators/programs.md
@@ -4,6 +4,6 @@ description: Public programs for partnering with and contributing to Programmabl
 
 # Creator programs
 
-Programmable uses public programs for focused partnerships, project review and ecosystem contributions. Participation does not replace the release process. A project can be interesting, complete or selected by a program and still require its own exact source review and execution binding before it launches through Programmable.
+Programmable uses public programs for focused partnerships, build work and ecosystem contributions. Participation does not replace the launch process. A project can be interesting, complete or selected by a program and still need one valid Custom API bundle, the controller wallet's confirmation and a matching final onchain record.
 
-Builders can use the same public tools. The [Programmable v4 Builder](https://github.com/0xprogrammable/hookbuilder/releases/latest) is open source and accepts unfamiliar project shapes, while [Submit a Launch](https://github.com/0xprogrammable/submit-launch) keeps the review record public and revision bound.
+Builders can use the same public tools. The [Programmable v4 Builder](https://github.com/0xprogrammable/hookbuilder/releases/latest) is open source and accepts unfamiliar project shapes, while the [Custom Launch API](https://programmable.market/developers/custom-launch-api-v1.md) binds one deterministic bundle to a wallet-owned request and prepared action.

--- a/docs/public/creators/templates.md
+++ b/docs/public/creators/templates.md
@@ -4,13 +4,13 @@ description: Current requirements and status for reusable public Programmable te
 
 # Public templates
 
-A public template is one versioned product that other creators can configure for their own launches. It can include a hook, factory, application or companion service, but every required component and configurable boundary belongs to the same review target.
+A public template is one versioned product that other creators can configure for their own launches. It can include a hook, factory, application or companion service, but every required component and configurable boundary belongs to the same version target.
 
-The [Submit a Template](https://github.com/0xprogrammable/submit-template) repository publishes the model and requirements. Public applications and template fee share activation are not open yet. This status is intentional and should not be replaced with a launch claim before the repository, contracts, payout path and exact template version are activated.
+Public template intake and template fee share activation are not open. Templates are not part of the current Custom launch submission flow. The Custom Launch API accepts one concrete project and token bundle; it does not publish a reusable catalog entry.
 
 ## Template or project
 
-Submit a Launch is for one concrete project and token. Submit a Template is for reusable behavior that other creators can select. A project that happens to contain reusable code is still a project unless it is reviewed and published through the template path.
+The [Custom Launch API](https://programmable.market/developers/custom-launch-api-v1.md) is for one concrete project and token. A future template path would publish reusable behavior that other creators can select. A project that happens to contain reusable code is still a project unless an active template program separately versions and publishes it.
 
 ## Version binding
 
@@ -20,4 +20,4 @@ Each template version identifies the source repository, commit, artifacts, param
 
 The intended public template policy is one 0.2% transaction fee on the supported trading route. The template creator receives 0.1% and Programmable receives 0.1%. This fee is not active until the exact version and payout route are activated. It is one complete fee, not a published rate followed by another unnamed Programmable charge.
 
-Partnership templates use a separate policy and review path. They are not submitted through the public repository.
+Partnership templates use a separate policy and review path. They are not available through public intake.

--- a/docs/public/developers/README.md
+++ b/docs/public/developers/README.md
@@ -4,7 +4,13 @@ description: Read only contracts and verification rules for detecting Programmab
 
 # Developer reference
 
-The Programmable Developer API gives terminals, explorers, scanners, bots and applications one read only integration for current Classic records and approved Custom records. No API key or SDK is required, and the service never authorizes a transaction.
+Programmable has two separate developer surfaces. The Developer API at `https://developers.programmable.family` is read only, requires no API key and never authorizes a transaction. The Custom Launch API at `https://api.programmable.market` is an authenticated write path for launch preparation and requires a wallet-bound Bearer key.
+
+## Prepare a Custom launch
+
+Create or revoke a key at [Custom Launch API keys](https://programmable.market/developers/api-keys), then follow the [Custom Launch API V1 guide](https://programmable.market/developers/custom-launch-api-v1.md). Send deterministic bundles only to `https://api.programmable.market/v1/custom-launches`.
+
+The key can create and read launch preparations for its wallet principal. It cannot sign or broadcast. The controller wallet reviews and confirms the prepared transaction separately.
 
 ## Start with discovery
 
@@ -20,7 +26,7 @@ Do not copy a Router address or event topic from token metadata, an old screensh
 
 ## Read normalized launches
 
-The launch feed combines current and historical Classic records with approved Custom Registry records. Consumers should finish cursor traversal, deduplicate by launch id and preserve unknown launch shapes even when their own application cannot chart, quote or execute them.
+The launch feed combines current and historical Classic records with Registry-verified Custom records. Consumers should finish cursor traversal, deduplicate by launch id and preserve unknown launch shapes even when their own application cannot chart, quote or execute them.
 
 ```bash
 curl -fsSL https://developers.programmable.family/api/v2/launches

--- a/docs/public/developers/indexing.md
+++ b/docs/public/developers/indexing.md
@@ -6,7 +6,7 @@ description: Index Programmable launches with finality, cursor completeness and 
 
 An indexer can use the normalized v2 feed or reproduce Router records directly. In both cases, finality, cursor traversal and unknown data need explicit handling.
 
-The normalized launch feed returns versioned records for Classic and approved Custom launches. Consumers should follow every cursor until completion, remove duplicate launch ids and retain records when optional price, chart or liquidity data is unavailable. A missing chart or quote is not permission to discard a valid launch record.
+The normalized launch feed returns versioned records for Classic and Registry-verified Custom launches. Consumers should follow every cursor until completion, remove duplicate launch ids and retain records when optional price, chart or liquidity data is unavailable. A missing chart or quote is not permission to discard a valid launch record.
 
 Direct Router indexing starts at the manifest's current start block. Process the published events in canonical order, retain block and log identity, and roll back records affected by a reorganization before finality. Cross check token or pool lookups at one canonical block before exposing the public label.
 

--- a/docs/public/developers/machine-readable.md
+++ b/docs/public/developers/machine-readable.md
@@ -1,10 +1,10 @@
 ---
-description: Interactive OpenAPI reference for the Programmable Developer API version 2
+description: Read-only Developer API reference and authenticated Custom Launch API resources
 ---
 
 # API reference
 
-The version 2 API is read only, requires no API key and publishes stable discovery, manifest, launch and compatibility responses. Existing fields keep their type and meaning within version 2, while new deployments and capabilities can be added.
+The Developer API version 2 at `https://developers.programmable.family` is read only, requires no API key and publishes stable discovery, manifest, launch and compatibility responses. The separate Custom Launch API at `https://api.programmable.market` is an authenticated write path. Create a wallet-bound key at [Custom Launch API keys](https://programmable.market/developers/api-keys) and use its [standalone OpenAPI contract](https://programmable.market/openapi/custom-launch-v1.json) or [V1 guide](https://programmable.market/developers/custom-launch-api-v1.md).
 
 ## Service status
 

--- a/docs/public/economics.md
+++ b/docs/public/economics.md
@@ -9,7 +9,7 @@ Costs and fee paths depend on the transaction that actually executes. A launch m
 | Path               | Share                                                    | How it works                                                     |
 | ------------------ | -------------------------------------------------------- | ---------------------------------------------------------------- |
 | Classic            | 0.1% of the gross ETH amount exchanged                   | Included in the selected buy or sell transaction fee             |
-| Standard Custom    | 0.1% of the gross amount exchanged on the approved route | Defined by the exact accepted release                            |
+| Standard Custom    | 0.1% of the gross amount exchanged on the supported route | Defined by the exact release used by the graph                   |
 | Prediction Markets | Defined by the active protocol release                   | Current rates, recipients and creator rewards live in its source |
 | Public template    | Intended 0.1% share inside a 0.2% total transaction fee  | Not active while public template intake remains closed           |
 
@@ -21,7 +21,7 @@ Classic creators select buy and sell transaction fees from 1% through 10%. Progr
 
 ## Custom releases
 
-Custom fees are specific to each release. The only accepted production policy assigns 0.1% of the gross amount exchanged on the exact reviewed market path to Programmable. A release without a qualifying market has no fee legs. Every other Custom fee mode fails closed.
+Custom fees are specific to each release. The published standard production policy assigns 0.1% of the gross amount exchanged on the verified supported market path to Programmable. A release without a qualifying market has no fee legs. Every other Custom fee mode fails closed.
 
 ## Prediction Markets
 

--- a/docs/public/infrastructure.md
+++ b/docs/public/infrastructure.md
@@ -1,5 +1,5 @@
 ---
-description: How Programmable separates launch creation, review, execution, finality and public discovery
+description: How Programmable separates launch preparation, execution, finality and public discovery
 ---
 
 # How Programmable works
@@ -12,7 +12,7 @@ Classic uses the current launcher and shared hook on Ethereum. One transaction c
 
 ## Custom execution
 
-Custom begins with an exact public source revision and review application. An accepted release identifies the code, wallet, permissions and transaction plan that may use the route. The creator wallet still submits the transaction, and the resulting launch must agree with the release and final chain record.
+Custom begins with one deterministic source and graph bundle submitted through the authenticated API. The platform validates the declared manifest digest, graph constraints, required agent evidence and permit binding, then prepares an exact wallet action. It does not compile the source, reproduce the build or audit the project. The controller wallet still submits the transaction, and the resulting launch must agree with the prepared action and final chain record.
 
 ## Prediction Markets execution
 

--- a/docs/public/models/custom.md
+++ b/docs/public/models/custom.md
@@ -1,24 +1,24 @@
 ---
-description: How reviewed Custom hook projects become exact, wallet bound Programmable releases
+description: How deterministic Custom hook bundles become exact, wallet bound Programmable releases
 cover: ../.gitbook/assets/custom-v2.png
 coverY: 0
 ---
 
 # Custom hooks
 
-Custom is the release path for products that need their own Uniswap v4 hook, application logic or execution graph. It is not one generic contract with a free form configuration. Each accepted project carries its own source identity, permissions, fee policy, dependency set and launch transaction requirements.
+Custom is the release path for products that need their own Uniswap v4 hook, application logic or execution graph. It is not one generic contract with a free form configuration. Each request carries its own source identity, permissions, fee policy, dependency set and launch transaction requirements.
 
-A hook is a smart contract that a Uniswap v4 pool calls at defined points in a transaction. It can apply product specific behavior directly around swaps and other pool actions. What it can do depends on its declared permissions and exact code, which is why Custom review is bound to one source revision rather than to a project name.
+A hook is a smart contract that a Uniswap v4 pool calls at defined points in a transaction. It can apply product specific behavior directly around swaps and other pool actions. What it can do depends on its declared permissions and exact code, which is why each Custom request is bound to one exact bundle rather than to a project name.
 
-## Public review
+## API-first preparation
 
-The current public intake starts with the stable [Programmable v4 Builder](https://github.com/0xprogrammable/hookbuilder/releases/latest). The Builder prepares one exact application and submits it to [Submit a Launch](https://github.com/0xprogrammable/submit-launch), where the repository records the source revision and review evidence.
+Start with the stable [Programmable v4 Builder](https://github.com/0xprogrammable/hookbuilder/releases/latest). The Builder prepares one deterministic source and graph bundle with the required agent evidence. The controller wallet creates a [wallet-bound API key](https://programmable.market/developers/api-keys), and the agent submits the bundle to `https://api.programmable.market/v1/custom-launches`.
 
-Submit a Launch intake is open. A draft application, green check or merged record does not by itself deploy a project or authorize a wallet transaction. The accepted revision still needs the matching execution profile and release binding before the named wallet can launch it.
+The API checks the declared bundle commitments and prepares the exact wallet action. It does not compile the project, reproduce its tests, audit it, sign the transaction or broadcast it. The API key is not wallet authority; the controller wallet must review and confirm the prepared action.
 
 ## Release binding
 
-A Custom release binds the repository identity, commit, tree, launch wallet, chain, contracts, permissions and transaction plan that were reviewed. If the source or a material configuration changes, it becomes a new review target rather than silently inheriting the previous result.
+A Custom release binds the source descriptor, manifest digest, graph bundle, launch wallet, chain, contracts, permissions and transaction plan used for that request. If the source or a material configuration changes, it becomes a new launch subject rather than silently inheriting the previous result.
 
 The creator sees the final network, destination, calldata and value before signing. Programmable prepares and verifies the route, while the creator wallet remains the only party that can submit the user transaction.
 
@@ -30,4 +30,4 @@ The canonical Launch Stamp Router is live on Ethereum at `0x8622DD5bAb44185f2A45
 A launch stamp is provenance, not an audit or guarantee. It does not prove current liquidity, sellability, terminal support or economic outcome.
 {% endhint %}
 
-The public developer feed currently discovers both Classic and approved Custom records. General Custom execution remains revision specific, so users should follow the accepted release rather than assume that any repository or hook is launchable.
+The public developer feed discovers Classic records and verified Custom records. Custom execution remains bundle specific, so users should follow the exact prepared action rather than assume that any repository or hook is launchable.

--- a/docs/public/reference/official-links.md
+++ b/docs/public/reference/official-links.md
@@ -13,11 +13,14 @@ description: Official Programmable product, source, community and analytics link
 | GitHub                  | [github.com/0xprogrammable](https://github.com/0xprogrammable)                                                     |
 | Prediction source       | [programmable-prediction-markets](https://github.com/0xprogrammable/programmable-prediction-markets)               |
 | Programmable v4 Builder | [Latest stable release](https://github.com/0xprogrammable/hookbuilder/releases/latest)                             |
-| Submit a Launch         | [github.com/0xprogrammable/submit-launch](https://github.com/0xprogrammable/submit-launch)                         |
-| Developer service       | [developers.programmable.family](https://developers.programmable.family)                                           |
+| Custom Launch API keys  | [programmable.market/developers/api-keys](https://programmable.market/developers/api-keys)                         |
+| Custom Launch API guide | [programmable.market/developers/custom-launch-api-v1.md](https://programmable.market/developers/custom-launch-api-v1.md) |
+| Custom write API        | [api.programmable.market](https://api.programmable.market)                                                         |
+| Launch policy           | [github.com/0xprogrammable/launch-policy](https://github.com/0xprogrammable/launch-policy)                         |
+| Read-only developer API | [developers.programmable.family](https://developers.programmable.family)                                           |
 | X                       | [x.com/0xProgrammable](https://x.com/0xProgrammable)                                                               |
 | Discord                 | [discord.com/invite/programmable](https://discord.com/invite/programmable)                                         |
 | Dune                    | [Programmable analytics](https://dune.com/0xprogrammable6098/programmable-analytics)                               |
 | V4 token                | [Dexscreener](https://dexscreener.com/ethereum/0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0) |
 
-Use the GitHub organization and current developer manifest when verifying Ethereum source or deployment data. Use the Prediction Markets repository for its current networks, contracts and release evidence. Community posts and analytics are useful context but do not replace the contract address, canonical chain record or versioned release evidence.
+Use `api.programmable.market` only for authenticated Custom launch preparation. Use the read-only developer service and current deployment manifest when verifying Ethereum source or deployment data. Use the Prediction Markets repository for its current networks, contracts and release evidence. Community posts and analytics are useful context but do not replace the contract address, canonical chain record or versioned release evidence.

--- a/docs/public/tokens.md
+++ b/docs/public/tokens.md
@@ -4,12 +4,12 @@ description: Compare Programmable launch models and understand how their token, 
 
 # Launch models
 
-Programmable separates direct public models from individually reviewed Custom releases. Prediction Markets is a separately versioned launch model. Choose the model by the behavior the product needs, not by how unusual its name or branding is.
+Programmable separates direct public models from deterministic Custom graph launches. Prediction Markets is a separately versioned launch model. Choose the model by the behavior the product needs, not by how unusual its name or branding is.
 
 | Model              | What it creates                                                            | Market                                        | Access                                |
 | ------------------ | -------------------------------------------------------------------------- | --------------------------------------------- | ------------------------------------- |
 | Classic            | Fixed supply tokens with configurable buy and sell transaction fees        | ETH on Uniswap v4                             | Open through Create                   |
-| Custom             | Tokens or applications that need an individually reviewed hook and release | The pool and route named in the exact release | Accepted and activated revisions only |
+| Custom             | Tokens or applications that need their own deterministic hook graph         | The pool and route in the prepared action      | Wallet-bound Custom Launch API         |
 | Prediction Markets | Onchain outcome markets                                                    | A separately versioned Uniswap v4 release     | Open through Create                   |
 
 ## What is a hook
@@ -28,7 +28,7 @@ Classic creates a fixed supply of one billion tokens and initializes its ETH poo
 
 ## Custom
 
-Custom releases are for products whose behavior cannot be represented by the Classic settings. A hook is code that can change how a Uniswap v4 pool behaves during a transaction. Each Custom release identifies the exact source, permissions, transaction fees, dependencies, transaction construction and the wallet allowed to launch it. Public review intake is open through Submit a Launch, while execution remains bound to the accepted release rather than to a project name.
+Custom releases are for products whose behavior cannot be represented by the Classic settings. A hook is code that can change how a Uniswap v4 pool behaves during a transaction. Each Custom request identifies the exact source bundle, graph, permissions, transaction fees, dependencies, transaction construction and controller wallet. Preparation uses a [wallet-bound API key](https://programmable.market/developers/api-keys), while signing remains with the controller wallet rather than the API key or a project name.
 
 {% content-ref url="models/custom.md" %}
 [custom.md](models/custom.md)

--- a/docs/public/trust.md
+++ b/docs/public/trust.md
@@ -1,18 +1,18 @@
 ---
-description: Understand the evidence boundaries behind review, release activation and onchain provenance
+description: Understand the evidence boundaries behind API preparation, wallet execution and onchain provenance
 ---
 
 # Verification and risk
 
-Programmable does not treat one green check as proof of the whole lifecycle. Source review, release activation, wallet execution, chain finality, Router provenance and public indexing answer different questions and can succeed or fail independently.
+Programmable does not treat one green check as proof of the whole lifecycle. Caller-declared source evidence, API preparation, wallet execution, chain finality, Router provenance and public indexing answer different questions and can succeed or fail independently.
 
-## Source review
+## Bundle evidence
 
-Review applies to one repository id, commit, tree and evidence set. A later commit is a new target even when the project name remains unchanged. An accepted revision means it passed the published gates for the named scope; it is not an external audit, endorsement or price opinion.
+Each Custom request binds one source descriptor, manifest digest, graph bundle and set of agent evidence digests. The platform checks their shape and internal bindings. It does not fetch the evidence, reproduce the build or adopt the agent's claims. A changed bundle is a new launch subject even when the project name remains unchanged.
 
-## Release activation
+## API preparation
 
-An accepted project receives launch authority only when a matching execution profile binds the revision, wallet, chain, contracts and transaction plan. The creator inspects and signs the final transaction. A draft application, repository merge or indexer observation cannot replace that authority.
+A prepared result means the exact action exists for the controller wallet. It is not an approval, audit, signed transaction or broadcast. The API key cannot authorize the wallet; the controller inspects and signs the final transaction separately.
 
 ## Finality and public projection
 

--- a/lib/developer-docs-content.ts
+++ b/lib/developer-docs-content.ts
@@ -52,6 +52,7 @@ export function buildDeveloperDocsMarkdown(): string {
     "Programmable read endpoints: no authentication",
     "Custom Launch API: wallet-bound pm_live_ API key",
     "Ethereum RPC authentication: provider-specific",
+    "Read-only Developer API: https://developers.programmable.family",
     "",
     "## API-first Custom launches",
     "",
@@ -267,7 +268,7 @@ export function buildDeveloperDocsMarkdown(): string {
     "",
     "It does not establish safety, tradability, current liquidity or pool state, audit coverage, review status, approval, endorsement, permission to launch, or terminal support. It does not automatically list or label a launch in GMGN, Axiom, FOMO, or any other terminal; each consumer must implement the published verification procedure.",
     "",
-    `Router verification is read-only. Launch access is a separate product path from verification: create a wallet-bound key at ${apiKeysUrl} and use ${customLaunchApiOrigin}/v1/custom-launches, or check https://programmable.market/docs/creators/launch for other current launch paths. The provenance reference alone grants neither access nor launch authorization.`,
+    `Router verification and the Developer API are read-only. Custom launch preparation is the separate authenticated write path: create a wallet-bound key at ${apiKeysUrl} and use ${customLaunchApiOrigin}/v1/custom-launches. The provenance reference alone grants neither access nor launch authorization.`,
   ].join("\n");
 }
 
@@ -407,7 +408,7 @@ export function buildProgrammableLlmsIndex(): string {
     "- Protocol fee claim discovery is a separate index: complete Classic Launcher and Custom Registry scans plus the fixed Stock release set. Unknown or unverified sources fail closed, and Custom V2 stays unavailable until its exact deployed release is finalized.",
     "- The live claim boundary is published at https://claimhazard.vercel.app/claim-discovery.json and requires one wallet-declared atomic batch from the fixed reward wallet.",
     "- A Router record establishes provenance only after the required address, runtime, binding, lookup, and cross-check verification passes. It does not establish safety, tradability, current liquidity, audit coverage, endorsement, terminal support, or launch authorization.",
-    `- Launch access is a separate product path from this provenance reference. Use ${apiKeysUrl} for API-first Custom launch access or check https://programmable.market/docs/creators/launch for other current paths; the provenance reference alone grants neither access nor launch authorization.`,
+    `- Launch access is a separate authenticated write path from this read-only provenance reference. Use ${apiKeysUrl} for API-first Custom launch access and ${customLaunchApiOrigin}/v1/custom-launches for launch preparation; the provenance reference alone grants neither access nor launch authorization.`,
   ].join("\n");
 }
 

--- a/lib/hookathon/config.ts
+++ b/lib/hookathon/config.ts
@@ -3,6 +3,8 @@ export type HookathonPrize = Readonly<{
   amountUsd: number;
 }>;
 
+// Immutable historical fixture for the retired Hookathon route. The public route
+// returns 404; this repository URL and label are not current launch intake.
 export type HookathonConfig = Readonly<{
   name: "Hookathon";
   confirmationIso: string;

--- a/tests/developer-docs-experience.test.ts
+++ b/tests/developer-docs-experience.test.ts
@@ -214,10 +214,13 @@ describe("Developer documentation experience", () => {
       "each consumer must implement the published verification procedure",
     );
     expect(developerDocsMarkdown).toMatch(
-      /Launch access is a separate product path/,
+      /Custom launch preparation is the separate authenticated write path/,
     );
     expect(developerDocsMarkdown).toContain(
-      "https://programmable.market/docs/creators/launch",
+      "https://api.programmable.market/v1/custom-launches",
+    );
+    expect(developerDocsMarkdown).toContain(
+      "Router verification and the Developer API are read-only",
     );
     expect(developerDocsMarkdown).toContain(
       "It does not automatically list or label a launch in GMGN, Axiom, FOMO",

--- a/tests/docs-information-architecture.test.ts
+++ b/tests/docs-information-architecture.test.ts
@@ -103,7 +103,7 @@ describe("Docs information architecture", () => {
           {
             depth: 1,
             href: "/docs/creators/templates",
-            label: "Publish a template",
+            label: "Public template policy",
           },
           {
             depth: 1,
@@ -212,7 +212,7 @@ describe("Docs information architecture", () => {
     for (const [source, path, title] of [
       [creatorsPage, "/docs/creators", "Create with Programmable"],
       [creatorLaunchPage, "/docs/creators/launch", "Launch a project"],
-      [creatorTemplatesPage, "/docs/creators/templates", "Publish a template"],
+      [creatorTemplatesPage, "/docs/creators/templates", "Public templates"],
       [creatorEarningsPage, "/docs/creators/earnings", "Creator earnings"],
       [creatorProgramsPage, "/docs/creators/programs", "Creator programs"],
     ] as const) {
@@ -223,18 +223,52 @@ describe("Docs information architecture", () => {
 
     expect(creatorsPage).toContain("Hook Builder");
     expect(creatorsPage).toContain("Custom Launch API");
-    expect(creatorsPage).toContain("Submit a Template");
-    expect(creatorTemplatesPage).toContain(
-      "Follow the Submit a Template repository",
-    );
-    expect(creatorTemplatesPage).toMatch(
-      /do not accept public template\s+applications/,
-    );
+    expect(creatorsPage).toContain("Public templates are planned");
+    expect(creatorTemplatesPage).toContain("Public template intake is closed");
+    expect(creatorTemplatesPage).not.toMatch(/submit[- a]+template/i);
     expect(creatorLaunchPage).toContain("The API does not control your wallet");
     expect(creatorLaunchPage).toContain("Create a Custom launch API key");
     expect(creatorLaunchPage).toContain("does not reproduce your build");
     expect(creatorLaunchPage).not.toContain(
       "Open public wallet self-service is not active",
+    );
+  });
+
+  it("keeps every normal public Custom launch surface API-first", () => {
+    const publicLaunchSurfaces = [
+      "README.md",
+      "components/create-guide.tsx",
+      "docs/public/README.md",
+      "docs/public/creators/README.md",
+      "docs/public/creators/launch.md",
+      "docs/public/creators/templates.md",
+      "docs/public/economics.md",
+      "docs/public/infrastructure.md",
+      "docs/public/models/custom.md",
+      "docs/public/tokens.md",
+      "docs/public/trust.md",
+      "docs/public/reference/official-links.md",
+      "app/docs/page.tsx",
+      "app/docs/creators/page.tsx",
+      "app/docs/creators/launch/page.tsx",
+      "app/docs/creators/templates/page.tsx",
+      "app/docs/launch-stamps/page.tsx",
+      "app/docs/models/[model]/page.tsx",
+      "app/docs/trust/page.tsx",
+    ];
+
+    for (const path of publicLaunchSurfaces) {
+      const source = read(path);
+      expect(source, path).not.toMatch(
+        /submit[- a]+launch|submit[- a]+template|public source review|review application|accepted revision|accepted release|individually reviewed/i,
+      );
+    }
+
+    expect(read("docs/public/creators/launch.md")).toContain(
+      "https://api.programmable.market/v1/custom-launches",
+    );
+    expect(read("docs/public/developers/README.md")).toContain(
+      "The Developer API at `https://developers.programmable.family` is read only",
     );
   });
 

--- a/tests/launch-stamp-docs.test.ts
+++ b/tests/launch-stamp-docs.test.ts
@@ -472,7 +472,9 @@ describe("Launch Stamp developer documentation", () => {
     expect(page).toContain("supplied handoff digests");
     expect(page).toMatch(/PCAN.*token symbol in this test case/s);
     expect(page).toContain("does not replace it");
-    expect(page).toMatch(/Custom releases\s+use a review and activation path/);
+    expect(page).toMatch(
+      /Custom launch\s+preparation uses a wallet-bound key and the authenticated API/,
+    );
     expect(page).toContain('href="/docs/trust"');
     expect(page).toContain('href="/docs/creators/launch"');
     expect(page).not.toContain("Classic onchain canary passed");


### PR DESCRIPTION
Routes website documentation, GitBook source, public LLM documentation, and Create guidance through API-key management, the Custom Launch API, and the renamed Launch Policy repository. Removes Submit Launch and Submit Template from the normal public flow while preserving clearly historical fixtures. No API runtime or contract code changes.\n\nLocal evidence: 71 focused tests passed, final 22-test delta passed, typecheck and targeted ESLint passed. Clean commit 4e9dffd9c8c8713a672551711ea6b470148fefca, tree 31dfd63e17e88adaf21688fc3ea0886c1a5dbcc4.