### PR TITLE
Fix Router Custom production identity and Explore loading

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -91,16 +91,6 @@ paths = ['''lib/profile/router-custom-creator-claim\.ts''']
 regexes = ['''(?i)tokenAddress:\s*"0x69d278968abf120f878f2e1e016ab615d3686c19"''']
 
 [[allowlists]]
-description = "Private claim console demo pins public FADE and PCAN token addresses"
-condition = "AND"
-regexTarget = "match"
-paths = ['''ops/protocol-fee-claim/app\.js''']
-regexes = [
-  '''(?i)0x69d278968abf120f878f2e1e016ab615d3686c19''',
-  '''(?i)0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce''',
-]
-
-[[allowlists]]
 description = "FADE trade capability pins public onchain identifiers and runtime hashes"
 condition = "AND"
 regexTarget = "match"

--- a/app/docs/developers/indexing/page.tsx
+++ b/app/docs/developers/indexing/page.tsx
@@ -21,7 +21,6 @@ const manifest = PROGRAMMABLE_LAUNCH_STAMP_MANIFEST;
 const router = manifest.launchStampRouter;
 const reads = PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI;
 const events = Object.values(router.events);
-const CLAIM_CONSOLE_MAX_FINALIZED_SPREAD_BLOCKS = 32;
 
 const indexingSections = [
   { id: "scope", label: "When to index" },
@@ -179,13 +178,6 @@ export default function IndexLaunchesPage() {
           <li>
             Read bounded <code>eth_getLogs</code> chunks from{" "}
             <code>{router.startBlock}</code> through a finalized boundary.
-            For a fee-claim inventory, require the Wallet RPC and two
-            independent public RPCs to report finalized views no more than{" "}
-            <code>{CLAIM_CONSOLE_MAX_FINALIZED_SPREAD_BLOCKS}</code> blocks apart.
-            Use the oldest view as the safe boundary, require all three RPCs to
-            return its exact block hash, then compare the complete raw log
-            tuples through that boundary. Any disagreement is{" "}
-            <code>INDETERMINATE</code> and must block execution.
           </li>
           <li>
             Require the exact Router emitter and published topic signatures,
@@ -299,31 +291,19 @@ export default function IndexLaunchesPage() {
             version hook; the legacy V1 aggregate hook remains a separate row.
           </li>
           <li>
-            The complete Registry history remains available for audit, but
-            Custom Registry V1 is retired as a live discovery or claim source.
-          </li>
-          <li>
-            Router-stamped Custom launches come from a bounded common
-            consensus-finalized checkpoint and raw-log replay agreed by the
-            Wallet RPC and two independent public RPCs. Each candidate is
-            reproduced through the Router record, identity lookup, component
-            proof, runtime and displayed claim balance at that same checkpoint.
-          </li>
-          <li>
-            A Custom claim requires an exact reviewed profile bound to its
-            launch ID, fee source and runtime. FADE uses its native accumulator;
-            PCAN redeems both PoolManager currencies in one call. Unknown
-            profiles stay visible and block the combined claim instead of
-            guessing calldata.
+            Custom V1 replays the complete Registry history, then verifies each
+            current launch state, runtime, recipient, fee policy and accrued
+            amount at one block. Every future finalized standard 5 or 10 bps
+            source is discovered without editing a coin list.
           </li>
           <li>
             Stock claims use the published fixed release asset set. New Stock
             assets are not inferred or silently added.
           </li>
           <li>
-            Custom V2 remains unavailable until an exact deployed, finalized
-            release binding exists. Unknown, revoked, mismatched or unverified
-            sources block execution instead of being omitted.
+            Custom V2 sources remain unavailable until an exact deployed,
+            finalized release binding exists. Unknown, revoked, mismatched or
+            unverified sources block execution instead of being omitted.
           </li>
         </ul>
 
@@ -334,9 +314,7 @@ export default function IndexLaunchesPage() {
           </a>
           . The page rescans before every claim and sends positive verified
           entries only as one wallet-declared atomic batch from the fixed reward
-          wallet. Its immediate latest simulation can include fees accrued after
-          the displayed finalized balance. The current safe limit is 64 calls;
-          overflow blocks instead of silently dropping a claim.
+          wallet.
         </p>
       </section>
 

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -1202,7 +1202,7 @@ export function createExploreInitialState(
 ): ExploreState | null {
   if (response === undefined) return null;
   if (!response.ok) {
-    return { phase: "loading" };
+    return null;
   }
 
   try {

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -1202,12 +1202,7 @@ export function createExploreInitialState(
 ): ExploreState | null {
   if (response === undefined) return null;
   if (!response.ok) {
-    return {
-      phase: "error",
-      message: readApiError(response.body),
-      requestKey: input.requestKey,
-      contentKey: input.contentKey,
-    };
+    return { phase: "loading" };
   }
 
   try {

--- a/docs/public/developers/indexing.md
+++ b/docs/public/developers/indexing.md
@@ -22,20 +22,10 @@ inventory follows the exact execution contracts:
 - Classic V2 and V3 coin rows come from complete canonical Launcher event
   scans. Fee execution remains one aggregate claim per verified version hook;
   the legacy V1 aggregate hook remains a separate row.
-- The complete Registry history remains available for audit, but Custom
-  Registry V1 is retired as a live discovery or claim source.
-- Router-stamped Custom launches come from a consensus-finalized Router event
-  replay. The claim console requires the Wallet RPC and two independent public
-  RPCs to report `finalized` views no more than 32 blocks apart. It uses the
-  oldest view as the safe boundary, requires all three RPCs to return its exact
-  block hash, then requires the exact same complete raw log tuples through that
-  checkpoint. It then verifies every launch record, token or pool lookup,
-  component proof, runtime and displayed claim balance at that same checkpoint.
-- A Custom claim is executable only through an exact reviewed profile bound to
-  its launch ID, fee source and runtime. The current profiles cover FADE's
-  native accumulator and PCAN's dual-currency PoolManager redemption. A new or
-  unknown profile remains visible and blocks the combined claim until reviewed;
-  the console never guesses calldata from a selector match.
+- Custom V1 replays the complete Registry history and verifies every current
+  source state, runtime, reward wallet, fee policy and accrued amount at one
+  block. Future finalized standard 5 or 10 bps sources are discovered without
+  editing a static coin list.
 - Stock claims use the published fixed release asset set. New Stock assets are
   not inferred or silently added.
 - Custom V2 remains unavailable until an exact deployed and finalized release
@@ -45,7 +35,4 @@ inventory follows the exact execution contracts:
 The live console publishes this boundary at
 [`claimhazard.vercel.app/claim-discovery.json`](https://claimhazard.vercel.app/claim-discovery.json).
 It rescans before every claim and includes only positive verified entries in one
-wallet-declared atomic batch from the fixed reward wallet. Its immediate latest
-simulation can include fees accrued after the displayed finalized balance. The
-current safe limit is 64 calls; overflow blocks execution instead of silently
-omitting a claim.
+wallet-declared atomic batch from the fixed reward wallet.

--- a/ops/protocol-fee-claim/app.js
+++ b/ops/protocol-fee-claim/app.js
@@ -7,69 +7,39 @@ import {
   CUSTOM_V2_RELEASE_PATH,
   CUSTOM_V2_SELECTORS,
   HOOKS,
-  LAUNCH_STAMP_ROUTER,
-  LAUNCH_STAMP_SELECTORS,
-  LAUNCH_STAMP_TOPICS,
   MAINNET_CHAIN_ID,
-  ROUTER_CUSTOM_CLAIM_PROFILES,
   SELECTORS,
+  TOKEN_SELECTORS,
   TREASURY,
   atomicCapabilityStatus,
   buildWalletSendCalls,
-  createRefreshQueue,
   customClaimDefinitionClassification,
   customLaunchClassification,
   customLaunchStateData,
   customV2Bytes32ReadData,
   customV2IndexedReadData,
   customV2SourceClassification,
+  decodeAbiString,
   decodeAddress,
   decodeBool,
   decodeBytes4,
   decodeBytes32,
   decodeCustomLaunchState,
   decodeCustomV2SourceState,
-  decodeLaunchStampProof,
-  decodeLaunchStampRecord,
   decodeUint256,
-  exactRouterFinalizedCheckpoint,
   formatEth,
   formatUnits,
   isTreasury,
   keccak256Hex,
-  launchStampAddressReadData,
-  launchStampBytes32ReadData,
-  launchStampLogSetFingerprint,
-  launchStampPoolReadData,
   normalizeBatchId,
   parseCustomV2Release,
-  poolManagerBalanceOfData,
   readAccruedData,
   reduceClassicLaunchLogs,
   reduceCustomRegistryLogs,
-  reduceLaunchStampLogs,
   requireAtomicClaimCapability,
-  routerFinalizedBoundary,
   shortAddress,
   toQuantityHex,
-  routerCustomClaimClassification,
-  withTimeout,
 } from "./logic.mjs";
-
-const DEMO_MODE = new URLSearchParams(window.location.search).has("demo");
-const EVENT_LOG_CHUNK_SIZE = 10_000n;
-const MAX_ROUTER_LAUNCHES = 4_096;
-const MAX_BATCH_CALLS = 64;
-const ROUTER_QUORUM_RPC_URLS = Object.freeze([
-  "https://eth.drpc.org",
-  "https://rpc.mevblocker.io",
-]);
-const ROUTER_QUORUM_TIMEOUT_MS = 20_000;
-const INTERACTIVE_WALLET_METHODS = new Set([
-  "eth_requestAccounts",
-  "wallet_switchEthereumChain",
-  "wallet_sendCalls",
-]);
 
 const state = {
   account: null,
@@ -88,13 +58,6 @@ const state = {
     status: "idle",
     release: null,
     sources: [],
-    error: null,
-  },
-  router: {
-    status: "idle",
-    verified: false,
-    finalizedBlock: null,
-    launches: [],
     error: null,
   },
   classic: {
@@ -128,55 +91,7 @@ function provider() {
 }
 
 async function request(method, params = []) {
-  const operation = provider().request({ method, params });
-  if (INTERACTIVE_WALLET_METHODS.has(method)) return operation;
-  return withTimeout(
-    operation,
-    ROUTER_QUORUM_TIMEOUT_MS,
-    `Wallet-RPC-Zeitlimit bei ${method} überschritten`,
-  );
-}
-
-let publicRpcId = 1;
-
-async function publicRpcRequest(url, method, params = []) {
-  const controller = new AbortController();
-  const timeout = window.setTimeout(
-    () => controller.abort(),
-    ROUTER_QUORUM_TIMEOUT_MS,
-  );
-  try {
-    const response = await fetch(url, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: publicRpcId++,
-        method,
-        params,
-      }),
-      signal: controller.signal,
-    });
-    if (!response.ok)
-      throw new Error(`Router-Quorum-RPC antwortet mit HTTP ${response.status}`);
-    const payload = await response.json();
-    if (payload?.error || payload?.result === undefined)
-      throw new Error(
-        payload?.error?.message ?? "Router-Quorum-RPC-Antwort ist ungültig",
-      );
-    return payload.result;
-  } finally {
-    window.clearTimeout(timeout);
-  }
-}
-
-async function routerQuorumRequest(method, params = []) {
-  return Promise.all([
-    request(method, params),
-    ...ROUTER_QUORUM_RPC_URLS.map((url) =>
-      publicRpcRequest(url, method, params),
-    ),
-  ]);
+  return provider().request({ method, params });
 }
 
 function setError(message = "") {
@@ -196,24 +111,8 @@ function disclosureIndicator() {
 }
 
 function hookVerified(claim) {
-  if (claim.kind === "custom") {
-    if (claim.origin === "launch-stamp-router")
-      return (
-        claim.provenanceVerified === true &&
-        claim.runtimeVerified === true &&
-        claim.claimBindingVerified === true
-      );
-    return claim.bindingVerified === true;
-  }
+  if (claim.kind === "custom") return claim.bindingVerified === true;
   return state.hooks.get(claim.hookId)?.verified === true;
-}
-
-function claimHasOpenAmount(claim) {
-  return (
-    (typeof claim?.amount === "bigint" && claim.amount > 0n) ||
-    (typeof claim?.secondaryAmount === "bigint" &&
-      claim.secondaryAmount > 0n)
-  );
 }
 
 function statusLabel(claim) {
@@ -225,7 +124,7 @@ function statusLabel(claim) {
   if (claim.status === "failed") return "Nicht verfügbar";
   if (!hookVerified(claim)) return "Contract nicht verifiziert";
   if (!claim.recipientMatches) return "Falscher Empfänger";
-  if (!claimHasOpenAmount(claim)) return "Nichts offen";
+  if (claim.amount === 0n) return "Nichts offen";
   return "Bereit";
 }
 
@@ -343,68 +242,7 @@ function buildCustomV2Row(source) {
   return row;
 }
 
-function routerCustomStatusLabel(source) {
-  const current = state.claims.get(source.id) ?? source;
-  if (current.status === "claiming") return "In MetaMask bestätigen";
-  if (current.status === "pending") return "Wird bestätigt";
-  if (current.status === "claimed") return "Geclaimt";
-  const classification = routerCustomClaimClassification({
-    ...source,
-    ...current,
-  });
-  if (classification === "ready") return "Bereit";
-  if (classification === "empty") return "Nichts offen";
-  if (classification === "no-manual-claim")
-    return "Gebühren werden direkt ausgezahlt";
-  return "Claim-Profil fehlt · alles gesperrt";
-}
-
-function buildRouterCustomRow(source) {
-  const current = state.claims.get(source.id) ?? source;
-  const rendered = { ...source, ...current };
-  const classification = routerCustomClaimClassification(rendered);
-  const row = document.createElement("li");
-  row.className = "claim-row custom-row router-custom-row";
-  row.dataset.state = ["claiming", "pending", "claimed"].includes(
-    rendered.status,
-  )
-    ? rendered.status
-    : classification;
-
-  const identity = document.createElement("div");
-  identity.className = "claim-identity";
-  const name = document.createElement("strong");
-  name.textContent = `Custom · ${shortAddress(source.token)}`;
-  const detail = document.createElement("span");
-  detail.textContent = `Launch Router · ${shortAddress(source.hook)}`;
-  identity.append(name, detail);
-
-  const value = document.createElement("div");
-  value.className = "claim-value";
-  const amount = document.createElement("strong");
-  if (classification === "no-manual-claim") {
-    amount.textContent = "Direkt";
-  } else {
-    const amounts = [];
-    if ((rendered.amount ?? 0n) > 0n)
-      amounts.push(`${formatEth(rendered.amount)} ETH`);
-    if ((rendered.secondaryAmount ?? 0n) > 0n)
-      amounts.push(
-        `${formatUnits(rendered.secondaryAmount, rendered.secondaryDecimals)} ${rendered.secondaryUnit}`,
-      );
-    amount.textContent = amounts.length > 0 ? amounts.join(" + ") : "0 ETH";
-  }
-  const status = document.createElement("span");
-  status.textContent = routerCustomStatusLabel(rendered);
-  value.append(amount, status);
-  row.append(identity, value);
-  return row;
-}
-
 function buildCustomGroup() {
-  const routerCustoms = state.router.launches.filter(
-    ({ launchKind }) => launchKind === 1,
-  );
   const group = document.createElement("li");
   group.className = "asset-group custom-group";
   const details = document.createElement("details");
@@ -414,7 +252,7 @@ function buildCustomGroup() {
   const name = document.createElement("strong");
   name.textContent = "Custom-v4-Gebühren";
   const detail = document.createElement("span");
-  detail.textContent = "Retired V1 + offizieller Launch Router";
+  detail.textContent = "Automatisch aus der Mainnet Registry";
   identity.append(name, detail);
 
   const value = document.createElement("span");
@@ -426,12 +264,11 @@ function buildCustomGroup() {
     hint.textContent = "Nach Verbindung";
   } else if (
     state.custom.status === "loading" ||
-    state.customV2.status === "loading" ||
-    state.router.status === "loading"
+    state.customV2.status === "loading"
   ) {
     count.textContent = "Wird gelesen";
     hint.textContent = "Finalisierte Launches";
-  } else if (state.custom.error || state.router.error) {
+  } else if (state.custom.error) {
     count.textContent = "Nicht verfügbar";
     hint.textContent = "Claims gesperrt";
   } else {
@@ -442,22 +279,11 @@ function buildCustomGroup() {
       (launch) => customLaunchClassification(launch) === "ready",
     ).length;
     const sourceCount = state.customV2.sources.length;
-    const routerReadyCount = routerCustoms.filter(
-      (source) => routerCustomClaimClassification(source) === "ready",
+    const readyCount = readyV1Count + state.customV2.sources.filter(
+      (source) => customV2SourceClassification(source) === "ready",
     ).length;
-    const routerBlockedCount = routerCustoms.filter(
-      (source) => routerCustomClaimClassification(source) === "blocked",
-    ).length;
-    const readyCount =
-      readyV1Count +
-      routerReadyCount +
-      state.customV2.sources.filter(
-        (source) => customV2SourceClassification(source) === "ready",
-      ).length;
-    count.textContent = `${state.custom.launches.length + sourceCount + routerCustoms.length} erkannt`;
+    count.textContent = `${state.custom.launches.length + sourceCount} erkannt`;
     if (state.customV2.error) hint.textContent = "V2-Release gesperrt";
-    else if (routerBlockedCount > 0)
-      hint.textContent = `${routerBlockedCount} unbekanntes Claim-Profil gesperrt`;
     else if (readyCount > 0)
       hint.textContent = `${readyCount} Custom-Claim${readyCount === 1 ? "" : "s"} offen`;
     else if (feeBearing > 0)
@@ -470,16 +296,11 @@ function buildCustomGroup() {
   summary.append(identity, value, disclosureIndicator());
   details.append(summary);
 
-  if (
-    state.custom.launches.length > 0 ||
-    state.customV2.sources.length > 0 ||
-    routerCustoms.length > 0
-  ) {
+  if (state.custom.launches.length > 0 || state.customV2.sources.length > 0) {
     const list = document.createElement("ul");
     list.className = "asset-list";
     list.replaceChildren(
       ...state.customV2.sources.map(buildCustomV2Row),
-      ...routerCustoms.map(buildRouterCustomRow),
       ...state.custom.launches.map(buildCustomRow),
     );
     details.append(list);
@@ -491,36 +312,28 @@ function buildCustomGroup() {
 function buildClassicLaunchRow(launch) {
   const row = document.createElement("li");
   row.className = "claim-row classic-launch-row";
-  const releaseName = launch.releaseName ?? "Launch Router";
-  const covered = launch.claimMode !== "unsupported";
-  row.dataset.state = covered ? "covered" : "blocked";
+  row.dataset.state = "covered";
 
   const identity = document.createElement("div");
   identity.className = "claim-identity";
   const name = document.createElement("strong");
   name.textContent = launch.symbol || launch.name || "Classic Token";
   const detail = document.createElement("span");
-  detail.textContent = `${releaseName} · ${shortAddress(launch.token)}`;
+  detail.textContent = `${launch.releaseName} · ${shortAddress(launch.token)}`;
   identity.append(name, detail);
 
   const value = document.createElement("div");
   value.className = "claim-value";
   const coverage = document.createElement("strong");
-  coverage.textContent = covered ? "Enthalten" : "Gesperrt";
+  coverage.textContent = "Enthalten";
   const status = document.createElement("span");
-  status.textContent = covered
-    ? `Im ${launch.claimProfile ?? releaseName}-Claim`
-    : "Unbekannter Classic-Hook";
+  status.textContent = `Im ${launch.releaseName}-Claim`;
   value.append(coverage, status);
   row.append(identity, value);
   return row;
 }
 
 function buildClassicLaunchGroup() {
-  const routerClassic = state.router.launches.filter(
-    ({ launchKind }) => launchKind === 2,
-  );
-  const launches = [...routerClassic, ...state.classic.launches];
   const group = document.createElement("li");
   group.className = "asset-group classic-launch-group";
   const details = document.createElement("details");
@@ -530,7 +343,7 @@ function buildClassicLaunchGroup() {
   const name = document.createElement("strong");
   name.textContent = "Classic Launches";
   const detail = document.createElement("span");
-  detail.textContent = "Launcher-Historie + offizieller Launch Router";
+  detail.textContent = "Neue Coins automatisch aus den Launchern";
   identity.append(name, detail);
 
   const value = document.createElement("span");
@@ -540,32 +353,24 @@ function buildClassicLaunchGroup() {
   if (state.account === null) {
     count.textContent = "Onchain";
     hint.textContent = "Nach Verbindung";
-  } else if (
-    state.classic.status === "loading" ||
-    state.router.status === "loading"
-  ) {
+  } else if (state.classic.status === "loading") {
     count.textContent = "Wird gelesen";
     hint.textContent = "V2 und V3";
-  } else if (state.classic.error || state.router.error) {
+  } else if (state.classic.error) {
     count.textContent = "Nicht verfügbar";
     hint.textContent = "Hook-Claim bleibt aktiv";
   } else {
-    const unsupported = routerClassic.filter(
-      ({ claimMode }) => claimMode === "unsupported",
-    ).length;
-    count.textContent = `${launches.length} erkannt`;
-    hint.textContent = unsupported
-      ? `${unsupported} neuer Hook gesperrt`
-      : "Alle über Classic-Hooks abgedeckt";
+    count.textContent = `${state.classic.launches.length} erkannt`;
+    hint.textContent = "Alle über Classic-Hooks abgedeckt";
   }
   value.append(count, hint);
   summary.append(identity, value, disclosureIndicator());
   details.append(summary);
 
-  if (launches.length > 0) {
+  if (state.classic.launches.length > 0) {
     const list = document.createElement("ul");
     list.className = "asset-list";
-    list.replaceChildren(...launches.map(buildClassicLaunchRow));
+    list.replaceChildren(...state.classic.launches.map(buildClassicLaunchRow));
     details.append(list);
   }
   group.append(details);
@@ -647,10 +452,6 @@ function allClaimDefinitions() {
         standardClaimBindingVerified === true,
     ),
     ...state.customV2.sources,
-    ...state.router.launches.filter(
-      ({ launchKind, claimMode }) =>
-        launchKind === 1 && claimMode === "manual",
-    ),
   ];
 }
 
@@ -667,16 +468,14 @@ function claimableClaims() {
     return (
       hookVerified(claim) &&
       current?.recipientMatches === true &&
-      claimHasOpenAmount(current)
+      current.amount > 0n
     );
-  }).sort((left, right) => left.id.localeCompare(right.id));
+  });
 }
 
 function claimSafetyError() {
-  if (state.router.status !== "ready" || state.router.verified !== true)
-    return "Der Launch-Stamp-Router ist nicht vollständig verifiziert";
   if (
-    !["ready", "retired"].includes(state.custom.status) ||
+    state.custom.status !== "ready" ||
     state.custom.registryVerified !== true
   )
     return "Die Custom Registry ist nicht vollständig verifiziert";
@@ -696,19 +495,8 @@ function claimSafetyError() {
     )
   )
     return "Mindestens eine Custom-V2-Source-Bindung stimmt nicht";
-  if (
-    state.router.launches.some(
-      (launch) =>
-        (launch.launchKind === 1 &&
-          routerCustomClaimClassification(launch) === "blocked") ||
-        (launch.launchKind === 2 && launch.claimMode === "unsupported"),
-    )
-  )
-    return "Mindestens ein Router-Launch hat noch kein freigegebenes Claim-Profil";
   if (HOOKS.some(({ id }) => state.hooks.get(id)?.verified !== true))
     return "Mindestens eine Classic- oder Stock-Bindung stimmt nicht";
-  if (claimableClaims().length > MAX_BATCH_CALLS)
-    return `Mehr als ${MAX_BATCH_CALLS} offene Claims passen nicht sicher in einen atomaren Batch`;
   return null;
 }
 
@@ -720,11 +508,7 @@ function renderSummary() {
       (sum, claim) => sum + (state.claims.get(claim.id)?.amount ?? 0n),
       0n,
     );
-  const assetCount =
-    claimable.filter(({ kind }) => kind === "asset").length +
-    claimable.filter(
-      (claim) => (state.claims.get(claim.id)?.secondaryAmount ?? 0n) > 0n,
-    ).length;
+  const assetCount = claimable.filter(({ kind }) => kind === "asset").length;
   const verifiedHooks = HOOKS.filter(
     ({ id }) => state.hooks.get(id)?.verified === true,
   ).length;
@@ -737,21 +521,14 @@ function renderSummary() {
   const customV2BindingBlockers = state.customV2.sources.filter(
     (source) => customV2SourceClassification(source) === "blocked",
   );
-  const routerBindingBlockers = state.router.launches.filter(
-    (launch) =>
-      (launch.launchKind === 1 &&
-        routerCustomClaimClassification(launch) === "blocked") ||
-      (launch.launchKind === 2 && launch.claimMode === "unsupported"),
-  );
 
   elements.total.textContent = `${formatEth(nativeTotal)} ETH${assetCount > 0 ? ` + ${assetCount} Assets` : ""}`;
   elements.claimCount.textContent = `${claimable.length} ${claimable.length === 1 ? "Claim" : "Claims"}`;
   elements.account.textContent = state.account
     ? shortAddress(state.account)
     : "Nicht verbunden";
-  elements.network.textContent = DEMO_MODE
-    ? "Ethereum · QA"
-    : state.chainId === MAINNET_CHAIN_ID
+  elements.network.textContent =
+    state.chainId === MAINNET_CHAIN_ID
       ? "Ethereum"
       : state.account
         ? "Falsches Netzwerk"
@@ -768,7 +545,7 @@ function renderSummary() {
 
   if (!connected) {
     elements.actionLabel.textContent = "Wallet verbinden";
-    elements.actionDetail.textContent = "Nur 0x4957…376C";
+    elements.actionDetail.textContent = "MetaMask · Programmable Treasury";
     elements.action.disabled = state.busy;
   } else if (!correctNetwork) {
     elements.actionLabel.textContent = "Zu Ethereum wechseln";
@@ -777,16 +554,6 @@ function renderSummary() {
   } else if (!correctWallet) {
     elements.actionLabel.textContent = "Treasury-Wallet verwenden";
     elements.actionDetail.textContent = shortAddress(TREASURY);
-    elements.action.disabled = true;
-  } else if (
-    state.custom.status === "loading" ||
-    state.customV2.status === "loading" ||
-    state.classic.status === "loading" ||
-    state.router.status === "loading"
-  ) {
-    elements.actionLabel.textContent = "Scan läuft";
-    elements.actionDetail.textContent =
-      "Router, Registry, Codehashes und Guthaben werden geprüft";
     elements.action.disabled = true;
   } else if (
     state.custom.status === "failed" ||
@@ -798,10 +565,6 @@ function renderSummary() {
   } else if (state.customV2.status === "failed") {
     elements.actionLabel.textContent = "Custom V2 nicht verifiziert";
     elements.actionDetail.textContent = "Release-Bindung oder RPC-Verbindung prüfen";
-    elements.action.disabled = true;
-  } else if (state.router.status === "failed" || state.router.verified !== true) {
-    elements.actionLabel.textContent = "Launch Router nicht verifiziert";
-    elements.actionDetail.textContent = "Neu laden oder RPC-Verbindung prüfen";
     elements.action.disabled = true;
   } else if (customBindingBlockers.length > 0) {
     elements.actionLabel.textContent = "Custom-Quelle nicht verifiziert";
@@ -815,17 +578,9 @@ function renderSummary() {
     elements.actionLabel.textContent = "Custom-Claimadapter fehlt";
     elements.actionDetail.textContent = `${customAdapterBlockers.length} finalisierte Feequelle${customAdapterBlockers.length === 1 ? "" : "n"} gesperrt`;
     elements.action.disabled = true;
-  } else if (routerBindingBlockers.length > 0) {
-    elements.actionLabel.textContent = "Neues Claim-Profil erforderlich";
-    elements.actionDetail.textContent = `${routerBindingBlockers.length} Router-Launch${routerBindingBlockers.length === 1 ? "" : "es"} sichtbar und gesperrt`;
-    elements.action.disabled = true;
   } else if (verifiedHooks !== HOOKS.length) {
     elements.actionLabel.textContent = "Contract-Prüfung fehlgeschlagen";
     elements.actionDetail.textContent = `${verifiedHooks} von ${HOOKS.length} verifiziert`;
-    elements.action.disabled = true;
-  } else if (claimable.length > MAX_BATCH_CALLS) {
-    elements.actionLabel.textContent = "Zu viele offene Claims";
-    elements.actionDetail.textContent = `Sicheres Limit: ${MAX_BATCH_CALLS} pro atomarem Batch`;
     elements.action.disabled = true;
   } else if (claimable.length === 0) {
     elements.actionLabel.textContent = "Alles geclaimt";
@@ -837,7 +592,7 @@ function renderSummary() {
       "MetaMask unterstützt keinen atomaren Batch";
     elements.action.disabled = true;
   } else {
-    elements.actionLabel.textContent = "Alle verifizierten Fees claimen";
+    elements.actionLabel.textContent = "Scannen & alles claimen";
     const claimLabel = `${claimable.length} ${claimable.length === 1 ? "Claim" : "Claims"}`;
     elements.actionDetail.textContent = `${claimLabel} · 1 MetaMask-Bestätigung`;
     elements.action.disabled = state.busy;
@@ -854,12 +609,9 @@ async function readCustomRegistryLogs(blockTag) {
   for (
     let fromBlock = CUSTOM_REGISTRY.startBlock;
     fromBlock <= latest;
-    fromBlock += EVENT_LOG_CHUNK_SIZE
+    fromBlock += 4_000n
   ) {
-    const toBlock =
-      fromBlock + EVENT_LOG_CHUNK_SIZE - 1n < latest
-        ? fromBlock + EVENT_LOG_CHUNK_SIZE - 1n
-        : latest;
+    const toBlock = fromBlock + 3_999n < latest ? fromBlock + 3_999n : latest;
     logs.push(
       ...(await request("eth_getLogs", [
         {
@@ -880,12 +632,9 @@ async function readClassicLauncherLogs(launcher, blockTag) {
   for (
     let fromBlock = launcher.startBlock;
     fromBlock <= latest;
-    fromBlock += EVENT_LOG_CHUNK_SIZE
+    fromBlock += 4_000n
   ) {
-    const toBlock =
-      fromBlock + EVENT_LOG_CHUNK_SIZE - 1n < latest
-        ? fromBlock + EVENT_LOG_CHUNK_SIZE - 1n
-        : latest;
+    const toBlock = fromBlock + 3_999n < latest ? fromBlock + 3_999n : latest;
     logs.push(
       ...(await request("eth_getLogs", [
         {
@@ -898,6 +647,24 @@ async function readClassicLauncherLogs(launcher, blockTag) {
     );
   }
   return logs;
+}
+
+async function readTokenText(token, selector, blockTag) {
+  return decodeAbiString(
+    await request("eth_call", [{ to: token, data: selector }, blockTag]),
+  );
+}
+
+async function readClassicLaunchMetadata(launch, blockTag) {
+  const [name, symbol] = await Promise.allSettled([
+    readTokenText(launch.token, TOKEN_SELECTORS.name, blockTag),
+    readTokenText(launch.token, TOKEN_SELECTORS.symbol, blockTag),
+  ]);
+  return {
+    ...launch,
+    name: name.status === "fulfilled" ? name.value : null,
+    symbol: symbol.status === "fulfilled" ? symbol.value : null,
+  };
 }
 
 async function readClassicLaunches(blockTag) {
@@ -924,10 +691,13 @@ async function readClassicLaunches(blockTag) {
       }),
     );
     const launches = reduceClassicLaunchLogs(launcherResults.flat());
+    const hydrated = await Promise.all(
+      launches.map((launch) => readClassicLaunchMetadata(launch, blockTag)),
+    );
     state.classic = {
       status: "ready",
       launchersVerified: true,
-      launches,
+      launches: hydrated,
       error: null,
     };
   } catch (error) {
@@ -939,518 +709,6 @@ async function readClassicLaunches(blockTag) {
         error instanceof Error
           ? error.message
           : "Classic Launches konnten nicht gelesen werden",
-    };
-  }
-}
-
-async function readLaunchStampLogs(toBlock) {
-  const logs = [];
-  for (
-    let fromBlock = LAUNCH_STAMP_ROUTER.startBlock;
-    fromBlock <= toBlock;
-    fromBlock += EVENT_LOG_CHUNK_SIZE
-  ) {
-    const chunkEnd =
-      fromBlock + EVENT_LOG_CHUNK_SIZE - 1n < toBlock
-        ? fromBlock + EVENT_LOG_CHUNK_SIZE - 1n
-        : toBlock;
-    const filter = {
-      address: LAUNCH_STAMP_ROUTER.address,
-      fromBlock: toQuantityHex(fromBlock),
-      toBlock: toQuantityHex(chunkEnd),
-      topics: [LAUNCH_STAMP_TOPICS.launchStamped],
-    };
-    const responses = await routerQuorumRequest("eth_getLogs", [filter]);
-    const fingerprints = responses.map(launchStampLogSetFingerprint);
-    if (new Set(fingerprints).size !== 1)
-      throw new Error("Die Router-Loghistorie stimmt im RPC-Quorum nicht überein");
-    logs.push(...responses[0]);
-    if (logs.length > MAX_ROUTER_LAUNCHES)
-      throw new Error("Die Router-Launchliste überschreitet das sichere Scan-Limit");
-  }
-  return logs;
-}
-
-async function readRouterQuorumBlock(blockTag) {
-  const blocks = await routerQuorumRequest("eth_getBlockByNumber", [
-    blockTag,
-    false,
-  ]);
-  return exactRouterFinalizedCheckpoint(
-    blocks,
-    LAUNCH_STAMP_ROUTER.startBlock,
-  );
-}
-
-async function readRouterFinalizedBoundary() {
-  const blocks = await routerQuorumRequest("eth_getBlockByNumber", [
-    LAUNCH_STAMP_ROUTER.finalizedTag,
-    false,
-  ]);
-  return routerFinalizedBoundary(
-    blocks,
-    LAUNCH_STAMP_ROUTER.startBlock,
-    LAUNCH_STAMP_ROUTER.maximumFinalizedSpread,
-  );
-}
-
-async function verifyLaunchStampInfrastructure(blockTag) {
-  const [
-    routerCode,
-    chainIdWord,
-    permitAuthorityWord,
-    permitAuthorityRuntimeWord,
-    graphFactoryWord,
-    graphFactoryRuntimeWord,
-    poolManagerWord,
-    poolManagerRuntimeWord,
-  ] = await Promise.all([
-    request("eth_getCode", [LAUNCH_STAMP_ROUTER.address, blockTag]),
-    readContractWord(
-      LAUNCH_STAMP_ROUTER.address,
-      LAUNCH_STAMP_SELECTORS.chainId,
-      blockTag,
-    ),
-    readContractWord(
-      LAUNCH_STAMP_ROUTER.address,
-      LAUNCH_STAMP_SELECTORS.permitAuthority,
-      blockTag,
-    ),
-    readContractWord(
-      LAUNCH_STAMP_ROUTER.address,
-      LAUNCH_STAMP_SELECTORS.permitAuthorityRuntimeCodeHash,
-      blockTag,
-    ),
-    readContractWord(
-      LAUNCH_STAMP_ROUTER.address,
-      LAUNCH_STAMP_SELECTORS.graphFactory,
-      blockTag,
-    ),
-    readContractWord(
-      LAUNCH_STAMP_ROUTER.address,
-      LAUNCH_STAMP_SELECTORS.graphFactoryRuntimeCodeHash,
-      blockTag,
-    ),
-    readContractWord(
-      LAUNCH_STAMP_ROUTER.address,
-      LAUNCH_STAMP_SELECTORS.poolManager,
-      blockTag,
-    ),
-    readContractWord(
-      LAUNCH_STAMP_ROUTER.address,
-      LAUNCH_STAMP_SELECTORS.poolManagerRuntimeCodeHash,
-      blockTag,
-    ),
-  ]);
-  const permitAuthority = decodeAddress(permitAuthorityWord);
-  const graphFactory = decodeAddress(graphFactoryWord);
-  const poolManager = decodeAddress(poolManagerWord);
-  if (
-    keccak256Hex(routerCode).toLowerCase() !==
-      LAUNCH_STAMP_ROUTER.runtimeCodeHash ||
-    decodeUint256(chainIdWord) !== 1n ||
-    permitAuthority.toLowerCase() !==
-      LAUNCH_STAMP_ROUTER.permitAuthority.address.toLowerCase() ||
-    decodeBytes32(permitAuthorityRuntimeWord) !==
-      LAUNCH_STAMP_ROUTER.permitAuthority.runtimeCodeHash ||
-    graphFactory.toLowerCase() !==
-      LAUNCH_STAMP_ROUTER.graphFactory.address.toLowerCase() ||
-    decodeBytes32(graphFactoryRuntimeWord) !==
-      LAUNCH_STAMP_ROUTER.graphFactory.runtimeCodeHash ||
-    poolManager.toLowerCase() !==
-      LAUNCH_STAMP_ROUTER.poolManager.address.toLowerCase() ||
-    decodeBytes32(poolManagerRuntimeWord) !==
-      LAUNCH_STAMP_ROUTER.poolManager.runtimeCodeHash
-  )
-    throw new Error("Launch-Stamp-Router-Bindung stimmt nicht");
-
-  const [permitCode, graphCode, poolManagerCode] = await Promise.all([
-    request("eth_getCode", [permitAuthority, blockTag]),
-    request("eth_getCode", [graphFactory, blockTag]),
-    request("eth_getCode", [poolManager, blockTag]),
-  ]);
-  if (
-    keccak256Hex(permitCode).toLowerCase() !==
-      LAUNCH_STAMP_ROUTER.permitAuthority.runtimeCodeHash ||
-    keccak256Hex(graphCode).toLowerCase() !==
-      LAUNCH_STAMP_ROUTER.graphFactory.runtimeCodeHash ||
-    keccak256Hex(poolManagerCode).toLowerCase() !==
-      LAUNCH_STAMP_ROUTER.poolManager.runtimeCodeHash
-  )
-    throw new Error("Launch-Stamp-Infrastruktur-Runtime stimmt nicht");
-}
-
-function routerProfileBindingMatches(launch, profile) {
-  return profile.bindings.some(
-    ({ launchId, source, runtimeCodeHash }) =>
-      launch.launchId === launchId &&
-      launch.hook.toLowerCase() === source.toLowerCase() &&
-      launch.runtimeCodeHash === runtimeCodeHash,
-  );
-}
-
-async function tryRouterClaimProfile(
-  launch,
-  runtimeCode,
-  profile,
-  blockTag,
-) {
-  if (!routerProfileBindingMatches(launch, profile)) return null;
-  try {
-    const [recipientWord, feeWord, accruedWord] = await Promise.all([
-      readContractWord(launch.hook, profile.recipient, blockTag),
-      readContractWord(launch.hook, profile.feeBps, blockTag),
-      readContractWord(launch.hook, profile.accrued, blockTag),
-    ]);
-    const amount = decodeUint256(accruedWord);
-    if (
-      !isTreasury(decodeAddress(recipientWord)) ||
-      decodeUint256(feeWord) !== profile.expectedFeeBps
-    )
-      return null;
-    if (amount > 0n) {
-      const simulated = await readContractWord(
-        launch.hook,
-        profile.claim,
-        blockTag,
-        TREASURY,
-      );
-      if (decodeUint256(simulated) !== amount)
-        throw new Error("Custom-Claim-Simulation stimmt nicht");
-    }
-    return {
-      ...launch,
-      id: `router-custom:${launch.launchId}`,
-      name: "Custom · Router",
-      detail: shortAddress(launch.token),
-      unit: "ETH",
-      decimals: 18,
-      kind: "custom",
-      origin: "launch-stamp-router",
-      address: launch.hook,
-      claimMode: "manual",
-      claimProfile: profile.id,
-      readData: profile.accrued,
-      claimData: profile.claim,
-      claimBindingVerified: true,
-      recipientMatches: true,
-      amount,
-      status: "ready",
-    };
-  } catch {
-    return null;
-  }
-}
-
-async function readRouterCustomClaim(launch, runtimeCode, blockTag) {
-  for (const profile of [
-    ROUTER_CUSTOM_CLAIM_PROFILES.nativeAccumulatorV1,
-    ROUTER_CUSTOM_CLAIM_PROFILES.protocolFeeSourceV1,
-  ]) {
-    const claim = await tryRouterClaimProfile(
-      launch,
-      runtimeCode,
-      profile,
-      blockTag,
-    );
-    if (claim) return claim;
-  }
-
-  const redeemer = ROUTER_CUSTOM_CLAIM_PROFILES.dualCurrencyRedeemerV1;
-  try {
-    if (!routerProfileBindingMatches(launch, redeemer))
-      throw new Error("Kein freigegebenes Mehrwährungs-Claim-Profil");
-    const [
-      recipientWord,
-      feePipsWord,
-      poolManagerWord,
-      currency0Word,
-      currency1Word,
-      poolIdWord,
-      nativeAmountWord,
-      tokenAmountWord,
-    ] = await Promise.all([
-      readContractWord(launch.hook, redeemer.recipient, blockTag),
-      readContractWord(launch.hook, redeemer.feePips, blockTag),
-      readContractWord(launch.hook, redeemer.poolManager, blockTag),
-      readContractWord(launch.hook, redeemer.currency0, blockTag),
-      readContractWord(launch.hook, redeemer.currency1, blockTag),
-      readContractWord(launch.hook, redeemer.poolId, blockTag),
-      readContractWord(
-        LAUNCH_STAMP_ROUTER.poolManager.address,
-        poolManagerBalanceOfData(
-          redeemer.balanceOf,
-          launch.hook,
-          CUSTOM_V2_POLICY.nativeAsset,
-        ),
-        blockTag,
-      ),
-      readContractWord(
-        LAUNCH_STAMP_ROUTER.poolManager.address,
-        poolManagerBalanceOfData(
-          redeemer.balanceOf,
-          launch.hook,
-          launch.token,
-        ),
-        blockTag,
-      ),
-    ]);
-    if (
-      !isTreasury(decodeAddress(recipientWord)) ||
-      decodeUint256(feePipsWord) !== redeemer.expectedFeePips ||
-      decodeAddress(poolManagerWord).toLowerCase() !==
-        LAUNCH_STAMP_ROUTER.poolManager.address.toLowerCase() ||
-      decodeAddress(currency0Word).toLowerCase() !==
-        CUSTOM_V2_POLICY.nativeAsset.toLowerCase() ||
-      decodeAddress(currency1Word).toLowerCase() !==
-        launch.token.toLowerCase() ||
-      decodeBytes32(poolIdWord) !== launch.poolId
-    )
-      throw new Error("Mehrwährungs-Claim-Bindung stimmt nicht");
-    const amount = decodeUint256(nativeAmountWord);
-    const secondaryAmount = decodeUint256(tokenAmountWord);
-    if (amount > 0n || secondaryAmount > 0n) {
-      const simulated = await request("eth_call", [
-        { from: TREASURY, to: launch.hook, data: redeemer.claim },
-        blockTag,
-      ]);
-      if (simulated !== "0x")
-        throw new Error("Mehrwährungs-Claim-Simulation stimmt nicht");
-    }
-    return {
-      ...launch,
-      id: `router-custom:${launch.launchId}`,
-      name: "Custom · Router",
-      detail: shortAddress(launch.token),
-      unit: "ETH",
-      decimals: 18,
-      secondaryAsset: launch.token,
-      secondaryUnit: redeemer.secondaryUnit,
-      secondaryDecimals: redeemer.secondaryDecimals,
-      kind: "custom",
-      origin: "launch-stamp-router",
-      address: launch.hook,
-      claimMode: "manual",
-      claimProfile: redeemer.id,
-      claimData: redeemer.claim,
-      claimBindingVerified: true,
-      recipientMatches: true,
-      amount,
-      secondaryAmount,
-      status: "ready",
-    };
-  } catch {
-    // Continue to the explicit unsupported disposition below.
-  }
-
-  return {
-    ...launch,
-    id: `router-custom:${launch.launchId}`,
-    name: "Custom · Router",
-    detail: shortAddress(launch.token),
-    unit: "ETH",
-    decimals: 18,
-    kind: "custom",
-    origin: "launch-stamp-router",
-    address: launch.hook,
-    claimMode: "unsupported",
-    claimProfile: null,
-    claimBindingVerified: false,
-    recipientMatches: false,
-    amount: 0n,
-    status: "failed",
-  };
-}
-
-async function readVerifiedRouterLaunch(candidate, finalizedTag) {
-  const [recordValue, tokenLaunchIdWord, poolLaunchIdWord, tokenProofValue] =
-    await Promise.all([
-    request("eth_call", [
-      {
-        to: LAUNCH_STAMP_ROUTER.address,
-        data: launchStampBytes32ReadData(
-          LAUNCH_STAMP_SELECTORS.launchStamp,
-          candidate.launchId,
-        ),
-      },
-      finalizedTag,
-    ]),
-    readContractWord(
-      LAUNCH_STAMP_ROUTER.address,
-      launchStampAddressReadData(
-        LAUNCH_STAMP_SELECTORS.launchIdByToken,
-        candidate.token,
-      ),
-      finalizedTag,
-    ),
-    readContractWord(
-      LAUNCH_STAMP_ROUTER.address,
-      launchStampPoolReadData(
-        LAUNCH_STAMP_SELECTORS.launchIdByPool,
-        candidate.poolManager,
-        candidate.poolId,
-      ),
-      finalizedTag,
-    ),
-    request("eth_call", [
-      {
-        to: LAUNCH_STAMP_ROUTER.address,
-        data: launchStampAddressReadData(
-          LAUNCH_STAMP_SELECTORS.stampProof,
-          candidate.token,
-        ),
-      },
-      finalizedTag,
-    ]),
-  ]);
-  const record = decodeLaunchStampRecord(recordValue);
-  const tokenProof = decodeLaunchStampProof(tokenProofValue);
-  if (
-    decodeBytes32(tokenLaunchIdWord) !== candidate.launchId ||
-    decodeBytes32(poolLaunchIdWord) !== candidate.launchId ||
-    tokenProof.launchId !== candidate.launchId ||
-    tokenProof.stampHash !== candidate.stampHash ||
-    record.token.toLowerCase() !== candidate.token.toLowerCase() ||
-    record.hook.toLowerCase() !== candidate.hook.toLowerCase() ||
-    record.poolManager.toLowerCase() !== candidate.poolManager.toLowerCase() ||
-    record.poolId !== candidate.poolId ||
-    record.stampHash !== candidate.stampHash
-  )
-    throw new Error("Launch-Stamp-Record stimmt nicht mit dem Event überein");
-
-  const routeCode = await request("eth_getCode", [
-    record.routeLauncher,
-    finalizedTag,
-  ]);
-  if (
-    keccak256Hex(routeCode).toLowerCase() !==
-    record.routeLauncherRuntimeCodeHash
-  )
-    throw new Error("Launch-Route-Runtime ist gedriftet");
-
-  const verified = {
-    ...candidate,
-    ...record,
-    launchKind: record.kind,
-    provenanceVerified: true,
-    runtimeVerified: true,
-  };
-  if (record.kind === 2) {
-    const knownHook = HOOKS.find(
-      ({ address }) => address.toLowerCase() === record.hook.toLowerCase(),
-    );
-    return {
-      ...verified,
-      claimMode: knownHook ? "covered-by-known-hook" : "unsupported",
-      claimProfile: knownHook?.id ?? null,
-      claimBindingVerified: Boolean(knownHook),
-      amount: 0n,
-    };
-  }
-
-  const [hookLaunchIdWord, hookProofValue, recordedRuntimeWord, hookCode] =
-    await Promise.all([
-      readContractWord(
-        LAUNCH_STAMP_ROUTER.address,
-        launchStampAddressReadData(
-          LAUNCH_STAMP_SELECTORS.launchIdByComponent,
-          record.hook,
-        ),
-        finalizedTag,
-      ),
-      request("eth_call", [
-        {
-          to: LAUNCH_STAMP_ROUTER.address,
-          data: launchStampAddressReadData(
-            LAUNCH_STAMP_SELECTORS.stampProof,
-            record.hook,
-          ),
-        },
-        finalizedTag,
-      ]),
-      readContractWord(
-        LAUNCH_STAMP_ROUTER.address,
-        launchStampAddressReadData(
-          LAUNCH_STAMP_SELECTORS.componentRuntimeCodeHash,
-          record.hook,
-        ),
-        finalizedTag,
-      ),
-      request("eth_getCode", [record.hook, finalizedTag]),
-    ]);
-  const hookProof = decodeLaunchStampProof(hookProofValue);
-  const recordedRuntime = decodeBytes32(recordedRuntimeWord);
-  if (
-    decodeBytes32(hookLaunchIdWord) !== candidate.launchId ||
-    hookProof.launchId !== candidate.launchId ||
-    hookProof.stampHash !== candidate.stampHash ||
-    /^0x0{64}$/i.test(recordedRuntime) ||
-    keccak256Hex(hookCode).toLowerCase() !== recordedRuntime
-  )
-    throw new Error("Custom-Hook-Stamp oder Runtime stimmt nicht");
-
-  return readRouterCustomClaim(
-    { ...verified, runtimeCodeHash: recordedRuntime },
-    hookCode,
-    finalizedTag,
-  );
-}
-
-async function readLaunchStampRouter() {
-  for (const key of state.claims.keys()) {
-    if (key.startsWith("router-custom:")) state.claims.delete(key);
-  }
-  state.router = {
-    status: "loading",
-    verified: false,
-    finalizedBlock: null,
-    launches: [],
-    error: null,
-  };
-  renderSummary();
-  try {
-    const finalizedBlock = await readRouterFinalizedBoundary();
-    const finalizedTag = toQuantityHex(finalizedBlock);
-    const openingBlock = await readRouterQuorumBlock(finalizedTag);
-    await verifyLaunchStampInfrastructure(finalizedTag);
-    const candidates = reduceLaunchStampLogs(
-      await readLaunchStampLogs(finalizedBlock),
-    );
-    const launches = await mapWithConcurrency(candidates, 8, (candidate) =>
-      readVerifiedRouterLaunch(candidate, finalizedTag),
-    );
-    const closingBlock = await readRouterQuorumBlock(finalizedTag);
-    if (
-      closingBlock.number !== openingBlock.number ||
-      closingBlock.hash !== openingBlock.hash
-    )
-      throw new Error("Finalisierter Router-Block hat sich während des Scans geändert");
-    for (const launch of launches) {
-      if (launch.launchKind !== 1 || launch.claimMode !== "manual") continue;
-      state.claims.set(launch.id, {
-        amount: launch.amount,
-        secondaryAmount: launch.secondaryAmount,
-        recipientMatches: launch.recipientMatches,
-        status: launch.status,
-      });
-    }
-    state.router = {
-      status: "ready",
-      verified: true,
-      finalizedBlock,
-      launches,
-      error: null,
-    };
-  } catch (error) {
-    state.router = {
-      status: "failed",
-      verified: false,
-      finalizedBlock: null,
-      launches: [],
-      error:
-        error instanceof Error
-          ? error.message
-          : "Launch-Stamp-Router konnte nicht gelesen werden",
     };
   }
 }
@@ -1552,18 +810,16 @@ async function readCustomRegistry(blockTag) {
     if (key.startsWith("custom-v1-standard:")) state.claims.delete(key);
   }
   state.custom = {
-    status: "retired",
-    registryVerified: true,
+    status: "failed",
+    registryVerified: false,
     launches: [],
-    error: null,
+    error: "Custom Registry V1 ist außer Betrieb",
   };
   renderSummary();
 }
 
-async function readContractWord(address, data, blockTag, from = null) {
-  const call = { to: address, data };
-  if (from) call.from = from;
-  const value = await request("eth_call", [call, blockTag]);
+async function readContractWord(address, data, blockTag) {
+  const value = await request("eth_call", [{ to: address, data }, blockTag]);
   if (typeof value !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(value))
     throw new Error(`Ungültige Contract-Antwort von ${shortAddress(address)}`);
   return value;
@@ -1819,9 +1075,6 @@ async function readCustomV2Source(release, indexed, blockTag) {
 }
 
 async function readCustomV2(blockTag) {
-  for (const key of state.claims.keys()) {
-    if (key.startsWith("custom-v2:")) state.claims.delete(key);
-  }
   state.customV2 = {
     status: "loading",
     release: null,
@@ -1964,7 +1217,7 @@ async function readCapabilities() {
   }
 }
 
-async function refreshClaimsOnce() {
+async function refreshClaims() {
   if (!state.account || state.chainId !== MAINNET_CHAIN_ID) return;
   setError();
   setStatus("Contract-Bindungen und Guthaben werden geprüft");
@@ -1975,7 +1228,6 @@ async function refreshClaimsOnce() {
     readCustomRegistry(blockTag),
     readCustomV2(blockTag),
     readClassicLaunches(blockTag),
-    readLaunchStampRouter(),
   ]);
 
   const hookResults = await Promise.allSettled(
@@ -2027,22 +1279,16 @@ async function refreshClaimsOnce() {
     errors.push(
       "Die Classic-Launchliste konnte nicht vollständig gelesen werden. Der verifizierte gemeinsame Hook-Claim bleibt verfügbar.",
     );
-  if (state.router.error)
-    errors.push(
-      "Der offizielle Launch-Stamp-Router konnte nicht vollständig verifiziert werden. Alle Claims bleiben gesperrt.",
-    );
   setError(errors.join(" "));
   setStatus(
-    state.custom.error || state.customV2.error || state.router.error
-      ? "Ecosystem-Scan konnte nicht vollständig gelesen werden"
+    state.custom.error || state.customV2.error
+      ? "Custom Registry konnte nicht vollständig gelesen werden"
       : failedClaims === 0
-        ? `Stand Block ${BigInt(blockTag).toString()} · ${state.classic.launches.length + state.router.launches.filter(({ launchKind }) => launchKind === 2).length} Classic · ${state.custom.launches.length + state.customV2.sources.length + state.router.launches.filter(({ launchKind }) => launchKind === 1).length} Custom`
+        ? `Stand Block ${BigInt(blockTag).toString()} · ${state.classic.launches.length} Classic · ${state.custom.launches.length + state.customV2.sources.length} Custom`
         : `${failedClaims} Guthaben konnten nicht gelesen werden`,
   );
   renderSummary();
 }
-
-const refreshClaims = createRefreshQueue(refreshClaimsOnce);
 
 async function syncWallet({ requestAccounts = false } = {}) {
   const method = requestAccounts ? "eth_requestAccounts" : "eth_accounts";
@@ -2054,7 +1300,7 @@ async function syncWallet({ requestAccounts = false } = {}) {
     Array.isArray(accounts) && accounts.length > 0 ? accounts[0] : null;
   state.chainId = chainId;
   renderSummary();
-  await refreshClaims();
+  if (state.account && chainId === MAINNET_CHAIN_ID) await refreshClaims();
 }
 
 async function switchToMainnet() {
@@ -2087,40 +1333,8 @@ async function waitForBatch(id) {
   );
 }
 
-async function preflightClaimBatch(claims) {
-  if (claims.length > MAX_BATCH_CALLS)
-    throw new Error(
-      `Mehr als ${MAX_BATCH_CALLS} offene Claims passen nicht sicher in einen atomaren Batch`,
-    );
-  const batch = buildWalletSendCalls(state.account, claims);
-  await Promise.all(
-    batch.calls.map(({ to, data, value }) =>
-      request("eth_call", [
-        { from: state.account, to, data, value },
-        "latest",
-      ]),
-    ),
-  );
-  return batch;
-}
-
 async function claimAll() {
-  const expectedAccount = state.account?.toLowerCase();
-  if (
-    state.chainId !== MAINNET_CHAIN_ID ||
-    !expectedAccount ||
-    !isTreasury(expectedAccount)
-  )
-    throw new Error("Treasury-Wallet auf Ethereum Mainnet erforderlich");
   await refreshClaims();
-  if (
-    state.chainId !== MAINNET_CHAIN_ID ||
-    state.account?.toLowerCase() !== expectedAccount ||
-    !isTreasury(state.account)
-  )
-    throw new Error(
-      "Wallet oder Netzwerk hat sich während des Scans geändert. Bitte erneut scannen.",
-    );
   const safetyError = claimSafetyError();
   if (safetyError) throw new Error(`${safetyError}. Claims bleiben gesperrt.`);
   const claims = claimableClaims();
@@ -2132,14 +1346,10 @@ async function claimAll() {
 
   try {
     setStatus(
-      `${claims.length} Claims werden direkt vor MetaMask erneut simuliert`,
-    );
-    const batch = await preflightClaimBatch(claims);
-    setStatus(
       `${claims.length} Claims werden in einer MetaMask-Bestätigung vorbereitet`,
     );
     const result = await request("wallet_sendCalls", [
-      batch,
+      buildWalletSendCalls(state.account, claims),
     ]);
     await waitForBatch(normalizeBatchId(result));
     setStatus("Alle verfügbaren Fees wurden geclaimt");
@@ -2164,12 +1374,6 @@ async function claimAll() {
 async function handlePrimaryAction() {
   try {
     setError();
-    if (DEMO_MODE) {
-      setStatus(
-        "QA-Vorschau: In der echten Ansicht öffnet dieser Button genau eine MetaMask-Bestätigung",
-      );
-      return;
-    }
     state.busy = true;
     renderSummary();
     if (!state.account) await syncWallet({ requestAccounts: true });
@@ -2193,10 +1397,6 @@ async function handlePrimaryAction() {
 
 elements.action.addEventListener("click", handlePrimaryAction);
 elements.refresh.addEventListener("click", async () => {
-  if (DEMO_MODE) {
-    setStatus("QA-Vorschau wurde neu geladen · keine Wallet-Aktion");
-    return;
-  }
   state.busy = true;
   renderSummary();
   try {
@@ -2218,132 +1418,8 @@ window.ethereum?.on?.("chainChanged", () =>
   syncWallet().catch(() => undefined),
 );
 
-function seedDemoState() {
-  state.account = TREASURY;
-  state.chainId = MAINNET_CHAIN_ID;
-  state.blockTag = "0x189f510";
-  state.capability = "ready";
-  for (const hook of HOOKS) {
-    state.hooks.set(hook.id, {
-      actualCodeHash: hook.runtimeCodeHash,
-      recipient: TREASURY,
-      verified: true,
-    });
-  }
-  const demoAmounts = new Map([
-    ["classic-v3", 3_831_314_566_506_772n],
-    ["classic-v2", 227_307_871_565_013_620n],
-    ["classic-v1", 46_446_511_178_969n],
-    ["stock-current-nvdaon", 84_200_000_000_000_000n],
-  ]);
-  for (const claim of CLAIMS) {
-    state.claims.set(claim.id, {
-      amount: demoAmounts.get(claim.id) ?? 0n,
-      recipient: TREASURY,
-      recipientMatches: true,
-      status: "ready",
-    });
-  }
-  state.custom = {
-    status: "retired",
-    registryVerified: true,
-    launches: [],
-    error: null,
-  };
-  state.customV2 = {
-    status: "hold",
-    release: null,
-    sources: [],
-    error: null,
-  };
-  state.classic = {
-    status: "ready",
-    launchersVerified: true,
-    launches: [],
-    error: null,
-  };
-  const fadeProfile = ROUTER_CUSTOM_CLAIM_PROFILES.nativeAccumulatorV1;
-  const fadeBinding = fadeProfile.bindings[0];
-  const fadeClaim = {
-    id: `router-custom:${fadeBinding.launchId}`,
-    launchId: fadeBinding.launchId,
-    token: "0x69d278968abf120f878f2e1e016ab615d3686c19",
-    hook: fadeBinding.source,
-    runtimeCodeHash: fadeBinding.runtimeCodeHash,
-    launchKind: 1,
-    kind: "custom",
-    origin: "launch-stamp-router",
-    address: fadeBinding.source,
-    unit: "ETH",
-    decimals: 18,
-    provenanceVerified: true,
-    runtimeVerified: true,
-    claimMode: "manual",
-    claimProfile: fadeProfile.id,
-    readData: fadeProfile.accrued,
-    claimData: fadeProfile.claim,
-    claimBindingVerified: true,
-    recipientMatches: true,
-    amount: 28_054_452_170_132_560n,
-    status: "ready",
-  };
-  const pcanProfile = ROUTER_CUSTOM_CLAIM_PROFILES.dualCurrencyRedeemerV1;
-  const pcanBinding = pcanProfile.bindings[0];
-  const pcanClaim = {
-    id: `router-custom:${pcanBinding.launchId}`,
-    launchId: pcanBinding.launchId,
-    token: "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce",
-    hook: pcanBinding.source,
-    runtimeCodeHash: pcanBinding.runtimeCodeHash,
-    launchKind: 1,
-    kind: "custom",
-    origin: "launch-stamp-router",
-    address: pcanBinding.source,
-    unit: "ETH",
-    decimals: 18,
-    provenanceVerified: true,
-    runtimeVerified: true,
-    claimMode: "manual",
-    claimProfile: pcanProfile.id,
-    claimData: pcanProfile.claim,
-    claimBindingVerified: true,
-    recipientMatches: true,
-    amount: 500_802_908_283_517n,
-    secondaryAsset: "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce",
-    secondaryAmount: 2_740_004_896_936_423_458_238n,
-    secondaryUnit: pcanProfile.secondaryUnit,
-    secondaryDecimals: pcanProfile.secondaryDecimals,
-    status: "ready",
-  };
-  state.router = {
-    status: "ready",
-    verified: true,
-    finalizedBlock: 25_827_076n,
-    launches: [fadeClaim, pcanClaim],
-    error: null,
-  };
-  state.claims.set(fadeClaim.id, {
-    amount: fadeClaim.amount,
-    recipientMatches: true,
-    status: "ready",
-  });
-  state.claims.set(pcanClaim.id, {
-    amount: pcanClaim.amount,
-    secondaryAmount: pcanClaim.secondaryAmount,
-    recipientMatches: true,
-    status: "ready",
-  });
+renderSummary();
+syncWallet().catch(() => {
+  setStatus("MetaMask verbinden, um offene Fees zu lesen");
   renderSummary();
-  elements.status.textContent =
-    "Sichere QA-Vorschau · Werte sind Testdaten · keine Wallet-Aktion";
-}
-
-if (DEMO_MODE) {
-  seedDemoState();
-} else {
-  renderSummary();
-  syncWallet().catch(() => {
-    setStatus("MetaMask verbinden, um offene Fees zu lesen");
-    renderSummary();
-  });
-}
+});

--- a/ops/protocol-fee-claim/claim-discovery.json
+++ b/ops/protocol-fee-claim/claim-discovery.json
@@ -1,92 +1,11 @@
 {
-  "schemaVersion": "programmable.fee-claim-discovery.v2",
+  "schemaVersion": "programmable.fee-claim-discovery.v1",
   "chainId": "1",
   "rewardWallet": "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c",
   "execution": {
     "method": "wallet_sendCalls",
     "atomicRequired": true,
-    "preflightEveryCallImmediatelyBeforeWallet": true,
-    "maximumCallsPerAtomicBatch": 64,
     "unsupportedWalletBehavior": "fail_closed"
-  },
-  "launchStampRouter": {
-    "discoveryMode": "complete_consensus_finalized_event_replay_plus_onchain_stamp_verification",
-    "address": "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
-    "startBlock": "25717612",
-    "finality": {
-      "blockTag": "finalized",
-      "maximumProviderSpreadBlocks": "32",
-      "policy": "bounded_three_provider_finalized_views_then_exact_common_block_hash_or_block"
-    },
-    "runtimeCodeHash": "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
-    "eventTopic": "0x6cf479a102f1eebc9244f48f8d68f6aa52b4c5a4516318df58ba46614a5b14f2",
-    "futureRouterLaunchesAutoDiscovered": true,
-    "maximumScannedLaunches": 4096,
-    "logQuorum": {
-      "policy": "wallet_plus_two_independent_rpc_exact_raw_match_or_block",
-      "publicRpcEndpoints": [
-        "https://eth.drpc.org",
-        "https://rpc.mevblocker.io"
-      ],
-      "canonicalTuple": [
-        "address",
-        "blockHash",
-        "blockNumber",
-        "transactionHash",
-        "transactionIndex",
-        "logIndex",
-        "topics",
-        "data"
-      ]
-    },
-    "verification": [
-      "router_and_trust_root_runtime_hashes",
-      "exact_consensus_finalized_checkpoint_quorum",
-      "independent_rpc_log_quorum",
-      "router_claim_bindings_and_displayed_balances_at_finalized_checkpoint",
-      "launch_id_by_token",
-      "launch_id_by_pool_manager_and_pool_id",
-      "launch_stamp_record_and_component_proofs",
-      "route_and_hook_runtime_hashes_at_finalized_checkpoint"
-    ],
-    "trustRoots": {
-      "permitAuthority": {
-        "address": "0x755509eA6e3F5Ec1aA2E797bb68f1B87DD8b886b",
-        "runtimeCodeHash": "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c"
-      },
-      "graphFactory": {
-        "address": "0xB012e4A8F2c5FC4E8E4faCA9D5Ad6FfF13FBA887",
-        "runtimeCodeHash": "0xd23692fae59331592048e71a96d4963e170ee56e449683dc9f7fa3f9470018b8"
-      },
-      "poolManager": {
-        "address": "0x000000000004444c5dc75cB358380D2e3dE08A90",
-        "runtimeCodeHash": "0x785f1014552b7ce7d5fb7d0c970ca60edee94fd00425d7ca21609acac7ce1293"
-      }
-    },
-    "claimProfiles": [
-      {
-        "id": "native-accumulator-v1",
-        "launchId": "0x6d6ed0e1e69a7cd6afa177e3454c9e32eed61cbd3f855ee56aff1915a6776fc2",
-        "source": "0xd7451a039373f54e493deE42A751fEcBfAFBa0cc",
-        "runtimeCodeHash": "0xff70a4d3d889b730a064b270fc187f0cba40582f1fa6f5875893066b17a1257b",
-        "accruedSelector": "0x0986bdb6",
-        "claimSelector": "0xa95e4f21"
-      },
-      {
-        "id": "dual-currency-redeemer-v1",
-        "launchId": "0x5a52180427785716bff0a36218dde89f0459db265d0c2bdfcfde81a8fe733c92",
-        "source": "0xEBa46F25dff528141DE5317109aCB5a989296044",
-        "runtimeCodeHash": "0xd59d31add7a3b206972725889dbb726782c0fbd82514710cf2d645749dc3fa25",
-        "claimSelector": "0xfc656ac5",
-        "claimCalldata": "0xfc656ac500000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
-        "balanceSelector": "0x00fdd58e",
-        "currencies": [
-          "0x0000000000000000000000000000000000000000",
-          "0x9DEeB39D2590b0cAD5fc473F755C5F97Dcc8f7cE"
-        ]
-      }
-    ],
-    "unknownClaimProfile": "visible_and_block_all_claims"
   },
   "classic": {
     "claimMode": "one_aggregate_claim_per_hook_version",
@@ -126,6 +45,6 @@
   "customV2": {
     "status": "HOLD",
     "futureFinalizedStandardSourcesAutoAdded": false,
-    "reason": "The proposed universal revenue registry is not deployed. Official future launches are discovered through the Launch Stamp Router and require an exact approved claim profile."
+    "reason": "No exact Mainnet deployment and finalized release binding exists yet."
   }
 }

--- a/ops/protocol-fee-claim/index.html
+++ b/ops/protocol-fee-claim/index.html
@@ -31,9 +31,8 @@
             <h1 id="claim-title">Alle Fees<br />claimen</h1>
           </div>
           <p class="intro">
-            Ein Scan. Ein atomarer Wallet-Batch. Classic V1–V3, bestehende
-            Stock-Assets und alle finalisierten Launch-Router-Einträge mit
-            geprüftem Claim-Profil.
+            Neue Classic- und Custom-Launches erscheinen bei jedem Scan
+            automatisch. Stock bleibt auf den bestehenden Assets.
           </p>
         </div>
 
@@ -76,15 +75,11 @@
           <span class="trust-mark" aria-hidden="true"></span>
           <p>
             Lokal und ohne Private Key. Vor jedem Claim werden Contract-Code,
-            Treasury-Empfänger und Guthaben erneut geprüft.
+            Treasury-Empfänger und Guthaben am selben Ethereum-Block geprüft.
             Classic-Launches laufen gesammelt über ihren gemeinsamen Hook.
-            Neue offizielle Classic- und Custom-Launches werden aus dem Launch
-            Stamp Router erkannt; finalisierter Checkpoint und rohe Router-Logs
-            müssen bei der Wallet und zwei unabhängigen Ethereum-RPCs exakt
-            übereinstimmen. Nur exakt
-            freigegebene, runtime-gebundene Claim-Profile kommen in denselben
-            Wallet-Batch; unbekannte Profile bleiben sichtbar und sperren den
-            Gesamtclaim. Ohne atomaren MetaMask-Batch wird nichts gesendet.
+            Standardisierte Custom-Quellen werden aus der Registry erkannt und
+            im selben Wallet-Batch geclaimt. Unbekannte Quellen bleiben
+            gesperrt. Ohne atomaren MetaMask-Batch wird nichts gesendet.
           </p>
         </footer>
       </section>

--- a/ops/protocol-fee-claim/logic.mjs
+++ b/ops/protocol-fee-claim/logic.mjs
@@ -51,113 +51,6 @@ export const CUSTOM_V2_POLICY = Object.freeze({
 
 export const CUSTOM_V2_RELEASE_PATH = "./custom-v2-release.json";
 
-export const LAUNCH_STAMP_ROUTER = Object.freeze({
-  address: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
-  startBlock: 25_717_612n,
-  endBlock: null,
-  finalizedTag: "finalized",
-  maximumFinalizedSpread: 32n,
-  runtimeCodeHash:
-    "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
-  sourceCommit: "0a7134bbb912222639627fb9078df2f8dd3a6c38",
-  sourceTree: "24ffb0c6b04af7993254560b4f03608de8f52231",
-  abiSha256:
-    "sha256:bb4e728e9f9c850eb01f928e8a798ac206a82e241a8d93b3b3c686635c88ed86",
-  permitAuthority: Object.freeze({
-    address: "0x755509eA6e3F5Ec1aA2E797bb68f1B87DD8b886b",
-    runtimeCodeHash:
-      "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c",
-  }),
-  graphFactory: Object.freeze({
-    address: "0xB012e4A8F2c5FC4E8E4faCA9D5Ad6FfF13FBA887",
-    runtimeCodeHash:
-      "0xd23692fae59331592048e71a96d4963e170ee56e449683dc9f7fa3f9470018b8",
-  }),
-  poolManager: Object.freeze({
-    address: "0x000000000004444c5dc75cB358380D2e3dE08A90",
-    runtimeCodeHash:
-      "0x785f1014552b7ce7d5fb7d0c970ca60edee94fd00425d7ca21609acac7ce1293",
-  }),
-});
-
-export const LAUNCH_STAMP_TOPICS = Object.freeze({
-  launchStamped:
-    "0x6cf479a102f1eebc9244f48f8d68f6aa52b4c5a4516318df58ba46614a5b14f2",
-  launchRouteStamped:
-    "0x45e7cc355b63ca67d6278a0d8d23470ce2a0741a9c60283d7dee712df7a877a5",
-  componentStamped:
-    "0x8147265e7396d6400cee8d049456a1f7438fdfbe2a7c81c976d51ba67e52ff4b",
-});
-
-export const LAUNCH_STAMP_SELECTORS = Object.freeze({
-  chainId: "0x85e1f4d0",
-  permitAuthority: "0xc3a3d03c",
-  permitAuthorityRuntimeCodeHash: "0xa497c61c",
-  graphFactory: "0x1cc9e5ce",
-  graphFactoryRuntimeCodeHash: "0x92989a00",
-  poolManager: "0x62308e85",
-  poolManagerRuntimeCodeHash: "0x38d831c4",
-  launchIdByToken: "0x1dad847c",
-  launchIdByPool: "0x361df6f3",
-  launchIdByComponent: "0x58c5e373",
-  componentRuntimeCodeHash: "0xc892d353",
-  launchStamp: "0x4c9e4764",
-  stampProof: "0x174b9f9d",
-});
-
-export const ROUTER_CUSTOM_CLAIM_PROFILES = Object.freeze({
-  nativeAccumulatorV1: Object.freeze({
-    id: "native-accumulator-v1",
-    bindings: Object.freeze([
-      Object.freeze({
-        launchId:
-          "0x6d6ed0e1e69a7cd6afa177e3454c9e32eed61cbd3f855ee56aff1915a6776fc2",
-        source: "0xd7451a039373f54e493deE42A751fEcBfAFBa0cc",
-        runtimeCodeHash:
-          "0xff70a4d3d889b730a064b270fc187f0cba40582f1fa6f5875893066b17a1257b",
-      }),
-    ]),
-    recipient: "0x4968150a",
-    feeBps: "0xb6c7448d",
-    accrued: "0x0986bdb6",
-    claim: "0xa95e4f21",
-    expectedFeeBps: 10n,
-  }),
-  protocolFeeSourceV1: Object.freeze({
-    id: "protocol-fee-source-v1",
-    bindings: Object.freeze([]),
-    recipient: CUSTOM_V2_SELECTORS.programmableFeeRecipient,
-    feeBps: `${CUSTOM_V2_SELECTORS.programmableFeeBps}${"0".repeat(64)}`,
-    accrued: `${CUSTOM_V2_SELECTORS.accruedProgrammableFees}${"0".repeat(64)}`,
-    claim: `${CUSTOM_V2_SELECTORS.claimProgrammableFees}${"0".repeat(64)}`,
-    expectedFeeBps: 10n,
-  }),
-  dualCurrencyRedeemerV1: Object.freeze({
-    id: "dual-currency-redeemer-v1",
-    bindings: Object.freeze([
-      Object.freeze({
-        launchId:
-          "0x5a52180427785716bff0a36218dde89f0459db265d0c2bdfcfde81a8fe733c92",
-        source: "0xEBa46F25dff528141DE5317109aCB5a989296044",
-        runtimeCodeHash:
-          "0xd59d31add7a3b206972725889dbb726782c0fbd82514710cf2d645749dc3fa25",
-      }),
-    ]),
-    recipient: "0x46904840",
-    feePips: "0x9fa59765",
-    poolManager: "0xdc4c90d3",
-    currency0: "0x79f1232b",
-    currency1: "0x10d737b8",
-    poolId: "0x3e0dc34e",
-    balanceOf: "0x00fdd58e",
-    claim:
-      "0xfc656ac500000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
-    expectedFeePips: 1_000n,
-    secondaryUnit: "PCAN",
-    secondaryDecimals: 18,
-  }),
-});
-
 export const CUSTOM_REGISTRY = Object.freeze({
   status: "retired",
   address: "0x0000000000000000000000000000000000000000",
@@ -435,25 +328,6 @@ export function normalizeAddress(value) {
   return typeof value === "string" ? value.toLowerCase() : "";
 }
 
-export async function withTimeout(promise, timeoutMs, message) {
-  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0)
-    throw new Error("Ungültiges RPC-Zeitlimit");
-  let timeout;
-  try {
-    return await Promise.race([
-      Promise.resolve(promise),
-      new Promise((_, reject) => {
-        timeout = setTimeout(
-          () => reject(new Error(message || "RPC-Zeitlimit überschritten")),
-          timeoutMs,
-        );
-      }),
-    ]);
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
 export function isTreasury(value) {
   return normalizeAddress(value) === normalizeAddress(TREASURY);
 }
@@ -590,197 +464,8 @@ export function reduceClassicLaunchLogs(entries) {
   });
 }
 
-export function decodeLaunchStampLog(log) {
-  if (
-    !log ||
-    log.removed === true ||
-    normalizeAddress(log.address) !== normalizeAddress(LAUNCH_STAMP_ROUTER.address) ||
-    !Array.isArray(log.topics) ||
-    log.topics.length !== 4 ||
-    log.topics[0]?.toLowerCase() !== LAUNCH_STAMP_TOPICS.launchStamped ||
-    typeof log.data !== "string" ||
-    !/^0x[0-9a-fA-F]{192}$/.test(log.data)
-  )
-    throw new Error("Launch-Stamp-Event ist nicht kanonisch");
-
-  const launchId = decodeBytes32(log.topics[1]);
-  const token = topicAddress(log.topics[2]);
-  const hook = topicAddress(log.topics[3]);
-  requireAbiWords(log.data, 3, "Launch-Stamp-Event");
-  const poolManager = wordAddress(abiWord(log.data, 0));
-  const poolId = decodeBytes32(abiWord(log.data, 1));
-  const stampHash = decodeBytes32(abiWord(log.data, 2));
-  if (
-    normalizeAddress(token) === normalizeAddress("0x0000000000000000000000000000000000000000") ||
-    normalizeAddress(poolManager) !== normalizeAddress(LAUNCH_STAMP_ROUTER.poolManager.address) ||
-    /^0x0{64}$/i.test(launchId) ||
-    /^0x0{64}$/i.test(poolId) ||
-    /^0x0{64}$/i.test(stampHash) ||
-    !/^0x[0-9a-fA-F]{64}$/.test(log.blockHash ?? "") ||
-    !/^0x[0-9a-fA-F]{64}$/.test(log.transactionHash ?? "")
-  )
-    throw new Error("Launch-Stamp-Identität ist unvollständig");
-
-  return Object.freeze({
-    launchId,
-    token,
-    hook,
-    poolManager,
-    poolId,
-    stampHash,
-    blockHash: log.blockHash.toLowerCase(),
-    blockNumber: BigInt(log.blockNumber),
-    transactionIndex: BigInt(log.transactionIndex),
-    logIndex: BigInt(log.logIndex),
-    transactionHash: log.transactionHash.toLowerCase(),
-  });
-}
-
-export function reduceLaunchStampLogs(logs) {
-  if (!Array.isArray(logs)) throw new Error("Launch-Stamp-Events fehlen");
-  const launches = new Map();
-  for (const log of logs) {
-    const launch = decodeLaunchStampLog(log);
-    if (launches.has(launch.launchId))
-      throw new Error("Doppelter Launch-Stamp");
-    launches.set(launch.launchId, launch);
-  }
-  return [...launches.values()].sort((left, right) => {
-    if (left.blockNumber !== right.blockNumber)
-      return left.blockNumber > right.blockNumber ? -1 : 1;
-    if (left.logIndex !== right.logIndex)
-      return left.logIndex > right.logIndex ? -1 : 1;
-    return left.launchId.localeCompare(right.launchId);
-  });
-}
-
-export function launchStampLogSetFingerprint(logs) {
-  if (!Array.isArray(logs)) throw new Error("Launch-Stamp-Events fehlen");
-  const tuples = logs.map((log) => {
-    const decoded = decodeLaunchStampLog(log);
-    return {
-      address: log.address.toLowerCase(),
-      blockHash: decoded.blockHash,
-      blockNumber: decoded.blockNumber.toString(),
-      transactionHash: decoded.transactionHash,
-      transactionIndex: decoded.transactionIndex.toString(),
-      logIndex: decoded.logIndex.toString(),
-      topics: log.topics.map((topic) => topic.toLowerCase()),
-      data: log.data.toLowerCase(),
-    };
-  });
-  tuples.sort((left, right) =>
-    JSON.stringify(left).localeCompare(JSON.stringify(right)),
-  );
-  return JSON.stringify(tuples);
-}
-
-function parseRouterCheckpoints(blocks) {
-  if (!Array.isArray(blocks) || blocks.length !== 3)
-    throw new Error("Finalisierter Router-Block fehlt im RPC-Quorum");
-  return blocks.map((block) => {
-    if (
-      !block ||
-      typeof block.number !== "string" ||
-      !/^0x(?:0|[1-9a-fA-F][0-9a-fA-F]*)$/.test(block.number) ||
-      typeof block.hash !== "string" ||
-      !/^0x[0-9a-fA-F]{64}$/.test(block.hash)
-    )
-      throw new Error("Finalisierter Router-Block fehlt im RPC-Quorum");
-    return Object.freeze({
-      number: BigInt(block.number),
-      hash: block.hash.toLowerCase(),
-    });
-  });
-}
-
-export function routerFinalizedBoundary(
-  blocks,
-  minimumBlock = 0n,
-  maximumSpread = 32n,
-) {
-  const checkpoints = parseRouterCheckpoints(blocks);
-  const numbers = checkpoints.map(({ number }) => number);
-  const first = numbers.reduce((minimum, number) =>
-    number < minimum ? number : minimum,
-  );
-  const last = numbers.reduce((maximum, number) =>
-    number > maximum ? number : maximum,
-  );
-  if (maximumSpread < 0n || last - first > maximumSpread)
-    throw new Error(
-      "Finalisierte Router-Stände liegen im RPC-Quorum zu weit auseinander",
-    );
-  if (first < BigInt(minimumBlock))
-    throw new Error("Launch-Stamp-Router hat noch keinen finalisierten Bereich");
-  return first;
-}
-
-export function exactRouterFinalizedCheckpoint(blocks, minimumBlock = 0n) {
-  const checkpoints = parseRouterCheckpoints(blocks);
-  if (
-    new Set(
-      checkpoints.map(({ number, hash }) => `${number.toString()}:${hash}`),
-    ).size !== 1
-  )
-    throw new Error(
-      "Finalisierter Router-Block stimmt im RPC-Quorum nicht überein",
-    );
-  if (checkpoints[0].number < BigInt(minimumBlock))
-    throw new Error("Launch-Stamp-Router hat noch keinen finalisierten Bereich");
-  return checkpoints[0];
-}
-
-export function decodeLaunchStampRecord(value) {
-  requireAbiWords(value, 14, "Launch-Stamp-Record");
-  const kind = Number(decodeUint256(abiWord(value, 0)));
-  if (kind !== 1 && kind !== 2)
-    throw new Error("Launch-Stamp-Art wird nicht unterstützt");
-  const record = {
-    kind,
-    launchWallet: wordAddress(abiWord(value, 1)),
-    token: wordAddress(abiWord(value, 2)),
-    hook: wordAddress(abiWord(value, 3)),
-    poolManager: wordAddress(abiWord(value, 4)),
-    poolId: decodeBytes32(abiWord(value, 5)),
-    poolKeyHash: decodeBytes32(abiWord(value, 6)),
-    componentSetHash: decodeBytes32(abiWord(value, 7)),
-    routePayloadHash: decodeBytes32(abiWord(value, 8)),
-    routeLauncher: wordAddress(abiWord(value, 9)),
-    routeLauncherRuntimeCodeHash: decodeBytes32(abiWord(value, 10)),
-    expectedResultHash: decodeBytes32(abiWord(value, 11)),
-    permitDigest: decodeBytes32(abiWord(value, 12)),
-    stampHash: decodeBytes32(abiWord(value, 13)),
-  };
-  for (const key of [
-    "poolId",
-    "poolKeyHash",
-    "componentSetHash",
-    "routePayloadHash",
-    "routeLauncherRuntimeCodeHash",
-    "expectedResultHash",
-    "permitDigest",
-    "stampHash",
-  ]) {
-    if (/^0x0{64}$/i.test(record[key]))
-      throw new Error(`Launch-Stamp ${key} ist null`);
-  }
-  return Object.freeze(record);
-}
-
-export function decodeLaunchStampProof(value) {
-  requireAbiWords(value, 2, "Launch-Stamp-Proof");
-  return Object.freeze({
-    launchId: decodeBytes32(abiWord(value, 0)),
-    stampHash: decodeBytes32(abiWord(value, 1)),
-  });
-}
-
 function topicAddress(topic) {
-  if (
-    typeof topic !== "string" ||
-    !/^0x0{24}[0-9a-fA-F]{40}$/.test(topic)
-  )
+  if (typeof topic !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(topic))
     throw new Error("Ungültige Custom-Eventadresse");
   return `0x${topic.slice(-40)}`;
 }
@@ -1048,69 +733,15 @@ export function customV2SourceClassification(source) {
   if (!source || source.bindingVerified !== true) return "blocked";
   if (!source.registered || source.quarantined || !source.executable)
     return "quarantined";
-  if (typeof source.amount !== "bigint" || source.amount < 0n) return "blocked";
   if (source.amount === 0n) return "empty";
   return "ready";
 }
 
-export function routerCustomClaimClassification(source) {
-  if (
-    !source ||
-    source.origin !== "launch-stamp-router" ||
-    source.provenanceVerified !== true ||
-    source.runtimeVerified !== true
-  )
-    return "blocked";
-  if (source.claimMode === "no-manual-claim") return "no-manual-claim";
-  if (
-    source.claimMode !== "manual" ||
-    source.claimBindingVerified !== true ||
-    typeof source.amount !== "bigint" ||
-    source.amount < 0n ||
-    (source.secondaryAmount !== undefined &&
-      (typeof source.secondaryAmount !== "bigint" ||
-        source.secondaryAmount < 0n))
-  )
-    return "blocked";
-  return source.amount === 0n && (source.secondaryAmount ?? 0n) === 0n
-    ? "empty"
-    : "ready";
-}
-
 export function customClaimDefinitionClassification(claim, current = {}) {
   const source = { ...claim, ...current };
-  if (claim?.origin === "launch-stamp-router")
-    return routerCustomClaimClassification(source);
   return claim?.standardClaimBindingVerified === true
     ? customLaunchClassification(source)
     : customV2SourceClassification(source);
-}
-
-export function createRefreshQueue(run) {
-  if (typeof run !== "function")
-    throw new Error("Refresh-Runner fehlt");
-  let requested = false;
-  let active = null;
-
-  return async function requestRefresh() {
-    requested = true;
-    while (true) {
-      if (!active) {
-        active = (async () => {
-          try {
-            while (requested) {
-              requested = false;
-              await run();
-            }
-          } finally {
-            active = null;
-          }
-        })();
-      }
-      await active;
-      if (!requested && active === null) return;
-    }
-  };
 }
 
 export function formatEth(value, maximumFractionDigits = 6) {
@@ -1155,42 +786,7 @@ export function customV2Bytes32ReadData(selector, value) {
   return `${selector}${encodeBytes32Argument(value)}`;
 }
 
-export function launchStampBytes32ReadData(selector, value) {
-  if (typeof selector !== "string" || !/^0x[0-9a-fA-F]{8}$/.test(selector))
-    throw new Error("Launch-Stamp-Selector ist ungültig");
-  return `${selector.toLowerCase()}${encodeBytes32Argument(value)}`;
-}
-
-export function launchStampAddressReadData(selector, value) {
-  if (typeof selector !== "string" || !/^0x[0-9a-fA-F]{8}$/.test(selector))
-    throw new Error("Launch-Stamp-Selector ist ungültig");
-  return `${selector.toLowerCase()}${encodeAddressArgument(value)}`;
-}
-
-export function launchStampPoolReadData(selector, poolManager, poolId) {
-  if (typeof selector !== "string" || !/^0x[0-9a-fA-F]{8}$/.test(selector))
-    throw new Error("Launch-Stamp-Selector ist ungültig");
-  return `${selector.toLowerCase()}${encodeAddressArgument(poolManager)}${encodeBytes32Argument(poolId)}`;
-}
-
-export function poolManagerBalanceOfData(selector, owner, currency) {
-  if (typeof selector !== "string" || !/^0x[0-9a-fA-F]{8}$/.test(selector))
-    throw new Error("PoolManager-Selector ist ungültig");
-  return `${selector.toLowerCase()}${encodeAddressArgument(owner)}${encodeAddressArgument(currency)}`;
-}
-
-function exactCallData(value, label) {
-  if (
-    typeof value !== "string" ||
-    !/^0x[0-9a-fA-F]{8}(?:[0-9a-fA-F]{64})*$/.test(value)
-  )
-    throw new Error(`${label} ist ungültig`);
-  return value.toLowerCase();
-}
-
 export function readAccruedData(claim) {
-  if (claim?.readData !== undefined)
-    return exactCallData(claim.readData, "Claim-Lesedaten");
   if (claim.kind === "custom")
     return `${CUSTOM_V2_SELECTORS.accruedProgrammableFees}${encodeAddressArgument(CUSTOM_V2_POLICY.nativeAsset)}`;
   return claim.kind === "asset"
@@ -1199,8 +795,6 @@ export function readAccruedData(claim) {
 }
 
 export function claimData(claim) {
-  if (claim?.claimData !== undefined)
-    return exactCallData(claim.claimData, "Claim-Calldata");
   if (claim.kind === "custom")
     return `${CUSTOM_V2_SELECTORS.claimProgrammableFees}${encodeAddressArgument(CUSTOM_V2_POLICY.nativeAsset)}`;
   return claim.kind === "asset"
@@ -1241,22 +835,16 @@ export function buildWalletSendCalls(account, claims) {
     throw new Error("Die Treasury-Wallet muss verbunden sein");
   if (!Array.isArray(claims) || claims.length === 0)
     throw new Error("Keine Claims verfügbar");
-  const calls = claims.map((claim) => ({
-    to: claim.address,
-    data: claimData(claim),
-    value: "0x0",
-  }));
-  const callKeys = calls.map(
-    ({ to, data }) => `${normalizeAddress(to)}:${data.toLowerCase()}`,
-  );
-  if (new Set(callKeys).size !== callKeys.length)
-    throw new Error("Doppelter Claim im atomaren Batch");
   return {
     version: "2.0.0",
     from: account,
     chainId: MAINNET_CHAIN_ID,
     atomicRequired: true,
-    calls,
+    calls: claims.map((claim) => ({
+      to: claim.address,
+      data: claimData(claim),
+      value: "0x0",
+    })),
   };
 }
 

--- a/ops/protocol-fee-claim/logic.test.mjs
+++ b/ops/protocol-fee-claim/logic.test.mjs
@@ -10,18 +10,13 @@ import {
   CUSTOM_V2_POLICY,
   CUSTOM_V2_SELECTORS,
   HOOKS,
-  LAUNCH_STAMP_ROUTER,
-  LAUNCH_STAMP_SELECTORS,
-  LAUNCH_STAMP_TOPICS,
   MAINNET_CHAIN_ID,
-  ROUTER_CUSTOM_CLAIM_PROFILES,
   SELECTORS,
   TREASURY,
   TOKEN_SELECTORS,
   atomicCapabilityStatus,
   buildWalletSendCalls,
   claimData,
-  createRefreshQueue,
   customClaimDefinitionClassification,
   customLaunchClassification,
   customLaunchStateData,
@@ -33,34 +28,21 @@ import {
   decodeCustomLaunchState,
   decodeCustomV2SourceState,
   decodeCustomRegistryLog,
-  decodeLaunchStampLog,
-  decodeLaunchStampProof,
-  decodeLaunchStampRecord,
   decodeAddress,
   decodeUint256,
   encodeAddressArgument,
-  exactRouterFinalizedCheckpoint,
   formatEth,
   formatUnits,
   isTreasury,
   keccak256Hex,
-  launchStampAddressReadData,
-  launchStampBytes32ReadData,
-  launchStampLogSetFingerprint,
-  launchStampPoolReadData,
   normalizeBatchId,
   parseCustomV2Release,
-  poolManagerBalanceOfData,
   readAccruedData,
   reduceClassicLaunchLogs,
   reduceCustomRegistryLogs,
-  reduceLaunchStampLogs,
   requireAtomicClaimCapability,
-  routerFinalizedBoundary,
-  routerCustomClaimClassification,
   shortAddress,
   toQuantityHex,
-  withTimeout,
 } from "./logic.mjs";
 
 test("binds exactly Classic and deployed Stock fee sources", () => {
@@ -79,7 +61,6 @@ test("binds exactly Classic and deployed Stock fee sources", () => {
     false,
   );
 });
-
 
 test("keeps the public claim discovery manifest aligned with the scanner", () => {
   const manifest = JSON.parse(
@@ -113,130 +94,8 @@ test("keeps the public claim discovery manifest aligned with the scanner", () =>
   );
   assert.equal(manifest.customV1.status, "HOLD");
   assert.equal(manifest.customV1.futureFinalizedStandardSourcesAutoAdded, false);
-  assert.equal(
-    manifest.schemaVersion,
-    "programmable.fee-claim-discovery.v2",
-  );
-  assert.equal(
-    manifest.launchStampRouter.address.toLowerCase(),
-    LAUNCH_STAMP_ROUTER.address.toLowerCase(),
-  );
-  assert.equal(
-    manifest.launchStampRouter.startBlock,
-    LAUNCH_STAMP_ROUTER.startBlock.toString(),
-  );
-  assert.equal(
-    manifest.launchStampRouter.runtimeCodeHash,
-    LAUNCH_STAMP_ROUTER.runtimeCodeHash,
-  );
-  assert.equal(
-    manifest.launchStampRouter.eventTopic,
-    LAUNCH_STAMP_TOPICS.launchStamped,
-  );
-  assert.deepEqual(manifest.launchStampRouter.finality, {
-    blockTag: LAUNCH_STAMP_ROUTER.finalizedTag,
-    maximumProviderSpreadBlocks:
-      LAUNCH_STAMP_ROUTER.maximumFinalizedSpread.toString(),
-    policy:
-      "bounded_three_provider_finalized_views_then_exact_common_block_hash_or_block",
-  });
-  assert.equal(
-    manifest.launchStampRouter.futureRouterLaunchesAutoDiscovered,
-    true,
-  );
-  assert.equal(
-    manifest.launchStampRouter.unknownClaimProfile,
-    "visible_and_block_all_claims",
-  );
-  assert.deepEqual(manifest.launchStampRouter.verification, [
-    "router_and_trust_root_runtime_hashes",
-    "exact_consensus_finalized_checkpoint_quorum",
-    "independent_rpc_log_quorum",
-    "router_claim_bindings_and_displayed_balances_at_finalized_checkpoint",
-    "launch_id_by_token",
-    "launch_id_by_pool_manager_and_pool_id",
-    "launch_stamp_record_and_component_proofs",
-    "route_and_hook_runtime_hashes_at_finalized_checkpoint",
-  ]);
-  assert.deepEqual(manifest.launchStampRouter.logQuorum.publicRpcEndpoints, [
-    "https://eth.drpc.org",
-    "https://rpc.mevblocker.io",
-  ]);
-  assert.deepEqual(
-    manifest.launchStampRouter.claimProfiles.map(
-      ({ id, launchId, source, runtimeCodeHash }) => ({
-        id,
-        launchId,
-        source: source.toLowerCase(),
-        runtimeCodeHash,
-      }),
-    ),
-    [
-      ROUTER_CUSTOM_CLAIM_PROFILES.nativeAccumulatorV1,
-      ROUTER_CUSTOM_CLAIM_PROFILES.dualCurrencyRedeemerV1,
-    ].map(({ id, bindings: [binding] }) => ({
-      id,
-      launchId: binding.launchId,
-      source: binding.source.toLowerCase(),
-      runtimeCodeHash: binding.runtimeCodeHash,
-    })),
-  );
   assert.equal(manifest.execution.atomicRequired, true);
-  assert.equal(manifest.execution.maximumCallsPerAtomicBatch, 64);
-  assert.equal(
-    manifest.execution.preflightEveryCallImmediatelyBeforeWallet,
-    true,
-  );
   assert.equal(manifest.execution.unsupportedWalletBehavior, "fail_closed");
-});
-
-test("keeps the static Vercel scanner on wallet RPC and serializes refreshes", () => {
-  const app = readFileSync(new URL("./app.js", import.meta.url), "utf8");
-  assert.match(
-    app,
-    /const operation = provider\(\)\.request\(\{ method, params \}\);/,
-  );
-  assert.doesNotMatch(app, /fetch\(["']\/rpc/);
-  assert.match(app, /const refreshClaims = createRefreshQueue\(refreshClaimsOnce\);/);
-  assert.match(app, /await refreshClaims\(\);/);
-  assert.match(app, /async function preflightClaimBatch\(claims\)/);
-  assert.match(app, /\{ from: state\.account, to, data, value \}/);
-  assert.match(app, /launchStampPoolReadData\(/);
-  assert.match(app, /status: "retired",\s*registryVerified: true/);
-  assert.match(
-    app,
-    /const finalizedBlock = await readRouterFinalizedBoundary\(\);/,
-  );
-  assert.match(
-    app,
-    /readVerifiedRouterLaunch\(candidate, finalizedTag\)/,
-  );
-  assert.doesNotMatch(
-    app,
-    /readVerifiedRouterLaunch\(candidate, finalizedTag, blockTag\)/,
-  );
-  assert.match(app, /withTimeout\(\s*operation,/);
-});
-
-test("queues one fresh scan when refresh is requested during an active scan", async () => {
-  let releaseFirst;
-  const firstGate = new Promise((resolve) => {
-    releaseFirst = resolve;
-  });
-  const runs = [];
-  const refresh = createRefreshQueue(async () => {
-    runs.push(runs.length + 1);
-    if (runs.length === 1) await firstGate;
-  });
-
-  const first = refresh();
-  await Promise.resolve();
-  const second = refresh();
-  const third = refresh();
-  releaseFirst();
-  await Promise.all([first, second, third]);
-
-  assert.deepEqual(runs, [1, 2]);
 });
 
 test("uses the deployed claim and read selectors", () => {
@@ -310,36 +169,6 @@ function classicLog(launcher, { block = 25_700_000n, index = 0n } = {}) {
   };
 }
 
-function launchStampLog({
-  launchId = `0x${"11".repeat(32)}`,
-  token = "0x1234567890123456789012345678901234567890",
-  hook = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
-  poolId = `0x${"22".repeat(32)}`,
-  stampHash = `0x${"33".repeat(32)}`,
-  block = 25_827_140n,
-  index = 0n,
-} = {}) {
-  return {
-    address: LAUNCH_STAMP_ROUTER.address,
-    blockHash: `0x${"88".repeat(32)}`,
-    blockNumber: `0x${block.toString(16)}`,
-    transactionIndex: "0x1",
-    logIndex: `0x${index.toString(16)}`,
-    transactionHash: `0x${"44".repeat(32)}`,
-    topics: [
-      LAUNCH_STAMP_TOPICS.launchStamped,
-      launchId,
-      `0x${addressWord(token)}`,
-      `0x${addressWord(hook)}`,
-    ],
-    data: `0x${[
-      addressWord(LAUNCH_STAMP_ROUTER.poolManager.address),
-      poolId.slice(2),
-      stampHash.slice(2),
-    ].join("")}`,
-  };
-}
-
 function abiString(value) {
   const bytes = Buffer.from(value, "utf8").toString("hex");
   const padded = bytes.padEnd(Math.ceil(bytes.length / 64) * 64, "0");
@@ -391,274 +220,9 @@ test("reduces canonical Classic V2 and V3 launch events newest first", () => {
   );
 });
 
-test("binds the canonical Mainnet Launch Stamp Router trust root", () => {
-  assert.deepEqual(LAUNCH_STAMP_ROUTER, {
-    address: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
-    startBlock: 25_717_612n,
-    endBlock: null,
-    finalizedTag: "finalized",
-    maximumFinalizedSpread: 32n,
-    runtimeCodeHash:
-      "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
-    sourceCommit: "0a7134bbb912222639627fb9078df2f8dd3a6c38",
-    sourceTree: "24ffb0c6b04af7993254560b4f03608de8f52231",
-    abiSha256:
-      "sha256:bb4e728e9f9c850eb01f928e8a798ac206a82e241a8d93b3b3c686635c88ed86",
-    permitAuthority: {
-      address: "0x755509eA6e3F5Ec1aA2E797bb68f1B87DD8b886b",
-      runtimeCodeHash:
-        "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c",
-    },
-    graphFactory: {
-      address: "0xB012e4A8F2c5FC4E8E4faCA9D5Ad6FfF13FBA887",
-      runtimeCodeHash:
-        "0xd23692fae59331592048e71a96d4963e170ee56e449683dc9f7fa3f9470018b8",
-    },
-    poolManager: {
-      address: "0x000000000004444c5dc75cB358380D2e3dE08A90",
-      runtimeCodeHash:
-        "0x785f1014552b7ce7d5fb7d0c970ca60edee94fd00425d7ca21609acac7ce1293",
-    },
-  });
-  assert.deepEqual(LAUNCH_STAMP_TOPICS, {
-    launchStamped:
-      "0x6cf479a102f1eebc9244f48f8d68f6aa52b4c5a4516318df58ba46614a5b14f2",
-    launchRouteStamped:
-      "0x45e7cc355b63ca67d6278a0d8d23470ce2a0741a9c60283d7dee712df7a877a5",
-    componentStamped:
-      "0x8147265e7396d6400cee8d049456a1f7438fdfbe2a7c81c976d51ba67e52ff4b",
-  });
-  assert.deepEqual(LAUNCH_STAMP_SELECTORS, {
-    chainId: "0x85e1f4d0",
-    permitAuthority: "0xc3a3d03c",
-    permitAuthorityRuntimeCodeHash: "0xa497c61c",
-    graphFactory: "0x1cc9e5ce",
-    graphFactoryRuntimeCodeHash: "0x92989a00",
-    poolManager: "0x62308e85",
-    poolManagerRuntimeCodeHash: "0x38d831c4",
-    launchIdByToken: "0x1dad847c",
-    launchIdByPool: "0x361df6f3",
-    launchIdByComponent: "0x58c5e373",
-    componentRuntimeCodeHash: "0xc892d353",
-    launchStamp: "0x4c9e4764",
-    stampProof: "0x174b9f9d",
-  });
-});
-
-test("decodes and reduces canonical Launch Stamp events", () => {
-  const older = launchStampLog({ block: 25_827_140n });
-  const newer = launchStampLog({
-    launchId: `0x${"55".repeat(32)}`,
-    poolId: `0x${"66".repeat(32)}`,
-    stampHash: `0x${"77".repeat(32)}`,
-    block: 25_827_141n,
-    index: 2n,
-  });
-  const decoded = decodeLaunchStampLog(older);
-  assert.equal(decoded.launchId, older.topics[1]);
-  assert.equal(decoded.token.toLowerCase(), `0x${older.topics[2].slice(-40)}`);
-  assert.equal(decoded.hook.toLowerCase(), `0x${older.topics[3].slice(-40)}`);
-  assert.equal(
-    decoded.poolManager.toLowerCase(),
-    LAUNCH_STAMP_ROUTER.poolManager.address.toLowerCase(),
-  );
-  assert.equal(decoded.poolId, `0x${"22".repeat(32)}`);
-  assert.equal(decoded.stampHash, `0x${"33".repeat(32)}`);
-
-  const launches = reduceLaunchStampLogs([older, newer]);
-  assert.deepEqual(
-    launches.map(({ launchId }) => launchId),
-    [newer.topics[1], older.topics[1]],
-  );
-  assert.throws(
-    () => reduceLaunchStampLogs([older, older]),
-    /Doppelter Launch-Stamp/,
-  );
-  assert.equal(
-    launchStampLogSetFingerprint([older, newer]),
-    launchStampLogSetFingerprint([newer, older]),
-  );
-  assert.notEqual(
-    launchStampLogSetFingerprint([older, newer]),
-    launchStampLogSetFingerprint([older]),
-  );
-  assert.notEqual(
-    launchStampLogSetFingerprint([older, newer]),
-    launchStampLogSetFingerprint([]),
-  );
-  const sameSizeRawDivergence = {
-    ...newer,
-    data: `${newer.data.slice(0, -1)}${newer.data.endsWith("0") ? "1" : "0"}`,
-  };
-  assert.notEqual(
-    launchStampLogSetFingerprint([older, newer]),
-    launchStampLogSetFingerprint([older, sameSizeRawDivergence]),
-  );
-  const malformedAddressPadding = {
-    ...older,
-    topics: [
-      older.topics[0],
-      older.topics[1],
-      `0x${"ff".repeat(12)}${older.topics[2].slice(-40)}`,
-      older.topics[3],
-    ],
-  };
-  assert.throws(
-    () => launchStampLogSetFingerprint([malformedAddressPadding]),
-    /Eventadresse/,
-  );
-  assert.throws(
-    () =>
-      decodeLaunchStampLog({
-        ...older,
-        data: `0x${[
-          addressWord("0x0000000000000000000000000000000000000001"),
-          "22".repeat(32),
-          "33".repeat(32),
-        ].join("")}`,
-      }),
-    /Identität ist unvollständig/,
-  );
-});
-
-test("uses a bounded common finalized Router boundary and rejects a stale wallet view", () => {
-  const older = {
-    number: "0x18a1b37",
-    hash: `0x${"ab".repeat(32)}`,
-  };
-  const newer = {
-    number: "0x18a1b57",
-    hash: `0x${"cd".repeat(32)}`,
-  };
-  assert.equal(
-    routerFinalizedBoundary([older, newer, { ...newer }], 1n, 32n),
-    BigInt(older.number),
-  );
-  assert.throws(
-    () =>
-      routerFinalizedBoundary(
-        [{ ...older, number: "0x18a1b36" }, newer, { ...newer }],
-        1n,
-        32n,
-      ),
-    /zu weit auseinander/,
-  );
-});
-
-test("requires one exact common Router checkpoint from all three RPCs", () => {
-  const hash = `0x${"ab".repeat(32)}`;
-  const block = { number: "0x18a1b17", hash };
-  assert.deepEqual(
-    exactRouterFinalizedCheckpoint([block, { ...block }, { ...block }], 1n),
-    { number: 25_828_119n, hash },
-  );
-  assert.throws(
-    () =>
-      exactRouterFinalizedCheckpoint(
-        [
-          { number: "0x18a1ad0", hash: `0x${"cd".repeat(32)}` },
-          block,
-          { ...block },
-        ],
-        1n,
-      ),
-    /stimmt im RPC-Quorum nicht überein/,
-  );
-  assert.throws(
-    () =>
-      exactRouterFinalizedCheckpoint(
-        [block, { ...block, hash: `0x${"ef".repeat(32)}` }, { ...block }],
-        1n,
-      ),
-    /stimmt im RPC-Quorum nicht überein/,
-  );
-  assert.throws(
-    () => exactRouterFinalizedCheckpoint([block, { ...block }], 1n),
-    /fehlt im RPC-Quorum/,
-  );
-});
-
-test("terminates a stalled scan RPC instead of occupying the refresh queue", async () => {
-  await assert.rejects(
-    withTimeout(
-      new Promise(() => {}),
-      5,
-      "Wallet-RPC-Zeitlimit im Test überschritten",
-    ),
-    /Wallet-RPC-Zeitlimit im Test überschritten/,
-  );
-});
-
-test("decodes exact Launch Stamp records, proofs and lookup calldata", () => {
-  const launchId = `0x${"11".repeat(32)}`;
-  const token = "0x1234567890123456789012345678901234567890";
-  const hook = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
-  const routeLauncher = "0x9876543210987654321098765432109876543210";
-  const hashes = Array.from({ length: 8 }, (_, index) =>
-    (index + 2).toString(16).padStart(2, "0").repeat(32),
-  );
-  const recordWords = [
-    word(1),
-    addressWord(TREASURY),
-    addressWord(token),
-    addressWord(hook),
-    addressWord(LAUNCH_STAMP_ROUTER.poolManager.address),
-    hashes[0],
-    hashes[1],
-    hashes[2],
-    hashes[3],
-    addressWord(routeLauncher),
-    hashes[4],
-    hashes[5],
-    hashes[6],
-    hashes[7],
-  ];
-  const poolId = `0x${hashes[0]}`;
-  const record = decodeLaunchStampRecord(`0x${recordWords.join("")}`);
-  assert.equal(record.kind, 1);
-  assert.equal(record.launchWallet.toLowerCase(), TREASURY.toLowerCase());
-  assert.equal(record.token.toLowerCase(), token.toLowerCase());
-  assert.equal(record.hook.toLowerCase(), hook.toLowerCase());
-  assert.equal(record.routeLauncher.toLowerCase(), routeLauncher.toLowerCase());
-  assert.equal(record.poolId, poolId);
-  assert.equal(record.stampHash, `0x${hashes[7]}`);
-
-  assert.deepEqual(
-    decodeLaunchStampProof(`0x${launchId.slice(2)}${hashes[7]}`),
-    { launchId, stampHash: `0x${hashes[7]}` },
-  );
-  assert.equal(
-    launchStampBytes32ReadData(LAUNCH_STAMP_SELECTORS.launchStamp, launchId),
-    `${LAUNCH_STAMP_SELECTORS.launchStamp}${launchId.slice(2)}`,
-  );
-  assert.equal(
-    launchStampAddressReadData(LAUNCH_STAMP_SELECTORS.launchIdByToken, token),
-    `${LAUNCH_STAMP_SELECTORS.launchIdByToken}${addressWord(token)}`,
-  );
-  assert.equal(
-    launchStampPoolReadData(
-      LAUNCH_STAMP_SELECTORS.launchIdByPool,
-      LAUNCH_STAMP_ROUTER.poolManager.address,
-      poolId,
-    ),
-    `${LAUNCH_STAMP_SELECTORS.launchIdByPool}${addressWord(LAUNCH_STAMP_ROUTER.poolManager.address)}${poolId.slice(2)}`,
-  );
-  assert.throws(
-    () => decodeLaunchStampRecord(`0x${[word(3), ...recordWords.slice(1)].join("")}`),
-    /Art wird nicht unterstützt/,
-  );
-  assert.throws(
-    () => decodeLaunchStampProof(`0x${launchId.slice(2)}`),
-    /ungültige ABI-Länge/,
-  );
-});
-
-test("keeps the retired Custom Registry V1 policy inert", () => {
+test("keeps retired Custom Registry V1 out of claim discovery", () => {
   assert.equal(CUSTOM_REGISTRY.status, "retired");
-  assert.equal(
-    CUSTOM_REGISTRY.address,
-    "0x0000000000000000000000000000000000000000",
-  );
+  assert.equal(CUSTOM_REGISTRY.address, "0x0000000000000000000000000000000000000000");
   assert.equal(CUSTOM_REGISTRY.startBlock, 0n);
   assert.equal(CUSTOM_REGISTRY.runtimeCodeHash, null);
   assert.deepEqual(Object.keys(CUSTOM_EVENT_TOPICS), [
@@ -1159,206 +723,5 @@ test("builds direct permissionless Custom claims into the same wallet batch", ()
       executable: true,
     }),
     "empty",
-  );
-  assert.equal(
-    customV2SourceClassification({
-      ...custom,
-      registered: true,
-      quarantined: false,
-      executable: true,
-    }),
-    "blocked",
-  );
-});
-
-test("binds audited Router Custom profiles with exact read and claim calldata", () => {
-  assert.deepEqual(ROUTER_CUSTOM_CLAIM_PROFILES, {
-    nativeAccumulatorV1: {
-      id: "native-accumulator-v1",
-      bindings: [
-        {
-          launchId:
-            "0x6d6ed0e1e69a7cd6afa177e3454c9e32eed61cbd3f855ee56aff1915a6776fc2",
-          source: "0xd7451a039373f54e493deE42A751fEcBfAFBa0cc",
-          runtimeCodeHash:
-            "0xff70a4d3d889b730a064b270fc187f0cba40582f1fa6f5875893066b17a1257b",
-        },
-      ],
-      recipient: "0x4968150a",
-      feeBps: "0xb6c7448d",
-      accrued: "0x0986bdb6",
-      claim: "0xa95e4f21",
-      expectedFeeBps: 10n,
-    },
-    protocolFeeSourceV1: {
-      id: "protocol-fee-source-v1",
-      bindings: [],
-      recipient: CUSTOM_V2_SELECTORS.programmableFeeRecipient,
-      feeBps: `${CUSTOM_V2_SELECTORS.programmableFeeBps}${"0".repeat(64)}`,
-      accrued: `${CUSTOM_V2_SELECTORS.accruedProgrammableFees}${"0".repeat(64)}`,
-      claim: `${CUSTOM_V2_SELECTORS.claimProgrammableFees}${"0".repeat(64)}`,
-      expectedFeeBps: 10n,
-    },
-    dualCurrencyRedeemerV1: {
-      id: "dual-currency-redeemer-v1",
-      bindings: [
-        {
-          launchId:
-            "0x5a52180427785716bff0a36218dde89f0459db265d0c2bdfcfde81a8fe733c92",
-          source: "0xEBa46F25dff528141DE5317109aCB5a989296044",
-          runtimeCodeHash:
-            "0xd59d31add7a3b206972725889dbb726782c0fbd82514710cf2d645749dc3fa25",
-        },
-      ],
-      recipient: "0x46904840",
-      feePips: "0x9fa59765",
-      poolManager: "0xdc4c90d3",
-      currency0: "0x79f1232b",
-      currency1: "0x10d737b8",
-      poolId: "0x3e0dc34e",
-      balanceOf: "0x00fdd58e",
-      claim:
-        "0xfc656ac500000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
-      expectedFeePips: 1_000n,
-      secondaryUnit: "PCAN",
-      secondaryDecimals: 18,
-    },
-  });
-
-  const nativeProfile = ROUTER_CUSTOM_CLAIM_PROFILES.nativeAccumulatorV1;
-  const protocolProfile = ROUTER_CUSTOM_CLAIM_PROFILES.protocolFeeSourceV1;
-  const nativeClaim = {
-    id: "launch-stamp:fade",
-    kind: "custom",
-    address: "0xd7451a039373f54e493dee42a751fecbfafba0cc",
-    readData: nativeProfile.accrued,
-    claimData: nativeProfile.claim,
-  };
-  assert.equal(readAccruedData(nativeClaim), nativeProfile.accrued);
-  assert.equal(claimData(nativeClaim), nativeProfile.claim);
-  assert.equal(
-    readAccruedData({ ...nativeClaim, readData: protocolProfile.accrued }),
-    protocolProfile.accrued,
-  );
-  assert.equal(
-    claimData({ ...nativeClaim, claimData: protocolProfile.claim }),
-    protocolProfile.claim,
-  );
-
-  const pcanProfile = ROUTER_CUSTOM_CLAIM_PROFILES.dualCurrencyRedeemerV1;
-  const pcanClaim = {
-    id: "launch-stamp:pcan",
-    kind: "custom",
-    address: pcanProfile.bindings[0].source,
-    claimData: pcanProfile.claim,
-  };
-  assert.equal(claimData(pcanClaim), pcanProfile.claim);
-  assert.equal(
-    poolManagerBalanceOfData(
-      pcanProfile.balanceOf,
-      pcanClaim.address,
-      "0x9DEeB39D2590b0cAD5fc473F755C5F97Dcc8f7cE",
-    ),
-    `${pcanProfile.balanceOf}${encodeAddressArgument(pcanClaim.address)}${encodeAddressArgument("0x9DEeB39D2590b0cAD5fc473F755C5F97Dcc8f7cE")}`,
-  );
-
-  const batch = buildWalletSendCalls(TREASURY, [nativeClaim, pcanClaim]);
-  assert.deepEqual(batch.calls, [
-    {
-      to: nativeClaim.address,
-      data: nativeProfile.claim,
-      value: "0x0",
-    },
-    {
-      to: pcanClaim.address,
-      data: pcanProfile.claim,
-      value: "0x0",
-    },
-  ]);
-  assert.throws(
-    () => readAccruedData({ ...nativeClaim, readData: "0x1234" }),
-    /Claim-Lesedaten/,
-  );
-  assert.throws(
-    () => claimData({ ...nativeClaim, claimData: "0x1234" }),
-    /Claim-Calldata/,
-  );
-});
-
-test("classifies Router Custom claims fail-closed", () => {
-  const ready = {
-    id: "launch-stamp:fade",
-    kind: "custom",
-    origin: "launch-stamp-router",
-    provenanceVerified: true,
-    runtimeVerified: true,
-    claimMode: "manual",
-    claimBindingVerified: true,
-    amount: 1n,
-  };
-  assert.equal(routerCustomClaimClassification(ready), "ready");
-  assert.equal(
-    routerCustomClaimClassification({ ...ready, amount: 0n }),
-    "empty",
-  );
-  assert.equal(
-    routerCustomClaimClassification({
-      ...ready,
-      amount: 0n,
-      secondaryAmount: 1n,
-    }),
-    "ready",
-  );
-  assert.equal(
-    routerCustomClaimClassification({
-      ...ready,
-      amount: 0n,
-      secondaryAmount: undefined,
-    }),
-    "empty",
-  );
-  assert.equal(
-    routerCustomClaimClassification({
-      ...ready,
-      amount: 0n,
-      secondaryAmount: "1",
-    }),
-    "blocked",
-  );
-  assert.equal(
-    routerCustomClaimClassification({ ...ready, amount: undefined }),
-    "blocked",
-  );
-  assert.equal(
-    routerCustomClaimClassification({ ...ready, runtimeVerified: false }),
-    "blocked",
-  );
-  assert.equal(
-    routerCustomClaimClassification({
-      ...ready,
-      claimMode: "no-manual-claim",
-      claimBindingVerified: false,
-      amount: undefined,
-    }),
-    "no-manual-claim",
-  );
-  assert.equal(
-    customClaimDefinitionClassification(ready, { amount: 2n }),
-    "ready",
-  );
-});
-
-test("rejects duplicate onchain calls in one atomic batch", () => {
-  const profile = ROUTER_CUSTOM_CLAIM_PROFILES.nativeAccumulatorV1;
-  const first = {
-    id: "launch-stamp:first",
-    kind: "custom",
-    address: "0xd7451a039373f54e493dee42a751fecbfafba0cc",
-    claimData: profile.claim,
-  };
-  const duplicate = { ...first, id: "launch-stamp:second" };
-  assert.throws(
-    () => buildWalletSendCalls(TREASURY, [first, duplicate]),
-    /Doppelter Claim im atomaren Batch/,
   );
 });

--- a/ops/protocol-fee-claim/package.json
+++ b/ops/protocol-fee-claim/package.json
@@ -2,8 +2,6 @@
   "name": "programmable-fee-claim",
   "private": true,
   "scripts": {
-    "build": "node build.mjs",
-    "test": "node --test logic.test.mjs",
-    "check": "npm test && npm run build"
+    "build": "node build.mjs"
   }
 }

--- a/scripts/smoke-static-dexscreener-public-apis.mjs
+++ b/scripts/smoke-static-dexscreener-public-apis.mjs
@@ -3,6 +3,7 @@ import { appendFileSync } from "node:fs";
 import { readBoundedResponseText } from "./read-bounded-response.mjs";
 
 const ADDRESS = /^0x[0-9a-f]{40}$/u;
+const BYTES32 = /^0x[0-9a-f]{64}$/u;
 const POSITIVE_INTEGER = /^[1-9][0-9]*$/u;
 const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
 const CATALOG_SOURCES = new Set(["envio-classic-v3"]);
@@ -101,12 +102,56 @@ function exactIdentity(token) {
   if (typeof token?.id !== "string" || token.id.trim() === "") return null;
   if (token.exploreKind === "token") {
     const tokenAddress = String(token.tokenAddress ?? "").toLowerCase();
+    const poolId = String(token.poolId ?? "").toLowerCase();
+    if (!ADDRESS.test(tokenAddress) || !BYTES32.test(poolId)) return null;
+
+    if (token.launchModel === "custom-graph") {
+      const stamp = token.launchStampProvenance;
+      const category = token.launchCategoryProvenance;
+      const launchId = String(stamp?.launchId ?? "").toLowerCase();
+      const stampHash = String(stamp?.stampHash ?? "").toLowerCase();
+      const poolManagerAddress = String(
+        stamp?.poolManagerAddress ?? "",
+      ).toLowerCase();
+      if (
+        token.launchModelVersion !== "programmable-launch-stamp-router-v1" ||
+        stamp?.schemaVersion !== "programmable.launch-stamp-provenance.v1" ||
+        stamp.chainId !== 1 ||
+        stamp.kind !== "custom-graph" ||
+        !BYTES32.test(launchId) ||
+        !BYTES32.test(stampHash) ||
+        String(stamp.poolId ?? "").toLowerCase() !== poolId ||
+        category?.schemaVersion !==
+          "programmable.explore-launch-category-provenance.v1" ||
+        category.category !== "custom" ||
+        category.source !== "canonical-launch-stamp-router" ||
+        String(category.launchId ?? "").toLowerCase() !== launchId ||
+        String(category.stampHash ?? "").toLowerCase() !== stampHash ||
+        !ADDRESS.test(poolManagerAddress) ||
+        String(stamp.tokenProof?.tokenAddress ?? "").toLowerCase() !==
+          tokenAddress ||
+        String(stamp.tokenProof?.launchId ?? "").toLowerCase() !== launchId ||
+        String(stamp.tokenProof?.stampHash ?? "").toLowerCase() !== stampHash ||
+        String(stamp.poolProof?.poolManagerAddress ?? "").toLowerCase() !==
+          poolManagerAddress ||
+        String(stamp.poolProof?.poolId ?? "").toLowerCase() !== poolId ||
+        String(stamp.poolProof?.launchId ?? "").toLowerCase() !== launchId ||
+        String(stamp.poolProof?.stampHash ?? "").toLowerCase() !== stampHash
+      ) return null;
+      return JSON.stringify([
+        "router-custom-token",
+        token.id,
+        tokenAddress,
+        poolId,
+        launchId,
+        stampHash,
+      ]);
+    }
+
     const exactOfficialException =
       tokenAddress === PROGRAMMABLE_MAIN_ASSET_ADDRESS &&
       token.launchModelVersion === "classic-v2";
     if (
-      !ADDRESS.test(tokenAddress) ||
-      !/^0x[0-9a-f]{64}$/u.test(String(token.poolId ?? "").toLowerCase()) ||
       token.launchModel !== "classic" ||
       (token.launchModelVersion !== "classic-v3" && !exactOfficialException) ||
       token.launchStampProvenance !== undefined
@@ -114,8 +159,8 @@ function exactIdentity(token) {
     return JSON.stringify([
       "token",
       token.id,
-      token.tokenAddress.toLowerCase(),
-      token.poolId.toLowerCase(),
+      tokenAddress,
+      poolId,
     ]);
   }
   if (

--- a/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
+++ b/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
@@ -12,6 +12,10 @@ const TOKEN = "0x1111111111111111111111111111111111111111";
 const CREATOR = "0x2222222222222222222222222222222222222222";
 const POOL = `0x${"33".repeat(32)}`;
 const CUSTOM_TOKEN = "0x9999999999999999999999999999999999999999";
+const ROUTER_TOKEN = "0x6969696969696969696969696969696969696969";
+const ROUTER_LAUNCH_ID = `0x${"ab".repeat(32)}`;
+const ROUTER_STAMP_HASH = `0x${"cd".repeat(32)}`;
+const POOL_MANAGER = "0x000000000004444c5dc75cb358380d2e3de08a90";
 
 function entry(index) {
   const tokenAddress = index === 0
@@ -94,6 +98,50 @@ function customProject() {
     ],
     launchCategoryProvenance: {},
     valuation: { status: "unavailable", reason: "source-unavailable" },
+  };
+}
+
+function routerCustomEntry() {
+  return {
+    ...entry(0),
+    id: `1:${ROUTER_TOKEN}`,
+    tokenAddress: ROUTER_TOKEN,
+    launchModel: "custom-graph",
+    launchModelVersion: "programmable-launch-stamp-router-v1",
+    launchCategoryProvenance: {
+      schemaVersion: "programmable.explore-launch-category-provenance.v1",
+      category: "custom",
+      source: "canonical-launch-stamp-router",
+      launchId: ROUTER_LAUNCH_ID,
+      stampHash: ROUTER_STAMP_HASH,
+    },
+    launchStampProvenance: {
+      schemaVersion: "programmable.launch-stamp-provenance.v1",
+      chainId: 1,
+      kind: "custom-graph",
+      launchId: ROUTER_LAUNCH_ID,
+      stampHash: ROUTER_STAMP_HASH,
+      poolManagerAddress: POOL_MANAGER,
+      poolId: POOL,
+      poolKey: {
+        currency0: "0x0000000000000000000000000000000000000000",
+        currency1: ROUTER_TOKEN,
+        fee: 8_388_608,
+        tickSpacing: 10,
+        hooks: "0xd7451a039373f54e493deE42A751fEcBfAFBa0cc",
+      },
+      tokenProof: {
+        tokenAddress: ROUTER_TOKEN,
+        launchId: ROUTER_LAUNCH_ID,
+        stampHash: ROUTER_STAMP_HASH,
+      },
+      poolProof: {
+        poolManagerAddress: POOL_MANAGER,
+        poolId: POOL,
+        launchId: ROUTER_LAUNCH_ID,
+        stampHash: ROUTER_STAMP_HASH,
+      },
+    },
   };
 }
 
@@ -313,6 +361,74 @@ function stagedFetch(
   };
 }
 
+function routerCustomStagedFetch(mutate = (value) => value) {
+  const launchSource =
+    "envio-classic-v3+canonical-launch-stamp-router";
+  return stagedFetch(
+    ({ body, url }) => {
+      if (url.pathname === "/api/explore") {
+        return {
+          ...body,
+          tokens: [mutate(routerCustomEntry()), entry(1)],
+          catalog: {
+            ...body.catalog,
+            launchSource,
+            completeness: {
+              ...body.catalog.completeness,
+              routerCustom: "current",
+            },
+            scope: {
+              ...body.catalog.scope,
+              included: [
+                ...body.catalog.scope.included,
+                "canonical-launch-stamp-router",
+              ],
+            },
+          },
+        };
+      }
+      if (url.pathname === "/api/explore/token") {
+        return {
+          ...body,
+          token: mutate(routerCustomEntry()),
+          catalog: {
+            ...body.catalog,
+            launchSource,
+            completeness: {
+              ...body.catalog.completeness,
+              routerCustom: "current",
+            },
+            scope: {
+              ...body.catalog.scope,
+              included: [
+                ...body.catalog.scope.included,
+                "canonical-launch-stamp-router",
+              ],
+            },
+          },
+        };
+      }
+      return body;
+    },
+    ({ extraHeaders, omittedHeaders, url }) => ({
+      extraHeaders: [
+        "/api/explore",
+        "/api/explore/token",
+        "/api/explore/token/chart",
+      ].includes(url.pathname)
+        ? {
+            ...extraHeaders,
+            "x-programmable-launch-source": launchSource,
+            "x-programmable-read-source": url.pathname.endsWith("/chart")
+              ? `${launchSource}+bitquery`
+              : `${launchSource}+dexscreener`,
+          }
+        : extraHeaders,
+      omittedHeaders,
+    }),
+  );
+}
+
 function pagedCatalogTransform(allEntries, options = {}) {
   return ({ body, url }) => {
     if (url.pathname === "/api/explore") {
@@ -439,6 +555,120 @@ test("staged smoke accepts identity-only Explore and token responses", async () 
   assert.equal(result.detailStatus, "verified-identity-market-unavailable");
   assert.equal(output.length, 1);
   assert.match(output[0][1], /market_read_status=unavailable/u);
+});
+
+test("staged smoke accepts an exact Router Custom token identity", async () => {
+  const result = await runStagedStaticDexscreenerSmokeV1({
+    environment: {
+      STAGED_TARGET_URL: "https://candidate.vercel.app/",
+      VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+      GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+    },
+    fetchImpl: routerCustomStagedFetch(),
+    appendOutput: () => undefined,
+  });
+
+  assert.equal(result.tokenAddress, ROUTER_TOKEN);
+  assert.equal(result.detailStatus, "verified-identity-market-unavailable");
+});
+
+test("staged smoke rejects malformed Router Custom identity provenance", async () => {
+  const scenarios = [
+    (value) => ({ ...value, launchModelVersion: "classic-v3" }),
+    (value) => ({
+      ...value,
+      launchStampProvenance: {
+        ...value.launchStampProvenance,
+        schemaVersion: "programmable.launch-stamp-provenance.v2",
+      },
+    }),
+    (value) => ({
+      ...value,
+      launchStampProvenance: {
+        ...value.launchStampProvenance,
+        poolId: `0x${"fe".repeat(32)}`,
+      },
+    }),
+    (value) => ({
+      ...value,
+      launchCategoryProvenance: {
+        ...value.launchCategoryProvenance,
+        source: "registry.custom-launched",
+      },
+    }),
+    (value) => ({
+      ...value,
+      launchCategoryProvenance: {
+        ...value.launchCategoryProvenance,
+        launchId: `0x${"fe".repeat(32)}`,
+      },
+    }),
+    (value) => ({
+      ...value,
+      launchStampProvenance: {
+        ...value.launchStampProvenance,
+        tokenProof: {
+          ...value.launchStampProvenance.tokenProof,
+          tokenAddress: TOKEN,
+        },
+      },
+    }),
+    (value) => ({
+      ...value,
+      launchStampProvenance: {
+        ...value.launchStampProvenance,
+        tokenProof: {
+          ...value.launchStampProvenance.tokenProof,
+          stampHash: `0x${"fe".repeat(32)}`,
+        },
+      },
+    }),
+    (value) => ({
+      ...value,
+      launchStampProvenance: {
+        ...value.launchStampProvenance,
+        poolProof: {
+          ...value.launchStampProvenance.poolProof,
+          poolManagerAddress: TOKEN,
+        },
+      },
+    }),
+    (value) => ({
+      ...value,
+      launchStampProvenance: {
+        ...value.launchStampProvenance,
+        poolProof: {
+          ...value.launchStampProvenance.poolProof,
+          poolId: `0x${"fe".repeat(32)}`,
+        },
+      },
+    }),
+    (value) => ({
+      ...value,
+      launchStampProvenance: {
+        ...value.launchStampProvenance,
+        poolProof: {
+          ...value.launchStampProvenance.poolProof,
+          launchId: `0x${"fe".repeat(32)}`,
+        },
+      },
+    }),
+  ];
+
+  for (const mutate of scenarios) {
+    await assert.rejects(
+      runStagedStaticDexscreenerSmokeV1({
+        environment: {
+          STAGED_TARGET_URL: "https://candidate.vercel.app/",
+          VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+          GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+        },
+        fetchImpl: routerCustomStagedFetch(mutate),
+        appendOutput: () => undefined,
+      }),
+      /Explore identity set is malformed or duplicated/u,
+    );
+  }
 });
 
 test("staged smoke accepts monotonic Envio progress with stable identities", async () => {

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -383,7 +383,7 @@ describe("Explore refresh state", () => {
         },
       );
 
-    expect(initialState).toEqual({ phase: "loading" });
+    expect(initialState).toBeNull();
     expect(
       handledInitialExploreRequestKey(initialState, "initial-request-error"),
     ).toBeNull();

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -370,7 +370,7 @@ describe("Explore refresh state", () => {
     });
   });
 
-  it("keeps a server-side Explore failure retryable without inventing data", () => {
+  it("keeps a server-side Explore failure behind skeletons while retrying", () => {
     const initialState = createExploreInitialState(
         {
           ok: false,
@@ -383,15 +383,28 @@ describe("Explore refresh state", () => {
         },
       );
 
-    expect(initialState).toEqual({
+    expect(initialState).toEqual({ phase: "loading" });
+    expect(
+      handledInitialExploreRequestKey(initialState, "initial-request-error"),
+    ).toBeNull();
+  });
+
+  it("surfaces an error only after the client retry also fails", () => {
+    expect(
+      preserveExplorePayloadOnRefreshFailure(
+        { phase: "loading" },
+        {
+          contentKey: "initial-content-error",
+          requestKey: "initial-request-error",
+          message: "Launch index is catching up",
+        },
+      ),
+    ).toEqual({
       phase: "error",
       message: "Launch index is catching up",
       contentKey: "initial-content-error",
       requestKey: "initial-request-error",
     });
-    expect(
-      handledInitialExploreRequestKey(initialState, "initial-request-error"),
-    ).toBeNull();
   });
 
   it("suppresses only the successful server response hydration request", () => {


### PR DESCRIPTION
## Outcome

Closes the two remaining website release gaps and keeps an unsafe unpublished sidecar out of the release:

- accepts Router Custom token identities in the canonical production Explore smoke only when the launch stamp, category, token proof and pool proof bind exactly;
- keeps the shape-preserving Explore skeleton (or a valid warm cache) visible when the bounded server read times out, and surfaces an error only if the automatic client read also fails;
- reverts #459 because its private treasury console can rehydrate pre-claim finalized balances after a confirmed batch and offer a duplicate claim. The separately hosted console was not promoted from that source.

## Safety

- Router Custom identity binds version, stamp schema, chain, kind, pool manager, token, pool, launch ID and stamp hash.
- Malformed or incomplete provenance fails closed.
- Classic identity behavior is unchanged.
- The four-second server deadline remains bounded; no retry timer or provider behavior changed.
- Relative to the last known-good production tree before #459, only the four verifier/Explore files differ.

## Focused verification

- Router Custom public smoke: 27/27
- Explore SSR/state/UI contract: 67/67
- Patched production smoke against https://programmable.market: passed
- final tree comparison against pre-#459 production: only four intended files
- git diff --check: passed

No wallet transaction was signed or sent.