### PR TITLE
Persist Router Custom snapshot during refresh

### DIFF
--- a/app/api/ops/alchemy-launch-refresh/route.ts
+++ b/app/api/ops/alchemy-launch-refresh/route.ts
@@ -7,6 +7,9 @@ import {
   ALCHEMY_EXPLORE_CACHE_TAG,
   refreshAlchemyExploreRegistry,
 } from "../../../../lib/alchemy/explore.server";
+import {
+  persistRouterCustomIdentitySnapshotFromSourceV1,
+} from "../../../../lib/alchemy/router-custom-public.server";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -47,6 +50,15 @@ export async function GET(request: NextRequest) {
       includeLatest: false,
       requirePersistence: true,
     });
+    const routerSnapshot =
+      await persistRouterCustomIdentitySnapshotFromSourceV1({
+        generatedAt: result.registryGeneratedAt,
+        status: result.launchStampRouterCaughtUp
+          ? "current"
+          : "last-known-good",
+        reorgDetected: result.launchStampRouterRebuiltAfterReorg,
+        slice: result.launchStampRouter,
+      });
     revalidateTag(ALCHEMY_EXPLORE_CACHE_TAG, { expire: 0 });
     return NextResponse.json(
       {
@@ -55,6 +67,8 @@ export async function GET(request: NextRequest) {
         registryChanged: result.registryChanged,
         confirmedBlockNumber: result.confirmedBlockNumber,
         launchStampRouterBlockNumber: result.launchStampRouterBlockNumber,
+        routerCustomIdentityCount: routerSnapshot.entries.length,
+        routerCustomIdentityCommitment: routerSnapshot.identityCommitment,
       },
       { headers: NO_STORE },
     );

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -144,7 +144,7 @@
     "maximumCatchUpBlocks": 50000,
     "route": {
       "path": "app/api/ops/alchemy-launch-refresh/route.ts",
-      "sha256": "9734a0498cb75773c08d3427e3bc9ffe957c3e94378756bb81bb6d459a99108d"
+      "sha256": "71a783691e226120836f3f26c603d1aa793159af5afbc35d2fb03909ee4add03"
     },
     "runtime": {
       "path": "lib/alchemy/explore.server.ts",
@@ -160,7 +160,7 @@
     },
     "publicSnapshot": {
       "path": "lib/alchemy/router-custom-public.server.ts",
-      "sha256": "f4d3b022955c677148deabb7b2cc7af5a7e8283d2cbbb82d3f546ed37392cddd"
+      "sha256": "95da23fd7a97667f7b5341f3bf1ef0674c83707666ff591e1884919c76d01b9b"
     }
   },
   "workers": [

--- a/lib/alchemy/router-custom-public.server.ts
+++ b/lib/alchemy/router-custom-public.server.ts
@@ -393,6 +393,16 @@ async function persistDurableRouterCustomIdentitySnapshotV1(
   );
 }
 
+export async function persistRouterCustomIdentitySnapshotFromSourceV1(
+  source: AlchemyRouterCustomIdentitySourceV1,
+) {
+  const snapshot = routerCustomIdentitySnapshotFromSourceV1(source);
+  await persistDurableRouterCustomIdentitySnapshotV1(snapshot, {
+    replaceAfterReorg: source.reorgDetected,
+  });
+  return snapshot;
+}
+
 export function createRouterCustomIdentitySnapshotReaderV1(
   dependencies: RouterCustomIdentitySnapshotDependenciesV1 = {},
 ) {

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -168,7 +168,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     route: Object.freeze({
       path: "app/api/ops/alchemy-launch-refresh/route.ts",
       sha256:
-        "9734a0498cb75773c08d3427e3bc9ffe957c3e94378756bb81bb6d459a99108d",
+        "71a783691e226120836f3f26c603d1aa793159af5afbc35d2fb03909ee4add03",
     }),
     runtime: Object.freeze({
       path: "lib/alchemy/explore.server.ts",
@@ -188,7 +188,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     publicSnapshot: Object.freeze({
       path: "lib/alchemy/router-custom-public.server.ts",
       sha256:
-        "f4d3b022955c677148deabb7b2cc7af5a7e8283d2cbbb82d3f546ed37392cddd",
+        "95da23fd7a97667f7b5341f3bf1ef0674c83707666ff591e1884919c76d01b9b",
     }),
   }),
   independentCrons: Object.freeze([
@@ -1317,6 +1317,9 @@ export function evaluateReadModelOperationsSourceContracts(
       routerRefresherRoute.includes("forcePersist: true") &&
       routerRefresherRoute.includes("includeLatest: false") &&
       routerRefresherRoute.includes("requirePersistence: true") &&
+      routerRefresherRoute.includes(
+        "persistRouterCustomIdentitySnapshotFromSourceV1",
+      ) &&
       routerRefresherRoute.includes(
         "revalidateTag(ALCHEMY_EXPLORE_CACHE_TAG, { expire: 0 })",
       ) &&

--- a/tests/alchemy-launch-refresh-cron.test.ts
+++ b/tests/alchemy-launch-refresh-cron.test.ts
@@ -8,6 +8,7 @@ vi.mock("server-only", () => ({}));
 const mocks = vi.hoisted(() => ({
   revalidateTag: vi.fn(),
   refreshAlchemyExploreRegistry: vi.fn(),
+  persistRouterCustomIdentitySnapshotFromSourceV1: vi.fn(),
 }));
 
 vi.mock("next/cache", () => ({
@@ -18,6 +19,11 @@ vi.mock("next/cache", () => ({
 vi.mock("../lib/alchemy/explore.server", () => ({
   ALCHEMY_EXPLORE_CACHE_TAG: "alchemy-explore-v1",
   refreshAlchemyExploreRegistry: mocks.refreshAlchemyExploreRegistry,
+}));
+
+vi.mock("../lib/alchemy/router-custom-public.server", () => ({
+  persistRouterCustomIdentitySnapshotFromSourceV1:
+    mocks.persistRouterCustomIdentitySnapshotFromSourceV1,
 }));
 
 import {
@@ -43,6 +49,20 @@ describe("Alchemy launch refresh Vercel cron", () => {
       registryChanged: true,
       confirmedBlockNumber: "25750000",
       launchStampRouterBlockNumber: "25749936",
+      registryGeneratedAt: "2026-08-25T07:00:00.000Z",
+      launchStampRouterCaughtUp: true,
+      launchStampRouterRebuiltAfterReorg: false,
+      launchStampRouter: {
+        cursor: {
+          blockNumber: "25749936",
+          blockHash: `0x${"ab".repeat(32)}`,
+        },
+        tokens: [],
+      },
+    });
+    mocks.persistRouterCustomIdentitySnapshotFromSourceV1.mockResolvedValue({
+      entries: [{ id: "1:token:router-custom" }, { id: "1:token:fade" }],
+      identityCommitment: `sha256:${"cd".repeat(32)}`,
     });
   });
 
@@ -79,11 +99,27 @@ describe("Alchemy launch refresh Vercel cron", () => {
       registryChanged: true,
       confirmedBlockNumber: "25750000",
       launchStampRouterBlockNumber: "25749936",
+      routerCustomIdentityCount: 2,
+      routerCustomIdentityCommitment: `sha256:${"cd".repeat(32)}`,
     });
     expect(mocks.refreshAlchemyExploreRegistry).toHaveBeenCalledWith({
       forcePersist: true,
       includeLatest: false,
       requirePersistence: true,
+    });
+    expect(
+      mocks.persistRouterCustomIdentitySnapshotFromSourceV1,
+    ).toHaveBeenCalledWith({
+      generatedAt: "2026-08-25T07:00:00.000Z",
+      status: "current",
+      reorgDetected: false,
+      slice: {
+        cursor: {
+          blockNumber: "25749936",
+          blockHash: `0x${"ab".repeat(32)}`,
+        },
+        tokens: [],
+      },
     });
     expect(mocks.revalidateTag).toHaveBeenCalledWith(
       "alchemy-explore-v1",
@@ -101,6 +137,22 @@ describe("Alchemy launch refresh Vercel cron", () => {
 
     expect(response.status).toBe(503);
     expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(JSON.parse(text)).toEqual({
+      error: "Alchemy launch registry refresh unavailable",
+    });
+    expect(text).not.toContain(SECRET);
+    expect(mocks.revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the Router Custom durable snapshot cannot persist", async () => {
+    mocks.persistRouterCustomIdentitySnapshotFromSourceV1.mockRejectedValueOnce(
+      new Error(`blob unavailable ${SECRET}`),
+    );
+
+    const response = await GET(request());
+    const text = await response.text();
+
+    expect(response.status).toBe(503);
     expect(JSON.parse(text)).toEqual({
       error: "Alchemy launch registry refresh unavailable",
     });


### PR DESCRIPTION
## Outcome

The authenticated Alchemy refresh now persists the bounded Router Custom identity snapshot from the exact registry result it just confirmed. Explore and token/profile reads can therefore fall back to the durable Router snapshot when the live RPC path exceeds its fast-lane budget.

## Scope

- persist the Router Custom snapshot in the existing cron refresh
- fail closed if durable snapshot persistence fails
- return only count and commitment as non-secret operational evidence
- cover success and persistence-failure behavior

## Focused verification

- `npx vitest run tests/alchemy-launch-refresh-cron.test.ts tests/router-custom-public.test.ts` (25 passed)
- `npm run typecheck`
- targeted ESLint on the three changed files
- `git diff --check`

No wallet action, broadcast, onchain write, or secret output.
