### PR TITLE
Restore private Router snapshot reads

### DIFF
--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -160,7 +160,7 @@
     },
     "publicSnapshot": {
       "path": "lib/alchemy/router-custom-public.server.ts",
-      "sha256": "95da23fd7a97667f7b5341f3bf1ef0674c83707666ff591e1884919c76d01b9b"
+      "sha256": "e137ee71b93cd9ff702399e3799ade92761c0ddd4e037c34cfe968c55a0bc78a"
     }
   },
   "workers": [

--- a/lib/alchemy/router-custom-public.server.ts
+++ b/lib/alchemy/router-custom-public.server.ts
@@ -300,6 +300,23 @@ export function normalizeRouterCustomSnapshotBlobEtagV1(value: string) {
   return normalized;
 }
 
+export function assertBoundedRouterCustomSnapshotBlobSizeV1(
+  declaredLength: number,
+  actualLength: number,
+) {
+  // Private Vercel Blob reads currently report `blob.size = 0` while still
+  // returning the complete stream. Treat zero as an unknown declared size and
+  // enforce the bound against the bytes that were actually read below.
+  if (
+    !Number.isSafeInteger(declaredLength)
+    || declaredLength < 0
+    || declaredLength > ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_BYTES
+    || !Number.isSafeInteger(actualLength)
+    || actualLength < 1
+    || actualLength > ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_BYTES
+  ) throw new Error("Router Custom durable snapshot size is invalid");
+}
+
 async function readDurableRouterCustomIdentitySnapshotRecordV1() {
   const token = resolveDurableExploreBlobToken();
   if (!token) throw new Error(
@@ -317,13 +334,14 @@ async function readDurableRouterCustomIdentitySnapshotRecordV1() {
   const declaredLength = Number(result.blob.size);
   if (
     !Number.isSafeInteger(declaredLength)
-    || declaredLength < 1
+    || declaredLength < 0
     || declaredLength > ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_BYTES
   ) throw new Error("Router Custom durable snapshot size is invalid");
   const source = await new Response(result.stream).text();
-  if (Buffer.byteLength(source, "utf8") > ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_BYTES) {
-    throw new Error("Router Custom durable snapshot is too large");
-  }
+  assertBoundedRouterCustomSnapshotBlobSizeV1(
+    declaredLength,
+    Buffer.byteLength(source, "utf8"),
+  );
   return Object.freeze({
     snapshot: parseDurableRouterCustomIdentitySnapshotV1(
       parseStrictJson(source, {

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -188,7 +188,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     publicSnapshot: Object.freeze({
       path: "lib/alchemy/router-custom-public.server.ts",
       sha256:
-        "95da23fd7a97667f7b5341f3bf1ef0674c83707666ff591e1884919c76d01b9b",
+        "e137ee71b93cd9ff702399e3799ade92761c0ddd4e037c34cfe968c55a0bc78a",
     }),
   }),
   independentCrons: Object.freeze([

--- a/tests/router-custom-public.test.ts
+++ b/tests/router-custom-public.test.ts
@@ -14,6 +14,7 @@ vi.mock("../lib/alchemy/explore.server", () => ({
 }));
 
 import {
+  assertBoundedRouterCustomSnapshotBlobSizeV1,
   createRouterCustomIdentitySnapshotReaderV1,
   mergeRouterCustomCreatorProfileV1,
   mergeRouterCustomExploreEntriesV1,
@@ -150,6 +151,25 @@ describe("finalized Router Custom public projection", () => {
     expect(() => normalizeRouterCustomSnapshotBlobEtagV1(
       "8e8ed5b7c65cfe481ae32dc684e98710",
     )).toThrow("ETag is invalid");
+  });
+
+  it("bounds private Blob streams when the provider omits their declared size", () => {
+    expect(() => assertBoundedRouterCustomSnapshotBlobSizeV1(
+      0,
+      11_499,
+    )).not.toThrow();
+    expect(() => assertBoundedRouterCustomSnapshotBlobSizeV1(
+      11_499,
+      11_499,
+    )).not.toThrow();
+    expect(() => assertBoundedRouterCustomSnapshotBlobSizeV1(
+      0,
+      0,
+    )).toThrow("snapshot size is invalid");
+    expect(() => assertBoundedRouterCustomSnapshotBlobSizeV1(
+      -1,
+      11_499,
+    )).toThrow("snapshot size is invalid");
   });
 
   it("keeps finalized identities as last-known-good across a long outage", async () => {


### PR DESCRIPTION
## Outcome

Restores the finalized Router Custom fallback when Vercel private Blob returns a complete stream with `blob.size = 0`. Zero is treated only as an unknown declared size; the actual bytes remain strictly bounded to 16 MiB before parsing.

## Evidence

- Real private snapshot: 11,499 streamed bytes with provider-declared size 0
- Focused Router Custom tests: 21 passed
- TypeScript typecheck: passed
- Targeted ESLint: passed
- Read-model source-contract gate: passed
- `git diff --check`: passed

No wallet action, transaction, or public generic launch enablement is included.