### PR TITLE
Stabilize prediction profile cold loads

### DIFF
--- a/components/prediction-market-experience.module.css
+++ b/components/prediction-market-experience.module.css
@@ -980,6 +980,14 @@
   width: 100%;
 }
 
+.portfolioSection[data-visible-card-count="1"] {
+  min-height: 252px;
+}
+
+.portfolioSection[data-visible-card-count="2"] {
+  min-height: 424px;
+}
+
 .portfolioHeading {
   align-items: center;
   display: flex;
@@ -1685,6 +1693,10 @@
 }
 
 @media (max-width: 52rem) {
+  .portfolioSection[data-visible-card-count="2"] {
+    min-height: 748px;
+  }
+
   .portfolioLoadingCard {
     align-items: start;
     grid-template-columns: 52px minmax(0, 1fr);
@@ -1924,9 +1936,12 @@
     flex-direction: column;
   }
 
-  .portfolioEmpty,
-  .portfolioError {
+  .portfolioEmpty {
     grid-template-columns: 44px minmax(0, 1fr);
+  }
+
+  .portfolioError {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .portfolioEmptyAction,

--- a/components/prediction-market-portfolio.tsx
+++ b/components/prediction-market-portfolio.tsx
@@ -35,6 +35,10 @@ import {
   type PredictionPortfolioRequest,
 } from "@/lib/prediction-market-portfolio";
 import {
+  readPredictionPortfolioWithRetry,
+  type PredictionPortfolioLoadMode,
+} from "@/lib/prediction-portfolio-load-policy";
+import {
   formatPredictionMarketObservation,
   formatPredictionOutcome,
   formatPredictionUsdg,
@@ -581,7 +585,7 @@ export function PredictionMarketPortfolio({
   const activeRequestRef = useRef<PredictionPortfolioRequest | null>(null);
   const tabRefs = useRef(new Map<PredictionPortfolioTabV1, HTMLButtonElement>());
 
-  const loadPortfolio = useCallback(async (mode: "initial" | "refresh" | "retry") => {
+  const loadPortfolio = useCallback(async (mode: PredictionPortfolioLoadMode) => {
     if (!account || !release) return;
     const accountKey = account.toLowerCase();
     const request = createPredictionPortfolioRequest(
@@ -608,9 +612,20 @@ export function PredictionMarketPortfolio({
         : "loading",
     }));
     try {
-      const data = await readPredictionMarketPortfolio({
-        config: release,
-        request,
+      const data = await readPredictionPortfolioWithRetry({
+        isCurrent: () => isPredictionPortfolioRequestCurrent(
+          request,
+          activeRequestRef.current,
+        ),
+        mode,
+        read: () => readPredictionMarketPortfolio({
+          config: release,
+          request,
+          shouldContinue: () => isPredictionPortfolioRequestCurrent(
+            request,
+            activeRequestRef.current,
+          ),
+        }),
       });
       if (!isPredictionPortfolioRequestCurrent(data, activeRequestRef.current)) return;
       setState({
@@ -756,7 +771,9 @@ export function PredictionMarketPortfolio({
       data-visible-card-count={
         visibleItems.length > 0
           ? Math.min(visibleItems.length, 2)
-          : undefined
+          : model.phase === "loading" || model.phase === "error"
+            ? 2
+            : undefined
       }
     >
       <p className="sr-only" role="status" aria-live="polite" aria-atomic="true">

--- a/lib/prediction-market-portfolio.ts
+++ b/lib/prediction-market-portfolio.ts
@@ -23,6 +23,9 @@ import {
   type PredictionMarketSnapshot,
   type PredictionMarketView,
 } from "./prediction-market-trading";
+import {
+  readPredictionPortfolioHistoryLanes,
+} from "./prediction-portfolio-load-policy";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const ZERO_BYTES32 = `0x${"00".repeat(32)}`;
@@ -790,38 +793,36 @@ async function readPredictionRedeemedLogs({
 }) {
   const logs = [];
   for (const addressBatch of predictionPortfolioAddressBatches(addresses)) {
-    const [holderLogs, recipientLogs] = await Promise.all([
-      readPredictionPortfolioLogs({
-        clients,
-        fromBlock,
-        read: (client, range) =>
-          client.getLogs({
+    const holderLogs = await readPredictionPortfolioLogs({
+      clients,
+      fromBlock,
+      read: (client, range) =>
+        client.getLogs({
+          address: addressBatch,
+          args: { holder: account },
+          event: predictionRedeemedEvent,
+          fromBlock: range.fromBlock,
+          strict: true,
+          toBlock: range.toBlock,
+        }),
+      toBlock,
+    });
+    const recipientLogs = await readPredictionPortfolioLogs({
+      clients,
+      fromBlock,
+      read: (client, range) =>
+        client
+          .getLogs({
             address: addressBatch,
-            args: { holder: account },
+            args: { recipient: account },
             event: predictionRedeemedEvent,
             fromBlock: range.fromBlock,
             strict: true,
             toBlock: range.toBlock,
-          }),
-        toBlock,
-      }),
-      readPredictionPortfolioLogs({
-        clients,
-        fromBlock,
-        read: (client, range) =>
-          client
-            .getLogs({
-              address: addressBatch,
-              args: { recipient: account },
-              event: predictionRedeemedEvent,
-              fromBlock: range.fromBlock,
-              strict: true,
-              toBlock: range.toBlock,
-            })
-            .then(filterFundedPredictionRedemptionRecipients),
-        toBlock,
-      }),
-    ]);
+          })
+          .then(filterFundedPredictionRedemptionRecipients),
+      toBlock,
+    });
     logs.push(
       ...holderLogs,
       ...recipientLogs,
@@ -845,36 +846,34 @@ async function readPredictionSplitLogs({
 }) {
   const logs = [];
   for (const addressBatch of predictionPortfolioAddressBatches(addresses)) {
-    const [payerLogs, recipientLogs] = await Promise.all([
-      readPredictionPortfolioLogs({
-        clients,
-        fromBlock,
-        read: (client, range) =>
-          client.getLogs({
-            address: addressBatch,
-            args: { payer: account },
-            event: predictionSplitEvent,
-            fromBlock: range.fromBlock,
-            strict: true,
-            toBlock: range.toBlock,
-          }),
-        toBlock,
-      }),
-      readPredictionPortfolioLogs({
-        clients,
-        fromBlock,
-        read: (client, range) =>
-          client.getLogs({
-            address: addressBatch,
-            args: { recipient: account },
-            event: predictionSplitEvent,
-            fromBlock: range.fromBlock,
-            strict: true,
-            toBlock: range.toBlock,
-          }),
-        toBlock,
-      }),
-    ]);
+    const payerLogs = await readPredictionPortfolioLogs({
+      clients,
+      fromBlock,
+      read: (client, range) =>
+        client.getLogs({
+          address: addressBatch,
+          args: { payer: account },
+          event: predictionSplitEvent,
+          fromBlock: range.fromBlock,
+          strict: true,
+          toBlock: range.toBlock,
+        }),
+      toBlock,
+    });
+    const recipientLogs = await readPredictionPortfolioLogs({
+      clients,
+      fromBlock,
+      read: (client, range) =>
+        client.getLogs({
+          address: addressBatch,
+          args: { recipient: account },
+          event: predictionSplitEvent,
+          fromBlock: range.fromBlock,
+          strict: true,
+          toBlock: range.toBlock,
+        }),
+      toBlock,
+    });
     logs.push(
       ...payerLogs,
       ...recipientLogs,
@@ -898,36 +897,34 @@ async function readPredictionMergedLogs({
 }) {
   const logs = [];
   for (const addressBatch of predictionPortfolioAddressBatches(addresses)) {
-    const [holderLogs, recipientLogs] = await Promise.all([
-      readPredictionPortfolioLogs({
-        clients,
-        fromBlock,
-        read: (client, range) =>
-          client.getLogs({
-            address: addressBatch,
-            args: { holder: account },
-            event: predictionMergedEvent,
-            fromBlock: range.fromBlock,
-            strict: true,
-            toBlock: range.toBlock,
-          }),
-        toBlock,
-      }),
-      readPredictionPortfolioLogs({
-        clients,
-        fromBlock,
-        read: (client, range) =>
-          client.getLogs({
-            address: addressBatch,
-            args: { recipient: account },
-            event: predictionMergedEvent,
-            fromBlock: range.fromBlock,
-            strict: true,
-            toBlock: range.toBlock,
-          }),
-        toBlock,
-      }),
-    ]);
+    const holderLogs = await readPredictionPortfolioLogs({
+      clients,
+      fromBlock,
+      read: (client, range) =>
+        client.getLogs({
+          address: addressBatch,
+          args: { holder: account },
+          event: predictionMergedEvent,
+          fromBlock: range.fromBlock,
+          strict: true,
+          toBlock: range.toBlock,
+        }),
+      toBlock,
+    });
+    const recipientLogs = await readPredictionPortfolioLogs({
+      clients,
+      fromBlock,
+      read: (client, range) =>
+        client.getLogs({
+          address: addressBatch,
+          args: { recipient: account },
+          event: predictionMergedEvent,
+          fromBlock: range.fromBlock,
+          strict: true,
+          toBlock: range.toBlock,
+        }),
+      toBlock,
+    });
     logs.push(
       ...holderLogs,
       ...recipientLogs,
@@ -1086,10 +1083,12 @@ async function readPredictionMarketPortfolioAtRequest({
   clients,
   config,
   request,
+  shouldContinue,
 }: {
   clients: PredictionMarketClients;
   config: PredictionMarketReleaseConfig;
   request: PredictionPortfolioRequest;
+  shouldContinue: () => boolean;
 }): Promise<PredictionMarketPortfolio> {
   const snapshot = await readPredictionMarketSnapshot({ clients, config });
   const fromBlock = config.deploymentBlock;
@@ -1143,8 +1142,8 @@ async function readPredictionMarketPortfolioAtRequest({
     mergedLogs,
     redeemedLogs,
   ] =
-    await Promise.all([
-      readPredictionPortfolioLogs({
+    await readPredictionPortfolioHistoryLanes([
+      () => readPredictionPortfolioLogs({
         clients,
         fromBlock,
         read: (client, range) =>
@@ -1158,7 +1157,7 @@ async function readPredictionMarketPortfolioAtRequest({
           }),
         toBlock,
       }),
-      readPredictionPortfolioLogs({
+      () => readPredictionPortfolioLogs({
         clients,
         fromBlock,
         read: (client, range) =>
@@ -1172,7 +1171,7 @@ async function readPredictionMarketPortfolioAtRequest({
           }),
         toBlock,
       }),
-      readPredictionPortfolioLogs({
+      () => readPredictionPortfolioLogs({
         clients,
         fromBlock,
         read: (client, range) =>
@@ -1186,7 +1185,7 @@ async function readPredictionMarketPortfolioAtRequest({
           }),
         toBlock,
       }),
-      readOutcomeTransferLogs({
+      () => readOutcomeTransferLogs({
         account: request.account,
         addresses: outcomeTokenAddresses,
         allowedTokens,
@@ -1195,7 +1194,7 @@ async function readPredictionMarketPortfolioAtRequest({
         fromBlock,
         toBlock,
       }),
-      readOutcomeTransferLogs({
+      () => readOutcomeTransferLogs({
         account: request.account,
         addresses: outcomeTokenAddresses,
         allowedTokens,
@@ -1204,28 +1203,28 @@ async function readPredictionMarketPortfolioAtRequest({
         fromBlock,
         toBlock,
       }),
-      readPredictionSplitLogs({
+      () => readPredictionSplitLogs({
         account: request.account,
         addresses: vaultAddresses,
         clients,
         fromBlock,
         toBlock,
       }),
-      readPredictionMergedLogs({
+      () => readPredictionMergedLogs({
         account: request.account,
         addresses: vaultAddresses,
         clients,
         fromBlock,
         toBlock,
       }),
-      readPredictionRedeemedLogs({
+      () => readPredictionRedeemedLogs({
         account: request.account,
         addresses: vaultAddresses,
         clients,
         fromBlock,
         toBlock,
       }),
-    ]);
+    ], shouldContinue);
   const transferLogs = dedupePortfolioLogs([
     ...incomingTransfers,
     ...outgoingTransfers,
@@ -1557,10 +1556,12 @@ export async function readPredictionMarketPortfolio({
   clients = createPredictionMarketPublicClients(),
   config,
   request,
+  shouldContinue = () => true,
 }: {
   clients?: PredictionMarketClients;
   config: PredictionMarketReleaseConfig;
   request: PredictionPortfolioRequest;
+  shouldContinue?: () => boolean;
 }): Promise<PredictionMarketPortfolio> {
   const normalizedRequest = createPredictionPortfolioRequest(
     request.account,
@@ -1571,6 +1572,7 @@ export async function readPredictionMarketPortfolio({
       clients,
       config,
       request: normalizedRequest,
+      shouldContinue,
     });
   } catch (error) {
     if (error instanceof PredictionPortfolioReadError) throw error;

--- a/lib/prediction-portfolio-load-policy.ts
+++ b/lib/prediction-portfolio-load-policy.ts
@@ -1,0 +1,123 @@
+export type PredictionPortfolioLoadMode = "initial" | "refresh" | "retry";
+
+export const PREDICTION_PORTFOLIO_INITIAL_ATTEMPT_LIMIT = 2;
+export const PREDICTION_PORTFOLIO_INITIAL_RETRY_DELAY_MS = 600;
+export const PREDICTION_PORTFOLIO_HISTORY_LANE_CONCURRENCY = 2;
+
+type PredictionPortfolioReadLane<Result> = () => Promise<Result>;
+
+const pendingPredictionPortfolioHistoryLanePermits: Array<() => void> = [];
+let activePredictionPortfolioHistoryLanes = 0;
+
+type PredictionPortfolioReadLaneResults<
+  Lanes extends readonly PredictionPortfolioReadLane<unknown>[],
+> = {
+  [Index in keyof Lanes]: Lanes[Index] extends PredictionPortfolioReadLane<infer Result>
+    ? Result
+    : never;
+};
+
+type PredictionPortfolioLoadPolicyInput<Result> = Readonly<{
+  isCurrent: () => boolean;
+  mode: PredictionPortfolioLoadMode;
+  read: () => Promise<Result>;
+  wait?: (delayMs: number) => Promise<void>;
+}>;
+
+function waitForRetry(delayMs: number) {
+  return new Promise<void>((resolve) => {
+    globalThis.setTimeout(resolve, delayMs);
+  });
+}
+
+async function withPredictionPortfolioHistoryLanePermit<Result>(
+  read: () => Promise<Result>,
+) {
+  if (
+    activePredictionPortfolioHistoryLanes <
+    PREDICTION_PORTFOLIO_HISTORY_LANE_CONCURRENCY
+  ) {
+    activePredictionPortfolioHistoryLanes += 1;
+  } else {
+    await new Promise<void>((resolve) => {
+      pendingPredictionPortfolioHistoryLanePermits.push(resolve);
+    });
+  }
+
+  try {
+    return await read();
+  } finally {
+    const next = pendingPredictionPortfolioHistoryLanePermits.shift();
+    if (next) next();
+    else activePredictionPortfolioHistoryLanes -= 1;
+  }
+}
+
+export async function readPredictionPortfolioHistoryLanes<
+  const Lanes extends readonly PredictionPortfolioReadLane<unknown>[],
+>(
+  lanes: Lanes,
+  shouldContinue: () => boolean = () => true,
+): Promise<PredictionPortfolioReadLaneResults<Lanes>> {
+  const results: unknown[] = new Array(lanes.length);
+  let failed = false;
+  let failure: unknown;
+  let nextLaneIndex = 0;
+
+  const worker = async () => {
+    while (!failed && shouldContinue() && nextLaneIndex < lanes.length) {
+      const laneIndex = nextLaneIndex;
+      nextLaneIndex += 1;
+      try {
+        results[laneIndex] = await withPredictionPortfolioHistoryLanePermit(
+          async () => {
+            if (!shouldContinue()) {
+              throw new Error("Prediction portfolio request was superseded");
+            }
+            return lanes[laneIndex]();
+          },
+        );
+      } catch (error) {
+        if (!failed) failure = error;
+        failed = true;
+      }
+    }
+  };
+
+  const workerCount = Math.min(
+    PREDICTION_PORTFOLIO_HISTORY_LANE_CONCURRENCY,
+    lanes.length,
+  );
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  if (failed) throw failure;
+  if (!shouldContinue()) {
+    throw new Error("Prediction portfolio request was superseded");
+  }
+
+  return results as PredictionPortfolioReadLaneResults<Lanes>;
+}
+
+export async function readPredictionPortfolioWithRetry<Result>({
+  isCurrent,
+  mode,
+  read,
+  wait = waitForRetry,
+}: PredictionPortfolioLoadPolicyInput<Result>): Promise<Result> {
+  const attemptLimit = mode === "initial"
+    ? PREDICTION_PORTFOLIO_INITIAL_ATTEMPT_LIMIT
+    : 1;
+
+  for (let attempt = 1; attempt <= attemptLimit; attempt += 1) {
+    try {
+      return await read();
+    } catch (error) {
+      const canRetry = attempt < attemptLimit && isCurrent();
+      if (!canRetry) throw error;
+
+      await wait(PREDICTION_PORTFOLIO_INITIAL_RETRY_DELAY_MS);
+      if (!isCurrent()) throw error;
+    }
+  }
+
+  throw new Error("Prediction portfolio retry policy exhausted unexpectedly");
+}

--- a/tests/prediction-portfolio-load-policy.test.ts
+++ b/tests/prediction-portfolio-load-policy.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  PREDICTION_PORTFOLIO_HISTORY_LANE_CONCURRENCY,
+  PREDICTION_PORTFOLIO_INITIAL_RETRY_DELAY_MS,
+  readPredictionPortfolioHistoryLanes,
+  readPredictionPortfolioWithRetry,
+} from "../lib/prediction-portfolio-load-policy";
+
+describe("prediction portfolio load policy", () => {
+  it("caps concurrent history lanes while preserving result order", async () => {
+    let activeLanes = 0;
+    let maximumActiveLanes = 0;
+    const laneStarts: number[] = [];
+    const lanes = Array.from({ length: 8 }, (_, index) => async () => {
+      activeLanes += 1;
+      maximumActiveLanes = Math.max(maximumActiveLanes, activeLanes);
+      laneStarts.push(index);
+      await new Promise<void>((resolve) => {
+        globalThis.setTimeout(resolve, 5);
+      });
+      activeLanes -= 1;
+      return `lane-${index}`;
+    });
+
+    await expect(readPredictionPortfolioHistoryLanes(lanes)).resolves.toEqual(
+      Array.from({ length: 8 }, (_, index) => `lane-${index}`),
+    );
+
+    expect(laneStarts).toHaveLength(8);
+    expect(maximumActiveLanes).toBe(
+      PREDICTION_PORTFOLIO_HISTORY_LANE_CONCURRENCY,
+    );
+  });
+
+  it("keeps the global lane cap across overlapping wallet reads", async () => {
+    let activeLanes = 0;
+    let maximumActiveLanes = 0;
+    const lane = async () => {
+      activeLanes += 1;
+      maximumActiveLanes = Math.max(maximumActiveLanes, activeLanes);
+      await new Promise<void>((resolve) => {
+        globalThis.setTimeout(resolve, 5);
+      });
+      activeLanes -= 1;
+      return activeLanes;
+    };
+
+    await Promise.all([
+      readPredictionPortfolioHistoryLanes([lane, lane, lane, lane]),
+      readPredictionPortfolioHistoryLanes([lane, lane, lane, lane]),
+    ]);
+
+    expect(maximumActiveLanes).toBe(
+      PREDICTION_PORTFOLIO_HISTORY_LANE_CONCURRENCY,
+    );
+  });
+
+  it("does not schedule more lanes after a wallet read becomes stale", async () => {
+    let current = true;
+    let releaseActiveLanes: (() => void) | undefined;
+    const activeLanes = new Promise<void>((resolve) => {
+      releaseActiveLanes = resolve;
+    });
+    const neverScheduled = vi.fn().mockResolvedValue("unexpected");
+
+    const read = readPredictionPortfolioHistoryLanes([
+      async () => {
+        await activeLanes;
+        return "first";
+      },
+      async () => {
+        await activeLanes;
+        return "second";
+      },
+      neverScheduled,
+    ], () => current);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    current = false;
+    releaseActiveLanes?.();
+
+    await expect(read).rejects.toThrow("superseded");
+    expect(neverScheduled).not.toHaveBeenCalled();
+  });
+
+  it("drains the active sibling and stops scheduling before an attempt fails", async () => {
+    const laneError = new Error("lane failed");
+    let releaseSibling: (() => void) | undefined;
+    const sibling = new Promise<void>((resolve) => {
+      releaseSibling = resolve;
+    });
+    const neverScheduled = vi.fn().mockResolvedValue("unexpected");
+    let settled = false;
+
+    const read = readPredictionPortfolioHistoryLanes([
+      async () => {
+        throw laneError;
+      },
+      async () => {
+        await sibling;
+        return "sibling";
+      },
+      neverScheduled,
+    ]).finally(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(neverScheduled).not.toHaveBeenCalled();
+
+    releaseSibling?.();
+    await expect(read).rejects.toBe(laneError);
+    expect(neverScheduled).not.toHaveBeenCalled();
+  });
+
+  it("retries an initial read exactly once after the bounded delay", async () => {
+    const read = vi.fn()
+      .mockRejectedValueOnce(new Error("temporary provider failure"))
+      .mockResolvedValueOnce("loaded");
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await expect(readPredictionPortfolioWithRetry({
+      isCurrent: () => true,
+      mode: "initial",
+      read,
+      wait,
+    })).resolves.toBe("loaded");
+
+    expect(read).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledOnce();
+    expect(wait).toHaveBeenCalledWith(
+      PREDICTION_PORTFOLIO_INITIAL_RETRY_DELAY_MS,
+    );
+  });
+
+  it("surfaces the terminal initial failure after two attempts", async () => {
+    const terminalError = new Error("provider unavailable");
+    const read = vi.fn().mockRejectedValue(terminalError);
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await expect(readPredictionPortfolioWithRetry({
+      isCurrent: () => true,
+      mode: "initial",
+      read,
+      wait,
+    })).rejects.toBe(terminalError);
+
+    expect(read).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledOnce();
+  });
+
+  it.each(["refresh", "retry"] as const)(
+    "keeps a manual %s action to one read",
+    async (mode) => {
+      const manualError = new Error("manual request failed");
+      const read = vi.fn().mockRejectedValue(manualError);
+      const wait = vi.fn().mockResolvedValue(undefined);
+
+      await expect(readPredictionPortfolioWithRetry({
+        isCurrent: () => true,
+        mode,
+        read,
+        wait,
+      })).rejects.toBe(manualError);
+
+      expect(read).toHaveBeenCalledOnce();
+      expect(wait).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not retry after the active wallet request becomes stale", async () => {
+    const staleError = new Error("stale request");
+    const read = vi.fn().mockRejectedValue(staleError);
+    const wait = vi.fn().mockResolvedValue(undefined);
+    const isCurrent = vi.fn()
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false);
+
+    await expect(readPredictionPortfolioWithRetry({
+      isCurrent,
+      mode: "initial",
+      read,
+      wait,
+    })).rejects.toBe(staleError);
+
+    expect(read).toHaveBeenCalledOnce();
+    expect(wait).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/prediction-profile-regression.test.ts
+++ b/tests/prediction-profile-regression.test.ts
@@ -19,6 +19,10 @@ const portfolioSource = readFileSync(
   join(root, "components/prediction-market-portfolio.tsx"),
   "utf8",
 );
+const portfolioDataSource = readFileSync(
+  join(root, "lib/prediction-market-portfolio.ts"),
+  "utf8",
+);
 const detailSource = readFileSync(
   join(root, "components/prediction-market-detail.tsx"),
   "utf8",
@@ -288,6 +292,18 @@ describe("prediction profile regression contract", () => {
     ).toBeGreaterThan(0);
   });
 
+  it("runs the eight history lanes through the bounded concurrency policy", () => {
+    expect(portfolioDataSource).toContain(
+      "await readPredictionPortfolioHistoryLanes([",
+    );
+    expect(portfolioDataSource).not.toMatch(
+      /createdLogs,[\s\S]{0,300}redeemedLogs,[\s\S]{0,100}await Promise\.all/u,
+    );
+    expect(portfolioDataSource).not.toMatch(
+      /const \[(?:holderLogs|payerLogs), recipientLogs\] = await Promise\.all/u,
+    );
+  });
+
   it("exposes Positions, Created, and History as one accessible tab set", () => {
     for (const label of ["Positions", "Created", "History"]) {
       expect(portfolioSource).toMatch(new RegExp(`(?:["']${label}["']|>${label}<)`, "u"));
@@ -334,6 +350,15 @@ describe("prediction profile regression contract", () => {
     expect(portfolioSource).toContain(
       "? Math.min(visibleItems.length, 2)",
     );
+    expect(portfolioSource).toMatch(
+      /model\.phase === "loading" \|\| model\.phase === "error"[\s\S]{0,80}\? 2/u,
+    );
+    expect(portfolioStyles).toMatch(
+      /\.portfolioSection\[data-visible-card-count="2"\]\s*\{[^}]*min-height:\s*424px;/s,
+    );
+    expect(portfolioStyles).toMatch(
+      /@media\s*\(max-width:\s*52rem\)[\s\S]*?\.portfolioSection\[data-visible-card-count="2"\]\s*\{[^}]*min-height:\s*748px;/u,
+    );
     expect(portfolioStyles).toMatch(
       /\.portfolioLoadingCard\s*\{[^}]*min-height:\s*82px;/s,
     );
@@ -349,6 +374,19 @@ describe("prediction profile regression contract", () => {
     expect(portfolioStyles).toMatch(
       /@media \(max-width:\s*620px\)[\s\S]*?\.portfolioSection\[data-visible-card-count="2"\]\s*\{[^}]*min-height:\s*806px;/s,
     );
+  });
+
+  it("keeps the iconless mobile error state readable in one column", () => {
+    const narrowStyles = mediaBodiesAtOrBelow(portfolioStyles, 620);
+    const errorLayout = cssDeclarationsFor(narrowStyles, ".portfolioError");
+
+    expect(errorLayout).toMatch(
+      /grid-template-columns\s*:\s*minmax\(0,\s*1fr\)/u,
+    );
+    expect(errorLayout).not.toMatch(/44px/u);
+    expect(
+      cssDeclarationsFor(narrowStyles, ".portfolioError button"),
+    ).toMatch(/width\s*:\s*100%/u);
   });
 
   it("uses vivid yes and no colors with AA text contrast and non-color labels", () => {


### PR DESCRIPTION
## Summary

- bound prediction history discovery to two lanes globally, including overlapping wallet requests, so at most four dual-provider RPC posts run at once
- stop stale wallet pools before they schedule another lane and allow only one delayed automatic retry on the initial load; manual refresh and retry remain single-attempt
- keep loading and error geometry stable at desktop, tablet, and mobile sizes, and render the iconless mobile error state as one readable column

## Validation

- `vitest`: 65 focused prediction portfolio/profile tests passed
- affected-file ESLint passed
- `git diff --check` passed
- full `tsc --noEmit` was attempted; it remains blocked by existing base-only errors in `media-api.server.ts` plus missing registry/script/indexer/Supabase artifacts. No touched file appears in the TypeScript errors.

## Release boundary

Feature branch only. Not merged or deployed by this operator.