### PR TITLE
feat(profile): add bound FADE creator claim

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -84,6 +84,13 @@ paths = ['''tests/alchemy-live-market\.test\.ts''']
 regexes = ['''(?i)0x7987f03462200b3d8a072e02c89a8a41dcb124ee''']
 
 [[allowlists]]
+description = "FADE claim capability pins its public onchain token address"
+condition = "AND"
+regexTarget = "match"
+paths = ['''lib/profile/router-custom-creator-claim\.ts''']
+regexes = ['''(?i)tokenAddress:\s*"0x69d278968abf120f878f2e1e016ab615d3686c19"''']
+
+[[allowlists]]
 description = "Launch stamp docs pin the public PCAN canary token address"
 condition = "AND"
 regexTarget = "match"

--- a/app/api/explore/profile/claim/route.ts
+++ b/app/api/explore/profile/claim/route.ts
@@ -34,6 +34,18 @@ import {
   errorChainIncludesData,
   safeServerErrorSummary,
 } from "../../../../../lib/server/safe-error";
+import {
+  readFinalizedRouterCustomExploreEntriesV1,
+} from "../../../../../lib/alchemy/router-custom-public.server";
+import {
+  encodeRouterCustomCreatorClaimV1,
+  readRouterCustomCreatorClaimStateV1,
+  requireRouterCustomCreatorClaimEntryV1,
+  RouterCustomCreatorClaimError,
+} from "../../../../../lib/profile/router-custom-creator-claim.server";
+import {
+  routerCustomCreatorClaimCapabilityForPoolV1,
+} from "../../../../../lib/profile/router-custom-creator-claim";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -250,56 +262,109 @@ export async function POST(request: NextRequest) {
         `Switch to chain ${deployment.chainId}`,
       );
     }
-    let releases;
-    try {
-      releases = getCreatorClaimOnchainDeployments(deployment);
-    } catch {
-      throw new CreatorClaimUnavailableError(
-        "runtime-mismatch",
-        "The creator claim releases do not match their manifests",
+    const reviewedCustomCapability =
+      routerCustomCreatorClaimCapabilityForPoolV1(
+        claimRequest.chainId,
+        claimRequest.poolId,
       );
+    let reviewedCustomEntry: ReturnType<
+      typeof requireRouterCustomCreatorClaimEntryV1
+    > | null = null;
+    if (reviewedCustomCapability) {
+      try {
+        const entries = await readFinalizedRouterCustomExploreEntriesV1({
+          signal: request.signal,
+          deadlineMs: Date.now() + 7_500,
+        });
+        reviewedCustomEntry = requireRouterCustomCreatorClaimEntryV1({
+          entries,
+          chainId: claimRequest.chainId,
+          poolId: claimRequest.poolId,
+        });
+      } catch (error) {
+        if (error instanceof RouterCustomCreatorClaimError) {
+          throw new CreatorClaimUnavailableError(error.code, error.message);
+        }
+        throw claimRpcUnavailable();
+      }
+    }
+    let releases: ReturnType<typeof getCreatorClaimOnchainDeployments> = [];
+    if (!reviewedCustomEntry) {
+      try {
+        releases = getCreatorClaimOnchainDeployments(deployment);
+      } catch {
+        throw new CreatorClaimUnavailableError(
+          "runtime-mismatch",
+          "The creator claim releases do not match their manifests",
+        );
+      }
     }
     const response = await withOperationalRpcFailover(
       deployment,
       async (selected) => {
         const client = claimClient(deployment, selected.rpcUrl);
         const snapshot = await currentClaimSnapshot(client);
-        const token = await readCreatorClaimIdentityFromRpc({
-          client,
-          releases,
-          poolId: claimRequest.poolId,
-          blockNumber: snapshot.blockNumber,
-        });
-        if (
-          token.creatorAddress.toLowerCase() !==
-          claimRequest.account.toLowerCase()
-        ) {
+        let tokenAddress: Address;
+        let hookAddress: Address;
+        let creatorAddress: Address;
+        let claimable: bigint;
+        let data: Hex;
+        if (reviewedCustomEntry) {
+          try {
+            const state = await readRouterCustomCreatorClaimStateV1({
+              client,
+              entry: reviewedCustomEntry.entry,
+              blockNumber: snapshot.blockNumber,
+            });
+            tokenAddress = state.capability.tokenAddress;
+            hookAddress = state.capability.hookAddress;
+            creatorAddress = state.capability.creatorAddress;
+            claimable = state.claimable;
+            data = encodeRouterCustomCreatorClaimV1(state.capability);
+          } catch (error) {
+            if (error instanceof RouterCustomCreatorClaimError) {
+              throw new CreatorClaimUnavailableError(error.code, error.message);
+            }
+            throw error;
+          }
+        } else {
+          const token = await readCreatorClaimIdentityFromRpc({
+            client,
+            releases,
+            poolId: claimRequest.poolId,
+            blockNumber: snapshot.blockNumber,
+          });
+          const state = await readCurrentClaimState({
+            client,
+            token,
+            blockNumber: snapshot.blockNumber,
+          });
+          tokenAddress = token.tokenAddress;
+          hookAddress = token.hookAddress;
+          creatorAddress = token.creatorAddress;
+          claimable = state.claimable;
+          data = encodeFunctionData({
+            abi: creatorFeeHookReadAbi,
+            functionName: "claimCreatorFees",
+            args: [claimRequest.poolId],
+          });
+        }
+        if (creatorAddress.toLowerCase() !== claimRequest.account.toLowerCase()) {
           throw new CreatorClaimUnavailableError(
             "not-creator",
             "This account is not the recorded creator for the pool",
           );
         }
-        const state = await readCurrentClaimState({
-          client,
-          token,
-          blockNumber: snapshot.blockNumber,
-        });
-        const claimable = state.claimable;
         if (claimable <= 0n) {
           throw new CreatorClaimUnavailableError(
             "nothing-to-claim",
             "There are no creator fees to claim for this pool",
           );
         }
-        const data = encodeFunctionData({
-          abi: creatorFeeHookReadAbi,
-          functionName: "claimCreatorFees",
-          args: [claimRequest.poolId],
-        });
         const value = 0n;
         const transaction = {
           account: claimRequest.account,
-          to: token.hookAddress,
+          to: hookAddress,
           data,
           value,
         };
@@ -311,8 +376,8 @@ export async function POST(request: NextRequest) {
         const intent = {
           account: claimRequest.account,
           poolId: claimRequest.poolId,
-          tokenAddress: token.tokenAddress,
-          hookAddress: token.hookAddress,
+          tokenAddress,
+          hookAddress,
           snapshotClaimableWei: claimable.toString(),
           snapshotClaimableEth: formatUnits(claimable, 18),
           snapshot: {
@@ -325,7 +390,7 @@ export async function POST(request: NextRequest) {
             kind: "claim-creator-fees" as const,
             chainId: deployment.chainId,
             from: claimRequest.account,
-            to: token.hookAddress,
+            to: hookAddress,
             data,
             value: "0" as const,
           },

--- a/app/api/explore/profile/route.ts
+++ b/app/api/explore/profile/route.ts
@@ -40,6 +40,12 @@ import {
   readFinalizedRouterCustomExploreEntriesV1,
   ROUTER_CUSTOM_LAUNCH_SOURCE,
 } from "@/lib/alchemy/router-custom-public.server";
+import {
+  projectRouterCustomCreatorClaimProfileV1,
+} from "@/lib/profile/router-custom-creator-claim.server";
+import {
+  resolveRouterCustomCreatorClaimCapabilityV1,
+} from "@/lib/profile/router-custom-creator-claim";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -704,6 +710,9 @@ export async function GET(request: NextRequest) {
     ]);
     let profile = result.profile;
     let routerStatus = routerResult.status;
+    let routerClaimStatus: "not-applicable" | "current" | "unavailable" =
+      "not-applicable";
+    let rpcProvider = result.provider;
     if (routerStatus === "current") {
       try {
         profile = mergeRouterCustomCreatorProfileV1(
@@ -711,6 +720,45 @@ export async function GET(request: NextRequest) {
           account,
           routerResult.entries,
         );
+        const hasReviewedClaim = routerResult.entries.some((entry) => {
+          const capability = resolveRouterCustomCreatorClaimCapabilityV1(entry);
+          return capability !== null &&
+            capability.creatorAddress.toLowerCase() === account.toLowerCase() &&
+            profile.snapshot !== null &&
+            BigInt(entry.launchStampProvenance!.finalizedAtBlockNumber) <=
+              BigInt(profile.snapshot.blockNumber);
+        });
+        if (hasReviewedClaim) {
+          try {
+            const deployment = getWebsiteReadOnchainDeployment("production");
+            if (deployment.status !== "ready" || deployment.chainId !== 1) {
+              throw new Error("Router Custom creator claims are not deployed");
+            }
+            const projected = await withOperationalRpcFailover(
+              deployment,
+              async (selected) => ({
+                profile: await projectRouterCustomCreatorClaimProfileV1({
+                  profile,
+                  account,
+                  entries: routerResult.entries,
+                  client: profileClient(selected.rpcUrl),
+                }),
+                provider: profileRpcProviderHeader(
+                  deployment,
+                  selected.rpcUrl,
+                ),
+              }),
+            );
+            profile = projected.profile;
+            rpcProvider = projected.provider;
+            routerClaimStatus = "current";
+          } catch {
+            console.error("Creator profile Router Custom claim read unavailable", {
+              name: "RouterCustomCreatorClaimReadError",
+            });
+            routerClaimStatus = "unavailable";
+          }
+        }
       } catch {
         console.error("Creator profile Router Custom merge unavailable", {
           name: "RouterCustomIdentityError",
@@ -721,7 +769,9 @@ export async function GET(request: NextRequest) {
     const launchSource = routerStatus === "current"
       ? `envio-classic-v3+${ROUTER_CUSTOM_LAUNCH_SOURCE}`
       : "envio-classic-v3";
-    const readSource = result.provider === "envio-indexer-state"
+    const usesRpc = result.provider !== "envio-indexer-state" ||
+      routerClaimStatus === "current";
+    const readSource = !usesRpc
       ? launchSource
       : `${launchSource}+rpc`;
     return NextResponse.json(profile, {
@@ -732,7 +782,8 @@ export async function GET(request: NextRequest) {
           : "envio-classic-v3",
         "X-Programmable-Read-Source": readSource,
         "X-Programmable-Router-Read-Status": routerStatus,
-        "X-Programmable-Rpc-Provider": result.provider,
+        "X-Programmable-Router-Claim-Read-Status": routerClaimStatus,
+        "X-Programmable-Rpc-Provider": rpcProvider,
       },
     });
   } catch (error) {

--- a/lib/onchain/types.ts
+++ b/lib/onchain/types.ts
@@ -1,5 +1,7 @@
 import type { Address, Hex } from "viem";
 
+import type { RouterCustomCreatorClaimProfileCapabilityV1 } from
+  "../profile/router-custom-creator-claim";
 import type { LauncherToken } from "../tokens";
 
 export type DeploymentEnvironment = "production" | "rehearsal";
@@ -190,8 +192,9 @@ export type CreatorProfilePool = {
   symbol: string;
   poolId: Hex;
   totalSwapFeeBps: number;
-  launchModel: "classic" | "adaptive" | "deep";
+  launchModel: "classic" | "adaptive" | "deep" | "custom-graph";
   adaptiveCurveHash?: Hex;
+  claimCapability?: RouterCustomCreatorClaimProfileCapabilityV1;
   claimableCreatorFeesWei: string;
   claimableCreatorFeesEth: string;
   generatedCreatorFeesWei: string;

--- a/lib/profile/onchain-profile.ts
+++ b/lib/profile/onchain-profile.ts
@@ -11,6 +11,12 @@ import {
   isLaunchStampProvenanceV1,
   type LaunchStampProvenanceV1,
 } from "../tokens";
+import {
+  FADE_ROUTER_CUSTOM_CREATOR_CLAIM_ADAPTER_ID,
+  resolveRouterCustomCreatorClaimCapabilityV1,
+  type RouterCustomCreatorClaimCapabilityV1,
+  type RouterCustomCreatorClaimProfileCapabilityV1,
+} from "./router-custom-creator-claim";
 
 export type ProfileDataStatus =
   "unavailable" | "not-deployed" | "loading" | "ready" | "error";
@@ -107,6 +113,7 @@ type ParsedProfileToken = ProfileToken & {
   launchLogIndex: number;
   totalSwapFeeBps?: number;
   launchStampProvenance?: LaunchStampProvenanceV1;
+  routerCustomCreatorClaimCapability?: RouterCustomCreatorClaimCapabilityV1;
 };
 
 type ParsedProfilePool = {
@@ -115,6 +122,8 @@ type ParsedProfilePool = {
   symbol: string;
   poolId: Hex;
   totalSwapFeeBps: number;
+  launchModel?: "classic" | "adaptive" | "deep" | "custom-graph";
+  claimCapability?: RouterCustomCreatorClaimProfileCapabilityV1;
   claimableWei: string;
   generatedWei: string;
 };
@@ -391,6 +400,64 @@ function readLaunchStampProvenance(
   return value;
 }
 
+function readRouterCustomClaimProfileCapability(
+  record: Record<string, unknown>,
+) {
+  const value = record.claimCapability;
+  if (value === undefined || value === null) return undefined;
+  const capability = asRecord(value, "creator claim capability");
+  const keys = Object.keys(capability).sort();
+  const expectedKeys = [
+    "adapterId",
+    "chainId",
+    "hookAddress",
+    "launchId",
+    "poolId",
+    "tokenAddress",
+  ].sort();
+  if (
+    keys.length !== expectedKeys.length ||
+    keys.some((key, index) => key !== expectedKeys[index]) ||
+    capability.adapterId !== FADE_ROUTER_CUSTOM_CREATOR_CLAIM_ADAPTER_ID
+  ) {
+    throw new ProfileResponseError("Invalid creator claim capability");
+  }
+  const chainId = readSafeInteger(
+    capability,
+    "chainId",
+    "creator claim capability chain",
+  );
+  if (chainId !== 1) {
+    throw new ProfileResponseError("Invalid creator claim capability chain");
+  }
+  return {
+    adapterId: FADE_ROUTER_CUSTOM_CREATOR_CLAIM_ADAPTER_ID,
+    chainId: 1,
+    launchId: readHex(
+      capability,
+      "launchId",
+      "creator claim capability launch",
+      32,
+    ),
+    tokenAddress: readAddress(
+      capability,
+      "tokenAddress",
+      "creator claim capability token",
+    ),
+    hookAddress: readAddress(
+      capability,
+      "hookAddress",
+      "creator claim capability hook",
+    ),
+    poolId: readHex(
+      capability,
+      "poolId",
+      "creator claim capability pool",
+      32,
+    ),
+  } as const satisfies RouterCustomCreatorClaimProfileCapabilityV1;
+}
+
 function readTimestamp(
   record: Record<string, unknown>,
   key: string,
@@ -433,6 +500,24 @@ function readArray(
 
 function sameAddress(first: string, second: string) {
   return first.toLowerCase() === second.toLowerCase();
+}
+
+function profileClaimCapabilityMatchesToken(
+  pool: ParsedProfilePool,
+  token: ParsedProfileToken,
+) {
+  const profileCapability = pool.claimCapability;
+  const reviewedCapability = token.routerCustomCreatorClaimCapability;
+  return Boolean(
+    profileCapability &&
+    reviewedCapability &&
+    profileCapability.adapterId === reviewedCapability.adapterId &&
+    profileCapability.chainId === reviewedCapability.chainId &&
+    sameAddress(profileCapability.launchId, reviewedCapability.launchId) &&
+    sameAddress(profileCapability.tokenAddress, token.address) &&
+    sameAddress(profileCapability.hookAddress, token.hookAddress) &&
+    sameAddress(profileCapability.poolId, token.poolId),
+  );
 }
 
 function tokenHref(address: Address) {
@@ -696,6 +781,21 @@ function parseToken(
       "Profile token does not match its launch stamp",
     );
   }
+  const routerCustomCreatorClaimCapability =
+    resolveRouterCustomCreatorClaimCapabilityV1({
+      tokenAddress: address,
+      hookAddress,
+      poolId,
+      creatorAddress,
+      totalSwapFeeBps:
+        token.totalSwapFeeBps === null ? null : totalSwapFeeBps,
+      launchModel,
+      launchModelVersion:
+        typeof token.launchModelVersion === "string"
+          ? token.launchModelVersion
+          : undefined,
+      launchStampProvenance,
+    });
 
   return {
     address,
@@ -720,11 +820,24 @@ function parseToken(
     launchLogIndex,
     ...(totalSwapFeeBps === undefined ? {} : { totalSwapFeeBps }),
     ...(launchStampProvenance ? { launchStampProvenance } : {}),
+    ...(routerCustomCreatorClaimCapability
+      ? { routerCustomCreatorClaimCapability }
+      : {}),
   };
 }
 
 function parsePool(value: unknown): ParsedProfilePool {
   const pool = asRecord(value, "profile pool");
+  const launchModel = pool.launchModel;
+  if (
+    launchModel !== undefined &&
+    launchModel !== "classic" &&
+    launchModel !== "adaptive" &&
+    launchModel !== "deep" &&
+    launchModel !== "custom-graph"
+  ) {
+    throw new ProfileResponseError("Invalid creator reward launch model");
+  }
   const claimableWei = readIntegerString(
     pool,
     "claimableCreatorFeesWei",
@@ -747,6 +860,7 @@ function parsePool(value: unknown): ParsedProfilePool {
     generatedWei,
     "generated creator fees in ETH",
   );
+  const claimCapability = readRouterCustomClaimProfileCapability(pool);
 
   return {
     tokenAddress: readAddress(pool, "tokenAddress", "pool token address"),
@@ -754,6 +868,8 @@ function parsePool(value: unknown): ParsedProfilePool {
     symbol: readString(pool, "symbol", "pool token symbol"),
     poolId: readHex(pool, "poolId", "pool id", 32),
     totalSwapFeeBps: readSafeInteger(pool, "totalSwapFeeBps", "pool swap fee"),
+    ...(launchModel ? { launchModel } : {}),
+    ...(claimCapability ? { claimCapability } : {}),
     claimableWei,
     generatedWei,
   };
@@ -867,8 +983,14 @@ export function mapCreatorProfileResponse(
     if (
       pool.name !== token.name ||
       pool.symbol !== token.symbol ||
-      token.totalSwapFeeBps === undefined ||
-      pool.totalSwapFeeBps !== token.totalSwapFeeBps
+      (pool.launchModel !== undefined && pool.launchModel !== token.launchModel) ||
+      (token.launchStampProvenance === undefined
+        ? token.totalSwapFeeBps === undefined ||
+          pool.totalSwapFeeBps !== token.totalSwapFeeBps ||
+          pool.claimCapability !== undefined
+        : token.totalSwapFeeBps !== undefined ||
+          pool.launchModel !== "custom-graph" ||
+          !profileClaimCapabilityMatchesToken(pool, token))
     ) {
       throw new ProfileResponseError(
         "Profile token metadata does not match its verified pool",
@@ -880,8 +1002,10 @@ export function mapCreatorProfileResponse(
     const token = tokenByPool.get(pool.poolId.toLowerCase());
     if (
       !token ||
-      token.launchStampProvenance !== undefined ||
-      !sameAddress(token.address, pool.tokenAddress)
+      !sameAddress(token.address, pool.tokenAddress) ||
+      (token.launchStampProvenance === undefined
+        ? pool.claimCapability !== undefined
+        : !profileClaimCapabilityMatchesToken(pool, token))
     ) {
       throw new ProfileResponseError(
         "Profile pool does not match a verified token",
@@ -895,8 +1019,10 @@ export function mapCreatorProfileResponse(
     if (
       !token ||
       !pool ||
-      token.launchStampProvenance !== undefined ||
-      !sameAddress(token.address, claim.tokenAddress)
+      !sameAddress(token.address, claim.tokenAddress) ||
+      (token.launchStampProvenance === undefined
+        ? pool.claimCapability !== undefined
+        : !profileClaimCapabilityMatchesToken(pool, token))
     ) {
       throw new ProfileResponseError(
         "Creator claim does not match a verified token",

--- a/lib/profile/router-custom-creator-claim.server.ts
+++ b/lib/profile/router-custom-creator-claim.server.ts
@@ -1,0 +1,447 @@
+import "server-only";
+
+import {
+  encodeFunctionData,
+  formatUnits,
+  getAddress,
+  keccak256,
+  parseAbi,
+  type Address,
+  type Hex,
+  type PublicClient,
+} from "viem";
+
+import type { CreatorClaim, CreatorProfile } from "../onchain/types";
+import { creatorFeesClaimedEvent } from "../onchain/abis";
+import type { CanonicalTokenExploreEntry } from "../tokens";
+import {
+  resolveRouterCustomCreatorClaimCapabilityV1,
+  routerCustomCreatorClaimProfileCapabilityV1,
+  type RouterCustomCreatorClaimCapabilityV1,
+} from "./router-custom-creator-claim";
+
+export const fadeRouterCustomClaimHookAbi = parseAbi([
+  "function poolFeeConfig(bytes32 poolId) view returns (address creator,address registrar,uint64 launchTimestamp,bool registered,uint256 creatorFeesAccrued)",
+  "function currentTotalSwapFeeBps(bytes32 poolId) view returns (uint16)",
+  "function claimCreatorFees(bytes32 poolId) returns (uint256 amount)",
+]);
+
+const creatorTokenAbi = parseAbi([
+  "function creator() view returns (address)",
+]);
+
+const CLAIM_LOG_RANGE = 10_000n;
+
+export class RouterCustomCreatorClaimError extends Error {
+  readonly code: "identity-mismatch" | "runtime-mismatch";
+
+  constructor(
+    code: "identity-mismatch" | "runtime-mismatch",
+    message: string,
+  ) {
+    super(message);
+    this.name = "RouterCustomCreatorClaimError";
+    this.code = code;
+  }
+}
+
+function sameHex(left: string, right: string) {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function requireCanonicalCapabilityEntry(
+  entry: CanonicalTokenExploreEntry,
+) {
+  const capability = resolveRouterCustomCreatorClaimCapabilityV1(entry);
+  const category = entry.launchCategoryProvenance;
+  const stamp = entry.launchStampProvenance;
+  if (
+    !capability ||
+    !stamp ||
+    entry.exploreKind !== "token" ||
+    category.source !== "canonical-launch-stamp-router" ||
+    category.category !== "custom" ||
+    !sameHex(category.launchId, capability.launchId) ||
+    !sameHex(category.stampHash, stamp.stampHash) ||
+    !sameHex(category.routerAddress, stamp.routerAddress) ||
+    !sameHex(category.transactionHash, stamp.transactionHash) ||
+    !sameHex(category.blockHash, stamp.blockHash) ||
+    category.blockNumber !== stamp.blockNumber ||
+    category.transactionIndex !== stamp.transactionIndex ||
+    category.logIndex !== stamp.launchLogIndex
+  ) {
+    throw new RouterCustomCreatorClaimError(
+      "identity-mismatch",
+      "The Router Custom creator claim is not bound to its finalized launch stamp",
+    );
+  }
+  return capability;
+}
+
+export function requireRouterCustomCreatorClaimEntryV1(input: Readonly<{
+  entries: readonly CanonicalTokenExploreEntry[];
+  chainId: number;
+  poolId: Hex;
+}>) {
+  const matches = input.entries.filter((entry) =>
+    entry.launchStampProvenance?.chainId === input.chainId &&
+    sameHex(entry.poolId, input.poolId)
+  );
+  if (matches.length !== 1) {
+    throw new RouterCustomCreatorClaimError(
+      "identity-mismatch",
+      matches.length === 0
+        ? "The Router Custom creator claim has no finalized launch stamp"
+        : "The Router Custom creator claim has ambiguous launch provenance",
+    );
+  }
+  const entry = matches[0]!;
+  return Object.freeze({
+    entry,
+    capability: requireCanonicalCapabilityEntry(entry),
+  });
+}
+
+function requireRuntime(
+  code: Hex | undefined,
+  expectedHash: Hex,
+  label: string,
+) {
+  if (
+    !code ||
+    code === "0x" ||
+    !sameHex(keccak256(code), expectedHash)
+  ) {
+    throw new RouterCustomCreatorClaimError(
+      "runtime-mismatch",
+      `The Router Custom creator claim ${label} runtime is not verified`,
+    );
+  }
+}
+
+export type RouterCustomCreatorClaimStateV1 = Readonly<{
+  capability: RouterCustomCreatorClaimCapabilityV1;
+  claimable: bigint;
+  currentTotalSwapFeeBps: number;
+}>;
+
+export async function readRouterCustomCreatorClaimStateV1(input: Readonly<{
+  client: PublicClient;
+  entry: CanonicalTokenExploreEntry;
+  blockNumber: bigint;
+}>): Promise<RouterCustomCreatorClaimStateV1> {
+  const capability = requireCanonicalCapabilityEntry(input.entry);
+  const stamp = input.entry.launchStampProvenance!;
+  if (BigInt(stamp.finalizedAtBlockNumber) > input.blockNumber) {
+    throw new RouterCustomCreatorClaimError(
+      "identity-mismatch",
+      "The Router Custom creator claim is not finalized at this snapshot",
+    );
+  }
+
+  const [
+    tokenCode,
+    hookCode,
+    registrarCode,
+    routeLauncherCode,
+    recordedTokenCreator,
+    config,
+    currentTotalSwapFeeBps,
+  ] = await Promise.all([
+    input.client.getCode({
+      address: capability.tokenAddress,
+      blockNumber: input.blockNumber,
+    }),
+    input.client.getCode({
+      address: capability.hookAddress,
+      blockNumber: input.blockNumber,
+    }),
+    input.client.getCode({
+      address: capability.registrarAddress,
+      blockNumber: input.blockNumber,
+    }),
+    input.client.getCode({
+      address: capability.routeLauncherAddress,
+      blockNumber: input.blockNumber,
+    }),
+    input.client.readContract({
+      address: capability.tokenAddress,
+      abi: creatorTokenAbi,
+      functionName: "creator",
+      blockNumber: input.blockNumber,
+    }),
+    input.client.readContract({
+      address: capability.hookAddress,
+      abi: fadeRouterCustomClaimHookAbi,
+      functionName: "poolFeeConfig",
+      args: [capability.poolId],
+      blockNumber: input.blockNumber,
+    }),
+    input.client.readContract({
+      address: capability.hookAddress,
+      abi: fadeRouterCustomClaimHookAbi,
+      functionName: "currentTotalSwapFeeBps",
+      args: [capability.poolId],
+      blockNumber: input.blockNumber,
+    }),
+  ]);
+
+  requireRuntime(
+    tokenCode,
+    capability.tokenRuntimeCodeHash,
+    "token",
+  );
+  requireRuntime(
+    hookCode,
+    capability.hookRuntimeCodeHash,
+    "hook",
+  );
+  requireRuntime(
+    registrarCode,
+    capability.registrarRuntimeCodeHash,
+    "registrar",
+  );
+  requireRuntime(
+    routeLauncherCode,
+    capability.routeLauncherRuntimeCodeHash,
+    "route launcher",
+  );
+
+  const [creator, registrar, launchTimestamp, registered, claimable] = config;
+  const currentFee = Number(currentTotalSwapFeeBps);
+  if (
+    !registered ||
+    !sameHex(getAddress(creator), capability.creatorAddress) ||
+    !sameHex(getAddress(registrar), capability.registrarAddress) ||
+    !sameHex(getAddress(recordedTokenCreator), capability.registrarAddress) ||
+    !sameHex(getAddress(recordedTokenCreator), getAddress(registrar)) ||
+    launchTimestamp !== capability.launchTimestamp ||
+    !Number.isSafeInteger(currentFee) ||
+    currentFee < 100 ||
+    currentFee > 300
+  ) {
+    throw new RouterCustomCreatorClaimError(
+      "identity-mismatch",
+      "The Router Custom creator fee state does not match the reviewed capability",
+    );
+  }
+
+  return Object.freeze({
+    capability,
+    claimable,
+    currentTotalSwapFeeBps: currentFee,
+  });
+}
+
+async function readRouterCustomCreatorClaimHistoryV1(input: Readonly<{
+  client: PublicClient;
+  entry: CanonicalTokenExploreEntry;
+  capability: RouterCustomCreatorClaimCapabilityV1;
+  blockNumber: bigint;
+}>) {
+  const fromBlock = BigInt(input.entry.launchStampProvenance!.blockNumber);
+  const logs = [];
+  for (let start = fromBlock; start <= input.blockNumber; start += CLAIM_LOG_RANGE) {
+    const toBlock = start + CLAIM_LOG_RANGE - 1n < input.blockNumber
+      ? start + CLAIM_LOG_RANGE - 1n
+      : input.blockNumber;
+    logs.push(...await input.client.getLogs({
+      address: input.capability.hookAddress,
+      event: creatorFeesClaimedEvent,
+      args: {
+        poolId: input.capability.poolId,
+        creator: input.capability.creatorAddress,
+        recipient: input.capability.creatorAddress,
+      },
+      fromBlock: start,
+      toBlock,
+      strict: true,
+    }));
+  }
+
+  const verified = logs.filter((log) => {
+    if (
+      log.removed ||
+      log.blockNumber === null ||
+      log.transactionHash === null ||
+      log.transactionIndex === null ||
+      log.logIndex === null ||
+      !sameHex(log.args.poolId, input.capability.poolId) ||
+      !sameHex(log.args.creator, input.capability.creatorAddress) ||
+      !sameHex(log.args.recipient, input.capability.creatorAddress) ||
+      log.args.amount <= 0n
+    ) {
+      throw new RouterCustomCreatorClaimError(
+        "identity-mismatch",
+        "The Router Custom creator claim history is not bound to the reviewed payout",
+      );
+    }
+    return true;
+  });
+  const blockNumbers = [...new Set(
+    verified.map((log) => log.blockNumber!.toString()),
+  )];
+  const timestamps = new Map<string, bigint>();
+  await Promise.all(blockNumbers.map(async (blockNumber) => {
+    const block = await input.client.getBlock({
+      blockNumber: BigInt(blockNumber),
+    });
+    timestamps.set(blockNumber, block.timestamp);
+  }));
+
+  return verified.map((log): CreatorClaim => {
+    const blockNumber = log.blockNumber!;
+    const timestamp = timestamps.get(blockNumber.toString());
+    if (timestamp === undefined) {
+      throw new RouterCustomCreatorClaimError(
+        "identity-mismatch",
+        "The Router Custom creator claim timestamp is unavailable",
+      );
+    }
+    return {
+      poolId: input.capability.poolId,
+      tokenAddress: input.capability.tokenAddress,
+      creatorAddress: input.capability.creatorAddress,
+      recipientAddress: input.capability.creatorAddress,
+      callerAddress: getAddress(log.args.caller),
+      amountWei: log.args.amount.toString(),
+      amountEth: formatUnits(log.args.amount, 18),
+      blockNumber: blockNumber.toString(),
+      transactionHash: log.transactionHash!,
+      transactionIndex: log.transactionIndex!,
+      logIndex: log.logIndex!,
+      claimedAt: new Date(Number(timestamp) * 1_000).toISOString(),
+    };
+  }).sort((left, right) => {
+    const blockDifference = BigInt(right.blockNumber) - BigInt(left.blockNumber);
+    if (blockDifference !== 0n) return blockDifference < 0n ? -1 : 1;
+    if (left.transactionIndex !== right.transactionIndex) {
+      return right.transactionIndex - left.transactionIndex;
+    }
+    return right.logIndex - left.logIndex;
+  });
+}
+
+export function encodeRouterCustomCreatorClaimV1(
+  capability: RouterCustomCreatorClaimCapabilityV1,
+) {
+  const data = encodeFunctionData({
+    abi: fadeRouterCustomClaimHookAbi,
+    functionName: "claimCreatorFees",
+    args: [capability.poolId],
+  });
+  if (!sameHex(data.slice(0, 10), capability.claimSelector)) {
+    throw new RouterCustomCreatorClaimError(
+      "runtime-mismatch",
+      "The Router Custom creator claim selector is not verified",
+    );
+  }
+  return data;
+}
+
+export async function projectRouterCustomCreatorClaimProfileV1(input: Readonly<{
+  profile: CreatorProfile;
+  account: Address;
+  entries: readonly CanonicalTokenExploreEntry[];
+  client: PublicClient;
+}>): Promise<CreatorProfile> {
+  const { profile } = input;
+  if (profile.status !== "ready" || profile.snapshot?.chainId !== 1) {
+    return profile;
+  }
+
+  const snapshotBlock = BigInt(profile.snapshot.blockNumber);
+  const existingPools = new Set(
+    profile.pools.map((pool) => pool.poolId.toLowerCase()),
+  );
+  const profileTokens = new Set(
+    profile.tokens.map((token) => token.tokenAddress.toLowerCase()),
+  );
+  const candidates = input.entries.filter((entry) => {
+    const capability = resolveRouterCustomCreatorClaimCapabilityV1(entry);
+    return capability !== null &&
+      sameHex(capability.creatorAddress, input.account) &&
+      BigInt(entry.launchStampProvenance!.finalizedAtBlockNumber) <=
+        snapshotBlock &&
+      profileTokens.has(capability.tokenAddress.toLowerCase()) &&
+      !existingPools.has(capability.poolId.toLowerCase());
+  });
+  if (candidates.length === 0) return profile;
+  if (candidates.length !== 1) {
+    throw new RouterCustomCreatorClaimError(
+      "identity-mismatch",
+      "The Router Custom creator claim profile is ambiguous",
+    );
+  }
+
+  const entry = candidates[0]!;
+  const capability = requireCanonicalCapabilityEntry(entry);
+  const [state, claims] = await Promise.all([
+    readRouterCustomCreatorClaimStateV1({
+      client: input.client,
+      entry,
+      blockNumber: snapshotBlock,
+    }),
+    readRouterCustomCreatorClaimHistoryV1({
+      client: input.client,
+      entry,
+      capability,
+      blockNumber: snapshotBlock,
+    }),
+  ]);
+  const existingClaimIds = new Set(
+    profile.claims.map((claim) =>
+      `${claim.transactionHash.toLowerCase()}:${claim.logIndex}`
+    ),
+  );
+  if (claims.some((claim) =>
+    existingClaimIds.has(
+      `${claim.transactionHash.toLowerCase()}:${claim.logIndex}`,
+    )
+  )) {
+    throw new RouterCustomCreatorClaimError(
+      "identity-mismatch",
+      "The Router Custom creator claim history duplicates another release",
+    );
+  }
+  const claimed = claims.reduce(
+    (total, claim) => total + BigInt(claim.amountWei),
+    0n,
+  );
+  const generated = state.claimable + claimed;
+  const claimableWei = state.claimable.toString();
+  const claimableEth = formatUnits(state.claimable, 18);
+  const pool = {
+    tokenAddress: state.capability.tokenAddress,
+    name: entry.name,
+    symbol: entry.symbol,
+    poolId: state.capability.poolId,
+    totalSwapFeeBps: state.currentTotalSwapFeeBps,
+    launchModel: "custom-graph" as const,
+    claimCapability: routerCustomCreatorClaimProfileCapabilityV1(
+      state.capability,
+    ),
+    claimableCreatorFeesWei: claimableWei,
+    claimableCreatorFeesEth: claimableEth,
+    generatedCreatorFeesWei: generated.toString(),
+    generatedCreatorFeesEth: formatUnits(generated, 18),
+  };
+
+  const totalClaimable = BigInt(profile.totals.claimableWei) + state.claimable;
+  const totalGenerated = BigInt(profile.totals.generatedWei) + generated;
+  const totalClaimed = BigInt(profile.totals.claimedWei) + claimed;
+  return {
+    ...profile,
+    pools: [...profile.pools, pool],
+    claims: [...profile.claims, ...claims],
+    totals: {
+      ...profile.totals,
+      claimableWei: totalClaimable.toString(),
+      claimableEth: formatUnits(totalClaimable, 18),
+      generatedWei: totalGenerated.toString(),
+      generatedEth: formatUnits(totalGenerated, 18),
+      claimedWei: totalClaimed.toString(),
+      claimedEth: formatUnits(totalClaimed, 18),
+    },
+  };
+}

--- a/lib/profile/router-custom-creator-claim.ts
+++ b/lib/profile/router-custom-creator-claim.ts
@@ -1,0 +1,195 @@
+import type { Address, Hex } from "viem";
+
+import {
+  isLaunchStampProvenanceV1,
+  type LaunchStampProvenanceV1,
+} from "../tokens";
+
+export const FADE_ROUTER_CUSTOM_CREATOR_CLAIM_ADAPTER_ID =
+  "router-custom-fade-decay-fee-v1" as const;
+
+export type RouterCustomCreatorClaimCapabilityV1 = Readonly<{
+  adapterId: typeof FADE_ROUTER_CUSTOM_CREATOR_CLAIM_ADAPTER_ID;
+  chainId: 1;
+  launchId: Hex;
+  tokenAddress: Address;
+  tokenRuntimeCodeHash: Hex;
+  hookAddress: Address;
+  hookRuntimeCodeHash: Hex;
+  poolId: Hex;
+  creatorAddress: Address;
+  registrarAddress: Address;
+  registrarRuntimeCodeHash: Hex;
+  routeLauncherAddress: Address;
+  routeLauncherRuntimeCodeHash: Hex;
+  launchTimestamp: bigint;
+  claimSelector: "0xaf8d60b5";
+}>;
+
+/**
+ * A code-owned capability for one reviewed Custom hook runtime. Router stamps
+ * remain discovery-only unless every field below and the live state reader
+ * agree. Adding another Custom claim model requires a separate adapter.
+ */
+export const FADE_ROUTER_CUSTOM_CREATOR_CLAIM_CAPABILITY = Object.freeze({
+  adapterId: FADE_ROUTER_CUSTOM_CREATOR_CLAIM_ADAPTER_ID,
+  chainId: 1,
+  launchId:
+    "0x6d6ed0e1e69a7cd6afa177e3454c9e32eed61cbd3f855ee56aff1915a6776fc2",
+  tokenAddress: "0x69d278968abf120f878f2e1e016ab615d3686c19",
+  tokenRuntimeCodeHash:
+    "0xe48c3827d558866b3d761d78b7d29416f24d277120ef1a7ce6a360962b917596",
+  hookAddress: "0xd7451a039373f54e493deE42A751fEcBfAFBa0cc",
+  hookRuntimeCodeHash:
+    "0xff70a4d3d889b730a064b270fc187f0cba40582f1fa6f5875893066b17a1257b",
+  poolId:
+    "0x6b6f0f8348bb08c7cbaa45cd48b4531e3a206ac7eabcc5355d9ffdd21c4b579a",
+  creatorAddress: "0x2Bb333d48DFAF1596D9036671d2E43168994249E",
+  registrarAddress: "0x5c5B5342696b197A21564ecDDB97915933eF6C9B",
+  registrarRuntimeCodeHash:
+    "0x9a924353c9d1c0302a190a1e930b02cfddf3e9ccbc9cc441eb5f7f62c39df78e",
+  routeLauncherAddress: "0xB012e4A8F2c5FC4E8E4faCA9D5Ad6FfF13FBA887",
+  routeLauncherRuntimeCodeHash:
+    "0xd23692fae59331592048e71a96d4963e170ee56e449683dc9f7fa3f9470018b8",
+  launchTimestamp: 1_787_599_787n,
+  claimSelector: "0xaf8d60b5",
+} as const satisfies RouterCustomCreatorClaimCapabilityV1);
+
+const CAPABILITIES = Object.freeze([
+  FADE_ROUTER_CUSTOM_CREATOR_CLAIM_CAPABILITY,
+] as const);
+
+type RouterCustomClaimTokenIdentityV1 = Readonly<{
+  tokenAddress: Address;
+  hookAddress: Address;
+  poolId: Hex;
+  creatorAddress?: Address;
+  totalSwapFeeBps?: number | null;
+  launchModel?: string;
+  launchModelVersion?: string;
+  launchStampProvenance?: LaunchStampProvenanceV1;
+}>;
+
+function sameHex(left: unknown, right: unknown) {
+  return typeof left === "string" &&
+    typeof right === "string" &&
+    left.toLowerCase() === right.toLowerCase();
+}
+
+function capabilityKey(chainId: number, launchId: string) {
+  return `${chainId}:${launchId.toLowerCase()}`;
+}
+
+const CAPABILITY_BY_LAUNCH = new Map(
+  CAPABILITIES.map((capability) => [
+    capabilityKey(capability.chainId, capability.launchId),
+    capability,
+  ]),
+);
+
+function exactExclusiveComponent(
+  stamp: LaunchStampProvenanceV1,
+  expected: Readonly<{
+    address: Address;
+    kind: "token" | "hook" | "other";
+    runtimeCodeHash: Hex;
+  }>,
+) {
+  return stamp.components.some((component) =>
+    component.kind === expected.kind &&
+    component.scope === "exclusive" &&
+    sameHex(component.address, expected.address) &&
+    sameHex(component.runtimeCodeHash, expected.runtimeCodeHash) &&
+    component.exclusiveProof !== null &&
+    sameHex(component.exclusiveProof.launchId, stamp.launchId) &&
+    sameHex(component.exclusiveProof.stampHash, stamp.stampHash)
+  );
+}
+
+export function routerCustomCreatorClaimCapabilityForPoolV1(
+  chainId: number,
+  poolId: string,
+) {
+  return CAPABILITIES.find((capability) =>
+    capability.chainId === chainId && sameHex(capability.poolId, poolId)
+  ) ?? null;
+}
+
+export function resolveRouterCustomCreatorClaimCapabilityV1(
+  token: RouterCustomClaimTokenIdentityV1,
+): RouterCustomCreatorClaimCapabilityV1 | null {
+  const stamp = token.launchStampProvenance;
+  if (!stamp) return null;
+  const capability = CAPABILITY_BY_LAUNCH.get(
+    capabilityKey(stamp.chainId, stamp.launchId),
+  );
+  if (!capability) return null;
+
+  if (
+    token.launchModel !== "custom-graph" ||
+    token.launchModelVersion !== "programmable-launch-stamp-router-v1" ||
+    token.totalSwapFeeBps !== null ||
+    !token.creatorAddress ||
+    stamp.kind !== "custom-graph" ||
+    !isLaunchStampProvenanceV1(stamp, {
+      chainId: capability.chainId,
+      tokenAddress: capability.tokenAddress,
+      hookAddress: capability.hookAddress,
+      poolId: capability.poolId,
+      launchWallet: capability.creatorAddress,
+    }) ||
+    !sameHex(token.tokenAddress, capability.tokenAddress) ||
+    !sameHex(token.hookAddress, capability.hookAddress) ||
+    !sameHex(token.poolId, capability.poolId) ||
+    !sameHex(token.creatorAddress, capability.creatorAddress) ||
+    !sameHex(stamp.launchId, capability.launchId) ||
+    !sameHex(stamp.routeLauncherAddress, capability.routeLauncherAddress) ||
+    !sameHex(
+      stamp.routeLauncherRuntimeCodeHash,
+      capability.routeLauncherRuntimeCodeHash,
+    ) ||
+    !sameHex(stamp.poolKey.currency0, "0x0000000000000000000000000000000000000000") ||
+    !sameHex(stamp.poolKey.currency1, capability.tokenAddress) ||
+    !exactExclusiveComponent(stamp, {
+      address: capability.tokenAddress,
+      kind: "token",
+      runtimeCodeHash: capability.tokenRuntimeCodeHash,
+    }) ||
+    !exactExclusiveComponent(stamp, {
+      address: capability.hookAddress,
+      kind: "hook",
+      runtimeCodeHash: capability.hookRuntimeCodeHash,
+    }) ||
+    !exactExclusiveComponent(stamp, {
+      address: capability.registrarAddress,
+      kind: "other",
+      runtimeCodeHash: capability.registrarRuntimeCodeHash,
+    })
+  ) {
+    return null;
+  }
+
+  return capability;
+}
+
+export type RouterCustomCreatorClaimProfileCapabilityV1 = Readonly<{
+  adapterId: typeof FADE_ROUTER_CUSTOM_CREATOR_CLAIM_ADAPTER_ID;
+  chainId: 1;
+  launchId: Hex;
+  tokenAddress: Address;
+  hookAddress: Address;
+  poolId: Hex;
+}>;
+
+export function routerCustomCreatorClaimProfileCapabilityV1(
+  capability: RouterCustomCreatorClaimCapabilityV1,
+): RouterCustomCreatorClaimProfileCapabilityV1 {
+  return Object.freeze({
+    adapterId: capability.adapterId,
+    chainId: capability.chainId,
+    launchId: capability.launchId,
+    tokenAddress: capability.tokenAddress,
+    hookAddress: capability.hookAddress,
+    poolId: capability.poolId,
+  });
+}

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2265,16 +2265,19 @@ export function evaluateReadModelOperationsSourceContracts(
       "readEnvioClassicV2CreatorClaimsV1",
       "readFinalizedRouterCustomExploreEntriesV1",
       "mergeRouterCustomCreatorProfileV1",
+      "projectRouterCustomCreatorClaimProfileV1",
       "LEGACY_RPC_PROFILE_FALLBACK_ENABLED: boolean = false",
       "getWebsiteReadOnchainDeployment",
       "withOperationalRpcFailover",
       "profileRpcProviderHeader",
       "const [result, routerResult] = await Promise.all([",
+      "let rpcProvider = result.provider",
       'const launchSource = routerStatus === "current"',
       ': "envio-classic-v3"',
       ': `${launchSource}+rpc`',
       '"X-Programmable-Router-Read-Status": routerStatus',
-      '"X-Programmable-Rpc-Provider": result.provider',
+      '"X-Programmable-Router-Claim-Read-Status": routerClaimStatus',
+      '"X-Programmable-Rpc-Provider": rpcProvider',
     ]) &&
       !publicCreatorProfile.includes("productionMainnetRpcPrimary") &&
       includesEverySourceFragment(publicClassicProfileGet, [
@@ -2343,7 +2346,7 @@ export function evaluateReadModelOperationsSourceContracts(
         (route) =>
           !/Promise\.allSettled|secondaryProvider|fallbackProvider/u.test(route),
       ),
-    "Profile identity is Envio-first and fail-closed, while the sole official Classic V2 reward read, Classic rewards, Claim, and Trade use the commitment-bound Website pair with at most one complete-operation QuickNode retry after an eligible dRPC transport or capacity failure; Stock retains its singular committed action provider and all action routes retain no write authority or hidden provider rotation",
+    "Profile identity is Envio-first and fail-closed, while reviewed reward reads, Classic rewards, Claim, and Trade use the commitment-bound Website pair with at most one complete-operation QuickNode retry after an eligible dRPC transport or capacity failure; Stock retains its singular committed action provider and all action routes retain no write authority or hidden provider rotation",
   );
   check(
     "ops-staged-envio-catalog-gate",

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -920,6 +920,12 @@ describe("read-model operations source contract", () => {
       '"X-Programmable-Router-Read-Status": "unknown"',
     ],
     [
+      "profile custom-claim provider provenance",
+      "app/api/explore/profile/route.ts",
+      '"X-Programmable-Router-Claim-Read-Status": routerClaimStatus',
+      '"X-Programmable-Router-Claim-Read-Status": "unknown"',
+    ],
+    [
       "claim receipt binding",
       "app/api/explore/profile/claim/route.ts",
       'status: "not-submitted" as const',

--- a/tests/router-custom-creator-claim.test.ts
+++ b/tests/router-custom-creator-claim.test.ts
@@ -1,0 +1,370 @@
+import type { PublicClient } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const runtimeCodes = vi.hoisted(() => ({
+  token: "0x01" as const,
+  hook: "0x02" as const,
+  registrar: "0x03" as const,
+  routeLauncher: "0x04" as const,
+}));
+
+vi.mock("viem", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("viem")>();
+  const hashes = new Map<string, `0x${string}`>([
+    [runtimeCodes.token,
+      "0xe48c3827d558866b3d761d78b7d29416f24d277120ef1a7ce6a360962b917596"],
+    [runtimeCodes.hook,
+      "0xff70a4d3d889b730a064b270fc187f0cba40582f1fa6f5875893066b17a1257b"],
+    [runtimeCodes.registrar,
+      "0x9a924353c9d1c0302a190a1e930b02cfddf3e9ccbc9cc441eb5f7f62c39df78e"],
+    [runtimeCodes.routeLauncher,
+      "0xd23692fae59331592048e71a96d4963e170ee56e449683dc9f7fa3f9470018b8"],
+  ]);
+  return {
+    ...actual,
+    keccak256: vi.fn((value: `0x${string}`) =>
+      hashes.get(value) ?? actual.keccak256(value)
+    ),
+  };
+});
+
+import {
+  encodeRouterCustomCreatorClaimV1,
+  projectRouterCustomCreatorClaimProfileV1,
+  readRouterCustomCreatorClaimStateV1,
+} from "../lib/profile/router-custom-creator-claim.server";
+import {
+  FADE_ROUTER_CUSTOM_CREATOR_CLAIM_ADAPTER_ID,
+  FADE_ROUTER_CUSTOM_CREATOR_CLAIM_CAPABILITY as capability,
+  resolveRouterCustomCreatorClaimCapabilityV1,
+} from "../lib/profile/router-custom-creator-claim";
+import { mapCreatorProfileResponse } from "../lib/profile/onchain-profile";
+import type { CreatorProfile } from "../lib/onchain/types";
+import type {
+  CanonicalTokenExploreEntry,
+  LaunchStampProvenanceV1,
+} from "../lib/tokens";
+
+const STAMP_HASH = `0x${"11".repeat(32)}` as const;
+const TX_HASH = `0x${"22".repeat(32)}` as const;
+const BLOCK_HASH = `0x${"33".repeat(32)}` as const;
+const FINALIZED_HASH = `0x${"44".repeat(32)}` as const;
+const SNAPSHOT_HASH = `0x${"55".repeat(32)}` as const;
+
+function fadeEntry(): CanonicalTokenExploreEntry {
+  const stamp = {
+    schemaVersion: "programmable.launch-stamp-provenance.v1",
+    chainId: 1,
+    routerAddress: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
+    routerRuntimeCodeHash:
+      "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
+    routerStartBlock: "25717612",
+    finalityConfirmations: 64,
+    kind: "custom-graph",
+    launchId: capability.launchId,
+    stampHash: STAMP_HASH,
+    launchWallet: capability.creatorAddress,
+    transactionHash: TX_HASH,
+    blockNumber: "25827140",
+    blockHash: BLOCK_HASH,
+    transactionIndex: 1,
+    routeLogIndex: 4,
+    launchLogIndex: 5,
+    finalizedAtBlockNumber: "25827204",
+    finalizedAtBlockHash: FINALIZED_HASH,
+    poolManagerAddress: "0x000000000004444c5dc75cB358380D2e3dE08A90",
+    poolId: capability.poolId,
+    poolKey: {
+      currency0: "0x0000000000000000000000000000000000000000",
+      currency1: capability.tokenAddress,
+      fee: 0,
+      tickSpacing: 200,
+      hooks: capability.hookAddress,
+    },
+    poolKeyHash: `0x${"66".repeat(32)}`,
+    componentSetHash: `0x${"77".repeat(32)}`,
+    routePayloadHash: `0x${"88".repeat(32)}`,
+    routeLauncherAddress: capability.routeLauncherAddress,
+    routeLauncherRuntimeCodeHash: capability.routeLauncherRuntimeCodeHash,
+    expectedResultHash: `0x${"99".repeat(32)}`,
+    permitDigest: `0x${"aa".repeat(32)}`,
+    components: [
+      {
+        address: capability.tokenAddress,
+        kind: "token",
+        scope: "exclusive",
+        runtimeCodeHash: capability.tokenRuntimeCodeHash,
+        logIndex: 1,
+        exclusiveProof: { launchId: capability.launchId, stampHash: STAMP_HASH },
+      },
+      {
+        address: capability.hookAddress,
+        kind: "hook",
+        scope: "exclusive",
+        runtimeCodeHash: capability.hookRuntimeCodeHash,
+        logIndex: 2,
+        exclusiveProof: { launchId: capability.launchId, stampHash: STAMP_HASH },
+      },
+      {
+        address: capability.registrarAddress,
+        kind: "other",
+        scope: "exclusive",
+        runtimeCodeHash: capability.registrarRuntimeCodeHash,
+        logIndex: 3,
+        exclusiveProof: { launchId: capability.launchId, stampHash: STAMP_HASH },
+      },
+    ],
+    tokenProof: {
+      tokenAddress: capability.tokenAddress,
+      launchId: capability.launchId,
+      stampHash: STAMP_HASH,
+    },
+    poolProof: {
+      poolManagerAddress: "0x000000000004444c5dc75cB358380D2e3dE08A90",
+      poolId: capability.poolId,
+      launchId: capability.launchId,
+      stampHash: STAMP_HASH,
+    },
+  } as const satisfies LaunchStampProvenanceV1;
+  return {
+    exploreKind: "token",
+    id: `1:${capability.tokenAddress.toLowerCase()}`,
+    name: "FADE",
+    symbol: "FADE",
+    tokenAddress: capability.tokenAddress,
+    hookAddress: capability.hookAddress,
+    poolId: capability.poolId,
+    creatorAddress: capability.creatorAddress,
+    launchBlockNumber: stamp.blockNumber,
+    launchTransactionHash: stamp.transactionHash,
+    launchTransactionIndex: stamp.transactionIndex,
+    launchLogIndex: stamp.launchLogIndex,
+    launchedAt: "2026-08-24T19:29:47.000Z",
+    totalSupplyRaw: "1000000000000000000000000000",
+    tokenDecimals: 18,
+    totalSwapFeeBps: null,
+    launchModel: "custom-graph",
+    launchModelVersion: "programmable-launch-stamp-router-v1",
+    launchStampProvenance: stamp,
+    liquidityPath: "programmable-v4",
+    launchCategoryProvenance: {
+      schemaVersion: "programmable.explore-launch-category-provenance.v1",
+      category: "custom",
+      source: "canonical-launch-stamp-router",
+      launchId: stamp.launchId,
+      stampHash: stamp.stampHash,
+      routerAddress: stamp.routerAddress,
+      transactionHash: stamp.transactionHash,
+      blockHash: stamp.blockHash,
+      blockNumber: stamp.blockNumber,
+      transactionIndex: stamp.transactionIndex,
+      logIndex: stamp.launchLogIndex,
+    },
+  };
+}
+
+function client(overrides: Readonly<{
+  hookCode?: `0x${string}`;
+  tokenCreator?: `0x${string}`;
+  claimable?: bigint;
+  claims?: readonly unknown[];
+}> = {}) {
+  return {
+    getCode: vi.fn(async ({ address }: { address: string }) => {
+      switch (address.toLowerCase()) {
+        case capability.tokenAddress.toLowerCase(): return runtimeCodes.token;
+        case capability.hookAddress.toLowerCase():
+          return overrides.hookCode ?? runtimeCodes.hook;
+        case capability.registrarAddress.toLowerCase():
+          return runtimeCodes.registrar;
+        case capability.routeLauncherAddress.toLowerCase():
+          return runtimeCodes.routeLauncher;
+        default: return "0x" as const;
+      }
+    }),
+    readContract: vi.fn(async ({ address, functionName }: {
+      address: string;
+      functionName: string;
+    }) => {
+      if (
+        address.toLowerCase() === capability.tokenAddress.toLowerCase() &&
+        functionName === "creator"
+      ) return overrides.tokenCreator ?? capability.registrarAddress;
+      if (functionName === "poolFeeConfig") {
+        return [
+          capability.creatorAddress,
+          capability.registrarAddress,
+          capability.launchTimestamp,
+          true,
+          overrides.claimable ?? 808_000_000_000_000_000n,
+        ] as const;
+      }
+      if (functionName === "currentTotalSwapFeeBps") return 100;
+      throw new Error("unexpected read");
+    }),
+    getLogs: vi.fn(async () => overrides.claims ?? []),
+    getBlock: vi.fn(async () => ({ timestamp: 1_787_600_100n })),
+  } as unknown as PublicClient;
+}
+
+function baseProfile(entry: CanonicalTokenExploreEntry): CreatorProfile {
+  return {
+    status: "ready",
+    account: capability.creatorAddress,
+    tokens: [entry],
+    pools: [],
+    claims: [],
+    totals: {
+      claimableWei: "0",
+      claimableEth: "0",
+      generatedWei: "0",
+      generatedEth: "0",
+      claimedWei: "0",
+      claimedEth: "0",
+    },
+    snapshot: {
+      chainId: 1,
+      blockNumber: "25827310",
+      blockHash: SNAPSHOT_HASH,
+      confirmations: 12,
+    },
+  };
+}
+
+describe("Router Custom creator claim capability", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("allows only the exact finalized FADE launch and exact calldata", () => {
+    const entry = fadeEntry();
+    const resolved = resolveRouterCustomCreatorClaimCapabilityV1(entry);
+    expect(resolved).toBe(capability);
+    expect(encodeRouterCustomCreatorClaimV1(capability)).toBe(
+      `${capability.claimSelector}${capability.poolId.slice(2)}`,
+    );
+
+    const wrongRegistrarRuntime = {
+      ...entry,
+      launchStampProvenance: {
+        ...entry.launchStampProvenance!,
+        components: entry.launchStampProvenance!.components.map(
+          (component, index) => index === 2
+            ? { ...component, runtimeCodeHash: `0x${"ff".repeat(32)}` as const }
+            : component,
+        ),
+      },
+    } as CanonicalTokenExploreEntry;
+    expect(resolveRouterCustomCreatorClaimCapabilityV1(
+      wrongRegistrarRuntime,
+    )).toBeNull();
+  });
+
+  it("rejects a live hook runtime mismatch", async () => {
+    await expect(readRouterCustomCreatorClaimStateV1({
+      client: client({ hookCode: "0x05" }),
+      entry: fadeEntry(),
+      blockNumber: 25_827_310n,
+    })).rejects.toMatchObject({
+      code: "runtime-mismatch",
+    });
+  });
+
+  it("rejects token creator, registrar, and fee-state identity drift", async () => {
+    await expect(readRouterCustomCreatorClaimStateV1({
+      client: client({
+        tokenCreator: "0x0000000000000000000000000000000000000001",
+      }),
+      entry: fadeEntry(),
+      blockNumber: 25_827_310n,
+    })).rejects.toMatchObject({
+      code: "identity-mismatch",
+    });
+  });
+
+  it("projects the verified pool at one snapshot without inventing a token fee", async () => {
+    const entry = fadeEntry();
+    const projected = await projectRouterCustomCreatorClaimProfileV1({
+      profile: baseProfile(entry),
+      account: capability.creatorAddress,
+      entries: [entry],
+      client: client(),
+    });
+
+    expect(projected.tokens[0]?.totalSwapFeeBps).toBeNull();
+    expect(projected.pools).toEqual([
+      expect.objectContaining({
+        tokenAddress: capability.tokenAddress,
+        poolId: capability.poolId,
+        totalSwapFeeBps: 100,
+        claimCapability: expect.objectContaining({
+          adapterId: FADE_ROUTER_CUSTOM_CREATOR_CLAIM_ADAPTER_ID,
+          hookAddress: capability.hookAddress,
+        }),
+        claimableCreatorFeesWei: "808000000000000000",
+      }),
+    ]);
+    expect(projected.totals).toMatchObject({
+      claimableWei: "808000000000000000",
+      generatedWei: "808000000000000000",
+    });
+
+    const mapped = mapCreatorProfileResponse(
+      projected,
+      capability.creatorAddress,
+    );
+    expect(mapped.claims).toEqual([
+      expect.objectContaining({
+        poolId: capability.poolId,
+        hookAddress: capability.hookAddress,
+        claimableWei: "808000000000000000",
+      }),
+    ]);
+  });
+
+  it("keeps generated and claimed totals consistent after the bound claim", async () => {
+    const entry = fadeEntry();
+    const claimedAmount = 808_000_000_000_000_000n;
+    const projected = await projectRouterCustomCreatorClaimProfileV1({
+      profile: baseProfile(entry),
+      account: capability.creatorAddress,
+      entries: [entry],
+      client: client({
+        claimable: 0n,
+        claims: [{
+          removed: false,
+          args: {
+            poolId: capability.poolId,
+            creator: capability.creatorAddress,
+            recipient: capability.creatorAddress,
+            caller: capability.creatorAddress,
+            amount: claimedAmount,
+          },
+          blockNumber: 25_827_250n,
+          transactionHash: `0x${"ab".repeat(32)}`,
+          transactionIndex: 2,
+          logIndex: 7,
+        }],
+      }),
+    });
+
+    expect(projected.pools[0]).toMatchObject({
+      claimableCreatorFeesWei: "0",
+      generatedCreatorFeesWei: claimedAmount.toString(),
+    });
+    expect(projected.totals).toMatchObject({
+      claimableWei: "0",
+      generatedWei: claimedAmount.toString(),
+      claimedWei: claimedAmount.toString(),
+    });
+    const mapped = mapCreatorProfileResponse(
+      projected,
+      capability.creatorAddress,
+    );
+    expect(mapped.claims).toEqual([]);
+    expect(mapped.claimedWei).toBe(claimedAmount.toString());
+    expect(mapped.activity).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: "Creator fees claimed" }),
+    ]));
+  });
+});


### PR DESCRIPTION
Adds the exact allowlist-bound FADE creator-fee claim capability to Profile. The server revalidates finalized launch provenance, runtime hashes, creator and registrar identity, pool state, exact calldata and value zero, then simulates the transaction before returning it. Existing arbitrary Router Custom launches remain display-only.

Verification:
- focused claim and profile tests passed
- TypeScript and affected-file lint passed
- independent security review found no material blocker
- no transaction is signed or broadcast by this change