### PR TITLE
Accept bounded launch identity fallback in production smoke

### DIFF
--- a/scripts/smoke-static-dexscreener-public-apis.mjs
+++ b/scripts/smoke-static-dexscreener-public-apis.mjs
@@ -423,7 +423,9 @@ function exactCatalogSnapshot(response) {
       generatedAt &&
     launchIdentity?.custom === customStatus &&
     ["current", "last-known-good"].includes(launchIdentity?.canonical) &&
-    ["current", "partial"].includes(launchIdentity?.status) &&
+    ["current", "last-known-good", "partial"].includes(
+      launchIdentity?.status,
+    ) &&
     Number.isSafeInteger(launchIdentity.ageMs) &&
     launchIdentity.ageMs >= 0
   )) return null;

--- a/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
+++ b/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
@@ -397,6 +397,9 @@ function routerCustomStagedFetch(
             ...body.dataQuality,
             launchIdentity: {
               ...body.dataQuality.launchIdentity,
+              status: customStatus === "last-known-good"
+                ? "last-known-good"
+                : body.dataQuality.launchIdentity.status,
               custom: customStatus,
             },
           },


### PR DESCRIPTION
## Summary
- accept the documented `last-known-good` launch identity status in the staged public smoke
- make the existing Router fallback fixture exercise that exact aggregate status

## Evidence
- production candidates on `b8d69154` passed Envio and Custom V2 gates but exposed the smoke-only mismatch
- focused smoke tests: 28/28 pass
- staged read-model contract tests: 17/17 pass
- `git diff --check`: pass

No runtime route, provider, signer, or authorization behavior changes.