### PR TITLE
Document V2 source verification status

### DIFF
--- a/public/openapi/custom-launch-v2.json
+++ b/public/openapi/custom-launch-v2.json
@@ -564,6 +564,9 @@
       "CustomLaunchOnchainEvidenceV1": {
         "$ref": "./custom-launch-v1.json#/components/schemas/CustomLaunchOnchainEvidenceV1"
       },
+      "SourceVerificationStatusV1": {
+        "$ref": "./custom-launch-v1.json#/components/schemas/SourceVerificationStatusV1"
+      },
       "CustomLaunchApiErrorV2": {
         "type": "object",
         "required": [
@@ -1396,6 +1399,17 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/CustomLaunchFailureV2"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sourceVerification": {
+            "description": "Optional server-authored post-finality verification state returned by the single-resource GET. It is absent or null when no durable status exists; create and list responses do not populate it.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SourceVerificationStatusV1"
               },
               {
                 "type": "null"

--- a/tests/custom-launch-cli-public-surface.test.ts
+++ b/tests/custom-launch-cli-public-surface.test.ts
@@ -170,6 +170,49 @@ describe("public Custom Launch CLI surface", () => {
     });
     expect(v2.components.schemas.CustomLaunchResourceV2.properties.status.enum)
       .toContain("simulating");
+    const sourceVerification =
+      v2.components.schemas.CustomLaunchResourceV2.properties.sourceVerification;
+    expect(v2.components.schemas.CustomLaunchResourceV2.required)
+      .not.toContain("sourceVerification");
+    expect(sourceVerification).toEqual({
+      description:
+        "Optional server-authored post-finality verification state returned by the single-resource GET. It is absent or null when no durable status exists; create and list responses do not populate it.",
+      oneOf: [
+        { $ref: "#/components/schemas/SourceVerificationStatusV1" },
+        { type: "null" },
+      ],
+    });
+    expect(v2.components.schemas.SourceVerificationStatusV1).toEqual({
+      $ref:
+        "./custom-launch-v1.json#/components/schemas/SourceVerificationStatusV1",
+    });
+    expect(v1.components.schemas.SourceVerificationStatusV1).toMatchObject({
+      additionalProperties: false,
+      required: ["schemaVersion", "status", "components", "updatedAt"],
+      properties: {
+        schemaVersion: {
+          const: "programmable.source-verification-status.v1",
+        },
+        status: {
+          enum: ["queued", "retrying", "exact_match", "needs_attention"],
+        },
+      },
+    });
+    expect(v1.components.schemas.SourceVerificationComponentV1).toMatchObject({
+      additionalProperties: false,
+      required: ["targetId", "address", "status", "provider"],
+      properties: {
+        status: {
+          enum: ["queued", "retrying", "exact_match", "needs_attention"],
+        },
+        provider: {
+          enum: ["sourcify", "etherscan", "blockscout", null],
+        },
+      },
+    });
+    expect(
+      v1.components.schemas.SourceVerificationStatusV1.description,
+    ).toContain("clients must not infer or submit this object");
     expect(
       v2.components.schemas.CustomLaunchSummaryV2.allOf[1].properties.output,
     ).toEqual({ type: "null" });


### PR DESCRIPTION
## Summary
- add the optional server-authored sourceVerification field to the V2 detail contract
- reuse the closed V1 schema for durable states and provider names
- document that clients cannot submit or infer verification

## Validation
- companion worktree: 2 focused files / 13 tests
- JSON parse
- git diff --check

The backend companion is PR #113 in the internal service repository.