### PR TITLE
Expose bounded Router Custom identity snapshot

### DIFF
--- a/app/api/indexers/v1/router-custom-identities/route.ts
+++ b/app/api/indexers/v1/router-custom-identities/route.ts
@@ -1,0 +1,60 @@
+import {
+  readFinalizedRouterCustomIdentitySnapshotCoreV1,
+  ROUTER_CUSTOM_SNAPSHOT_MAX_IDENTITIES,
+  ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_BYTES,
+} from "../../../../../lib/alchemy/router-custom-public.server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const SUCCESS_CACHE_CONTROL =
+  "public, max-age=0, s-maxage=15, stale-while-revalidate=45";
+
+const PUBLIC_HEADERS = Object.freeze({
+  "Access-Control-Allow-Origin": "*",
+  "Content-Type": "application/json; charset=utf-8",
+});
+
+function unavailableResponse() {
+  return new Response(
+    JSON.stringify({
+      error: "Router Custom identities are temporarily unavailable",
+    }),
+    {
+      status: 503,
+      headers: {
+        ...PUBLIC_HEADERS,
+        "Cache-Control": "no-store",
+        "Retry-After": "5",
+      },
+    },
+  );
+}
+
+export async function GET() {
+  try {
+    const snapshot =
+      await readFinalizedRouterCustomIdentitySnapshotCoreV1();
+    const body = JSON.stringify(snapshot);
+    if (
+      !Array.isArray(snapshot.entries) ||
+      snapshot.entries.length > ROUTER_CUSTOM_SNAPSHOT_MAX_IDENTITIES ||
+      Buffer.byteLength(body, "utf8") > ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_BYTES
+    ) {
+      return unavailableResponse();
+    }
+    return new Response(body, {
+      status: 200,
+      headers: {
+        ...PUBLIC_HEADERS,
+        "Cache-Control": SUCCESS_CACHE_CONTROL,
+        "X-Programmable-Status": snapshot.status,
+      },
+    });
+  } catch {
+    console.error("Router Custom public snapshot unavailable", {
+      name: "RouterCustomSnapshotReadError",
+    });
+    return unavailableResponse();
+  }
+}

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -160,7 +160,7 @@
     },
     "publicSnapshot": {
       "path": "lib/alchemy/router-custom-public.server.ts",
-      "sha256": "6f622b8eff5ef7e917d7c7a5d17fe98e2651414daf5f3aa4945fa4a85f4a2884"
+      "sha256": "b5dbb13c98bc69e7b94d6e67844bd1c89478ad02a823eab1c900e6523a272613"
     }
   },
   "workers": [

--- a/lib/alchemy/router-custom-public.server.ts
+++ b/lib/alchemy/router-custom-public.server.ts
@@ -36,11 +36,11 @@ export const ROUTER_CUSTOM_SNAPSHOT_SCHEMA_VERSION =
   "programmable.router-custom-identity-snapshot.v1" as const;
 export const ROUTER_CUSTOM_SNAPSHOT_CACHE_TTL_MS = 15_000;
 export const ROUTER_CUSTOM_SNAPSHOT_MAX_IDENTITIES = 10_000;
+export const ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_BYTES = 16 * 1_024 * 1_024;
 export const ROUTER_CUSTOM_SNAPSHOT_CURRENT_READ_TIMEOUT_MS = 3_000;
 const ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_FUTURE_SKEW_MS = 60_000;
 const ROUTER_CUSTOM_SNAPSHOT_DURABLE_READ_TIMEOUT_MS = 2_000;
 const ROUTER_CUSTOM_SNAPSHOT_PERSIST_TIMEOUT_MS = 2_000;
-const ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_BYTES = 16 * 1_024 * 1_024;
 const ROUTER_CUSTOM_SNAPSHOT_ENVELOPE_SCHEMA_VERSION =
   "programmable.router-custom-identity-snapshot-envelope.v1" as const;
 const ROUTER_CUSTOM_SNAPSHOT_BLOB_PATH = [
@@ -247,6 +247,70 @@ function lastKnownGoodRouterCustomSnapshotV1(
     : Object.freeze({ ...snapshot, status: "last-known-good" as const });
 }
 
+function immutableRouterCustomIdentityV1(entry: CanonicalTokenExploreEntry) {
+  requireRouterCustomEntryV1(entry);
+  const {
+    finalizedAtBlockNumber: _finalizedAtBlockNumber,
+    finalizedAtBlockHash: _finalizedAtBlockHash,
+    ...immutableLaunchStampProvenance
+  } = entry.launchStampProvenance!;
+  void _finalizedAtBlockNumber;
+  void _finalizedAtBlockHash;
+  return {
+    id: entry.id,
+    name: entry.name,
+    symbol: entry.symbol ?? null,
+    tokenAddress: entry.tokenAddress.toLowerCase(),
+    tokenDecimals: entry.tokenDecimals ?? null,
+    hookAddress: entry.hookAddress.toLowerCase(),
+    poolId: entry.poolId.toLowerCase(),
+    creatorAddress: entry.creatorAddress?.toLowerCase() ?? null,
+    launchBlockNumber: entry.launchBlockNumber ?? null,
+    launchTransactionHash:
+      entry.launchTransactionHash?.toLowerCase() ?? null,
+    launchTransactionIndex: entry.launchTransactionIndex ?? null,
+    launchLogIndex: entry.launchLogIndex ?? null,
+    launchedAt: entry.launchedAt,
+    launchModel: entry.launchModel ?? null,
+    launchModelVersion: entry.launchModelVersion ?? null,
+    launchCategoryProvenance: entry.launchCategoryProvenance,
+    // These two fields record when finality was observed, not launch identity.
+    // A reorg-safe rebuild may legitimately rehydrate them at a later block.
+    launchStampProvenance: immutableLaunchStampProvenance,
+  };
+}
+
+export function routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+  previous: RouterCustomIdentitySnapshotV1,
+  next: RouterCustomIdentitySnapshotV1,
+) {
+  try {
+    const nextByLaunchId = new Map<string, CanonicalTokenExploreEntry>();
+    for (const entry of next.entries) {
+      const launchId = entry.launchStampProvenance?.launchId.toLowerCase();
+      if (!launchId || nextByLaunchId.has(launchId)) return false;
+      nextByLaunchId.set(launchId, entry);
+    }
+    const previousLaunchIds = new Set<string>();
+    for (const entry of previous.entries) {
+      const launchId = entry.launchStampProvenance?.launchId.toLowerCase();
+      if (!launchId || previousLaunchIds.has(launchId)) return false;
+      previousLaunchIds.add(launchId);
+      const candidate = nextByLaunchId.get(launchId);
+      if (
+        !candidate ||
+        candidate.tokenAddress.toLowerCase() !==
+          entry.tokenAddress.toLowerCase() ||
+        canonicalizeJson(immutableRouterCustomIdentityV1(candidate)) !==
+          canonicalizeJson(immutableRouterCustomIdentityV1(entry))
+      ) return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function jsonRecord(
   value: JsonValue | undefined,
 ): Readonly<Record<string, JsonValue>> {
@@ -378,8 +442,15 @@ async function persistDurableRouterCustomIdentitySnapshotV1(
   if (existing) {
     const previousBlock = BigInt(existing.snapshot.asOfBlock);
     const nextBlock = BigInt(snapshot.asOfBlock);
-    if (!options.replaceAfterReorg && previousBlock > nextBlock) return;
-    if (!options.replaceAfterReorg && previousBlock === nextBlock) {
+    if (previousBlock > nextBlock) {
+      if (options.replaceAfterReorg) {
+        throw new RouterCustomSnapshotConflictError(
+          "Router Custom durable snapshot cannot delete finalized identities after a reorg",
+        );
+      }
+      return;
+    }
+    if (previousBlock === nextBlock) {
       if (existing.snapshot.identityCommitment !== snapshot.identityCommitment) {
         throw new RouterCustomSnapshotConflictError(
           "Router Custom durable snapshot conflicts at one block",
@@ -388,10 +459,15 @@ async function persistDurableRouterCustomIdentitySnapshotV1(
       return;
     }
     if (
-      options.replaceAfterReorg &&
-      previousBlock === nextBlock &&
-      existing.snapshot.identityCommitment === snapshot.identityCommitment
-    ) return;
+      !routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+        existing.snapshot,
+        snapshot,
+      )
+    ) {
+      throw new RouterCustomSnapshotConflictError(
+        "Router Custom durable snapshot cannot rewrite finalized identities",
+      );
+    }
   }
   const { put } = await import("@vercel/blob");
   await put(
@@ -456,51 +532,86 @@ export function createRouterCustomIdentitySnapshotReaderV1(
 
   const refresh = async () => {
     try {
+      let previous = cached
+        ? lastKnownGoodRouterCustomSnapshotV1(cached.snapshot)
+        : null;
       const source = await withinDuration(
         readCurrentSource,
         currentReadTimeoutMs,
       );
       const snapshot = routerCustomIdentitySnapshotFromSourceV1(source);
-      if (!source.reorgDetected) {
-        try {
-          const durable = lastKnownGoodRouterCustomSnapshotV1(
-            await withinDuration(
-              readDurableSnapshot,
-              ROUTER_CUSTOM_SNAPSHOT_DURABLE_READ_TIMEOUT_MS,
-            ),
+      try {
+        const durable = lastKnownGoodRouterCustomSnapshotV1(
+          await withinDuration(
+            readDurableSnapshot,
+            ROUTER_CUSTOM_SNAPSHOT_DURABLE_READ_TIMEOUT_MS,
+          ),
+        );
+        const generatedAtMs = Date.parse(durable.generatedAt);
+        const ageMs = now() - generatedAtMs;
+        if (
+          !Number.isFinite(generatedAtMs) ||
+          ageMs < -ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_FUTURE_SKEW_MS
+        ) {
+          throw new Error(
+            "Router Custom durable snapshot timestamp is invalid",
           );
-          const generatedAtMs = Date.parse(durable.generatedAt);
-          const ageMs = now() - generatedAtMs;
-          if (
-            !Number.isFinite(generatedAtMs) ||
-            ageMs < -ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_FUTURE_SKEW_MS
-          ) {
-            throw new Error(
-              "Router Custom durable snapshot timestamp is invalid",
-            );
-          }
+        }
+        if (previous) {
+          const previousBlock = BigInt(previous.asOfBlock);
           const durableBlock = BigInt(durable.asOfBlock);
-          const currentBlock = BigInt(snapshot.asOfBlock);
-          if (durableBlock > currentBlock) {
-            return cacheSnapshot(durable);
-          }
           if (
-            durableBlock === currentBlock &&
-            (durable.asOfBlockHash.toLowerCase() !==
-                snapshot.asOfBlockHash.toLowerCase() ||
-              durable.identityCommitment !== snapshot.identityCommitment)
+            previousBlock === durableBlock &&
+            (previous.asOfBlockHash.toLowerCase() !==
+                durable.asOfBlockHash.toLowerCase() ||
+              previous.identityCommitment !== durable.identityCommitment)
           ) {
             throw new RouterCustomSnapshotConflictError(
-              "Router Custom snapshots conflict at one boundary",
+              "Router Custom cached and durable snapshots conflict",
             );
           }
-        } catch (error) {
-          if (error instanceof RouterCustomSnapshotConflictError) throw error;
-          console.warn("Router Custom durable snapshot comparison unavailable", {
-            name: error instanceof Error
-              ? error.name
-              : "RouterCustomSnapshotCompareError",
-          });
+          if (
+            durableBlock > previousBlock &&
+            routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+              previous,
+              durable,
+            )
+          ) previous = durable;
+        } else {
+          previous = durable;
+        }
+      } catch (error) {
+        if (error instanceof RouterCustomSnapshotConflictError) throw error;
+        console.warn("Router Custom durable snapshot comparison unavailable", {
+          name: error instanceof Error
+            ? error.name
+            : "RouterCustomSnapshotCompareError",
+        });
+      }
+      if (previous) {
+        const previousBlock = BigInt(previous.asOfBlock);
+        const currentBlock = BigInt(snapshot.asOfBlock);
+        if (previousBlock > currentBlock) {
+          return cacheSnapshot(previous);
+        }
+        if (
+          previousBlock === currentBlock &&
+          (previous.asOfBlockHash.toLowerCase() !==
+              snapshot.asOfBlockHash.toLowerCase() ||
+            previous.identityCommitment !== snapshot.identityCommitment)
+        ) {
+          throw new RouterCustomSnapshotConflictError(
+            "Router Custom snapshots conflict at one boundary",
+          );
+        }
+        if (
+          currentBlock > previousBlock &&
+          !routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+            previous,
+            snapshot,
+          )
+        ) {
+          return cacheSnapshot(previous);
         }
       }
       cacheSnapshot(snapshot);
@@ -596,10 +707,18 @@ async function withinDuration<T>(
 const readProductionRouterCustomIdentitySnapshotV1 =
   createRouterCustomIdentitySnapshotReaderV1();
 
+export async function readFinalizedRouterCustomIdentitySnapshotCoreV1(
+  options: RouterCustomReadOptionsV1 = {},
+) {
+  return await readProductionRouterCustomIdentitySnapshotV1(options);
+}
+
 export async function readFinalizedRouterCustomIdentitySnapshotV1(
   options: RouterCustomReadOptionsV1 = {},
 ) {
-  const snapshot = await readProductionRouterCustomIdentitySnapshotV1(options);
+  const snapshot = await readFinalizedRouterCustomIdentitySnapshotCoreV1(
+    options,
+  );
   // Fee policy evidence is deliberately derived after the durable identity
   // commitment. A fee-provider failure can therefore remove only the optional
   // evidence block; it can never hide a finalized Router identity.

--- a/lib/server/custom-launch/well-known-v1.ts
+++ b/lib/server/custom-launch/well-known-v1.ts
@@ -25,6 +25,8 @@ export function programmableWellKnownDocumentV1(
     manifestUrl: "https://developers.programmable.family/api/v2/manifest",
     launchesUrl: "https://developers.programmable.family/api/v2/launches",
     tokenListUrl: "https://developers.programmable.family/api/v2/token-list",
+    routerCustomIdentitySnapshotUrl:
+      "https://programmable.market/api/indexers/v1/router-custom-identities",
     openApiUrl:
       "https://developers.programmable.family/openapi/programmable-v2.yaml",
     schemasBaseUrl: "https://developers.programmable.family/schemas/v2/",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -188,7 +188,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     publicSnapshot: Object.freeze({
       path: "lib/alchemy/router-custom-public.server.ts",
       sha256:
-        "6f622b8eff5ef7e917d7c7a5d17fe98e2651414daf5f3aa4945fa4a85f4a2884",
+        "b5dbb13c98bc69e7b94d6e67844bd1c89478ad02a823eab1c900e6523a272613",
     }),
   }),
   independentCrons: Object.freeze([

--- a/tests/custom-launch-cli-public-surface.test.ts
+++ b/tests/custom-launch-cli-public-surface.test.ts
@@ -17,6 +17,9 @@ describe("public Custom Launch CLI surface", () => {
     const document = programmableWellKnownDocumentV1(
       PRELAUNCH_CUSTOM_REGISTRY_PUBLIC_MANIFEST_V1,
     );
+    expect(document.routerCustomIdentitySnapshotUrl).toBe(
+      "https://programmable.market/api/indexers/v1/router-custom-identities",
+    );
     expect(document.customLaunchApi).toMatchObject({
       status: "read-only",
       readStatus: "live",

--- a/tests/router-custom-identity-snapshot-route.test.ts
+++ b/tests/router-custom-identity-snapshot-route.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  readCore: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("../lib/alchemy/router-custom-public.server", () => ({
+  readFinalizedRouterCustomIdentitySnapshotCoreV1: mocks.readCore,
+  ROUTER_CUSTOM_SNAPSHOT_MAX_IDENTITIES: 10_000,
+  ROUTER_CUSTOM_SNAPSHOT_MAXIMUM_BYTES: 16 * 1_024 * 1_024,
+}));
+
+import { GET } from
+  "../app/api/indexers/v1/router-custom-identities/route";
+
+const snapshot = Object.freeze({
+  schemaVersion: "programmable.router-custom-identity-snapshot.v1",
+  source: "canonical-launch-stamp-router",
+  status: "current",
+  generatedAt: "2026-08-25T16:20:39.656Z",
+  asOfBlock: "25833303",
+  asOfBlockHash: `0x${"8a".repeat(32)}`,
+  finalityConfirmations: 12,
+  identityCommitment: `sha256:${"c2".repeat(32)}`,
+  entries: Object.freeze([
+    Object.freeze({
+      id: `0x${"6d".repeat(32)}`,
+      tokenAddress: "0x1111111111111111111111111111111111111111",
+    }),
+  ]),
+});
+
+describe("Router Custom identity snapshot route", () => {
+  beforeEach(() => {
+    mocks.readCore.mockReset();
+    mocks.readCore.mockResolvedValue(snapshot);
+  });
+
+  it("returns the unwrapped core snapshot with public cache metadata", async () => {
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=0, s-maxage=15, stale-while-revalidate=45",
+    );
+    expect(response.headers.get("x-programmable-status")).toBe("current");
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(await response.json()).toEqual(snapshot);
+    expect(mocks.readCore).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not add optional fee-policy enrichment to committed entries", async () => {
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.entries).toEqual(snapshot.entries);
+    expect(body.entries[0]).not.toHaveProperty("platformFeePolicy");
+    expect(body.entries[0]).not.toHaveProperty("feePolicyEvidence");
+  });
+
+  it("fails closed without exposing reader internals", async () => {
+    mocks.readCore.mockRejectedValueOnce(
+      new Error("secret provider detail must not escape"),
+    );
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("retry-after")).toBe("5");
+    expect(await response.json()).toEqual({
+      error: "Router Custom identities are temporarily unavailable",
+    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Router Custom public snapshot unavailable",
+      { name: "RouterCustomSnapshotReadError" },
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("rejects a serialized snapshot larger than the 16 MiB bound", async () => {
+    mocks.readCore.mockResolvedValueOnce({
+      ...snapshot,
+      entries: [{ ...snapshot.entries[0], padding: "x".repeat(16 * 1_024 * 1_024) }],
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("x-programmable-status")).toBeNull();
+    expect(response.headers.get("retry-after")).toBe("5");
+  });
+
+  it("rejects more than 10,000 identities", async () => {
+    mocks.readCore.mockResolvedValueOnce({
+      ...snapshot,
+      entries: Array.from({ length: 10_001 }, () => snapshot.entries[0]),
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("x-programmable-status")).toBeNull();
+  });
+});

--- a/tests/router-custom-public.test.ts
+++ b/tests/router-custom-public.test.ts
@@ -23,6 +23,7 @@ import {
   readFinalizedRouterCustomExploreEntriesV1,
   ROUTER_CUSTOM_SNAPSHOT_CACHE_TTL_MS,
   ROUTER_CUSTOM_SNAPSHOT_MAX_IDENTITIES,
+  routerCustomSnapshotPreservesFinalizedIdentitiesV1,
   routerCustomEntriesAtOrBeforeBlockV1,
   routerCustomExploreEntriesFromModelV1,
   routerCustomIdentitySnapshotFromSourceV1,
@@ -35,6 +36,7 @@ import { mapCreatorProfileResponse } from "../lib/profile/onchain-profile";
 import type {
   CustomProjectExploreEntry,
   ExploreEntry,
+  LauncherToken,
 } from "../lib/tokens";
 import {
   customGraphExploreEntry,
@@ -59,7 +61,7 @@ function model(tokens = [customGraphToken, stampedClassicToken]) {
 }
 
 function source(
-  tokens = [customGraphToken, stampedClassicToken],
+  tokens: readonly LauncherToken[] = [customGraphToken, stampedClassicToken],
   input: Readonly<{
     blockNumber?: string;
     blockHash?: `0x${string}`;
@@ -287,6 +289,120 @@ describe("finalized Router Custom public projection", () => {
     });
   });
 
+  it("accepts a newer boundary only when every finalized identity is unchanged", () => {
+    const durable = routerCustomIdentitySnapshotFromSourceV1(source());
+    const next = routerCustomIdentitySnapshotFromSourceV1(source(undefined, {
+      blockNumber: "25740100",
+      blockHash: `0x${"bd".repeat(32)}`,
+      generatedAt: "2026-08-25T06:01:00.000Z",
+    }));
+    const rewritten = {
+      ...next,
+      entries: [{
+        ...next.entries[0],
+        launchStampProvenance: {
+          ...next.entries[0]!.launchStampProvenance!,
+          routePayloadHash: `0x${"de".repeat(32)}` as `0x${string}`,
+        },
+      }],
+    };
+    const rehydrated = routerCustomIdentitySnapshotFromSourceV1(source([
+      {
+        ...customGraphToken,
+        launchStampProvenance: {
+          ...customGraphToken.launchStampProvenance!,
+          finalizedAtBlockNumber: "25740099",
+          finalizedAtBlockHash: `0x${"df".repeat(32)}` as `0x${string}`,
+        },
+      },
+      stampedClassicToken,
+    ], {
+      blockNumber: "25740100",
+      blockHash: `0x${"bd".repeat(32)}`,
+      generatedAt: "2026-08-25T06:01:00.000Z",
+    }));
+
+    expect(routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+      durable,
+      next,
+    )).toBe(true);
+    expect(routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+      durable,
+      { ...next, entries: [] },
+    )).toBe(false);
+    expect(routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+      durable,
+      rewritten,
+    )).toBe(false);
+    expect(routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+      durable,
+      rehydrated,
+    )).toBe(true);
+  });
+
+  it("serves the durable LKG instead of accepting a newer shrinking snapshot", async () => {
+    const durable = routerCustomIdentitySnapshotFromSourceV1(source());
+    const shrinking = source([], {
+      blockNumber: "25740100",
+      blockHash: `0x${"bd".repeat(32)}`,
+      generatedAt: "2026-08-25T06:01:00.000Z",
+    });
+    const persistDurableSnapshot = vi.fn().mockResolvedValue(undefined);
+    const reader = createRouterCustomIdentitySnapshotReaderV1({
+      now: () => Date.parse("2026-08-25T06:02:00.000Z"),
+      readCurrentSource: vi.fn().mockResolvedValue(shrinking),
+      readDurableSnapshot: vi.fn().mockResolvedValue(durable),
+      persistDurableSnapshot,
+    });
+
+    await expect(reader()).resolves.toMatchObject({
+      status: "last-known-good",
+      asOfBlock: "25740001",
+      entries: [customGraphExploreEntry],
+    });
+    expect(persistDurableSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("does not replace a warm finalized identity with a newer shrinking durable snapshot", async () => {
+    const startedAt = Date.parse("2026-08-25T06:01:00.000Z");
+    let now = startedAt;
+    const current = source();
+    const shrinkingDurable = routerCustomIdentitySnapshotFromSourceV1(source(
+      [],
+      {
+        blockNumber: "25740100",
+        blockHash: `0x${"bd".repeat(32)}`,
+        generatedAt: "2026-08-25T06:01:30.000Z",
+      },
+    ));
+    const advancedCurrent = source(undefined, {
+      blockNumber: "25740200",
+      blockHash: `0x${"be".repeat(32)}`,
+      generatedAt: "2026-08-25T06:02:00.000Z",
+    });
+    const reader = createRouterCustomIdentitySnapshotReaderV1({
+      now: () => now,
+      readCurrentSource: vi.fn()
+        .mockResolvedValueOnce(current)
+        .mockResolvedValueOnce(advancedCurrent),
+      readDurableSnapshot: vi.fn()
+        .mockRejectedValueOnce(new Error("missing"))
+        .mockResolvedValueOnce(shrinkingDurable),
+      persistDurableSnapshot: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await expect(reader()).resolves.toMatchObject({
+      status: "current",
+      entries: [customGraphExploreEntry],
+    });
+    now += ROUTER_CUSTOM_SNAPSHOT_CACHE_TTL_MS + 1;
+    await expect(reader()).resolves.toMatchObject({
+      status: "current",
+      asOfBlock: "25740200",
+      entries: [customGraphExploreEntry],
+    });
+  });
+
   it("fails closed on a warm-cache same-boundary conflict", async () => {
     const startedAt = Date.parse("2026-08-25T06:01:00.000Z");
     let now = startedAt;
@@ -314,7 +430,7 @@ describe("finalized Router Custom public projection", () => {
     );
   });
 
-  it("replaces a stale durable snapshot after an explicit Router reorg", async () => {
+  it("does not delete finalized durable identities after an explicit Router reorg", async () => {
     const durable = routerCustomIdentitySnapshotFromSourceV1(source());
     const rebuilt = {
       ...source([], {
@@ -334,13 +450,10 @@ describe("finalized Router Custom public projection", () => {
 
     await expect(reader()).resolves.toMatchObject({
       status: "last-known-good",
-      asOfBlock: "25718016",
-      entries: [],
+      asOfBlock: "25740001",
+      entries: [customGraphExploreEntry],
     });
-    expect(persistDurableSnapshot).toHaveBeenCalledWith(
-      expect.objectContaining({ asOfBlock: "25718016" }),
-      { replaceAfterReorg: true },
-    );
+    expect(persistDurableSnapshot).not.toHaveBeenCalled();
   });
 
   it("falls back durably when the cold current read never settles", async () => {


### PR DESCRIPTION
## Summary
- expose the chain-validated, un-enriched Router Custom identity snapshot at `/api/indexers/v1/router-custom-identities`
- preserve the exact snapshot commitment and durable current/LKG boundary for automated public consumers
- make every later boundary append-only for finalized identities: a reorg, provider, cache, or durable-store mismatch cannot delete or rewrite an accepted launch
- enforce 10,000-identity and 16 MiB response bounds with a safe retryable 503
- advertise the canonical snapshot URL in `/.well-known/programmable.json`

## Verification
- focused Router/API/cron Vitest: 34/34
- read-model operations source contract: 92/92
- focused ESLint
- `npm run typecheck`
- exact-history gitleaks: no leaks
- `git diff --check`

No deployment or activation is performed by this PR.
