### PR TITLE
Fix Router registry Blob CAS writes

### DIFF
--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -152,7 +152,7 @@
     },
     "store": {
       "path": "lib/alchemy/launch-registry.server.ts",
-      "sha256": "349896552268e09949974546991dfb77ea88878470b6ea969dafdd5f446cde09"
+      "sha256": "8010bdbce557cbb9999e26d6c6ca036b537abfe723d57aadd1535399152316a7"
     },
     "routerReader": {
       "path": "lib/alchemy/launch-stamp.server.ts",

--- a/lib/alchemy/launch-registry.server.ts
+++ b/lib/alchemy/launch-registry.server.ts
@@ -23,6 +23,7 @@ const SCHEMA_VERSION = "programmable-alchemy-launch-registry-v2";
 const ROUTER_SLICE_SCHEMA_VERSION =
   "programmable-launch-stamp-router-registry-v1";
 const REPOSITORY_COMMIT = /^[0-9a-f]{40}$/u;
+const VERCEL_BLOB_STRONG_ETAG = /^"[0-9a-f]{32}"$/iu;
 
 export const LAUNCH_STAMP_ROUTER_BINDING = Object.freeze({
   chainId: CANONICAL_LAUNCH_STAMP_V1.chainId,
@@ -95,6 +96,14 @@ function requiredRepositoryCommit(
 
 function registryPath(repositoryCommit: string) {
   return `${ALCHEMY_LAUNCH_REGISTRY_DIRECTORY}/${repositoryCommit}.json`;
+}
+
+function normalizeVercelBlobEtag(value: string) {
+  const normalized = value.trim().replace(/^W\//u, "");
+  if (!VERCEL_BLOB_STRONG_ETAG.test(normalized)) {
+    throw new Error("Alchemy launch registry ETag is invalid");
+  }
+  return normalized;
 }
 
 function validLaunchToken(value: unknown, cursorBlock: bigint) {
@@ -531,7 +540,7 @@ export async function readAlchemyLaunchRegistry(
     JSON.parse(await new Response(result.stream).text()),
     deployment,
   );
-  return { registry, etag: result.blob.etag };
+  return { registry, etag: normalizeVercelBlobEtag(result.blob.etag) };
 }
 
 export async function writeAlchemyLaunchRegistry(

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -178,7 +178,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     store: Object.freeze({
       path: "lib/alchemy/launch-registry.server.ts",
       sha256:
-        "349896552268e09949974546991dfb77ea88878470b6ea969dafdd5f446cde09",
+        "8010bdbce557cbb9999e26d6c6ca036b537abfe723d57aadd1535399152316a7",
     }),
     routerReader: Object.freeze({
       path: "lib/alchemy/launch-stamp.server.ts",

--- a/tests/alchemy-launch-registry.test.ts
+++ b/tests/alchemy-launch-registry.test.ts
@@ -13,6 +13,7 @@ vi.mock("@vercel/blob", () => blobMocks);
 import {
   LAUNCH_STAMP_ROUTER_BINDING,
   LAUNCH_STAMP_ROUTER_INITIAL_CURSOR,
+  readAlchemyLaunchRegistry,
   validateAlchemyLaunchRegistryEnvelope,
   writeAlchemyLaunchRegistry,
   type AlchemyLaunchRegistry,
@@ -406,6 +407,21 @@ describe("Alchemy incremental launch registry", () => {
         ifMatch: "exact-etag",
       }),
     );
+  });
+
+  it("normalizes the private Blob weak ETag before a conditional update", async () => {
+    blobMocks.get.mockResolvedValueOnce({
+      statusCode: 200,
+      stream: new Response(JSON.stringify(envelope())).body,
+      blob: { etag: 'W/"8e8ed5b7c65cfe481ae32dc684e98710"' },
+    });
+
+    await expect(
+      readAlchemyLaunchRegistry(deployment, LAUNCH_STAMP_ROUTER_INITIAL_CURSOR),
+    ).resolves.toMatchObject({
+      etag: '"8e8ed5b7c65cfe481ae32dc684e98710"',
+      registry: { launchStampRouter: { tokens: [{ name: "Stamped" }] } },
+    });
   });
 
   it("reports a retryable conflict when another writer wins initial creation", async () => {


### PR DESCRIPTION
The production Router registry receives a weak Vercel Blob ETag from private GET and forwards it unchanged to `ifMatch`. Blob CAS requires the corresponding strong validator, so refresh persistence stalls at the same 50,000-block catch-up window.

This normalizes only a valid weak/strong Vercel Blob ETag before the conditional write and adds a focused regression test.

Targeted evidence: `vitest run tests/alchemy-launch-registry.test.ts` (16/16).

Live symptom bound to this fix: persisted Router cursor 25767611; FADE launch block 25827140; runtime error `Vercel Blob: Precondition failed: ETag mismatch.`