### PR TITLE
Clarify API reconciliation and Registry intake docs

### DIFF
--- a/app/docs/developers/machine-readable/page.tsx
+++ b/app/docs/developers/machine-readable/page.tsx
@@ -264,8 +264,9 @@ export default function MachineReadableDocsPage() {
           </li>
           <li>
             <code>GET /v1/custom-launches</code> returns a wallet-owned,
-            cursor-paginated snapshot. It does not run per-launch chain reads;
-            only the exact single-launch GET reconciles current onchain state.
+            cursor-paginated snapshot. It makes a bounded best-effort
+            reconciliation pass over pending rows and still returns durable
+            history when RPC is unavailable.
           </li>
           <li>
             After broadcast, poll the single-launch status route. It reconciles

--- a/components/docs-data.ts
+++ b/components/docs-data.ts
@@ -164,7 +164,7 @@ export const docsSearchItems: DocsSearchItem[] = [
   {
     title: "Creator overview",
     description:
-      "Prepare a Custom launch, understand earnings and publish reusable hook logic.",
+      "Prepare a Custom launch, understand earnings and read the planned template policy.",
     href: "/docs/creators",
     keywords: ["creator", "earn", "launch"],
   },

--- a/docs/public/.gitbook/assets/programmable-v2.yaml
+++ b/docs/public/.gitbook/assets/programmable-v2.yaml
@@ -7,11 +7,12 @@ info:
   description: |
     Read-only discovery for terminals, scanners, explorers, bots, wallets and apps.
 
-    Classic is live on Ethereum. Programmable Custom is reserved for launches
-    accepted through the canonical Custom Registry. Registry discovery and its
-    finalized approved launch feed are live, while general public intake remains
-    prelaunch. Historical Stock-Paired launches are not part of the version 2
-    Programmable Custom classification.
+    Classic is live on Ethereum. Custom discovery includes Registry-verified and
+    finalized Router-stamped launches. The separate authenticated Custom Launch
+    API at `https://api.programmable.market` is the API-first write path; this v2
+    service remains read only. Its `publicSubmissionStatus` field describes only
+    the legacy Registry intake, which remains prelaunch. Historical Stock-Paired
+    launches are not part of the version 2 Programmable Custom classification.
 
     Within v2, existing fields keep their type and meaning. New deployments,
     capabilities and market kinds are additive. Consumers must ignore unknown
@@ -127,8 +128,9 @@ paths:
         record's `LaunchKindV1` value. The shared Classic hook is not a launch
         identity and must not classify a Classic launch. Only a consistent
         record from the exact canonical Router qualifies through Router V1.
-        Publication does not imply named-terminal adoption, and the GitHub
-        approval to permit to wallet self-service launch flow is not live.
+        Publication does not imply named-terminal adoption. Launch submission is
+        not part of this read-only API; use the separate authenticated Custom
+        Launch API for API-first preparation and wallet handoff.
       responses:
         "200":
           description: Current deployment manifest.
@@ -418,6 +420,7 @@ components:
                   const: live
                 publicSubmissionStatus:
                   const: prelaunch
+                  description: Legacy Custom Registry intake status. This does not describe the separate authenticated API-first Custom Launch route.
                 registryAddress:
                   type: string
                   pattern: ^0x[0-9a-fA-F]{40}$

--- a/lib/public-openapi.ts
+++ b/lib/public-openapi.ts
@@ -1553,7 +1553,7 @@ export const programmablePublicOpenApi = {
     market:
       "Router verification requires pool initialization and fixed runtime and pool bindings, not active liquidity or tradability; the Custom graph owns liquidity behavior.",
     actions:
-      "The Custom Launch API validates manifest digest, graph, attestation subject, evidence digest, and permit bindings, prepares one exact wallet action, and reconciles only when its single-resource status is polled. It does not compile source, assess attestation evidence, simulate the transaction, audit, or attest safety. API keys never sign, broadcast, trade, claim fees, manage buybacks, or write profiles.",
+      "The Custom Launch API validates manifest digest, graph, attestation subject, evidence digest, and permit bindings, prepares one exact wallet action, reconciles exact state when its single-resource status is polled, and makes a bounded best-effort reconciliation pass over pending history rows. It does not compile source, assess attestation evidence, simulate the transaction, audit, or attest safety. API keys never sign, broadcast, trade, claim fees, manage buybacks, or write profiles.",
   },
   "x-programmable-api-scopes": {
     "custom-launch:create": {

--- a/public/developers/custom-launch-api-v1.md
+++ b/public/developers/custom-launch-api-v1.md
@@ -186,9 +186,10 @@ received -> validating -> prepared -> authorized -> submitted -> finalized
   event has fewer than 64 confirmations.
 - `finalized`: the same canonical Router evidence has at least 64 confirmations.
 
-After the controller wallet broadcasts the exact transaction, poll this single-resource GET. Reconciliation is
-request-driven for `authorized` and `submitted` resources. POST only captures the bounded observation window, list
-reads do not perform per-launch chain reads and there is no background reconciliation timer.
+After the controller wallet broadcasts the exact transaction, poll this single-resource GET for the full output.
+Reconciliation is request-driven for `authorized` and `submitted` resources. The bounded history route also makes a
+best-effort reconciliation pass over pending rows without hiding durable history when RPC is unavailable. There is no
+background reconciliation timer.
 
 Once the canonical Router stamp has 64 confirmations and website discovery refreshes, the launch is eligible to appear
 in Explore and in the connected wallet's Profile. Router provenance does not require Registry publication. Third-party

--- a/public/openapi/custom-launch-v1.json
+++ b/public/openapi/custom-launch-v1.json
@@ -1681,7 +1681,7 @@
     "attestation": "agent-self-attested",
     "platform": "validates manifest digest, graph, attestation subject, evidence digest and permit bindings only",
     "wallet": "controller wallet or separately wallet-authorized agent signs and broadcasts",
-    "reconciliation": "request-driven only when the single-resource GET is polled after wallet broadcast",
+    "reconciliation": "request-driven after wallet broadcast: the single-resource GET reconciles exact state and the bounded history GET makes a best-effort pass over pending rows",
     "finality": "canonical Router event and same-block getter evidence at 64 confirmations",
     "indexing": "eligible for Programmable discovery after finality; third-party discovery and listing remain consumer-controlled",
     "market": "Router verification requires pool initialization and fixed runtime and pool bindings, not active liquidity or tradability; the Custom graph owns liquidity behavior",

--- a/tests/custom-launch-docs.test.ts
+++ b/tests/custom-launch-docs.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import { docsNavigation, docsSearchItems } from "../components/docs-data";
 import sitemap from "../app/sitemap";
 import { developerDocsMarkdown } from "../lib/developer-docs-content";
+import { programmablePublicOpenApi } from "../lib/public-openapi";
 
 const root = process.cwd();
 const read = (path: string) => readFileSync(join(root, path), "utf8");
@@ -14,6 +15,10 @@ const gitBookGuide = read("docs/public/developers/custom-launch.md");
 const websiteGuide = read("app/docs/developers/custom-launch/page.tsx");
 const summary = read("docs/public/SUMMARY.md");
 const createGuide = read("components/create-guide.tsx");
+const rawGuide = read("public/developers/custom-launch-api-v1.md");
+const machineReadableGuide = read(
+  "app/docs/developers/machine-readable/page.tsx",
+);
 
 describe("Custom Launch API documentation", () => {
   it("publishes one canonical human guide in both documentation systems", () => {
@@ -39,6 +44,10 @@ describe("Custom Launch API documentation", () => {
     expect(sitemap().map(({ url }) => url)).toContain(
       "https://programmable.market/docs/developers/custom-launch",
     );
+    expect(
+      docsSearchItems.find(({ title }) => title === "Creator overview")
+        ?.description,
+    ).not.toContain("publish reusable hook logic");
   });
 
   it("keeps prepared artifacts separate from authorized wallet transactions", () => {
@@ -81,5 +90,16 @@ describe("Custom Launch API documentation", () => {
       expect(source).toContain("error.requestId");
       expect(source).toContain("resource-level");
     }
+  });
+
+  it("describes request-driven reconciliation consistently", () => {
+    for (const source of [rawGuide, machineReadableGuide]) {
+      expect(source).toContain("bounded best-effort");
+      expect(source).not.toContain("only the exact single-launch GET reconciles");
+      expect(source).not.toContain("list reads do not perform per-launch chain reads");
+    }
+    expect(programmablePublicOpenApi["x-programmable-boundary"].actions).toContain(
+      "pending history rows",
+    );
   });
 });


### PR DESCRIPTION
## What changed
- align launch history and single-resource reconciliation copy with the live API behavior
- identify publicSubmissionStatus as the legacy Registry intake field, separate from the API-first write path
- remove a closed-template promise from docs search
- keep the website, raw guide, standalone OpenAPI, and GitBook mirror consistent

## Verification
- vitest: 16/16 focused docs and API-readiness tests
- scoped ESLint passed
- git diff --check passed