### PR TITLE
Keep public CLI rehearsal evidence pre-submit

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ provider availability or onchain lifecycle completion.
 | Custom Launch API keys       | [programmable.market/developers/api-keys](https://programmable.market/developers/api-keys)               |
 | Authenticated Custom writes  | [api.programmable.market/v1/custom-launches](https://api.programmable.market/v1/custom-launches)          |
 | Custom Launch API readiness  | [api.programmable.market/readyz](https://api.programmable.market/readyz)                                  |
-| Custom Launch CLI 1.0.0      | [versioned GitHub Release asset](https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.0/programmable-launch-1.0.0.tgz) |
+| Custom Launch CLI 1.0.1      | [versioned GitHub Release asset](https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz) |
 | Read-only developer reference | [programmable.market/docs/developers](https://programmable.market/docs/developers)                       |
 | Read-only service status     | [developers.programmable.family/api/v2/status](https://developers.programmable.family/api/v2/status)     |
 | Deployment manifest          | [developers.programmable.family/api/v2/manifest](https://developers.programmable.family/api/v2/manifest) |

--- a/docs/public/developers/custom-launch.md
+++ b/docs/public/developers/custom-launch.md
@@ -21,13 +21,14 @@ Install the pinned public GitHub Release asset. Do not substitute an unverified 
 
 ```bash
 npm install --global \
-  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.0/programmable-launch-1.0.0.tgz
+  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz
 programmable-launch --version
 ```
 
 The release includes `examples/no-broadcast/README.md`, real Solidity sources, exact Standard JSON and matching solc
-artifacts. Its generated config uses the pack-native deterministic hook-permission salt grind, reaches `authorized`
-with a real wallet-bound request and then stops without signing or broadcasting.
+artifacts. Its generated evidence is limited to `pre-submit`. The separate authenticated commands can use the
+pack-native deterministic hook-permission salt grind, reach `authorized` with a real wallet-bound request and then
+stop without signing or broadcasting.
 
 Build the project from one pinned source revision and preserve:
 

--- a/docs/public/reference/official-links.md
+++ b/docs/public/reference/official-links.md
@@ -16,7 +16,7 @@ description: Official Programmable product, source, community and analytics link
 | Custom Launch API guide | [programmable.market/developers/custom-launch-api-v1.md](https://programmable.market/developers/custom-launch-api-v1.md) |
 | Custom write API        | [api.programmable.market](https://api.programmable.market)                                                         |
 | Custom API readiness    | [api.programmable.market/readyz](https://api.programmable.market/readyz)                                           |
-| Custom Launch CLI 1.0.0 | [versioned GitHub Release asset](https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.0/programmable-launch-1.0.0.tgz) |
+| Custom Launch CLI 1.0.1 | [versioned GitHub Release asset](https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz) |
 | Launch policy           | [github.com/0xprogrammable/launch-policy](https://github.com/0xprogrammable/launch-policy)                         |
 | Read-only developer API | [developers.programmable.family](https://developers.programmable.family)                                           |
 | X                       | [x.com/0xProgrammable](https://x.com/0xProgrammable)                                                               |

--- a/lib/custom-launch/agent-setup-v1.ts
+++ b/lib/custom-launch/agent-setup-v1.ts
@@ -1,5 +1,5 @@
 export const PROGRAMMABLE_AGENT_SETUP_LINKS_V1 = Object.freeze({
-  cli: "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.0/programmable-launch-1.0.0.tgz",
+  cli: "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz",
   guide: "https://programmable.market/docs/developers/custom-launch",
   openApi: "https://programmable.market/openapi/custom-launch-v1.json",
 });

--- a/lib/developer-docs-content.ts
+++ b/lib/developer-docs-content.ts
@@ -21,7 +21,7 @@ const customLaunchHumanGuideUrl =
   "https://programmable.market/docs/developers/custom-launch";
 const customLaunchReadyzUrl = "https://api.programmable.market/readyz";
 const customLaunchCliReleaseUrl =
-  "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.0/programmable-launch-1.0.0.tgz";
+  "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz";
 
 const manifest = PROGRAMMABLE_LAUNCH_STAMP_MANIFEST;
 const router = manifest.launchStampRouter;
@@ -387,7 +387,7 @@ export function buildProgrammableLlmsIndex(): string {
     `- Create or revoke API keys: ${apiKeysUrl}`,
     `- Custom Launch API guide: ${customLaunchHumanGuideUrl}`,
     `- Custom Launch API readiness: ${customLaunchReadyzUrl}`,
-    `- Programmable Launch CLI 1.0.0: ${customLaunchCliReleaseUrl}`,
+    `- Programmable Launch CLI 1.0.1: ${customLaunchCliReleaseUrl}`,
     `- Create a Custom launch: POST ${customLaunchApiOrigin}/v1/custom-launches`,
     `- List wallet-owned Custom launches: GET ${customLaunchApiOrigin}/v1/custom-launches`,
     `- Read a Custom launch: GET ${customLaunchApiOrigin}/v1/custom-launches/{launchId}`,

--- a/lib/server/custom-launch/well-known-v1.ts
+++ b/lib/server/custom-launch/well-known-v1.ts
@@ -40,11 +40,11 @@ export function programmableWellKnownDocumentV1(
       cli: Object.freeze({
         packageName: "@programmable/launch",
         binary: "programmable-launch",
-        releaseVersion: "1.0.0",
+        releaseVersion: "1.0.1",
         releaseUrl:
-          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/tag/programmable-launch-v1.0.0",
+          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/tag/programmable-launch-v1.0.1",
         tarballUrl:
-          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.0/programmable-launch-1.0.0.tgz",
+          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz",
       }),
       authentication: "wallet-bound-api-key" as const,
       walletAuthority: "separate-review-and-sign" as const,

--- a/packages/launch/README.md
+++ b/packages/launch/README.md
@@ -8,7 +8,7 @@ transaction.
 
 ```sh
 npm install --global \
-  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.0/programmable-launch-1.0.0.tgz
+  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz
 programmable-launch --version
 ```
 
@@ -41,8 +41,9 @@ separate wallet flow. After broadcast, use `status REQUEST_UUID --watch --until 
 `cancelled` always stop polling.
 
 For an executable cold-room rehearsal, use `examples/no-broadcast/README.md` from the installed package. It contains
-real Solidity sources, exact Standard JSON, matching solc artifacts and a config generator. It packs, validates,
-submits and polls to `authorized`, then explicitly stops without signing or broadcasting.
+real Solidity sources, exact Standard JSON, matching solc artifacts and a config generator. The generated evidence is
+truthfully scoped to `pre-submit`; separate commands can then pack, validate, submit and poll to `authorized`, where
+the workflow explicitly stops without signing or broadcasting.
 
 ## Pack config V1
 

--- a/packages/launch/examples/no-broadcast/README.md
+++ b/packages/launch/examples/no-broadcast/README.md
@@ -1,8 +1,8 @@
 # No-broadcast clean-room example
 
 This example uses real Solidity 0.8.26 sources, exact Standard JSON input and matching compiler artifacts. It derives a
-wallet-specific request, submits it to the production API and stops at `authorized`. It must never be signed or
-broadcast. It creates no Mainnet coin.
+wallet-specific request and provides separate commands that can submit it to the production API and stop at
+`authorized`. It must never be signed or broadcast. It creates no Mainnet coin.
 
 After installing the pinned CLI release, copy only the immutable project files into a clean directory:
 
@@ -18,8 +18,8 @@ the release tag. Choose a fresh nonzero nonce for this one rehearsal.
 export PROGRAMMABLE_LAUNCH_WALLET="0x..."
 export PROGRAMMABLE_SOURCE_REVISION="$(
   git ls-remote https://github.com/0xprogrammable/PROGRAMMABLE.git \
-    refs/tags/programmable-launch-v1.0.0 \
-    'refs/tags/programmable-launch-v1.0.0^{}' |
+    refs/tags/programmable-launch-v1.0.1 \
+    'refs/tags/programmable-launch-v1.0.1^{}' |
   tail -n 1 | cut -f 1
 )"
 export PROGRAMMABLE_LAUNCH_NONCE="0x$(openssl rand -hex 32)"
@@ -27,6 +27,10 @@ export PROGRAMMABLE_LAUNCH_NONCE="0x$(openssl rand -hex 32)"
 node "$PACKAGE_ROOT/examples/no-broadcast/prepare-config.mjs" \
   ./programmable-no-broadcast
 ```
+
+`prepare-config.mjs` writes only pre-submit evidence. Its `scope` records `submit: false`, `status: false` and
+`stopAt: "pre-submit"`; it does not claim that any authenticated API action has happened. Preserve the later command
+output and request UUID separately if you perform the authenticated steps.
 
 The generated config uses `deterministic-hook-permission-grind-v1`. Its real no-op hook implements the PoolManager-only
 `afterInitialize` callback and declares that one permission, so it is a valid static-fee v4 hook. `pack` tries salts in
@@ -54,5 +58,6 @@ programmable-launch status REQUEST_UUID --watch --until authorized
 ```
 
 Stop at `authorized`. Record the request UUID and confirm that the response contains a wallet transaction for separate
-review, but do not sign and do not call `eth_sendTransaction`. This example is evidence for packaging, validation,
-idempotent API submission and the safe wallet boundary only.
+review, but do not sign and do not call `eth_sendTransaction`. The generated `evidence/rehearsal.json` proves only the
+inspected build inputs before `pack`. The command output and API resource are the separate evidence for any packaging,
+validation, idempotent submission or status polling that is actually performed.

--- a/packages/launch/examples/no-broadcast/prepare-config.mjs
+++ b/packages/launch/examples/no-broadcast/prepare-config.mjs
@@ -62,10 +62,11 @@ if (compilerVersions.size !== 1
 const evidence = {
   schemaVersion: "programmable.no-broadcast-rehearsal-evidence.v1",
   scope: {
-    pack: true,
-    validate: true,
-    submit: true,
-    stopAt: "authorized",
+    pack: false,
+    validate: false,
+    submit: false,
+    status: false,
+    stopAt: "pre-submit",
     walletBroadcast: false,
   },
   launchWallet,

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@programmable/launch",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Deterministic pack, validation, submission, and status tooling for the Programmable Custom Launch API",
   "type": "module",
   "bin": {

--- a/packages/launch/src/constants.mjs
+++ b/packages/launch/src/constants.mjs
@@ -1,4 +1,4 @@
-export const PACKAGE_VERSION = "1.0.0";
+export const PACKAGE_VERSION = "1.0.1";
 export const PACK_CONFIG_SCHEMA = "programmable.launch-pack-config.v1";
 export const CREATE_REQUEST_SCHEMA = "programmable.custom-launch-create-request.v1";
 export const SOURCE_DESCRIPTOR_SCHEMA = "2.0.0";
@@ -13,8 +13,8 @@ export const READY_PATH = "/readyz";
 export const OPENAPI_URL = "https://programmable.market/openapi/custom-launch-v1.json";
 export const GUIDE_URL = "https://programmable.market/docs/developers/custom-launch";
 export const API_KEYS_URL = "https://programmable.market/developers/api-keys";
-export const RELEASE_TAG = "programmable-launch-v1.0.0";
-export const RELEASE_TARBALL = "programmable-launch-1.0.0.tgz";
+export const RELEASE_TAG = "programmable-launch-v1.0.1";
+export const RELEASE_TARBALL = "programmable-launch-1.0.1.tgz";
 export const RELEASE_URL =
   `https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/${RELEASE_TAG}/${RELEASE_TARBALL}`;
 

--- a/packages/launch/test/launch.test.mjs
+++ b/packages/launch/test/launch.test.mjs
@@ -197,6 +197,18 @@ test("the bundled no-broadcast example derives a real graph and deterministic ho
     },
     encoding: "utf8",
   });
+  const rehearsalEvidence = JSON.parse(await readFile(
+    path.join(projectDirectory, "evidence", "rehearsal.json"),
+    "utf8",
+  ));
+  assert.deepEqual(rehearsalEvidence.scope, {
+    pack: false,
+    validate: false,
+    submit: false,
+    status: false,
+    stopAt: "pre-submit",
+    walletBroadcast: false,
+  });
   const configPath = path.join(projectDirectory, "programmable-launch.config.json");
   const first = await packLaunch({
     configPath,

--- a/public/developers/custom-launch-api-v1.md
+++ b/public/developers/custom-launch-api-v1.md
@@ -13,7 +13,7 @@ Readiness: <https://api.programmable.market/readyz>
 
 ```sh
 npm install --global \
-  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.0/programmable-launch-1.0.0.tgz
+  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz
 programmable-launch --version
 ```
 
@@ -31,7 +31,8 @@ programmable-launch status REQUEST_UUID --watch --until authorized
 
 The release tarball includes `examples/no-broadcast/README.md` with real Solidity source, exact Standard JSON, matching
 solc artifacts and a config generator. Its pack-native hook salt grind is deterministic after source, wallet and nonce
-are fixed. The rehearsal submits and polls to `authorized`, then stops without a wallet signature or broadcast.
+are fixed. Generated evidence stops truthfully at `pre-submit`; separately recorded commands can submit and poll to
+`authorized`, then stop without a wallet signature or broadcast.
 
 `pack` derives the sorted manifest, source descriptor, ABI-encoded arguments, graph, target locators, CREATE2
 predictions, evidence digests, canonical hashes and exact-source verification bundle from exact source, Standard JSON,

--- a/tests/custom-launch-cli-public-surface.test.ts
+++ b/tests/custom-launch-cli-public-surface.test.ts
@@ -25,9 +25,9 @@ describe("public Custom Launch CLI surface", () => {
       cli: {
         packageName: "@programmable/launch",
         binary: "programmable-launch",
-        releaseVersion: "1.0.0",
+        releaseVersion: "1.0.1",
         tarballUrl:
-          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.0/programmable-launch-1.0.0.tgz",
+          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz",
       },
     });
     expect(document.publicCategories.custom).toMatchObject({
@@ -54,6 +54,8 @@ describe("public Custom Launch CLI surface", () => {
     expect(guide).toContain("--until authorized");
     expect(guide).toContain("do not sign");
     expect(guide).toContain("do not call `eth_sendTransaction`");
+    expect(guide).toContain("`submit: false`");
+    expect(guide).toContain('`stopAt: "pre-submit"`');
   });
 
   it("keeps request and exact-source limits aligned with the live API", () => {

--- a/tests/custom-launch-docs.test.ts
+++ b/tests/custom-launch-docs.test.ts
@@ -94,7 +94,7 @@ describe("Custom Launch API documentation", () => {
 
   it("publishes the exact-source and no-broadcast cold-agent path", () => {
     for (const source of [gitBookGuide, rawGuide, developerDocsMarkdown]) {
-      expect(source).toContain("programmable-launch-1.0.0.tgz");
+      expect(source).toContain("programmable-launch-1.0.1.tgz");
       expect(source).toContain("verificationBundle");
       expect(source).toContain("exact_match");
       expect(source).toContain("PROGRAMMABLE_API_KEY");


### PR DESCRIPTION
## Summary
- scope generated no-broadcast evidence truthfully to pre-submit with submit/status false
- release the immutable public package as 1.0.1 and update canonical links
- add focused regression coverage for the evidence scope and public release metadata

## Checks
- `npm test` in `packages/launch` (7/7)
- `vitest run tests/custom-launch-cli-public-surface.test.ts tests/custom-launch-docs.test.ts` (10/10)
- `npm pack --dry-run` in `packages/launch`
- `git diff --check`

No API key, wallet action, transaction, or broadcast was used.