### PR TITLE
feat: integrate public launch handoff and Router discovery

### DIFF
--- a/app/api/indexers/v1/router-custom-identities/route.ts
+++ b/app/api/indexers/v1/router-custom-identities/route.ts
@@ -1,0 +1,60 @@
+import {
+  readFinalizedRouterCustomIdentitySnapshotCoreV1,
+  ROUTER_CUSTOM_SNAPSHOT_MAX_IDENTITIES,
+  ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_BYTES,
+} from "../../../../../lib/alchemy/router-custom-public.server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const SUCCESS_CACHE_CONTROL =
+  "public, max-age=0, s-maxage=15, stale-while-revalidate=45";
+
+const PUBLIC_HEADERS = Object.freeze({
+  "Access-Control-Allow-Origin": "*",
+  "Content-Type": "application/json; charset=utf-8",
+});
+
+function unavailableResponse() {
+  return new Response(
+    JSON.stringify({
+      error: "Router Custom identities are temporarily unavailable",
+    }),
+    {
+      status: 503,
+      headers: {
+        ...PUBLIC_HEADERS,
+        "Cache-Control": "no-store",
+        "Retry-After": "5",
+      },
+    },
+  );
+}
+
+export async function GET() {
+  try {
+    const snapshot =
+      await readFinalizedRouterCustomIdentitySnapshotCoreV1();
+    const body = JSON.stringify(snapshot);
+    if (
+      !Array.isArray(snapshot.entries) ||
+      snapshot.entries.length > ROUTER_CUSTOM_SNAPSHOT_MAX_IDENTITIES ||
+      Buffer.byteLength(body, "utf8") > ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_BYTES
+    ) {
+      return unavailableResponse();
+    }
+    return new Response(body, {
+      status: 200,
+      headers: {
+        ...PUBLIC_HEADERS,
+        "Cache-Control": SUCCESS_CACHE_CONTROL,
+        "X-Programmable-Status": snapshot.status,
+      },
+    });
+  } catch {
+    console.error("Router Custom public snapshot unavailable", {
+      name: "RouterCustomSnapshotReadError",
+    });
+    return unavailableResponse();
+  }
+}

--- a/app/docs/developers/custom-launch/page.tsx
+++ b/app/docs/developers/custom-launch/page.tsx
@@ -15,6 +15,7 @@ const customLaunchSections = [
   { id: "quickstart", label: "Quickstart" },
   { id: "authentication", label: "Authentication" },
   { id: "request", label: "Request contract" },
+  { id: "fees", label: "RC2 fee policy" },
   { id: "verification", label: "Exact-source verification" },
   { id: "checks", label: "Attested checks" },
   { id: "submit", label: "Write fence" },
@@ -249,6 +250,41 @@ export default function CustomLaunchApiDocsPage() {
           bytecode has no unresolved link or immutable references. Otherwise it
           fails closed with <code>RUNTIME_MATERIALIZATION_REQUIRED</code>.
         </p>
+      </section>
+
+      <section id="fees">
+        <div className={styles.sectionIntro}>
+          <h2>Review the RC2 fee policy</h2>
+          <p>
+            This disclosure describes only the frozen RC2 profile. It does not
+            activate public V2 submission. The profile is for Ethereum Mainnet
+            only (<code>chainId: &quot;1&quot;</code>) and has{" "}
+            <code>productionLaunchAuthorized: false</code>.
+          </p>
+        </div>
+
+        <p className={styles.bodyCopy}>
+          For each successful swap, the mandatory platform charge is 1,000
+          parts per 1,000,000 of the documented{" "}
+          <code>gross-unspecified-pool-currency-amount</code> basis:{" "}
+          <code>1,000 ppm = 0.10% = 10 bps</code>. It accrues in the
+          profile&apos;s unspecified pool currency to{" "}
+          <code>0x4957f49620AFf3Adbbe8195a4f633E49cc93376c</code>.
+          The frozen profile enforces this path independently of custom
+          behavior; a Custom module cannot reduce or redirect it. A reverted
+          swap rolls back the fee with the rest of the transaction.
+        </p>
+
+        <aside className={styles.callout}>
+          <strong>Keep platform, LP and future operations separate</strong>
+          <p>
+            The pool&apos;s LP fee is separate from this platform charge and must
+            be disclosed separately. Generic fee claiming and buyback
+            management for arbitrary hooks are not live. The reserved{" "}
+            <code>fees:claim</code> and <code>buybacks:manage</code> scopes remain
+            disabled.
+          </p>
+        </aside>
       </section>
 
       <section id="verification">

--- a/components/prediction-market-experience.module.css
+++ b/components/prediction-market-experience.module.css
@@ -980,6 +980,14 @@
   width: 100%;
 }
 
+.portfolioSection[data-visible-card-count="1"] {
+  min-height: 252px;
+}
+
+.portfolioSection[data-visible-card-count="2"] {
+  min-height: 424px;
+}
+
 .portfolioHeading {
   align-items: center;
   display: flex;
@@ -1685,6 +1693,10 @@
 }
 
 @media (max-width: 52rem) {
+  .portfolioSection[data-visible-card-count="2"] {
+    min-height: 748px;
+  }
+
   .portfolioLoadingCard {
     align-items: start;
     grid-template-columns: 52px minmax(0, 1fr);
@@ -1924,9 +1936,12 @@
     flex-direction: column;
   }
 
-  .portfolioEmpty,
-  .portfolioError {
+  .portfolioEmpty {
     grid-template-columns: 44px minmax(0, 1fr);
+  }
+
+  .portfolioError {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .portfolioEmptyAction,

--- a/components/prediction-market-portfolio.tsx
+++ b/components/prediction-market-portfolio.tsx
@@ -35,6 +35,10 @@ import {
   type PredictionPortfolioRequest,
 } from "@/lib/prediction-market-portfolio";
 import {
+  readPredictionPortfolioWithRetry,
+  type PredictionPortfolioLoadMode,
+} from "@/lib/prediction-portfolio-load-policy";
+import {
   formatPredictionMarketObservation,
   formatPredictionOutcome,
   formatPredictionUsdg,
@@ -581,7 +585,7 @@ export function PredictionMarketPortfolio({
   const activeRequestRef = useRef<PredictionPortfolioRequest | null>(null);
   const tabRefs = useRef(new Map<PredictionPortfolioTabV1, HTMLButtonElement>());
 
-  const loadPortfolio = useCallback(async (mode: "initial" | "refresh" | "retry") => {
+  const loadPortfolio = useCallback(async (mode: PredictionPortfolioLoadMode) => {
     if (!account || !release) return;
     const accountKey = account.toLowerCase();
     const request = createPredictionPortfolioRequest(
@@ -608,9 +612,20 @@ export function PredictionMarketPortfolio({
         : "loading",
     }));
     try {
-      const data = await readPredictionMarketPortfolio({
-        config: release,
-        request,
+      const data = await readPredictionPortfolioWithRetry({
+        isCurrent: () => isPredictionPortfolioRequestCurrent(
+          request,
+          activeRequestRef.current,
+        ),
+        mode,
+        read: () => readPredictionMarketPortfolio({
+          config: release,
+          request,
+          shouldContinue: () => isPredictionPortfolioRequestCurrent(
+            request,
+            activeRequestRef.current,
+          ),
+        }),
       });
       if (!isPredictionPortfolioRequestCurrent(data, activeRequestRef.current)) return;
       setState({
@@ -756,7 +771,9 @@ export function PredictionMarketPortfolio({
       data-visible-card-count={
         visibleItems.length > 0
           ? Math.min(visibleItems.length, 2)
-          : undefined
+          : model.phase === "loading" || model.phase === "error"
+            ? 2
+            : undefined
       }
     >
       <p className="sr-only" role="status" aria-live="polite" aria-atomic="true">

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -160,7 +160,7 @@
     },
     "publicSnapshot": {
       "path": "lib/alchemy/router-custom-public.server.ts",
-      "sha256": "02dc2a835a637657a00c7b770bdf4ada238fe7fd1233cf465d81ec75a3f995d7"
+      "sha256": "b5dbb13c98bc69e7b94d6e67844bd1c89478ad02a823eab1c900e6523a272613"
     }
   },
   "workers": [

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -160,7 +160,7 @@
     },
     "publicSnapshot": {
       "path": "lib/alchemy/router-custom-public.server.ts",
-      "sha256": "6f622b8eff5ef7e917d7c7a5d17fe98e2651414daf5f3aa4945fa4a85f4a2884"
+      "sha256": "02dc2a835a637657a00c7b770bdf4ada238fe7fd1233cf465d81ec75a3f995d7"
     }
   },
   "workers": [

--- a/docs/public/developers/custom-launch.md
+++ b/docs/public/developers/custom-launch.md
@@ -19,6 +19,21 @@ The live V1 reads and write fence are defined by the
 future/private-canary request and lifecycle shapes without authorizing public submission. The raw
 [V1 agent guide](https://programmable.market/developers/custom-launch-api-v1.md) remains compatible.
 
+## RC2 fee policy (private canary)
+
+This disclosure describes only the frozen RC2 profile. It does not activate public V2 submission. The profile is for
+Ethereum Mainnet only (`chainId: "1"`) and has `productionLaunchAuthorized: false`.
+
+For each successful swap, the mandatory platform charge is 1,000 parts per 1,000,000 of the documented
+`gross-unspecified-pool-currency-amount` basis: `1,000 ppm = 0.10% = 10 bps`. It accrues in the profile's unspecified
+pool currency to `0x4957f49620AFf3Adbbe8195a4f633E49cc93376c`. The frozen profile enforces this path independently
+of custom behavior; a Custom module cannot reduce or redirect it. A reverted swap rolls back the fee with the rest of
+the transaction.
+
+The pool's LP fee is separate from this platform charge and must be disclosed separately. Generic fee claiming and
+buyback management for arbitrary hooks are not live. The reserved `fees:claim` and `buybacks:manage` scopes remain
+disabled.
+
 ## Cold-agent quickstart
 
 Install the pinned public GitHub Release asset. Do not substitute an unverified npm-registry package with the same name.

--- a/lib/alchemy/router-custom-public.server.ts
+++ b/lib/alchemy/router-custom-public.server.ts
@@ -36,11 +36,11 @@ export const ROUTER_CUSTOM_SNAPSHOT_SCHEMA_VERSION =
   "programmable.router-custom-identity-snapshot.v1" as const;
 export const ROUTER_CUSTOM_SNAPSHOT_CACHE_TTL_MS = 15_000;
 export const ROUTER_CUSTOM_SNAPSHOT_MAX_IDENTITIES = 10_000;
+export const ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_BYTES = 16 * 1_024 * 1_024;
 export const ROUTER_CUSTOM_SNAPSHOT_CURRENT_READ_TIMEOUT_MS = 3_000;
 const ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_FUTURE_SKEW_MS = 60_000;
 const ROUTER_CUSTOM_SNAPSHOT_DURABLE_READ_TIMEOUT_MS = 2_000;
 const ROUTER_CUSTOM_SNAPSHOT_PERSIST_TIMEOUT_MS = 2_000;
-const ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_BYTES = 16 * 1_024 * 1_024;
 const ROUTER_CUSTOM_SNAPSHOT_ENVELOPE_SCHEMA_VERSION =
   "programmable.router-custom-identity-snapshot-envelope.v1" as const;
 const ROUTER_CUSTOM_SNAPSHOT_BLOB_PATH = [
@@ -247,6 +247,61 @@ function lastKnownGoodRouterCustomSnapshotV1(
     : Object.freeze({ ...snapshot, status: "last-known-good" as const });
 }
 
+function immutableRouterCustomIdentityV1(entry: CanonicalTokenExploreEntry) {
+  requireRouterCustomEntryV1(entry);
+  return {
+    id: entry.id,
+    name: entry.name,
+    symbol: entry.symbol ?? null,
+    tokenAddress: entry.tokenAddress.toLowerCase(),
+    tokenDecimals: entry.tokenDecimals ?? null,
+    hookAddress: entry.hookAddress.toLowerCase(),
+    poolId: entry.poolId.toLowerCase(),
+    creatorAddress: entry.creatorAddress?.toLowerCase() ?? null,
+    launchBlockNumber: entry.launchBlockNumber ?? null,
+    launchTransactionHash:
+      entry.launchTransactionHash?.toLowerCase() ?? null,
+    launchTransactionIndex: entry.launchTransactionIndex ?? null,
+    launchLogIndex: entry.launchLogIndex ?? null,
+    launchedAt: entry.launchedAt,
+    launchModel: entry.launchModel ?? null,
+    launchModelVersion: entry.launchModelVersion ?? null,
+    launchCategoryProvenance: entry.launchCategoryProvenance,
+    launchStampProvenance: entry.launchStampProvenance!,
+  };
+}
+
+export function routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+  previous: RouterCustomIdentitySnapshotV1,
+  next: RouterCustomIdentitySnapshotV1,
+) {
+  try {
+    const nextByLaunchId = new Map<string, CanonicalTokenExploreEntry>();
+    for (const entry of next.entries) {
+      const launchId = entry.launchStampProvenance?.launchId.toLowerCase();
+      if (!launchId || nextByLaunchId.has(launchId)) return false;
+      nextByLaunchId.set(launchId, entry);
+    }
+    const previousLaunchIds = new Set<string>();
+    for (const entry of previous.entries) {
+      const launchId = entry.launchStampProvenance?.launchId.toLowerCase();
+      if (!launchId || previousLaunchIds.has(launchId)) return false;
+      previousLaunchIds.add(launchId);
+      const candidate = nextByLaunchId.get(launchId);
+      if (
+        !candidate ||
+        candidate.tokenAddress.toLowerCase() !==
+          entry.tokenAddress.toLowerCase() ||
+        canonicalizeJson(immutableRouterCustomIdentityV1(candidate)) !==
+          canonicalizeJson(immutableRouterCustomIdentityV1(entry))
+      ) return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function jsonRecord(
   value: JsonValue | undefined,
 ): Readonly<Record<string, JsonValue>> {
@@ -378,8 +433,15 @@ async function persistDurableRouterCustomIdentitySnapshotV1(
   if (existing) {
     const previousBlock = BigInt(existing.snapshot.asOfBlock);
     const nextBlock = BigInt(snapshot.asOfBlock);
-    if (!options.replaceAfterReorg && previousBlock > nextBlock) return;
-    if (!options.replaceAfterReorg && previousBlock === nextBlock) {
+    if (previousBlock > nextBlock) {
+      if (options.replaceAfterReorg) {
+        throw new RouterCustomSnapshotConflictError(
+          "Router Custom durable snapshot cannot delete finalized identities after a reorg",
+        );
+      }
+      return;
+    }
+    if (previousBlock === nextBlock) {
       if (existing.snapshot.identityCommitment !== snapshot.identityCommitment) {
         throw new RouterCustomSnapshotConflictError(
           "Router Custom durable snapshot conflicts at one block",
@@ -388,10 +450,15 @@ async function persistDurableRouterCustomIdentitySnapshotV1(
       return;
     }
     if (
-      options.replaceAfterReorg &&
-      previousBlock === nextBlock &&
-      existing.snapshot.identityCommitment === snapshot.identityCommitment
-    ) return;
+      !routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+        existing.snapshot,
+        snapshot,
+      )
+    ) {
+      throw new RouterCustomSnapshotConflictError(
+        "Router Custom durable snapshot cannot rewrite finalized identities",
+      );
+    }
   }
   const { put } = await import("@vercel/blob");
   await put(
@@ -456,51 +523,86 @@ export function createRouterCustomIdentitySnapshotReaderV1(
 
   const refresh = async () => {
     try {
+      let previous = cached
+        ? lastKnownGoodRouterCustomSnapshotV1(cached.snapshot)
+        : null;
       const source = await withinDuration(
         readCurrentSource,
         currentReadTimeoutMs,
       );
       const snapshot = routerCustomIdentitySnapshotFromSourceV1(source);
-      if (!source.reorgDetected) {
-        try {
-          const durable = lastKnownGoodRouterCustomSnapshotV1(
-            await withinDuration(
-              readDurableSnapshot,
-              ROUTER_CUSTOM_SNAPSHOT_DURABLE_READ_TIMEOUT_MS,
-            ),
+      try {
+        const durable = lastKnownGoodRouterCustomSnapshotV1(
+          await withinDuration(
+            readDurableSnapshot,
+            ROUTER_CUSTOM_SNAPSHOT_DURABLE_READ_TIMEOUT_MS,
+          ),
+        );
+        const generatedAtMs = Date.parse(durable.generatedAt);
+        const ageMs = now() - generatedAtMs;
+        if (
+          !Number.isFinite(generatedAtMs) ||
+          ageMs < -ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_FUTURE_SKEW_MS
+        ) {
+          throw new Error(
+            "Router Custom durable snapshot timestamp is invalid",
           );
-          const generatedAtMs = Date.parse(durable.generatedAt);
-          const ageMs = now() - generatedAtMs;
-          if (
-            !Number.isFinite(generatedAtMs) ||
-            ageMs < -ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_FUTURE_SKEW_MS
-          ) {
-            throw new Error(
-              "Router Custom durable snapshot timestamp is invalid",
-            );
-          }
+        }
+        if (previous) {
+          const previousBlock = BigInt(previous.asOfBlock);
           const durableBlock = BigInt(durable.asOfBlock);
-          const currentBlock = BigInt(snapshot.asOfBlock);
-          if (durableBlock > currentBlock) {
-            return cacheSnapshot(durable);
-          }
           if (
-            durableBlock === currentBlock &&
-            (durable.asOfBlockHash.toLowerCase() !==
-                snapshot.asOfBlockHash.toLowerCase() ||
-              durable.identityCommitment !== snapshot.identityCommitment)
+            previousBlock === durableBlock &&
+            (previous.asOfBlockHash.toLowerCase() !==
+                durable.asOfBlockHash.toLowerCase() ||
+              previous.identityCommitment !== durable.identityCommitment)
           ) {
             throw new RouterCustomSnapshotConflictError(
-              "Router Custom snapshots conflict at one boundary",
+              "Router Custom cached and durable snapshots conflict",
             );
           }
-        } catch (error) {
-          if (error instanceof RouterCustomSnapshotConflictError) throw error;
-          console.warn("Router Custom durable snapshot comparison unavailable", {
-            name: error instanceof Error
-              ? error.name
-              : "RouterCustomSnapshotCompareError",
-          });
+          if (
+            durableBlock > previousBlock &&
+            routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+              previous,
+              durable,
+            )
+          ) previous = durable;
+        } else {
+          previous = durable;
+        }
+      } catch (error) {
+        if (error instanceof RouterCustomSnapshotConflictError) throw error;
+        console.warn("Router Custom durable snapshot comparison unavailable", {
+          name: error instanceof Error
+            ? error.name
+            : "RouterCustomSnapshotCompareError",
+        });
+      }
+      if (previous) {
+        const previousBlock = BigInt(previous.asOfBlock);
+        const currentBlock = BigInt(snapshot.asOfBlock);
+        if (previousBlock > currentBlock) {
+          return cacheSnapshot(previous);
+        }
+        if (
+          previousBlock === currentBlock &&
+          (previous.asOfBlockHash.toLowerCase() !==
+              snapshot.asOfBlockHash.toLowerCase() ||
+            previous.identityCommitment !== snapshot.identityCommitment)
+        ) {
+          throw new RouterCustomSnapshotConflictError(
+            "Router Custom snapshots conflict at one boundary",
+          );
+        }
+        if (
+          currentBlock > previousBlock &&
+          !routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+            previous,
+            snapshot,
+          )
+        ) {
+          return cacheSnapshot(previous);
         }
       }
       cacheSnapshot(snapshot);
@@ -596,10 +698,18 @@ async function withinDuration<T>(
 const readProductionRouterCustomIdentitySnapshotV1 =
   createRouterCustomIdentitySnapshotReaderV1();
 
+export async function readFinalizedRouterCustomIdentitySnapshotCoreV1(
+  options: RouterCustomReadOptionsV1 = {},
+) {
+  return await readProductionRouterCustomIdentitySnapshotV1(options);
+}
+
 export async function readFinalizedRouterCustomIdentitySnapshotV1(
   options: RouterCustomReadOptionsV1 = {},
 ) {
-  const snapshot = await readProductionRouterCustomIdentitySnapshotV1(options);
+  const snapshot = await readFinalizedRouterCustomIdentitySnapshotCoreV1(
+    options,
+  );
   // Fee policy evidence is deliberately derived after the durable identity
   // commitment. A fee-provider failure can therefore remove only the optional
   // evidence block; it can never hide a finalized Router identity.

--- a/lib/alchemy/router-custom-public.server.ts
+++ b/lib/alchemy/router-custom-public.server.ts
@@ -249,6 +249,13 @@ function lastKnownGoodRouterCustomSnapshotV1(
 
 function immutableRouterCustomIdentityV1(entry: CanonicalTokenExploreEntry) {
   requireRouterCustomEntryV1(entry);
+  const {
+    finalizedAtBlockNumber: _finalizedAtBlockNumber,
+    finalizedAtBlockHash: _finalizedAtBlockHash,
+    ...immutableLaunchStampProvenance
+  } = entry.launchStampProvenance!;
+  void _finalizedAtBlockNumber;
+  void _finalizedAtBlockHash;
   return {
     id: entry.id,
     name: entry.name,
@@ -267,7 +274,9 @@ function immutableRouterCustomIdentityV1(entry: CanonicalTokenExploreEntry) {
     launchModel: entry.launchModel ?? null,
     launchModelVersion: entry.launchModelVersion ?? null,
     launchCategoryProvenance: entry.launchCategoryProvenance,
-    launchStampProvenance: entry.launchStampProvenance!,
+    // These two fields record when finality was observed, not launch identity.
+    // A reorg-safe rebuild may legitimately rehydrate them at a later block.
+    launchStampProvenance: immutableLaunchStampProvenance,
   };
 }
 

--- a/lib/prediction-market-portfolio.ts
+++ b/lib/prediction-market-portfolio.ts
@@ -23,6 +23,9 @@ import {
   type PredictionMarketSnapshot,
   type PredictionMarketView,
 } from "./prediction-market-trading";
+import {
+  readPredictionPortfolioHistoryLanes,
+} from "./prediction-portfolio-load-policy";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const ZERO_BYTES32 = `0x${"00".repeat(32)}`;
@@ -790,38 +793,36 @@ async function readPredictionRedeemedLogs({
 }) {
   const logs = [];
   for (const addressBatch of predictionPortfolioAddressBatches(addresses)) {
-    const [holderLogs, recipientLogs] = await Promise.all([
-      readPredictionPortfolioLogs({
-        clients,
-        fromBlock,
-        read: (client, range) =>
-          client.getLogs({
+    const holderLogs = await readPredictionPortfolioLogs({
+      clients,
+      fromBlock,
+      read: (client, range) =>
+        client.getLogs({
+          address: addressBatch,
+          args: { holder: account },
+          event: predictionRedeemedEvent,
+          fromBlock: range.fromBlock,
+          strict: true,
+          toBlock: range.toBlock,
+        }),
+      toBlock,
+    });
+    const recipientLogs = await readPredictionPortfolioLogs({
+      clients,
+      fromBlock,
+      read: (client, range) =>
+        client
+          .getLogs({
             address: addressBatch,
-            args: { holder: account },
+            args: { recipient: account },
             event: predictionRedeemedEvent,
             fromBlock: range.fromBlock,
             strict: true,
             toBlock: range.toBlock,
-          }),
-        toBlock,
-      }),
-      readPredictionPortfolioLogs({
-        clients,
-        fromBlock,
-        read: (client, range) =>
-          client
-            .getLogs({
-              address: addressBatch,
-              args: { recipient: account },
-              event: predictionRedeemedEvent,
-              fromBlock: range.fromBlock,
-              strict: true,
-              toBlock: range.toBlock,
-            })
-            .then(filterFundedPredictionRedemptionRecipients),
-        toBlock,
-      }),
-    ]);
+          })
+          .then(filterFundedPredictionRedemptionRecipients),
+      toBlock,
+    });
     logs.push(
       ...holderLogs,
       ...recipientLogs,
@@ -845,36 +846,34 @@ async function readPredictionSplitLogs({
 }) {
   const logs = [];
   for (const addressBatch of predictionPortfolioAddressBatches(addresses)) {
-    const [payerLogs, recipientLogs] = await Promise.all([
-      readPredictionPortfolioLogs({
-        clients,
-        fromBlock,
-        read: (client, range) =>
-          client.getLogs({
-            address: addressBatch,
-            args: { payer: account },
-            event: predictionSplitEvent,
-            fromBlock: range.fromBlock,
-            strict: true,
-            toBlock: range.toBlock,
-          }),
-        toBlock,
-      }),
-      readPredictionPortfolioLogs({
-        clients,
-        fromBlock,
-        read: (client, range) =>
-          client.getLogs({
-            address: addressBatch,
-            args: { recipient: account },
-            event: predictionSplitEvent,
-            fromBlock: range.fromBlock,
-            strict: true,
-            toBlock: range.toBlock,
-          }),
-        toBlock,
-      }),
-    ]);
+    const payerLogs = await readPredictionPortfolioLogs({
+      clients,
+      fromBlock,
+      read: (client, range) =>
+        client.getLogs({
+          address: addressBatch,
+          args: { payer: account },
+          event: predictionSplitEvent,
+          fromBlock: range.fromBlock,
+          strict: true,
+          toBlock: range.toBlock,
+        }),
+      toBlock,
+    });
+    const recipientLogs = await readPredictionPortfolioLogs({
+      clients,
+      fromBlock,
+      read: (client, range) =>
+        client.getLogs({
+          address: addressBatch,
+          args: { recipient: account },
+          event: predictionSplitEvent,
+          fromBlock: range.fromBlock,
+          strict: true,
+          toBlock: range.toBlock,
+        }),
+      toBlock,
+    });
     logs.push(
       ...payerLogs,
       ...recipientLogs,
@@ -898,36 +897,34 @@ async function readPredictionMergedLogs({
 }) {
   const logs = [];
   for (const addressBatch of predictionPortfolioAddressBatches(addresses)) {
-    const [holderLogs, recipientLogs] = await Promise.all([
-      readPredictionPortfolioLogs({
-        clients,
-        fromBlock,
-        read: (client, range) =>
-          client.getLogs({
-            address: addressBatch,
-            args: { holder: account },
-            event: predictionMergedEvent,
-            fromBlock: range.fromBlock,
-            strict: true,
-            toBlock: range.toBlock,
-          }),
-        toBlock,
-      }),
-      readPredictionPortfolioLogs({
-        clients,
-        fromBlock,
-        read: (client, range) =>
-          client.getLogs({
-            address: addressBatch,
-            args: { recipient: account },
-            event: predictionMergedEvent,
-            fromBlock: range.fromBlock,
-            strict: true,
-            toBlock: range.toBlock,
-          }),
-        toBlock,
-      }),
-    ]);
+    const holderLogs = await readPredictionPortfolioLogs({
+      clients,
+      fromBlock,
+      read: (client, range) =>
+        client.getLogs({
+          address: addressBatch,
+          args: { holder: account },
+          event: predictionMergedEvent,
+          fromBlock: range.fromBlock,
+          strict: true,
+          toBlock: range.toBlock,
+        }),
+      toBlock,
+    });
+    const recipientLogs = await readPredictionPortfolioLogs({
+      clients,
+      fromBlock,
+      read: (client, range) =>
+        client.getLogs({
+          address: addressBatch,
+          args: { recipient: account },
+          event: predictionMergedEvent,
+          fromBlock: range.fromBlock,
+          strict: true,
+          toBlock: range.toBlock,
+        }),
+      toBlock,
+    });
     logs.push(
       ...holderLogs,
       ...recipientLogs,
@@ -1086,10 +1083,12 @@ async function readPredictionMarketPortfolioAtRequest({
   clients,
   config,
   request,
+  shouldContinue,
 }: {
   clients: PredictionMarketClients;
   config: PredictionMarketReleaseConfig;
   request: PredictionPortfolioRequest;
+  shouldContinue: () => boolean;
 }): Promise<PredictionMarketPortfolio> {
   const snapshot = await readPredictionMarketSnapshot({ clients, config });
   const fromBlock = config.deploymentBlock;
@@ -1143,8 +1142,8 @@ async function readPredictionMarketPortfolioAtRequest({
     mergedLogs,
     redeemedLogs,
   ] =
-    await Promise.all([
-      readPredictionPortfolioLogs({
+    await readPredictionPortfolioHistoryLanes([
+      () => readPredictionPortfolioLogs({
         clients,
         fromBlock,
         read: (client, range) =>
@@ -1158,7 +1157,7 @@ async function readPredictionMarketPortfolioAtRequest({
           }),
         toBlock,
       }),
-      readPredictionPortfolioLogs({
+      () => readPredictionPortfolioLogs({
         clients,
         fromBlock,
         read: (client, range) =>
@@ -1172,7 +1171,7 @@ async function readPredictionMarketPortfolioAtRequest({
           }),
         toBlock,
       }),
-      readPredictionPortfolioLogs({
+      () => readPredictionPortfolioLogs({
         clients,
         fromBlock,
         read: (client, range) =>
@@ -1186,7 +1185,7 @@ async function readPredictionMarketPortfolioAtRequest({
           }),
         toBlock,
       }),
-      readOutcomeTransferLogs({
+      () => readOutcomeTransferLogs({
         account: request.account,
         addresses: outcomeTokenAddresses,
         allowedTokens,
@@ -1195,7 +1194,7 @@ async function readPredictionMarketPortfolioAtRequest({
         fromBlock,
         toBlock,
       }),
-      readOutcomeTransferLogs({
+      () => readOutcomeTransferLogs({
         account: request.account,
         addresses: outcomeTokenAddresses,
         allowedTokens,
@@ -1204,28 +1203,28 @@ async function readPredictionMarketPortfolioAtRequest({
         fromBlock,
         toBlock,
       }),
-      readPredictionSplitLogs({
+      () => readPredictionSplitLogs({
         account: request.account,
         addresses: vaultAddresses,
         clients,
         fromBlock,
         toBlock,
       }),
-      readPredictionMergedLogs({
+      () => readPredictionMergedLogs({
         account: request.account,
         addresses: vaultAddresses,
         clients,
         fromBlock,
         toBlock,
       }),
-      readPredictionRedeemedLogs({
+      () => readPredictionRedeemedLogs({
         account: request.account,
         addresses: vaultAddresses,
         clients,
         fromBlock,
         toBlock,
       }),
-    ]);
+    ], shouldContinue);
   const transferLogs = dedupePortfolioLogs([
     ...incomingTransfers,
     ...outgoingTransfers,
@@ -1557,10 +1556,12 @@ export async function readPredictionMarketPortfolio({
   clients = createPredictionMarketPublicClients(),
   config,
   request,
+  shouldContinue = () => true,
 }: {
   clients?: PredictionMarketClients;
   config: PredictionMarketReleaseConfig;
   request: PredictionPortfolioRequest;
+  shouldContinue?: () => boolean;
 }): Promise<PredictionMarketPortfolio> {
   const normalizedRequest = createPredictionPortfolioRequest(
     request.account,
@@ -1571,6 +1572,7 @@ export async function readPredictionMarketPortfolio({
       clients,
       config,
       request: normalizedRequest,
+      shouldContinue,
     });
   } catch (error) {
     if (error instanceof PredictionPortfolioReadError) throw error;

--- a/lib/prediction-portfolio-load-policy.ts
+++ b/lib/prediction-portfolio-load-policy.ts
@@ -1,0 +1,123 @@
+export type PredictionPortfolioLoadMode = "initial" | "refresh" | "retry";
+
+export const PREDICTION_PORTFOLIO_INITIAL_ATTEMPT_LIMIT = 2;
+export const PREDICTION_PORTFOLIO_INITIAL_RETRY_DELAY_MS = 600;
+export const PREDICTION_PORTFOLIO_HISTORY_LANE_CONCURRENCY = 2;
+
+type PredictionPortfolioReadLane<Result> = () => Promise<Result>;
+
+const pendingPredictionPortfolioHistoryLanePermits: Array<() => void> = [];
+let activePredictionPortfolioHistoryLanes = 0;
+
+type PredictionPortfolioReadLaneResults<
+  Lanes extends readonly PredictionPortfolioReadLane<unknown>[],
+> = {
+  [Index in keyof Lanes]: Lanes[Index] extends PredictionPortfolioReadLane<infer Result>
+    ? Result
+    : never;
+};
+
+type PredictionPortfolioLoadPolicyInput<Result> = Readonly<{
+  isCurrent: () => boolean;
+  mode: PredictionPortfolioLoadMode;
+  read: () => Promise<Result>;
+  wait?: (delayMs: number) => Promise<void>;
+}>;
+
+function waitForRetry(delayMs: number) {
+  return new Promise<void>((resolve) => {
+    globalThis.setTimeout(resolve, delayMs);
+  });
+}
+
+async function withPredictionPortfolioHistoryLanePermit<Result>(
+  read: () => Promise<Result>,
+) {
+  if (
+    activePredictionPortfolioHistoryLanes <
+    PREDICTION_PORTFOLIO_HISTORY_LANE_CONCURRENCY
+  ) {
+    activePredictionPortfolioHistoryLanes += 1;
+  } else {
+    await new Promise<void>((resolve) => {
+      pendingPredictionPortfolioHistoryLanePermits.push(resolve);
+    });
+  }
+
+  try {
+    return await read();
+  } finally {
+    const next = pendingPredictionPortfolioHistoryLanePermits.shift();
+    if (next) next();
+    else activePredictionPortfolioHistoryLanes -= 1;
+  }
+}
+
+export async function readPredictionPortfolioHistoryLanes<
+  const Lanes extends readonly PredictionPortfolioReadLane<unknown>[],
+>(
+  lanes: Lanes,
+  shouldContinue: () => boolean = () => true,
+): Promise<PredictionPortfolioReadLaneResults<Lanes>> {
+  const results: unknown[] = new Array(lanes.length);
+  let failed = false;
+  let failure: unknown;
+  let nextLaneIndex = 0;
+
+  const worker = async () => {
+    while (!failed && shouldContinue() && nextLaneIndex < lanes.length) {
+      const laneIndex = nextLaneIndex;
+      nextLaneIndex += 1;
+      try {
+        results[laneIndex] = await withPredictionPortfolioHistoryLanePermit(
+          async () => {
+            if (!shouldContinue()) {
+              throw new Error("Prediction portfolio request was superseded");
+            }
+            return lanes[laneIndex]();
+          },
+        );
+      } catch (error) {
+        if (!failed) failure = error;
+        failed = true;
+      }
+    }
+  };
+
+  const workerCount = Math.min(
+    PREDICTION_PORTFOLIO_HISTORY_LANE_CONCURRENCY,
+    lanes.length,
+  );
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  if (failed) throw failure;
+  if (!shouldContinue()) {
+    throw new Error("Prediction portfolio request was superseded");
+  }
+
+  return results as PredictionPortfolioReadLaneResults<Lanes>;
+}
+
+export async function readPredictionPortfolioWithRetry<Result>({
+  isCurrent,
+  mode,
+  read,
+  wait = waitForRetry,
+}: PredictionPortfolioLoadPolicyInput<Result>): Promise<Result> {
+  const attemptLimit = mode === "initial"
+    ? PREDICTION_PORTFOLIO_INITIAL_ATTEMPT_LIMIT
+    : 1;
+
+  for (let attempt = 1; attempt <= attemptLimit; attempt += 1) {
+    try {
+      return await read();
+    } catch (error) {
+      const canRetry = attempt < attemptLimit && isCurrent();
+      if (!canRetry) throw error;
+
+      await wait(PREDICTION_PORTFOLIO_INITIAL_RETRY_DELAY_MS);
+      if (!isCurrent()) throw error;
+    }
+  }
+
+  throw new Error("Prediction portfolio retry policy exhausted unexpectedly");
+}

--- a/lib/server/custom-launch/well-known-v1.ts
+++ b/lib/server/custom-launch/well-known-v1.ts
@@ -60,6 +60,32 @@ export function programmableWellKnownDocumentV1(
           "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0-rc.2/programmable-launch-2.0.0-rc.2.tgz",
         openApiUrl:
           "https://programmable.market/openapi/custom-launch-v2.json",
+        feePolicy: Object.freeze({
+          profileId:
+            "programmable.fee-enforced-isolated-after-swap.zero-delta.v1",
+          profileRevision: 2 as const,
+          launchProfileHash:
+            "sha256:1eca209637922b9a8627d073a6d92fede0ae355fb5bd2dfebe3e5382f12f55f8",
+          productionLaunchAuthorized: false as const,
+          chainId: "1" as const,
+          network: "Ethereum Mainnet" as const,
+          chargeTrigger: "successful-swap" as const,
+          basis: "gross-unspecified-pool-currency-amount" as const,
+          assetMode: "unspecified-pool-currency-per-swap" as const,
+          ratePpm: 1_000 as const,
+          denominatorPpm: 1_000_000 as const,
+          ratePercent: "0.10%" as const,
+          rateBps: 10 as const,
+          recipient: "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c",
+          enforcement: Object.freeze({
+            frozenProfile: true as const,
+            customModuleMayReduce: false as const,
+            customModuleMayRedirect: false as const,
+          }),
+          lpFee: "separate-from-platform-fee" as const,
+          genericFeeClaiming: "not-live" as const,
+          genericBuybackManagement: "not-live" as const,
+        }),
       }),
       authentication: "wallet-bound-api-key" as const,
       walletAuthority: "separate-review-and-sign" as const,

--- a/lib/server/custom-launch/well-known-v1.ts
+++ b/lib/server/custom-launch/well-known-v1.ts
@@ -25,6 +25,8 @@ export function programmableWellKnownDocumentV1(
     manifestUrl: "https://developers.programmable.family/api/v2/manifest",
     launchesUrl: "https://developers.programmable.family/api/v2/launches",
     tokenListUrl: "https://developers.programmable.family/api/v2/token-list",
+    routerCustomIdentitySnapshotUrl:
+      "https://programmable.market/api/indexers/v1/router-custom-identities",
     openApiUrl:
       "https://developers.programmable.family/openapi/programmable-v2.yaml",
     schemasBaseUrl: "https://developers.programmable.family/schemas/v2/",

--- a/packages/launch/README.md
+++ b/packages/launch/README.md
@@ -27,6 +27,21 @@ programmable-launch --version
 The V2 Rev2 profile is a canary artifact with `productionLaunchAuthorized:false`; package installation is not launch
 authority. The human guide is <https://programmable.market/docs/developers/custom-launch>.
 
+## RC2 fee policy (private canary)
+
+This disclosure describes only the frozen RC2 profile. It does not activate public V2 submission. The profile is for
+Ethereum Mainnet only (`chainId: "1"`) and has `productionLaunchAuthorized: false`.
+
+For each successful swap, the mandatory platform charge is 1,000 parts per 1,000,000 of the documented
+`gross-unspecified-pool-currency-amount` basis: `1,000 ppm = 0.10% = 10 bps`. It accrues in the profile's unspecified
+pool currency to `0x4957f49620AFf3Adbbe8195a4f633E49cc93376c`. The frozen profile enforces this path independently
+of custom behavior; a Custom module cannot reduce or redirect it. A reverted swap rolls back the fee with the rest of
+the transaction.
+
+The pool's LP fee is separate from this platform charge and must be disclosed separately. Generic fee claiming and
+buyback management for arbitrary hooks are not live. The reserved `fees:claim` and `buybacks:manage` scopes remain
+disabled.
+
 ## Cold-agent flow
 
 1. Produce exact Solidity Standard JSON input and compiler artifacts from one pinned build. Standard JSON sources must

--- a/public/developers/custom-launch-api-v1.md
+++ b/public/developers/custom-launch-api-v1.md
@@ -18,6 +18,21 @@ Human guide: <https://programmable.market/docs/developers/custom-launch>
 
 Readiness: <https://api.programmable.market/readyz>
 
+## RC2 fee policy (private canary)
+
+This disclosure describes only the frozen RC2 profile. It does not activate public V2 submission. The profile is for
+Ethereum Mainnet only (`chainId: "1"`) and has `productionLaunchAuthorized: false`.
+
+For each successful swap, the mandatory platform charge is 1,000 parts per 1,000,000 of the documented
+`gross-unspecified-pool-currency-amount` basis: `1,000 ppm = 0.10% = 10 bps`. It accrues in the profile's unspecified
+pool currency to `0x4957f49620AFf3Adbbe8195a4f633E49cc93376c`. The frozen profile enforces this path independently
+of custom behavior; a Custom module cannot reduce or redirect it. A reverted swap rolls back the fee with the rest of
+the transaction.
+
+The pool's LP fee is separate from this platform charge and must be disclosed separately. Generic fee claiming and
+buyback management for arbitrary hooks are not live. The reserved `fees:claim` and `buybacks:manage` scopes remain
+disabled.
+
 ## Install the public CLI
 
 ```sh

--- a/public/openapi/custom-launch-v2.json
+++ b/public/openapi/custom-launch-v2.json
@@ -46,6 +46,30 @@
     "launchProfileHash": "sha256:1eca209637922b9a8627d073a6d92fede0ae355fb5bd2dfebe3e5382f12f55f8",
     "productionLaunchAuthorized": false
   },
+  "x-programmable-fee-policy": {
+    "profileId": "programmable.fee-enforced-isolated-after-swap.zero-delta.v1",
+    "profileRevision": 2,
+    "launchProfileHash": "sha256:1eca209637922b9a8627d073a6d92fede0ae355fb5bd2dfebe3e5382f12f55f8",
+    "productionLaunchAuthorized": false,
+    "chainId": "1",
+    "network": "Ethereum Mainnet",
+    "chargeTrigger": "successful-swap",
+    "basis": "gross-unspecified-pool-currency-amount",
+    "assetMode": "unspecified-pool-currency-per-swap",
+    "ratePpm": 1000,
+    "denominatorPpm": 1000000,
+    "ratePercent": "0.10%",
+    "rateBps": 10,
+    "recipient": "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c",
+    "enforcement": {
+      "frozenProfile": true,
+      "customModuleMayReduce": false,
+      "customModuleMayRedirect": false
+    },
+    "lpFee": "separate-from-platform-fee",
+    "genericFeeClaiming": "not-live",
+    "genericBuybackManagement": "not-live"
+  },
   "x-programmable-error-status": {
     "400": [
       "INVALID_IDEMPOTENCY_KEY",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -188,7 +188,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     publicSnapshot: Object.freeze({
       path: "lib/alchemy/router-custom-public.server.ts",
       sha256:
-        "02dc2a835a637657a00c7b770bdf4ada238fe7fd1233cf465d81ec75a3f995d7",
+        "b5dbb13c98bc69e7b94d6e67844bd1c89478ad02a823eab1c900e6523a272613",
     }),
   }),
   independentCrons: Object.freeze([

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -188,7 +188,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     publicSnapshot: Object.freeze({
       path: "lib/alchemy/router-custom-public.server.ts",
       sha256:
-        "6f622b8eff5ef7e917d7c7a5d17fe98e2651414daf5f3aa4945fa4a85f4a2884",
+        "02dc2a835a637657a00c7b770bdf4ada238fe7fd1233cf465d81ec75a3f995d7",
     }),
   }),
   independentCrons: Object.freeze([

--- a/tests/custom-launch-cli-public-surface.test.ts
+++ b/tests/custom-launch-cli-public-surface.test.ts
@@ -39,6 +39,32 @@ describe("public Custom Launch CLI surface", () => {
           "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0-rc.2/programmable-launch-2.0.0-rc.2.tgz",
         openApiUrl:
           "https://programmable.market/openapi/custom-launch-v2.json",
+        feePolicy: {
+          profileId:
+            "programmable.fee-enforced-isolated-after-swap.zero-delta.v1",
+          profileRevision: 2,
+          launchProfileHash:
+            "sha256:1eca209637922b9a8627d073a6d92fede0ae355fb5bd2dfebe3e5382f12f55f8",
+          productionLaunchAuthorized: false,
+          chainId: "1",
+          network: "Ethereum Mainnet",
+          chargeTrigger: "successful-swap",
+          basis: "gross-unspecified-pool-currency-amount",
+          assetMode: "unspecified-pool-currency-per-swap",
+          ratePpm: 1_000,
+          denominatorPpm: 1_000_000,
+          ratePercent: "0.10%",
+          rateBps: 10,
+          recipient: "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c",
+          enforcement: {
+            frozenProfile: true,
+            customModuleMayReduce: false,
+            customModuleMayRedirect: false,
+          },
+          lpFee: "separate-from-platform-fee",
+          genericFeeClaiming: "not-live",
+          genericBuybackManagement: "not-live",
+        },
       },
       versions: {
         v1: {

--- a/tests/custom-launch-cli-public-surface.test.ts
+++ b/tests/custom-launch-cli-public-surface.test.ts
@@ -17,6 +17,9 @@ describe("public Custom Launch CLI surface", () => {
     const document = programmableWellKnownDocumentV1(
       PRELAUNCH_CUSTOM_REGISTRY_PUBLIC_MANIFEST_V1,
     );
+    expect(document.routerCustomIdentitySnapshotUrl).toBe(
+      "https://programmable.market/api/indexers/v1/router-custom-identities",
+    );
     expect(document.customLaunchApi).toMatchObject({
       status: "read-only",
       readStatus: "live",

--- a/tests/custom-launch-docs.test.ts
+++ b/tests/custom-launch-docs.test.ts
@@ -16,6 +16,8 @@ const websiteGuide = read("app/docs/developers/custom-launch/page.tsx");
 const summary = read("docs/public/SUMMARY.md");
 const createGuide = read("components/create-guide.tsx");
 const rawGuide = read("public/developers/custom-launch-api-v1.md");
+const cliGuide = read("packages/launch/README.md");
+const v2OpenApi = JSON.parse(read("public/openapi/custom-launch-v2.json"));
 const machineReadableGuide = read(
   "app/docs/developers/machine-readable/page.tsx",
 );
@@ -152,6 +154,48 @@ describe("Custom Launch API documentation", () => {
         },
         legacyIntake: { registry: "closed", github: "closed" },
       });
+  });
+
+  it("discloses the exact held RC2 fee without conflating LP fees or future operations", () => {
+    for (const source of [gitBookGuide, websiteGuide, rawGuide, cliGuide]) {
+      expect(source).toContain("Ethereum Mainnet");
+      expect(source).toContain("productionLaunchAuthorized: false");
+      expect(source).toContain("gross-unspecified-pool-currency-amount");
+      expect(source).toContain("1,000 ppm = 0.10% = 10 bps");
+      expect(source).toContain("0x4957f49620AFf3Adbbe8195a4f633E49cc93376c");
+      expect(source).toContain("cannot reduce or redirect");
+      expect(source).toContain("LP fee is separate");
+      expect(source).toMatch(/Generic fee claiming and\s+buyback/);
+      expect(source).toMatch(/private[- ]canary/i);
+      expect(source).not.toContain("public V2 is active");
+    }
+
+    expect(v2OpenApi["x-programmable-fee-policy"]).toEqual({
+      profileId:
+        "programmable.fee-enforced-isolated-after-swap.zero-delta.v1",
+      profileRevision: 2,
+      launchProfileHash:
+        "sha256:1eca209637922b9a8627d073a6d92fede0ae355fb5bd2dfebe3e5382f12f55f8",
+      productionLaunchAuthorized: false,
+      chainId: "1",
+      network: "Ethereum Mainnet",
+      chargeTrigger: "successful-swap",
+      basis: "gross-unspecified-pool-currency-amount",
+      assetMode: "unspecified-pool-currency-per-swap",
+      ratePpm: 1_000,
+      denominatorPpm: 1_000_000,
+      ratePercent: "0.10%",
+      rateBps: 10,
+      recipient: "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c",
+      enforcement: {
+        frozenProfile: true,
+        customModuleMayReduce: false,
+        customModuleMayRedirect: false,
+      },
+      lpFee: "separate-from-platform-fee",
+      genericFeeClaiming: "not-live",
+      genericBuybackManagement: "not-live",
+    });
   });
 
   it("describes request-driven reconciliation consistently", () => {

--- a/tests/prediction-portfolio-load-policy.test.ts
+++ b/tests/prediction-portfolio-load-policy.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  PREDICTION_PORTFOLIO_HISTORY_LANE_CONCURRENCY,
+  PREDICTION_PORTFOLIO_INITIAL_RETRY_DELAY_MS,
+  readPredictionPortfolioHistoryLanes,
+  readPredictionPortfolioWithRetry,
+} from "../lib/prediction-portfolio-load-policy";
+
+describe("prediction portfolio load policy", () => {
+  it("caps concurrent history lanes while preserving result order", async () => {
+    let activeLanes = 0;
+    let maximumActiveLanes = 0;
+    const laneStarts: number[] = [];
+    const lanes = Array.from({ length: 8 }, (_, index) => async () => {
+      activeLanes += 1;
+      maximumActiveLanes = Math.max(maximumActiveLanes, activeLanes);
+      laneStarts.push(index);
+      await new Promise<void>((resolve) => {
+        globalThis.setTimeout(resolve, 5);
+      });
+      activeLanes -= 1;
+      return `lane-${index}`;
+    });
+
+    await expect(readPredictionPortfolioHistoryLanes(lanes)).resolves.toEqual(
+      Array.from({ length: 8 }, (_, index) => `lane-${index}`),
+    );
+
+    expect(laneStarts).toHaveLength(8);
+    expect(maximumActiveLanes).toBe(
+      PREDICTION_PORTFOLIO_HISTORY_LANE_CONCURRENCY,
+    );
+  });
+
+  it("keeps the global lane cap across overlapping wallet reads", async () => {
+    let activeLanes = 0;
+    let maximumActiveLanes = 0;
+    const lane = async () => {
+      activeLanes += 1;
+      maximumActiveLanes = Math.max(maximumActiveLanes, activeLanes);
+      await new Promise<void>((resolve) => {
+        globalThis.setTimeout(resolve, 5);
+      });
+      activeLanes -= 1;
+      return activeLanes;
+    };
+
+    await Promise.all([
+      readPredictionPortfolioHistoryLanes([lane, lane, lane, lane]),
+      readPredictionPortfolioHistoryLanes([lane, lane, lane, lane]),
+    ]);
+
+    expect(maximumActiveLanes).toBe(
+      PREDICTION_PORTFOLIO_HISTORY_LANE_CONCURRENCY,
+    );
+  });
+
+  it("does not schedule more lanes after a wallet read becomes stale", async () => {
+    let current = true;
+    let releaseActiveLanes: (() => void) | undefined;
+    const activeLanes = new Promise<void>((resolve) => {
+      releaseActiveLanes = resolve;
+    });
+    const neverScheduled = vi.fn().mockResolvedValue("unexpected");
+
+    const read = readPredictionPortfolioHistoryLanes([
+      async () => {
+        await activeLanes;
+        return "first";
+      },
+      async () => {
+        await activeLanes;
+        return "second";
+      },
+      neverScheduled,
+    ], () => current);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    current = false;
+    releaseActiveLanes?.();
+
+    await expect(read).rejects.toThrow("superseded");
+    expect(neverScheduled).not.toHaveBeenCalled();
+  });
+
+  it("drains the active sibling and stops scheduling before an attempt fails", async () => {
+    const laneError = new Error("lane failed");
+    let releaseSibling: (() => void) | undefined;
+    const sibling = new Promise<void>((resolve) => {
+      releaseSibling = resolve;
+    });
+    const neverScheduled = vi.fn().mockResolvedValue("unexpected");
+    let settled = false;
+
+    const read = readPredictionPortfolioHistoryLanes([
+      async () => {
+        throw laneError;
+      },
+      async () => {
+        await sibling;
+        return "sibling";
+      },
+      neverScheduled,
+    ]).finally(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(neverScheduled).not.toHaveBeenCalled();
+
+    releaseSibling?.();
+    await expect(read).rejects.toBe(laneError);
+    expect(neverScheduled).not.toHaveBeenCalled();
+  });
+
+  it("retries an initial read exactly once after the bounded delay", async () => {
+    const read = vi.fn()
+      .mockRejectedValueOnce(new Error("temporary provider failure"))
+      .mockResolvedValueOnce("loaded");
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await expect(readPredictionPortfolioWithRetry({
+      isCurrent: () => true,
+      mode: "initial",
+      read,
+      wait,
+    })).resolves.toBe("loaded");
+
+    expect(read).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledOnce();
+    expect(wait).toHaveBeenCalledWith(
+      PREDICTION_PORTFOLIO_INITIAL_RETRY_DELAY_MS,
+    );
+  });
+
+  it("surfaces the terminal initial failure after two attempts", async () => {
+    const terminalError = new Error("provider unavailable");
+    const read = vi.fn().mockRejectedValue(terminalError);
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await expect(readPredictionPortfolioWithRetry({
+      isCurrent: () => true,
+      mode: "initial",
+      read,
+      wait,
+    })).rejects.toBe(terminalError);
+
+    expect(read).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledOnce();
+  });
+
+  it.each(["refresh", "retry"] as const)(
+    "keeps a manual %s action to one read",
+    async (mode) => {
+      const manualError = new Error("manual request failed");
+      const read = vi.fn().mockRejectedValue(manualError);
+      const wait = vi.fn().mockResolvedValue(undefined);
+
+      await expect(readPredictionPortfolioWithRetry({
+        isCurrent: () => true,
+        mode,
+        read,
+        wait,
+      })).rejects.toBe(manualError);
+
+      expect(read).toHaveBeenCalledOnce();
+      expect(wait).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not retry after the active wallet request becomes stale", async () => {
+    const staleError = new Error("stale request");
+    const read = vi.fn().mockRejectedValue(staleError);
+    const wait = vi.fn().mockResolvedValue(undefined);
+    const isCurrent = vi.fn()
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false);
+
+    await expect(readPredictionPortfolioWithRetry({
+      isCurrent,
+      mode: "initial",
+      read,
+      wait,
+    })).rejects.toBe(staleError);
+
+    expect(read).toHaveBeenCalledOnce();
+    expect(wait).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/prediction-profile-regression.test.ts
+++ b/tests/prediction-profile-regression.test.ts
@@ -19,6 +19,10 @@ const portfolioSource = readFileSync(
   join(root, "components/prediction-market-portfolio.tsx"),
   "utf8",
 );
+const portfolioDataSource = readFileSync(
+  join(root, "lib/prediction-market-portfolio.ts"),
+  "utf8",
+);
 const detailSource = readFileSync(
   join(root, "components/prediction-market-detail.tsx"),
   "utf8",
@@ -288,6 +292,18 @@ describe("prediction profile regression contract", () => {
     ).toBeGreaterThan(0);
   });
 
+  it("runs the eight history lanes through the bounded concurrency policy", () => {
+    expect(portfolioDataSource).toContain(
+      "await readPredictionPortfolioHistoryLanes([",
+    );
+    expect(portfolioDataSource).not.toMatch(
+      /createdLogs,[\s\S]{0,300}redeemedLogs,[\s\S]{0,100}await Promise\.all/u,
+    );
+    expect(portfolioDataSource).not.toMatch(
+      /const \[(?:holderLogs|payerLogs), recipientLogs\] = await Promise\.all/u,
+    );
+  });
+
   it("exposes Positions, Created, and History as one accessible tab set", () => {
     for (const label of ["Positions", "Created", "History"]) {
       expect(portfolioSource).toMatch(new RegExp(`(?:["']${label}["']|>${label}<)`, "u"));
@@ -334,6 +350,15 @@ describe("prediction profile regression contract", () => {
     expect(portfolioSource).toContain(
       "? Math.min(visibleItems.length, 2)",
     );
+    expect(portfolioSource).toMatch(
+      /model\.phase === "loading" \|\| model\.phase === "error"[\s\S]{0,80}\? 2/u,
+    );
+    expect(portfolioStyles).toMatch(
+      /\.portfolioSection\[data-visible-card-count="2"\]\s*\{[^}]*min-height:\s*424px;/s,
+    );
+    expect(portfolioStyles).toMatch(
+      /@media\s*\(max-width:\s*52rem\)[\s\S]*?\.portfolioSection\[data-visible-card-count="2"\]\s*\{[^}]*min-height:\s*748px;/u,
+    );
     expect(portfolioStyles).toMatch(
       /\.portfolioLoadingCard\s*\{[^}]*min-height:\s*82px;/s,
     );
@@ -349,6 +374,19 @@ describe("prediction profile regression contract", () => {
     expect(portfolioStyles).toMatch(
       /@media \(max-width:\s*620px\)[\s\S]*?\.portfolioSection\[data-visible-card-count="2"\]\s*\{[^}]*min-height:\s*806px;/s,
     );
+  });
+
+  it("keeps the iconless mobile error state readable in one column", () => {
+    const narrowStyles = mediaBodiesAtOrBelow(portfolioStyles, 620);
+    const errorLayout = cssDeclarationsFor(narrowStyles, ".portfolioError");
+
+    expect(errorLayout).toMatch(
+      /grid-template-columns\s*:\s*minmax\(0,\s*1fr\)/u,
+    );
+    expect(errorLayout).not.toMatch(/44px/u);
+    expect(
+      cssDeclarationsFor(narrowStyles, ".portfolioError button"),
+    ).toMatch(/width\s*:\s*100%/u);
   });
 
   it("uses vivid yes and no colors with AA text contrast and non-color labels", () => {

--- a/tests/router-custom-identity-snapshot-route.test.ts
+++ b/tests/router-custom-identity-snapshot-route.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  readCore: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("../lib/alchemy/router-custom-public.server", () => ({
+  readFinalizedRouterCustomIdentitySnapshotCoreV1: mocks.readCore,
+  ROUTER_CUSTOM_SNAPSHOT_MAX_IDENTITIES: 10_000,
+  ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_BYTES: 16 * 1_024 * 1_024,
+}));
+
+import { GET } from
+  "../app/api/indexers/v1/router-custom-identities/route";
+
+const snapshot = Object.freeze({
+  schemaVersion: "programmable.router-custom-identity-snapshot.v1",
+  source: "canonical-launch-stamp-router",
+  status: "current",
+  generatedAt: "2026-08-25T16:20:39.656Z",
+  asOfBlock: "25833303",
+  asOfBlockHash: `0x${"8a".repeat(32)}`,
+  finalityConfirmations: 12,
+  identityCommitment: `sha256:${"c2".repeat(32)}`,
+  entries: Object.freeze([
+    Object.freeze({
+      id: `0x${"6d".repeat(32)}`,
+      tokenAddress: "0x1111111111111111111111111111111111111111",
+    }),
+  ]),
+});
+
+describe("Router Custom identity snapshot route", () => {
+  beforeEach(() => {
+    mocks.readCore.mockReset();
+    mocks.readCore.mockResolvedValue(snapshot);
+  });
+
+  it("returns the unwrapped core snapshot with public cache metadata", async () => {
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=0, s-maxage=15, stale-while-revalidate=45",
+    );
+    expect(response.headers.get("x-programmable-status")).toBe("current");
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(await response.json()).toEqual(snapshot);
+    expect(mocks.readCore).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not add optional fee-policy enrichment to committed entries", async () => {
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.entries).toEqual(snapshot.entries);
+    expect(body.entries[0]).not.toHaveProperty("platformFeePolicy");
+    expect(body.entries[0]).not.toHaveProperty("feePolicyEvidence");
+  });
+
+  it("fails closed without exposing reader internals", async () => {
+    mocks.readCore.mockRejectedValueOnce(
+      new Error("secret provider detail must not escape"),
+    );
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("retry-after")).toBe("5");
+    expect(await response.json()).toEqual({
+      error: "Router Custom identities are temporarily unavailable",
+    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Router Custom public snapshot unavailable",
+      { name: "RouterCustomSnapshotReadError" },
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("rejects a serialized snapshot larger than the 16 MiB bound", async () => {
+    mocks.readCore.mockResolvedValueOnce({
+      ...snapshot,
+      entries: [{ ...snapshot.entries[0], padding: "x".repeat(16 * 1_024 * 1_024) }],
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("x-programmable-status")).toBeNull();
+    expect(response.headers.get("retry-after")).toBe("5");
+  });
+
+  it("rejects more than 10,000 identities", async () => {
+    mocks.readCore.mockResolvedValueOnce({
+      ...snapshot,
+      entries: Array.from({ length: 10_001 }, () => snapshot.entries[0]),
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("x-programmable-status")).toBeNull();
+  });
+});

--- a/tests/router-custom-public.test.ts
+++ b/tests/router-custom-public.test.ts
@@ -36,6 +36,7 @@ import { mapCreatorProfileResponse } from "../lib/profile/onchain-profile";
 import type {
   CustomProjectExploreEntry,
   ExploreEntry,
+  LauncherToken,
 } from "../lib/tokens";
 import {
   customGraphExploreEntry,
@@ -60,7 +61,7 @@ function model(tokens = [customGraphToken, stampedClassicToken]) {
 }
 
 function source(
-  tokens = [customGraphToken, stampedClassicToken],
+  tokens: readonly LauncherToken[] = [customGraphToken, stampedClassicToken],
   input: Readonly<{
     blockNumber?: string;
     blockHash?: `0x${string}`;
@@ -305,6 +306,21 @@ describe("finalized Router Custom public projection", () => {
         },
       }],
     };
+    const rehydrated = routerCustomIdentitySnapshotFromSourceV1(source([
+      {
+        ...customGraphToken,
+        launchStampProvenance: {
+          ...customGraphToken.launchStampProvenance!,
+          finalizedAtBlockNumber: "25740099",
+          finalizedAtBlockHash: `0x${"df".repeat(32)}` as `0x${string}`,
+        },
+      },
+      stampedClassicToken,
+    ], {
+      blockNumber: "25740100",
+      blockHash: `0x${"bd".repeat(32)}`,
+      generatedAt: "2026-08-25T06:01:00.000Z",
+    }));
 
     expect(routerCustomSnapshotPreservesFinalizedIdentitiesV1(
       durable,
@@ -318,6 +334,10 @@ describe("finalized Router Custom public projection", () => {
       durable,
       rewritten,
     )).toBe(false);
+    expect(routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+      durable,
+      rehydrated,
+    )).toBe(true);
   });
 
   it("serves the durable LKG instead of accepting a newer shrinking snapshot", async () => {

--- a/tests/router-custom-public.test.ts
+++ b/tests/router-custom-public.test.ts
@@ -23,6 +23,7 @@ import {
   readFinalizedRouterCustomExploreEntriesV1,
   ROUTER_CUSTOM_SNAPSHOT_CACHE_TTL_MS,
   ROUTER_CUSTOM_SNAPSHOT_MAX_IDENTITIES,
+  routerCustomSnapshotPreservesFinalizedIdentitiesV1,
   routerCustomEntriesAtOrBeforeBlockV1,
   routerCustomExploreEntriesFromModelV1,
   routerCustomIdentitySnapshotFromSourceV1,
@@ -287,6 +288,101 @@ describe("finalized Router Custom public projection", () => {
     });
   });
 
+  it("accepts a newer boundary only when every finalized identity is unchanged", () => {
+    const durable = routerCustomIdentitySnapshotFromSourceV1(source());
+    const next = routerCustomIdentitySnapshotFromSourceV1(source(undefined, {
+      blockNumber: "25740100",
+      blockHash: `0x${"bd".repeat(32)}`,
+      generatedAt: "2026-08-25T06:01:00.000Z",
+    }));
+    const rewritten = {
+      ...next,
+      entries: [{
+        ...next.entries[0],
+        launchStampProvenance: {
+          ...next.entries[0]!.launchStampProvenance!,
+          routePayloadHash: `0x${"de".repeat(32)}` as `0x${string}`,
+        },
+      }],
+    };
+
+    expect(routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+      durable,
+      next,
+    )).toBe(true);
+    expect(routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+      durable,
+      { ...next, entries: [] },
+    )).toBe(false);
+    expect(routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+      durable,
+      rewritten,
+    )).toBe(false);
+  });
+
+  it("serves the durable LKG instead of accepting a newer shrinking snapshot", async () => {
+    const durable = routerCustomIdentitySnapshotFromSourceV1(source());
+    const shrinking = source([], {
+      blockNumber: "25740100",
+      blockHash: `0x${"bd".repeat(32)}`,
+      generatedAt: "2026-08-25T06:01:00.000Z",
+    });
+    const persistDurableSnapshot = vi.fn().mockResolvedValue(undefined);
+    const reader = createRouterCustomIdentitySnapshotReaderV1({
+      now: () => Date.parse("2026-08-25T06:02:00.000Z"),
+      readCurrentSource: vi.fn().mockResolvedValue(shrinking),
+      readDurableSnapshot: vi.fn().mockResolvedValue(durable),
+      persistDurableSnapshot,
+    });
+
+    await expect(reader()).resolves.toMatchObject({
+      status: "last-known-good",
+      asOfBlock: "25740001",
+      entries: [customGraphExploreEntry],
+    });
+    expect(persistDurableSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("does not replace a warm finalized identity with a newer shrinking durable snapshot", async () => {
+    const startedAt = Date.parse("2026-08-25T06:01:00.000Z");
+    let now = startedAt;
+    const current = source();
+    const shrinkingDurable = routerCustomIdentitySnapshotFromSourceV1(source(
+      [],
+      {
+        blockNumber: "25740100",
+        blockHash: `0x${"bd".repeat(32)}`,
+        generatedAt: "2026-08-25T06:01:30.000Z",
+      },
+    ));
+    const advancedCurrent = source(undefined, {
+      blockNumber: "25740200",
+      blockHash: `0x${"be".repeat(32)}`,
+      generatedAt: "2026-08-25T06:02:00.000Z",
+    });
+    const reader = createRouterCustomIdentitySnapshotReaderV1({
+      now: () => now,
+      readCurrentSource: vi.fn()
+        .mockResolvedValueOnce(current)
+        .mockResolvedValueOnce(advancedCurrent),
+      readDurableSnapshot: vi.fn()
+        .mockRejectedValueOnce(new Error("missing"))
+        .mockResolvedValueOnce(shrinkingDurable),
+      persistDurableSnapshot: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await expect(reader()).resolves.toMatchObject({
+      status: "current",
+      entries: [customGraphExploreEntry],
+    });
+    now += ROUTER_CUSTOM_SNAPSHOT_CACHE_TTL_MS + 1;
+    await expect(reader()).resolves.toMatchObject({
+      status: "current",
+      asOfBlock: "25740200",
+      entries: [customGraphExploreEntry],
+    });
+  });
+
   it("fails closed on a warm-cache same-boundary conflict", async () => {
     const startedAt = Date.parse("2026-08-25T06:01:00.000Z");
     let now = startedAt;
@@ -314,7 +410,7 @@ describe("finalized Router Custom public projection", () => {
     );
   });
 
-  it("replaces a stale durable snapshot after an explicit Router reorg", async () => {
+  it("does not delete finalized durable identities after an explicit Router reorg", async () => {
     const durable = routerCustomIdentitySnapshotFromSourceV1(source());
     const rebuilt = {
       ...source([], {
@@ -334,13 +430,10 @@ describe("finalized Router Custom public projection", () => {
 
     await expect(reader()).resolves.toMatchObject({
       status: "last-known-good",
-      asOfBlock: "25718016",
-      entries: [],
+      asOfBlock: "25740001",
+      entries: [customGraphExploreEntry],
     });
-    expect(persistDurableSnapshot).toHaveBeenCalledWith(
-      expect.objectContaining({ asOfBlock: "25718016" }),
-      { replaceAfterReorg: true },
-    );
+    expect(persistDurableSnapshot).not.toHaveBeenCalled();
   });
 
   it("falls back durably when the cold current read never settles", async () => {


### PR DESCRIPTION
## Summary

- publish the exact held RC2 private-canary fee contract in the public guide, CLI README, OpenAPI, and well-known manifest
- add the bounded public Router Custom identity snapshot with durable current/LKG persistence and finalized-identity preservation
- stabilize prediction/profile cold loading with bounded global RPC concurrency, a single automatic retry, and fixed responsive geometry
- preserve the explicit launch boundary: V2 remains private-canary-only with `productionLaunchAuthorized: false`

## Exact fee policy

- Ethereum Mainnet (`chainId: "1"`)
- 1,000 parts per 1,000,000 (`1,000 ppm = 0.10% = 10 bps`) of `gross-unspecified-pool-currency-amount` on successful swaps
- recipient `0x4957f49620AFf3Adbbe8195a4f633E49cc93376c`
- frozen enforcement; a Custom module cannot reduce or redirect the platform charge
- separate from pool LP fees; generic fee claiming and buyback management are not live

## Verification

- combined focused Vitest: 207/207 passed
- affected ESLint passed
- `npm run typecheck` passed
- `npm run build` passed, including candidate-neutrality and production-bundle scans
- `git diff --check` passed
