### PR TITLE
Polish profile, API keys, loading states, and API-first docs

### DIFF
--- a/app/custom-launches/[recordHash]/page.tsx
+++ b/app/custom-launches/[recordHash]/page.tsx
@@ -1,7 +1,15 @@
+import type { Metadata } from "next";
+
 import { GenericLaunchDetailV2 } from
   "@/components/generic-launch-directory-v2";
 
 export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Legacy Registry record · Programmable",
+  description: "A historical Custom launch record from the retired Registry approval flow.",
+  robots: { follow: false, index: false },
+};
 
 export default async function CustomLaunchDetailPage({ params }: Readonly<{
   params: Promise<{ recordHash: string }>;

--- a/app/custom-launches/page.tsx
+++ b/app/custom-launches/page.tsx
@@ -1,7 +1,15 @@
+import type { Metadata } from "next";
+
 import { GenericLaunchDirectoryV2 } from
   "@/components/generic-launch-directory-v2";
 
 export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Legacy Registry records · Programmable",
+  description: "Historical Custom launch records from the retired Registry approval flow.",
+  robots: { follow: false, index: false },
+};
 
 export default function CustomLaunchesPage() {
   return <GenericLaunchDirectoryV2 />;

--- a/app/docs/creators/launch/page.tsx
+++ b/app/docs/creators/launch/page.tsx
@@ -4,13 +4,12 @@ import Link from "next/link";
 import { DocsExternalLink } from "@/components/docs-external-link";
 import docsStyles from "@/components/docs-experience.module.css";
 import styles from "@/components/docs-hub.module.css";
-import { PROGRAMMABLE_PUBLIC_REPOSITORIES } from "@/components/docs-public-policy";
 import { DocsShell } from "@/components/docs-shell";
 
 export const metadata: Metadata = {
   title: "Launch a project · Programmable",
   description:
-    "Use a wallet-bound API key to check a Custom launch bundle and prepare the exact wallet action.",
+    "Use a wallet-bound API key to validate a Custom launch bundle, wait for authorization and track finality.",
   alternates: { canonical: "/docs/creators/launch" },
 };
 
@@ -28,7 +27,7 @@ export default function CreatorLaunchDocsPage() {
   return (
     <DocsShell
       currentPath="/docs/creators/launch"
-      description="Create a wallet-bound API key, submit one deterministic bundle for checks and review the prepared launch in your wallet."
+      description="Create a wallet-bound API key, submit one deterministic bundle, then review the wallet transaction only after authorization."
       parentHref="/docs/creators"
       parentLabel="Creators"
       sections={sections}
@@ -44,9 +43,9 @@ export default function CreatorLaunchDocsPage() {
         <div className={docsStyles.callout}>
           <strong>The API does not control your wallet.</strong>
           <p>
-            An API key can submit and read launch preparations. It cannot sign
-            or broadcast the prepared transaction. The controller wallet must
-            review and confirm the final action separately.
+            An API key can submit and read launch preparations. It cannot
+            authorize, sign or broadcast the wallet transaction. The controller
+            wallet reviews it only after the API status becomes authorized.
           </p>
         </div>
       </section>
@@ -85,10 +84,10 @@ export default function CreatorLaunchDocsPage() {
           </li>
         </ol>
         <DocsExternalLink
-          href={PROGRAMMABLE_PUBLIC_REPOSITORIES.hookbuilder}
+          href="https://github.com/0xprogrammable/Hookbuilder-Skill"
           variant="chip"
         >
-          Open Hook Builder
+          Open Hookbuilder-Skill as a project starting point
         </DocsExternalLink>
       </section>
 
@@ -112,11 +111,11 @@ export default function CreatorLaunchDocsPage() {
           <code>https://api.programmable.market/v1/custom-launches</code> with
           the key as a Bearer credential. The API validates the declared
           manifest commitment, wallet binding, graph, hook permissions and
-          launch constraints before it prepares an action. It does not compile
-          or simulate the submitted project.
+          launch constraints before it prepares an artifact. It does not
+          compile or simulate the submitted project.
         </p>
         <p className={styles.inlineAction}>
-          <Link href="/developers/custom-launch-api-v1.md">
+          <Link href="/docs/developers/custom-launch">
             Read the Custom Launch API guide
           </Link>
         </p>
@@ -126,18 +125,20 @@ export default function CreatorLaunchDocsPage() {
         <h2>Prepared launch</h2>
         <p>
           A <code>prepared</code> result means the exact launch artifact exists.
-          It is not a signed transaction, a broadcast, an approval, an audit or
-          a safety claim. Read the launch status with the same API key and stop
-          on any failed or mismatched check.
+          Its signed permit and wallet transaction are still null. It is not a
+          wallet authorization, approval, audit or safety claim. Read the launch
+          status with the same API key and stop on any failed or mismatched
+          binding.
         </p>
       </section>
 
       <section id="launch">
         <h2>Wallet confirmation</h2>
         <p>
-          Review the exact prepared action with the controller wallet. Only that
-          wallet, or an agent separately authorized to use it, can sign and
-          broadcast the transaction. The API key alone cannot do either.
+          Wait for <code>authorized</code>, then review the exact permit-attached
+          transaction with the controller wallet. Only that wallet, or an agent
+          separately authorized to use it, can sign and broadcast. The API key
+          alone cannot do either.
         </p>
         <p>
           The launch is not complete when a transaction is merely submitted. It

--- a/app/docs/creators/page.tsx
+++ b/app/docs/creators/page.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import { ArrowRight, ArrowUpRight } from "lucide-react";
 
 import styles from "@/components/docs-hub.module.css";
-import { PROGRAMMABLE_PUBLIC_REPOSITORIES } from "@/components/docs-public-policy";
 import { DocsShell } from "@/components/docs-shell";
 
 export const metadata: Metadata = {
@@ -43,8 +42,8 @@ export default function CreatorsDocsPage() {
             <span>Custom Launch API</span>
             <strong>Prepare one Custom launch</strong>
             <small>
-              Create a wallet-bound API key, submit one deterministic bundle for
-              checks and receive a prepared wallet action.
+              Create a wallet-bound API key, submit one deterministic bundle and
+              wait for an authorized wallet transaction.
             </small>
           </Link>
           <Link className={styles.pathCard} href="/docs/creators/templates">
@@ -57,17 +56,17 @@ export default function CreatorsDocsPage() {
           </Link>
           <a
             className={styles.pathCard}
-            href={PROGRAMMABLE_PUBLIC_REPOSITORIES.hookbuilder}
+            href="https://github.com/0xprogrammable/Hookbuilder-Skill"
             rel="noreferrer"
             target="_blank"
           >
-            <span>Hook Builder</span>
+            <span>Hookbuilder-Skill</span>
             <strong>Build with the skill and tools</strong>
             <small>
-              Use the Hook Builder skill to create a reproducible Uniswap v4
-              project before packaging it for the Custom Launch API.
+              Use Hookbuilder-Skill as a starting point for a Uniswap v4 project.
+              Package the API request with project-specific tooling.
             </small>
-            <span className="sr-only">Opens Hook Builder on GitHub</span>
+            <span className="sr-only">Opens Hookbuilder-Skill on GitHub</span>
           </a>
         </div>
       </section>
@@ -75,15 +74,15 @@ export default function CreatorsDocsPage() {
       <section id="project">
         <h2>Launch a project</h2>
         <p>
-          Start with Hook Builder, create a deterministic source and graph
-          bundle, then submit it through the Custom Launch API with a
-          wallet-bound key. The API validates its declared commitments and graph
-          bindings, then prepares the exact wallet action without reproducing
-          the build.
+          Build and test the project, then create a deterministic source and
+          graph bundle with project-specific tooling. Submit it through the
+          Custom Launch API with a wallet-bound key. The API validates the
+          declared commitments and graph bindings without reproducing the build.
         </p>
         <p>
-          The API key cannot sign or broadcast. The controller wallet must
-          review and confirm the prepared launch separately.
+          A prepared result contains the artifact but no wallet transaction.
+          After authorization, the controller wallet must review, sign and
+          broadcast the exact transaction separately. The API key cannot do so.
         </p>
         <p className={styles.inlineAction}>
           <Link href="/docs/creators/launch">
@@ -114,8 +113,10 @@ export default function CreatorsDocsPage() {
         <h2>Checks and wallet action</h2>
         <p>
           The Custom Launch API checks one deterministic bundle and prepares an
-          exact wallet action. A future template program would separately bind
-          one reusable version, parameter range and payout identity.
+          exact artifact. After platform authorization, it exposes the exact
+          transaction for separate wallet review. A future template program
+          would separately bind one reusable version, parameter range and payout
+          identity.
         </p>
         <p>
           Preparation and wallet execution are separate. An API result does not
@@ -146,15 +147,15 @@ export default function CreatorsDocsPage() {
         <ul className={styles.linkList}>
           <li>
             <a
-              href={PROGRAMMABLE_PUBLIC_REPOSITORIES.hookbuilder}
+              href="https://github.com/0xprogrammable/Hookbuilder-Skill"
               rel="noreferrer"
               target="_blank"
             >
               <span>
-                <strong>Hook Builder</strong>
+                <strong>Hookbuilder-Skill</strong>
                 <small>
-                  The skill and local tools for building a reproducible Uniswap
-                  v4 project.
+                  A starting point for building and testing a Uniswap v4
+                  project; the API schema defines launch packaging.
                 </small>
               </span>
               <ArrowUpRight aria-hidden="true" size={17} strokeWidth={1.8} />

--- a/app/docs/creators/programs/page.tsx
+++ b/app/docs/creators/programs/page.tsx
@@ -50,7 +50,7 @@ export default function CreatorProgramsDocsPage() {
       <section id="contributions">
         <h2>Contributions</h2>
         <p>
-          Builders can improve the public product, Hook Builder, developer
+          Builders can improve the public product, Hookbuilder-Skill, developer
           references and submission workflows through their respective
           repositories. A contribution is reviewed against that
           repository&apos;s scope and rules.
@@ -68,10 +68,10 @@ export default function CreatorProgramsDocsPage() {
             Product repository
           </DocsExternalLink>
           <DocsExternalLink
-            href={PROGRAMMABLE_PUBLIC_REPOSITORIES.hookbuilder}
+            href="https://github.com/0xprogrammable/Hookbuilder-Skill"
             variant="chip"
           >
-            Hook Builder
+            Hookbuilder-Skill
           </DocsExternalLink>
           <DocsExternalLink
             href={PROGRAMMABLE_PUBLIC_REPOSITORIES.developers}

--- a/app/docs/developers/custom-launch/page.tsx
+++ b/app/docs/developers/custom-launch/page.tsx
@@ -111,9 +111,9 @@ export default function CustomLaunchApiDocsPage() {
         <div className={styles.sectionIntro}>
           <h2>Quickstart</h2>
           <p>
-            The API validates one wallet-bound request and prepares an exact
-            artifact. The API key never authorizes, signs or broadcasts the
-            wallet transaction.
+            Create a key, generate <code>launch.json</code> from the built
+            project, submit it and wait for the controller wallet transaction.
+            The API key never signs or broadcasts that transaction.
           </p>
         </div>
 
@@ -123,47 +123,33 @@ export default function CustomLaunchApiDocsPage() {
             <a href="https://github.com/0xprogrammable/Hookbuilder-Skill">
               Hookbuilder-Skill
             </a>{" "}
-            is an optional starting point for the project; it is not a
-            substitute for the API schema or project-specific packaging.
+            is an optional way to build and check the project.
           </li>
           <li>
-            Use the project&apos;s packaging tooling to derive the source
-            descriptor, sorted source manifest, executable graph and evidence
-            digests from the exact artifacts being launched.
+            Generate <code>launch.json</code> from that exact build with the
+            project&apos;s packaging tooling, then validate it against the{" "}
+            <a href="/openapi/custom-launch-v1.json">OpenAPI contract</a>.
           </li>
           <li>
             Connect the controller wallet at{" "}
-            <Link href="/developers/api-keys">Custom Launch API keys</Link>,
-            create a key and copy the secret when it is shown.
+            <Link href="/developers/api-keys">API keys</Link>, create a key and
+            submit <code>launch.json</code> with a stable idempotency key.
           </li>
           <li>
-            Validate <code>launch.json</code> against the{" "}
-            <a href="/openapi/custom-launch-v1.json">
-              standalone OpenAPI contract
-            </a>
-            , then submit it with a stable idempotency key.
-          </li>
-          <li>
-            Poll the single-request route. Do not hand a transaction to the
-            wallet while the request is only <code>prepared</code>. Wait for{" "}
-            <code>authorized</code>, then inspect{" "}
-            <code>output.walletTransaction</code> and the attached permit.
-          </li>
-          <li>
-            The controller wallet separately reviews, signs and broadcasts that
-            exact transaction. Continue polling until the request is{" "}
-            <code>finalized</code> or terminally failed.
+            Poll the request until it is <code>authorized</code>. The controller
+            wallet then reviews, signs and broadcasts{" "}
+            <code>output.walletTransaction</code>. Keep polling until the request
+            is <code>finalized</code> or terminally failed.
           </li>
         </ol>
 
         <aside className={styles.callout}>
           <strong>Generate the request from the exact project</strong>
           <p>
-            The docs do not publish a hand-written launch fixture. A valid graph
-            contains project-specific bytecode, address locators, permission
-            bits and digests. Generate those values with the project&apos;s
-            packaging tooling and validate them against OpenAPI. Do not copy
-            test-only hashes or invent them by hand.
+            <code>launch.json</code> contains project-specific bytecode,
+            addresses, permission bits and hashes from one exact build.
+            Generate it from the project being launched.{" "}
+            {"Do not copy test-only hashes or another project's file."}
           </p>
         </aside>
 

--- a/app/docs/developers/custom-launch/page.tsx
+++ b/app/docs/developers/custom-launch/page.tsx
@@ -1,0 +1,439 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import styles from "@/components/developer-docs.module.css";
+import { DocsShell } from "@/components/docs-shell";
+
+export const metadata: Metadata = {
+  title: "Custom Launch API · Programmable",
+  description:
+    "Authenticate, submit and track one wallet-bound Custom launch through the V1 API.",
+  alternates: { canonical: "/docs/developers/custom-launch" },
+};
+
+const customLaunchSections = [
+  { id: "quickstart", label: "Quickstart" },
+  { id: "authentication", label: "Authentication" },
+  { id: "request", label: "Request contract" },
+  { id: "checks", label: "Attested checks" },
+  { id: "submit", label: "Submit and retry" },
+  { id: "lifecycle", label: "Lifecycle" },
+  { id: "discovery", label: "Explore, Profile and claims" },
+  { id: "errors", label: "Errors" },
+  { id: "extensions", label: "Future extensions" },
+] as const;
+
+const requestFields = [
+  ["schemaVersion", "programmable.custom-launch-create-request.v1"],
+  ["launchWallet", "The Ethereum wallet bound to the API key"],
+  ["chainId", "String 1"],
+  ["nonce", "A nonzero lowercase bytes32"],
+  ["sourceDescriptor", "One DeterministicSourceBundleV2 descriptor"],
+  [
+    "sourceBundleManifest",
+    "One complete, non-empty, UTF-8 path-sorted SourceBundleManifestV2",
+  ],
+  ["graphBundle", "One executable CustomGraphBundleV1"],
+  ["agentAttestation", "One self-attestation for the exact graph subject"],
+] as const;
+
+const lifecycle = [
+  ["received", "The request is durably accepted."],
+  ["validating", "Request and graph validation are running."],
+  [
+    "prepared",
+    "The exact artifact exists. output.signedPermit and output.walletTransaction are both null. There is nothing for the wallet to sign yet.",
+  ],
+  [
+    "authorized",
+    "The platform permit and exact output.walletTransaction exist. The controller wallet has not signed or broadcast it.",
+  ],
+  [
+    "submitted",
+    "Canonical Router event and same-block getter evidence match below 64 confirmations.",
+  ],
+  [
+    "finalized",
+    "The matching canonical evidence has at least 64 confirmations.",
+  ],
+  [
+    "failed / cancelled",
+    "The request is terminal. Read failure before deciding whether to create a new request.",
+  ],
+] as const;
+
+const errors = [
+  [
+    "400",
+    "Fix malformed JSON, fields, query values or the idempotency key before retrying.",
+  ],
+  ["401", "Use an active, unexpired and unrevoked pm_live_ key."],
+  [
+    "403",
+    "Use a key with the required scope and the exact wallet named by the request.",
+  ],
+  [
+    "404",
+    "Verify the request UUID and key. Do not infer whether another wallet owns that ID.",
+  ],
+  [
+    "409",
+    "Replay an ambiguous request with its original body. For nonce conflict or permit expiry, use a new nonce and idempotency key as directed by the error code.",
+  ],
+  ["413", "Reduce the body below 2 MiB."],
+  ["415", "Send Content-Type: application/json."],
+  [
+    "422",
+    "Fix the reported manifest, graph, attestation or permit binding. Do not retry unchanged.",
+  ],
+  [
+    "429",
+    "Honor Retry-After. An exact replay does not consume reservation quota.",
+  ],
+  [
+    "503",
+    "Retry later. If create is ambiguous, keep the same idempotency key and identical body.",
+  ],
+] as const;
+
+export default function CustomLaunchApiDocsPage() {
+  return (
+    <DocsShell
+      currentPath="/docs/developers/custom-launch"
+      description="Submit one deterministic launch request, wait for an authorized wallet transaction and track the exact onchain result."
+      kicker="Developer integration"
+      parentHref="/docs/developers"
+      parentLabel="Developers"
+      sections={customLaunchSections}
+      title="Custom Launch API"
+    >
+      <section id="quickstart">
+        <div className={styles.sectionIntro}>
+          <h2>Quickstart</h2>
+          <p>
+            The API validates one wallet-bound request and prepares an exact
+            artifact. The API key never authorizes, signs or broadcasts the
+            wallet transaction.
+          </p>
+        </div>
+
+        <ol className={styles.steps}>
+          <li>
+            Build and test the hook and every launch component. The{" "}
+            <a href="https://github.com/0xprogrammable/Hookbuilder-Skill">
+              Hookbuilder-Skill
+            </a>{" "}
+            is an optional starting point for the project; it is not a
+            substitute for the API schema or project-specific packaging.
+          </li>
+          <li>
+            Use the project&apos;s packaging tooling to derive the source
+            descriptor, sorted source manifest, executable graph and evidence
+            digests from the exact artifacts being launched.
+          </li>
+          <li>
+            Connect the controller wallet at{" "}
+            <Link href="/developers/api-keys">Custom Launch API keys</Link>,
+            create a key and copy the secret when it is shown.
+          </li>
+          <li>
+            Validate <code>launch.json</code> against the{" "}
+            <a href="/openapi/custom-launch-v1.json">
+              standalone OpenAPI contract
+            </a>
+            , then submit it with a stable idempotency key.
+          </li>
+          <li>
+            Poll the single-request route. Do not hand a transaction to the
+            wallet while the request is only <code>prepared</code>. Wait for{" "}
+            <code>authorized</code>, then inspect{" "}
+            <code>output.walletTransaction</code> and the attached permit.
+          </li>
+          <li>
+            The controller wallet separately reviews, signs and broadcasts that
+            exact transaction. Continue polling until the request is{" "}
+            <code>finalized</code> or terminally failed.
+          </li>
+        </ol>
+
+        <aside className={styles.callout}>
+          <strong>Generate the request from the exact project</strong>
+          <p>
+            The docs do not publish a hand-written launch fixture. A valid graph
+            contains project-specific bytecode, address locators, permission
+            bits and digests. Generate those values with the project&apos;s
+            packaging tooling and validate them against OpenAPI. Do not copy
+            test-only hashes or invent them by hand.
+          </p>
+        </aside>
+
+        <p className={styles.inlineAction}>
+          <a href="/developers/custom-launch-api-v1.md">Open the raw V1 guide</a>
+        </p>
+      </section>
+
+      <section id="authentication">
+        <div className={styles.sectionIntro}>
+          <h2>Keep wallet and API authentication separate</h2>
+        </div>
+
+        <ul className={styles.checkList}>
+          <li>
+            Connect the controller wallet on <code>programmable.market</code> to
+            create, list or revoke its keys.
+          </li>
+          <li>
+            Send <code>Authorization: Bearer pm_live_...</code> only to{" "}
+            <code>https://api.programmable.market</code>.
+          </li>
+          <li>
+            Do not send the website wallet session token to the Custom Launch
+            API.
+          </li>
+          <li>
+            V1 keys have <code>custom-launch:create</code> and{" "}
+            <code>custom-launch:read</code>. A key can access only requests owned
+            by its bound wallet.
+          </li>
+          <li>
+            Store the secret outside source control and logs. Key lists never
+            return the full secret again.
+          </li>
+        </ul>
+
+        <p className={styles.bodyCopy}>
+          The V1 contract states a 90-day default expiry, a 366-day maximum and
+          no more than 10 active keys per wallet.
+        </p>
+      </section>
+
+      <section id="request">
+        <div className={styles.sectionIntro}>
+          <h2>Use the closed request contract</h2>
+          <p>
+            <code>POST /v1/custom-launches</code> accepts a JSON object up to 2
+            MiB with all eight fields.
+          </p>
+        </div>
+
+        <dl className={`${styles.dataList} ${styles.technicalData}`}>
+          {requestFields.map(([field, requirement]) => (
+            <div key={field}>
+              <dt>
+                <code>{field}</code>
+              </dt>
+              <dd>{requirement}</dd>
+            </div>
+          ))}
+        </dl>
+
+        <p className={styles.bodyCopy}>
+          The platform recomputes the manifest digest and checks that the source
+          descriptor, manifest and graph name the same source bundle. The graph
+          accepts 1 to 16 acyclic targets, exactly one token target and one hook
+          target. The complete graph input is limited to 524,288 bytes;
+          per-target init code is limited to 49,152 bytes and initializer
+          calldata to 131,072 bytes. Use the{" "}
+          <a href="/openapi/custom-launch-v1.json">OpenAPI contract</a> for every
+          nested field, enum and bound.
+        </p>
+
+        <aside className={styles.callout}>
+          <strong>Validation is not source verification</strong>
+          <p>
+            The platform does not fetch source files, reproduce dependencies,
+            compile the project, prove source-to-bytecode correspondence,
+            simulate the transaction, audit the project or attest safety.
+          </p>
+        </aside>
+      </section>
+
+      <section id="checks">
+        <div className={styles.sectionIntro}>
+          <h2>Attest the checks you ran</h2>
+          <p>
+            <code>agentAttestation</code> requires the exact schema version,
+            canonical graph hash, agent identifier, canonical UTC timestamp and
+            1 to 64 unique <code>{"{ checkId, evidenceSha256 }"}</code> entries.
+          </p>
+        </div>
+
+        <p className={styles.bodyCopy}>
+          V1 does not publish a universal check-ID catalog or define
+          project-independent pass/fail semantics for those IDs. The submitting
+          workflow chooses stable IDs for checks it actually ran, preserves the
+          underlying evidence and attests each <code>sha256:</code> digest.
+          Programmable validates shape, digest presence and graph-subject
+          binding; it does not fetch or assess the evidence or adopt the
+          attestation as its own claim.
+        </p>
+      </section>
+
+      <section id="submit">
+        <div className={styles.sectionIntro}>
+          <h2>Submit and retry safely</h2>
+          <p>
+            <code>Idempotency-Key</code> must contain 16 to 128 characters from{" "}
+            <code>[A-Za-z0-9._:-]</code>.
+          </p>
+        </div>
+
+        <ul className={styles.checkList}>
+          <li>A new request returns <code>202</code>.</li>
+          <li>
+            An identical replay may return <code>200</code> with the original
+            resource.
+          </li>
+          <li>
+            After an ambiguous timeout or <code>503</code>, retry with the same
+            key and byte-identical body.
+          </li>
+          <li>
+            Reusing the key with a changed body returns{" "}
+            <code>409 IDEMPOTENCY_CONFLICT</code>.
+          </li>
+          <li>
+            A conflicting wallet nonce returns <code>409 NONCE_CONFLICT</code>.
+            An expired permit requires a new request with a new nonce and
+            idempotency key.
+          </li>
+        </ul>
+
+        <p className={styles.bodyCopy}>
+          The V1 contract states limits of 30 new reservations per rolling hour
+          and 100 per rolling day for the wallet principal and route. Exact
+          idempotent replays bypass quota. For <code>429</code>, wait for the{" "}
+          <code>Retry-After</code> delay.
+        </p>
+      </section>
+
+      <section id="lifecycle">
+        <div className={styles.sectionIntro}>
+          <h2>Track the resource, not an assumed transaction</h2>
+          <p>
+            Read <code>GET /v1/custom-launches/{"{launchId}"}</code> with the same
+            Bearer key. The path value and resource <code>requestId</code> are
+            the API request UUID; <code>onchainLaunchId</code> is the distinct
+            Router <code>bytes32</code> identifier.
+          </p>
+        </div>
+
+        <dl className={styles.resultList}>
+          {lifecycle.map(([status, meaning]) => (
+            <div key={status}>
+              <dt>
+                <code>{status}</code>
+              </dt>
+              <dd>{meaning}</dd>
+            </div>
+          ))}
+        </dl>
+
+        <p className={styles.bodyCopy}>
+          After wallet broadcast, poll the single-resource route to drive exact
+          reconciliation. <code>GET /v1/custom-launches</code> is a newest-first
+          wallet-owned history view with bounded summaries; its{" "}
+          <code>output</code> is always <code>null</code>. Use the single-resource
+          route for the artifact, wallet transaction and durable failure.
+        </p>
+
+        <aside className={styles.callout}>
+          <strong>API access is not wallet authorization</strong>
+          <p>
+            The API key authorizes only the API request. It is never proof that
+            the controller wallet approved the transaction.
+          </p>
+        </aside>
+      </section>
+
+      <section id="discovery">
+        <div className={styles.sectionIntro}>
+          <h2>Keep discovery and claims separate</h2>
+        </div>
+
+        <ul className={styles.checkList}>
+          <li>
+            A finalized Router launch is eligible for Explore and the connected
+            wallet&apos;s Profile after website discovery data refreshes. Finality
+            is not an immediate listing SLA.
+          </li>
+          <li>
+            Router provenance does not require a Custom Registry record.
+            Third-party discovery remains controlled by each indexer.
+          </li>
+          <li>
+            Router provenance alone does not create a claim route. Only
+            explicitly supported fee models appear in the current website claim
+            flow; an arbitrary Custom hook is not automatically claimable.
+          </li>
+          <li>
+            V1 scopes <code>fees:claim</code> and{" "}
+            <code>buybacks:manage</code> are reserved and disabled.
+          </li>
+        </ul>
+      </section>
+
+      <section id="errors">
+        <div className={styles.sectionIntro}>
+          <h2>Handle errors by status and code</h2>
+        </div>
+
+        <dl className={styles.resultList}>
+          {errors.map(([status, recovery]) => (
+            <div key={status}>
+              <dt>
+                <code>{status}</code>
+              </dt>
+              <dd>{recovery}</dd>
+            </div>
+          ))}
+        </dl>
+
+        <p className={styles.bodyCopy}>
+          In an HTTP error, <code>error.requestId</code> is a correlation ID for
+          that response. It is not the Custom launch resource{" "}
+          <code>requestId</code>. A resource-level <code>failure</code> is the
+          durable lifecycle failure for that launch request.
+        </p>
+      </section>
+
+      <section id="extensions">
+        <div className={styles.sectionIntro}>
+          <h2>Treat future capabilities as separate contracts</h2>
+          <p>
+            Only operations and scopes in the current OpenAPI contract are
+            active. New scopes or endpoints require an explicit contract update,
+            and existing keys do not gain a newly enabled scope automatically.
+          </p>
+        </div>
+
+        <p className={styles.bodyCopy}>
+          Wallet signing, fee claims, buyback management, reusable-template
+          publication and source review are not granted by the V1 Custom Launch
+          API.
+        </p>
+      </section>
+
+      <nav
+        aria-label="Continue developer integration"
+        className={styles.nextLinks}
+      >
+        <p>Continue</p>
+        <ul>
+          <li>
+            <Link href="/developers/api-keys">Create or manage API keys</Link>
+          </li>
+          <li>
+            <a href="/openapi/custom-launch-v1.json">Open the V1 contract</a>
+          </li>
+          <li>
+            <Link href="/docs/developers/verify">Verify a token or pool</Link>
+          </li>
+          <li>
+            <Link href="/docs/developers/indexing">Index new launches</Link>
+          </li>
+        </ul>
+      </nav>
+    </DocsShell>
+  );
+}

--- a/app/docs/developers/machine-readable/page.tsx
+++ b/app/docs/developers/machine-readable/page.tsx
@@ -46,6 +46,15 @@ export default function MachineReadableDocsPage() {
 
         <ul className={styles.linkList}>
           <li>
+            <Link href="/docs/developers/custom-launch">
+              Custom Launch API guide
+            </Link>
+            <span>
+              Canonical human guide for authentication, request construction,
+              lifecycle, errors, discovery and claims.
+            </span>
+          </li>
+          <li>
             <a href="/openapi.json">
               <code>/openapi.json</code>
             </a>
@@ -69,8 +78,7 @@ export default function MachineReadableDocsPage() {
               <code>/developers/custom-launch-api-v1.md</code>
             </a>
             <span>
-              Concise agent guide for required bundle evidence, idempotency and
-              wallet handoff.
+              Existing raw guide for agent and script compatibility.
             </span>
           </li>
           <li>
@@ -208,9 +216,9 @@ export default function MachineReadableDocsPage() {
           <div>
             <dt>Custom Launch API contract</dt>
             <dd>
-              Defines the authenticated request, required manifest and agent
-              evidence, graph constraints, permit binding and wallet handoff.
-              It does not define a safety review.
+              Defines the authenticated request, manifest and attestation
+              shapes, graph constraints, permit binding and wallet handoff. It
+              does not define a universal check-ID catalog or a safety review.
             </dd>
           </div>
           <div>
@@ -244,14 +252,15 @@ export default function MachineReadableDocsPage() {
             bypass launch quota.
           </li>
           <li>
-            The platform validates manifest digest, graph, required agent
+            The platform validates manifest digest, graph, attestation shape,
             evidence digests and permit bindings. It does not compile source,
             simulate the transaction, audit the project or attest safety.
           </li>
           <li>
-            The API key is not wallet signing authority. The bound wallet, or
-            an agent with separate wallet authority, signs and broadcasts the
-            prepared Router action.
+            <code>prepared</code> contains an artifact but no wallet transaction.
+            <code>authorized</code> contains the permit-attached transaction for
+            the bound wallet to review, sign and broadcast. The API key is not
+            wallet authority.
           </li>
           <li>
             <code>GET /v1/custom-launches</code> returns a wallet-owned,
@@ -297,7 +306,9 @@ export default function MachineReadableDocsPage() {
         <p>Continue</p>
         <ul>
           <li>
-            <Link href="/developers/api-keys">Create or manage API keys</Link>
+            <Link href="/docs/developers/custom-launch">
+              Use the Custom Launch API
+            </Link>
           </li>
           <li>
             <Link href="/docs/developers/verify">Verify a token or pool</Link>

--- a/app/docs/developers/page.tsx
+++ b/app/docs/developers/page.tsx
@@ -71,15 +71,20 @@ export default function DeveloperDocsPage() {
         <ul className={styles.taskList}>
           <li id="custom-api">
             <h3>
-              <Link href="/developers/api-keys">Prepare a Custom launch</Link>
+              <Link href="/docs/developers/custom-launch">
+                Prepare a Custom launch
+              </Link>
             </h3>
             <p>
               Create a wallet-bound key, submit one deterministic graph bundle
-              with agent evidence and receive the exact wallet action. The key
-              cannot sign or broadcast.
+              with caller-attested evidence and track it to an authorized wallet
+              transaction. The key cannot authorize, sign or broadcast.
             </p>
-            <Link className={styles.textLink} href="/developers/api-keys">
-              Create or manage API keys
+            <Link
+              className={styles.textLink}
+              href="/docs/developers/custom-launch"
+            >
+              Read the Custom Launch API guide
             </Link>
           </li>
           <li id="identity">
@@ -326,7 +331,9 @@ export default function DeveloperDocsPage() {
         <p>Continue</p>
         <ul>
           <li>
-            <Link href="/developers/api-keys">Prepare a Custom launch</Link>
+            <Link href="/docs/developers/custom-launch">
+              Prepare a Custom launch
+            </Link>
           </li>
           <li>
             <Link href="/docs/developers/verify">Verify a token or pool</Link>

--- a/app/docs/models/[model]/page.tsx
+++ b/app/docs/models/[model]/page.tsx
@@ -389,11 +389,15 @@ function CustomDocs() {
         </p>
         <p>
           Each request binds one source descriptor, manifest digest, graph
-          bundle and controller wallet. The authenticated API prepares the exact
-          wallet action without signing or broadcasting it.
+          bundle and controller wallet. The authenticated API prepares an exact
+          artifact. Only the later <code>authorized</code> state contains the
+          permit-attached wallet transaction, and the API does not wallet-sign
+          or broadcast it.
         </p>
         <p className={styles.inlineAction}>
-          <Link href="/developers/api-keys">Create a Custom launch API key</Link>
+          <Link href="/docs/developers/custom-launch">
+            Read the Custom Launch API guide
+          </Link>
         </p>
       </section>
 
@@ -449,7 +453,8 @@ function CustomDocs() {
       <section id="project-presentation">
         <h2>What preparation does not prove</h2>
         <p>
-          A prepared action does not establish current tradability, liquidity,
+          A prepared artifact is not a wallet transaction or wallet
+          authorization. It does not establish current tradability, liquidity,
           price, pool state, audit coverage, support in an external terminal or
           the behavior of an interface outside the submitted graph. Project
           artwork, descriptions and links do not verify the hook or make another

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -112,15 +112,15 @@ export default function DocsIndexPage() {
             <h3>Creators</h3>
             <p>
               Build a concrete project, prepare it through the Custom Launch API
-              and review the exact wallet action before launch.
+              and review the exact transaction after it is authorized.
             </p>
           </div>
           <div>
             <h3>Builders</h3>
             <p>
-              Use Hook Builder as the skill and tooling layer. It produces the
-              reproducible project that can become a deterministic Custom
-              Launch API bundle.
+              Use Hookbuilder-Skill as an optional project starting point.
+              Derive the launch request with project-specific packaging that
+              follows the Custom Launch API schema.
             </p>
           </div>
           <div>
@@ -151,7 +151,7 @@ export default function DocsIndexPage() {
           </div>
           <div className={docsStyles.flowItem}>
             <span>03</span>
-            <strong>Review the prepared wallet action</strong>
+            <strong>Wait for authorization, then review the transaction</strong>
           </div>
           <div className={docsStyles.flowItem}>
             <span>04</span>
@@ -160,10 +160,11 @@ export default function DocsIndexPage() {
         </div>
 
         <p>
-          Bundle checks and transaction preparation do not sign or broadcast a
-          launch. The controller wallet still reviews the exact action and
-          authorizes any transaction. Public integrations can then verify the
-          resulting onchain record.
+          Bundle checks and artifact preparation do not produce a wallet
+          transaction. Platform authorization attaches the exact transaction,
+          but does not wallet-sign or broadcast it. The controller wallet still
+          reviews and authorizes its own transaction. Public integrations can
+          then verify the resulting onchain record.
         </p>
       </section>
 
@@ -241,8 +242,8 @@ export default function DocsIndexPage() {
               <span>
                 <strong>Creator paths</strong>
                 <small>
-                  Use Hook Builder and the Custom Launch API. The public template
-                  program remains separate and is not open for submissions.
+                  Build the project, package it against the Custom Launch API
+                  schema and keep the closed public-template program separate.
                 </small>
               </span>
               <ArrowRight aria-hidden="true" size={17} strokeWidth={1.8} />
@@ -253,8 +254,8 @@ export default function DocsIndexPage() {
               <span>
                 <strong>Custom Launch API keys</strong>
                 <small>
-                  Create a wallet-bound key for bundle checks and prepared
-                  launches.
+                  Create a wallet-bound key for Custom launch requests and
+                  status reads.
                 </small>
               </span>
               <ArrowRight aria-hidden="true" size={17} strokeWidth={1.8} />

--- a/app/docs/trust/page.tsx
+++ b/app/docs/trust/page.tsx
@@ -47,7 +47,7 @@ export default function TrustDocsPage() {
             <strong>API preparation</strong>
             <span>
               Did the platform validate the declared manifest, graph, evidence
-              digests and wallet binding and return an exact action?
+              digests and wallet binding and prepare the exact artifact?
             </span>
           </li>
           <li>
@@ -93,7 +93,13 @@ export default function TrustDocsPage() {
           </div>
           <div className={docsStyles.fact}>
             <span>Prepared</span>
-            <strong>The exact wallet action exists but is not signed</strong>
+            <strong>
+              The exact artifact exists; the wallet transaction is null
+            </strong>
+          </div>
+          <div className={docsStyles.fact}>
+            <span>Authorized</span>
+            <strong>The exact transaction exists but is not wallet-signed</strong>
           </div>
           <div className={docsStyles.fact}>
             <span>Failed</span>
@@ -103,9 +109,9 @@ export default function TrustDocsPage() {
         <p>
           The platform validates shapes, digests and graph bindings. It does not
           fetch the evidence, reproduce the build, compile or simulate the
-          project, audit it or adopt the agent&apos;s claims. A prepared result is
-          not an approval, endorsement, price opinion or promise that a launch
-          will trade.
+          project, audit it or adopt the agent&apos;s claims. Prepared and
+          authorized results are not an approval, endorsement, price opinion or
+          promise that a launch will trade.
         </p>
       </section>
 

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -10,7 +10,10 @@ import { DEFAULT_EXPLORE_VIEW_SORT } from "@/lib/explore-defaults";
 
 export const dynamic = "force-dynamic";
 
-const INITIAL_EXPLORE_TIMEOUT_MS = 4_000;
+// The route owns an eight-second provider budget. Give it a small response
+// margin so a valid slow read is not aborted and immediately repeated by the
+// browser, while keeping the initial render strictly bounded.
+export const INITIAL_EXPLORE_TIMEOUT_MS = 8_500;
 export const INITIAL_EXPLORE_QUERY = new URLSearchParams({
   q: "",
   sort: DEFAULT_EXPLORE_VIEW_SORT,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -21,6 +21,7 @@ const PUBLIC_ROUTES = [
   "/docs/creators/earnings",
   "/docs/creators/programs",
   "/docs/developers",
+  "/docs/developers/custom-launch",
   "/docs/developers/verify",
   "/docs/developers/indexing",
   "/docs/developers/machine-readable",

--- a/app/token/[address]/page.tsx
+++ b/app/token/[address]/page.tsx
@@ -11,7 +11,10 @@ import { TokenDetailShell } from "@/components/token-detail-shell";
 
 export const dynamic = "force-dynamic";
 
-const INITIAL_TOKEN_DETAIL_TIMEOUT_MS = 4_000;
+// The route owns an eight-second provider budget. Give it a small response
+// margin so a valid slow read is not aborted and immediately repeated by the
+// browser, while keeping the initial render strictly bounded.
+export const INITIAL_TOKEN_DETAIL_TIMEOUT_MS = 8_500;
 
 function unavailableInitialTokenDetailResponse(): TokenDetailInitialResponse {
   return {

--- a/components/create-guide.tsx
+++ b/components/create-guide.tsx
@@ -11,7 +11,7 @@ import { ArrowRight, Check, CircleHelp, Copy, ExternalLink, X } from "lucide-rea
 
 import styles from "@/components/create-guide.module.css";
 
-const BUILD_PROMPT = `Build a Uniswap v4 hook for Programmable. Start from the official Hook Builder at https://github.com/0xprogrammable/hookbuilder. The token should [describe the behavior in plain words]. Keep the project limited to that behavior, add tests, run the applicable local checks, and explain the results. Follow https://programmable.market/developers/custom-launch-api-v1.md to package one deterministic source and graph bundle with the required evidence digests. Use my Programmable API key only for the authenticated request to https://api.programmable.market/v1/custom-launches. Never print the key or store it in source control. Do not sign or broadcast. Stop after the API returns the prepared wallet action so I can review it.`;
+const BUILD_PROMPT = `Build and test a Programmable Uniswap v4 hook for this behavior: [describe the behavior in plain words]. Hookbuilder-Skill at https://github.com/0xprogrammable/Hookbuilder-Skill is an optional project starting point; follow https://programmable.market/docs/developers/custom-launch for the exact packaging and API steps. Derive the request and evidence digests from the exact artifacts, never expose the API key, and never invent check results. Poll the single-request status: prepared has no wallet transaction, so stop at authorized and return the exact transaction and permit for my review. Never sign or broadcast.`;
 
 type CopyState = "idle" | "copied" | "failed";
 
@@ -188,22 +188,28 @@ export function CreateGuide() {
               <div>
                 <h3>Prepare the launch through the API</h3>
                 <p>
-                  Hook Builder packages the project and required evidence. Create
-                  a wallet-bound API key, submit the deterministic bundle to the
-                  Custom Launch API, then review the prepared action in the
-                  controller wallet. The API key cannot sign or broadcast.
+                  Package the request with project-specific tooling that follows
+                  the API schema. Create a wallet-bound API key, submit the
+                  deterministic bundle and wait for <code>authorized</code>. The
+                  controller wallet reviews the exact transaction separately.
+                  A <code>prepared</code> result has no wallet transaction, and
+                  the API key cannot authorize, sign or broadcast.
                 </p>
                 <div className={styles.links}>
                   <a
-                    href="https://github.com/0xprogrammable/hookbuilder/releases/latest"
+                    href="https://github.com/0xprogrammable/Hookbuilder-Skill"
                     target="_blank"
                     rel="noreferrer"
                   >
-                    Open Hookbuilder
+                    Open Hookbuilder-Skill
                     <ExternalLink aria-hidden="true" size={15} strokeWidth={1.8} />
                   </a>
                   <Link href="/developers/api-keys">
                     Create a Custom launch API key
+                    <ArrowRight aria-hidden="true" size={15} strokeWidth={1.8} />
+                  </Link>
+                  <Link href="/docs/developers/custom-launch">
+                    Read the Custom Launch API guide
                     <ArrowRight aria-hidden="true" size={15} strokeWidth={1.8} />
                   </Link>
                 </div>

--- a/components/developer-api-keys.module.css
+++ b/components/developer-api-keys.module.css
@@ -1,20 +1,18 @@
 .page {
-  --api-panel: var(--liquid-glass-surface-background);
-  --api-panel-strong: var(--liquid-glass-surface-background-strong);
-  --api-subtle: var(--liquid-glass-inner-background);
-  --api-line: var(--liquid-glass-border);
+  --api-panel: var(--webde-surface);
+  --api-panel-strong: var(--webde-surface-raised);
+  --api-subtle: var(--webde-surface-raised);
+  --api-line: var(--webde-line);
   max-width: 1180px;
   min-height: calc(100svh - var(--header-height));
   min-width: 0;
   overflow-x: clip;
-  padding-block: 48px 32px;
+  padding-block: 32px 64px;
 }
 
 .hero {
-  display: grid;
-  gap: 32px;
-  grid-template-columns: minmax(0, 1.15fr) minmax(360px, 0.85fr);
-  margin: 0 auto 32px;
+  margin: 0 0 24px;
+  max-width: 720px;
 }
 
 .heroCopy {
@@ -23,7 +21,7 @@
 
 .kicker,
 .accountLabel {
-  color: var(--brand-pink);
+  color: var(--webde-dim);
   font-size: 12px;
   font-weight: 650;
   letter-spacing: 0.08em;
@@ -31,87 +29,50 @@
 }
 
 .hero h1 {
-  color: var(--text);
-  font-size: clamp(48px, 6vw, 72px);
+  color: var(--webde-ink);
+  font-size: clamp(44px, 5vw, 64px);
   font-weight: 580;
   letter-spacing: -0.052em;
-  line-height: 0.98;
-  margin-top: 12px;
-  max-width: 12ch;
+  line-height: 0.95;
+  margin-top: 8px;
   text-wrap: balance;
 }
 
 .intro {
-  color: var(--text-soft);
-  font-size: 18px;
+  color: var(--webde-muted);
+  font-size: 16px;
   line-height: 1.55;
-  margin-top: 24px;
+  margin-top: 14px;
   max-width: 620px;
   text-wrap: pretty;
-}
-
-.launchPath {
-  align-self: end;
-  display: grid;
-  gap: 0;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.launchPath li {
-  align-items: center;
-  border-top: 1px solid var(--api-line);
-  display: grid;
-  gap: 12px;
-  grid-template-columns: 28px minmax(0, 1fr);
-  min-height: 52px;
-  padding: 8px 0;
-}
-
-.launchPath li:last-child {
-  border-bottom: 1px solid var(--api-line);
-}
-
-.launchPath span {
-  color: var(--muted);
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 12px;
-  font-variant-numeric: tabular-nums;
-}
-
-.launchPath strong {
-  color: var(--text-soft);
-  font-size: 14px;
-  font-weight: 570;
 }
 
 .walletGate {
   align-items: center;
   background: var(--api-panel);
   border: 1px solid var(--api-line);
-  border-radius: 24px;
-  box-shadow: var(--liquid-glass-shadow);
+  border-radius: var(--webde-radius-card);
+  box-shadow: none;
   display: flex;
   flex-direction: column;
   justify-content: center;
   margin: 0 auto;
-  max-width: 620px;
-  min-height: 360px;
-  padding: 40px 32px;
+  max-width: 640px;
+  min-height: 280px;
+  padding: 32px;
   text-align: center;
 }
 
 .loopMark {
-  height: 64px;
-  margin-bottom: 24px;
+  height: 52px;
+  margin-bottom: 16px;
   object-fit: contain;
-  width: 52px;
+  width: 40px;
 }
 
 .walletGate h2 {
-  color: var(--text);
-  font-size: 30px;
+  color: var(--webde-ink);
+  font-size: 28px;
   font-weight: 580;
   letter-spacing: -0.035em;
   line-height: 1.08;
@@ -120,16 +81,20 @@
 }
 
 .walletGate p {
-  color: var(--text-soft);
+  color: var(--webde-muted);
   font-size: 16px;
   line-height: 1.55;
-  margin-top: 16px;
+  margin-top: 12px;
   max-width: 460px;
   text-wrap: pretty;
 }
 
 .walletGate .primaryButton {
-  margin-top: 24px;
+  margin-top: 20px;
+}
+
+.walletGate .secondaryButton {
+  margin-top: 20px;
 }
 
 .walletGateMark,
@@ -145,22 +110,22 @@
 }
 
 .walletGateMark {
-  height: 64px;
-  width: 52px;
+  height: 52px;
+  width: 40px;
 }
 
 .walletGateTitle {
-  height: 32px;
-  margin-top: 24px;
-  max-width: 360px;
-  width: 72%;
+  height: 28px;
+  margin-top: 16px;
+  max-width: 320px;
+  width: 68%;
 }
 
 .walletGateLine {
-  height: 16px;
-  margin-top: 16px;
-  max-width: 440px;
-  width: 88%;
+  height: 14px;
+  margin-top: 12px;
+  max-width: 400px;
+  width: 82%;
 }
 
 .accountBar {
@@ -169,9 +134,9 @@
   border-top: 1px solid var(--api-line);
   display: flex;
   justify-content: space-between;
-  margin-bottom: 24px;
-  min-height: 64px;
-  padding-block: 8px;
+  margin-bottom: 12px;
+  min-height: 52px;
+  padding-block: 6px;
 }
 
 .accountBar > div {
@@ -182,7 +147,7 @@
 }
 
 .accountBar code {
-  color: var(--text);
+  color: var(--webde-ink);
   font-family: var(--font-plex-mono), monospace;
   font-size: 13px;
 }
@@ -190,32 +155,58 @@
 .accountActions {
   align-items: center;
   display: flex;
-  gap: 16px;
+  gap: 12px;
 }
 
 .accountActions p {
-  color: var(--muted);
+  color: var(--webde-dim);
   font-size: 13px;
 }
 
-.accountActions a {
-  align-items: center;
-  color: var(--text-soft);
-  display: inline-flex;
-  font-size: 13px;
-  font-weight: 620;
+.sectionSwitch {
+  background: var(--api-panel);
+  border: 1px solid var(--api-line);
+  border-radius: var(--webde-radius-control);
+  display: inline-grid;
+  gap: 4px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-bottom: 16px;
+  padding: 4px;
+}
+
+.sectionSwitch button {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--webde-dim);
+  font-size: 14px;
+  font-weight: 650;
   min-height: 44px;
-  text-decoration: underline;
-  text-underline-offset: 4px;
+  padding-inline: 16px;
+  transition:
+    background-color 180ms cubic-bezier(0.32, 0.72, 0, 1),
+    border-color 180ms cubic-bezier(0.32, 0.72, 0, 1),
+    color 180ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.sectionSwitch button[aria-pressed="true"] {
+  background: var(--webde-control);
+  border-color: var(--webde-line);
+  color: var(--webde-ink);
+}
+
+.sectionSwitch button:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 3px;
 }
 
 .keyReveal {
   background: var(--api-panel-strong);
   border: 1px solid color-mix(in srgb, var(--success) 42%, var(--api-line));
-  border-radius: 20px;
-  box-shadow: var(--liquid-glass-shadow);
-  margin-bottom: 24px;
-  padding: 24px;
+  border-radius: var(--webde-radius-card);
+  box-shadow: none;
+  margin-bottom: 16px;
+  padding: 20px;
 }
 
 .keyReveal:focus-visible {
@@ -225,7 +216,6 @@
 
 .revealHeading,
 .panelHeading,
-.scopeHeading,
 .keyIdentity > div,
 .revokeConfirmation > div {
   align-items: center;
@@ -235,7 +225,7 @@
 
 .revealHeading h2,
 .panelHeading h2 {
-  color: var(--text);
+  color: var(--webde-ink);
   font-size: 24px;
   font-weight: 590;
   letter-spacing: -0.035em;
@@ -250,10 +240,10 @@
 }
 
 .revealWarning {
-  color: var(--text-soft);
+  color: var(--webde-muted);
   font-size: 14px;
   line-height: 1.55;
-  margin-top: 16px;
+  margin-top: 12px;
   max-width: 760px;
   text-wrap: pretty;
 }
@@ -263,14 +253,14 @@
   display: grid;
   gap: 8px;
   grid-template-columns: minmax(0, 1fr) auto;
-  margin-top: 16px;
+  margin-top: 12px;
 }
 
 .secretRow > code {
-  background: #0b141d;
+  background: #111;
   border: 1px solid var(--api-line);
-  border-radius: 12px;
-  color: #f7f1ea;
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-ink);
   font-family: var(--font-plex-mono), monospace;
   font-size: 13px;
   line-height: 1.55;
@@ -282,10 +272,10 @@
 
 .dismissButton {
   background: transparent;
-  color: var(--text-soft);
+  color: var(--webde-muted);
   font-size: 13px;
   font-weight: 620;
-  margin-top: 16px;
+  margin-top: 12px;
   min-height: 44px;
   padding-inline: 0;
   text-decoration: underline;
@@ -293,19 +283,28 @@
 }
 
 .workspace {
-  align-items: start;
+  align-items: stretch;
   display: grid;
-  gap: 20px;
-  grid-template-columns: minmax(300px, 0.78fr) minmax(0, 1.22fr);
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  height: clamp(
+    380px,
+    calc(100svh - var(--header-height) - 282px),
+    440px
+  );
 }
 
 .panel {
   background: var(--api-panel);
   border: 1px solid var(--api-line);
-  border-radius: 20px;
-  box-shadow: var(--liquid-glass-shadow);
+  border-radius: var(--webde-radius-card);
+  box-shadow: none;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   min-width: 0;
-  padding: 24px;
+  overflow: hidden;
+  padding: 22px;
 }
 
 .createPanel,
@@ -313,36 +312,52 @@
   min-width: 0;
 }
 
+.createPanel {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
 .panelHeading {
   gap: 16px;
+  min-height: 48px;
 }
 
 .createForm {
-  margin-top: 24px;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  margin-top: 18px;
+  min-height: 0;
+}
+
+.formFields {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) 168px;
+}
+
+.formFields > div {
+  min-width: 0;
 }
 
 .field {
   display: grid;
   gap: 8px;
-  margin-top: 20px;
-}
-
-.field:first-child {
-  margin-top: 0;
+  margin: 0;
 }
 
 .field > span {
-  color: var(--text);
+  color: var(--webde-ink);
   font-size: 14px;
   font-weight: 620;
 }
 
 .field input,
 .field select {
-  background: var(--liquid-glass-control-background);
-  border: 1px solid var(--liquid-glass-border);
-  border-radius: 12px;
-  color: var(--text);
+  background: var(--webde-control);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-ink);
   font-size: 16px;
   min-height: 48px;
   padding-inline: 12px;
@@ -357,49 +372,47 @@
   border-color: var(--danger);
 }
 
-.fieldHelp,
 .inlineError {
   font-size: 12px;
+  color: var(--danger);
   line-height: 1.5;
   margin-top: 8px;
 }
 
-.fieldHelp {
-  color: var(--muted);
-}
-
-.inlineError {
-  color: var(--danger);
-}
-
 .scopeLedger {
   border: 1px solid var(--api-line);
-  border-radius: 14px;
-  margin-top: 24px;
-  padding: 16px;
+  border-radius: var(--webde-radius-control);
+  margin-top: 16px;
+  overflow: hidden;
 }
 
-.scopeHeading {
+.scopeLedger summary {
+  align-items: center;
+  color: var(--webde-muted);
+  cursor: pointer;
+  display: flex;
   gap: 12px;
+  justify-content: space-between;
+  min-height: 44px;
+  padding: 10px 14px;
 }
 
-.scopeHeading span,
-.scopeHeading strong {
+.scopeLedger summary span,
+.scopeLedger summary strong {
   font-size: 12px;
 }
 
-.scopeHeading span {
-  color: var(--text-soft);
+.scopeLedger summary span {
+  color: var(--webde-muted);
   font-weight: 620;
 }
 
-.scopeHeading strong {
-  color: var(--muted);
+.scopeLedger summary strong {
+  color: var(--webde-dim);
   font-weight: 500;
 }
 
 .scopeLedger ul,
-.keyScopes,
 .keyList {
   list-style: none;
   margin: 0;
@@ -409,27 +422,26 @@
 .scopeLedger ul {
   display: grid;
   gap: 8px;
-  margin-top: 14px;
+  padding: 0 14px 14px;
 }
 
 .scopeLedger li {
-  color: var(--text);
+  color: var(--webde-ink);
   font-size: 12px;
   min-width: 0;
 }
 
 .scopeLedger code,
-.keyScopes code,
 .keyIdentity > code {
   font-family: var(--font-plex-mono), monospace;
   overflow-wrap: anywhere;
 }
 
 .securityNote {
-  color: var(--text-soft);
+  color: var(--webde-muted);
   font-size: 13px;
   line-height: 1.55;
-  margin-top: 16px;
+  margin-top: 12px;
   text-wrap: pretty;
 }
 
@@ -439,7 +451,7 @@
 .revokeButton,
 .textButton {
   align-items: center;
-  border-radius: 12px;
+  border-radius: var(--webde-radius-control);
   display: inline-flex;
   font-size: 14px;
   font-weight: 650;
@@ -454,20 +466,20 @@
 }
 
 .primaryButton {
-  background: var(--brand-pink-action);
-  border: 1px solid var(--brand-pink-action);
-  color: var(--brand-pink-ink);
+  background: var(--webde-ink);
+  border: 1px solid var(--webde-ink);
+  color: var(--webde-canvas);
 }
 
 .createForm > .primaryButton {
-  margin-top: 24px;
+  margin-top: auto;
   width: 100%;
 }
 
 .secondaryButton {
-  background: var(--liquid-glass-control-background);
-  border: 1px solid var(--liquid-glass-border);
-  color: var(--text);
+  background: var(--webde-control);
+  border: 1px solid var(--webde-line);
+  color: var(--webde-ink);
 }
 
 .dangerButton {
@@ -480,7 +492,7 @@
 .textButton {
   background: transparent;
   border: 1px solid transparent;
-  color: var(--text-soft);
+  color: var(--webde-muted);
 }
 
 .revokeButton {
@@ -495,20 +507,25 @@
 .secondaryButton:disabled,
 .dangerButton:disabled,
 .textButton:disabled {
-  cursor: not-allowed;
   opacity: 0.58;
 }
 
 .keyList {
+  align-content: start;
   display: grid;
+  flex: 1;
   gap: 12px;
   margin-top: 20px;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-inline-end: 4px;
 }
 
 .keyItem {
   background: var(--api-subtle);
   border: 1px solid var(--api-line);
-  border-radius: 16px;
+  border-radius: 10px;
   min-width: 0;
   padding: 16px;
 }
@@ -525,7 +542,7 @@
 
 .keyIdentity h3,
 .statePanel h3 {
-  color: var(--text);
+  color: var(--webde-ink);
   font-size: 17px;
   font-weight: 590;
   line-height: 1.3;
@@ -534,13 +551,13 @@
 }
 
 .keyIdentity > code {
-  color: var(--muted);
+  color: var(--webde-dim);
   font-size: 12px;
 }
 
 .keyStatus {
   align-items: center;
-  color: var(--muted);
+  color: var(--webde-dim);
   display: inline-flex;
   flex: none;
   font-size: 12px;
@@ -561,7 +578,7 @@
 
 .keyStatus[data-status="revoked"],
 .keyStatus[data-status="expired"] {
-  color: var(--muted);
+  color: var(--webde-dim);
 }
 
 .keyMetadata {
@@ -576,40 +593,28 @@
 }
 
 .keyMetadata dt {
-  color: var(--muted);
+  color: var(--webde-dim);
   font-size: 11px;
   font-weight: 620;
 }
 
 .keyMetadata dd {
-  color: var(--text-soft);
+  color: var(--webde-muted);
   font-size: 12px;
   line-height: 1.45;
   margin: 4px 0 0;
   overflow-wrap: anywhere;
 }
 
-.keyScopes {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 14px;
-  margin-top: 16px;
-}
-
-.keyScopes li {
-  color: var(--text-soft);
-  font-size: 11px;
-}
-
 .revokeConfirmation {
   border: 1px solid color-mix(in srgb, var(--danger) 36%, var(--api-line));
-  border-radius: 12px;
+  border-radius: var(--webde-radius-control);
   margin-top: 16px;
   padding: 12px;
 }
 
 .revokeConfirmation > p:first-child {
-  color: var(--text-soft);
+  color: var(--webde-muted);
   font-size: 13px;
   line-height: 1.5;
 }
@@ -623,14 +628,15 @@
 .statePanel {
   align-items: flex-start;
   display: flex;
+  flex: 1;
   flex-direction: column;
   justify-content: center;
-  min-height: 240px;
-  padding: 32px 8px;
+  min-height: 0;
+  padding: 24px 8px;
 }
 
 .statePanel p {
-  color: var(--text-soft);
+  color: var(--webde-muted);
   font-size: 14px;
   line-height: 1.55;
   margin-top: 8px;
@@ -643,16 +649,19 @@
 }
 
 .skeletonList {
+  align-content: start;
   display: grid;
+  flex: 1;
   gap: 12px;
   margin-top: 20px;
+  min-height: 0;
 }
 
 .skeletonRow {
   background: var(--api-subtle);
   border: 1px solid var(--api-line);
-  border-radius: 16px;
-  min-height: 160px;
+  border-radius: 10px;
+  min-height: 148px;
   padding: 16px;
 }
 
@@ -685,14 +694,15 @@
 
 @media (hover: hover) and (pointer: fine) {
   .primaryButton:not(:disabled):hover {
-    background: var(--brand-pink-hover);
-    border-color: var(--brand-pink-hover);
+    background: #f2f2f2;
+    border-color: #f2f2f2;
     transform: translateY(-1px);
   }
 
   .secondaryButton:not(:disabled):hover,
-  .textButton:not(:disabled):hover {
-    background: var(--liquid-glass-control-background-hover);
+  .textButton:not(:disabled):hover,
+  .sectionSwitch button:not([aria-pressed="true"]):hover {
+    background: var(--webde-control);
   }
 
   .dangerButton:not(:disabled):hover {
@@ -700,9 +710,8 @@
   }
 
   .dismissButton:hover,
-  .revokeButton:hover,
-  .accountActions a:hover {
-    color: var(--text);
+  .revokeButton:hover {
+    color: var(--webde-ink);
   }
 }
 
@@ -711,7 +720,8 @@
 .dangerButton:active,
 .dismissButton:active,
 .revokeButton:active,
-.textButton:active {
+.textButton:active,
+.sectionSwitch button:active {
   transform: scale(0.98);
 }
 
@@ -721,70 +731,41 @@
 .dismissButton:focus-visible,
 .revokeButton:focus-visible,
 .textButton:focus-visible,
-.accountActions a:focus-visible,
+.scopeLedger summary:focus-visible,
 .field input:focus-visible,
 .field select:focus-visible {
   outline: 2px solid var(--focus);
   outline-offset: 3px;
 }
 
-@media (max-width: 900px) {
-  .hero {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .hero h1 {
-    max-width: 13ch;
-  }
-
-  .launchPath {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .launchPath li:nth-child(2) {
-    border-bottom: 1px solid var(--api-line);
-  }
-
+@media (max-width: 760px) {
   .workspace {
     grid-template-columns: minmax(0, 1fr);
+    height: auto;
+  }
+
+  .panel {
+    min-height: 360px;
+    overflow: visible;
   }
 }
 
 @media (max-width: 600px) {
   .page {
-    padding-block: 32px 80px;
-  }
-
-  .accountBar {
-    align-items: stretch;
-    flex-direction: column;
-    gap: 12px;
-  }
-
-  .accountActions {
-    justify-content: space-between;
+    padding-block: 24px 72px;
   }
 
   .hero {
-    gap: 24px;
     margin-bottom: 24px;
   }
 
   .hero h1 {
-    font-size: clamp(44px, 13vw, 60px);
+    font-size: clamp(42px, 13vw, 54px);
   }
 
   .intro {
     font-size: 16px;
     margin-top: 16px;
-  }
-
-  .launchPath {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .launchPath li:nth-child(2) {
-    border-bottom: 0;
   }
 
   .accountBar {
@@ -807,7 +788,16 @@
   }
 
   .walletGate {
-    min-height: 340px;
+    min-height: 260px;
+  }
+
+  .sectionSwitch {
+    display: grid;
+    width: 100%;
+  }
+
+  .formFields {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .secretRow {
@@ -862,7 +852,8 @@
   .dangerButton,
   .dismissButton,
   .revokeButton,
-  .textButton {
+  .textButton,
+  .sectionSwitch button {
     transition: none;
   }
 
@@ -883,7 +874,8 @@
   .keyItem,
   .panel,
   .keyReveal,
-  .walletGate {
+  .walletGate,
+  .sectionSwitch {
     border: 1px solid CanvasText;
   }
 

--- a/components/developer-api-keys.tsx
+++ b/components/developer-api-keys.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Image from "next/image";
-import Link from "next/link";
 import {
   useCallback,
   useEffect,
@@ -33,6 +32,7 @@ type CreatedApiKey = Readonly<{
 
 type ListState = "idle" | "loading" | "ready" | "error";
 type CreateState = "idle" | "creating";
+type ActiveSection = "keys" | "history";
 type DeveloperApiKeysViewProps = Readonly<{
   account: `0x${string}` | null;
   authReady: boolean;
@@ -180,15 +180,18 @@ async function copyToClipboard(value: string) {
 
 function KeyListSkeleton() {
   return (
-    <div className={styles.skeletonList} aria-hidden="true">
-      {[0, 1].map((index) => (
-        <div className={styles.skeletonRow} key={index}>
+    <>
+      <span className={styles.visuallyHidden} role="status">
+        Loading API keys
+      </span>
+      <div className={styles.skeletonList} aria-hidden="true">
+        <div className={styles.skeletonRow}>
           <span className={styles.skeletonTitle} />
           <span className={styles.skeletonLine} />
           <span className={styles.skeletonLineShort} />
         </div>
-      ))}
-    </div>
+      </div>
+    </>
   );
 }
 
@@ -247,6 +250,8 @@ function DeveloperApiKeysView({
   const [revokingId, setRevokingId] = useState<string | null>(null);
   const [revokeError, setRevokeError] = useState("");
   const [statusMessage, setStatusMessage] = useState("");
+  const [activeSection, setActiveSection] = useState<ActiveSection>("keys");
+  const [walletSessionTimedOut, setWalletSessionTimedOut] = useState(false);
   const labelRef = useRef<HTMLInputElement>(null);
   const revealRef = useRef<HTMLDivElement>(null);
   const createButtonRef = useRef<HTMLButtonElement>(null);
@@ -339,6 +344,14 @@ function DeveloperApiKeysView({
     if (confirmingRevokeId) confirmRevokeRef.current?.focus();
   }, [confirmingRevokeId]);
 
+  useEffect(() => {
+    if (authReady) return;
+    const timeoutId = window.setTimeout(() => {
+      setWalletSessionTimedOut(true);
+    }, 8_000);
+    return () => window.clearTimeout(timeoutId);
+  }, [authReady]);
+
   const activeCount = useMemo(
     () => apiKeys.filter((apiKey) => keyStatus(apiKey) === "Active").length,
     [apiKeys],
@@ -355,7 +368,7 @@ function DeveloperApiKeysView({
 
     const cleanLabel = label.trim();
     if (!cleanLabel) {
-      setLabelError("Enter a name that identifies this agent or workflow.");
+      setLabelError("Enter a name for this key.");
       labelRef.current?.focus();
       return;
     }
@@ -426,8 +439,15 @@ function DeveloperApiKeysView({
   const dismissApiKey = () => {
     setCreatedApiKey(null);
     setCopyState("idle");
-    setStatusMessage("The one time key display was cleared.");
+    setStatusMessage("Key hidden.");
     window.setTimeout(() => createButtonRef.current?.focus(), 0);
+  };
+
+  const showSection = (section: ActiveSection) => {
+    setActiveSection(section);
+    setStatusMessage(
+      section === "keys" ? "Showing API keys." : "Showing launch history.",
+    );
   };
 
   const beginRevoke = (apiKeyId: string, trigger: HTMLButtonElement) => {
@@ -500,41 +520,45 @@ function DeveloperApiKeysView({
       <header className={styles.hero}>
         <div className={styles.heroCopy}>
           <p className={styles.kicker}>Developer access</p>
-          <h1>Give your agent a launch key</h1>
+          <h1>API keys</h1>
           <p className={styles.intro}>
-            Create a scoped API key for custom launches. Your agent can submit
-            and read launch preparations, while your wallet keeps control of the
-            final transaction.
+            Create and revoke keys for Custom launch workflows. A key can
+            prepare a launch, but only your wallet can sign it.
           </p>
         </div>
-
-        <ol className={styles.launchPath} aria-label="Custom launch path">
-          <li>
-            <span>1</span>
-            <strong>Connect wallet</strong>
-          </li>
-          <li>
-            <span>2</span>
-            <strong>Give the key to your agent</strong>
-          </li>
-          <li>
-            <span>3</span>
-            <strong>Review the prepared launch</strong>
-          </li>
-          <li>
-            <span>4</span>
-            <strong>Confirm in your wallet</strong>
-          </li>
-        </ol>
       </header>
 
       {!authReady ? (
-        <section className={styles.walletGate} aria-busy="true">
-          <span className={styles.walletGateMark} aria-hidden="true" />
-          <span className={styles.walletGateTitle} aria-hidden="true" />
-          <span className={styles.walletGateLine} aria-hidden="true" />
-          <span className={styles.visuallyHidden}>Loading wallet session</span>
-        </section>
+        walletSessionTimedOut ? (
+          <section className={styles.walletGate} role="alert">
+            <Image
+              className={styles.loopMark}
+              src="/brand/loop/programmable-loop-mark-header-warm-ivory-v1-1536.png"
+              alt=""
+              width={1168}
+              height={1536}
+              sizes="52px"
+            />
+            <h2>Wallet access is unavailable</h2>
+            <p>Reload the page or try again shortly.</p>
+            <button
+              className={styles.secondaryButton}
+              type="button"
+              onClick={() => window.location.reload()}
+            >
+              Reload page
+            </button>
+          </section>
+        ) : (
+          <section className={styles.walletGate} aria-busy="true">
+            <span className={styles.walletGateMark} aria-hidden="true" />
+            <span className={styles.walletGateTitle} aria-hidden="true" />
+            <span className={styles.walletGateLine} aria-hidden="true" />
+            <span className={styles.visuallyHidden} role="status">
+              Loading wallet session
+            </span>
+          </section>
+        )
       ) : !account ? (
         <section className={styles.walletGate} aria-labelledby="connect-title">
           <Image
@@ -543,12 +567,12 @@ function DeveloperApiKeysView({
             alt=""
             width={1168}
             height={1536}
-            sizes="64px"
+            sizes="52px"
           />
-          <h2 id="connect-title">Connect the wallet that owns your keys</h2>
+          <h2 id="connect-title">Connect your wallet</h2>
           <p>
-            Your wallet session controls key creation and revocation. No wallet
-            signature is requested just to manage keys.
+            Use the wallet that will own these keys. Connecting does not request
+            a signature.
           </p>
           <button
             className={styles.primaryButton}
@@ -570,7 +594,6 @@ function DeveloperApiKeysView({
               <p>
                 {activeCount} active {activeCount === 1 ? "key" : "keys"}
               </p>
-              <Link href="/profile">View finalized launches</Link>
             </div>
           </div>
 
@@ -589,9 +612,8 @@ function DeveloperApiKeysView({
                 <span className={styles.oneTimeBadge}>Shown once</span>
               </div>
               <p className={styles.revealWarning}>
-                This secret will not be available again. Store it in your
-                agent&apos;s secret manager. Do not commit it or paste it into a
-                public chat.
+                Copy this secret now. It will not be shown again. Store it in
+                your agent&apos;s secret manager and keep it out of source control.
               </p>
               <div className={styles.secretRow}>
                 <code>{createdApiKey.apiKeySecret}</code>
@@ -618,279 +640,287 @@ function DeveloperApiKeysView({
             </div>
           ) : null}
 
-          <div className={styles.workspace}>
-            <section
-              className={`${styles.panel} ${styles.createPanel}`}
-              aria-labelledby="create-key-title"
+          <div
+            className={styles.sectionSwitch}
+            role="group"
+            aria-label="Developer access view"
+          >
+            <button
+              aria-pressed={activeSection === "keys"}
+              type="button"
+              onClick={() => showSection("keys")}
             >
-              <div className={styles.panelHeading}>
-                <div>
-                  <p className={styles.kicker}>New credential</p>
-                  <h2 id="create-key-title">Create an API key</h2>
-                </div>
-              </div>
+              API keys
+            </button>
+            <button
+              aria-pressed={activeSection === "history"}
+              type="button"
+              onClick={() => showSection("history")}
+            >
+              Launch history
+            </button>
+          </div>
 
-              <form className={styles.createForm} onSubmit={createApiKey}>
-                <label className={styles.field} htmlFor="api-key-label">
-                  <span>Key name</span>
-                  <input
-                    ref={labelRef}
-                    id="api-key-label"
-                    aria-describedby={
-                      labelError ? "api-key-label-error" : "api-key-label-help"
-                    }
-                    aria-invalid={Boolean(labelError)}
-                    autoComplete="off"
-                    maxLength={64}
-                    name="label"
-                    placeholder="Launch agent"
-                    spellCheck={false}
-                    type="text"
-                    value={label}
-                    onChange={(event) => {
-                      setLabel(event.target.value);
-                      if (labelError) setLabelError("");
-                    }}
-                  />
-                </label>
-                <p
-                  className={labelError ? styles.inlineError : styles.fieldHelp}
-                  id={labelError ? "api-key-label-error" : "api-key-label-help"}
-                >
-                  {labelError || "Use a name you will recognize later."}
-                </p>
-
-                <label className={styles.field} htmlFor="api-key-expiry">
-                  <span>Expires after</span>
-                  <select
-                    id="api-key-expiry"
-                    name="expiresInDays"
-                    value={expiresInDays}
-                    onChange={(event) =>
-                      setExpiresInDays(Number(event.target.value))
-                    }
-                  >
-                    {expiryOptions.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <p className={styles.fieldHelp}>
-                  You can revoke the key immediately at any time.
-                </p>
-
-                <div className={styles.scopeLedger}>
-                  <div className={styles.scopeHeading}>
-                    <span>Granted now</span>
-                    <strong>2 scopes</strong>
+          {activeSection === "keys" ? (
+            <div className={styles.workspace}>
+              <section
+                className={`${styles.panel} ${styles.createPanel}`}
+                aria-labelledby="create-key-title"
+              >
+                <div className={styles.panelHeading}>
+                  <div>
+                    <p className={styles.kicker}>New key</p>
+                    <h2 id="create-key-title">Create key</h2>
                   </div>
-                  <ul>
-                    {fixedScopes.map((scope) => (
-                      <li key={scope}>
-                        <code>{scope}</code>
-                      </li>
-                    ))}
-                  </ul>
                 </div>
 
-                <p className={styles.securityNote}>
-                  This key cannot sign or broadcast wallet transactions. Fee
-                  claims and automated buybacks will require separate scopes
-                  when those API operations become available.
-                </p>
+                <form className={styles.createForm} onSubmit={createApiKey}>
+                  <div className={styles.formFields}>
+                    <div>
+                      <label className={styles.field} htmlFor="api-key-label">
+                        <span>Name</span>
+                        <input
+                          ref={labelRef}
+                          id="api-key-label"
+                          aria-describedby={
+                            labelError ? "api-key-label-error" : undefined
+                          }
+                          aria-invalid={Boolean(labelError)}
+                          autoComplete="off"
+                          maxLength={64}
+                          name="label"
+                          placeholder="Launch agent"
+                          spellCheck={false}
+                          type="text"
+                          value={label}
+                          onChange={(event) => {
+                            setLabel(event.target.value);
+                            if (labelError) setLabelError("");
+                          }}
+                        />
+                      </label>
+                      {labelError ? (
+                        <p
+                          className={styles.inlineError}
+                          id="api-key-label-error"
+                        >
+                          {labelError}
+                        </p>
+                      ) : null}
+                    </div>
 
-                {createError ? (
-                  <p className={styles.inlineError} role="alert">
-                    {createError}
+                    <label className={styles.field} htmlFor="api-key-expiry">
+                      <span>Expires after</span>
+                      <select
+                        id="api-key-expiry"
+                        name="expiresInDays"
+                        value={expiresInDays}
+                        onChange={(event) =>
+                          setExpiresInDays(Number(event.target.value))
+                        }
+                      >
+                        {expiryOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  </div>
+
+                  <details className={styles.scopeLedger}>
+                    <summary>
+                      <span>Permissions</span>
+                      <strong>2 launch scopes</strong>
+                    </summary>
+                    <ul>
+                      {fixedScopes.map((scope) => (
+                        <li key={scope}>
+                          <code>{scope}</code>
+                        </li>
+                      ))}
+                    </ul>
+                  </details>
+
+                  <p className={styles.securityNote}>
+                    API keys cannot sign or broadcast wallet transactions.
                   </p>
-                ) : null}
 
-                <button
-                  ref={createButtonRef}
-                  className={styles.primaryButton}
-                  disabled={createState === "creating" || Boolean(createdApiKey)}
-                  type="submit"
-                >
-                  {createState === "creating"
-                    ? "Creating key"
-                    : createdApiKey
-                      ? "Save current key first"
-                      : "Create key"}
-                </button>
-              </form>
-            </section>
+                  {createError ? (
+                    <p className={styles.inlineError} role="alert">
+                      {createError}
+                    </p>
+                  ) : null}
 
-            <section
-              className={`${styles.panel} ${styles.listPanel}`}
-              aria-labelledby="api-keys-title"
-              aria-busy={listState === "loading"}
-            >
-              <div className={styles.panelHeading}>
-                <div>
-                  <p className={styles.kicker}>Credentials</p>
-                  <h2 id="api-keys-title">Your API keys</h2>
-                </div>
-                <button
-                  className={styles.textButton}
-                  disabled={listState === "loading"}
-                  type="button"
-                  onClick={refreshApiKeys}
-                >
-                  Refresh
-                </button>
-              </div>
-
-              {listState === "loading" ? <KeyListSkeleton /> : null}
-
-              {listState === "error" ? (
-                <div className={styles.statePanel} role="alert">
-                  <h3>API keys are unavailable</h3>
-                  <p>{listError}</p>
                   <button
-                    className={styles.secondaryButton}
+                    ref={createButtonRef}
+                    className={styles.primaryButton}
+                    disabled={
+                      createState === "creating" || Boolean(createdApiKey)
+                    }
+                    type="submit"
+                  >
+                    {createState === "creating"
+                      ? "Creating key"
+                      : createdApiKey
+                        ? "Save current key first"
+                        : "Create key"}
+                  </button>
+                </form>
+              </section>
+
+              <section
+                className={`${styles.panel} ${styles.listPanel}`}
+                aria-labelledby="api-keys-title"
+                aria-busy={listState === "loading"}
+              >
+                <div className={styles.panelHeading}>
+                  <div>
+                    <p className={styles.kicker}>Existing</p>
+                    <h2 id="api-keys-title">Your keys</h2>
+                  </div>
+                  <button
+                    className={styles.textButton}
+                    disabled={listState === "loading"}
                     type="button"
                     onClick={refreshApiKeys}
                   >
-                    Try again
+                    Refresh
                   </button>
                 </div>
-              ) : null}
 
-              {listState === "ready" && apiKeys.length === 0 ? (
-                <div className={styles.statePanel}>
-                  <h3>No API keys yet</h3>
-                  <p>
-                    Create a key for the agent or workflow that prepares your
-                    first custom launch.
-                  </p>
-                </div>
-              ) : null}
+                {listState === "loading" ? <KeyListSkeleton /> : null}
 
-              {listState === "ready" && apiKeys.length > 0 ? (
-                <ul className={styles.keyList}>
-                  {apiKeys.map((apiKey) => {
-                    const status = keyStatus(apiKey);
-                    const confirming = confirmingRevokeId === apiKey.id;
-                    const revoking = revokingId === apiKey.id;
-                    return (
-                      <li className={styles.keyItem} key={apiKey.id}>
-                        <div className={styles.keyIdentity}>
-                          <div>
-                            <h3>{apiKey.label}</h3>
-                            <span
-                              className={styles.keyStatus}
-                              data-status={status.toLowerCase()}
-                            >
-                              {status}
-                            </span>
-                          </div>
-                          <code>{displayPrefix(apiKey.keyPrefix)}</code>
-                        </div>
+                {listState === "error" ? (
+                  <div className={styles.statePanel} role="alert">
+                    <h3>Unable to load keys</h3>
+                    <p>{listError}</p>
+                    <button
+                      className={styles.secondaryButton}
+                      type="button"
+                      onClick={refreshApiKeys}
+                    >
+                      Try again
+                    </button>
+                  </div>
+                ) : null}
 
-                        <dl className={styles.keyMetadata}>
-                          <div>
-                            <dt>Created</dt>
-                            <dd>{formatDate(apiKey.createdAt, "Unknown")}</dd>
-                          </div>
-                          <div>
-                            <dt>Expires</dt>
-                            <dd>
-                              {formatDate(apiKey.expiresAt, "Unavailable")}
-                            </dd>
-                          </div>
-                          <div>
-                            <dt>Last used</dt>
-                            <dd>{formatDate(apiKey.lastUsedAt, "Never")}</dd>
-                          </div>
-                          {apiKey.revokedAt ? (
+                {listState === "ready" && apiKeys.length === 0 ? (
+                  <div className={styles.statePanel}>
+                    <h3>No keys yet</h3>
+                    <p>Create a key to start preparing Custom launches.</p>
+                  </div>
+                ) : null}
+
+                {listState === "ready" && apiKeys.length > 0 ? (
+                  <ul className={styles.keyList}>
+                    {apiKeys.map((apiKey) => {
+                      const status = keyStatus(apiKey);
+                      const confirming = confirmingRevokeId === apiKey.id;
+                      const revoking = revokingId === apiKey.id;
+                      return (
+                        <li className={styles.keyItem} key={apiKey.id}>
+                          <div className={styles.keyIdentity}>
                             <div>
-                              <dt>Revoked</dt>
+                              <h3>{apiKey.label}</h3>
+                              <span
+                                className={styles.keyStatus}
+                                data-status={status.toLowerCase()}
+                              >
+                                {status}
+                              </span>
+                            </div>
+                            <code>{displayPrefix(apiKey.keyPrefix)}</code>
+                          </div>
+
+                          <dl className={styles.keyMetadata}>
+                            <div>
+                              <dt>Expires</dt>
                               <dd>
-                                {formatDate(apiKey.revokedAt, "Unavailable")}
+                                {formatDate(apiKey.expiresAt, "Unavailable")}
                               </dd>
                             </div>
-                          ) : null}
-                        </dl>
-
-                        <ul
-                          className={styles.keyScopes}
-                          aria-label="Key scopes"
-                        >
-                          {apiKey.scopes.map((scope) => (
-                            <li key={scope}>
-                              <code>{scope}</code>
-                            </li>
-                          ))}
-                        </ul>
-
-                        {confirming ? (
-                          <div
-                            className={styles.revokeConfirmation}
-                            role="group"
-                            aria-label={`Revoke ${apiKey.label}`}
-                            onKeyDown={(event) => {
-                              if (event.key === "Escape" && !revoking) {
-                                event.preventDefault();
-                                cancelRevoke();
-                              }
-                            }}
-                          >
-                            <p>
-                              Revoke this key? Requests using it will stop
-                              immediately.
-                            </p>
-                            {revokeError ? (
-                              <p className={styles.inlineError} role="alert">
-                                {revokeError}
-                              </p>
-                            ) : null}
                             <div>
-                              <button
-                                className={styles.secondaryButton}
-                                disabled={revoking}
-                                type="button"
-                                onClick={cancelRevoke}
-                              >
-                                Cancel
-                              </button>
-                              <button
-                                ref={confirmRevokeRef}
-                                className={styles.dangerButton}
-                                disabled={revoking}
-                                type="button"
-                                data-confirm-revoke
-                                onClick={() => void revokeApiKey(apiKey)}
-                              >
-                                {revoking ? "Revoking key" : "Revoke key"}
-                              </button>
+                              <dt>Last used</dt>
+                              <dd>{formatDate(apiKey.lastUsedAt, "Never")}</dd>
                             </div>
-                          </div>
-                        ) : status === "Active" ? (
-                          <button
-                            className={styles.revokeButton}
-                            type="button"
-                            onClick={(event) =>
-                              beginRevoke(apiKey.id, event.currentTarget)
-                            }
-                          >
-                            Revoke key
-                          </button>
-                        ) : null}
-                      </li>
-                    );
-                  })}
-                </ul>
-              ) : null}
-            </section>
-          </div>
+                            {apiKey.revokedAt ? (
+                              <div>
+                                <dt>Revoked</dt>
+                                <dd>
+                                  {formatDate(apiKey.revokedAt, "Unavailable")}
+                                </dd>
+                              </div>
+                            ) : null}
+                          </dl>
 
-          <DeveloperLaunchHistory
-            account={account}
-            getAccessToken={getAccessToken}
-            getIdentityToken={getIdentityToken}
-          />
+                          {confirming ? (
+                            <div
+                              className={styles.revokeConfirmation}
+                              role="group"
+                              aria-label={`Revoke ${apiKey.label}`}
+                              onKeyDown={(event) => {
+                                if (event.key === "Escape" && !revoking) {
+                                  event.preventDefault();
+                                  cancelRevoke();
+                                }
+                              }}
+                            >
+                              <p>
+                                Revoke this key? Requests using it will stop
+                                immediately.
+                              </p>
+                              {revokeError ? (
+                                <p className={styles.inlineError} role="alert">
+                                  {revokeError}
+                                </p>
+                              ) : null}
+                              <div>
+                                <button
+                                  className={styles.secondaryButton}
+                                  disabled={revoking}
+                                  type="button"
+                                  onClick={cancelRevoke}
+                                >
+                                  Cancel
+                                </button>
+                                <button
+                                  ref={confirmRevokeRef}
+                                  className={styles.dangerButton}
+                                  disabled={revoking}
+                                  type="button"
+                                  data-confirm-revoke
+                                  onClick={() => void revokeApiKey(apiKey)}
+                                >
+                                  {revoking ? "Revoking key" : "Revoke key"}
+                                </button>
+                              </div>
+                            </div>
+                          ) : status === "Active" ? (
+                            <button
+                              className={styles.revokeButton}
+                              type="button"
+                              onClick={(event) =>
+                                beginRevoke(apiKey.id, event.currentTarget)
+                              }
+                            >
+                              Revoke key
+                            </button>
+                          ) : null}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                ) : null}
+              </section>
+            </div>
+          ) : (
+            <DeveloperLaunchHistory
+              account={account}
+              getAccessToken={getAccessToken}
+              getIdentityToken={getIdentityToken}
+            />
+          )}
         </>
       )}
     </div>

--- a/components/developer-launch-history.module.css
+++ b/components/developer-launch-history.module.css
@@ -1,11 +1,18 @@
 .history {
-  background: var(--liquid-glass-surface-background);
-  border: 1px solid var(--liquid-glass-border);
-  border-radius: 20px;
-  box-shadow: var(--liquid-glass-shadow);
-  margin-top: 20px;
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-card);
+  box-shadow: none;
+  display: flex;
+  flex-direction: column;
+  height: clamp(
+    380px,
+    calc(100svh - var(--header-height) - 282px),
+    440px
+  );
   min-width: 0;
-  padding: 24px;
+  overflow: hidden;
+  padding: 22px;
 }
 
 .heading,
@@ -16,8 +23,12 @@
   justify-content: space-between;
 }
 
+.heading {
+  min-height: 48px;
+}
+
 .kicker {
-  color: var(--brand-pink);
+  color: var(--webde-dim);
   font-size: 12px;
   font-weight: 650;
   letter-spacing: 0.08em;
@@ -25,7 +36,7 @@
 }
 
 .heading h2 {
-  color: var(--text);
+  color: var(--webde-ink);
   font-size: 24px;
   font-weight: 590;
   letter-spacing: -0.035em;
@@ -34,27 +45,34 @@
 }
 
 .intro {
-  color: var(--text-soft);
+  color: var(--webde-muted);
   font-size: 14px;
   line-height: 1.55;
-  margin-top: 12px;
+  margin-top: 8px;
   max-width: 720px;
   text-wrap: pretty;
 }
 
 .launchList {
+  align-content: start;
   display: grid;
+  flex: 1;
   gap: 12px;
   list-style: none;
   margin: 20px 0 0;
-  padding: 0;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-inline-end: 4px;
+  padding-block: 0;
+  padding-inline-start: 0;
 }
 
 .launchItem,
 .skeletonRow {
-  background: var(--liquid-glass-inner-background);
-  border: 1px solid var(--liquid-glass-border);
-  border-radius: 16px;
+  background: var(--webde-surface-raised);
+  border: 1px solid var(--webde-line);
+  border-radius: 10px;
   min-width: 0;
   padding: 16px;
 }
@@ -65,24 +83,15 @@
 
 .launchTopline h3,
 .statePanel h3 {
-  color: var(--text);
+  color: var(--webde-ink);
   font-size: 17px;
   font-weight: 590;
   line-height: 1.3;
 }
 
-.launchTopline code {
-  color: var(--muted);
-  display: block;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 12px;
-  margin-top: 5px;
-  overflow-wrap: anywhere;
-}
-
 .status {
   align-items: center;
-  color: var(--muted);
+  color: var(--webde-dim);
   display: inline-flex;
   flex: none;
   font-size: 12px;
@@ -117,13 +126,13 @@
 }
 
 .metadata dt {
-  color: var(--muted);
+  color: var(--webde-dim);
   font-size: 11px;
   font-weight: 620;
 }
 
 .metadata dd {
-  color: var(--text-soft);
+  color: var(--webde-muted);
   font-size: 12px;
   line-height: 1.45;
   margin: 4px 0 0;
@@ -143,13 +152,13 @@
 }
 
 .transaction {
-  border-top: 1px solid var(--liquid-glass-border);
+  border-top: 1px solid var(--webde-line);
   margin-top: 16px;
   padding-top: 14px;
 }
 
 .transaction summary {
-  color: var(--text-soft);
+  color: var(--webde-muted);
   cursor: pointer;
   font-size: 13px;
   font-weight: 620;
@@ -158,16 +167,16 @@
 }
 
 .transaction p {
-  color: var(--muted);
+  color: var(--webde-dim);
   font-size: 12px;
   line-height: 1.5;
 }
 
 .transaction pre {
-  background: #0b141d;
-  border: 1px solid var(--liquid-glass-border);
-  border-radius: 12px;
-  color: #f7f1ea;
+  background: #111;
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-ink);
   font-family: var(--font-plex-mono), monospace;
   font-size: 11px;
   line-height: 1.55;
@@ -183,7 +192,7 @@
 .secondaryButton,
 .checkButton {
   align-items: center;
-  border-radius: 12px;
+  border-radius: var(--webde-radius-control);
   display: inline-flex;
   font-size: 14px;
   font-weight: 650;
@@ -195,26 +204,25 @@
 .textButton {
   background: transparent;
   border: 1px solid transparent;
-  color: var(--text-soft);
+  color: var(--webde-muted);
 }
 
 .secondaryButton {
-  background: var(--liquid-glass-control-background);
-  border: 1px solid var(--liquid-glass-border);
-  color: var(--text);
+  background: var(--webde-control);
+  border: 1px solid var(--webde-line);
+  color: var(--webde-ink);
   margin-top: 16px;
 }
 
 .checkButton {
   background: transparent;
-  border: 1px solid var(--liquid-glass-border);
-  color: var(--text-soft);
+  border: 1px solid var(--webde-line);
+  color: var(--webde-muted);
   margin-top: 14px;
 }
 
 .secondaryButton:disabled,
 .checkButton:disabled {
-  cursor: not-allowed;
   opacity: 0.58;
 }
 
@@ -229,41 +237,58 @@
 .statePanel {
   align-items: flex-start;
   display: flex;
+  flex: 1;
   flex-direction: column;
   justify-content: center;
-  min-height: 180px;
-  padding: 28px 8px;
+  min-height: 0;
+  padding: 24px 8px;
 }
 
 .statePanel p {
-  color: var(--text-soft);
+  color: var(--webde-muted);
   font-size: 14px;
   line-height: 1.55;
   margin-top: 8px;
 }
 
 .skeletonList {
+  align-content: start;
   display: grid;
+  flex: 1;
   gap: 12px;
   margin-top: 20px;
+  min-height: 0;
 }
 
 .skeletonRow {
   animation: historySkeleton 1.6s cubic-bezier(0.32, 0.72, 0, 1) infinite;
   display: block;
-  min-height: 116px;
+  min-height: 148px;
+}
+
+.visuallyHidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 
 @media (hover: hover) and (pointer: fine) {
   .textButton:hover,
   .secondaryButton:not(:disabled):hover,
   .checkButton:not(:disabled):hover {
-    background: var(--liquid-glass-control-background-hover);
+    background: var(--webde-control);
   }
 }
 
 @media (max-width: 600px) {
   .history {
+    height: auto;
+    min-height: 360px;
+    overflow: visible;
     padding: 20px;
   }
 
@@ -279,6 +304,20 @@
 
   .metadata {
     grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 360px) {
+  .heading {
+    gap: 8px;
+  }
+
+  .heading h2 {
+    font-size: 22px;
+  }
+
+  .textButton {
+    padding-inline: 8px;
   }
 }
 

--- a/components/developer-launch-history.tsx
+++ b/components/developer-launch-history.tsx
@@ -178,11 +178,14 @@ function walletTransaction(launch: LaunchResource) {
 
 function HistorySkeleton() {
   return (
-    <div className={styles.skeletonList} aria-hidden="true">
-      {[0, 1].map((index) => (
-        <span className={styles.skeletonRow} key={index} />
-      ))}
-    </div>
+    <>
+      <span className={styles.visuallyHidden} role="status">
+        Loading launch history
+      </span>
+      <div className={styles.skeletonList} aria-hidden="true">
+        <span className={styles.skeletonRow} />
+      </div>
+    </>
   );
 }
 
@@ -197,6 +200,7 @@ export function DeveloperLaunchHistory({
   const [loadingMore, setLoadingMore] = useState(false);
   const [checkingId, setCheckingId] = useState<string | null>(null);
   const [error, setError] = useState("");
+  const [statusMessage, setStatusMessage] = useState("");
   const requestSequenceRef = useRef(0);
   const loadMoreInFlightRef = useRef(false);
   const checkInFlightRef = useRef(false);
@@ -309,6 +313,7 @@ export function DeveloperLaunchHistory({
       setLaunches((current) => current.map((candidate) =>
         candidate.requestId === updated.requestId ? updated : candidate
       ));
+      setStatusMessage("Launch status updated.");
     } catch (cause) {
       setError(
         cause instanceof Error ? cause.message : "Unable to check launch status.",
@@ -325,19 +330,26 @@ export function DeveloperLaunchHistory({
       aria-busy={state === "loading" || loadingMore}
       aria-labelledby="launch-history-title"
     >
+      <p className={styles.visuallyHidden} role="status" aria-live="polite">
+        {statusMessage}
+      </p>
       <div className={styles.heading}>
         <div>
-          <p className={styles.kicker}>API requests</p>
+          <p className={styles.kicker}>Custom Launch API</p>
           <h2 id="launch-history-title">Launch history</h2>
         </div>
-        <button className={styles.textButton} type="button" onClick={refresh}>
+        <button
+          className={styles.textButton}
+          disabled={state === "loading" || loadingMore}
+          type="button"
+          onClick={refresh}
+        >
           Refresh
         </button>
       </div>
       <p className={styles.intro}>
-        Wallet-owned preparation records. A request is only onchain after the
-        controller wallet signs and broadcasts it. Open a pending request to
-        load its prepared transaction and refresh its exact onchain state.
+        Requests prepared for this wallet. A launch is onchain only after the
+        wallet signs and broadcasts it.
       </p>
 
       {state === "loading" ? <HistorySkeleton /> : null}
@@ -354,8 +366,8 @@ export function DeveloperLaunchHistory({
 
       {state === "ready" && launches.length === 0 ? (
         <div className={styles.statePanel}>
-          <h3>No API launch requests yet</h3>
-          <p>Your agent&apos;s first accepted request will appear here.</p>
+          <h3>No launch requests</h3>
+          <p>Accepted API requests will appear here.</p>
         </div>
       ) : null}
 
@@ -367,10 +379,7 @@ export function DeveloperLaunchHistory({
               <li className={styles.launchItem} key={launch.launchId}>
                 <div className={styles.launchTopline}>
                   <div>
-                    <h3>Custom launch request</h3>
-                    <code title={launch.requestId}>
-                      API request {shortId(launch.requestId)}
-                    </code>
+                    <h3>Request {shortId(launch.requestId)}</h3>
                   </div>
                   <span className={styles.status} data-status={launch.status}>
                     {statusCopy(launch.status)}
@@ -403,8 +412,8 @@ export function DeveloperLaunchHistory({
                 ) : null}
                 {transaction ? (
                   <details className={styles.transaction}>
-                    <summary>Prepared wallet transaction</summary>
-                    <p>Review these exact fields before signing in your wallet.</p>
+                    <summary>Prepared transaction</summary>
+                    <p>Review these fields before signing in your wallet.</p>
                     <pre>{JSON.stringify(transaction, null, 2)}</pre>
                   </details>
                 ) : null}
@@ -416,8 +425,8 @@ export function DeveloperLaunchHistory({
                     onClick={() => void checkOnchainStatus(launch)}
                   >
                     {checkingId === launch.requestId
-                      ? "Loading launch details"
-                      : "Open launch details"}
+                      ? "Checking status"
+                      : "Check onchain status"}
                   </button>
                 ) : null}
               </li>

--- a/components/docs-data.ts
+++ b/components/docs-data.ts
@@ -25,6 +25,7 @@ const tokenModelPaths = [
 ] as const;
 
 const developerReferencePaths = [
+  "/docs/developers/custom-launch",
   "/docs/developers/verify",
   "/docs/developers/indexing",
   "/docs/developers/machine-readable",
@@ -62,7 +63,7 @@ export const docsCategories = [
     relatedPaths: creatorPaths,
   },
   {
-    description: "Verification and indexing",
+    description: "Custom launches, verification and indexing",
     href: "/docs/developers",
     label: "Developers",
     relatedPaths: developerReferencePaths,
@@ -131,6 +132,11 @@ export const docsNavigation: readonly DocsNavigationGroup[] = [
       },
       {
         depth: 1,
+        href: "/docs/developers/custom-launch",
+        label: "Custom Launch API",
+      },
+      {
+        depth: 1,
         href: "/docs/developers/verify",
         label: "Verify a token or pool",
       },
@@ -165,7 +171,7 @@ export const docsSearchItems: DocsSearchItem[] = [
   {
     title: "Launch a project",
     description:
-      "Create an API key, submit a deterministic bundle for checks and review the prepared launch.",
+      "Create an API key, submit a deterministic bundle and review the transaction after authorization.",
     href: "/docs/creators/launch",
   },
   {
@@ -253,8 +259,21 @@ export const docsSearchItems: DocsSearchItem[] = [
   {
     title: "Developer overview",
     description:
-      "Choose the verification or indexing path for a terminal, wallet, scanner or app.",
+      "Prepare a Custom launch or choose a verification and indexing path.",
     href: "/docs/developers",
+  },
+  {
+    title: "Custom Launch API",
+    description:
+      "Authenticate, submit and track one wallet-bound Custom launch.",
+    href: "/docs/developers/custom-launch",
+    keywords: [
+      "custom API",
+      "API key",
+      "idempotency",
+      "agent attestation",
+      "authorized wallet transaction",
+    ],
   },
   {
     title: "Verify a token or pool",

--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -492,8 +492,21 @@
 }
 
 .loadingState {
+  display: grid;
+  gap: 16px;
   min-height: clamp(280px, 46svh, 520px);
   width: 100%;
+}
+
+.loadingStatus {
+  color: var(--explore-ivory-soft);
+  font-size: 13px;
+  margin: 24px 0 0;
+  text-align: center;
+}
+
+.loadingState .runnerGrid {
+  margin-top: 0;
 }
 
 .messageState {
@@ -1467,7 +1480,7 @@
   }
 
   .runnerHeading > span {
-    font-size: 10px;
+    font-size: 11px;
   }
 
   .runnerData {
@@ -1476,7 +1489,7 @@
   }
 
   .runnerData small {
-    font-size: 10px;
+    font-size: 11px;
   }
 
   .runnerData strong {
@@ -1492,7 +1505,7 @@
 
   .runnerCategory,
   .runnerMarketStatus {
-    font-size: 10px;
+    font-size: 11px;
   }
 
   .runnerCategory {
@@ -1512,7 +1525,7 @@
   }
 
   .runnerContract code {
-    font-size: 9px;
+    font-size: 11px;
   }
 
   .runnerCopyButton {

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -1202,7 +1202,12 @@ export function createExploreInitialState(
 ): ExploreState | null {
   if (response === undefined) return null;
   if (!response.ok) {
-    return null;
+    return {
+      phase: "error",
+      message: readApiError(response.body),
+      requestKey: input.requestKey,
+      contentKey: input.contentKey,
+    };
   }
 
   try {
@@ -1251,7 +1256,7 @@ export function handledInitialExploreRequestKey(
   state: ExploreState | null,
   requestKey: string,
 ): string | null {
-  return state?.phase === "ready" ? requestKey : null;
+  return state === null ? null : requestKey;
 }
 
 export function createResponsiveExploreInitialState(
@@ -1265,8 +1270,7 @@ export function createResponsiveExploreInitialState(
   }>,
 ): ExploreState | null {
   if (!input.reuseAvailable || !input.isInitialRequest) return null;
-  const state = createExploreInitialState(response, input);
-  return state?.phase === "ready" ? state : null;
+  return createExploreInitialState(response, input);
 }
 
 type PendingExploreRequest = {
@@ -2001,6 +2005,10 @@ export function exploreTokenCardDescription(token: ExploreEntry) {
     : undefined;
 }
 
+export function formatExploreContractAddress(address: `0x${string}`) {
+  return `${address.slice(0, 6)}…${address.slice(-3)}`;
+}
+
 export function getTokenCards(
   tokens: Array<ExploreEntry | ValuedExploreEntry>,
 ): TokenCard[] {
@@ -2181,7 +2189,7 @@ export function ExploreView({
     }),
   );
   const initialResponseReuseAvailable = useRef(
-    initialState?.phase === "ready",
+    initialState !== null,
   );
   const handledRequestKey = useRef<string | null>(
     handledInitialExploreRequestKey(initialState, requestKey),
@@ -2309,12 +2317,14 @@ export function ExploreView({
         pageSize,
       },
     );
-    if (responsiveInitialState?.phase === "ready") {
+    if (responsiveInitialState !== null) {
       activeExploreContentKey.current = activeRequestContentKey;
-      cacheResolvedExplorePayload(
-        activeRequestContentKey,
-        responsiveInitialState.payload,
-      );
+      if (responsiveInitialState.phase === "ready") {
+        cacheResolvedExplorePayload(
+          activeRequestContentKey,
+          responsiveInitialState.payload,
+        );
+      }
       if (handledRequestKey.current !== requestKey) {
         handledRequestKey.current = requestKey;
         setState(responsiveInitialState);
@@ -2541,9 +2551,9 @@ export function ExploreView({
     ) {
       return (
         <div className={styles.loadingState} aria-busy="true">
-          <span className="sr-only" role="status">
+          <p className={styles.loadingStatus} role="status" aria-live="polite">
             Loading launches
-          </span>
+          </p>
           <ExploreGridSkeleton count={EXPLORE_TOKENS_PER_PAGE} />
         </div>
       );
@@ -2715,7 +2725,7 @@ export function ExploreView({
                 {token.tokenAddress ? (
                   <div className={styles.runnerContract}>
                     <code title={token.tokenAddress}>
-                      {`${token.tokenAddress.slice(0, 6)}…${token.tokenAddress.slice(-4)}`}
+                      {formatExploreContractAddress(token.tokenAddress)}
                     </code>
                     <button
                       className={styles.runnerCopyButton}

--- a/components/generic-launch-directory-v2.module.css
+++ b/components/generic-launch-directory-v2.module.css
@@ -1,24 +1,224 @@
-.page { min-height: 100vh; padding: 9rem max(1.25rem, 6vw) 5rem; background: #f5f2e9; color: #11110f; }
-.header { max-width: 56rem; margin-bottom: 3.5rem; }
-.eyebrow, .cardState { margin: 0 0 .8rem; font: 600 .75rem/1.2 var(--font-mono, monospace); letter-spacing: .12em; text-transform: uppercase; color: #5d5a50; }
-.header h1, .detail h1 { max-width: 14ch; margin: 0; font-size: clamp(2.7rem, 7vw, 6.6rem); line-height: .92; letter-spacing: -.065em; }
-.intro { max-width: 46rem; margin: 1.5rem 0 0; font-size: clamp(1rem, 2vw, 1.3rem); line-height: 1.5; color: #555248; }
-.status { padding: 2rem 0; font-size: 1rem; color: #5d5a50; }
-.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 19rem), 1fr)); gap: 1px; border: 1px solid #cac5b8; background: #cac5b8; }
-.card { min-height: 20rem; padding: 1.5rem; background: #fbf9f3; display: flex; flex-direction: column; }
-.card h2 { margin: 1.2rem 0 .55rem; font-size: 1.4rem; line-height: 1.1; overflow-wrap: anywhere; }
-.card > p:not(.cardState) { margin: 0; color: #6b675d; }
-.cardFacts, .facts { margin: 2rem 0; display: grid; gap: 1rem; }
-.cardFacts div, .facts div { min-width: 0; }
-.cardFacts dt, .facts dt { margin-bottom: .25rem; font-size: .72rem; text-transform: uppercase; letter-spacing: .08em; color: #78746a; }
-.cardFacts dd, .facts dd { margin: 0; font-family: var(--font-mono, monospace); font-size: .82rem; overflow-wrap: anywhere; }
-.cardLink { margin-top: auto; color: inherit; font-weight: 650; text-decoration-thickness: 1px; text-underline-offset: .25em; }
-.back { display: inline-block; margin-bottom: 3rem; color: inherit; }
-.detail { max-width: 72rem; }
-.facts { grid-template-columns: repeat(2, minmax(0, 1fr)); margin-top: 3.5rem; padding: 1.5rem 0; border-block: 1px solid #cac5b8; }
-.actions { display: flex; flex-wrap: wrap; gap: .75rem; margin-top: 2rem; }
-.actions a { display: inline-flex; min-height: 2.9rem; align-items: center; padding: .65rem 1rem; border: 1px solid #11110f; color: inherit; text-decoration: none; }
-.actions a:first-child { background: #11110f; color: #f5f2e9; }
-.actions a:focus-visible, .cardLink:focus-visible, .back:focus-visible { outline: 3px solid #6e5cff; outline-offset: 3px; }
-.srOnly { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
-@media (max-width: 42rem) { .page { padding-top: 6.5rem; } .facts { grid-template-columns: 1fr; } .card { min-height: 17rem; } }
+.page {
+  background: var(--webde-canvas, #080808);
+  color: var(--webde-ink, #f8f0e9);
+  margin: 0 auto;
+  max-width: 1180px;
+  min-height: calc(100svh - var(--header-height));
+  padding: 48px max(20px, 3vw) 72px;
+}
+
+.header {
+  margin-bottom: 32px;
+  max-width: 760px;
+}
+
+.eyebrow,
+.cardState {
+  color: var(--webde-dim, rgb(248 240 233 / 52%));
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 12px;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  margin: 0 0 10px;
+  text-transform: uppercase;
+}
+
+.header h1,
+.detail h1 {
+  font-size: clamp(40px, 5vw, 64px);
+  font-weight: 570;
+  letter-spacing: -0.052em;
+  line-height: 0.98;
+  margin: 0;
+  max-width: 15ch;
+  overflow-wrap: anywhere;
+  text-wrap: balance;
+}
+
+.intro {
+  color: var(--webde-muted, rgb(248 240 233 / 68%));
+  font-size: 15px;
+  line-height: 1.55;
+  margin: 16px 0 0;
+  max-width: 64ch;
+  text-wrap: pretty;
+}
+
+.headerActions,
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.headerActions a,
+.actions a {
+  align-items: center;
+  background: var(--webde-control, #121212);
+  border: 1px solid var(--webde-line, rgb(248 240 233 / 14%));
+  border-radius: var(--webde-radius-control, 12px);
+  color: var(--webde-ink, #f8f0e9);
+  display: inline-flex;
+  font-size: 13px;
+  font-weight: 650;
+  min-height: 44px;
+  padding: 8px 14px;
+  text-decoration: none;
+}
+
+.headerActions a:first-child,
+.actions a:first-child {
+  background: var(--webde-ink, #f8f0e9);
+  border-color: var(--webde-ink, #f8f0e9);
+  color: var(--webde-canvas, #080808);
+}
+
+.status {
+  color: var(--webde-muted, rgb(248 240 233 / 68%));
+  font-size: 14px;
+  padding: 32px 0;
+}
+
+.grid {
+  background: var(--webde-line, rgb(248 240 233 / 14%));
+  border: 1px solid var(--webde-line, rgb(248 240 233 / 14%));
+  border-radius: var(--webde-radius-card, 17px);
+  display: grid;
+  gap: 1px;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
+  overflow: hidden;
+}
+
+.card {
+  background: var(--webde-surface, #0d0d0d);
+  display: flex;
+  flex-direction: column;
+  min-height: 280px;
+  padding: 22px;
+}
+
+.card h2 {
+  font-size: 18px;
+  font-weight: 620;
+  line-height: 1.25;
+  margin: 18px 0 6px;
+  overflow-wrap: anywhere;
+}
+
+.card > p:not(.cardState) {
+  color: var(--webde-muted, rgb(248 240 233 / 68%));
+  font-size: 13px;
+  margin: 0;
+}
+
+.cardFacts,
+.facts {
+  display: grid;
+  gap: 14px;
+  margin: 24px 0;
+}
+
+.cardFacts div,
+.facts div {
+  min-width: 0;
+}
+
+.cardFacts dt,
+.facts dt {
+  color: var(--webde-dim, rgb(248 240 233 / 52%));
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+
+.cardFacts dd,
+.facts dd {
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 12px;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.cardLink {
+  color: var(--webde-ink, #f8f0e9);
+  font-size: 13px;
+  font-weight: 650;
+  margin-top: auto;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+}
+
+.back {
+  color: var(--webde-muted, rgb(248 240 233 / 68%));
+  display: inline-block;
+  font-size: 13px;
+  margin-bottom: 28px;
+}
+
+.detail {
+  background: var(--webde-surface, #0d0d0d);
+  border: 1px solid var(--webde-line, rgb(248 240 233 / 14%));
+  border-radius: var(--webde-radius-card, 17px);
+  max-width: 960px;
+  padding: clamp(22px, 4vw, 40px);
+}
+
+.facts {
+  border-block: 1px solid var(--webde-line, rgb(248 240 233 / 14%));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 32px;
+  padding: 22px 0;
+}
+
+.headerActions a:focus-visible,
+.actions a:focus-visible,
+.cardLink:focus-visible,
+.back:focus-visible {
+  outline: 2px solid var(--focus, #fff);
+  outline-offset: 3px;
+}
+
+.srOnly {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+@media (hover: hover) {
+  .headerActions a:hover,
+  .actions a:hover {
+    background: var(--webde-surface-raised, #151515);
+    color: var(--webde-ink, #f8f0e9);
+  }
+}
+
+@media (max-width: 620px) {
+  .page {
+    padding: 28px 16px 56px;
+  }
+
+  .header h1,
+  .detail h1 {
+    font-size: clamp(32px, 10vw, 44px);
+  }
+
+  .facts {
+    grid-template-columns: 1fr;
+  }
+
+  .card {
+    min-height: 250px;
+  }
+
+  .headerActions a,
+  .actions a {
+    justify-content: center;
+    width: 100%;
+  }
+}

--- a/components/generic-launch-directory-v2.tsx
+++ b/components/generic-launch-directory-v2.tsx
@@ -41,18 +41,22 @@ export function GenericLaunchDirectoryV2() {
   return (
     <main className={styles.page}>
       <header className={styles.header}>
-        <p className={styles.eyebrow}>Custom launches</p>
-        <h1>Launched from an approved revision.</h1>
+        <p className={styles.eyebrow}>Legacy Custom records</p>
+        <h1>Registry launch history</h1>
         <p className={styles.intro}>
-          Each record joins the signed source revision to its finalized,
-          non-revoked Registry lifecycle.
+          These records come from the retired Registry approval flow. New
+          Custom launches use the Custom Launch API.
         </p>
+        <div className={styles.headerActions}>
+          <Link href="/developers/api-keys">Manage API keys</Link>
+          <Link href="/docs/developers/custom-launch">Read the API guide</Link>
+        </div>
       </header>
       {state.status === "loading" ? (
         <p role="status" className={styles.status}>Loading launch records…</p>
       ) : state.status === "error" ? (
         <p role="status" className={styles.status}>
-          Custom launch records are not active yet.
+          Registry records are unavailable right now.
         </p>
       ) : state.records.length === 0 ? (
         <p role="status" className={styles.status}>No finalized launches yet.</p>
@@ -97,12 +101,12 @@ export function GenericLaunchDetailV2({ recordHash }: { recordHash: string }) {
   const source = record.sourceProjection;
   return (
     <main className={styles.page}>
-      <Link className={styles.back} href="/custom-launches">← Custom launches</Link>
+      <Link className={styles.back} href="/custom-launches">← Registry records</Link>
       <article className={styles.detail} aria-labelledby="launch-title">
-        <p className={styles.eyebrow}>Finalized custom launch</p>
+        <p className={styles.eyebrow}>Legacy Registry launch</p>
         <h1 id="launch-title">{source.sourceRevision.repositoryFullName}</h1>
         <p className={styles.intro}>
-          Approval revision {source.approval.approvalRevision} · source {short(source.sourceRevision.commitObjectId)}
+          Registry approval {source.approval.approvalRevision} · source {short(source.sourceRevision.commitObjectId)}
         </p>
         <dl className={styles.facts}>
           <Fact label="Launch ID" value={source.descriptor.launchId} />
@@ -121,7 +125,7 @@ export function GenericLaunchDetailV2({ recordHash }: { recordHash: string }) {
           <a href={`https://github.com/${source.sourceRevision.repositoryFullName}/tree/${source.sourceRevision.commitObjectId}`} target="_blank" rel="noreferrer">
             View source revision
           </a>
-          <Link href="/launch">Launch a project</Link>
+          <Link href="/developers/api-keys">Manage API keys</Link>
         </div>
       </article>
     </main>

--- a/components/prediction-market-experience.module.css
+++ b/components/prediction-market-experience.module.css
@@ -941,9 +941,9 @@
 }
 
 .portfolioSection {
-  --portfolio-no: #e58d96;
+  --portfolio-no: #ff6475;
   --portfolio-pending: #e6b46f;
-  --portfolio-yes: #72d3a4;
+  --portfolio-yes: #3ee58f;
   background: var(--webde-surface, var(--profile-panel, var(--surface-raised)));
   border: 1px solid var(--webde-line, var(--profile-line, var(--border)));
   border-radius: var(--webde-radius-card, 17px);
@@ -968,16 +968,6 @@
   min-width: 0;
 }
 
-.portfolioEyebrow {
-  color: var(--muted, rgb(255 255 255 / 52%));
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
-  font-weight: 560;
-  letter-spacing: 0.045em;
-  line-height: 1.2;
-  text-transform: uppercase;
-}
-
 .portfolioHeading h2 {
   color: var(--text);
   font-size: 20px;
@@ -996,7 +986,7 @@
   align-items: center;
   display: inline-flex;
   font: inherit;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 620;
   justify-content: center;
   min-height: 44px;
@@ -1041,7 +1031,7 @@
   cursor: pointer;
   display: inline-flex;
   font: inherit;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 620;
   gap: 6px;
   justify-content: center;
@@ -1065,7 +1055,7 @@
   border-radius: 999px;
   display: inline-flex;
   font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
+  font-size: 12px;
   font-variant-numeric: tabular-nums;
   justify-content: center;
   line-height: 1;
@@ -1149,14 +1139,14 @@
 
 .portfolioArtwork span {
   color: var(--muted, rgb(255 255 255 / 58%));
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 640;
   letter-spacing: 0.04em;
   line-height: 1;
 }
 
 .portfolioArtwork strong {
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 680;
   line-height: 1.15;
   margin-block-start: 3px;
@@ -1173,7 +1163,7 @@
   color: var(--text-soft, rgb(255 255 255 / 68%));
   display: flex;
   flex-wrap: wrap;
-  font-size: 11px;
+  font-size: 12px;
   gap: 3px 10px;
   line-height: 1.35;
   min-width: 0;
@@ -1210,13 +1200,13 @@
 
 .portfolioCardStatus small {
   color: var(--muted, rgb(255 255 255 / 52%));
-  font-size: 11px;
+  font-size: 12px;
   font-variant-numeric: tabular-nums;
   overflow-wrap: anywhere;
 }
 
 .portfolioCardCopy h3 {
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 640;
   letter-spacing: -0.012em;
   line-height: 1.4;
@@ -1247,7 +1237,7 @@
   cursor: pointer;
   display: flex;
   font: inherit;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
   justify-content: center;
   margin: 12px auto 0;
@@ -1273,7 +1263,7 @@
 .portfolioHoldings small,
 .portfolioHoldings > small {
   font-family: var(--font-plex-mono), monospace;
-  font-size: 11px;
+  font-size: 12px;
   font-variant-numeric: tabular-nums;
   line-height: 1.3;
 }
@@ -1308,7 +1298,7 @@
 
 .portfolioMetrics dt {
   color: var(--muted, rgb(255 255 255 / 52%));
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 520;
   line-height: 1.3;
 }
@@ -1316,7 +1306,7 @@
 .portfolioMetrics dd {
   color: var(--text, #fff);
   font-family: var(--font-plex-mono), monospace;
-  font-size: 12px;
+  font-size: 13px;
   font-variant-numeric: tabular-nums;
   font-weight: 640;
   line-height: 1.35;
@@ -1334,7 +1324,7 @@
 
 .portfolioMetrics small {
   color: var(--muted, rgb(255 255 255 / 52%));
-  font-size: 11px;
+  font-size: 12px;
   line-height: 1.4;
   margin-block-start: 3px;
   overflow-wrap: break-word;
@@ -1384,7 +1374,7 @@
 .portfolioEmpty strong,
 .portfolioError strong {
   color: var(--text);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 640;
   line-height: 1.35;
 }
@@ -1392,7 +1382,7 @@
 .portfolioEmpty small,
 .portfolioError small {
   color: var(--muted, rgb(255 255 255 / 54%));
-  font-size: 12px;
+  font-size: 13px;
   line-height: 1.45;
   overflow-wrap: break-word;
   text-wrap: pretty;
@@ -1460,7 +1450,7 @@
   border-radius: 10px;
   color: var(--text-soft, rgb(255 255 255 / 76%));
   display: flex;
-  font-size: 12px;
+  font-size: 13px;
   gap: 12px;
   justify-content: space-between;
   line-height: 1.45;
@@ -1838,7 +1828,7 @@
   }
 
   .portfolioTabs button {
-    font-size: 11px;
+    font-size: 12px;
     padding-inline: 5px;
   }
 

--- a/components/prediction-market-portfolio.tsx
+++ b/components/prediction-market-portfolio.tsx
@@ -759,7 +759,6 @@ export function PredictionMarketPortfolio({
 
       <header className={styles.portfolioHeading}>
         <div>
-          <span className={styles.portfolioEyebrow}>Profile activity</span>
           <h2 id="prediction-portfolio-title">Predictions</h2>
         </div>
         {canRefresh ? (

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -87,11 +87,12 @@
   font-weight: 585;
   letter-spacing: -0.042em;
   line-height: 1;
+  max-width: 100%;
   min-width: 0;
-  overflow: hidden;
+  overflow-wrap: anywhere;
   padding-block-end: 0.04em;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  text-wrap: balance;
+  white-space: normal;
 }
 
 .address {
@@ -612,7 +613,7 @@
   border-radius: 10px;
   color: var(--text-soft);
   display: inline-flex;
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 620;
   gap: 6px;
   min-height: 44px;
@@ -1035,7 +1036,7 @@
 }
 
 .claimRow .claimButton {
-  font-size: 11px;
+  font-size: 13px;
   min-height: 44px;
   min-width: 0;
   padding-inline: 10px;
@@ -1079,7 +1080,7 @@
 
 .claimEmpty p {
   color: var(--muted);
-  font-size: 12px;
+  font-size: 13px;
   line-height: 1.5;
   margin-block-start: 5px;
   max-width: 100%;
@@ -1091,7 +1092,7 @@
 .rowError {
   display: flex;
   flex-wrap: wrap;
-  font-size: 10px;
+  font-size: 12px;
   gap: 4px 7px;
   grid-column: 1 / -1;
   line-height: 1.4;
@@ -1174,7 +1175,7 @@
 
 .claimDialogHeader p {
   color: var(--text-soft);
-  font-size: 12px;
+  font-size: 13px;
   margin-block-start: 7px;
   overflow-wrap: anywhere;
 }
@@ -1254,7 +1255,7 @@
 
 .claimDialogAction p {
   color: var(--text-soft);
-  font-size: 11px;
+  font-size: 13px;
   line-height: 1.45;
   margin: 0;
   overflow-wrap: anywhere;
@@ -1263,7 +1264,7 @@
 
 .claimDialogAction .claimButton,
 .claimDialogAction .secondaryAction {
-  font-size: 11px;
+  font-size: 13px;
   min-width: 154px;
   padding-inline: 13px;
   white-space: nowrap;
@@ -2021,8 +2022,8 @@
 }
 
 .editButton {
-  font-size: 13px;
-  min-height: 40px;
+  font-size: 14px;
+  min-height: 44px;
 }
 
 .profileBio {
@@ -2408,7 +2409,7 @@
   }
 
   .nameRow h1 {
-    font-size: 32px;
+    font-size: clamp(24px, 8.2vw, 32px);
   }
 
   .bannerActions {

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -734,7 +734,8 @@ export function resolveProfileNotFoundTransaction(retryAllowed: boolean) {
     : Object.freeze({
         release: false,
         status: "not-found" as const,
-        message: "Transaction not found. Check your wallet activity.",
+        message:
+          "Transaction is not visible yet. Check your wallet activity, then check again.",
       });
 }
 
@@ -2130,7 +2131,6 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
         setActionState,
         submittedAt: record.submittedAt,
         manualCheck: Date.now() - record.submittedAt >= 60_000,
-        retryNotFound: Date.now() - record.submittedAt >= 60_000,
       }).finally(() => {
         autoResumingProfileTransactionsRef.current.delete(resumeKey);
       });

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -123,6 +123,8 @@ export type TokenMetric = {
   value: string;
 };
 
+export const TOKEN_DETAIL_REQUEST_TIMEOUT_MS = 10_000;
+
 function chartTotalSupply(input: {
   totalSupply?: string;
   marketData?: TokenMarketDataV1;
@@ -940,10 +942,15 @@ export function createTokenDetailInitialState(
   if (!response || !tokenAddress) return null;
   try {
     return detailStateFromResponse(response, tokenAddress, requestKey);
-  } catch {
-    // A malformed, timed-out or unavailable server read is never treated as a
-    // terminal browser state. The client gets one bounded retry instead.
-    return null;
+  } catch (error) {
+    return {
+      phase: "error",
+      message:
+        error instanceof Error
+          ? error.message
+          : "Token data is temporarily unavailable",
+      requestKey,
+    };
   }
 }
 
@@ -1119,10 +1126,10 @@ export function buildChartVolumeMetric(
   return {
     label: CHART_VOLUME_LABELS[volume.range],
     value: volume.pending
-      ? ""
+      ? "Loading…"
       : (formatUsdWadAmount(volume.volumeUsdWad) ??
         formatEth(volume.volumeEth, "amount") ??
-        ""),
+        "Not available yet"),
   };
 }
 
@@ -1234,9 +1241,7 @@ export function buildTokenDetailMetrics(
   return values.filter(
     (metric): metric is TokenMetric =>
       metric !== null &&
-      (metric.value.length > 0 ||
-        metric.label === "Market cap" ||
-        metric.label.startsWith("Volume ")),
+      (metric.value.length > 0 || metric.label === "Market cap"),
   );
 }
 
@@ -2456,6 +2461,11 @@ export function TokenDetailView({
 
     const tokenAddress = normalizedAddress;
     const controller = new AbortController();
+    let timedOut = false;
+    const timeout = window.setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, TOKEN_DETAIL_REQUEST_TIMEOUT_MS);
 
     async function loadToken() {
       try {
@@ -2475,9 +2485,11 @@ export function TokenDetailView({
           requestKey,
         ));
       } catch (error) {
-        if (controller.signal.aborted) return;
+        if (controller.signal.aborted && !timedOut) return;
         const message =
-          error instanceof Error
+          timedOut
+            ? "Token details took too long to load"
+            : error instanceof Error
             ? error.message
             : "Token data is temporarily unavailable";
         setState((current) =>
@@ -2486,11 +2498,16 @@ export function TokenDetailView({
             ? current
             : { phase: "error", requestKey, message },
         );
+      } finally {
+        window.clearTimeout(timeout);
       }
     }
 
     void loadToken();
-    return () => controller.abort();
+    return () => {
+      window.clearTimeout(timeout);
+      controller.abort();
+    };
   }, [
     initialState,
     normalizedAddress,

--- a/components/token-experience.module.css
+++ b/components/token-experience.module.css
@@ -1909,6 +1909,15 @@
 }
 
 @media (max-width: 360px) {
+  .metrics,
+  .metrics[data-count="3"] {
+    grid-template-columns: 1fr;
+  }
+
+  .metrics[data-count="3"] .metric:last-child {
+    grid-column: auto;
+  }
+
   .name {
     font-size: 27px;
     letter-spacing: -0.025em;

--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -8,10 +8,10 @@ coverY: 0
 
 Programmable is a launch platform for Uniswap v4 products. Classic turns a focused set of choices into a fixed supply token, a permanently locked ETH pool and creator rewards. Custom is the API-first path for products that need their own hook, application logic or execution graph. Prediction Markets is the separately versioned launch model for onchain outcome markets.
 
-Classic and Prediction Markets are available from Create. For Custom, the controller wallet creates a scoped API key, an agent submits one deterministic bundle for checks, and the API returns a prepared action. In every case, the wallet reviews and signs its own transaction on the required network.
+Classic and Prediction Markets are available from Create. For Custom, the controller wallet creates a scoped API key and a workflow submits one deterministic bundle. The API first prepares an artifact without a wallet transaction; after authorization, it returns the exact transaction for separate wallet review. In every case, the wallet signs its own transaction on the required network.
 
 {% hint style="info" %}
-These docs describe current public products and the evidence available for them. A successful check, prepared action or visible token page is not a guarantee of safety, liquidity or future value.
+These docs describe current public products and the evidence available for them. A successful check, prepared artifact, authorized transaction or visible token page is not a guarantee of safety, liquidity or future value.
 {% endhint %}
 
 ## Choose a path
@@ -20,7 +20,7 @@ These docs describe current public products and the evidence available for them.
 | ---------------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | Launch a standard token      | [Create Classic](https://programmable.market/launch)                                     | Configure the token, fees, reward recipients and Initial Buy before signing one Ethereum transaction                         |
 | Create a prediction market   | [Create Prediction Market](https://programmable.market/launch)                           | Choose an available market and review the current release requirements before signing                                        |
-| Build with a custom hook     | [Programmable v4 Builder](https://github.com/0xprogrammable/hookbuilder/releases/latest) | Create a [wallet-bound API key](https://programmable.market/developers/api-keys), submit one deterministic bundle to the Custom Launch API, then review the prepared wallet action |
+| Build with a custom hook     | [Custom Launch API guide](developers/custom-launch.md)                                  | Build and package the exact project, create a wallet-bound key, submit the request, then review the wallet transaction only after it is authorized |
 | Verify or integrate launches | [Developer reference](developers/README.md)                                              | Resolve current deployments from the manifest and reproduce provenance from Ethereum                                         |
 
 To inspect an existing token, begin with [Explore](https://programmable.market/explore) and use its contract address rather than only a name or ticker.

--- a/docs/public/SUMMARY.md
+++ b/docs/public/SUMMARY.md
@@ -17,6 +17,7 @@
   - [Verification and risk](trust.md)
   - [Service status](status.md)
 - [Developers](developers/README.md)
+  - [Custom Launch API](developers/custom-launch.md)
   - [Verify a launch](developers/verify.md)
   - [Index launches](developers/indexing.md)
   - [API reference](developers/machine-readable.md)

--- a/docs/public/creators/README.md
+++ b/docs/public/creators/README.md
@@ -16,9 +16,9 @@ Prediction Markets is available from [Create](https://programmable.market/launch
 
 ## Build a Custom project
 
-Custom work starts with the [Programmable v4 Builder](https://github.com/0xprogrammable/hookbuilder/releases/latest). The Builder can turn a plain idea or an existing public repository into a deterministic project, run the applicable checks and package the source and graph bundle required by the [Custom Launch API](https://programmable.market/developers/custom-launch-api-v1.md).
+Build and test the exact hook project. [Hookbuilder-Skill](https://github.com/0xprogrammable/Hookbuilder-Skill) is an optional starting point. Create the deterministic source manifest, graph bundle and evidence digests with project-specific packaging that follows the [Custom Launch API schema](../developers/custom-launch.md); do not assume the current stable Builder emits that request.
 
-Connect the controller wallet and create a [wallet-bound API key](https://programmable.market/developers/api-keys). The authenticated write endpoint is `https://api.programmable.market/v1/custom-launches`. The API validates and prepares an exact action, but the key cannot sign or broadcast. The controller wallet reviews and confirms the action separately.
+Connect the controller wallet and create a [wallet-bound API key](https://programmable.market/developers/api-keys). The authenticated write endpoint is `https://api.programmable.market/v1/custom-launches`. A `prepared` result contains the exact artifact but no wallet transaction. An `authorized` result contains the transaction for separate controller-wallet review, signing and broadcast. The API key cannot perform those wallet actions.
 
 ## Reusable work
 

--- a/docs/public/creators/launch.md
+++ b/docs/public/creators/launch.md
@@ -4,13 +4,13 @@ description: Prepare one deterministic Custom project through the authenticated 
 
 # Launch a project
 
-Custom launch preparation is API-first. The Builder packages one deterministic source and graph bundle, the authenticated API validates its declared commitments, and the controller wallet separately reviews and signs the prepared transaction. No GitHub pull request submits the launch.
+Custom launch preparation is API-first. The submitting workflow packages one deterministic source and graph bundle, and the authenticated API validates its declared commitments. A `prepared` result contains no wallet transaction. After the request becomes `authorized`, the controller wallet separately reviews, signs and broadcasts the exact transaction. No GitHub pull request submits the launch.
 
 ## Prepare the source
 
-Keep the contracts, tests, deployment logic and material project information needed to understand the release in one reproducible source bundle. Use the latest stable [Programmable v4 Builder release](https://github.com/0xprogrammable/hookbuilder/releases/latest) rather than the moving development branch.
+Keep the contracts, tests, deployment logic and material project information needed to understand the release in one reproducible source bundle. [Hookbuilder-Skill](https://github.com/0xprogrammable/Hookbuilder-Skill) is an optional project starting point; the exact API request still comes from project-specific packaging against the published schema.
 
-The Builder preserves the product intent, chooses the smallest complete architecture and runs the checks that apply to that project. The source descriptor, manifest digest, graph bundle and agent evidence must all identify the same exact launch subject.
+The source descriptor, manifest digest, graph bundle and agent evidence must all identify the same exact launch subject. Run the checks that apply to the project and keep their underlying evidence. V1 requires check IDs and evidence digests but does not publish a universal check catalog or assess the evidence.
 
 ## Create an API key
 
@@ -20,13 +20,13 @@ The key grants only `custom-launch:create` and `custom-launch:read`. It is not a
 
 ## Submit the bundle
 
-Send one closed request to `https://api.programmable.market/v1/custom-launches` with the API key as a Bearer credential and a stable idempotency key. Follow the [Custom Launch API V1 guide](https://programmable.market/developers/custom-launch-api-v1.md) for the exact schema, graph limits, evidence fields and response states.
+Send one closed request to `https://api.programmable.market/v1/custom-launches` with the API key as a Bearer credential and a stable idempotency key. Follow the [Custom Launch API guide](../developers/custom-launch.md) for authentication, the exact schema, graph limits, evidence fields and response states.
 
-The platform validates the manifest digest, graph constraints, required agent evidence and permit binding. It does not compile the source, reproduce the build, audit the project or adopt the agent's claims as a safety conclusion.
+The platform validates the manifest digest, graph constraints, attestation shape, evidence digests and permit binding. It does not compile the source, reproduce the build, audit the project or adopt the agent's claims as a safety conclusion.
 
 ## Launch from the bound wallet
 
-When the request is prepared, the controller wallet checks the network, transaction destination, calldata and value, then signs the transaction itself. A submitted transaction becomes a completed launch only after it succeeds, reaches the required finality and agrees with the public Router record.
+When the request is `prepared`, only the exact artifact exists. Wait for `authorized`, then have the controller wallet check the network, destination, calldata and value before it signs and broadcasts. A submitted transaction becomes a completed launch only after it succeeds, reaches the required finality and agrees with the public Router record.
 
 ## Keep the record useful
 

--- a/docs/public/creators/programs.md
+++ b/docs/public/creators/programs.md
@@ -6,4 +6,4 @@ description: Public programs for partnering with and contributing to Programmabl
 
 Programmable uses public programs for focused partnerships, build work and ecosystem contributions. Participation does not replace the launch process. A project can be interesting, complete or selected by a program and still need one valid Custom API bundle, the controller wallet's confirmation and a matching final onchain record.
 
-Builders can use the same public tools. The [Programmable v4 Builder](https://github.com/0xprogrammable/hookbuilder/releases/latest) is open source and accepts unfamiliar project shapes, while the [Custom Launch API](https://programmable.market/developers/custom-launch-api-v1.md) binds one deterministic bundle to a wallet-owned request and prepared action.
+Builders can use the same public tools. [Hookbuilder-Skill](https://github.com/0xprogrammable/Hookbuilder-Skill) is an optional project starting point. The [Custom Launch API](../developers/custom-launch.md) separately binds one project-specific deterministic bundle to a wallet-owned request. `prepared` contains an artifact; `authorized` contains the transaction for separate wallet review.

--- a/docs/public/developers/README.md
+++ b/docs/public/developers/README.md
@@ -8,9 +8,9 @@ Programmable has two separate developer surfaces. The Developer API at `https://
 
 ## Prepare a Custom launch
 
-Create or revoke a key at [Custom Launch API keys](https://programmable.market/developers/api-keys), then follow the [Custom Launch API V1 guide](https://programmable.market/developers/custom-launch-api-v1.md). Send deterministic bundles only to `https://api.programmable.market/v1/custom-launches`.
+Start with the [Custom Launch API guide](custom-launch.md). Create or revoke a key at [Custom Launch API keys](https://programmable.market/developers/api-keys), then send deterministic bundles only to `https://api.programmable.market/v1/custom-launches`.
 
-The key can create and read launch preparations for its wallet principal. It cannot sign or broadcast. The controller wallet reviews and confirms the prepared transaction separately.
+The key can create and read launch preparations for its wallet principal. It cannot authorize, sign or broadcast. A `prepared` response contains an exact artifact but no wallet transaction. Only `authorized` contains the exact transaction for the controller wallet to review, sign and broadcast separately.
 
 ## Start with discovery
 
@@ -39,6 +39,10 @@ Protocol fee claim discovery is a separate execution index. The claim console
 uses complete Classic Launcher and Custom Registry scans plus the fixed Stock
 release set; see [Index Programmable launches](indexing.md#index-protocol-fee-claims-separately)
 for the exact completeness and fail-closed rules.
+
+{% content-ref url="custom-launch.md" %}
+[custom-launch.md](custom-launch.md)
+{% endcontent-ref %}
 
 {% content-ref url="verify.md" %}
 [verify.md](verify.md)

--- a/docs/public/developers/custom-launch.md
+++ b/docs/public/developers/custom-launch.md
@@ -4,18 +4,16 @@ description: Submit, authorize and track one wallet-bound Custom launch through 
 
 # Custom Launch API
 
-The Custom Launch API accepts one deterministic launch request for an Ethereum wallet. It validates the request and prepares an exact artifact. The API key never authorizes, signs or broadcasts the wallet transaction.
+Use the Custom Launch API when an agent or developer has a complete Custom hook project and needs the exact transaction for its controller wallet. Create a key, generate `launch.json` from the built project, submit it and wait for the wallet transaction. The API key never signs or broadcasts that transaction.
 
 The human guide on the website is [programmable.market/docs/developers/custom-launch](https://programmable.market/docs/developers/custom-launch). The [standalone OpenAPI contract](https://programmable.market/openapi/custom-launch-v1.json) is the normative source for request fields, bounds and response schemas. The existing [raw V1 guide](https://programmable.market/developers/custom-launch-api-v1.md) remains available for agents and scripts.
 
 ## Quickstart
 
-1. Build and test the hook and every launch component. [Hookbuilder-Skill](https://github.com/0xprogrammable/Hookbuilder-Skill) is an optional starting point for the project; it is not a substitute for the API schema or project-specific packaging.
-2. Use the project's packaging tooling to derive the source descriptor, sorted source manifest, executable graph bundle and evidence digests from the exact artifacts being launched.
-3. Connect the controller wallet at [Custom Launch API keys](https://programmable.market/developers/api-keys), create a key and copy the secret when it is shown.
-4. Validate `launch.json` against the [standalone OpenAPI contract](https://programmable.market/openapi/custom-launch-v1.json), then submit it with a stable idempotency key.
-5. Poll the single-request route. Do not hand a transaction to the wallet while the request is only `prepared`. Wait for `authorized`, then inspect `output.walletTransaction` and the attached permit.
-6. The controller wallet separately reviews, signs and broadcasts that exact transaction. Continue polling until the request is `finalized` or terminally failed.
+1. Build and test the hook and every launch component. [Hookbuilder-Skill](https://github.com/0xprogrammable/Hookbuilder-Skill) is an optional way to build and check the project.
+2. Generate `launch.json` from that exact build with the project's packaging tooling, then validate it against the [OpenAPI contract](https://programmable.market/openapi/custom-launch-v1.json).
+3. Connect the controller wallet at [API keys](https://programmable.market/developers/api-keys), create a key and submit `launch.json` with a stable idempotency key.
+4. Poll the request until it is `authorized`. The controller wallet then reviews, signs and broadcasts `output.walletTransaction`. Keep polling until the request is `finalized` or terminally failed.
 
 ```bash
 curl --fail-with-body https://api.programmable.market/v1/custom-launches \
@@ -26,7 +24,7 @@ curl --fail-with-body https://api.programmable.market/v1/custom-launches \
   --data-binary @launch.json
 ```
 
-The docs do not publish a hand-written launch fixture. A valid graph contains project-specific bytecode, address locators, permission bits and digests derived from the exact source and build artifacts. Generate those values with the packaging tooling for the project and validate the result against OpenAPI; do not copy test-only hashes or invent them by hand.
+`launch.json` contains project-specific bytecode, addresses, permission bits and hashes from one exact build. Generate it from the project being launched. Do not copy test-only hashes or another project's file.
 
 ## Authentication
 

--- a/docs/public/developers/custom-launch.md
+++ b/docs/public/developers/custom-launch.md
@@ -1,0 +1,124 @@
+---
+description: Submit, authorize and track one wallet-bound Custom launch through the V1 API
+---
+
+# Custom Launch API
+
+The Custom Launch API accepts one deterministic launch request for an Ethereum wallet. It validates the request and prepares an exact artifact. The API key never authorizes, signs or broadcasts the wallet transaction.
+
+The human guide on the website is [programmable.market/docs/developers/custom-launch](https://programmable.market/docs/developers/custom-launch). The [standalone OpenAPI contract](https://programmable.market/openapi/custom-launch-v1.json) is the normative source for request fields, bounds and response schemas. The existing [raw V1 guide](https://programmable.market/developers/custom-launch-api-v1.md) remains available for agents and scripts.
+
+## Quickstart
+
+1. Build and test the hook and every launch component. [Hookbuilder-Skill](https://github.com/0xprogrammable/Hookbuilder-Skill) is an optional starting point for the project; it is not a substitute for the API schema or project-specific packaging.
+2. Use the project's packaging tooling to derive the source descriptor, sorted source manifest, executable graph bundle and evidence digests from the exact artifacts being launched.
+3. Connect the controller wallet at [Custom Launch API keys](https://programmable.market/developers/api-keys), create a key and copy the secret when it is shown.
+4. Validate `launch.json` against the [standalone OpenAPI contract](https://programmable.market/openapi/custom-launch-v1.json), then submit it with a stable idempotency key.
+5. Poll the single-request route. Do not hand a transaction to the wallet while the request is only `prepared`. Wait for `authorized`, then inspect `output.walletTransaction` and the attached permit.
+6. The controller wallet separately reviews, signs and broadcasts that exact transaction. Continue polling until the request is `finalized` or terminally failed.
+
+```bash
+curl --fail-with-body https://api.programmable.market/v1/custom-launches \
+  --request POST \
+  --header "Authorization: Bearer $PROGRAMMABLE_API_KEY" \
+  --header "Content-Type: application/json" \
+  --header "Idempotency-Key: agent-launch-2026-0001" \
+  --data-binary @launch.json
+```
+
+The docs do not publish a hand-written launch fixture. A valid graph contains project-specific bytecode, address locators, permission bits and digests derived from the exact source and build artifacts. Generate those values with the packaging tooling for the project and validate the result against OpenAPI; do not copy test-only hashes or invent them by hand.
+
+## Authentication
+
+Key management and API authentication are separate:
+
+- Connect the controller wallet on `programmable.market` to create, list or revoke its keys.
+- Send `Authorization: Bearer pm_live_...` only to `https://api.programmable.market`.
+- Do not send the website wallet session token to the Custom Launch API.
+- V1 keys have `custom-launch:create` and `custom-launch:read`. A key can access only requests owned by its bound wallet.
+- Store the secret outside source control and logs. Key lists never return the full secret again.
+
+The V1 contract states a 90-day default expiry, a 366-day maximum and no more than 10 active keys per wallet.
+
+## Request contract
+
+`POST /v1/custom-launches` accepts a closed JSON object up to 2 MiB with all eight fields:
+
+| Field | Requirement |
+| --- | --- |
+| `schemaVersion` | `programmable.custom-launch-create-request.v1` |
+| `launchWallet` | The Ethereum wallet bound to the API key |
+| `chainId` | String `1` |
+| `nonce` | A nonzero lowercase `bytes32` |
+| `sourceDescriptor` | One `DeterministicSourceBundleV2` descriptor |
+| `sourceBundleManifest` | One complete, non-empty, UTF-8 path-sorted `SourceBundleManifestV2` |
+| `graphBundle` | One executable `CustomGraphBundleV1` |
+| `agentAttestation` | One self-attestation for the exact graph subject |
+
+The platform recomputes the manifest digest and checks that the source descriptor, manifest and graph name the same source bundle. The graph accepts 1 to 16 acyclic targets, exactly one token target and one hook target. The complete graph input is limited to 524,288 bytes; per-target init code is limited to 49,152 bytes and initializer calldata to 131,072 bytes. Use OpenAPI for every nested field, enum and bound.
+
+These checks bind caller-declared data. The platform does not fetch the source files, reproduce dependencies, compile the project, prove source-to-bytecode correspondence, simulate the transaction, audit the project or attest safety.
+
+## Attested checks
+
+`agentAttestation` requires the exact schema version, canonical graph hash, agent identifier, canonical UTC timestamp and 1 to 64 unique `{ checkId, evidenceSha256 }` entries. Each evidence digest uses `sha256:<64 lowercase hex>`.
+
+V1 does not publish a universal check-ID catalog or define project-independent pass/fail semantics for those IDs. The submitting workflow chooses stable IDs for the checks it actually ran, preserves the underlying evidence and attests the digest for each result. Programmable validates the shape, digest presence and graph-subject binding; it does not fetch or assess the evidence or adopt the attestation as its own claim.
+
+## Submit and retry safely
+
+`Idempotency-Key` must contain 16 to 128 characters from `[A-Za-z0-9._:-]`.
+
+- A new request returns `202`.
+- An identical replay may return `200` with the original resource.
+- After an ambiguous timeout or `503`, retry with the same key and byte-identical body.
+- Never reuse that key with a changed body. That returns `409 IDEMPOTENCY_CONFLICT`.
+- A conflicting wallet nonce returns `409 NONCE_CONFLICT`.
+- An expired permit requires a new request with a new nonce and idempotency key.
+
+The V1 contract states limits of 30 new reservations per rolling hour and 100 per rolling day for the wallet principal and route. Exact idempotent replays bypass the reservation quota. For `429`, wait for the `Retry-After` delay before creating another reservation.
+
+## Lifecycle and wallet boundary
+
+Read `GET /v1/custom-launches/{launchId}` with the same Bearer key. The path parameter keeps the legacy name `launchId`, but its value is the API request UUID. The resource also returns that UUID as `requestId`; `onchainLaunchId` is the distinct Router `bytes32` identifier.
+
+| Status | Meaning |
+| --- | --- |
+| `received` | The request is durably accepted. |
+| `validating` | Request and graph validation are running. |
+| `prepared` | The exact artifact exists. `output.signedPermit` and `output.walletTransaction` are both `null`. There is nothing for the wallet to sign yet. |
+| `authorized` | The platform permit and exact `output.walletTransaction` exist. The controller wallet has not signed or broadcast it. |
+| `submitted` | Canonical Router event and same-block getter evidence match below 64 confirmations. |
+| `finalized` | The matching canonical evidence has at least 64 confirmations. |
+| `failed` or `cancelled` | The request is terminal. Read `failure` before deciding whether to create a new request. |
+
+After wallet broadcast, poll the single-request route to drive exact reconciliation. `GET /v1/custom-launches` is a newest-first wallet-owned history view with bounded summaries; its `output` is always `null`. Use the single-resource route for the artifact, wallet transaction and durable failure.
+
+The API key authorizes only the API request. It is never proof that the controller wallet approved the transaction.
+
+## Explore, Profile and claims
+
+A finalized Router launch is eligible for Explore and the connected wallet's Profile after the website's discovery data refreshes. Finality is not an immediate listing SLA, and third-party discovery remains controlled by each indexer. Router provenance does not require a Custom Registry record.
+
+Claims are a separate website capability. Router provenance alone does not create a claim route. Only explicitly supported fee models appear in the current claim flow; an arbitrary Custom hook is not automatically claimable. The V1 API scopes `fees:claim` and `buybacks:manage` are reserved and disabled.
+
+## Errors and recovery
+
+| HTTP | What to do |
+| --- | --- |
+| `400` | Fix malformed JSON, fields, query values or the idempotency key before retrying. |
+| `401` | Use an active, unexpired and unrevoked `pm_live_` key. |
+| `403` | Use a key with the required scope and the exact wallet named by the request. |
+| `404` | Verify the request UUID and key. Do not infer whether another wallet owns that ID. |
+| `409` | For an ambiguous replay, keep the original body unchanged. For nonce conflict or permit expiry, create a new nonce and idempotency key as directed by the error code. |
+| `413` | Reduce the body below 2 MiB. |
+| `415` | Send `Content-Type: application/json`. |
+| `422` | Fix the reported manifest, graph, attestation or permit binding. Do not retry unchanged. |
+| `429` | Honor `Retry-After`. An exact replay of an existing request does not consume reservation quota. |
+| `503` | Retry later. If the create result is ambiguous, keep the same idempotency key and identical body. |
+
+In an HTTP error, `error.requestId` is a correlation ID for that response. It is not the Custom launch resource `requestId`. A resource-level `failure` is the durable lifecycle failure for that launch request.
+
+## Future extensions
+
+Treat only the operations and scopes in the current OpenAPI contract as active. New scopes or endpoints require an explicit contract update. Existing keys do not gain a newly enabled scope automatically. Wallet signing, fee claims, buyback management, reusable-template publication and source review are not granted by the V1 Custom Launch API.

--- a/docs/public/developers/machine-readable.md
+++ b/docs/public/developers/machine-readable.md
@@ -4,7 +4,9 @@ description: Read-only Developer API reference and authenticated Custom Launch A
 
 # API reference
 
-The Developer API version 2 at `https://developers.programmable.family` is read only, requires no API key and publishes stable discovery, manifest, launch and compatibility responses. The separate Custom Launch API at `https://api.programmable.market` is an authenticated write path. Create a wallet-bound key at [Custom Launch API keys](https://programmable.market/developers/api-keys) and use its [standalone OpenAPI contract](https://programmable.market/openapi/custom-launch-v1.json) or [V1 guide](https://programmable.market/developers/custom-launch-api-v1.md).
+The Developer API version 2 at `https://developers.programmable.family` is read only, requires no API key and publishes stable discovery, manifest, launch and compatibility responses. The separate Custom Launch API at `https://api.programmable.market` is an authenticated write path. Start with the [Custom Launch API guide](custom-launch.md), then use the [standalone OpenAPI contract](https://programmable.market/openapi/custom-launch-v1.json) for the normative request and response schema. The existing [raw V1 guide](https://programmable.market/developers/custom-launch-api-v1.md) remains compatible for agents and scripts.
+
+The public-read OpenAPI below describes the Developer API. It does not define Custom launch writes. The standalone Custom Launch API contract defines those authenticated operations.
 
 ## Service status
 

--- a/docs/public/infrastructure.md
+++ b/docs/public/infrastructure.md
@@ -12,7 +12,7 @@ Classic uses the current launcher and shared hook on Ethereum. One transaction c
 
 ## Custom execution
 
-Custom begins with one deterministic source and graph bundle submitted through the authenticated API. The platform validates the declared manifest digest, graph constraints, required agent evidence and permit binding, then prepares an exact wallet action. It does not compile the source, reproduce the build or audit the project. The controller wallet still submits the transaction, and the resulting launch must agree with the prepared action and final chain record.
+Custom begins with one deterministic source and graph bundle submitted through the authenticated API. The platform validates the declared manifest digest, graph constraints, attestation shape, evidence digests and permit binding. A `prepared` result contains the exact artifact but no wallet transaction. An `authorized` result contains the permit-attached transaction for separate controller-wallet signing and broadcast. The platform does not compile the source, reproduce the build or audit the project, and the resulting launch must agree with the authorized transaction and final chain record.
 
 ## Prediction Markets execution
 

--- a/docs/public/models/custom.md
+++ b/docs/public/models/custom.md
@@ -12,9 +12,9 @@ A hook is a smart contract that a Uniswap v4 pool calls at defined points in a t
 
 ## API-first preparation
 
-Start with the stable [Programmable v4 Builder](https://github.com/0xprogrammable/hookbuilder/releases/latest). The Builder prepares one deterministic source and graph bundle with the required agent evidence. The controller wallet creates a [wallet-bound API key](https://programmable.market/developers/api-keys), and the agent submits the bundle to `https://api.programmable.market/v1/custom-launches`.
+Build and test the exact project. [Hookbuilder-Skill](https://github.com/0xprogrammable/Hookbuilder-Skill) is an optional starting point, not a claim that the current stable Builder packages the API request. Project-specific tooling derives the deterministic source manifest, graph bundle and evidence digests against the [Custom Launch API schema](../developers/custom-launch.md). The controller wallet creates a [wallet-bound API key](https://programmable.market/developers/api-keys), and the workflow submits the bundle to `https://api.programmable.market/v1/custom-launches`.
 
-The API checks the declared bundle commitments and prepares the exact wallet action. It does not compile the project, reproduce its tests, audit it, sign the transaction or broadcast it. The API key is not wallet authority; the controller wallet must review and confirm the prepared action.
+The API checks the declared bundle commitments. `prepared` means the exact artifact exists while the signed permit and wallet transaction remain null. `authorized` supplies the permit-attached transaction for separate controller-wallet review. The API does not compile the project, reproduce its tests, audit it, sign the transaction or broadcast it, and the API key is not wallet authority.
 
 ## Release binding
 
@@ -30,4 +30,4 @@ The canonical Launch Stamp Router is live on Ethereum at `0x8622DD5bAb44185f2A45
 A launch stamp is provenance, not an audit or guarantee. It does not prove current liquidity, sellability, terminal support or economic outcome.
 {% endhint %}
 
-The public developer feed discovers Classic records and verified Custom records. Custom execution remains bundle specific, so users should follow the exact prepared action rather than assume that any repository or hook is launchable.
+The public developer feed discovers Classic records and verified Custom records. Custom execution remains bundle specific, so users should inspect the exact authorized transaction rather than assume that any repository or hook is launchable.

--- a/docs/public/reference/official-links.md
+++ b/docs/public/reference/official-links.md
@@ -12,7 +12,7 @@ description: Official Programmable product, source, community and analytics link
 | Prediction Markets      | [programmable.market/markets](https://programmable.market/markets)                                                 |
 | GitHub                  | [github.com/0xprogrammable](https://github.com/0xprogrammable)                                                     |
 | Prediction source       | [programmable-prediction-markets](https://github.com/0xprogrammable/programmable-prediction-markets)               |
-| Programmable v4 Builder | [Latest stable release](https://github.com/0xprogrammable/hookbuilder/releases/latest)                             |
+| Hookbuilder-Skill       | [Canonical repository](https://github.com/0xprogrammable/Hookbuilder-Skill)                                      |
 | Custom Launch API keys  | [programmable.market/developers/api-keys](https://programmable.market/developers/api-keys)                         |
 | Custom Launch API guide | [programmable.market/developers/custom-launch-api-v1.md](https://programmable.market/developers/custom-launch-api-v1.md) |
 | Custom write API        | [api.programmable.market](https://api.programmable.market)                                                         |

--- a/docs/public/tokens.md
+++ b/docs/public/tokens.md
@@ -9,7 +9,7 @@ Programmable separates direct public models from deterministic Custom graph laun
 | Model              | What it creates                                                            | Market                                        | Access                                |
 | ------------------ | -------------------------------------------------------------------------- | --------------------------------------------- | ------------------------------------- |
 | Classic            | Fixed supply tokens with configurable buy and sell transaction fees        | ETH on Uniswap v4                             | Open through Create                   |
-| Custom             | Tokens or applications that need their own deterministic hook graph         | The pool and route in the prepared action      | Wallet-bound Custom Launch API         |
+| Custom             | Tokens or applications that need their own deterministic hook graph         | The pool and route in the authorized transaction | Wallet-bound Custom Launch API       |
 | Prediction Markets | Onchain outcome markets                                                    | A separately versioned Uniswap v4 release     | Open through Create                   |
 
 ## What is a hook

--- a/docs/public/trust.md
+++ b/docs/public/trust.md
@@ -12,7 +12,7 @@ Each Custom request binds one source descriptor, manifest digest, graph bundle a
 
 ## API preparation
 
-A prepared result means the exact action exists for the controller wallet. It is not an approval, audit, signed transaction or broadcast. The API key cannot authorize the wallet; the controller inspects and signs the final transaction separately.
+A `prepared` result means the exact artifact exists, while the signed permit and wallet transaction are still null. An `authorized` result supplies the permit-attached transaction, but it is not wallet-signed or broadcast. The API key cannot authorize the wallet; the controller inspects, signs and broadcasts separately.
 
 ## Finality and public projection
 

--- a/lib/developer-docs-content.ts
+++ b/lib/developer-docs-content.ts
@@ -17,6 +17,8 @@ const customLaunchApiOpenApiUrl =
   "https://programmable.market/openapi/custom-launch-v1.json";
 const customLaunchApiGuideUrl =
   "https://programmable.market/developers/custom-launch-api-v1.md";
+const customLaunchHumanGuideUrl =
+  "https://programmable.market/docs/developers/custom-launch";
 
 const manifest = PROGRAMMABLE_LAUNCH_STAMP_MANIFEST;
 const router = manifest.launchStampRouter;
@@ -44,7 +46,8 @@ export function buildDeveloperDocsMarkdown(): string {
     `Custom Launch API: ${customLaunchApiOrigin}`,
     `Create and revoke API keys: ${apiKeysUrl}`,
     `Custom Launch API OpenAPI: ${customLaunchApiOpenApiUrl}`,
-    `Custom Launch API guide: ${customLaunchApiGuideUrl}`,
+    `Custom Launch API guide: ${customLaunchHumanGuideUrl}`,
+    `Raw Custom Launch API guide: ${customLaunchApiGuideUrl}`,
     `Deployment manifest: ${resources.manifestUrl}`,
     `Frozen Router ABI: ${resources.abiUrl}`,
     `ABI SHA-256: ${resources.abiSha256}`,
@@ -62,7 +65,7 @@ export function buildDeveloperDocsMarkdown(): string {
     "",
     "Keys expire after 90 days by default, may be issued for at most 366 days, and are limited to 10 active keys per wallet.",
     "",
-    "An API key is not a wallet or private key. The platform validates the submitted manifest digest, graph constraints, required agent attestation and evidence digests, and exact permit binding, then returns the prepared Router action. It does not compile source, simulate the transaction, audit the project, or attest safety. A controller wallet, or an agent separately authorized to use that wallet, must review, sign, and broadcast the action. The API key alone never grants wallet signing authority.",
+    "An API key is not a wallet or private key. The platform validates the submitted manifest digest, graph constraints, attestation shape and evidence digests, and exact permit binding. `prepared` contains an exact artifact but no wallet transaction. `authorized` contains the permit-attached wallet transaction, which a controller wallet, or an agent separately authorized to use that wallet, must review, sign, and broadcast. The platform does not compile source, simulate the transaction, audit the project, or attest safety. The API key alone never grants wallet signing authority.",
     "",
     "### Create a launch",
     "",
@@ -106,7 +109,7 @@ export function buildDeveloperDocsMarkdown(): string {
     "",
     `The pool contains exactly \`tokenTargetId\`, \`hookTargetId\`, \`fee\`, and \`tickSpacing\`. Target IDs must select the declared token and hook. The standalone Custom Launch API schema, including every bound, enum, and response, is published at ${customLaunchApiOpenApiUrl}.`,
     "",
-    "The required agent attestation contains exactly `schemaVersion: programmable.agent-launch-attestation.v1`, `subjectGraphBundleHash`, `agentId`, canonical UTC `checkedAt`, and 1 to 64 unique checks. Each check contains `checkId` and a non-null `sha256:<64 lowercase hex>` evidence digest. It is the agent's self-attestation for the submitted graph subject, is excluded from platform permit authorization and is not a Programmable safety, audit, approval, compilation, or simulation claim.",
+    "The agent attestation is a required request field and contains exactly `schemaVersion: programmable.agent-launch-attestation.v1`, `subjectGraphBundleHash`, `agentId`, canonical UTC `checkedAt`, and 1 to 64 unique checks. Each check contains `checkId` and a non-null `sha256:<64 lowercase hex>` evidence digest. V1 does not publish a universal check-ID catalog or project-independent pass/fail semantics. The submitting workflow chooses IDs for checks it actually ran and preserves the underlying evidence. This is the agent's self-attestation for the submitted graph subject, is excluded from platform permit authorization and is not a Programmable safety, audit, approval, compilation, or simulation claim.",
     "",
     "### List wallet launch requests",
     "",
@@ -338,7 +341,7 @@ export function buildProgrammableLlmsIndex(): string {
     "- Understand the public scope, creator information, launch provenance, and available market context before directing a user to the website.",
     "- Integrate a read-only terminal, wallet, scanner, catalog, or research tool with the documented public endpoints.",
     `- Prepare a Custom launch with a wallet-bound API key from ${apiKeysUrl} and \`POST ${customLaunchApiOrigin}/v1/custom-launches\`.`,
-    "- Direct a human to trade, manage a project, claim rewards, or sign a prepared launch transaction through the website. Those wallet actions require explicit wallet authority.",
+    "- Direct a human to trade, manage a project, claim rewards, or sign an authorized Custom launch transaction through the website. A prepared Custom launch has no wallet transaction. Every wallet action requires explicit wallet authority.",
     "",
     "## Do not use Programmable to infer",
     "",
@@ -361,6 +364,7 @@ export function buildProgrammableLlmsIndex(): string {
     "",
     "- OpenAPI: https://programmable.market/openapi.json",
     `- Create or revoke API keys: ${apiKeysUrl}`,
+    `- Custom Launch API guide: ${customLaunchHumanGuideUrl}`,
     `- Create a Custom launch: POST ${customLaunchApiOrigin}/v1/custom-launches`,
     `- List wallet-owned Custom launches: GET ${customLaunchApiOrigin}/v1/custom-launches`,
     `- Read a Custom launch: GET ${customLaunchApiOrigin}/v1/custom-launches/{launchId}`,

--- a/tests/custom-launch-docs.test.ts
+++ b/tests/custom-launch-docs.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { docsNavigation, docsSearchItems } from "../components/docs-data";
+import sitemap from "../app/sitemap";
+import { developerDocsMarkdown } from "../lib/developer-docs-content";
+
+const root = process.cwd();
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+
+const gitBookGuide = read("docs/public/developers/custom-launch.md");
+const websiteGuide = read("app/docs/developers/custom-launch/page.tsx");
+const summary = read("docs/public/SUMMARY.md");
+const createGuide = read("components/create-guide.tsx");
+
+describe("Custom Launch API documentation", () => {
+  it("publishes one canonical human guide in both documentation systems", () => {
+    expect(summary).toContain(
+      "[Custom Launch API](developers/custom-launch.md)",
+    );
+    expect(websiteGuide).toContain(
+      'alternates: { canonical: "/docs/developers/custom-launch" }',
+    );
+    expect(websiteGuide).toContain(
+      'currentPath="/docs/developers/custom-launch"',
+    );
+    expect(
+      docsNavigation
+        .find(({ label }) => label === "Developers")
+        ?.items.some(({ href }) => href === "/docs/developers/custom-launch"),
+    ).toBe(true);
+    expect(
+      docsSearchItems.some(
+        ({ href }) => href === "/docs/developers/custom-launch",
+      ),
+    ).toBe(true);
+    expect(sitemap().map(({ url }) => url)).toContain(
+      "https://programmable.market/docs/developers/custom-launch",
+    );
+  });
+
+  it("keeps prepared artifacts separate from authorized wallet transactions", () => {
+    for (const source of [gitBookGuide, websiteGuide, developerDocsMarkdown]) {
+      expect(source).toContain("prepared");
+      expect(source).toContain("authorized");
+      expect(source).toMatch(/prepared[\s\S]{0,240}(?:no wallet transaction|walletTransaction[^\n]{0,80}(?:null|both null))/i);
+      expect(source).toMatch(/authorized[\s\S]{0,240}(?:walletTransaction|wallet transaction)/i);
+    }
+    expect(createGuide).toContain("prepared has no wallet transaction");
+    expect(createGuide).toContain("stop at authorized");
+  });
+
+  it("documents the real schema boundary without a copied fixture or invented checks", () => {
+    for (const source of [gitBookGuide, websiteGuide]) {
+      expect(source).toContain("/openapi/custom-launch-v1.json");
+      expect(source).toContain("does not publish a universal check-ID catalog");
+      expect(source).toMatch(/project-specific (?:bytecode|packaging)/);
+      expect(source).toMatch(/do not (?:copy test-only hashes|publish a hand-written launch fixture)/i);
+    }
+    expect(createGuide).toContain("optional project starting point");
+    expect(createGuide).not.toContain("Hook Builder packages");
+  });
+
+  it("keeps the raw guide and OpenAPI URLs compatible", () => {
+    for (const source of [gitBookGuide, websiteGuide, developerDocsMarkdown]) {
+      expect(source).toContain("/openapi/custom-launch-v1.json");
+      expect(source).toContain("/developers/custom-launch-api-v1.md");
+    }
+  });
+
+  it("states authentication, retry, discovery, claim and error boundaries", () => {
+    for (const source of [gitBookGuide, websiteGuide]) {
+      expect(source).toContain("Authorization: Bearer");
+      expect(source).toContain("Idempotency-Key");
+      expect(source).toContain("Retry-After");
+      expect(source).toContain("Explore");
+      expect(source).toContain("Profile");
+      expect(source).toContain("not automatically claimable");
+      expect(source).toContain("error.requestId");
+      expect(source).toContain("resource-level");
+    }
+  });
+});

--- a/tests/developer-api-keys-ui.test.ts
+++ b/tests/developer-api-keys-ui.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const apiKeysSource = readFileSync(
+  new URL("../components/developer-api-keys.tsx", import.meta.url),
+  "utf8",
+);
+const apiKeysStyles = readFileSync(
+  new URL("../components/developer-api-keys.module.css", import.meta.url),
+  "utf8",
+);
+const historySource = readFileSync(
+  new URL("../components/developer-launch-history.tsx", import.meta.url),
+  "utf8",
+);
+const historyStyles = readFileSync(
+  new URL("../components/developer-launch-history.module.css", import.meta.url),
+  "utf8",
+);
+
+describe("developer API key interface", () => {
+  it("keeps the first view compact and focused on key management", () => {
+    expect(apiKeysSource).toContain("<h1>API keys</h1>");
+    expect(apiKeysSource).toContain('aria-label="Developer access view"');
+    expect(apiKeysSource).toContain('aria-pressed={activeSection === "keys"}');
+    expect(apiKeysSource).toContain('aria-pressed={activeSection === "history"}');
+    expect(apiKeysSource).toContain('activeSection === "keys" ?');
+    expect(apiKeysSource).not.toContain("launchPath");
+    expect(apiKeysSource).not.toContain("Fee claims and automated buybacks");
+
+    expect(apiKeysStyles).toMatch(
+      /\.workspace\s*\{[^}]*align-items:\s*stretch;/su,
+    );
+    expect(apiKeysStyles).toMatch(
+      /\.workspace\s*\{[^}]*grid-template-columns:\s*repeat\(2,/su,
+    );
+    expect(apiKeysStyles).toContain("height: clamp(");
+    expect(apiKeysStyles).toContain("--api-panel: var(--webde-surface)");
+    expect(apiKeysStyles).toContain("--api-line: var(--webde-line)");
+    expect(apiKeysStyles).not.toContain("liquid-glass");
+    expect(apiKeysStyles).toMatch(
+      /@media \(max-width: 760px\)[\s\S]*?\.workspace\s*\{[^}]*height:\s*auto;/u,
+    );
+  });
+
+  it("preserves wallet authority and one-time secret handling", () => {
+    expect(apiKeysSource).toContain(
+      "API keys cannot sign or broadcast wallet transactions.",
+    );
+    expect(apiKeysSource).toContain("Save this key now");
+    expect(apiKeysSource).toContain("It will not be shown again.");
+    expect(apiKeysSource).toContain("data-confirm-revoke");
+    expect(apiKeysSource).toContain('event.key === "Escape"');
+    expect(apiKeysSource).toContain("revealRef.current?.focus()");
+    expect(apiKeysSource).toContain("confirmRevokeRef.current?.focus()");
+  });
+
+  it("offers named loading, failure, empty and recovery states", () => {
+    expect(apiKeysSource).toContain("Loading wallet session");
+    expect(apiKeysSource).toContain("Wallet access is unavailable");
+    expect(apiKeysSource).toContain("Reload page");
+    expect(apiKeysSource).toContain("Loading API keys");
+    expect(apiKeysSource).toContain("Unable to load keys");
+    expect(apiKeysSource).toContain("No keys yet");
+    expect(apiKeysSource).toContain("Try again");
+    expect(apiKeysSource).toContain("8_000");
+    expect(apiKeysStyles).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(apiKeysStyles).toContain("min-height: 44px");
+  });
+});
+
+describe("developer launch history interface", () => {
+  it("stays behind the compact view switch and keeps the signing boundary clear", () => {
+    expect(historySource).toContain("Launch history");
+    expect(historySource).toContain(
+      "A launch is onchain only after the\n        wallet signs and broadcasts it.",
+    );
+    expect(historySource).toContain("Check onchain status");
+    expect(historySource).not.toContain("Your agent&apos;s first accepted request");
+    expect(historyStyles).toContain("height: clamp(");
+    expect(historyStyles).toContain("background: var(--webde-surface)");
+    expect(historyStyles).toContain("background: var(--webde-surface-raised)");
+    expect(historyStyles).not.toContain("liquid-glass");
+    expect(historyStyles).toMatch(
+      /\.launchList\s*\{[^}]*overflow-y:\s*auto;/su,
+    );
+    expect(historyStyles).toMatch(
+      /@media \(max-width: 600px\)[\s\S]*?\.history\s*\{[^}]*height:\s*auto;/u,
+    );
+  });
+
+  it("announces loading and refreshed status without changing wallet authority", () => {
+    expect(historySource).toContain("Loading launch history");
+    expect(historySource).toContain("Launch status updated.");
+    expect(historySource).toContain('aria-live="polite"');
+    expect(historySource).toContain('disabled={state === "loading" || loadingMore}');
+    expect(historySource).toContain("Prepared transaction");
+  });
+});

--- a/tests/developer-docs-experience.test.ts
+++ b/tests/developer-docs-experience.test.ts
@@ -13,6 +13,7 @@ import {
 const root = process.cwd();
 const read = (path: string) => readFileSync(join(root, path), "utf8");
 const developerPage = read("app/docs/developers/page.tsx");
+const customLaunchPage = read("app/docs/developers/custom-launch/page.tsx");
 const verifyPage = read("app/docs/developers/verify/page.tsx");
 const indexingPage = read("app/docs/developers/indexing/page.tsx");
 const machineReadablePage = read(
@@ -45,9 +46,14 @@ describe("Developer documentation experience", () => {
     );
   });
 
-  it("publishes focused verification, indexing and machine-readable routes", () => {
+  it("publishes focused Custom launch, verification, indexing and machine-readable routes", () => {
     expect(docsSearch).toContain("key={`${item.href}:${item.title}`}");
     for (const [source, path, canonical] of [
+      [
+        customLaunchPage,
+        "/docs/developers/custom-launch",
+        'alternates: { canonical: "/docs/developers/custom-launch" }',
+      ],
       [
         verifyPage,
         "/docs/developers/verify",

--- a/tests/docs-information-architecture.test.ts
+++ b/tests/docs-information-architecture.test.ts
@@ -25,6 +25,7 @@ const creatorEarningsPage = read("app/docs/creators/earnings/page.tsx");
 const creatorProgramsPage = read("app/docs/creators/programs/page.tsx");
 const infrastructurePage = read("app/docs/infrastructure/page.tsx");
 const developerOverview = read("app/docs/developers/page.tsx");
+const customLaunchPage = read("app/docs/developers/custom-launch/page.tsx");
 const verifyPage = read("app/docs/developers/verify/page.tsx");
 const indexingPage = read("app/docs/developers/indexing/page.tsx");
 const machineReadablePage = read(
@@ -123,6 +124,11 @@ describe("Docs information architecture", () => {
           { depth: 0, href: "/docs/developers", label: "Overview" },
           {
             depth: 1,
+            href: "/docs/developers/custom-launch",
+            label: "Custom Launch API",
+          },
+          {
+            depth: 1,
             href: "/docs/developers/verify",
             label: "Verify a token or pool",
           },
@@ -158,6 +164,7 @@ describe("Docs information architecture", () => {
           "/docs/creators/earnings",
           "/docs/creators/programs",
           "/docs/developers",
+          "/docs/developers/custom-launch",
           "/docs/developers/verify",
           "/docs/developers/indexing",
           "/docs/developers/machine-readable",
@@ -171,7 +178,7 @@ describe("Docs information architecture", () => {
     );
   });
 
-  it("keeps the three developer tasks in the same shell and breadcrumb hierarchy", () => {
+  it("keeps the developer tasks in the same shell and breadcrumb hierarchy", () => {
     for (const [source, path, title] of [
       [
         developerOverview,
@@ -180,6 +187,11 @@ describe("Docs information architecture", () => {
       ],
       [verifyPage, "/docs/developers/verify", "Verify a token or pool"],
       [indexingPage, "/docs/developers/indexing", "Index new launches"],
+      [
+        customLaunchPage,
+        "/docs/developers/custom-launch",
+        "Custom Launch API",
+      ],
       [
         machineReadablePage,
         "/docs/developers/machine-readable",
@@ -190,7 +202,12 @@ describe("Docs information architecture", () => {
       expect(source).toContain(`title="${title}"`);
       expect(source).toContain("<DocsShell");
     }
-    for (const source of [verifyPage, indexingPage, machineReadablePage]) {
+    for (const source of [
+      customLaunchPage,
+      verifyPage,
+      indexingPage,
+      machineReadablePage,
+    ]) {
       expect(source).toContain('parentHref="/docs/developers"');
       expect(source).toContain('parentLabel="Developers"');
     }
@@ -221,7 +238,7 @@ describe("Docs information architecture", () => {
       expect(source).toContain("<DocsShell");
     }
 
-    expect(creatorsPage).toContain("Hook Builder");
+    expect(creatorsPage).toContain("Hookbuilder-Skill");
     expect(creatorsPage).toContain("Custom Launch API");
     expect(creatorsPage).toContain("Public templates are planned");
     expect(creatorTemplatesPage).toContain("Public template intake is closed");
@@ -245,6 +262,7 @@ describe("Docs information architecture", () => {
       "docs/public/economics.md",
       "docs/public/infrastructure.md",
       "docs/public/models/custom.md",
+      "docs/public/developers/custom-launch.md",
       "docs/public/tokens.md",
       "docs/public/trust.md",
       "docs/public/reference/official-links.md",
@@ -252,6 +270,7 @@ describe("Docs information architecture", () => {
       "app/docs/creators/page.tsx",
       "app/docs/creators/launch/page.tsx",
       "app/docs/creators/templates/page.tsx",
+      "app/docs/developers/custom-launch/page.tsx",
       "app/docs/launch-stamps/page.tsx",
       "app/docs/models/[model]/page.tsx",
       "app/docs/trust/page.tsx",

--- a/tests/docs-navigation.test.ts
+++ b/tests/docs-navigation.test.ts
@@ -132,6 +132,7 @@ describe("Docs navigation state", () => {
       href: "/docs/developers",
       label: "Overview",
       relatedPaths: [
+        "/docs/developers/custom-launch",
         "/docs/developers/verify",
         "/docs/developers/indexing",
         "/docs/developers/machine-readable",
@@ -299,7 +300,11 @@ describe("Docs navigation state", () => {
     ).toBe(true);
   });
 
-  it("finds the three dedicated developer guides", () => {
+  it("finds the four dedicated developer guides", () => {
+    expect(getDocsSearchResults("idempotency")[0]).toMatchObject({
+      href: "/docs/developers/custom-launch",
+      title: "Custom Launch API",
+    });
     expect(getDocsSearchResults("verify")[0]).toMatchObject({
       href: "/docs/developers/verify",
       title: "Verify a token or pool",

--- a/tests/explore-page-ssr.test.ts
+++ b/tests/explore-page-ssr.test.ts
@@ -5,6 +5,7 @@ vi.mock("@/components/explore-view", () => ({ ExploreView: () => null }));
 vi.mock("next/headers", () => ({ headers: vi.fn() }));
 
 import {
+  INITIAL_EXPLORE_TIMEOUT_MS,
   INITIAL_EXPLORE_QUERY,
   readInitialExploreWithinDeadline,
 } from "../app/explore/page";
@@ -15,6 +16,11 @@ afterEach(() => {
 });
 
 describe("Explore initial server read", () => {
+  it("covers the API provider budget without allowing an unbounded render", () => {
+    expect(INITIAL_EXPLORE_TIMEOUT_MS).toBeGreaterThan(8_000);
+    expect(INITIAL_EXPLORE_TIMEOUT_MS).toBeLessThanOrEqual(9_000);
+  });
+
   it("starts with the highest available FDV ranking", () => {
     const query = new URLSearchParams(INITIAL_EXPLORE_QUERY);
 

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -48,6 +48,9 @@ describe("Explore UI contract", () => {
     expect(source).toContain(
       'className={styles.loadingState} aria-busy="true"',
     );
+    expect(source).toContain(
+      'className={styles.loadingStatus} role="status" aria-live="polite"',
+    );
   });
 
   it("keeps token and prediction discovery inside one Explore destination", () => {
@@ -312,6 +315,10 @@ describe("Explore UI contract", () => {
     );
     expect(source).not.toContain("<small>CA</small>");
     expect(source).toContain("<small>Market cap</small>");
+    expect(source).toContain("formatExploreContractAddress(token.tokenAddress)");
+    expect(styles).toMatch(
+      /@media \(max-width: 700px\)[\s\S]*?\.runnerHeading > span\s*\{[^}]*font-size:\s*11px;[\s\S]*?\.runnerData small\s*\{[^}]*font-size:\s*11px;[\s\S]*?\.runnerCategory,[\s\S]*?font-size:\s*11px;[\s\S]*?\.runnerContract code\s*\{[^}]*font-size:\s*11px;/s,
+    );
     expect(source).toMatch(
       /\{valuationLabel \? \([\s\S]*?<small>Market cap<\/small>[\s\S]*?\) : null\}/,
     );

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -14,6 +14,7 @@ import {
   handledInitialExploreRequestKey,
   filterTokensByLaunchModel,
   filterTokensBySocialPresence,
+  formatExploreContractAddress,
   getTokenCards,
   getExplorePaginationItems,
   getExploreValuationMetric,
@@ -349,6 +350,12 @@ afterEach(() => {
 });
 
 describe("Explore refresh state", () => {
+  it("keeps compact contract identity readable on narrow cards", () => {
+    expect(formatExploreContractAddress(
+      "0x1234567890abcdef1234567890abcdef12345678",
+    )).toBe("0x1234…678");
+  });
+
   it("hydrates the first server page without waiting for a client request", () => {
     expect(
       createExploreInitialState(
@@ -370,7 +377,7 @@ describe("Explore refresh state", () => {
     });
   });
 
-  it("keeps a server-side Explore failure behind skeletons while retrying", () => {
+  it("surfaces a server-side Explore failure with explicit recovery", () => {
     const initialState = createExploreInitialState(
         {
           ok: false,
@@ -383,10 +390,15 @@ describe("Explore refresh state", () => {
         },
       );
 
-    expect(initialState).toBeNull();
+    expect(initialState).toEqual({
+      phase: "error",
+      message: "Launch index is catching up",
+      contentKey: "initial-content-error",
+      requestKey: "initial-request-error",
+    });
     expect(
       handledInitialExploreRequestKey(initialState, "initial-request-error"),
-    ).toBeNull();
+    ).toBe("initial-request-error");
   });
 
   it("surfaces an error only after the client retry also fails", () => {
@@ -448,6 +460,24 @@ describe("Explore refresh state", () => {
     expect(
       handledInitialExploreRequestKey(initialState, "initial-mobile-request"),
     ).toBe("initial-mobile-request");
+  });
+
+  it("keeps a responsive initial failure explicit instead of refetching it", () => {
+    expect(createResponsiveExploreInitialState(
+      { ok: false, body: { error: "Launch index is catching up" } },
+      {
+        reuseAvailable: true,
+        isInitialRequest: true,
+        contentKey: "initial-mobile-error-content",
+        requestKey: "initial-mobile-error-request",
+        pageSize: EXPLORE_MOBILE_TOKENS_PER_PAGE,
+      },
+    )).toEqual({
+      phase: "error",
+      message: "Launch index is catching up",
+      contentKey: "initial-mobile-error-content",
+      requestKey: "initial-mobile-error-request",
+    });
   });
 
   it("stops reusing the server page after the first non-initial request", () => {

--- a/tests/legacy-custom-launch-directory.test.ts
+++ b/tests/legacy-custom-launch-directory.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const component = readFileSync(
+  join(root, "components/generic-launch-directory-v2.tsx"),
+  "utf8",
+);
+const styles = readFileSync(
+  join(root, "components/generic-launch-directory-v2.module.css"),
+  "utf8",
+);
+const directoryPage = readFileSync(
+  join(root, "app/custom-launches/page.tsx"),
+  "utf8",
+);
+
+describe("legacy Custom Registry directory", () => {
+  it("labels the retired flow and routes new launches to the API path", () => {
+    expect(component).toContain("Legacy Custom records");
+    expect(component).toContain("retired Registry approval flow");
+    expect(component).toContain('href="/developers/api-keys"');
+    expect(component).toContain('href="/docs/developers/custom-launch"');
+    expect(component).not.toContain("Launched from an approved revision.");
+  });
+
+  it("uses the current flat product surface and stays out of search results", () => {
+    expect(styles).toContain("var(--webde-surface");
+    expect(styles).toContain("var(--webde-line");
+    expect(styles).not.toContain("liquid-glass");
+    expect(directoryPage).toContain("robots: { follow: false, index: false }");
+  });
+});

--- a/tests/prediction-profile-regression.test.ts
+++ b/tests/prediction-profile-regression.test.ts
@@ -59,6 +59,51 @@ function hasTouchHeight(declarations: string) {
     .some((match) => Number(match[1]) >= 44);
 }
 
+function hexChannels(value: string) {
+  const normalized = value.trim().replace(/^#/u, "");
+  if (!/^[0-9a-f]{6}$/iu.test(normalized)) {
+    throw new Error(`Expected a six-digit hex color, received ${value}`);
+  }
+  return [0, 2, 4].map((offset) =>
+    Number.parseInt(normalized.slice(offset, offset + 2), 16)
+  );
+}
+
+function relativeLuminance(value: string) {
+  const channels = hexChannels(value).map((channel) => {
+    const normalized = channel / 255;
+    return normalized <= 0.04045
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrastRatio(first: string, second: string) {
+  const firstLuminance = relativeLuminance(first);
+  const secondLuminance = relativeLuminance(second);
+  return (
+    (Math.max(firstLuminance, secondLuminance) + 0.05) /
+    (Math.min(firstLuminance, secondLuminance) + 0.05)
+  );
+}
+
+function rgbChroma(value: string) {
+  const channels = hexChannels(value);
+  return Math.max(...channels) - Math.min(...channels);
+}
+
+function cssHexVariable(css: string, variable: string) {
+  const match = css.match(new RegExp(`${variable}\\s*:\\s*(#[0-9a-f]{6})`, "iu"));
+  if (!match?.[1]) throw new Error(`Missing ${variable}`);
+  return match[1];
+}
+
+function hasFontSizeAtLeast(declarations: string, minimum: number) {
+  return [...declarations.matchAll(/font-size\s*:\s*(\d+)px/gu)]
+    .some((match) => Number(match[1]) >= minimum);
+}
+
 const account = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const otherAccount = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
@@ -254,6 +299,63 @@ describe("prediction profile regression contract", () => {
       /useState<[^>]*(?:Tab|"positions")[^>]*>\(["']positions["']\)/u,
     );
     expect(portfolioSource).toMatch(/(?:model|viewModel)\s*\[\s*activeTab\s*\]/u);
+  });
+
+  it("presents Predictions without a redundant profile-activity eyebrow", () => {
+    expect(portfolioSource).toContain(
+      '<h2 id="prediction-portfolio-title">Predictions</h2>',
+    );
+    expect(portfolioSource).not.toContain("Profile activity");
+    expect(portfolioSource).not.toContain("portfolioEyebrow");
+    expect(portfolioStyles).not.toContain(".portfolioEyebrow");
+  });
+
+  it("uses vivid yes and no colors with AA text contrast and non-color labels", () => {
+    const yes = cssHexVariable(portfolioStyles, "--portfolio-yes");
+    const no = cssHexVariable(portfolioStyles, "--portfolio-no");
+
+    expect(rgbChroma(yes)).toBeGreaterThan(rgbChroma("#72d3a4"));
+    expect(rgbChroma(no)).toBeGreaterThan(rgbChroma("#e58d96"));
+    for (const surface of ["#181818", "#202020"]) {
+      expect(contrastRatio(yes, surface)).toBeGreaterThanOrEqual(4.5);
+      expect(contrastRatio(no, surface)).toBeGreaterThanOrEqual(4.5);
+    }
+
+    expect(portfolioSource).toContain("{item.statusLabel}");
+    expect(portfolioSource).toContain("data-outcome={side.outcome}");
+    expect(portfolioSource).toContain("<strong>{side.outcome}</strong>");
+    expect(portfolioSource).toContain("{item.probabilityLabel}");
+    expect(portfolioStyles).toMatch(
+      /\.portfolioCardStatus > span::before\s*\{[^}]*background:\s*currentcolor;/su,
+    );
+  });
+
+  it("keeps compact portfolio actions and supporting copy legible", () => {
+    for (const [selector, minimum] of [
+      [".portfolioRefresh", 13],
+      [".portfolioTabs button", 13],
+      [".portfolioCardStatus", 12],
+      [".portfolioCardCopy h3", 14],
+      [".portfolioHoldings strong", 12],
+      [".portfolioMetrics dt", 12],
+      [".portfolioMetrics dd", 13],
+      [".portfolioMetrics small", 12],
+      [".portfolioEmpty small", 13],
+      [".portfolioInlineError", 13],
+    ] as const) {
+      expect(
+        hasFontSizeAtLeast(cssDeclarationsFor(portfolioStyles, selector), minimum),
+        `${selector} needs at least ${minimum}px type`,
+      ).toBe(true);
+    }
+
+    const narrowStyles = mediaBodiesAtOrBelow(portfolioStyles, 360);
+    expect(
+      hasFontSizeAtLeast(
+        cssDeclarationsFor(narrowStyles, ".portfolioTabs button"),
+        12,
+      ),
+    ).toBe(true);
   });
 
   it("does not present an OPEN market as tradable after its cutoff", () => {

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -75,6 +75,15 @@ const profileViewSource = readFileSync(
   "utf8",
 );
 
+function profileCssDeclarationsFor(selectorFragment: string) {
+  return [...profileExperienceCss.matchAll(/([^{}]+)\{([^{}]*)\}/gu)]
+    .filter(([, selectors]) => selectors.split(",").some(
+      (selector) => selector.trim() === selectorFragment,
+    ))
+    .map(([, , declarations]) => declarations)
+    .join("\n");
+}
+
 describe("profile editor composition", () => {
   it("keeps banner actions on the trailing edge away from the avatar", () => {
     expect(profileExperienceCss).toMatch(
@@ -85,6 +94,55 @@ describe("profile editor composition", () => {
     );
     expect(profileExperienceCss).toMatch(
       /@media \(max-width:\s*620px\)[\s\S]*?\.bannerActions\s*\{[^}]*align-items:\s*flex-end;[^}]*right:\s*10px;/,
+    );
+  });
+
+  it("wraps the hero name instead of clipping it behind Edit profile", () => {
+    const nameRule = profileExperienceCss.match(
+      /\.nameRow h1\s*\{([^}]*)\}/su,
+    )?.[1] ?? "";
+    expect(nameRule).toMatch(/max-width:\s*100%;/u);
+    expect(nameRule).toMatch(/overflow-wrap:\s*anywhere;/u);
+    expect(nameRule).toMatch(/white-space:\s*normal;/u);
+    expect(nameRule).not.toMatch(/overflow:\s*hidden;/u);
+    expect(nameRule).not.toMatch(/text-overflow:\s*ellipsis;/u);
+
+    const finalMobileRules = profileExperienceCss.slice(
+      profileExperienceCss.lastIndexOf("@media (max-width: 620px)"),
+    );
+    expect(finalMobileRules).toMatch(
+      /\.nameRow\s*\{[^}]*flex-direction:\s*column;/su,
+    );
+    expect(finalMobileRules).toMatch(
+      /\.nameRow h1\s*\{[^}]*font-size:\s*clamp\(24px,\s*8\.2vw,\s*32px\);/su,
+    );
+    expect(profileExperienceCss).toMatch(
+      /\.editButton\s*\{\s*font-size:\s*14px;\s*min-height:\s*44px;\s*\}/su,
+    );
+  });
+
+  it("raises only compact claim actions and supporting descriptions", () => {
+    for (const [selector, fontSize] of [
+      [".claimRefresh", 13],
+      [".claimRow .claimButton", 13],
+      [".actionState", 12],
+      [".rowError", 12],
+      [".claimEmpty p", 13],
+      [".claimDialogHeader p", 13],
+      [".claimDialogAction p", 13],
+      [".claimDialogAction .claimButton", 13],
+      [".claimDialogAction .secondaryAction", 13],
+    ] as const) {
+      expect(profileCssDeclarationsFor(selector)).toMatch(
+        new RegExp(`font-size:\\s*${fontSize}px;`, "u"),
+      );
+    }
+
+    expect(profileCssDeclarationsFor(".claimCopy small")).toMatch(
+      /font-size:\s*10px;/u,
+    );
+    expect(profileCssDeclarationsFor(".claimAmount small")).toMatch(
+      /font-size:\s*11px;/u,
     );
   });
 });
@@ -1047,7 +1105,8 @@ describe("profile transaction status", () => {
     expect(resolveProfileNotFoundTransaction(false)).toEqual({
       release: false,
       status: "not-found",
-      message: "Transaction not found. Check your wallet activity.",
+      message:
+        "Transaction is not visible yet. Check your wallet activity, then check again.",
     });
     expect(resolveProfileNotFoundTransaction(true)).toEqual({
       release: true,
@@ -1058,6 +1117,100 @@ describe("profile transaction status", () => {
       /if \(resolution\.release\) \{\s*forgetPendingProfileTransaction\(pendingTransaction\);/s,
     );
   });
+
+  it("keeps the first not-found result for aged restored Classic transactions", () => {
+    const resumeLoop = profileViewSource.indexOf("for (const record of pending)");
+    const resumeCall = profileViewSource.indexOf(
+      "void settleSubmittedTransaction({",
+      resumeLoop,
+    );
+    const resumeCallEnd = profileViewSource.indexOf("}).finally", resumeCall);
+    expect(resumeLoop).toBeGreaterThan(-1);
+    expect(resumeCall).toBeGreaterThan(resumeLoop);
+    expect(resumeCallEnd).toBeGreaterThan(resumeCall);
+    const autoResumeSource = profileViewSource.slice(resumeCall, resumeCallEnd);
+    expect(autoResumeSource).toContain(
+      "manualCheck: Date.now() - record.submittedAt >= 60_000",
+    );
+    expect(autoResumeSource).not.toContain("retryNotFound");
+
+    const classicActionStart = profileViewSource.indexOf(
+      "const submitCreatorClaim",
+    );
+    const classicV3ActionStart = profileViewSource.indexOf(
+      "const submitClassicV3Action",
+    );
+    const deepActionStart = profileViewSource.indexOf("const submitDeepAction");
+    expect(
+      profileViewSource.slice(classicActionStart, classicV3ActionStart),
+    ).toContain('retryNotFound: existingState.status === "not-found"');
+    expect(
+      profileViewSource.slice(classicV3ActionStart, deepActionStart),
+    ).toContain('retryNotFound: existingState.status === "not-found"');
+
+    for (const [index, source] of (["classic", "classic-v3"] as const).entries()) {
+      const stateKey = `${secondAddress.toLowerCase()}:${source}:claim`;
+      const record = {
+        version: 1,
+        account: firstAddress.toLowerCase(),
+        chainId: 1,
+        source,
+        stateKey,
+        action: "claim",
+        transactionHash: index === 0 ? transactionHash : secondTransactionHash,
+        submittedAt: Date.now() - 5 * 60_000,
+      } satisfies PendingProfileTransactionRecord;
+      const restored = groupPendingProfileTransactionStates([record]);
+      expect(restored[source][stateKey]).toMatchObject({
+        status: "pending",
+        transactionHash: record.transactionHash,
+      });
+
+      const firstObservation = resolveProfileNotFoundTransaction(false);
+      const afterFirstObservation = firstObservation.release
+        ? removePendingProfileTransactionRecord([record], record)
+        : [record];
+      expect(firstObservation.status).toBe("not-found");
+      expect(afterFirstObservation).toEqual([record]);
+
+      const explicitRecheck = resolveProfileNotFoundTransaction(true);
+      const afterExplicitRecheck = explicitRecheck.release
+        ? removePendingProfileTransactionRecord(afterFirstObservation, record)
+        : afterFirstObservation;
+      expect(explicitRecheck.status).toBe("error");
+      expect(afterExplicitRecheck).toEqual([]);
+    }
+  });
+
+  it.each(["classic", "classic-v3"] as const)(
+    "clears a persisted %s transaction when a not-found recheck confirms",
+    (source) => {
+      const record = {
+        version: 1,
+        account: firstAddress.toLowerCase(),
+        chainId: 1,
+        source,
+        stateKey: `${secondAddress.toLowerCase()}:${source}:claim`,
+        action: "claim",
+        transactionHash,
+        submittedAt: Date.now() - 5 * 60_000,
+      } satisfies PendingProfileTransactionRecord;
+      const notFound = resolveProfileNotFoundTransaction(false);
+      const afterNotFound = notFound.release
+        ? removePendingProfileTransactionRecord([record], record)
+        : [record];
+      expect(afterNotFound).toEqual([record]);
+
+      const afterConfirmed = removePendingProfileTransactionRecord(
+        afterNotFound,
+        record,
+      );
+      expect(afterConfirmed).toEqual([]);
+      expect(profileViewSource).toMatch(
+        /if \(receiptStatus === "not-found"\)[\s\S]*?return;\s*\}\s*if \(receiptStatus === "reverted"\)[\s\S]*?return;\s*\}\s*forgetPendingProfileTransaction\(pendingTransaction\);\s*confirmedProfileTransactionsRef/u,
+      );
+    },
+  );
 
   it("uses one receipt request for a manual status check", async () => {
     const fetcher = vi.fn<typeof fetch>(async () =>

--- a/tests/token-detail-layout.test.ts
+++ b/tests/token-detail-layout.test.ts
@@ -149,6 +149,15 @@ describe("token detail layout", () => {
     expect(visualOrder).toEqual(domOrder);
   });
 
+  it("stacks detail metrics at the narrowest supported width", () => {
+    expect(detailStyles).toMatch(
+      /@media \(max-width: 360px\)[\s\S]*?\.metrics,[\s\S]*?\.metrics\[data-count="3"\]\s*\{[^}]*grid-template-columns:\s*1fr;/s,
+    );
+    expect(detailStyles).toMatch(
+      /@media \(max-width: 360px\)[\s\S]*?\.metrics\[data-count="3"\] \.metric:last-child\s*\{[^}]*grid-column:\s*auto;/s,
+    );
+  });
+
   it("keeps only useful identity metadata", () => {
     expect(detailSource).not.toMatch(/<h2>\s*Token details\s*<\/h2>/i);
     expect(detailSource).not.toMatch(/<dt>\s*Network\s*<\/dt>/i);

--- a/tests/token-detail-view.test.ts
+++ b/tests/token-detail-view.test.ts
@@ -9,6 +9,7 @@ import {
   formatStockPairedGrossVolume,
   getValuationMetricLabel,
   parseDetailPayload,
+  TOKEN_DETAIL_REQUEST_TIMEOUT_MS,
 } from "../components/token-detail-view";
 import type { PreparedTokenTrade } from "../components/token-trade";
 import type { TokenMarketDataV1 } from "../lib/market-data/market-data-v1";
@@ -50,6 +51,11 @@ const canonicalToken = {
 } satisfies CanonicalTokenExploreEntry;
 
 describe("token detail metrics", () => {
+  it("keeps client retries bounded beyond the route provider budget", () => {
+    expect(TOKEN_DETAIL_REQUEST_TIMEOUT_MS).toBeGreaterThan(8_000);
+    expect(TOKEN_DETAIL_REQUEST_TIMEOUT_MS).toBeLessThanOrEqual(10_000);
+  });
+
   it("hydrates a verified server response without a duplicate client request", () => {
     const state = createTokenDetailInitialState(
       {
@@ -73,12 +79,16 @@ describe("token detail metrics", () => {
     });
   });
 
-  it("keeps unavailable or mismatched server responses retryable", () => {
+  it("surfaces unavailable or mismatched server responses with explicit retry", () => {
     expect(createTokenDetailInitialState(
       { status: 503, body: { error: "temporarily unavailable" } },
       canonicalToken.tokenAddress,
       "unavailable-request",
-    )).toBeNull();
+    )).toEqual({
+      phase: "error",
+      message: "temporarily unavailable",
+      requestKey: "unavailable-request",
+    });
     expect(createTokenDetailInitialState(
       {
         status: 200,
@@ -91,7 +101,11 @@ describe("token detail metrics", () => {
       },
       "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "mismatched-request",
-    )).toBeNull();
+    )).toEqual({
+      phase: "error",
+      message: "The token registry returned the wrong token",
+      requestKey: "mismatched-request",
+    });
   });
 
   it("hydrates a verified not-found response as a terminal empty state", () => {
@@ -245,7 +259,11 @@ describe("token detail metrics", () => {
       buildTokenDetailMetrics(token, null, volume).find((metric) =>
         metric.label.startsWith("Volume"),
       ),
-    ).toEqual({ label: "Volume 1W", value: "" });
+    ).toEqual({ label: "Volume 1W", value: "Loading…" });
+    expect(buildChartVolumeMetric({
+      range: "1d",
+      pending: false,
+    })).toEqual({ label: "Volume 1D", value: "Not available yet" });
     expect(buildChartVolumeMetric(null)).toBeUndefined();
     expect(
       buildChartVolumeMetric({

--- a/tests/token-page-ssr.test.ts
+++ b/tests/token-page-ssr.test.ts
@@ -7,7 +7,10 @@ vi.mock("@/components/token-detail-view", () => ({
   TokenDetailView: () => null,
 }));
 
-import { readInitialTokenDetailWithinDeadline } from
+import {
+  INITIAL_TOKEN_DETAIL_TIMEOUT_MS,
+  readInitialTokenDetailWithinDeadline,
+} from
   "../app/token/[address]/page";
 
 afterEach(() => {
@@ -15,6 +18,11 @@ afterEach(() => {
 });
 
 describe("token detail initial server read", () => {
+  it("covers the API provider budget without allowing an unbounded render", () => {
+    expect(INITIAL_TOKEN_DETAIL_TIMEOUT_MS).toBeGreaterThan(8_000);
+    expect(INITIAL_TOKEN_DETAIL_TIMEOUT_MS).toBeLessThanOrEqual(9_000);
+  });
+
   it("places the bounded detail read behind an immediate Suspense shell", () => {
     const source = readFileSync(
       join(process.cwd(), "app/token/[address]/page.tsx"),


### PR DESCRIPTION
## What changed
- fix profile name/edit overlap, prediction section copy and colors, and stale claim recovery
- compact API key management and launch history into the existing product system
- improve Explore and token loading/error/mobile states
- publish one canonical Custom Launch API guide and mark the retired registry directory as legacy

## Local verification
- 259 focused regression tests passed
- TypeScript and scoped ESLint passed
- production build and candidate-neutral bundle scan passed
- desktop and 390/320 mobile UI checks completed

No contract, signer, wallet, provider, or database migration changes.