### PR TITLE
Bound stalled prediction refreshes

### DIFF
--- a/components/prediction-market-portfolio.tsx
+++ b/components/prediction-market-portfolio.tsx
@@ -35,6 +35,7 @@ import {
   type PredictionPortfolioRequest,
 } from "@/lib/prediction-market-portfolio";
 import {
+  PredictionPortfolioReadTimeoutError,
   readPredictionPortfolioWithRetry,
   type PredictionPortfolioLoadMode,
 } from "@/lib/prediction-portfolio-load-policy";
@@ -115,6 +116,8 @@ const INITIAL_INTERNAL_STATE: InternalPortfolioState = Object.freeze({
 const OUTCOME_FACE_SCALE = 10n;
 const PORTFOLIO_ERROR =
   "Unable to load your prediction activity. Check your connection and try again.";
+const PORTFOLIO_TIMEOUT_ERROR =
+  "Prediction activity took too long. Any existing results are unchanged; try again.";
 const PORTFOLIO_PARTIAL_ERROR =
   "Some markets could not be verified. Refresh to try them again.";
 const PORTFOLIO_INITIAL_VISIBLE_ITEMS = 12;
@@ -643,17 +646,22 @@ export function PredictionMarketPortfolio({
         ? error.request
         : request;
       if (!isPredictionPortfolioRequestCurrent(failedRequest, activeRequestRef.current)) return;
+      const errorMessage = error instanceof PredictionPortfolioReadTimeoutError
+        ? PORTFOLIO_TIMEOUT_ERROR
+        : PORTFOLIO_ERROR;
       setState((current) => current.accountKey === accountKey
         && current.phase === "ready"
         && current.data
-        ? { ...current, errorMessage: PORTFOLIO_ERROR }
+        ? { ...current, errorMessage }
         : {
             ...INITIAL_INTERNAL_STATE,
             accountKey,
-            errorMessage: PORTFOLIO_ERROR,
+            errorMessage,
             phase: "error",
           });
-      setAnnouncement("Prediction activity could not be loaded.");
+      setAnnouncement(error instanceof PredictionPortfolioReadTimeoutError
+        ? "Prediction activity refresh stopped after taking too long."
+        : "Prediction activity could not be loaded.");
     } finally {
       if (isPredictionPortfolioRequestCurrent(request, activeRequestRef.current)) {
         setRefreshing(false);

--- a/lib/prediction-portfolio-load-policy.ts
+++ b/lib/prediction-portfolio-load-policy.ts
@@ -3,6 +3,14 @@ export type PredictionPortfolioLoadMode = "initial" | "refresh" | "retry";
 export const PREDICTION_PORTFOLIO_INITIAL_ATTEMPT_LIMIT = 2;
 export const PREDICTION_PORTFOLIO_INITIAL_RETRY_DELAY_MS = 600;
 export const PREDICTION_PORTFOLIO_HISTORY_LANE_CONCURRENCY = 2;
+export const PREDICTION_PORTFOLIO_ATTEMPT_TIMEOUT_MS = 12_000;
+
+export class PredictionPortfolioReadTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Prediction portfolio read exceeded ${timeoutMs}ms`);
+    this.name = "PredictionPortfolioReadTimeoutError";
+  }
+}
 
 type PredictionPortfolioReadLane<Result> = () => Promise<Result>;
 
@@ -21,6 +29,7 @@ type PredictionPortfolioLoadPolicyInput<Result> = Readonly<{
   isCurrent: () => boolean;
   mode: PredictionPortfolioLoadMode;
   read: () => Promise<Result>;
+  timeoutMs?: number;
   wait?: (delayMs: number) => Promise<void>;
 }>;
 
@@ -28,6 +37,27 @@ function waitForRetry(delayMs: number) {
   return new Promise<void>((resolve) => {
     globalThis.setTimeout(resolve, delayMs);
   });
+}
+
+async function readWithinTimeout<Result>(
+  read: () => Promise<Result>,
+  timeoutMs: number,
+) {
+  let timeout: ReturnType<typeof globalThis.setTimeout> | undefined;
+  const timeoutResult = new Promise<never>((_resolve, reject) => {
+    timeout = globalThis.setTimeout(() => {
+      reject(new PredictionPortfolioReadTimeoutError(timeoutMs));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([
+      Promise.resolve().then(read),
+      timeoutResult,
+    ]);
+  } finally {
+    if (timeout !== undefined) globalThis.clearTimeout(timeout);
+  }
 }
 
 async function withPredictionPortfolioHistoryLanePermit<Result>(
@@ -101,6 +131,7 @@ export async function readPredictionPortfolioWithRetry<Result>({
   isCurrent,
   mode,
   read,
+  timeoutMs = PREDICTION_PORTFOLIO_ATTEMPT_TIMEOUT_MS,
   wait = waitForRetry,
 }: PredictionPortfolioLoadPolicyInput<Result>): Promise<Result> {
   const attemptLimit = mode === "initial"
@@ -109,7 +140,7 @@ export async function readPredictionPortfolioWithRetry<Result>({
 
   for (let attempt = 1; attempt <= attemptLimit; attempt += 1) {
     try {
-      return await read();
+      return await readWithinTimeout(read, timeoutMs);
     } catch (error) {
       const canRetry = attempt < attemptLimit && isCurrent();
       if (!canRetry) throw error;

--- a/tests/prediction-portfolio-load-policy.test.ts
+++ b/tests/prediction-portfolio-load-policy.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  PREDICTION_PORTFOLIO_ATTEMPT_TIMEOUT_MS,
   PREDICTION_PORTFOLIO_HISTORY_LANE_CONCURRENCY,
   PREDICTION_PORTFOLIO_INITIAL_RETRY_DELAY_MS,
+  PredictionPortfolioReadTimeoutError,
   readPredictionPortfolioHistoryLanes,
   readPredictionPortfolioWithRetry,
 } from "../lib/prediction-portfolio-load-policy";
@@ -171,6 +173,28 @@ describe("prediction portfolio load policy", () => {
       expect(wait).not.toHaveBeenCalled();
     },
   );
+
+  it("ends a stalled manual refresh within the bounded attempt timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const read = vi.fn(() => new Promise<string>(() => undefined));
+      const result = readPredictionPortfolioWithRetry({
+        isCurrent: () => true,
+        mode: "refresh",
+        read,
+      }).catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(
+        PREDICTION_PORTFOLIO_ATTEMPT_TIMEOUT_MS,
+      );
+
+      expect(await result).toBeInstanceOf(PredictionPortfolioReadTimeoutError);
+      expect(read).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   it("does not retry after the active wallet request becomes stale", async () => {
     const staleError = new Error("stale request");

--- a/tests/prediction-profile-regression.test.ts
+++ b/tests/prediction-profile-regression.test.ts
@@ -340,6 +340,10 @@ describe("prediction profile regression contract", () => {
     expect(portfolioStyles).toMatch(
       /@media \(prefers-reduced-motion: no-preference\) \{[\s\S]*\.portfolioRefresh\[aria-busy="true"\] \.portfolioRefreshIcon\s*\{[^}]*animation:\s*prediction-market-refresh-spin 800ms linear infinite;/u,
     );
+    expect(portfolioSource).toContain("PredictionPortfolioReadTimeoutError");
+    expect(portfolioSource).toContain(
+      "Prediction activity took too long. Any existing results are unchanged; try again.",
+    );
   });
 
   it("reserves the populated profile geometry while prediction activity loads", () => {


### PR DESCRIPTION
Ends stalled prediction portfolio reads after a bounded 12-second attempt, preserves existing cards, re-enables the refresh control, and exposes calm accessible status copy. Focused tests: 35 passed. Typecheck, focused ESLint, production build, and git diff check passed.