### PR TITLE
Stabilize profile loading geometry

### DIFF
--- a/components/prediction-market-experience.module.css
+++ b/components/prediction-market-experience.module.css
@@ -1110,6 +1110,66 @@
   min-width: 0;
 }
 
+.portfolioLoadingCards {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.portfolioLoadingCard {
+  align-items: center;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: 58px minmax(210px, 1fr) 252px 148px;
+  min-height: 82px;
+  min-width: 0;
+  padding: 10px;
+}
+
+.portfolioLoadingArtwork,
+.portfolioLoadingCopy > span,
+.portfolioLoadingMetrics > span,
+.portfolioLoadingAction {
+  background: color-mix(in srgb, var(--text, #fff) 9%, transparent);
+}
+
+.portfolioLoadingArtwork {
+  border-radius: 15px;
+  height: 58px;
+  width: 58px;
+}
+
+.portfolioLoadingCopy,
+.portfolioLoadingMetrics {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.portfolioLoadingCopy > span,
+.portfolioLoadingMetrics > span {
+  border-radius: 999px;
+  display: block;
+  height: 10px;
+}
+
+.portfolioLoadingCopy > span:first-child {
+  width: 74%;
+}
+
+.portfolioLoadingCopy > span:last-child {
+  width: 52%;
+}
+
+.portfolioLoadingMetrics {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.portfolioLoadingAction {
+  border-radius: 10px;
+  height: 44px;
+}
+
 .portfolioCard {
   align-items: center;
   background: var(
@@ -1625,6 +1685,22 @@
 }
 
 @media (max-width: 52rem) {
+  .portfolioLoadingCard {
+    align-items: start;
+    grid-template-columns: 52px minmax(0, 1fr);
+    min-height: 190px;
+  }
+
+  .portfolioLoadingArtwork {
+    height: 52px;
+    width: 52px;
+  }
+
+  .portfolioLoadingMetrics,
+  .portfolioLoadingAction {
+    grid-column: 1 / -1;
+  }
+
   .portfolioCard {
     align-items: start;
     grid-template-columns: 52px minmax(0, 1fr);
@@ -1777,6 +1853,27 @@
 
   .portfolioSection {
     padding: 16px;
+  }
+
+  .portfolioLoadingCard {
+    grid-template-columns: minmax(0, 1fr);
+    min-height: 256px;
+    position: relative;
+  }
+
+  .portfolioLoadingArtwork {
+    inset-block-start: 10px;
+    inset-inline-start: 10px;
+    position: absolute;
+  }
+
+  .portfolioLoadingCopy {
+    min-height: 52px;
+    padding-inline-start: 64px;
+  }
+
+  .portfolioLoadingMetrics {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .portfolioCard {

--- a/components/prediction-market-portfolio.tsx
+++ b/components/prediction-market-portfolio.tsx
@@ -116,6 +116,7 @@ const PORTFOLIO_PARTIAL_ERROR =
 const PORTFOLIO_INITIAL_VISIBLE_ITEMS = 12;
 const PORTFOLIO_VISIBLE_ITEM_STEP = 12;
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+export const predictionPortfolioLoadingPlaceholderCount = 3;
 
 const PORTFOLIO_TABS = [
   { id: "positions", label: "Positions" },
@@ -842,11 +843,7 @@ export function PredictionMarketPortfolio({
                   )}
                 />
               ) : model.phase === "loading" && visibleItems.length === 0 ? (
-                <PortfolioEmptyState
-                  icon={<CircleDollarSign aria-hidden="true" size={21} strokeWidth={1.8} />}
-                  title="Loading prediction activity"
-                  description="Your latest positions will appear here."
-                />
+                <PredictionPortfolioLoadingState />
               ) : model.phase === "error" && visibleItems.length === 0 ? (
                 <div className={styles.portfolioError} role="alert">
                   <span>
@@ -908,6 +905,30 @@ export function PredictionMarketPortfolio({
         </div>
       ))}
     </section>
+  );
+}
+
+function PredictionPortfolioLoadingState() {
+  return (
+    <div className={styles.portfolioLoadingCards} aria-hidden="true">
+      {Array.from(
+        { length: predictionPortfolioLoadingPlaceholderCount },
+        (_, item) => (
+          <div className={styles.portfolioLoadingCard} key={item}>
+            <span className={styles.portfolioLoadingArtwork} />
+            <span className={styles.portfolioLoadingCopy}>
+              <span />
+              <span />
+            </span>
+            <span className={styles.portfolioLoadingMetrics}>
+              <span />
+              <span />
+            </span>
+            <span className={styles.portfolioLoadingAction} />
+          </div>
+        ),
+      )}
+    </div>
   );
 }
 

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -1303,11 +1303,14 @@
 }
 
 .profileSkeletonInline {
+  margin-block-start: 34px;
   min-height: 360px;
+  padding-block-start: 0;
 }
 
 .profileSkeletonPage {
   min-height: calc(100svh - 88px);
+  padding-block-start: 0;
 }
 
 .profileSkeletonHero {
@@ -1382,6 +1385,10 @@
   min-height: 360px;
 }
 
+.profileSkeletonWorkspacePage {
+  margin-block-start: 18px;
+}
+
 .profileSkeletonSummary,
 .profileSkeletonClaims,
 .profileSkeletonSection {
@@ -1393,13 +1400,29 @@
   padding: 20px;
 }
 
+.profileSkeletonSummary,
+.profileSkeletonClaims {
+  min-height: 360px;
+}
+
 .profileSkeletonSection {
   align-content: start;
-  min-height: 285px;
+  gap: 12px;
+}
+
+.profileSkeletonLaunch {
+  margin-block-start: 40px;
+  min-height: 448px;
 }
 
 .profileSkeletonPrediction {
-  min-height: 220px;
+  min-height: 422px;
+}
+
+.profileSkeletonSectionHeader {
+  align-items: center;
+  display: flex;
+  min-height: 44px;
 }
 
 .profileSkeletonTabs {
@@ -1412,8 +1435,13 @@
 .profileSkeletonPredictionRow {
   border-radius: 11px;
   display: block;
-  height: 92px;
+  min-height: 82px;
   width: 100%;
+}
+
+.profileSkeletonPredictionRows {
+  display: grid;
+  gap: 8px;
 }
 
 .profileSkeletonHeading {
@@ -1438,7 +1466,7 @@
 
 .profileSkeletonRows {
   display: grid;
-  gap: 8px;
+  gap: 3px;
 }
 
 .profileSkeletonRow {
@@ -1631,6 +1659,15 @@
 
   .profileSkeletonWorkspace {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .profileSkeletonSummary,
+  .profileSkeletonClaims {
+    min-height: 340px;
+  }
+
+  .profileSkeletonPredictionRow {
+    min-height: 190px;
   }
 
   .customProjects {
@@ -2500,6 +2537,36 @@
 
   .portfolio {
     margin-top: 28px;
+  }
+
+  .profileSkeletonInline {
+    margin-block-start: 28px;
+  }
+
+  .profileSkeletonLaunch,
+  .profileSkeletonPrediction {
+    padding: 16px;
+  }
+
+  .profileSkeletonLaunch {
+    margin-block-start: 16px;
+  }
+
+  .profileSkeletonWorkspacePage {
+    margin-block-start: 12px;
+  }
+
+  .profileSkeletonLaunch .profileSkeletonRow {
+    grid-template-columns: 44px minmax(0, 1fr);
+    min-height: 109px;
+  }
+
+  .profileSkeletonLaunch .profileSkeletonRow > span:last-child {
+    grid-column: 1 / -1;
+  }
+
+  .profileSkeletonPredictionRow {
+    min-height: 256px;
   }
 
   .profileSkeletonHero {

--- a/components/profile-projects.module.css
+++ b/components/profile-projects.module.css
@@ -326,7 +326,7 @@
 .skeletonList {
   display: grid;
   gap: 3px;
-  min-height: 213px;
+  min-height: 352px;
 }
 
 .skeletonProject {

--- a/components/profile-projects.tsx
+++ b/components/profile-projects.tsx
@@ -491,7 +491,7 @@ function ProfileProjectsSkeleton() {
       <span className={styles.visuallyHidden} role="status">
         Loading launches
       </span>
-      {[0, 1, 2].map((item) => (
+      {Array.from({ length: creatorProjectPageSize }, (_, item) => (
         <div className={styles.skeletonProject} aria-hidden="true" key={item}>
           <span className={styles.skeletonArt} />
           <span className={styles.skeletonCopy}>

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -18,12 +18,16 @@ import {
 
 import { useWallet } from "@/components/wallet-provider";
 import {
+  creatorProjectPageSize,
   ProfileProjects,
   type CreatorProjectInitialBuyV1,
   type CreatorProjectMarketCapV1,
   type CreatorProjectSummaryV1,
 } from "@/components/profile-projects";
-import { PredictionMarketPortfolio } from "@/components/prediction-market-portfolio";
+import {
+  PredictionMarketPortfolio,
+  predictionPortfolioLoadingPlaceholderCount,
+} from "@/components/prediction-market-portfolio";
 import { useLiveDataRefresh } from "@/components/use-live-data-refresh";
 import { formatMarketCapMetric } from "@/components/animated-market-cap";
 import { isConfiguredClassicV3ReleaseReady } from "@/lib/classic-v3-release";
@@ -4353,27 +4357,51 @@ function ProfileLoadingSkeleton({
       ) : null}
       {showHero ? (
         <>
-          <div className={styles.profileSkeletonSection} aria-hidden="true">
-            <span className={styles.profileSkeletonHeading} />
-            {[0, 1, 2].map((item) => (
-              <span className={styles.profileSkeletonRow} key={item}>
-                <span />
-                <span />
-                <span />
-              </span>
-            ))}
+          <div
+            className={`${styles.profileSkeletonSection} ${styles.profileSkeletonLaunch}`}
+            aria-hidden="true"
+          >
+            <span className={styles.profileSkeletonSectionHeader}>
+              <span className={styles.profileSkeletonHeading} />
+            </span>
+            <span className={styles.profileSkeletonRows}>
+              {Array.from({ length: creatorProjectPageSize }, (_, item) => (
+                <span className={styles.profileSkeletonRow} key={item}>
+                  <span />
+                  <span />
+                  <span />
+                </span>
+              ))}
+            </span>
           </div>
           <div
             className={`${styles.profileSkeletonSection} ${styles.profileSkeletonPrediction}`}
             aria-hidden="true"
           >
-            <span className={styles.profileSkeletonHeading} />
+            <span className={styles.profileSkeletonSectionHeader}>
+              <span className={styles.profileSkeletonHeading} />
+            </span>
             <span className={styles.profileSkeletonTabs} />
-            <span className={styles.profileSkeletonPredictionRow} />
+            <span className={styles.profileSkeletonPredictionRows}>
+              {Array.from(
+                { length: predictionPortfolioLoadingPlaceholderCount },
+                (_, item) => (
+                  <span
+                    className={styles.profileSkeletonPredictionRow}
+                    key={item}
+                  />
+                ),
+              )}
+            </span>
           </div>
         </>
       ) : null}
-      <div className={styles.profileSkeletonWorkspace} aria-hidden="true">
+      <div
+        className={`${styles.profileSkeletonWorkspace} ${
+          showHero ? styles.profileSkeletonWorkspacePage : ""
+        }`}
+        aria-hidden="true"
+      >
         <div className={styles.profileSkeletonSummary}>
           <span className={styles.profileSkeletonHeading} />
           <span className={styles.profileSkeletonMetric} />
@@ -4707,6 +4735,7 @@ function ProfileAccountWorkspace({
                     : "Refresh claimable rewards"
                 }
                 aria-busy={refreshing || undefined}
+                disabled={refreshing}
                 onClick={onRetry}
               >
                 <RefreshCw aria-hidden="true" size={15} strokeWidth={1.8} />

--- a/tests/prediction-profile-regression.test.ts
+++ b/tests/prediction-profile-regression.test.ts
@@ -326,6 +326,19 @@ describe("prediction profile regression contract", () => {
     );
   });
 
+  it("reserves the populated profile geometry while prediction activity loads", () => {
+    expect(portfolioSource).toContain(
+      "predictionPortfolioLoadingPlaceholderCount = 3",
+    );
+    expect(portfolioSource).toContain("<PredictionPortfolioLoadingState />");
+    expect(portfolioStyles).toMatch(
+      /\.portfolioLoadingCard\s*\{[^}]*min-height:\s*82px;/s,
+    );
+    expect(portfolioStyles).toMatch(
+      /@media \(max-width:\s*620px\)[\s\S]*?\.portfolioLoadingCard\s*\{[^}]*min-height:\s*256px;/s,
+    );
+  });
+
   it("uses vivid yes and no colors with AA text contrast and non-color labels", () => {
     const yes = cssHexVariable(portfolioStyles, "--portfolio-yes");
     const no = cssHexVariable(portfolioStyles, "--portfolio-no");

--- a/tests/profile-projects-editor-open.test.ts
+++ b/tests/profile-projects-editor-open.test.ts
@@ -129,6 +129,26 @@ describe("My projects editor opening", () => {
     );
   });
 
+  it("reserves a complete first page while keeping warm launch actions visible", () => {
+    const source = readFileSync(
+      join(process.cwd(), "components/profile-projects.tsx"),
+      "utf8",
+    );
+    const styles = readFileSync(
+      join(process.cwd(), "components/profile-projects.module.css"),
+      "utf8",
+    );
+
+    expect(source).toContain(
+      "Array.from({ length: creatorProjectPageSize }, (_, item)",
+    );
+    expect(styles).toMatch(/\.skeletonList\s*\{[^}]*min-height:\s*352px;/s);
+    expect(source).toContain(
+      'phase === "loading" && visibleProjects.length === 0',
+    );
+    expect(source).toContain("{canEditArticle ? (");
+  });
+
   it("paginates verified projects by highest available market cap", () => {
     const paginate = (profileProjects as unknown as {
       paginateCreatorProjectsV1(

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -498,6 +498,21 @@ describe("profile workspace loading state", () => {
       /@media \(max-width:\s*620px\)[\s\S]*?\.profileSkeletonBanner\s*\{[^}]*height:\s*108px;/s,
     );
     expect(profileViewSource).toContain("styles.profileSkeletonSection");
+    expect(profileViewSource).toContain(
+      "Array.from({ length: creatorProjectPageSize }, (_, item)",
+    );
+    expect(profileViewSource).toContain(
+      "length: predictionPortfolioLoadingPlaceholderCount",
+    );
+    expect(profileExperienceCss).toMatch(
+      /\.profileSkeletonLaunch\s*\{[^}]*min-height:\s*448px;/s,
+    );
+    expect(profileExperienceCss).toMatch(
+      /\.profileSkeletonPrediction\s*\{[^}]*min-height:\s*422px;/s,
+    );
+    expect(profileExperienceCss).toMatch(
+      /@media \(max-width:\s*820px\)[\s\S]*?\.profileSkeletonSummary,[\s\S]*?\.profileSkeletonClaims\s*\{[^}]*min-height:\s*340px;/s,
+    );
     expect(profileExperienceCss).not.toContain("profile-content-reveal");
     expect(profileExperienceCss).toContain("profile-skeleton-pulse");
   });
@@ -511,6 +526,7 @@ describe("profile workspace loading state", () => {
       '{refreshing ? "Refreshing" : "Refresh"}',
     );
     expect(profileViewSource).toContain("aria-busy={refreshing || undefined}");
+    expect(profileViewSource).toContain("disabled={refreshing}");
     expect(profileViewSource).toContain(
       '{refreshing ? "Refreshing rewards" : ""}',
     );


### PR DESCRIPTION
## Outcome

- reserve the full five-row Launches first-page geometry during cold loading
- reserve the measured three-card Predictions geometry with responsive desktop and mobile skeleton cards
- keep cold and inline Profile overview placeholders aligned with the populated 360px desktop and 340px-per-panel mobile layout
- preserve verified launch rows and article actions during warm refreshes
- disable the Claim rewards refresh control while `aria-busy` to prevent re-entrant refreshes

## Verification

- `npx vitest run tests/profile-projects-editor-open.test.ts tests/profile-view.test.ts tests/prediction-profile-regression.test.ts` — 3 files, 103 tests passed
- `git diff --check` — passed

No merge, deployment, wallet action, signing, or secret is included.