### PR TITLE
Stabilize populated profile geometry

### DIFF
--- a/components/prediction-market-experience.module.css
+++ b/components/prediction-market-experience.module.css
@@ -1857,8 +1857,16 @@
 
   .portfolioLoadingCard {
     grid-template-columns: minmax(0, 1fr);
-    min-height: 256px;
+    min-height: 322px;
     position: relative;
+  }
+
+  .portfolioLoadingCard:nth-child(n + 3) {
+    display: none;
+  }
+
+  .portfolioSection[data-populated="true"] {
+    min-height: 806px;
   }
 
   .portfolioLoadingArtwork {

--- a/components/prediction-market-experience.module.css
+++ b/components/prediction-market-experience.module.css
@@ -1865,7 +1865,11 @@
     display: none;
   }
 
-  .portfolioSection[data-populated="true"] {
+  .portfolioSection[data-visible-card-count="1"] {
+    min-height: 476px;
+  }
+
+  .portfolioSection[data-visible-card-count="2"] {
     min-height: 806px;
   }
 

--- a/components/prediction-market-portfolio.tsx
+++ b/components/prediction-market-portfolio.tsx
@@ -753,7 +753,11 @@ export function PredictionMarketPortfolio({
       className={styles.portfolioSection}
       aria-busy={isBusy}
       aria-labelledby="prediction-portfolio-title"
-      data-populated={visibleItems.length > 0 || undefined}
+      data-visible-card-count={
+        visibleItems.length > 0
+          ? Math.min(visibleItems.length, 2)
+          : undefined
+      }
     >
       <p className="sr-only" role="status" aria-live="polite" aria-atomic="true">
         {announcement || model.statusMessage}

--- a/components/prediction-market-portfolio.tsx
+++ b/components/prediction-market-portfolio.tsx
@@ -753,6 +753,7 @@ export function PredictionMarketPortfolio({
       className={styles.portfolioSection}
       aria-busy={isBusy}
       aria-labelledby="prediction-portfolio-title"
+      data-populated={visibleItems.length > 0 || undefined}
     >
       <p className="sr-only" role="status" aria-live="polite" aria-atomic="true">
         {announcement || model.statusMessage}

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -1304,7 +1304,7 @@
 
 .profileSkeletonInline {
   margin-block-start: 34px;
-  min-height: 360px;
+  min-height: 398px;
   padding-block-start: 0;
 }
 
@@ -1318,7 +1318,7 @@
   display: grid;
   gap: 0 20px;
   grid-template-columns: 96px minmax(0, 1fr);
-  min-height: 227px;
+  min-height: 282px;
 }
 
 .profileSkeletonBanner,
@@ -1382,7 +1382,7 @@
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  min-height: 360px;
+  min-height: 398px;
 }
 
 .profileSkeletonWorkspacePage {
@@ -1402,7 +1402,7 @@
 
 .profileSkeletonSummary,
 .profileSkeletonClaims {
-  min-height: 360px;
+  min-height: 398px;
 }
 
 .profileSkeletonSection {
@@ -1412,7 +1412,7 @@
 
 .profileSkeletonLaunch {
   margin-block-start: 40px;
-  min-height: 448px;
+  min-height: 463px;
 }
 
 .profileSkeletonPrediction {
@@ -2558,7 +2558,7 @@
 
   .profileSkeletonLaunch .profileSkeletonRow {
     grid-template-columns: 44px minmax(0, 1fr);
-    min-height: 109px;
+    min-height: 142.5px;
   }
 
   .profileSkeletonLaunch .profileSkeletonRow > span:last-child {
@@ -2566,13 +2566,22 @@
   }
 
   .profileSkeletonPredictionRow {
-    min-height: 256px;
+    min-height: 322px;
+  }
+
+  .profileSkeletonPredictionRow:nth-child(n + 3) {
+    display: none;
   }
 
   .profileSkeletonHero {
     gap: 0 14px;
     grid-template-columns: 76px minmax(0, 1fr);
-    min-height: 175px;
+    min-height: 350px;
+  }
+
+  .profileSkeletonClaims,
+  .claimablePanel:not(.claimablePanelEmpty) {
+    min-height: 637px !important;
   }
 
   .profileSkeletonBanner {

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -2543,26 +2543,12 @@
     margin-block-start: 28px;
   }
 
-  .profileSkeletonLaunch,
   .profileSkeletonPrediction {
     padding: 16px;
   }
 
-  .profileSkeletonLaunch {
-    margin-block-start: 16px;
-  }
-
   .profileSkeletonWorkspacePage {
     margin-block-start: 12px;
-  }
-
-  .profileSkeletonLaunch .profileSkeletonRow {
-    grid-template-columns: 44px minmax(0, 1fr);
-    min-height: 142.5px;
-  }
-
-  .profileSkeletonLaunch .profileSkeletonRow > span:last-child {
-    grid-column: 1 / -1;
   }
 
   .profileSkeletonPredictionRow {
@@ -2579,9 +2565,24 @@
     min-height: 350px;
   }
 
-  .profileSkeletonClaims,
-  .claimablePanel:not(.claimablePanelEmpty) {
-    min-height: 637px !important;
+  .profileSkeletonClaims {
+    min-height: 591px;
+  }
+
+  .profileSkeletonClaims .profileSkeletonRow {
+    min-height: 112px;
+  }
+
+  .claimablePanel[data-visible-count="2"] {
+    min-height: 361px;
+  }
+
+  .claimablePanel[data-visible-count="3"] {
+    min-height: 476px;
+  }
+
+  .claimablePanel[data-visible-count="4"] {
+    min-height: 591px;
   }
 
   .profileSkeletonBanner {
@@ -2604,5 +2605,21 @@
   .profileSkeletonCopy span:first-child {
     height: 27px;
     width: 62%;
+  }
+}
+
+@media (max-width: 42rem) {
+  .profileSkeletonLaunch {
+    margin-block-start: 16px;
+    padding: 16px;
+  }
+
+  .profileSkeletonLaunch .profileSkeletonRow {
+    grid-template-columns: 44px minmax(0, 1fr);
+    min-height: 142.5px;
+  }
+
+  .profileSkeletonLaunch .profileSkeletonRow > span:last-child {
+    grid-column: 1 / -1;
   }
 }

--- a/components/profile-projects.module.css
+++ b/components/profile-projects.module.css
@@ -239,7 +239,7 @@
   display: grid;
   gap: 9px;
   grid-template-columns: 42px minmax(0, 1fr) auto;
-  min-height: 68px;
+  min-height: 71px;
   min-width: 0;
   padding: 7px 8px;
   transition: background-color 150ms ease;
@@ -326,7 +326,7 @@
 .skeletonList {
   display: grid;
   gap: 3px;
-  min-height: 352px;
+  min-height: 367px;
 }
 
 .skeletonProject {
@@ -334,7 +334,7 @@
   display: grid;
   gap: 9px;
   grid-template-columns: 42px minmax(0, 1fr) 104px;
-  min-height: 68px;
+  min-height: 71px;
   padding: 7px 8px;
 }
 
@@ -547,11 +547,13 @@
   .project {
     align-items: center;
     grid-template-columns: 42px minmax(0, 1fr);
+    min-height: 143px;
     padding-block: 9px;
   }
 
   .skeletonProject {
     grid-template-columns: 42px minmax(0, 1fr);
+    min-height: 143px;
   }
 
   .skeletonAction {

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -4410,7 +4410,7 @@ function ProfileLoadingSkeleton({
         </div>
         <div className={styles.profileSkeletonClaims}>
           <span className={styles.profileSkeletonHeading} />
-          {[0, 1].map((item) => (
+          {Array.from({ length: profileClaimPageSize }, (_, item) => (
             <span className={styles.profileSkeletonRow} key={item}>
               <span />
               <span />
@@ -4712,6 +4712,7 @@ function ProfileAccountWorkspace({
             claimableEntries.length ? "" : styles.claimablePanelEmpty
           }`}
           aria-labelledby="profile-claimable-title"
+          data-visible-count={claimPageData.items.length}
         >
           <header className={styles.panelHeader}>
             <h2 id="profile-claimable-title">Claim rewards</h2>
@@ -5434,13 +5435,15 @@ function ProfileActionState({
   ) {
     return null;
   }
+  if (state.status !== "error") {
+    return (
+      <span className={styles.visuallyHidden} role="status">
+        {state.message}
+      </span>
+    );
+  }
   return (
-    <p
-      className={
-        state.status === "error" ? styles.rowError : styles.actionState
-      }
-      role={state.status === "error" ? "alert" : "status"}
-    >
+    <p className={styles.rowError} role="alert">
       {state.message}
     </p>
   );

--- a/tests/prediction-profile-regression.test.ts
+++ b/tests/prediction-profile-regression.test.ts
@@ -331,11 +331,20 @@ describe("prediction profile regression contract", () => {
       "predictionPortfolioLoadingPlaceholderCount = 3",
     );
     expect(portfolioSource).toContain("<PredictionPortfolioLoadingState />");
+    expect(portfolioSource).toContain(
+      "data-populated={visibleItems.length > 0 || undefined}",
+    );
     expect(portfolioStyles).toMatch(
       /\.portfolioLoadingCard\s*\{[^}]*min-height:\s*82px;/s,
     );
     expect(portfolioStyles).toMatch(
-      /@media \(max-width:\s*620px\)[\s\S]*?\.portfolioLoadingCard\s*\{[^}]*min-height:\s*256px;/s,
+      /@media \(max-width:\s*620px\)[\s\S]*?\.portfolioLoadingCard\s*\{[^}]*min-height:\s*322px;/s,
+    );
+    expect(portfolioStyles).toMatch(
+      /@media \(max-width:\s*620px\)[\s\S]*?\.portfolioLoadingCard:nth-child\(n \+ 3\)\s*\{[^}]*display:\s*none;/s,
+    );
+    expect(portfolioStyles).toMatch(
+      /@media \(max-width:\s*620px\)[\s\S]*?\.portfolioSection\[data-populated="true"\]\s*\{[^}]*min-height:\s*806px;/s,
     );
   });
 

--- a/tests/prediction-profile-regression.test.ts
+++ b/tests/prediction-profile-regression.test.ts
@@ -332,7 +332,7 @@ describe("prediction profile regression contract", () => {
     );
     expect(portfolioSource).toContain("<PredictionPortfolioLoadingState />");
     expect(portfolioSource).toContain(
-      "data-populated={visibleItems.length > 0 || undefined}",
+      "? Math.min(visibleItems.length, 2)",
     );
     expect(portfolioStyles).toMatch(
       /\.portfolioLoadingCard\s*\{[^}]*min-height:\s*82px;/s,
@@ -344,7 +344,10 @@ describe("prediction profile regression contract", () => {
       /@media \(max-width:\s*620px\)[\s\S]*?\.portfolioLoadingCard:nth-child\(n \+ 3\)\s*\{[^}]*display:\s*none;/s,
     );
     expect(portfolioStyles).toMatch(
-      /@media \(max-width:\s*620px\)[\s\S]*?\.portfolioSection\[data-populated="true"\]\s*\{[^}]*min-height:\s*806px;/s,
+      /@media \(max-width:\s*620px\)[\s\S]*?\.portfolioSection\[data-visible-card-count="1"\]\s*\{[^}]*min-height:\s*476px;/s,
+    );
+    expect(portfolioStyles).toMatch(
+      /@media \(max-width:\s*620px\)[\s\S]*?\.portfolioSection\[data-visible-card-count="2"\]\s*\{[^}]*min-height:\s*806px;/s,
     );
   });
 

--- a/tests/profile-projects-editor-open.test.ts
+++ b/tests/profile-projects-editor-open.test.ts
@@ -142,7 +142,13 @@ describe("My projects editor opening", () => {
     expect(source).toContain(
       "Array.from({ length: creatorProjectPageSize }, (_, item)",
     );
-    expect(styles).toMatch(/\.skeletonList\s*\{[^}]*min-height:\s*352px;/s);
+    expect(styles).toMatch(/\.skeletonList\s*\{[^}]*min-height:\s*367px;/s);
+    expect(styles).toMatch(
+      /@media \(max-width:\s*42rem\)[\s\S]*?\.project\s*\{[^}]*min-height:\s*143px;/s,
+    );
+    expect(styles).toMatch(
+      /@media \(max-width:\s*42rem\)[\s\S]*?\.skeletonProject\s*\{[^}]*min-height:\s*143px;/s,
+    );
     expect(source).toContain(
       'phase === "loading" && visibleProjects.length === 0',
     );

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -504,6 +504,9 @@ describe("profile workspace loading state", () => {
     expect(profileViewSource).toContain(
       "length: predictionPortfolioLoadingPlaceholderCount",
     );
+    expect(profileViewSource).toContain(
+      "Array.from({ length: profileClaimPageSize }, (_, item)",
+    );
     expect(profileExperienceCss).toMatch(
       /\.profileSkeletonLaunch\s*\{[^}]*min-height:\s*463px;/s,
     );
@@ -520,13 +523,28 @@ describe("profile workspace loading state", () => {
       /\.profileSkeletonWorkspace\s*\{[^}]*min-height:\s*398px;/s,
     );
     expect(profileExperienceCss).toMatch(
-      /@media \(max-width:\s*620px\)[\s\S]*?\.profileSkeletonPredictionRow\s*\{[^}]*min-height:\s*322px;[\s\S]*?\.profileSkeletonPredictionRow:nth-child\(n \+ 3\)\s*\{[^}]*display:\s*none;/s,
+      /\.profileSkeletonPredictionRow\s*\{[^}]*min-height:\s*322px;/s,
     );
     expect(profileExperienceCss).toMatch(
-      /@media \(max-width:\s*620px\)[\s\S]*?\.profileSkeletonHero\s*\{[^}]*min-height:\s*350px;/s,
+      /\.profileSkeletonPredictionRow:nth-child\(n \+ 3\)\s*\{[^}]*display:\s*none;/s,
     );
     expect(profileExperienceCss).toMatch(
-      /@media \(max-width:\s*620px\)[\s\S]*?\.profileSkeletonClaims,[\s\S]*?\.claimablePanel:not\(\.claimablePanelEmpty\)\s*\{[^}]*min-height:\s*637px !important;/s,
+      /\.profileSkeletonHero\s*\{[^}]*min-height:\s*350px;/s,
+    );
+    expect(profileExperienceCss).toMatch(
+      /\.profileSkeletonClaims\s*\{[^}]*min-height:\s*591px;/s,
+    );
+    expect(profileExperienceCss).toMatch(
+      /\.claimablePanel\[data-visible-count="2"\]\s*\{[^}]*min-height:\s*361px;/s,
+    );
+    expect(profileExperienceCss).toMatch(
+      /\.claimablePanel\[data-visible-count="3"\]\s*\{[^}]*min-height:\s*476px;/s,
+    );
+    expect(profileExperienceCss).toMatch(
+      /\.claimablePanel\[data-visible-count="4"\]\s*\{[^}]*min-height:\s*591px;/s,
+    );
+    expect(profileExperienceCss).toMatch(
+      /@media \(max-width:\s*42rem\)[\s\S]*?\.profileSkeletonLaunch \.profileSkeletonRow\s*\{[^}]*min-height:\s*142\.5px;/s,
     );
     expect(profileExperienceCss).not.toContain("profile-content-reveal");
     expect(profileExperienceCss).toContain("profile-skeleton-pulse");
@@ -542,6 +560,10 @@ describe("profile workspace loading state", () => {
     );
     expect(profileViewSource).toContain("aria-busy={refreshing || undefined}");
     expect(profileViewSource).toContain("disabled={refreshing}");
+    expect(profileViewSource).toContain(
+      'data-visible-count={claimPageData.items.length}',
+    );
+    expect(profileViewSource).toContain('if (state.status !== "error")');
     expect(profileViewSource).toContain(
       '{refreshing ? "Refreshing rewards" : ""}',
     );

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -505,13 +505,28 @@ describe("profile workspace loading state", () => {
       "length: predictionPortfolioLoadingPlaceholderCount",
     );
     expect(profileExperienceCss).toMatch(
-      /\.profileSkeletonLaunch\s*\{[^}]*min-height:\s*448px;/s,
+      /\.profileSkeletonLaunch\s*\{[^}]*min-height:\s*463px;/s,
     );
     expect(profileExperienceCss).toMatch(
       /\.profileSkeletonPrediction\s*\{[^}]*min-height:\s*422px;/s,
     );
     expect(profileExperienceCss).toMatch(
       /@media \(max-width:\s*820px\)[\s\S]*?\.profileSkeletonSummary,[\s\S]*?\.profileSkeletonClaims\s*\{[^}]*min-height:\s*340px;/s,
+    );
+    expect(profileExperienceCss).toMatch(
+      /\.profileSkeletonHero\s*\{[^}]*min-height:\s*282px;/s,
+    );
+    expect(profileExperienceCss).toMatch(
+      /\.profileSkeletonWorkspace\s*\{[^}]*min-height:\s*398px;/s,
+    );
+    expect(profileExperienceCss).toMatch(
+      /@media \(max-width:\s*620px\)[\s\S]*?\.profileSkeletonPredictionRow\s*\{[^}]*min-height:\s*322px;[\s\S]*?\.profileSkeletonPredictionRow:nth-child\(n \+ 3\)\s*\{[^}]*display:\s*none;/s,
+    );
+    expect(profileExperienceCss).toMatch(
+      /@media \(max-width:\s*620px\)[\s\S]*?\.profileSkeletonHero\s*\{[^}]*min-height:\s*350px;/s,
+    );
+    expect(profileExperienceCss).toMatch(
+      /@media \(max-width:\s*620px\)[\s\S]*?\.profileSkeletonClaims,[\s\S]*?\.claimablePanel:not\(\.claimablePanelEmpty\)\s*\{[^}]*min-height:\s*637px !important;/s,
     );
     expect(profileExperienceCss).not.toContain("profile-content-reveal");
     expect(profileExperienceCss).toContain("profile-skeleton-pulse");


### PR DESCRIPTION
## Summary

- reserve the populated Launches card geometry on desktop and mobile
- match mobile Predictions loading geometry to the two visible cards
- reserve the populated Claim rewards and profile hero geometry
- keep empty states compact while stabilizing populated panels

## Verification

- focused Vitest: 3 files, 103 tests passed
- static layout contract assertions passed
- git diff --check passed

Production branch only. No wallet action, API secret, or onchain transaction is included.