### PR TITLE
Fix staged catalog probe for newest Custom launches

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -717,6 +717,7 @@ jobs:
             body?.status !== "ready" ||
             body?.catalog?.source !== "envio-classic-v3" ||
             body.catalog.launchSource !== expectedLaunchSource ||
+            body.catalog.completeness?.classic !== "current" ||
             body.catalog.completeness?.custom !== expectedCustomStatus ||
             body.catalog.completeness?.stock !== "excluded" ||
             body.catalog.evidence?.kind !== "envio-indexer-state" ||
@@ -726,8 +727,6 @@ jobs:
               JSON.stringify(["classic", "custom"]) ||
             !Number.isSafeInteger(body.total) || body.total < 1 ||
             !Array.isArray(body.tokens) || body.tokens.length !== 1 ||
-            body.tokens[0]?.launchModel !== "classic" ||
-            body.tokens[0]?.launchModelVersion !== "classic-v3" ||
             response.headers.get("x-programmable-launch-source") !==
               expectedLaunchSource
           ) {

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2358,11 +2358,12 @@ export function evaluateReadModelOperationsSourceContracts(
         '"/api/explore?limit=1&page=1&sort=newest"',
         "response.status !== 200",
         'body?.catalog?.source !== "envio-classic-v3"',
+        'body.catalog.completeness?.classic !== "current"',
         'body.catalog.completeness?.stock !== "excluded"',
         'body.catalog.evidence?.kind !== "envio-indexer-state"',
-        'body.tokens[0]?.launchModelVersion !== "classic-v3"',
         "body.total < 1",
       ]) &&
+      !stagedCatalogProbeBlock.includes("body.tokens[0]?.launchModel") &&
       !stagedCatalogProbeBlock.includes("CRON_SECRET") &&
       !stagedCatalogProbeBlock.includes("/api/ops/index-v2") &&
       !stagedCatalogProbeBlock.includes("        if:"),

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -278,6 +278,7 @@ test("every staged candidate proves the Envio catalog before public data smoke",
   assert.match(probe, /VERCEL_AUTOMATION_BYPASS_SECRET:/u);
   assert.match(probe, /\/api\/explore\?limit=1&page=1&sort=newest/u);
   assert.match(probe, /catalog\?\.source !== "envio-classic-v3"/u);
+  assert.match(probe, /completeness\?\.classic !== "current"/u);
   assert.match(probe, /completeness\?\.stock !== "excluded"/u);
   assert.match(
     probe,
@@ -292,7 +293,7 @@ test("every staged candidate proves the Envio catalog before public data smoke",
     /envio-classic-v3\+registry\.custom-launched\+canonical-launch-stamp-router/u,
   );
   assert.match(probe, /expectedCustomStatus/u);
-  assert.match(probe, /launchModelVersion !== "classic-v3"/u);
+  assert.doesNotMatch(probe, /tokens\[0\].*launchModel/u);
   assert.match(probe, /body\.total < 1/u);
   assert.doesNotMatch(probe, /CRON_SECRET|\/api\/ops\/index-v2/u);
   assert.doesNotMatch(probe, /\n        if:/u);

--- a/tests/data-pipeline/read-model-staged-refresh.test.ts
+++ b/tests/data-pipeline/read-model-staged-refresh.test.ts
@@ -403,6 +403,11 @@ describe("staged Envio catalog probe source contract", () => {
         step.replace('            body?.catalog?.source !== "envio-classic-v3" ||\n', ""),
     ],
     [
+      "drops Classic catalog completeness",
+      (step: string) =>
+        step.replace('            body.catalog.completeness?.classic !== "current" ||\n', ""),
+    ],
+    [
       "allows stock families",
       (step: string) =>
         step.replace('            body.catalog.completeness?.stock !== "excluded" ||\n', ""),


### PR DESCRIPTION
## What changed
- require the Envio Classic V3 catalog itself to report Classic identities as current
- keep non-empty catalog, evidence, source, scope, stock exclusion, Registry and Router completeness checks
- stop assuming the newest merged Explore entry must be a Classic V3 token

## Production evidence
- staged candidate dpl_3y7zs2QaydA9kiyjhcqw1FxEFE2B is READY on cf733dfc6b78277c6360eed517196179c878f1eb
- its Explore response is ready and the newest item is the valid finalized FADE Router launch
- catalog source is envio-classic-v3, Classic completeness is current, Registry and Router completeness are current, and total is 290

## Targeted checks
- workflow contract tests: 9/9 passed
- staged refresh tests: 17/17 passed
- operations source gate passed
- git diff --check passed