### PR TITLE
Publish finalized Router identities at the correct boundary

### DIFF
--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -160,7 +160,7 @@
     },
     "publicSnapshot": {
       "path": "lib/alchemy/router-custom-public.server.ts",
-      "sha256": "b5dbb13c98bc69e7b94d6e67844bd1c89478ad02a823eab1c900e6523a272613"
+      "sha256": "45b2f31c00f7ca7fa93ea72f2815b1d2a77d583a1df2ac16427f713e17f8f0f8"
     }
   },
   "workers": [

--- a/lib/alchemy/router-custom-public.server.ts
+++ b/lib/alchemy/router-custom-public.server.ts
@@ -197,8 +197,12 @@ function buildRouterCustomIdentitySnapshotV1(input: Readonly<{
   const entries = canonicalRouterEntriesV1(input.entries);
   const boundary = BigInt(input.asOfBlock);
   for (const entry of entries) {
-    if (BigInt(entry.launchStampProvenance!.finalizedAtBlockNumber) > boundary) {
-      throw new Error("Router Custom identity is newer than its snapshot");
+    // The Router cursor is the highest launch-event block for which a separate
+    // 64-confirmation observation has already been recorded in the provenance.
+    // `finalizedAtBlockNumber` is that later observation head, so comparing it
+    // to the scan cursor would impose the finality depth a second time.
+    if (BigInt(entry.launchStampProvenance!.blockNumber) > boundary) {
+      throw new Error("Router Custom identity launch is newer than its snapshot");
     }
   }
   const identityCore = {
@@ -739,7 +743,7 @@ export function routerCustomEntriesAtOrBeforeBlockV1(
   return Object.freeze(
     entries.filter((entry) => {
       requireRouterCustomEntryV1(entry);
-      return BigInt(entry.launchStampProvenance!.finalizedAtBlockNumber) <= boundary;
+      return BigInt(entry.launchStampProvenance!.blockNumber) <= boundary;
     }),
   );
 }
@@ -838,7 +842,7 @@ export function mergeRouterCustomCreatorProfileV1(
     const tokenAddress = entry.tokenAddress.toLowerCase();
     if (
       entry.creatorAddress?.toLowerCase() !== account.toLowerCase() ||
-      BigInt(stamp.finalizedAtBlockNumber) > snapshotBlock ||
+      BigInt(stamp.blockNumber) > snapshotBlock ||
       tokenAddresses.has(tokenAddress)
     ) {
       return false;

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -188,7 +188,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     publicSnapshot: Object.freeze({
       path: "lib/alchemy/router-custom-public.server.ts",
       sha256:
-        "b5dbb13c98bc69e7b94d6e67844bd1c89478ad02a823eab1c900e6523a272613",
+        "45b2f31c00f7ca7fa93ea72f2815b1d2a77d583a1df2ac16427f713e17f8f0f8",
     }),
   }),
   independentCrons: Object.freeze([
@@ -2262,7 +2262,7 @@ export function evaluateReadModelOperationsSourceContracts(
       "suppressRouterBoundCustomProjectDuplicates",
       "routerCustomEntriesAtOrBeforeBlockV1",
       "mergeRouterCustomCreatorProfileV1",
-      "BigInt(stamp.finalizedAtBlockNumber) > snapshotBlock",
+      "BigInt(stamp.blockNumber) > snapshotBlock",
       'entry.launchCategoryProvenance.source !== ROUTER_CUSTOM_LAUNCH_SOURCE',
     ]);
   check(

--- a/tests/router-custom-public.test.ts
+++ b/tests/router-custom-public.test.ts
@@ -41,6 +41,7 @@ import type {
 import {
   customGraphExploreEntry,
   customGraphToken,
+  launchStampProvenance,
   stampedClassicToken,
 } from "./launch-stamp-surface-fixture";
 
@@ -144,6 +145,24 @@ describe("finalized Router Custom public projection", () => {
       entries: [customGraphExploreEntry],
     });
     expect(snapshot.identityCommitment).toMatch(/^sha256:[0-9a-f]{64}$/u);
+  });
+
+  it("publishes an identity as soon as its launch enters the 64-confirmation cursor", () => {
+    const snapshot = routerCustomIdentitySnapshotFromSourceV1(source(
+      [customGraphToken],
+      {
+        blockNumber: launchStampProvenance.blockNumber,
+        blockHash: launchStampProvenance.blockHash,
+      },
+    ));
+
+    expect(BigInt(launchStampProvenance.finalizedAtBlockNumber)).toBe(
+      BigInt(launchStampProvenance.blockNumber) + 64n,
+    );
+    expect(snapshot).toMatchObject({
+      asOfBlock: launchStampProvenance.blockNumber,
+      entries: [customGraphExploreEntry],
+    });
   });
 
   it("preserves the Blob API strong ETag contract for conditional writes", () => {
@@ -505,14 +524,14 @@ describe("finalized Router Custom public projection", () => {
     })).toThrow("not ready");
   });
 
-  it("publishes only stamps finalized at or before the Envio snapshot", () => {
+  it("projects only Router launches at or before the consumer snapshot", () => {
     expect(routerCustomEntriesAtOrBeforeBlockV1(
       [customGraphExploreEntry],
-      "25718016",
+      "25717952",
     )).toEqual([]);
     expect(routerCustomEntriesAtOrBeforeBlockV1(
       [customGraphExploreEntry],
-      "25718017",
+      "25717953",
     )).toEqual([customGraphExploreEntry]);
   });
 
@@ -575,10 +594,15 @@ describe("finalized Router Custom public projection", () => {
       }),
     ]);
     expect(mergeRouterCustomCreatorProfileV1(
-      profile("25718016"),
+      profile("25717952"),
       customGraphExploreEntry.creatorAddress!,
       [customGraphExploreEntry],
     ).tokens).toEqual([]);
+    expect(mergeRouterCustomCreatorProfileV1(
+      profile("25717953"),
+      customGraphExploreEntry.creatorAddress!,
+      [customGraphExploreEntry],
+    ).tokens).toEqual([customGraphExploreEntry]);
   });
 
   it("reports the exact set of healthy public identity lanes", () => {


### PR DESCRIPTION
## Outcome

Publishes a Router-backed Custom identity as soon as its launch event enters the independently 64-confirmed Router scan cursor. The previous comparison charged finality twice by comparing the later observation head to the earlier event cursor.

## Safety

- Keeps the existing 64-confirmation provenance requirement unchanged.
- Bounds snapshot/list/profile membership by immutable launch event block.
- Updates the pinned read-model source contract hash.

## Checks

- Focused Router Custom and read-model operation tests: 117 passed.
- Scoped ESLint: passed.
- `git diff --check`: passed.