### PR TITLE
Keep released claim retries neutral

### DIFF
--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -227,6 +227,7 @@ type ProfileClaimActionState = {
     | "error";
   message: string;
   transactionHash?: Hex;
+  recoverable?: true;
 };
 
 type ClassicV3ActionState = {
@@ -241,6 +242,7 @@ type ClassicV3ActionState = {
     | "error";
   message: string;
   transactionHash?: Hex;
+  recoverable?: true;
 };
 
 type DeepActionState = ClassicV3ActionState;
@@ -749,6 +751,7 @@ export function resolveProfileNotFoundTransaction(retryAllowed: boolean) {
         release: true,
         status: "error" as const,
         message: "No transaction was found. You can submit the claim again.",
+        recoverable: true as const,
       })
     : Object.freeze({
         release: false,
@@ -2194,6 +2197,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
             status: resolution.status,
             message: resolution.message,
             transactionHash,
+            ...(resolution.release ? { recoverable: true as const } : {}),
           });
           return;
         }
@@ -2932,6 +2936,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
           );
           if (gate.outcome === "hold") {
             if (receiptStatus === "not-found" && retryNotFound) {
+              const resolution = resolveProfileNotFoundTransaction(true);
               const checkpoint = stockPairedCheckpointAfterReceipt(
                 pendingTransaction,
                 "reverted",
@@ -2942,9 +2947,10 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
                 forgetPendingProfileTransaction(pendingTransaction);
               }
               setActionState({
-                status: "error",
-                message: "Transaction not found. You can try again.",
+                status: resolution.status,
+                message: resolution.message,
                 transactionHash,
+                recoverable: true,
                 ...(pendingStage === "claim"
                   ? {}
                   : {
@@ -4897,6 +4903,14 @@ export function actionSettling(
   return actionPending(state);
 }
 
+export function profileActionStateUsesNeutralStatus(
+  state: ProfileClaimActionState | ClassicV3ActionState | undefined,
+) {
+  return Boolean(
+    state && (state.status !== "error" || state.recoverable === true),
+  );
+}
+
 export function prioritizedProfileActionState(
   states: readonly (
     | ProfileClaimActionState
@@ -5435,7 +5449,7 @@ function ProfileActionState({
   ) {
     return null;
   }
-  if (state.status !== "error") {
+  if (profileActionStateUsesNeutralStatus(state)) {
     return (
       <span className={styles.visuallyHidden} role="status">
         {state.message}

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -21,6 +21,7 @@ import {
   profileClaimableWei,
   profileClaimActionCount,
   profileClaimSubmissionAllowed,
+  profileActionStateUsesNeutralStatus,
   profileCreatorClaimErrorMessage,
   profileEntryHasClaimableReward,
   profileHasRewardSurface,
@@ -563,7 +564,9 @@ describe("profile workspace loading state", () => {
     expect(profileViewSource).toContain(
       'data-visible-count={claimPageData.items.length}',
     );
-    expect(profileViewSource).toContain('if (state.status !== "error")');
+    expect(profileViewSource).toContain(
+      "if (profileActionStateUsesNeutralStatus(state))",
+    );
     expect(profileViewSource).toContain(
       '{refreshing ? "Refreshing rewards" : ""}',
     );
@@ -1227,9 +1230,44 @@ describe("profile transaction status", () => {
       release: true,
       status: "error",
       message: "No transaction was found. You can submit the claim again.",
+      recoverable: true,
     });
     expect(profileViewSource).toMatch(
       /if \(resolution\.release\) \{\s*forgetPendingProfileTransaction\(pendingTransaction\);/s,
+    );
+  });
+
+  it("announces released missing transactions neutrally without hiding true errors", () => {
+    expect(
+      profileActionStateUsesNeutralStatus({
+        account: firstAddress,
+        status: "error",
+        message: "No transaction was found. You can submit the claim again.",
+        transactionHash,
+        recoverable: true,
+      }),
+    ).toBe(true);
+    expect(
+      profileActionStateUsesNeutralStatus({
+        account: firstAddress,
+        status: "error",
+        message: "No transaction was found. You can submit the claim again.",
+        transactionHash,
+      }),
+    ).toBe(false);
+    expect(
+      profileActionStateUsesNeutralStatus({
+        account: firstAddress,
+        status: "error",
+        message: "The reward transaction reverted onchain",
+        transactionHash,
+      }),
+    ).toBe(false);
+    expect(profileViewSource).toContain(
+      "if (profileActionStateUsesNeutralStatus(state))",
+    );
+    expect(profileViewSource).toContain(
+      "const resolution = resolveProfileNotFoundTransaction(true);",
     );
   });
 


### PR DESCRIPTION
Summary
- mark repeatedly missing, released claim transactions as explicitly recoverable
- announce recoverable retry states through a visually hidden polite status while preserving visible alerts for real RPC, revert, and contract errors
- cover Classic, Classic V3, Deep, Stock-Paired, and the multi-stage Stock-Paired ETH conversion path

Checks
- vitest run tests/profile-view.test.ts (67 passed)
- eslint components/profile-view.tsx tests/profile-view.test.ts
- git diff --check