### PR TITLE
Ship public V2 Custom launch surface

### DIFF
--- a/app/docs/creators/launch/page.tsx
+++ b/app/docs/creators/launch/page.tsx
@@ -35,14 +35,14 @@ export default function CreatorLaunchDocsPage() {
       <section id="access">
         <h2>Start here</h2>
         <p>
-           Public V2 Custom launch creation is live on Ethereum Mainnet. Package
-           and validate locally, then use a scoped API key to submit and track
-           the bound wallet&apos;s request.
-         </p>
-         <p>
-           The retained V1 create endpoint is read-only and returns
-           <code>409 CUSTOM_LAUNCH_V1_READ_ONLY</code>.
-         </p>
+          Public V2 Custom launch creation is live on Ethereum Mainnet. Package
+          and validate locally, then use a scoped API key to submit and track
+          the bound wallet&apos;s request.
+        </p>
+        <p>
+          The retained V1 create endpoint is read-only and returns{" "}
+          <code>409 CUSTOM_LAUNCH_V1_READ_ONLY</code>.
+        </p>
         <div className={docsStyles.callout}>
           <strong>The API does not control your wallet.</strong>
           <p>

--- a/app/docs/creators/launch/page.tsx
+++ b/app/docs/creators/launch/page.tsx
@@ -8,7 +8,7 @@ import { DocsShell } from "@/components/docs-shell";
 export const metadata: Metadata = {
   title: "Launch a project · Programmable",
   description:
-    "Package a Custom launch bundle locally and understand the held public creation boundary.",
+    "Package, submit and track a deterministic Custom launch bundle.",
   alternates: { canonical: "/docs/creators/launch" },
 };
 
@@ -16,7 +16,7 @@ const sections = [
   { id: "access", label: "Start here" },
   { id: "prepare", label: "Prepare the project" },
   { id: "key", label: "Create an API key" },
-  { id: "submit", label: "Public write fence" },
+  { id: "submit", label: "Submit safely" },
   { id: "prepared", label: "Prepared launch" },
   { id: "launch", label: "Wallet confirmation" },
   { id: "after", label: "After launch" },
@@ -26,7 +26,7 @@ export default function CreatorLaunchDocsPage() {
   return (
     <DocsShell
       currentPath="/docs/creators/launch"
-      description="Package one deterministic bundle locally, then read existing V1 history while public launch creation is held."
+      description="Package one deterministic bundle locally, submit the exact V2 request and stop for separate wallet review."
       parentHref="/docs/creators"
       parentLabel="Creators"
       sections={sections}
@@ -35,16 +35,15 @@ export default function CreatorLaunchDocsPage() {
       <section id="access">
         <h2>Start here</h2>
         <p>
-          Public Custom launch creation is currently held. You can package and
-          validate locally, and use an existing scoped API key to read the
-          bound wallet&apos;s existing V1 launch history.
+          Public V2 Custom launch creation is live on Ethereum Mainnet. Package
+          and validate locally, then use a scoped API key to submit and track
+          the bound wallet&apos;s request.
         </p>
         <div className={docsStyles.callout}>
           <strong>The API does not control your wallet.</strong>
           <p>
-            An API key can read its wallet-owned V1 launch history. A legacy
-            create scope does not override the V1 write fence, and a key cannot
-            authorize, sign or broadcast a wallet transaction.
+            An API key can use its authorized API operations for the bound
+            wallet. It cannot authorize, sign or broadcast a wallet transaction.
           </p>
         </div>
       </section>
@@ -87,10 +86,10 @@ export default function CreatorLaunchDocsPage() {
       <section id="key">
         <h2>Manage an API key</h2>
         <p>
-          Connect the controller wallet to manage its scoped keys. Existing
-          keys can use <code>custom-launch:read</code>; a legacy{" "}
-          <code>custom-launch:create</code> scope does not reopen V1 creation.
-          Keep every secret out of source control and public chats.
+          Connect the controller wallet to manage its scoped keys. Use only the
+          authorized V2 operations for that bound wallet. API scopes never
+          grant wallet signing. Keep every secret out of source control and
+          public chats.
         </p>
         <p className={styles.inlineAction}>
           <Link href="/developers/api-keys">Manage Custom launch API keys</Link>
@@ -98,13 +97,11 @@ export default function CreatorLaunchDocsPage() {
       </section>
 
       <section id="submit">
-        <h2>Stop at the public write fence</h2>
+        <h2>Submit the exact V2 request</h2>
         <p>
-          Do not submit the bundle to V1. Authenticated{" "}
-          <code>POST /v1/custom-launches</code> returns non-retryable{" "}
-          <code>409 CUSTOM_LAUNCH_V1_READ_ONLY</code>. The fee-enforced V2
-          release candidate returns <code>503 CUSTOM_LAUNCH_V2_UNAVAILABLE</code>{" "}
-          with <code>Retry-After</code> until canary and public activation.
+          Use <code>POST /v2/custom-launches</code>. Preserve the exact request
+          bytes and idempotency key across timeout, <code>429</code> and{" "}
+          <code>503</code> retries, and honor <code>Retry-After</code>.
         </p>
         <p className={styles.inlineAction}>
           <Link href="/docs/developers/custom-launch">

--- a/app/docs/creators/launch/page.tsx
+++ b/app/docs/creators/launch/page.tsx
@@ -35,10 +35,14 @@ export default function CreatorLaunchDocsPage() {
       <section id="access">
         <h2>Start here</h2>
         <p>
-          Public V2 Custom launch creation is live on Ethereum Mainnet. Package
-          and validate locally, then use a scoped API key to submit and track
-          the bound wallet&apos;s request.
-        </p>
+           Public V2 Custom launch creation is live on Ethereum Mainnet. Package
+           and validate locally, then use a scoped API key to submit and track
+           the bound wallet&apos;s request.
+         </p>
+         <p>
+           The retained V1 create endpoint is read-only and returns
+           <code>409 CUSTOM_LAUNCH_V1_READ_ONLY</code>.
+         </p>
         <div className={docsStyles.callout}>
           <strong>The API does not control your wallet.</strong>
           <p>

--- a/app/docs/creators/page.tsx
+++ b/app/docs/creators/page.tsx
@@ -25,17 +25,16 @@ export default function CreatorsDocsPage() {
   return (
     <DocsShell
       currentPath="/docs/creators"
-      description="Package a Custom project locally, understand the held public launch path and review current creator programs."
+      description="Package, submit and track a Custom project, then review current creator programs."
       sections={sections}
       title="Create with Programmable"
     >
       <section id="paths">
         <h2>Choose a creator path</h2>
         <p>
-          Public Custom launch creation is currently held. V1 reads remain live
-          for existing requests, while the fee-enforced V2 release candidate
-          awaits canary and public activation. Reusable-template intake is also
-          closed.
+          Public V2 Custom launch creation and lifecycle reads are live on
+          Ethereum Mainnet. Wallet review and signing remain separate.
+          Reusable-template intake is closed.
         </p>
 
         <div className={styles.pathGrid}>
@@ -63,8 +62,7 @@ export default function CreatorsDocsPage() {
         <p>
           Build and test the project, then create a deterministic source and
           graph bundle with project-specific tooling. Package and validate it
-          locally. V1 POST is read-only, and V2 is not public until its canary
-          and activation evidence is published.
+          locally, then submit and track the byte-identical public V2 request.
         </p>
         <p>
           A prepared result contains the artifact but no wallet transaction.

--- a/app/docs/creators/templates/page.tsx
+++ b/app/docs/creators/templates/page.tsx
@@ -171,11 +171,11 @@ export default function CreatorTemplateDocsPage() {
         <h2>Current status</h2>
         <p>
           Public template submissions and fee share activation are not active.
-          Public Custom creation is also held. Package concrete projects locally
-          and follow the Custom Launch API guide for activation status.
+          Public V2 Custom launch creation is live for concrete projects. Package
+          the exact project locally and follow the Custom Launch API guide.
         </p>
         <p className={styles.inlineAction}>
-          <Link href="/docs/developers/custom-launch">Read API availability</Link>
+          <Link href="/docs/developers/custom-launch">Open the Custom Launch API guide</Link>
         </p>
       </section>
     </DocsShell>

--- a/app/docs/developers/custom-launch/page.tsx
+++ b/app/docs/developers/custom-launch/page.tsx
@@ -155,7 +155,7 @@ export default function CustomLaunchApiDocsPage() {
             <code>PROGRAMMABLE_API_KEY</code>.
           </li>
           <li>
-            Run <code>submit launch.json --config programmable-launch.config.json</code>.
+            Run <code>submit ./launch.json --config programmable-launch.config.json</code>.
             At <code>authorized</code>, stop for exact wallet review and signing,
             then run <code>status REQUEST_UUID --watch --until finalized</code>.
           </li>

--- a/app/docs/developers/custom-launch/page.tsx
+++ b/app/docs/developers/custom-launch/page.tsx
@@ -7,7 +7,7 @@ import { DocsShell } from "@/components/docs-shell";
 export const metadata: Metadata = {
   title: "Custom Launch API · Programmable",
   description:
-    "Package exact build artifacts locally and read existing wallet-bound V1 Custom launch history.",
+    "Package, submit and track deterministic wallet-bound Custom launches on Ethereum Mainnet.",
   alternates: { canonical: "/docs/developers/custom-launch" },
 };
 
@@ -15,10 +15,10 @@ const customLaunchSections = [
   { id: "quickstart", label: "Quickstart" },
   { id: "authentication", label: "Authentication" },
   { id: "request", label: "Request contract" },
-  { id: "fees", label: "RC2 fee policy" },
+  { id: "fees", label: "Rev3 fee policy" },
   { id: "verification", label: "Exact-source verification" },
   { id: "checks", label: "Attested checks" },
-  { id: "submit", label: "Write fence" },
+  { id: "submit", label: "Submit safely" },
   { id: "lifecycle", label: "Lifecycle" },
   { id: "discovery", label: "Explore, Profile and claims" },
   { id: "errors", label: "Errors" },
@@ -26,7 +26,7 @@ const customLaunchSections = [
 ] as const;
 
 const requestFields = [
-  ["schemaVersion", "programmable.custom-launch-create-request.v1"],
+  ["schemaVersion", "programmable.custom-launch-create-request.v2"],
   ["launchWallet", "The Ethereum wallet bound to the API key"],
   ["chainId", "String 1"],
   ["nonce", "A nonzero lowercase bytes32"],
@@ -36,7 +36,12 @@ const requestFields = [
     "One complete, non-empty, UTF-8 path-sorted SourceBundleManifestV2",
   ],
   ["graphBundle", "One executable CustomGraphBundleV1"],
-  ["agentAttestation", "One self-attestation for the exact graph subject"],
+  ["launchProfile", "The complete closed Rev3 production profile"],
+  ["launchProfileSelection", "The exact target-role and deployment bindings"],
+  ["launchProfileHash", "The CLI-derived canonical Rev3 profile digest"],
+  ["launchIntentHash", "The CLI-derived request intent digest"],
+  ["agentAttestation", "One self-attestation for the exact launch intent"],
+  ["verificationBundle", "Exact source, compiler and constructor bindings"],
 ] as const;
 
 const lifecycle = [
@@ -80,7 +85,7 @@ const errors = [
   ],
   [
     "409",
-    "CUSTOM_LAUNCH_V1_READ_ONLY is the permanent V1 POST result. Do not retry it.",
+    "Keep the original idempotency key and bytes. A conflicting binding must be fixed locally, not retried with changed bytes.",
   ],
   ["413", "Reduce the body to at most 8,388,608 bytes."],
   ["415", "Send Content-Type: application/json."],
@@ -94,7 +99,7 @@ const errors = [
   ],
   [
     "503",
-    "Honor Retry-After for reads. CUSTOM_LAUNCH_V2_UNAVAILABLE means the V2 release candidate remains held.",
+    "Honor Retry-After and retry only the byte-identical request. Service availability never grants wallet signing authority.",
   ],
 ] as const;
 
@@ -102,26 +107,30 @@ export default function CustomLaunchApiDocsPage() {
   return (
     <DocsShell
       currentPath="/docs/developers/custom-launch"
-      description="Package and validate exact launch artifacts locally, then read existing V1 launch history while public creation is held."
+      description="Package exact launch artifacts locally, submit byte-identical V2 requests, and stop for separate controller-wallet review and signing."
       kicker="Developer integration"
       parentHref="/docs/developers"
       parentLabel="Developers"
       sections={customLaunchSections}
       title="Custom Launch API"
     >
+      <p className={styles.bodyCopy}>
+        Public V2 is the creation contract. V1 history remains readable, while
+        V1 creation is permanently write fenced with the nonretryable error{" "}
+        <code>CUSTOM_LAUNCH_V1_READ_ONLY</code>.
+      </p>
+
       <section id="quickstart">
         <div className={styles.sectionIntro}>
           <h2>Quickstart</h2>
           <p>
-            V1 launch-history reads remain live, but V1 creation is read-only.
-            The fee-enforced V2 release candidate remains held until canary and
-            explicit public activation. Legacy Registry and GitHub submission
-            intake is closed. Its separate{" "}
+            Public V2 launch creation is live on Ethereum Mainnet. V1 history
+            reads remain available, while V1 creation stays read-only. Legacy
+            Registry and GitHub submission intake is closed. Use the{" "}
             <a href="/openapi/custom-launch-v2.json">
-              V2 machine contract
+              public V2 machine contract
             </a>{" "}
-            is for offline and private-canary integration, not public
-            authorization.
+            for the exact request, response and retry contract.
           </p>
         </div>
 
@@ -142,14 +151,13 @@ export default function CustomLaunchApiDocsPage() {
           </li>
           <li>
             Use <Link href="/developers/api-keys">API keys</Link> to manage the
-            wallet-bound key for existing history. Store it as{" "}
+            wallet-bound key. Store it as{" "}
             <code>PROGRAMMABLE_API_KEY</code>.
           </li>
           <li>
-            Run <code>status REQUEST_UUID --watch --until finalized</code> only
-            for an existing V1 request. Do not run <code>submit</code> against
-            V1; it receives non-retryable{" "}
-            <code>409 CUSTOM_LAUNCH_V1_READ_ONLY</code>.
+            Run <code>submit launch.json --config programmable-launch.config.json</code>.
+            At <code>authorized</code>, stop for exact wallet review and signing,
+            then run <code>status REQUEST_UUID --watch --until finalized</code>.
           </li>
         </ol>
 
@@ -163,7 +171,7 @@ export default function CustomLaunchApiDocsPage() {
         </aside>
 
         <p className={styles.inlineAction}>
-          <a href="/developers/custom-launch-api-v1.md">Open the raw V1 guide</a>
+          <a href="/developers/custom-launch-api-v1.md">Open the raw compatibility guide</a>
         </p>
       </section>
 
@@ -191,9 +199,8 @@ export default function CustomLaunchApiDocsPage() {
             API.
           </li>
           <li>
-            Existing V1 keys can use <code>custom-launch:read</code>. A legacy
-            <code>custom-launch:create</code> scope does not override the write
-            fence. A key can access only requests owned by its bound wallet.
+            A key can access only requests owned by its bound wallet. API
+            scopes grant API operations only; they never grant wallet signing.
           </li>
           <li>
             Store the secret outside source control and logs. Key lists never
@@ -210,13 +217,11 @@ export default function CustomLaunchApiDocsPage() {
 
       <section id="request">
         <div className={styles.sectionIntro}>
-          <h2>Understand the retained V1 request contract</h2>
+          <h2>Understand the public V2 request contract</h2>
           <p>
-            After successful authentication and scope checks,{" "}
-            <code>POST /v1/custom-launches</code> returns{" "}
-            <code>409 CUSTOM_LAUNCH_V1_READ_ONLY</code> before reading an
-            idempotency key or body. The schema below remains available for
-            compatibility with existing resources and local tooling.
+            <code>POST /v2/custom-launches</code> accepts only the closed,
+            byte-bound Rev3 request. V1 remains available for existing history;
+            its POST route stays read-only.
           </p>
         </div>
 
@@ -238,10 +243,10 @@ export default function CustomLaunchApiDocsPage() {
           target. The complete graph input is limited to 524,288 bytes;
           per-target init code is limited to 49,152 bytes and initializer
           calldata to 131,072 bytes. Use the{" "}
-          <a href="/openapi/custom-launch-v1.json">OpenAPI contract</a> for every
-          V1 nested field, enum and bound. The held V2 profile, exact runtime
-          materialization and simulation response are defined separately in the{" "}
-          <a href="/openapi/custom-launch-v2.json">V2 RC contract</a>.
+          <a href="/openapi/custom-launch-v2.json">V2 OpenAPI contract</a> for every
+          nested field, enum and bound. The retained{" "}
+          <a href="/openapi/custom-launch-v1.json">V1 contract</a> documents
+          compatibility reads and its read-only creation route.
         </p>
 
         <p className={styles.bodyCopy}>
@@ -254,12 +259,11 @@ export default function CustomLaunchApiDocsPage() {
 
       <section id="fees">
         <div className={styles.sectionIntro}>
-          <h2>Review the RC2 fee policy</h2>
+          <h2>Review the Rev3 fee policy</h2>
           <p>
-            This disclosure describes only the frozen RC2 profile. It does not
-            activate public V2 submission. The profile is for Ethereum Mainnet
-            only (<code>chainId: &quot;1&quot;</code>) and has{" "}
-            <code>productionLaunchAuthorized: false</code>.
+            The frozen Rev3 profile is public on Ethereum Mainnet only
+            (<code>chainId: &quot;1&quot;</code>) and has{" "}
+            <code>productionLaunchAuthorized: true</code>.
           </p>
         </div>
 
@@ -339,34 +343,38 @@ export default function CustomLaunchApiDocsPage() {
 
       <section id="submit">
         <div className={styles.sectionIntro}>
-          <h2>Stop at the public write fence</h2>
+          <h2>Submit byte-identical requests</h2>
           <p>
-            V1 POST is not an active public creation path. Its authenticated
-            result is <code>409 CUSTOM_LAUNCH_V1_READ_ONLY</code>.
+            Use <code>POST /v2/custom-launches</code>. The CLI persistently binds
+            the idempotency key to the exact request bytes before network access.
           </p>
         </div>
 
         <ul className={styles.checkList}>
           <li>
-            Do not retry, rotate a nonce or change request bytes to bypass the
-            fence.
+            On timeout, <code>429</code> or <code>503</code>, retry only the exact
+            persisted bytes and honor <code>Retry-After</code>.
           </li>
           <li>
-            V1 list and single-resource reads remain live. Honor{" "}
-            <code>Retry-After</code> on read <code>429</code> or <code>503</code>.
+            A byte-identical replay can return the existing resource. A reused
+            key bound to different bytes is a conflict.
           </li>
           <li>
-            The V2 release candidate is not public. Until canary and public
-            activation, unavailable V2 requests return{" "}
-            <code>503 CUSTOM_LAUNCH_V2_UNAVAILABLE</code> with{" "}
-            <code>Retry-After</code>.
+            Stop at <code>authorized</code>. The API and CLI never sign or
+            broadcast the returned transaction.
           </li>
         </ul>
 
         <p className={styles.bodyCopy}>
-          Service readiness does not activate a held write route. Wait for a
-          versioned public V2 contract and explicit activation notice before
-          treating launch creation as available.
+          Service readiness and API authorization do not replace controller
+          approval. The connected wallet must review the exact chain, sender,
+          Router, value and calldata before a separate signature.
+        </p>
+
+        <p className={styles.bodyCopy}>
+          New V2 requests share a durable global admission cap of 120 created
+          requests per hour and 500 per day. An exact idempotent replay is
+          checked first and consumes no additional capacity.
         </p>
       </section>
 
@@ -374,7 +382,7 @@ export default function CustomLaunchApiDocsPage() {
         <div className={styles.sectionIntro}>
           <h2>Track the resource, not an assumed transaction</h2>
           <p>
-            Read <code>GET /v1/custom-launches/{"{launchId}"}</code> with the same
+            Read <code>GET /v2/custom-launches/{"{launchId}"}</code> with the same
             Bearer key. The path value and resource <code>requestId</code> are
             the API request UUID; <code>onchainLaunchId</code> is the distinct
             Router <code>bytes32</code> identifier.
@@ -394,7 +402,7 @@ export default function CustomLaunchApiDocsPage() {
 
         <p className={styles.bodyCopy}>
           After wallet broadcast, poll the single-resource route to drive exact
-          reconciliation. <code>GET /v1/custom-launches</code> is a newest-first
+          reconciliation. <code>GET /v2/custom-launches</code> is a newest-first
           wallet-owned history view with bounded summaries; its{" "}
           <code>output</code> is always <code>null</code>. Use the single-resource
           route for the artifact, wallet transaction and durable failure.
@@ -502,7 +510,7 @@ export default function CustomLaunchApiDocsPage() {
           </li>
           <li>
             <a href="/openapi/custom-launch-v2.json">
-              Inspect the held V2 RC contract
+              Inspect the public V2 contract
             </a>
           </li>
           <li>

--- a/app/docs/developers/machine-readable/page.tsx
+++ b/app/docs/developers/machine-readable/page.tsx
@@ -50,8 +50,8 @@ export default function MachineReadableDocsPage() {
               Custom Launch API guide
             </Link>
             <span>
-              Canonical human guide for V1 reads, the public write fence,
-              lifecycle, errors, discovery and claims.
+              Canonical human guide for public V2 creation, lifecycle, wallet
+              handoff, errors, discovery and claims.
             </span>
           </li>
           <li>
@@ -78,8 +78,8 @@ export default function MachineReadableDocsPage() {
               <code>/openapi/custom-launch-v2.json</code>
             </a>
             <span>
-              Held 2.0.0-rc.2 machine contract for offline and private-canary
-              integration. It does not activate public V2 submission.
+              Public 2.0.0 machine contract for creation, idempotent retries,
+              lifecycle reads and separate wallet signing.
             </span>
           </li>
           <li>
@@ -251,20 +251,18 @@ export default function MachineReadableDocsPage() {
             no authentication.
           </li>
           <li>
-            <code>https://api.programmable.market/v1/custom-launches</code>{" "}
-            requires a wallet-bound <code>pm_live_</code> Bearer key for reads.
+            <code>https://api.programmable.market/v2/custom-launches</code>{" "}
+            requires a wallet-bound <code>pm_live_</code> Bearer key.
           </li>
           <li>
-            V1 list and single-resource reads remain live. Authenticated V1 POST
-            returns non-retryable <code>409 CUSTOM_LAUNCH_V1_READ_ONLY</code>.
-            V2 remains held and returns{" "}
-            <code>503 CUSTOM_LAUNCH_V2_UNAVAILABLE</code> with{" "}
-            <code>Retry-After</code> until activation.
+            Public V2 creation, list and single-resource reads are live. V1
+            history remains readable, while authenticated V1 POST returns
+            non-retryable <code>409 CUSTOM_LAUNCH_V1_READ_ONLY</code>.
           </li>
           <li>
             The platform validates manifest digest, graph, attestation shape,
-            evidence digests, optional exact-source build inputs and permit
-            bindings. It does not simulate the wallet transaction, audit the
+            evidence digests, exact-source build inputs, the Rev3 profile,
+            simulation and permit bindings. It does not audit the
             project or attest safety.
           </li>
           <li>
@@ -274,7 +272,7 @@ export default function MachineReadableDocsPage() {
             wallet authority.
           </li>
           <li>
-            <code>GET /v1/custom-launches</code> returns a wallet-owned,
+            <code>GET /v2/custom-launches</code> returns a wallet-owned,
             cursor-paginated snapshot. It makes a bounded best-effort
             reconciliation pass over pending rows and still returns durable
             history when RPC is unavailable.
@@ -302,7 +300,7 @@ export default function MachineReadableDocsPage() {
           </li>
           <li>
             Fee claims and automated buybacks are not active Custom Launch API
-            operations in V1.
+            operations for arbitrary hooks.
           </li>
           <li>Ethereum RPC authentication depends on your provider.</li>
           <li>

--- a/app/docs/developers/page.tsx
+++ b/app/docs/developers/page.tsx
@@ -53,7 +53,7 @@ export default function DeveloperDocsPage() {
   return (
     <DocsShell
       currentPath="/docs/developers"
-      description="Read existing wallet-bound V1 launch history, verify Router-stamped tokens and pools, or index new launches."
+      description="Create and track wallet-bound V2 launches, verify Router-stamped tokens and pools, or index new launches."
       kicker="Developer integration"
       sections={developerSections}
       title="Integrate Programmable launches"
@@ -62,9 +62,9 @@ export default function DeveloperDocsPage() {
         <div className={styles.sectionIntro}>
           <h2>Choose a path</h2>
           <p>
-            Start with the task your product needs. V1 launch history remains
-            an authenticated read path; public launch creation is held.
-            Verification and indexing are public read paths.
+            Start with the task your product needs. Public V2 launch creation
+            and lifecycle reads use a wallet-bound API key. Verification and
+            indexing remain public read paths.
           </p>
         </div>
 
@@ -77,8 +77,8 @@ export default function DeveloperDocsPage() {
             </h3>
             <p>
               Package and validate one deterministic graph locally, then use a
-              wallet-bound key to read existing V1 resources. V1 POST is
-              read-only and V2 is held until public activation.
+              wallet-bound key to submit and track the exact V2 request. Wallet
+              review and signing remain separate.
             </p>
             <Link
               className={styles.textLink}

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -111,9 +111,8 @@ export default function DocsIndexPage() {
           <div>
             <h3>Creators</h3>
             <p>
-              Build and package a concrete project locally. Public Custom
-              creation remains held until the V2 release is explicitly
-              activated.
+              Build and package a concrete project locally, then use the public
+              V2 API for a wallet-owned Custom launch on Ethereum Mainnet.
             </p>
           </div>
           <div>

--- a/components/create-guide.tsx
+++ b/components/create-guide.tsx
@@ -11,7 +11,7 @@ import { ArrowRight, Check, CircleHelp, Copy, X } from "lucide-react";
 
 import styles from "@/components/create-guide.module.css";
 
-const BUILD_PROMPT = `Build and test a Programmable Uniswap v4 hook for this behavior: [describe the behavior in plain words]. Follow https://programmable.market/docs/developers/custom-launch, https://programmable.market/openapi/custom-launch-v1.json for the live V1 reads/write fence, and https://programmable.market/openapi/custom-launch-v2.json for the held V2 release-candidate shapes. Derive the request and evidence digests from the exact artifacts, never expose an API key, and never invent check results. Stop after local pack and validate. Do not submit: V1 creation returns 409 CUSTOM_LAUNCH_V1_READ_ONLY and V2 is not public until explicit activation. Never sign or broadcast.`;
+const BUILD_PROMPT = `Build and test a Programmable Uniswap v4 hook for this behavior: [describe the behavior in plain words]. Follow https://programmable.market/docs/developers/custom-launch and the public V2 contract at https://programmable.market/openapi/custom-launch-v2.json. Derive the request and evidence digests from the exact artifacts, never expose an API key, and never invent check results. Run local pack and validate, then submit the byte-identical request with $PROGRAMMABLE_API_KEY. Stop at authorized so the connected controller can review and sign the exact transaction separately. Never sign or broadcast automatically.`;
 
 type CopyState = "idle" | "copied" | "failed";
 
@@ -186,13 +186,13 @@ export function CreateGuide() {
                 4
               </span>
               <div>
-                <h3>Package locally and check availability</h3>
+                <h3>Package, validate and submit</h3>
                 <p>
                   Package the request with project-specific tooling that follows
-                  the API schema, then validate it locally. Do not submit to V1:
-                  creation returns <code>409 CUSTOM_LAUNCH_V1_READ_ONLY</code>.
-                  V2 remains held until canary and explicit public activation.
-                  An API key never authorizes, signs or broadcasts.
+                  the public V2 API schema, validate it locally, then submit the
+                  byte-identical request. Stop at <code>authorized</code> for
+                  separate controller-wallet review and signing. An API key
+                  never authorizes, signs or broadcasts.
                 </p>
                 <div className={styles.links}>
                   <Link href="/developers/api-keys">

--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -295,19 +295,19 @@ export function LaunchModelPicker({
           className={`launch-model-card-heading ${launchExperience.modelHeading}`}
         >
           <strong id="launch-model-custom-title">Custom</strong>
-          <small data-status="held">Held</small>
+          <small data-status="live">Live API</small>
         </span>
         <span
           className={`launch-model-description ${launchExperience.modelDescription}`}
           id="launch-model-custom-description"
         >
-          Package and validate a deterministic bundle locally. Public Custom
-          creation remains held until the fee-enforced V2 release is activated.
+          Package, validate and submit a deterministic Custom launch through
+          the public V2 API. Your connected wallet reviews and signs separately.
         </span>
         <span
           className={`launch-model-action ${launchExperience.modelAction}`}
         >
-          Read API availability
+          Launch with the API
           <ArrowRight aria-hidden="true" size={16} />
         </span>
       </span>
@@ -401,8 +401,8 @@ export function LaunchModelPicker({
         <Link
           className={`launch-model-card ${launchExperience.modelCard} liquid-glass-surface`}
           data-launch-model-option="custom"
-          data-launch-model-available="false"
-          data-launch-model-entry="release-held"
+          data-launch-model-available="true"
+          data-launch-model-entry="public-api"
           data-launch-model-launchable="false"
           href="/docs/developers/custom-launch"
           aria-labelledby="launch-model-custom-title"

--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -8,7 +8,7 @@ coverY: 0
 
 Programmable is a launch platform for Uniswap v4 products. Classic turns a focused set of choices into a fixed supply token, a permanently locked ETH pool and creator rewards. Custom is the deterministic bundle model for products that need their own hook, application logic or execution graph. Prediction Markets is the separately versioned launch model for onchain outcome markets.
 
-Classic and Prediction Markets are available from Create. Public Custom creation is currently held: V1 history reads remain live, authenticated V1 POST returns `409 CUSTOM_LAUNCH_V1_READ_ONLY`, and V2 awaits canary and explicit public activation. In every active wallet flow, the wallet signs its own transaction on the required network.
+Classic and Prediction Markets are available from Create. Public V2 Custom launch creation and wallet-owned lifecycle reads are live on Ethereum Mainnet. V1 history reads remain live, while authenticated V1 POST returns the nonretryable `409 CUSTOM_LAUNCH_V1_READ_ONLY`. Legacy Registry and GitHub submission intake is closed. In every active wallet flow, the wallet reviews and signs its own transaction on the required network.
 
 {% hint style="info" %}
 These docs describe current public products and the evidence available for them. A successful check, prepared artifact, authorized transaction or visible token page is not a guarantee of safety, liquidity or future value.
@@ -20,7 +20,7 @@ These docs describe current public products and the evidence available for them.
 | ---------------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | Launch a standard token      | [Create Classic](https://programmable.market/launch)                                     | Configure the token, fees, reward recipients and Initial Buy before signing one Ethereum transaction                         |
 | Create a prediction market   | [Create Prediction Market](https://programmable.market/launch)                           | Choose an available market and review the current release requirements before signing                                        |
-| Build with a custom hook     | [Custom Launch API guide](developers/custom-launch.md)                                  | Build, package and validate the exact project locally; read the current write-fence and activation status before any submission |
+| Build with a custom hook     | [Custom Launch API guide](developers/custom-launch.md)                                  | Build, package, validate, submit and track the exact V2 request; stop for separate wallet review and signing                    |
 | Verify or integrate launches | [Developer reference](developers/README.md)                                              | Resolve current deployments from the manifest and reproduce provenance from Ethereum                                         |
 
 To inspect an existing token, begin with [Explore](https://programmable.market/explore) and use its contract address rather than only a name or ticker.

--- a/docs/public/creators/README.md
+++ b/docs/public/creators/README.md
@@ -18,7 +18,7 @@ Prediction Markets is available from [Create](https://programmable.market/launch
 
 Build and test the exact hook project. Use the versioned public `programmable-launch` CLI to derive the deterministic source manifest, graph bundle, address locators, evidence digests and exact-source verification metadata described by the [Custom Launch API schema](../developers/custom-launch.md).
 
-Pack and validate locally. Public Custom creation is currently held: authenticated V1 POST returns non-retryable `409 CUSTOM_LAUNCH_V1_READ_ONLY`, while V2 returns `503 CUSTOM_LAUNCH_V2_UNAVAILABLE` with `Retry-After` until canary and explicit public activation. A [wallet-bound API key](https://programmable.market/developers/api-keys) can still read its existing V1 history and must remain in an encrypted environment or secret store, never in chat or prompts.
+Pack and validate locally, then submit the byte identical V2 request with a [wallet-bound API key](https://programmable.market/developers/api-keys). Keep the key in an encrypted environment or secret store, never in chat or prompts. At `authorized`, stop for separate controller wallet review and signing.
 
 ## Reusable work
 

--- a/docs/public/creators/launch.md
+++ b/docs/public/creators/launch.md
@@ -1,10 +1,10 @@
 ---
-description: Package one deterministic Custom project locally and understand the held public launch path
+description: Package, submit and track one deterministic Custom project
 ---
 
 # Launch a project
 
-Public Custom launch creation is currently held. V1 list and single-resource reads remain live for existing requests, while authenticated V1 POST returns non-retryable `409 CUSTOM_LAUNCH_V1_READ_ONLY`. The fee-enforced V2 release candidate returns `503 CUSTOM_LAUNCH_V2_UNAVAILABLE` with `Retry-After` until canary and explicit public activation. Legacy Registry and GitHub submission intake is closed.
+Public V2 Custom launch creation and lifecycle reads are live on Ethereum Mainnet. V1 history remains readable, while authenticated V1 POST remains nonretryable `409 CUSTOM_LAUNCH_V1_READ_ONLY`. Legacy Registry and GitHub submission intake is closed.
 
 ## Prepare the source
 
@@ -16,11 +16,11 @@ The source descriptor, manifest digest, graph bundle and agent evidence must all
 
 Connect the controller wallet at [Custom Launch API keys](https://programmable.market/developers/api-keys) and create a scoped key. Store it only as `PROGRAMMABLE_API_KEY` in an encrypted environment or secret store. Put only `$PROGRAMMABLE_API_KEY` in source, chat, prompts and agent setup.
 
-Existing keys can use `custom-launch:read` for their wallet-owned V1 history. A legacy `custom-launch:create` scope does not override the write fence. The key is not a wallet key and cannot sign or broadcast a transaction.
+The key is bound to its controller wallet and API scopes. It is not a wallet key and cannot sign or broadcast a transaction.
 
-## Stop at the public write fence
+## Submit the V2 request
 
-Do not submit the bundle to V1. Authenticated `POST https://api.programmable.market/v1/custom-launches` returns `409 CUSTOM_LAUNCH_V1_READ_ONLY`; do not retry, rotate the nonce or change bytes to bypass it. V2 is not a public API contract until its canary and activation evidence are explicitly published. Follow the [Custom Launch API guide](../developers/custom-launch.md) for the current read and write-fence contract.
+Submit the bundle to `POST https://api.programmable.market/v2/custom-launches` with the CLI. Preserve the exact request bytes and idempotency key across timeout, `429` and `503` retries and honor `Retry-After`. Follow the [Custom Launch API guide](../developers/custom-launch.md) for the exact public contract.
 
 Existing durable resources record the platform's manifest, graph, attestation, exact-source and permit checks. Post-finality provider verification is independent from launch finality. Programmable does not reproduce project tests, audit the project or adopt the agent's claims as a safety conclusion.
 

--- a/docs/public/creators/launch.md
+++ b/docs/public/creators/launch.md
@@ -4,7 +4,7 @@ description: Package, submit and track one deterministic Custom project
 
 # Launch a project
 
-Public V2 Custom launch creation and lifecycle reads are live on Ethereum Mainnet. V1 history remains readable, while authenticated V1 POST remains nonretryable `409 CUSTOM_LAUNCH_V1_READ_ONLY`. Legacy Registry and GitHub submission intake is closed.
+Public V2 Custom launch creation and lifecycle reads are live on Ethereum Mainnet. V1 history remains readable at `https://api.programmable.market/v1/custom-launches`, while authenticated V1 POST remains nonretryable `409 CUSTOM_LAUNCH_V1_READ_ONLY`. Legacy Registry and GitHub submission intake is closed.
 
 ## Prepare the source
 

--- a/docs/public/developers/README.md
+++ b/docs/public/developers/README.md
@@ -4,11 +4,11 @@ description: Read only contracts and verification rules for detecting Programmab
 
 # Developer reference
 
-Programmable has two separate developer surfaces. The Developer API at `https://developers.programmable.family` is read only, requires no API key and never authorizes a transaction. At `https://api.programmable.market`, authenticated V1 list and single-resource reads remain live for existing wallet-owned requests. V1 launch creation is read-only and V2 remains held until canary and explicit public activation.
+Programmable has two separate developer surfaces. The Developer API at `https://developers.programmable.family` is read only, requires no API key and never authorizes a transaction. At `https://api.programmable.market`, authenticated public V2 creation and lifecycle reads are live for wallet-owned requests. V1 history remains readable and V1 creation remains read only.
 
 ## Package locally and read existing launches
 
-Start with the [Custom Launch API guide](custom-launch.md). Install the pinned public `programmable-launch` CLI to pack and validate locally, and manage a key at [Custom Launch API keys](https://programmable.market/developers/api-keys) to read existing V1 resources. Do not submit to V1: authenticated POST returns non-retryable `409 CUSTOM_LAUNCH_V1_READ_ONLY`. The [fee-enforced V2 release-candidate contract](https://programmable.market/openapi/custom-launch-v2.json) is published for offline/private-canary integration, but public V2 requests return `503 CUSTOM_LAUNCH_V2_UNAVAILABLE` with `Retry-After` until activation. Legacy Registry and GitHub submission intake is closed.
+Start with the [Custom Launch API guide](custom-launch.md). Install the pinned public `programmable-launch` CLI to pack, validate, submit and track V2 requests, and manage a key at [Custom Launch API keys](https://programmable.market/developers/api-keys). The [public V2 contract](https://programmable.market/openapi/custom-launch-v2.json) is normative. V1 POST remains nonretryable `409 CUSTOM_LAUNCH_V1_READ_ONLY`. Legacy Registry and GitHub submission intake is closed.
 
 The key can create and read launch preparations for its wallet principal. Keep it only as `PROGRAMMABLE_API_KEY` in an encrypted secret store. It cannot authorize, sign or broadcast. A `prepared` response contains an exact artifact but no wallet transaction. Only `authorized` contains the exact transaction for the controller wallet to review, sign and broadcast separately.
 

--- a/docs/public/developers/custom-launch.md
+++ b/docs/public/developers/custom-launch.md
@@ -60,7 +60,7 @@ programmable-launch pack \
   --output launch.json
 programmable-launch validate launch.json \
   --config programmable-launch.config.json
-programmable-launch submit launch.json \
+programmable-launch submit ./launch.json \
   --config programmable-launch.config.json
 programmable-launch status REQUEST_UUID --watch --until authorized
 ```

--- a/docs/public/developers/custom-launch.md
+++ b/docs/public/developers/custom-launch.md
@@ -52,7 +52,10 @@ Build the project from one pinned source revision and preserve:
 - project-specific check evidence;
 - exact constructor values, initializer values, salts and declared hook permissions.
 
-Create the closed `programmable.launch-pack-config.v1` file described in the installed package README, then run:
+Create the closed `programmable.launch-pack-config.v2` file described in the installed package README. Set
+`source.publicOrigin.url` to the public HTTPS source repository and `source.publicOrigin.revision` to the exact
+lowercase merged production commit used for the release (`PROGRAMMABLE_SOURCE_REVISION` in the packaged Rev3 sample),
+then run:
 
 ```bash
 programmable-launch pack \

--- a/docs/public/developers/custom-launch.md
+++ b/docs/public/developers/custom-launch.md
@@ -1,28 +1,25 @@
 ---
-description: Package locally and read existing wallet-bound V1 Custom launch history
+description: Package, submit and track deterministic wallet-bound Custom launches
 ---
 
 # Custom Launch API
 
-V1 list and single-resource reads remain live for existing wallet-bound launch requests on Ethereum Mainnet. V1
-creation is read-only: every authenticated `POST /v1/custom-launches` returns non-retryable
-`409 CUSTOM_LAUNCH_V1_READ_ONLY`. The fee-enforced V2 release candidate remains held until canary and explicit public
-activation; unavailable V2 requests return `503 CUSTOM_LAUNCH_V2_UNAVAILABLE` with `Retry-After`. There is currently no
-public Custom launch-creation route. Legacy Registry and GitHub submission intake is closed.
+Public V2 creation, list and single resource reads are live for wallet bound requests on Ethereum Mainnet. V1 history
+reads remain available, while authenticated `POST /v1/custom-launches` stays permanently read only with
+`409 CUSTOM_LAUNCH_V1_READ_ONLY`. Legacy Registry and GitHub submission intake is closed.
 
-An external agent can still package exact source and build artifacts and validate the local result. Existing request
-owners can read and poll their V1 resources. An API key never signs or broadcasts a controller-wallet transaction.
+An external agent can package exact source and build artifacts, submit a byte identical V2 request and track its
+resource. An API key never signs or broadcasts a controller wallet transaction.
 
-The live V1 reads and write fence are defined by the
-[standalone V1 OpenAPI document](https://programmable.market/openapi/custom-launch-v1.json). The separate
-[held V2 release-candidate contract](https://programmable.market/openapi/custom-launch-v2.json) publishes the exact
-future/private-canary request and lifecycle shapes without authorizing public submission. The raw
-[V1 agent guide](https://programmable.market/developers/custom-launch-api-v1.md) remains compatible.
+The [public V2 OpenAPI document](https://programmable.market/openapi/custom-launch-v2.json) is normative for creation
+and current resources. The [V1 OpenAPI document](https://programmable.market/openapi/custom-launch-v1.json) remains the
+compatibility contract. The [raw agent guide](https://programmable.market/developers/custom-launch-api-v1.md) is
+executable by a cold external agent.
 
-## RC2 fee policy (private canary)
+## Rev3 fee policy
 
-This disclosure describes only the frozen RC2 profile. It does not activate public V2 submission. The profile is for
-Ethereum Mainnet only (`chainId: "1"`) and has `productionLaunchAuthorized: false`.
+The frozen Rev3 profile is public on Ethereum Mainnet only (`chainId: "1"`) and has
+`productionLaunchAuthorized: true`.
 
 For each successful swap, the mandatory platform charge is 1,000 parts per 1,000,000 of the documented
 `gross-unspecified-pool-currency-amount` basis: `1,000 ppm = 0.10% = 10 bps`. It accrues in the profile's unspecified
@@ -40,14 +37,13 @@ Install the pinned public GitHub Release asset. Do not substitute an unverified 
 
 ```bash
 npm install --global \
-  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz
+  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz
 programmable-launch --version
 ```
 
-The release includes `examples/no-broadcast/README.md`, real Solidity sources, exact Standard JSON and matching solc
-artifacts. Its generated evidence is limited to `pre-submit`. The pack-native deterministic hook-permission salt grind
-remains usable locally. The public write fence means a new request cannot currently advance from that evidence to
-`authorized`.
+The release includes `examples/fee-enforced-v2-no-broadcast/README.md`, real Solidity sources, exact Standard JSON and
+matching solc artifacts. Its generated evidence is limited to `pre-submit`. The deterministic permission salt grind
+remains usable locally, and the example never submits, polls, signs or broadcasts.
 
 Build the project from one pinned source revision and preserve:
 
@@ -64,13 +60,13 @@ programmable-launch pack \
   --output launch.json
 programmable-launch validate launch.json \
   --config programmable-launch.config.json
-# Existing V1 resources only:
-programmable-launch status REQUEST_UUID --watch --until finalized
+programmable-launch submit launch.json \
+  --config programmable-launch.config.json
+programmable-launch status REQUEST_UUID --watch --until authorized
 ```
 
-Do not run `submit` against V1 during the write fence. It receives non-retryable
-`409 CUSTOM_LAUNCH_V1_READ_ONLY`. V2 is not a public CLI/API contract until canary and public activation are
-explicitly published.
+At `authorized`, stop so the connected controller can review and sign the exact wallet transaction separately. After
+the wallet broadcasts, poll the same V2 resource until `finalized`.
 
 Manage a wallet-bound key at [API keys](https://programmable.market/developers/api-keys). Store it in an encrypted
 secret or environment variable named `PROGRAMMABLE_API_KEY`. Put only the literal placeholder
@@ -117,16 +113,14 @@ runtime hash or metadata-stripped compiler template.
 `validate` recalculates the manifest, source, graph, evidence and verification commitments. With `--config`, it also
 requires `launch.json` to be byte-identical to a fresh pack of the same source and build inputs.
 
-## V1 write fence and retained request contract
+## Public V2 request contract
 
-After successful API-key authentication and scope checks, `POST /v1/custom-launches` returns
-`409 CUSTOM_LAUNCH_V1_READ_ONLY` before reading an idempotency key or request body. Do not retry it. The eight-field V1
-schema remains published for compatibility with existing resources and local tooling; it is not an active public
-creation contract:
+`POST /v2/custom-launches` accepts the closed Rev3 request. V1 POST remains read only for compatibility. The V2 fields
+are:
 
 | Field | Requirement |
 | --- | --- |
-| `schemaVersion` | `programmable.custom-launch-create-request.v1` |
+| `schemaVersion` | `programmable.custom-launch-create-request.v2` |
 | `launchWallet` | The Ethereum wallet bound to the API key |
 | `chainId` | String `1` |
 | `nonce` | A nonzero lowercase `bytes32` |
@@ -134,8 +128,13 @@ creation contract:
 | `sourceBundleManifest` | One complete, non-empty, UTF-8 path-sorted manifest |
 | `graphBundle` | One executable `CustomGraphBundleV1` |
 | `agentAttestation` | One self-attestation for the exact graph subject |
+| `launchProfile` | The complete closed Rev3 production profile |
+| `launchProfileSelection` | Exact target role and deployment bindings |
+| `launchProfileHash` | CLI derived canonical profile digest |
+| `launchIntentHash` | CLI derived exact request intent digest |
+| `verificationBundle` | Exact source, compiler, runtime and constructor bindings |
 
-`verificationBundle` is additive and optional so legacy V1 requests remain valid. When present, its compilation units
+`verificationBundle` is required in V2. Its compilation units
 are uniquely UTF-8 sorted by `compilationUnitId`; its components are uniquely UTF-8 sorted by `targetId` and exactly
 cover every graph target. The API validates the exact Standard JSON bytes and SHA-256, exact compiler build, source and
 contract identity, and resolved constructor arguments against the prepared init code. URL-only source inputs fail.
@@ -149,19 +148,22 @@ nested field, enum and bound.
 Programmable does not publish a universal check-ID catalog, fetch or assess that evidence, or adopt it as an audit,
 approval or safety claim.
 
-## Handle the write fence safely
+## Submit safely
 
-`submit` still proves that `launch.json` is byte-identical to a fresh pack and preserves its local secret and journal
-boundaries. It must stop on the current `409 CUSTOM_LAUNCH_V1_READ_ONLY`; do not loop or change the request to bypass
-the fence. Raw HTTP clients send `Authorization: Bearer $PROGRAMMABLE_API_KEY` only to
-`https://api.programmable.market`. Live V1 reads honor `Retry-After` on `429` or `503`.
+`submit` proves that `launch.json` is byte identical to a fresh pack and writes its mode `0600` journal before network
+access. Raw HTTP clients send `Authorization: Bearer $PROGRAMMABLE_API_KEY` only to
+`https://api.programmable.market`. Retry timeout, `429` and `503` responses only with the exact persisted bytes and
+idempotency key. Honor `Retry-After`.
+
+New V2 requests share a durable global admission cap of 120 created requests per hour and 500 per day. Exact
+idempotent replay is checked first and consumes no additional capacity.
 
 The response `requestHash` is the server's canonical idempotency digest. It is distinct from the CLI receipt's local
 SHA-256 of exact `launch.json` bytes.
 
 ## Lifecycle and wallet boundary
 
-Use `GET /v1/custom-launches/{launchId}` as the precise polling route. The legacy path name receives the API request
+Use `GET /v2/custom-launches/{launchId}` as the precise polling route. The path receives the API request
 UUID returned as both `launchId` and `requestId`; `onchainLaunchId` is a different Router `bytes32` value. The bounded
 history list can opportunistically reconcile pending rows, but returns `output: null`. It does not replace the
 single-resource route. The single-resource response is the resource-level source of the exact prepared output and
@@ -194,7 +196,7 @@ Router provenance is not approval, audit coverage, active liquidity, tradability
 ## Errors and support
 
 The service readiness endpoint is [api.programmable.market/readyz](https://api.programmable.market/readyz). Readiness
-does not activate a held write route. For support, send only the response `error.requestId`, HTTP status, UTC time and
+does not grant wallet signing authority. For support, send only the response `error.requestId`, HTTP status, UTC time and
 public error code. Never send the API key.
 
 | HTTP | Action |
@@ -203,12 +205,12 @@ public error code. Never send the API key.
 | `401` | Use an active key from the encrypted secret store. |
 | `403` | Use the required scope and exact bound wallet. |
 | `404` | Verify the request UUID and key without inferring another wallet's ownership. |
-| `409` | `CUSTOM_LAUNCH_V1_READ_ONLY` is the current permanent V1 POST result. Do not retry it. |
+| `409` | Preserve the original idempotency binding. Fix a byte conflict locally before sending a new request. |
 | `413` | Reduce the request to at most 8,388,608 bytes. |
 | `415` | Send `Content-Type: application/json`. |
 | `422` | Fix the reported source, graph, attestation, verification or permit binding. |
 | `429` | Honor `Retry-After`. |
-| `503` | Honor `Retry-After` for reads. `CUSTOM_LAUNCH_V2_UNAVAILABLE` means the V2 RC remains held. |
+| `503` | Honor `Retry-After` and retry only the byte identical journaled request. |
 
 ## Current boundary
 

--- a/docs/public/developers/machine-readable.md
+++ b/docs/public/developers/machine-readable.md
@@ -1,12 +1,12 @@
 ---
-description: Read-only Developer API reference and wallet-owned V1 Custom launch resources
+description: Developer API reference and public wallet-owned V2 Custom launch resources
 ---
 
 # API reference
 
-The Developer API version 2 at `https://developers.programmable.family` is read only, requires no API key and publishes stable discovery, manifest, launch and compatibility responses. At `https://api.programmable.market`, wallet-bound V1 list and single-resource reads remain live for existing requests. V1 POST is read-only and V2 remains held until canary and explicit public activation. Start with the [Custom Launch API guide](custom-launch.md), then use the [standalone V1 OpenAPI contract](https://programmable.market/openapi/custom-launch-v1.json) for the normative V1 read and write-fence contract. The separate [held V2 release-candidate contract](https://programmable.market/openapi/custom-launch-v2.json) describes future/private-canary request and lifecycle shapes without activating public submission. The existing [raw V1 guide](https://programmable.market/developers/custom-launch-api-v1.md) remains compatible for agents and scripts.
+The Developer API version 2 at `https://developers.programmable.family` is read only, requires no API key and publishes stable discovery, manifest, launch and compatibility responses. At `https://api.programmable.market`, wallet-bound V2 creation and lifecycle reads are public on Ethereum Mainnet. V1 history remains readable while V1 POST remains read only. Start with the [Custom Launch API guide](custom-launch.md), then use the [public V2 OpenAPI contract](https://programmable.market/openapi/custom-launch-v2.json) for the normative request, lifecycle and wallet handoff contract. The [V1 OpenAPI contract](https://programmable.market/openapi/custom-launch-v1.json) remains available for compatibility. The [raw agent guide](https://programmable.market/developers/custom-launch-api-v1.md) is executable by agents and scripts.
 
-The public-read OpenAPI below describes the Developer API. The standalone V1 Custom Launch API contract defines its authenticated reads and explicit `409 CUSTOM_LAUNCH_V1_READ_ONLY` write fence. The separate V2 release-candidate contract is machine-readable but held and does not grant public access.
+The public-read OpenAPI below describes the Developer API. The standalone V2 Custom Launch API contract defines authenticated public creation, reads and separate wallet handoff. The V1 contract retains its authenticated reads and explicit `409 CUSTOM_LAUNCH_V1_READ_ONLY` write fence.
 
 ## Service status
 

--- a/docs/public/models/custom.md
+++ b/docs/public/models/custom.md
@@ -12,7 +12,7 @@ A hook is a smart contract that a Uniswap v4 pool calls at defined points in a t
 
 ## Local packaging and API availability
 
-Build and test the exact project. The public `programmable-launch` CLI derives the deterministic source manifest, graph bundle, CREATE2 locators, evidence digests and exact-source verification bundle against the [Custom Launch API schema](../developers/custom-launch.md). Pack and validate locally. Do not submit to V1: authenticated POST returns non-retryable `409 CUSTOM_LAUNCH_V1_READ_ONLY`. V2 remains held until canary and explicit public activation.
+Build and test the exact project. The public `programmable-launch` CLI derives the deterministic source manifest, graph bundle, CREATE2 locators, evidence digests and exact-source verification bundle against the [Custom Launch API schema](../developers/custom-launch.md). Pack and validate locally, then submit the byte-identical public V2 request. Stop at `authorized` for separate controller-wallet review and signing.
 
 Existing durable resources record the API's declared bundle checks. `prepared` means the exact artifact exists while the signed permit and wallet transaction remain null. An already `authorized` resource supplies the permit-attached transaction for separate controller-wallet review. Exact-source provider status begins only after finality and never revises it. The API does not audit the project, sign the transaction or broadcast it, and the API key is not wallet authority.
 

--- a/docs/public/reference/official-links.md
+++ b/docs/public/reference/official-links.md
@@ -15,10 +15,11 @@ description: Official Programmable product, source, community and analytics link
 | Custom Launch API keys  | [programmable.market/developers/api-keys](https://programmable.market/developers/api-keys)                         |
 | Custom Launch API guide | [programmable.market/developers/custom-launch-api-v1.md](https://programmable.market/developers/custom-launch-api-v1.md) |
 | Custom Launch V1 OpenAPI | [live reads and write fence](https://programmable.market/openapi/custom-launch-v1.json)                    |
-| Custom Launch V2 RC OpenAPI | [held/private-canary contract](https://programmable.market/openapi/custom-launch-v2.json)               |
-| Custom V1 read API      | [api.programmable.market](https://api.programmable.market)                                                         |
+| Custom Launch V2 OpenAPI | [public creation and lifecycle contract](https://programmable.market/openapi/custom-launch-v2.json)               |
+| Custom Launch API      | [api.programmable.market](https://api.programmable.market)                                                         |
 | Custom API readiness    | [api.programmable.market/readyz](https://api.programmable.market/readyz)                                           |
-| Custom Launch CLI 1.0.1 | [versioned GitHub Release asset](https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz) |
+| Custom Launch CLI 2.0.0 | [public V2 GitHub Release asset](https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz) |
+| Custom Launch CLI 1.0.1 | [V1 compatibility asset](https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz) |
 | Launch policy           | [github.com/0xprogrammable/launch-policy](https://github.com/0xprogrammable/launch-policy)                         |
 | Read-only developer API | [developers.programmable.family](https://developers.programmable.family)                                           |
 | X                       | [x.com/0xProgrammable](https://x.com/0xProgrammable)                                                               |
@@ -26,4 +27,4 @@ description: Official Programmable product, source, community and analytics link
 | Dune                    | [Programmable analytics](https://dune.com/0xprogrammable6098/programmable-analytics)                               |
 | V4 token                | [Dexscreener](https://dexscreener.com/ethereum/0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0) |
 
-Use `api.programmable.market` for authenticated reads of existing wallet-owned V1 launch history. V1 creation is read-only, V2 remains held until canary and explicit public activation, and legacy Registry and GitHub submission intake is closed. Use the read-only developer service and current deployment manifest when verifying Ethereum source or deployment data. Use the Prediction Markets repository for its current networks, contracts and release evidence. Community posts and analytics are useful context but do not replace the contract address, canonical chain record or versioned release evidence.
+Use `api.programmable.market` for authenticated public V2 creation and wallet-owned lifecycle reads. V1 history remains readable, V1 creation remains read only, and legacy Registry and GitHub submission intake is closed. Use the read-only developer service and current deployment manifest when verifying Ethereum source or deployment data. Use the Prediction Markets repository for its current networks, contracts and release evidence. Community posts and analytics are useful context but do not replace the contract address, canonical chain record or versioned release evidence.

--- a/lib/custom-launch/agent-setup-v1.ts
+++ b/lib/custom-launch/agent-setup-v1.ts
@@ -1,11 +1,9 @@
 export const PROGRAMMABLE_AGENT_SETUP_LINKS_V1 = Object.freeze({
-  cli: "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz",
+  cli: "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz",
   guide: "https://programmable.market/docs/developers/custom-launch",
-  openApi: "https://programmable.market/openapi/custom-launch-v1.json",
-  openApiV2ReleaseCandidate:
-    "https://programmable.market/openapi/custom-launch-v2.json",
-  cliV2ReleaseCandidate:
-    "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0-rc.2/programmable-launch-2.0.0-rc.2.tgz",
+  openApi: "https://programmable.market/openapi/custom-launch-v2.json",
+  openApiV1Compatibility:
+    "https://programmable.market/openapi/custom-launch-v1.json",
 });
 
 export const PROGRAMMABLE_AGENT_SETUP_TEXT_V1 = Object.freeze([
@@ -17,8 +15,7 @@ export const PROGRAMMABLE_AGENT_SETUP_TEXT_V1 = Object.freeze([
   "CLI: programmable-launch --help",
   `Release asset: ${PROGRAMMABLE_AGENT_SETUP_LINKS_V1.cli}`,
   `Guide: ${PROGRAMMABLE_AGENT_SETUP_LINKS_V1.guide}`,
-  `Stable V1 OpenAPI: ${PROGRAMMABLE_AGENT_SETUP_LINKS_V1.openApi}`,
-  `Held V2 RC OpenAPI: ${PROGRAMMABLE_AGENT_SETUP_LINKS_V1.openApiV2ReleaseCandidate}`,
-  `Held V2 RC package: ${PROGRAMMABLE_AGENT_SETUP_LINKS_V1.cliV2ReleaseCandidate}`,
-  "V2 is held for private canary. Its contract and package support offline integration only and do not authorize public submit, wallet signing, or broadcast.",
+  `Public V2 OpenAPI: ${PROGRAMMABLE_AGENT_SETUP_LINKS_V1.openApi}`,
+  `V1 read compatibility: ${PROGRAMMABLE_AGENT_SETUP_LINKS_V1.openApiV1Compatibility}`,
+  "Use pack and validate locally, then submit the byte-identical V2 request. Stop at authorized so the connected controller reviews and signs the exact wallet transaction separately. The CLI never signs or broadcasts.",
 ].join("\n"));

--- a/lib/developer-docs-content.ts
+++ b/lib/developer-docs-content.ts
@@ -14,7 +14,7 @@ export const developerDocsMarkdownPath = "/docs/developers.md";
 const customLaunchApiOrigin = "https://api.programmable.market";
 const apiKeysUrl = "https://programmable.market/developers/api-keys";
 const customLaunchApiOpenApiUrl =
-  "https://programmable.market/openapi/custom-launch-v1.json";
+  "https://programmable.market/openapi/custom-launch-v2.json";
 const customLaunchApiV2OpenApiUrl =
   "https://programmable.market/openapi/custom-launch-v2.json";
 const customLaunchApiGuideUrl =
@@ -23,7 +23,7 @@ const customLaunchHumanGuideUrl =
   "https://programmable.market/docs/developers/custom-launch";
 const customLaunchReadyzUrl = "https://api.programmable.market/readyz";
 const customLaunchCliReleaseUrl =
-  "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz";
+  "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz";
 
 const manifest = PROGRAMMABLE_LAUNCH_STAMP_MANIFEST;
 const router = manifest.launchStampRouter;
@@ -46,12 +46,13 @@ export function buildDeveloperDocsMarkdown(): string {
   return [
     "# Programmable developer APIs",
     "",
-    "> Wallet-owned V1 Custom launch history plus read-only verification of Router-stamped Programmable provenance on Ethereum.",
+    "> Public wallet-owned V2 Custom launch creation plus verified Router-stamped Programmable provenance on Ethereum.",
     "",
     `Custom Launch API: ${customLaunchApiOrigin}`,
     `Manage API keys: ${apiKeysUrl}`,
     `Custom Launch API OpenAPI: ${customLaunchApiOpenApiUrl}`,
-    `Held V2 RC OpenAPI: ${customLaunchApiV2OpenApiUrl}`,
+    `Public V2 OpenAPI: ${customLaunchApiV2OpenApiUrl}`,
+    "V1 compatibility OpenAPI: https://programmable.market/openapi/custom-launch-v1.json",
     `Custom Launch API guide: ${customLaunchHumanGuideUrl}`,
     `Raw Custom Launch API guide: ${customLaunchApiGuideUrl}`,
     `Custom Launch API readiness: ${customLaunchReadyzUrl}`,
@@ -67,39 +68,44 @@ export function buildDeveloperDocsMarkdown(): string {
     "",
     "## Custom Launch API availability",
     "",
-    `V1 list and single-resource reads remain live for existing wallet-bound requests. V1 creation is read-only: authenticated \`POST /v1/custom-launches\` returns non-retryable \`409 CUSTOM_LAUNCH_V1_READ_ONLY\`. The fee-enforced V2 release candidate is held until canary and explicit public activation; unavailable V2 requests return \`503 CUSTOM_LAUNCH_V2_UNAVAILABLE\` with \`Retry-After\`. Its exact future/private-canary machine contract is ${customLaunchApiV2OpenApiUrl}; publication of that contract does not activate public submission. There is currently no public Custom launch-creation route. Legacy Registry and GitHub submission intake is closed.`,
-    `Custom launch preparation is the separate authenticated write path at ${customLaunchApiOrigin}/v1/custom-launches. That V1 method is write-fenced, and the V2 method remains unavailable outside the private canary until explicit public activation.`,
+    `Public V2 creation, list and single-resource reads are live for wallet-bound requests on Ethereum Mainnet at ${customLaunchApiOrigin}/v2/custom-launches. V1 history reads remain live and V1 creation stays read-only with non-retryable \`409 CUSTOM_LAUNCH_V1_READ_ONLY\`. Legacy Registry and GitHub submission intake is closed.`,
+    `The exact public request, lifecycle, idempotency and wallet-handoff contract is ${customLaunchApiV2OpenApiUrl}.`,
     "",
     `Install the pinned public CLI with \`npm install --global ${customLaunchCliReleaseUrl}\`. The package is \`@programmable/launch\` and the binary is \`programmable-launch\`.`,
     "",
-    "Run `pack` and `validate` locally. The pack command derives the sorted manifest, SourceDescriptor, graph, locators, CREATE2 predictions, canonical hashes and exact-source bundle from real source, Standard JSON, compiler artifacts and evidence files. It does not accept hand-written derived hashes. The release contains an executable `examples/no-broadcast/` that stops at `pre-submit` without a wallet signature or broadcast. `status REQUEST_UUID --watch --until finalized` remains available for existing V1 resources. Do not run `submit` against V1 during the write fence.",
+    "Run `pack` and `validate` locally, then `submit` the byte-identical V2 request. The pack command derives the sorted manifest, SourceDescriptor, graph, locators, CREATE2 predictions, canonical hashes and exact-source bundle from real source, Standard JSON, compiler artifacts and evidence files. At `authorized`, stop for separate controller-wallet review and signing. The CLI never signs or broadcasts.",
     "",
     `Connect a wallet and create a key at ${apiKeysUrl}. Store the one-time \`pm_live_\` secret only as the encrypted environment secret \`PROGRAMMABLE_API_KEY\` or in the OS secret store. Put only \`$PROGRAMMABLE_API_KEY\` in chat, prompts and agent setup.`,
     "",
-    "Existing V1 keys can use `custom-launch:read` for their wallet-owned history. A legacy `custom-launch:create` scope does not override the V1 write fence. `fees:claim` and `buybacks:manage` are reserved and disabled. Future endpoints and scopes are additive, and existing keys never inherit a newly enabled scope.",
+    "A wallet-bound key can use its authorized public V2 operations and read existing V1 history. API scopes never grant wallet signing. `fees:claim` and `buybacks:manage` are reserved and disabled.",
     "",
     "Keys expire after 90 days by default, may be issued for at most 366 days, and are limited to 10 active keys per wallet.",
     "",
     "An API key is not a wallet or private key. Existing durable resources record the platform's manifest, graph, attestation, exact-source and permit checks. `prepared` contains an exact artifact but no wallet transaction. `authorized` contains the permit-attached wallet transaction, which the controller wallet reviews, signs and broadcasts separately. Programmable does not audit the project or attest safety. The API key alone never grants wallet signing authority.",
     "",
-    "### V1 write fence",
+    "### Public V2 submission",
     "",
-    "After successful authentication and scope checks, `POST /v1/custom-launches` returns `409 CUSTOM_LAUNCH_V1_READ_ONLY` before reading an idempotency key or request body. This response is permanent and non-retryable. Do not change bytes, rotate a nonce or loop to bypass the fence. V2 remains held and returns `503 CUSTOM_LAUNCH_V2_UNAVAILABLE` with `Retry-After` until canary and public activation.",
+    "`POST /v2/custom-launches` binds the idempotency key to the exact request bytes. Retry timeout, `429` and `503` results only with those persisted bytes and honor `Retry-After`. V1 POST remains permanently read-only with `409 CUSTOM_LAUNCH_V1_READ_ONLY`.",
     "",
     "### Closed request body",
     "",
-    "The top-level object has no unknown fields, is limited to 8,388,608 bytes (8 MiB) and keeps all eight original V1 fields required:",
+    "The top-level V2 object has no unknown fields, is limited to 8,388,608 bytes (8 MiB) and requires all 13 fields:",
     "",
-    "- `schemaVersion`: exactly `programmable.custom-launch-create-request.v1`",
+    "- `schemaVersion`: exactly `programmable.custom-launch-create-request.v2`",
     "- `launchWallet`: the Ethereum address bound to the API key",
     "- `chainId`: the string `1`",
     "- `nonce`: one nonzero lowercase `bytes32`",
     "- `sourceDescriptor`: one `DeterministicSourceBundleV2` descriptor",
     "- `sourceBundleManifest`: one complete, non-empty `SourceBundleManifestV2`",
     "- `graphBundle`: one executable `CustomGraphBundleV1`",
-    "- `agentAttestation`: one `AgentLaunchAttestationV1` self-attestation with evidence digests",
+    "- `launchProfile`: the complete closed Rev3 production profile",
+    "- `launchProfileSelection`: exact five-target role and deployment bindings",
+    "- `launchProfileHash`: the canonical profile digest derived by the CLI",
+    "- `launchIntentHash`: the canonical request-intent digest derived by the CLI",
+    "- `agentAttestation`: one `AgentLaunchAttestationV2` self-attestation bound to `launchIntentHash`",
+    "- `verificationBundle`: required exact-source material using `programmable.exact-source-verification-bundle.v2`",
     "",
-    "- Optional additive `verificationBundle`: exact-source material using `programmable.exact-source-verification-bundle.v1`. Legacy V1 requests remain valid without it.",
+    "Legacy V1 requests remain readable and compatible without the V2-only profile, intent and verification fields, but V1 creation is permanently write fenced.",
     "",
     "`sourceDescriptor` requires exactly `schemaVersion: 2.0.0`, `kind: deterministic-source-bundle`, `controllerWallet`, `sourceLineageNonce`, `sourceBundleDigest`, `bundleContentSha256`, and `publicOriginCommitment`. `controllerWallet` must equal `launchWallet`. `graphBundle.sourceBundleSha256` must equal `sourceDescriptor.bundleContentSha256`.",
     "",
@@ -111,7 +117,7 @@ export function buildDeveloperDocsMarkdown(): string {
     "",
     `The pool contains exactly \`tokenTargetId\`, \`hookTargetId\`, \`fee\`, and \`tickSpacing\`. Target IDs must select the declared token and hook. The standalone Custom Launch API schema, including every bound, enum, and response, is published at ${customLaunchApiOpenApiUrl}.`,
     "",
-    "The agent attestation is a required request field and contains exactly `schemaVersion: programmable.agent-launch-attestation.v1`, `subjectGraphBundleHash`, `agentId`, canonical UTC `checkedAt`, and 1 to 64 unique checks. Each check contains `checkId` and a non-null `sha256:<64 lowercase hex>` evidence digest. V1 does not publish a universal check-ID catalog or project-independent pass/fail semantics. The submitting workflow chooses IDs for checks it actually ran and preserves the underlying evidence. This is the agent's self-attestation for the submitted graph subject, is excluded from platform permit authorization and is not a Programmable safety, audit, approval, compilation, or simulation claim.",
+    "The agent attestation is a required request field and contains exactly `schemaVersion: programmable.agent-launch-attestation.v2`, `subjectLaunchIntentHash`, `agentId`, canonical UTC `checkedAt`, and 1 to 64 checks with unique `checkId` values. Each check contains `checkId` and a non-null `sha256:<64 lowercase hex>` evidence digest. Programmable does not publish a universal check-ID catalog or project-independent pass/fail semantics. The submitting workflow chooses IDs for checks it actually ran and preserves the underlying evidence. This is the agent's self-attestation for the exact launch intent, is excluded from platform permit authorization and is not a Programmable safety, audit, approval, compilation, or simulation claim.",
     "",
     "`verificationBundle` contains 1 to 16 exact compilation units and components. Units are uniquely UTF-8 sorted by `compilationUnitId`; components are uniquely UTF-8 sorted by `targetId` and exactly cover the graph. Exact Standard JSON bytes use canonical base64, inline source content, an exact solc build and SHA-256. Decoded Standard JSON is limited to 5,242,880 bytes per unit and across all units. Components bind source path, contract name and resolved constructor arguments. URL-only sources fail. The public CLI derives this field and its domain-separated hash from the build artifacts.",
     "",
@@ -119,11 +125,11 @@ export function buildDeveloperDocsMarkdown(): string {
     "",
     "### List wallet launch requests",
     "",
-    `Read \`${customLaunchApiOrigin}/v1/custom-launches?limit=10\` with \`custom-launch:read\`. The newest-first collection contains only requests owned by the key's wallet principal. \`limit\` defaults to 10 and is capped at 25; pass an unchanged non-null \`nextCursor\` as \`cursor\` for the next page. The collection is durable. For \`authorized\` or \`submitted\` rows in the requested page, list reads perform bounded best-effort chain reconciliation; RPC failure never hides durable history. Use the single-resource route for the full prepared artifact and exact output.`,
+    `Read \`${customLaunchApiOrigin}/v2/custom-launches?limit=10\` with \`custom-launch:read\`. The newest-first collection contains only requests owned by the key's wallet principal. \`limit\` defaults to 10 and is capped at 25; pass an unchanged non-null \`nextCursor\` as \`cursor\` for the next page. The collection is durable. For pending rows in the requested page, list reads may perform bounded best-effort chain reconciliation; RPC failure never hides durable history. Use the V2 single-resource route for the full prepared artifact and exact output.`,
     "",
     "### Read launch state",
     "",
-    `Read \`${customLaunchApiOrigin}/v1/custom-launches/{launchId}\` with the same Bearer key. The state is one of \`received\`, \`validating\`, \`prepared\`, \`authorized\`, \`submitted\`, \`finalized\`, \`failed\`, or \`cancelled\`.`,
+    `Read \`${customLaunchApiOrigin}/v2/custom-launches/{launchId}\` with the same Bearer key. The state is one of \`received\`, \`validating\`, \`simulating\`, \`prepared\`, \`authorized\`, \`submitted\`, \`finalized\`, \`failed\`, or \`cancelled\`.`,
     "",
     "The path keeps the legacy name `launchId`, but its value is the API request UUID. Every resource returns that UUID as both `launchId` and the explicit `requestId`. The separate `onchainLaunchId` is a bytes32 Router identifier; it is null before preparation and when a terminal failure clears the durable output.",
     "",
@@ -133,7 +139,7 @@ export function buildDeveloperDocsMarkdown(): string {
     "",
     "After a bundled request is finalized, provider verification runs independently for every exclusive component. Optional `sourceVerification` is server-authored and uses `queued`, `retrying`, `exact_match` or `needs_attention`. Only literal `exact_match` for every component means Source verified. Clients never submit or infer this state. Explorer failure never blocks or revises launch finality.",
     "",
-    "The current website claim flow supports only explicitly verified fee models. A Router-stamped arbitrary Custom hook is not automatically claimable. FADE has a specifically bound adapter, not a generic hook capability. The `fees:claim` and `buybacks:manage` API operations are not active in V1.",
+    "The current website claim flow supports only explicitly verified fee models. A Router-stamped arbitrary Custom hook is not automatically claimable. FADE has a specifically bound adapter, not a generic hook capability. The reserved `fees:claim` and `buybacks:manage` API operations are not live.",
     "",
     "### Provenance boundary",
     "",
@@ -279,7 +285,7 @@ export function buildDeveloperDocsMarkdown(): string {
     "",
     "It does not establish safety, tradability, current liquidity or pool state, audit coverage, review status, approval, endorsement, permission to launch, or terminal support. It does not automatically list or label a launch in GMGN, Axiom, FOMO, or any other terminal; each consumer must implement the published verification procedure.",
     "",
-    `Router verification and the Developer API are read-only. V1 Custom launch history remains readable with a wallet-bound key from ${apiKeysUrl}; V1 creation is write-fenced and V2 remains held. The provenance reference alone grants neither access nor launch authorization.`,
+    `Router verification and the Developer API are read-only. Public V2 creation and lifecycle reads use a wallet-bound key from ${apiKeysUrl}; V1 history remains readable and V1 creation remains write-fenced. The provenance reference alone grants neither access nor wallet authorization.`,
   ].join("\n");
 }
 
@@ -339,7 +345,7 @@ export function buildProgrammableLlmsIndex(): string {
   return [
     "# Programmable",
     "",
-    "> Agent guide for existing V1 Custom launch history and verified Programmable launch discovery.",
+    "> Agent guide for public V2 Custom launch creation and verified Programmable launch discovery.",
     "",
     "## When to use Programmable",
     "",
@@ -348,8 +354,8 @@ export function buildProgrammableLlmsIndex(): string {
     "- Look up one displayed token by Ethereum address without depending on optional market enrichment for identity.",
     "- Understand the public scope, creator information, launch provenance, and available market context before directing a user to the website.",
     "- Integrate a read-only terminal, wallet, scanner, catalog, or research tool with the documented public endpoints.",
-    "- Package and validate a prospective Custom launch locally with the pinned public CLI; public launch creation is currently held.",
-    "- Read existing wallet-owned V1 Custom launch history. V1 POST is read-only, V2 is held, and legacy Registry and GitHub submission intake is closed.",
+    "- Package, validate, submit and track a Custom launch with the pinned public CLI.",
+    "- Use public wallet-owned V2 creation and lifecycle reads. V1 history remains readable, V1 POST remains read-only, and legacy Registry and GitHub submission intake is closed.",
     "- Direct a human to trade, manage a project, claim rewards, or sign an authorized Custom launch transaction through the website. A prepared Custom launch has no wallet transaction. Every wallet action requires explicit wallet authority.",
     "",
     "## Do not use Programmable to infer",
@@ -373,14 +379,14 @@ export function buildProgrammableLlmsIndex(): string {
     "",
     "- OpenAPI: https://programmable.market/openapi.json",
     `- Custom Launch OpenAPI: ${customLaunchApiOpenApiUrl}`,
-    `- Held V2 RC OpenAPI: ${customLaunchApiV2OpenApiUrl}`,
+    `- Public V2 OpenAPI: ${customLaunchApiV2OpenApiUrl}`,
     `- Create or revoke API keys: ${apiKeysUrl}`,
     `- Custom Launch API guide: ${customLaunchHumanGuideUrl}`,
     `- Custom Launch API readiness: ${customLaunchReadyzUrl}`,
-    `- Programmable Launch CLI 1.0.1: ${customLaunchCliReleaseUrl}`,
+    `- Programmable Launch CLI 2.0.0: ${customLaunchCliReleaseUrl}`,
     `- V1 write fence: POST ${customLaunchApiOrigin}/v1/custom-launches returns 409 CUSTOM_LAUNCH_V1_READ_ONLY`,
-    `- List wallet-owned Custom launches: GET ${customLaunchApiOrigin}/v1/custom-launches`,
-    `- Read a Custom launch: GET ${customLaunchApiOrigin}/v1/custom-launches/{launchId}`,
+    `- Create or list wallet-owned Custom launches: POST or GET ${customLaunchApiOrigin}/v2/custom-launches`,
+    `- Read a Custom launch: GET ${customLaunchApiOrigin}/v2/custom-launches/{launchId}`,
     "- API index: https://programmable.market/api",
     "- Explore catalog: https://programmable.market/api/explore",
     "- Prediction Markets: https://programmable.market/markets",
@@ -422,10 +428,10 @@ export function buildProgrammableLlmsIndex(): string {
     "- A successful canonical zero lookup is not stamped. RPC failure or inconsistent evidence is not a negative result.",
     "- After manifest and ABI bootstrap, point verification needs an Ethereum provider only. Indexing, Supabase, a Programmable launch-feed API, and an application server are not trust dependencies.",
     "- Event backfill and checkpoint-based subscription are optional for continuous discovery; logs are candidates until getter verification succeeds.",
-    "- Protocol fee claim discovery is a separate index: complete Classic Launcher and Custom Registry scans plus the fixed Stock release set. Unknown or unverified sources fail closed, and Custom V2 stays unavailable until its exact deployed release is finalized.",
+    "- Protocol fee claim discovery is a separate index: complete Classic Launcher and Custom Registry scans plus the fixed Stock release set. Unknown or unverified sources fail closed. Generic fee claiming for arbitrary Custom hooks is not live.",
     "- The live claim boundary is published at https://claimhazard.vercel.app/claim-discovery.json and requires one wallet-declared atomic batch from the fixed reward wallet.",
     "- A Router record establishes provenance only after the required address, runtime, binding, lookup, and cross-check verification passes. It does not establish safety, tradability, current liquidity, audit coverage, endorsement, terminal support, or launch authorization.",
-    `- Existing V1 history is a separate authenticated read path from this provenance reference. V1 creation is write-fenced and V2 remains held until canary and explicit public activation; the provenance reference grants neither access nor launch authorization.`,
+    `- Public V2 creation and lifecycle reads are a separate authenticated path from this provenance reference. V1 history remains readable and V1 creation remains write-fenced; the provenance reference grants neither API access nor wallet authorization.`,
   ].join("\n");
 }
 

--- a/lib/developer-docs-content.ts
+++ b/lib/developer-docs-content.ts
@@ -69,6 +69,7 @@ export function buildDeveloperDocsMarkdown(): string {
     "## Custom Launch API availability",
     "",
     `Public V2 creation, list and single-resource reads are live for wallet-bound requests on Ethereum Mainnet at ${customLaunchApiOrigin}/v2/custom-launches. V1 history reads remain live and V1 creation stays read-only with non-retryable \`409 CUSTOM_LAUNCH_V1_READ_ONLY\`. Legacy Registry and GitHub submission intake is closed.`,
+    `Custom launch preparation is the separate authenticated write path at ${customLaunchApiOrigin}/v2/custom-launches; the retained ${customLaunchApiOrigin}/v1/custom-launches endpoint remains read-only.`,
     `The exact public request, lifecycle, idempotency and wallet-handoff contract is ${customLaunchApiV2OpenApiUrl}.`,
     "",
     `Install the pinned public CLI with \`npm install --global ${customLaunchCliReleaseUrl}\`. The package is \`@programmable/launch\` and the binary is \`programmable-launch\`.`,

--- a/lib/developer-docs-content.ts
+++ b/lib/developer-docs-content.ts
@@ -78,7 +78,7 @@ export function buildDeveloperDocsMarkdown(): string {
     "",
     `Connect a wallet and create a key at ${apiKeysUrl}. Store the one-time \`pm_live_\` secret only as the encrypted environment secret \`PROGRAMMABLE_API_KEY\` or in the OS secret store. Put only \`$PROGRAMMABLE_API_KEY\` in chat, prompts and agent setup.`,
     "",
-    "A wallet-bound key can use its authorized public V2 operations and read existing V1 history. API scopes never grant wallet signing. `fees:claim` and `buybacks:manage` are reserved and disabled.",
+    "A wallet-bound key can use its authorized public V2 operations and read existing V1 history. API authorization is not launch authorization: API scopes never grant wallet signing, and the controller wallet must review and sign separately. `fees:claim` and `buybacks:manage` are reserved and disabled.",
     "",
     "Keys expire after 90 days by default, may be issued for at most 366 days, and are limited to 10 active keys per wallet.",
     "",

--- a/lib/public-openapi.ts
+++ b/lib/public-openapi.ts
@@ -2,7 +2,6 @@ import { V4_TOKEN_ADDRESS } from "@/components/docs-public-policy";
 
 const SITE_ORIGIN = "https://programmable.market";
 const CUSTOM_LAUNCH_API_ORIGIN = "https://api.programmable.market";
-const API_KEYS_URL = `${SITE_ORIGIN}/developers/api-keys`;
 
 const jsonResponse = (schema: Record<string, unknown>, description: string) => ({
   description,
@@ -21,11 +20,11 @@ export const programmablePublicOpenApi = {
   openapi: "3.1.0",
   info: {
     title: "Programmable developer APIs",
-    version: "1.4.0",
+    version: "1.5.0",
     summary:
-      "Verified launch discovery plus existing wallet-owned V1 Custom launch history on Ethereum.",
+      "Verified launch discovery plus public wallet-owned V2 Custom launch creation on Ethereum.",
     description:
-      "The programmable.market read endpoints remain unauthenticated and read-only. At the separately hosted Custom Launch API, V1 list and single-resource reads remain live for existing wallet-owned requests. V1 launch creation is read-only and returns non-retryable 409 CUSTOM_LAUNCH_V1_READ_ONLY. The fee-enforced V2 release candidate is held until canary and explicit public activation; unavailable V2 requests return 503 CUSTOM_LAUNCH_V2_UNAVAILABLE with Retry-After. Legacy Registry and GitHub submission intake is closed. An API key never signs or broadcasts a controller-wallet transaction.",
+      "The programmable.market discovery endpoints remain unauthenticated and read-only. At the separately hosted Custom Launch API, public V2 creation and wallet-owned lifecycle reads are live on Ethereum Mainnet. V1 history reads remain live and V1 creation remains read-only with non-retryable 409 CUSTOM_LAUNCH_V1_READ_ONLY. Legacy Registry and GitHub submission intake is closed. An API key never signs or broadcasts a controller-wallet transaction.",
     contact: {
       name: "Programmable",
       url: `${SITE_ORIGIN}/docs/developers`,
@@ -53,7 +52,7 @@ export const programmablePublicOpenApi = {
     {
       name: "Custom launch",
       description:
-        "Wallet-bound V1 launch history and explicit public write fence. Manage API keys at programmable.market/developers/api-keys.",
+        "Public wallet-bound V2 launch creation plus retained V1 history. Manage API keys at programmable.market/developers/api-keys.",
     },
   ],
   paths: {
@@ -277,7 +276,7 @@ export const programmablePublicOpenApi = {
         deprecated: true,
         summary: "V1 launch creation is read-only",
         description:
-          "The V1 creation route is retained only as an explicit write fence. After successful API-key authentication and scope checks it returns 409 CUSTOM_LAUNCH_V1_READ_ONLY before reading an idempotency key or request body. This response is non-retryable. Use the live V1 GET operations for existing history. V2 remains held until canary and explicit public activation.",
+          "The V1 creation route is retained only as an explicit write fence. After successful API-key authentication and scope checks it returns 409 CUSTOM_LAUNCH_V1_READ_ONLY before reading an idempotency key or request body. This response is non-retryable. Use the live V1 GET operations for existing history and the standalone public V2 contract for new launches.",
         tags: ["Custom launch"],
         servers: [
           {
@@ -411,7 +410,7 @@ export const programmablePublicOpenApi = {
         scheme: "bearer",
         bearerFormat: "pm_live_<22-char-key-id>_<43-char-secret>",
         description:
-          "Wallet-bound API key managed at https://programmable.market/developers/api-keys. Existing keys can read their wallet-owned V1 history. A legacy custom-launch:create scope does not override the V1 write fence. Keys are not wallets and cannot sign or broadcast transactions.",
+          "Wallet-bound API key managed at https://programmable.market/developers/api-keys. Keys can use authorized V2 operations and read their wallet-owned V1 history. Keys are not wallets and cannot sign or broadcast transactions.",
       },
     },
     schemas: {
@@ -1660,10 +1659,17 @@ export const programmablePublicOpenApi = {
       retryable: false,
     },
     v2ReleaseCandidate: {
-      status: "held",
-      httpStatus: 503,
-      errorCode: "CUSTOM_LAUNCH_V2_UNAVAILABLE",
-      retryAfter: "honor-until-canary-and-public-activation",
+      status: "promoted-to-public",
+      release: "2.0.0",
+      publicAuthorization: true,
+      openApiUrl: `${SITE_ORIGIN}/openapi/custom-launch-v2.json`,
+    },
+    v2: {
+      status: "live",
+      createHttpStatus: 202,
+      replayHttpStatus: 200,
+      retryAfter: "honor-on-429-or-503",
+      openApiUrl: `${SITE_ORIGIN}/openapi/custom-launch-v2.json`,
     },
     legacyIntake: { registry: "closed", github: "closed" },
   },
@@ -1679,13 +1685,13 @@ export const programmablePublicOpenApi = {
     market:
       "Router verification requires pool initialization and fixed runtime and pool bindings, not active liquidity or tradability; the Custom graph owns liquidity behavior.",
     actions:
-      "V1 list and single-resource reads preserve existing durable launch history, including a bounded best-effort reconciliation pass over pending history rows and precise single-resource polling. V1 creation is write-fenced and V2 remains held. Exact-source provider verification for existing finalized resources runs independently and never revises launch finality. API keys never sign, broadcast, trade, claim fees, manage buybacks, or write profiles.",
+      "Public V2 creation and lifecycle reads preserve exact idempotent request bytes, bounded best-effort reconciliation of pending history rows and precise single-resource polling. V1 history remains readable and V1 creation remains write-fenced. Exact-source provider verification runs independently and never revises launch finality. API keys never sign, broadcast, trade, claim fees, manage buybacks, or write profiles.",
   },
   "x-programmable-api-scopes": {
     "custom-launch:create": {
-      state: "write-fenced",
+      state: "v1-write-fenced-v2-live",
       description:
-        "A legacy key scope may exist, but V1 POST returns non-retryable CUSTOM_LAUNCH_V1_READ_ONLY.",
+        "Authorized public V2 creation is live. V1 POST remains non-retryable CUSTOM_LAUNCH_V1_READ_ONLY.",
     },
     "custom-launch:read": {
       state: "grantable",

--- a/lib/server/custom-launch/well-known-v1.ts
+++ b/lib/server/custom-launch/well-known-v1.ts
@@ -18,7 +18,7 @@ export function programmableWellKnownDocumentV1(
     platformId: "programmable" as const,
     name: "Programmable Developer Platform",
     description:
-      "Canonical discovery for Programmable Classic and Custom launches. V1 launch history reads remain live while public launch creation is held for the fee-enforced V2 release candidate.",
+      "Canonical discovery for Programmable Classic and Custom launches. Public V2 launch creation and wallet-owned lifecycle reads are live on Ethereum Mainnet.",
     apiVersion: "2" as const,
     apiBaseUrl: "https://developers.programmable.family/api/v2",
     statusUrl: "https://developers.programmable.family/api/v2/status",
@@ -33,7 +33,7 @@ export function programmableWellKnownDocumentV1(
     documentationUrl: "https://developers.programmable.family/",
     sourceUrl: "https://github.com/0xprogrammable/developers",
     customLaunchApi: Object.freeze({
-      status: "read-only" as const,
+      status: "live" as const,
       readStatus: "live" as const,
       apiBaseUrl: "https://api.programmable.market",
       readyzUrl: "https://api.programmable.market/readyz",
@@ -49,26 +49,43 @@ export function programmableWellKnownDocumentV1(
         tarballUrl:
           "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz",
       }),
+      publicRelease: Object.freeze({
+        status: "live" as const,
+        apiVersion: "2" as const,
+        guideUrl: "https://programmable.market/docs/developers/custom-launch",
+        openApiUrl: "https://programmable.market/openapi/custom-launch-v2.json",
+        authentication: "wallet-bound-api-key" as const,
+        walletBoundary: "separate-wallet-signature" as const,
+        cli: Object.freeze({
+          packageName: "@programmable/launch",
+          binary: "programmable-launch",
+          releaseVersion: "2.0.0",
+          releaseUrl:
+            "https://github.com/0xprogrammable/PROGRAMMABLE/releases/tag/programmable-launch-v2.0.0",
+          tarballUrl:
+            "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz",
+        }),
+      }),
       releaseCandidate: Object.freeze({
-        status: "private-canary-held" as const,
-        publicAuthorization: false as const,
+        status: "promoted-to-public" as const,
+        publicAuthorization: true as const,
         packageName: "@programmable/launch",
         binary: "programmable-launch",
-        releaseVersion: "2.0.0-rc.2",
-        releaseTag: "programmable-launch-v2.0.0-rc.2",
+        releaseVersion: "2.0.0",
+        releaseTag: "programmable-launch-v2.0.0",
         releaseUrl:
-          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/tag/programmable-launch-v2.0.0-rc.2",
+          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/tag/programmable-launch-v2.0.0",
         tarballUrl:
-          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0-rc.2/programmable-launch-2.0.0-rc.2.tgz",
+          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz",
         openApiUrl:
           "https://programmable.market/openapi/custom-launch-v2.json",
         feePolicy: Object.freeze({
           profileId:
             "programmable.fee-enforced-isolated-after-swap.zero-delta.v1",
-          profileRevision: 2 as const,
+          profileRevision: 3 as const,
           launchProfileHash:
-            "sha256:1eca209637922b9a8627d073a6d92fede0ae355fb5bd2dfebe3e5382f12f55f8",
-          productionLaunchAuthorized: false as const,
+            "sha256:fd2d738117c4c69304efb49c75d402d2e8b8968832fd2e27548c3d9814c5c9ee",
+          productionLaunchAuthorized: true as const,
           chainId: "1" as const,
           network: "Ethereum Mainnet" as const,
           chargeTrigger: "successful-swap" as const,
@@ -100,10 +117,10 @@ export function programmableWellKnownDocumentV1(
           retryable: false as const,
         }),
         v2: Object.freeze({
-          status: "release-candidate-held" as const,
-          createHttpStatus: 503 as const,
-          createErrorCode: "CUSTOM_LAUNCH_V2_UNAVAILABLE" as const,
-          retryAfter: "honor" as const,
+          status: "live" as const,
+          createHttpStatus: 202 as const,
+          replayHttpStatus: 200 as const,
+          retryAfter: "honor-on-429-or-503" as const,
         }),
       }),
       legacyIntake: Object.freeze({
@@ -122,7 +139,8 @@ export function programmableWellKnownDocumentV1(
       classic: Object.freeze({ discoveryStatus: "live" as const }),
       custom: Object.freeze({
         discoveryStatus: "live" as const,
-        publicSubmissionStatus: "release-candidate-held" as const,
+        publicSubmissionStatus: "closed" as const,
+        customLaunchApiStatus: "live" as const,
         registryDiscoveryStatus: manifest.status,
         legacyRegistrySubmissionStatus: "closed" as const,
         legacyGithubSubmissionStatus: "closed" as const,
@@ -132,8 +150,8 @@ export function programmableWellKnownDocumentV1(
           ? "1"
           : null,
         note: manifest.status === "live"
-          ? "V1 launch history reads are live, V1 launch creation is read-only, and the fee-enforced V2 release candidate is held until canary and public activation. Finalized Router and approved Custom Registry identities remain discoverable. Legacy Registry and GitHub submission intake is closed."
-          : "V1 launch history reads are live, V1 launch creation is read-only, and the fee-enforced V2 release candidate is held until canary and public activation. Finalized Router identities remain discoverable. The legacy Registry has no live deployment, and Registry or GitHub submission intake is closed.",
+          ? "Public V2 launch creation and lifecycle reads are live on Ethereum Mainnet. V1 history reads remain live and V1 creation is read-only. Finalized Router and approved Custom Registry identities remain discoverable. Legacy Registry and GitHub submission intake is closed."
+          : "Public V2 launch creation and lifecycle reads are live on Ethereum Mainnet. V1 history reads remain live and V1 creation is read-only. Finalized Router identities remain discoverable. The legacy Registry has no live deployment, and Registry or GitHub submission intake is closed.",
       }),
     }),
     compatibility: Object.freeze({

--- a/packages/launch/README.md
+++ b/packages/launch/README.md
@@ -15,22 +15,23 @@ programmable-launch --version
 That immutable release remains the V1 compatibility package. V1 request preparation and status reads remain valid,
 but new V1 submissions are read-only fenced with non-retryable `CUSTOM_LAUNCH_V1_READ_ONLY`.
 
-This source tree is the dual-version `2.0.0-rc.2` candidate. After its immutable release asset and digest are
-published, install that exact asset rather than an unverified npm-registry package with the same name:
+For public V2 preparation and submission, install the immutable `2.0.0` GitHub Release asset rather than an
+unverified npm-registry package with the same name:
 
 ```sh
 npm install --global \
-  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0-rc.2/programmable-launch-2.0.0-rc.2.tgz
+  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz
 programmable-launch --version
 ```
 
-The V2 Rev2 profile is a canary artifact with `productionLaunchAuthorized:false`; package installation is not launch
-authority. The human guide is <https://programmable.market/docs/developers/custom-launch>.
+The V2 Rev3 profile is the public production profile. Package installation is not wallet authority: the API prepares
+the exact Router transaction, then the connected controller reviews and signs it separately. The human guide is
+<https://programmable.market/docs/developers/custom-launch>.
 
-## RC2 fee policy (private canary)
+## Rev3 fee policy
 
-This disclosure describes only the frozen RC2 profile. It does not activate public V2 submission. The profile is for
-Ethereum Mainnet only (`chainId: "1"`) and has `productionLaunchAuthorized: false`.
+The frozen Rev3 profile is public on Ethereum Mainnet only (`chainId: "1"`) and has
+`productionLaunchAuthorized: true`.
 
 For each successful swap, the mandatory platform charge is 1,000 parts per 1,000,000 of the documented
 `gross-unspecified-pool-currency-amount` basis: `1,000 ppm = 0.10% = 10 bps`. It accrues in the profile's unspecified
@@ -56,22 +57,20 @@ programmable-launch pack --config programmable-launch.config.json --output launc
 programmable-launch validate launch.json --config programmable-launch.config.json
 ```
 
-For an executable V2 cold-room rehearsal, use `examples/fee-enforced-v2-no-broadcast/README.md` from the installed RC.
+For an executable V2 cold-room rehearsal, use `examples/fee-enforced-v2-no-broadcast/README.md` from the installed package.
 It invokes real solc 0.8.26, uses the exact distributed profile sources and artifacts, and ends after byte-reproducible
 `pack` and `validate`. The older `examples/no-broadcast` fixture remains only for V1 golden compatibility.
 
-If a later API activation authorizes this exact profile revision, save the API key only as the encrypted environment
-secret `PROGRAMMABLE_API_KEY` or in the supported OS
+Save the API key only as the encrypted environment secret `PROGRAMMABLE_API_KEY` or in the supported OS
 secret store. Put the literal text `$PROGRAMMABLE_API_KEY` in agent setup or chat, never the key. On macOS, the fallback
 secret-store lookup is the Keychain service `api.programmable.market`, account `PROGRAMMABLE_API_KEY`.
 
-V2 `submit` routes only to `/v2/custom-launches`; while the profile is held it stops on
-`CUSTOM_LAUNCH_V2_UNAVAILABLE` and preserves `Retry-After` and `requestId`. It never falls back to V1. If a future
-authorized response is returned, stop the agent flow: the controller reviews the exact `walletTransaction` and signs
-it in a separate wallet flow. After a human broadcast, use `status REQUEST_UUID --api-version 2 --watch --until
-finalized`. `finalized`, `failed`, and `cancelled` always stop polling.
+V2 `submit` routes only to `/v2/custom-launches`. It never falls back to V1. Preserve the exact request bytes and
+idempotency key across timeout, `429`, or `503` retries and honor `Retry-After`. At `authorized`, stop the agent flow:
+the controller reviews the exact `walletTransaction` and signs it in a separate wallet flow. After a human broadcast,
+use `status REQUEST_UUID --watch --until finalized`. `finalized`, `failed`, and `cancelled` always stop polling.
 
-Neither included rehearsal claims authenticated submit, status, authorization, signing, or broadcast evidence.
+The included rehearsal proves only offline pack and validation. It does not submit, poll, sign, or broadcast.
 
 ## Pack config V1
 

--- a/packages/launch/README.md
+++ b/packages/launch/README.md
@@ -72,14 +72,14 @@ use `status REQUEST_UUID --watch --until finalized`. `finalized`, `failed`, and 
 
 The included rehearsal proves only offline pack and validation. It does not submit, poll, sign, or broadcast.
 
-## Pack config V1
+## Pack config V2
 
 The top-level fields are:
 
-- `schemaVersion`: `programmable.launch-pack-config.v1`
+- `schemaVersion`: `programmable.launch-pack-config.v2`
 - `launchWallet`, `chainId: "1"`, and a nonzero lowercase bytes32 `nonce`
-- `source`: relative `root`, non-empty exact `paths`, decimal `sourceLineageNonce`, and public HTTPS `url` plus exact
-  lowercase Git `revision`
+- `source`: relative `root`, non-empty exact `paths`, decimal `sourceLineageNonce`, and `publicOrigin` containing a
+  public HTTPS `url` plus the exact lowercase merged production Git `revision` used for the release
 - `compilationUnits`: unique `{ compilationUnitId, standardJson }` entries
 - `targets`: 1–16 target definitions
 - `pool`: exact token/hook target IDs, fee, and tick spacing

--- a/packages/launch/contracts/profile-v2/manifest.json
+++ b/packages/launch/contracts/profile-v2/manifest.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": "programmable.fee-enforced-profile-assets.v1",
   "profileId": "programmable.fee-enforced-isolated-after-swap.zero-delta.v1",
-  "profileRevision": 2,
-  "profileVersion": "2.0.0-rc.2",
-  "activationStatus": "canary",
-  "productionLaunchAuthorized": false,
+  "profileRevision": 3,
+  "profileVersion": "2.0.0",
+  "activationStatus": "production",
+  "productionLaunchAuthorized": true,
   "compiler": {
     "version": "0.8.26+commit.8a97fa7a",
     "evmVersion": "cancun",

--- a/packages/launch/examples/fee-enforced-v2-no-broadcast/README.md
+++ b/packages/launch/examples/fee-enforced-v2-no-broadcast/README.md
@@ -2,8 +2,8 @@
 
 This installed example compiles a real isolated custom module with exact solc 0.8.26, combines it with the package's
 closed four-contract profile assets, then runs offline `pack` and `validate`. It does not submit, poll, sign, broadcast,
-or create a Mainnet coin. The RC profile remains production-disabled; an API may return
-`CUSTOM_LAUNCH_V2_UNAVAILABLE` even if the offline gates pass.
+or create a Mainnet coin. Passing this offline rehearsal does not authenticate an API request or authorize a wallet
+transaction.
 
 From a neutral temporary directory, locate the installed package and copy the sample plus immutable profile assets:
 

--- a/packages/launch/examples/fee-enforced-v2-no-broadcast/project/build-and-configure.mjs
+++ b/packages/launch/examples/fee-enforced-v2-no-broadcast/project/build-and-configure.mjs
@@ -224,7 +224,7 @@ const config = {
   launchProfile: {
     schemaVersion: "programmable.fee-enforced-launch-profile-selection.v1",
     profileId: "programmable.fee-enforced-isolated-after-swap.zero-delta.v1",
-    profileRevision: 2,
+    profileRevision: 3,
     targetRoles: {
       tokenTargetId: "token",
       customModuleTargetId: "custom-module",

--- a/packages/launch/examples/no-broadcast/README.md
+++ b/packages/launch/examples/no-broadcast/README.md
@@ -50,5 +50,5 @@ programmable-launch validate launch.json \
 
 Stop after `validate`. The generated `evidence/rehearsal.json` proves only the inspected build inputs before `pack`.
 Calling V1 `submit` would return the non-retryable `CUSTOM_LAUNCH_V1_READ_ONLY`; this example does not present that as a
-successful wallet handoff. Use the separate fee-enforced V2 no-broadcast example to exercise the held five-role RC
-profile offline.
+successful wallet handoff. Use the separate fee-enforced V2 no-broadcast example to exercise the public Rev3 five-role
+profile offline without submitting, signing or broadcasting.

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@programmable/launch",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0",
   "description": "Deterministic pack, validation, submission, and status tooling for the Programmable Custom Launch API",
   "type": "module",
   "bin": {

--- a/packages/launch/src/api-client.mjs
+++ b/packages/launch/src/api-client.mjs
@@ -99,7 +99,7 @@ export async function statusLaunch(options) {
     throw new TypeError("status requires the Custom launch request UUID");
   }
   const apiOrigin = normalizeApiOrigin(options.apiOrigin ?? API_ORIGIN);
-  const requestPath = createPathForApiVersion(options.apiVersion ?? 1);
+  const requestPath = createPathForApiVersion(options.apiVersion ?? 2);
   const apiKey = await (options.loadApiKeyImpl ?? loadApiKey)();
   const until = options.until ?? WALLET_HANDOFF_STATUS;
   if (until !== WALLET_HANDOFF_STATUS && until !== "finalized") {

--- a/packages/launch/src/cli.mjs
+++ b/packages/launch/src/cli.mjs
@@ -151,6 +151,7 @@ function usage(command) {
     ],
     status: [
       "Usage: programmable-launch status <request-id> [--api-version 1|2] [--watch] [--until authorized|finalized]",
+      "V2 is the default. Use --api-version 1 only for retained V1 history.",
       "This command never signs or broadcasts a wallet transaction.",
     ],
   };
@@ -159,8 +160,8 @@ function usage(command) {
     "",
     `Guide: ${GUIDE_URL}`,
     `OpenAPI V1 (read-only create): ${OPENAPI_URL_V1}`,
-    `OpenAPI V2 (release candidate; public create held): ${OPENAPI_URL_V2}`,
+    `OpenAPI V2 (public create): ${OPENAPI_URL_V2}`,
     `Stable V1 release: ${RELEASE_URL_V1}`,
-    `V2 release candidate: ${RELEASE_URL}`,
+    `Public V2 release: ${RELEASE_URL}`,
   ].join("\n");
 }

--- a/packages/launch/src/constants.mjs
+++ b/packages/launch/src/constants.mjs
@@ -1,4 +1,4 @@
-export const PACKAGE_VERSION = "2.0.0-rc.2";
+export const PACKAGE_VERSION = "2.0.0";
 export const PACK_CONFIG_SCHEMA_V1 = "programmable.launch-pack-config.v1";
 export const PACK_CONFIG_SCHEMA_V2 = "programmable.launch-pack-config.v2";
 export const PACK_CONFIG_SCHEMA = PACK_CONFIG_SCHEMA_V1;
@@ -19,8 +19,8 @@ export const LAUNCH_PROFILE_BINDING_SCHEMA =
 export const LAUNCH_PROFILE_SCHEMA = "programmable.fee-enforced-launch-profile.v1";
 export const LAUNCH_PROFILE_ID =
   "programmable.fee-enforced-isolated-after-swap.zero-delta.v1";
-export const LAUNCH_PROFILE_REVISION = 2;
-export const LAUNCH_PROFILE_VERSION = "2.0.0-rc.2";
+export const LAUNCH_PROFILE_REVISION = 3;
+export const LAUNCH_PROFILE_VERSION = "2.0.0";
 export const LAUNCH_PROFILE_HASH_DOMAIN = "programmable.fee-enforced-launch-profile.v2";
 export const LAUNCH_INTENT_HASH_DOMAIN = "programmable.custom-launch-intent.v2";
 
@@ -38,8 +38,8 @@ export const RELEASE_TAG_V1 = "programmable-launch-v1.0.1";
 export const RELEASE_TARBALL_V1 = "programmable-launch-1.0.1.tgz";
 export const RELEASE_URL_V1 =
   `https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/${RELEASE_TAG_V1}/${RELEASE_TARBALL_V1}`;
-export const RELEASE_TAG = "programmable-launch-v2.0.0-rc.2";
-export const RELEASE_TARBALL = "programmable-launch-2.0.0-rc.2.tgz";
+export const RELEASE_TAG = "programmable-launch-v2.0.0";
+export const RELEASE_TARBALL = "programmable-launch-2.0.0.tgz";
 export const RELEASE_URL =
   `https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/${RELEASE_TAG}/${RELEASE_TARBALL}`;
 

--- a/packages/launch/src/profile-v2.mjs
+++ b/packages/launch/src/profile-v2.mjs
@@ -87,7 +87,7 @@ export function validateLaunchProfileSelection(selection) {
   if (selection.schemaVersion !== LAUNCH_PROFILE_SELECTION_SCHEMA
     || selection.profileId !== LAUNCH_PROFILE_ID
     || selection.profileRevision !== LAUNCH_PROFILE_REVISION) {
-    throw new TypeError("launchProfile selection does not resolve to an embedded RC profile");
+    throw new TypeError("launchProfile selection does not resolve to the embedded production profile");
   }
   return {
     schemaVersion: LAUNCH_PROFILE_SELECTION_SCHEMA,
@@ -104,7 +104,7 @@ export function resolveLaunchProfile(selection) {
     profileId: LAUNCH_PROFILE_ID,
     profileRevision: LAUNCH_PROFILE_REVISION,
     profileVersion: LAUNCH_PROFILE_VERSION,
-    productionLaunchAuthorized: false,
+    productionLaunchAuthorized: true,
     chainId: MAINNET_CHAIN_ID,
     router: ROUTER,
     routerRuntimeCodeHash: "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
@@ -114,17 +114,17 @@ export function resolveLaunchProfile(selection) {
     poolManagerRuntimeCodeHash: "0x785f1014552b7ce7d5fb7d0c970ca60edee94fd00425d7ca21609acac7ce1293",
     policy: {
       policyId: "programmable-central-launch-policy",
-      policyVersion: "2.1.0",
-      effectiveAt: "2026-08-20T00:00:00Z",
-      sourceRepository: "https://github.com/0xprogrammable/submit-launch",
-      sourceCommit: "afafed19da43f0246d5ba8827aec634fa596e091",
-      sourceBlob: "af10761f1643297969295aef894ea664f61a2686",
-      sourceContentSha256: "sha256:9f081e02b626b421bcdc38d84f25b5cf3cfb92bd77f27a987520fa0bae675b67",
-      productionLaunchEnabled: false,
+      policyVersion: "2.2.0",
+      effectiveAt: "2026-08-25T20:30:00Z",
+      sourceRepository: "https://github.com/0xprogrammable/Launch-Policy",
+      sourceCommit: "5f8b633dc8e43b3300bc9e05cb32d7d7b7ac406d",
+      sourceBlob: "b00aa38438813ebddaea55aa3ff3aa057c2b8e6a",
+      sourceContentSha256: "sha256:8ec75c79d37535d9c9469f7662f9bf760387de34df55157df0203c6dd1b8b808",
+      productionLaunchEnabled: true,
       requiredRuleIds: [
         "LAUNCH.ETHEREUM_AND_TREASURY_10_BPS",
+        "LAUNCH.ETHEREUM_EXACT_FEE_TEMPLATE_BEFORE_AUTHORIZATION",
         "LAUNCH.ETHEREUM_FINALIZED_ROUTER_STAMP_BEFORE_PROMOTION",
-        "LAUNCH.ETHEREUM_FINALIZED_RUNTIME_FEE_SETTLEMENT_BEFORE_PROMOTION",
         "LAUNCH.ETHEREUM_ROUTER_PROVENANCE_READINESS",
       ],
     },
@@ -162,7 +162,7 @@ export function resolveLaunchProfile(selection) {
       externalCallRisk: "custom-risk-disclosed",
     },
     contractBuildBindings: {
-      activationStatus: "canary",
+      activationStatus: "production",
       compilerVersion: "0.8.26+commit.8a97fa7a",
       compilerSettingsHash: "0xd8985cd6554daab2848a8df4d90f9d5e0d81f15d062ee04bcd8414f292ccaf43",
       compilerSettings: {

--- a/packages/launch/test/launch.test.mjs
+++ b/packages/launch/test/launch.test.mjs
@@ -380,11 +380,7 @@ test("the bundled no-broadcast example derives a real graph and deterministic ho
   const projectDirectory = path.join(root, "project");
   const exampleRoot = new URL("../examples/no-broadcast/", import.meta.url);
   await cp(new URL("project/", exampleRoot), projectDirectory, { recursive: true });
-  const repositoryRoot = path.resolve(process.cwd(), "../..");
-  const revision = execFileSync("git", ["rev-parse", "HEAD"], {
-    cwd: repositoryRoot,
-    encoding: "utf8",
-  }).trim();
+  const revision = "f6eb3e95dd7728c590c2a3bb115b6dd29c8c5607";
   execFileSync(process.execPath, [new URL("prepare-config.mjs", exampleRoot).pathname, projectDirectory], {
     env: {
       ...process.env,
@@ -418,8 +414,8 @@ test("the bundled no-broadcast example derives a real graph and deterministic ho
   });
   assert.equal(
     first.requestSha256,
-    "sha256:0de407187c0edc2f1e9ddb8146d03f31b8f07565c597c1c62e6473ceada5636f",
-    "V1 request golden bytes must remain deterministic in @programmable/launch 2.0.0-rc.2",
+    "sha256:b44f9dc43b51bc69ca52ec6769b9e3d64cd9472387e2f5a3b83cf73078a029aa",
+    "V1 request golden bytes must remain deterministic in @programmable/launch 2.0.0",
   );
   assert.deepEqual(await readFile(first.outputPath), await readFile(second.outputPath));
   const request = JSON.parse(await readFile(first.outputPath, "utf8"));
@@ -450,9 +446,9 @@ test("V2 binds a closed fee profile, launch intent, and compiler immutables", as
     request.launchProfile.profileId,
     "programmable.fee-enforced-isolated-after-swap.zero-delta.v1",
   );
-  assert.equal(request.launchProfile.profileRevision, 2);
-  assert.equal(request.launchProfile.productionLaunchAuthorized, false);
-  assert.equal(request.launchProfile.contractBuildBindings.activationStatus, "canary");
+  assert.equal(request.launchProfile.profileRevision, 3);
+  assert.equal(request.launchProfile.productionLaunchAuthorized, true);
+  assert.equal(request.launchProfile.contractBuildBindings.activationStatus, "production");
   assert.equal(
     request.launchProfile.feePolicy.policyId,
     "0xb7ff874d418bc714d0ec6c36a2df03ea6251bc8b6eb125adc4f5b6b4899d2517",
@@ -537,7 +533,7 @@ test("V2 embedded profile matches every distributed fixed-build asset digest", a
   assert.equal(profile.contractBuildBindings.activationStatus, manifest.activationStatus);
   assert.equal(
     hashLaunchProfile(profile),
-    "sha256:1eca209637922b9a8627d073a6d92fede0ae355fb5bd2dfebe3e5382f12f55f8",
+    "sha256:fd2d738117c4c69304efb49c75d402d2e8b8968832fd2e27548c3d9814c5c9ee",
   );
   const distributedOnly = new Set([
     "standardJsonAssetPath",
@@ -776,7 +772,6 @@ test("V2 submit and status use the schema-selected path and bind it in the journ
 
   const statusResult = await statusLaunch({
     requestId: "515a4b20-a7bd-40e1-8cfa-f6da5457036b",
-    apiVersion: 2,
     apiOrigin: "http://127.0.0.1:43194",
     maxAttempts: 1,
     fetchImpl: async (url) => {
@@ -1028,7 +1023,7 @@ async function materializeV2CompiledFixture({ dangerousCustomModule = false } = 
     launchProfile: {
       schemaVersion: "programmable.fee-enforced-launch-profile-selection.v1",
       profileId: "programmable.fee-enforced-isolated-after-swap.zero-delta.v1",
-      profileRevision: 2,
+      profileRevision: 3,
       targetRoles: {
         tokenTargetId: "token",
         customModuleTargetId: "custom-module",

--- a/public/developers/custom-launch-api-v1.md
+++ b/public/developers/custom-launch-api-v1.md
@@ -1,27 +1,22 @@
-# Programmable Custom Launch API V1
+# Programmable Custom Launch API
 
-V1 list and single-resource reads remain live at `https://api.programmable.market` for existing wallet-bound launch
-requests. V1 creation is read-only: every authenticated `POST /v1/custom-launches` returns
-`409 CUSTOM_LAUNCH_V1_READ_ONLY`, which is non-retryable. The fee-enforced V2 release candidate remains held until
-canary and explicit public activation; unavailable V2 requests return `503 CUSTOM_LAUNCH_V2_UNAVAILABLE` with
-`Retry-After`. There is currently no public Custom launch-creation route. Legacy Registry and GitHub submission intake
-is closed.
+V2 is public and live: launch creation, list and single resource reads are available at `https://api.programmable.market` for
+wallet bound API keys. V1 history reads remain available for existing requests, while authenticated
+`POST /v1/custom-launches` remains permanently read only with `409 CUSTOM_LAUNCH_V1_READ_ONLY`. Legacy Registry and
+GitHub submission intake is closed.
 
-Normative OpenAPI: <https://programmable.market/openapi/custom-launch-v1.json>
+Normative public V2 OpenAPI: <https://programmable.market/openapi/custom-launch-v2.json>
 
-Held V2 release-candidate OpenAPI: <https://programmable.market/openapi/custom-launch-v2.json>
-
-The V2 contract is published for offline integration and private-canary compatibility only. It does not activate a
-public create route.
+V1 compatibility OpenAPI: <https://programmable.market/openapi/custom-launch-v1.json>
 
 Human guide: <https://programmable.market/docs/developers/custom-launch>
 
 Readiness: <https://api.programmable.market/readyz>
 
-## RC2 fee policy (private canary)
+## Rev3 fee policy
 
-This disclosure describes only the frozen RC2 profile. It does not activate public V2 submission. The profile is for
-Ethereum Mainnet only (`chainId: "1"`) and has `productionLaunchAuthorized: false`.
+The frozen Rev3 production profile is available on Ethereum Mainnet only (`chainId: "1"`) and has
+`productionLaunchAuthorized: true`.
 
 For each successful swap, the mandatory platform charge is 1,000 parts per 1,000,000 of the documented
 `gross-unspecified-pool-currency-amount` basis: `1,000 ppm = 0.10% = 10 bps`. It accrues in the profile's unspecified
@@ -35,14 +30,16 @@ disabled.
 
 ## Install the public CLI
 
+Install only the immutable GitHub Release asset:
+
 ```sh
 npm install --global \
-  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz
+  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz
 programmable-launch --version
 ```
 
-The package name is `@programmable/launch`; the binary is `programmable-launch`. The pinned GitHub Release asset is
-the install authority. Do not substitute an unverified npm-registry package.
+The package name is `@programmable/launch`; the binary is `programmable-launch`. Do not substitute an unverified
+npm registry package.
 
 The CLI has exactly four commands:
 
@@ -53,134 +50,91 @@ programmable-launch submit launch.json --config programmable-launch.config.json
 programmable-launch status REQUEST_UUID --watch --until authorized
 ```
 
-`pack` and `validate` remain usable locally. `status` remains usable for an existing V1 request UUID. Do not run
-`submit` against V1 during the write fence: it receives the non-retryable 409 above. The V2 release candidate is not a
-public CLI/API contract until its canary and public activation are published.
+`pack` derives the sorted manifest, source descriptor, ABI encoded arguments, graph, target locators, CREATE2
+predictions, evidence digests, canonical hashes and exact source verification bundle from exact source, Standard JSON,
+compiler artifacts and evidence files. It accepts no hand written derived hashes. `validate` recomputes those
+commitments and, with `--config`, requires byte identical reproduction of `launch.json`.
 
-The release tarball includes `examples/no-broadcast/README.md` with real Solidity source, exact Standard JSON, matching
-solc artifacts and a config generator. Its pack-native hook salt grind is deterministic after source, wallet and nonce
-are fixed. Generated evidence stops truthfully at `pre-submit`, without signing or broadcasting. The held public write
-surface does not currently provide a path from that evidence to a new authorized resource.
+The release includes `examples/fee-enforced-v2-no-broadcast/README.md`. It compiles a real custom module and the exact
+distributed profile sources, then stops after deterministic `pack` and `validate`. It never submits, polls, signs,
+broadcasts or creates a Mainnet coin.
 
-`pack` derives the sorted manifest, source descriptor, ABI-encoded arguments, graph, target locators, CREATE2
-predictions, evidence digests, canonical hashes and exact-source verification bundle from exact source, Standard JSON,
-compiler artifacts and evidence files. It accepts no hand-written derived hashes. If a deployed runtime cannot be
-derived exactly because immutable references remain, it stops with `RUNTIME_MATERIALIZATION_REQUIRED`.
-
-`validate` recomputes those commitments. With `--config`, it requires byte-identical reproduction of `launch.json`.
-
-## Secret boundary
+## Secret and wallet boundary
 
 Create or revoke a key at <https://programmable.market/developers/api-keys>. Store it only in an encrypted secret or
 environment variable named `PROGRAMMABLE_API_KEY`, or in the supported operating system secret store. Put only
-`$PROGRAMMABLE_API_KEY` in chat, prompts and agent setup. The CLI has no API-key argument, never prints the key and
+`$PROGRAMMABLE_API_KEY` in chat, prompts and agent setup. The CLI has no API key argument, never prints the key and
 never stores it in its journal.
 
-Existing V1 keys can use `custom-launch:read` for their wallet-owned history. A key may still contain the legacy
-`custom-launch:create` scope, but that scope does not override the V1 write fence. The key is not a wallet key and
-cannot sign or broadcast.
+The API key is bound to its controller wallet and API scopes. The API and CLI never sign or broadcast.
+At `authorized`, the API returns the exact prepared wallet transaction. Stop the agent flow so the connected controller
+can independently review the chain, sender, Router, value, selector and calldata before signing.
 
-## V1 write fence and retained request schema
+## Public V2 request
 
-After successful API-key authentication and scope checks, `POST /v1/custom-launches` returns
-`409 CUSTOM_LAUNCH_V1_READ_ONLY` before reading an Idempotency-Key or request body. Do not retry it. The schema below
-is retained for compatibility with existing resources and tooling; it is not an active public creation contract.
+`POST /v2/custom-launches` accepts the closed `programmable.custom-launch-create-request.v2` body. The CLI derives and
+validates every required field, including the exact source descriptor and manifest, graph bundle, closed Rev3 launch
+profile and selection, canonical profile and intent hashes, agent attestation and `verificationBundle` exact source material.
+Use the normative V2 OpenAPI for every nested field, enum and size bound.
 
-The eight legacy V1 fields remain required:
+The complete request is limited to 8,388,608 bytes. Decoded Standard JSON is limited to 5,242,880 bytes per
+compilation unit and across all units in one request. Sources use exact inline UTF 8 content. Compiler version,
+settings, libraries, constructor arguments, runtime materialization and every exclusive graph component are bound to
+the launch intent.
 
-| Field | Requirement |
-| --- | --- |
-| `schemaVersion` | `programmable.custom-launch-create-request.v1` |
-| `launchWallet` | Exact wallet bound to the API key |
-| `chainId` | String `1` |
-| `nonce` | Nonzero lowercase `bytes32` |
-| `sourceDescriptor` | `DeterministicSourceBundleV2` |
-| `sourceBundleManifest` | Complete non-empty UTF-8 path-sorted manifest |
-| `graphBundle` | `programmable.custom-graph-bundle.v1` |
-| `agentAttestation` | Evidence digests bound to the exact graph hash |
+## Idempotent submission
 
-The optional additive field is:
+`submit` freshly repacks the config and proves that `launch.json` is byte identical before network access. It then
+writes a mode `0600` journal that permanently binds the idempotency key, API origin and exact request bytes. Reusing
+the key with different bytes fails locally.
 
-```text
-verificationBundle = {
-  schemaVersion: "programmable.exact-source-verification-bundle.v1",
-  compilationUnits: [{
-    compilationUnitId,
-    compilerVersion,
-    standardJsonInputBase64,
-    standardJsonInputSha256
-  }],
-  components: [{
-    targetId,
-    compilationUnitId,
-    sourcePath,
-    contractName,
-    constructorArguments
-  }]
-}
-```
+Timeouts, ambiguous transport results, `429` and `503` retry only those persisted bytes. Honor `Retry-After`. Never
+rotate the nonce, idempotency key or request bytes to work around an ambiguous result. The API can return `202` for a
+new durable request or `200` for an exact replay.
 
-Compilation units are unique and UTF-8 sorted by `compilationUnitId`. Components are unique and UTF-8 sorted by
-`targetId` and exactly cover every graph target. Standard JSON is exact UTF-8, canonically base64-encoded, closed to
-`language`, `sources` and `settings`, and uses inline source content only. Compiler version includes the exact solc
-commit. Constructor arguments are lowercase even hex after graph locators are resolved.
-Decoded Standard JSON is limited to 5,242,880 bytes per compilation unit and across all units in one request.
+New V2 requests share a durable global admission cap of 120 created requests per hour and 500 per day. An exact
+idempotent replay is resolved before admission and consumes no additional capacity.
 
-For existing resources, the durable server record reflects whether `creationBytecode || constructorArguments` matched
-the prepared init code and whether a canonical verification bundle hash was bound. Legacy requests without the field
-remain readable and unverified.
+## Status and wallet handoff
 
-## Transport during the write fence
-
-The CLI still proves that `launch.json` is byte-identical to a fresh pack before any `submit` network access and keeps
-its request journal and key boundary. During the V1 write fence, however, the definitive response is
-`409 CUSTOM_LAUNCH_V1_READ_ONLY`; stop and do not retry. For live V1 reads, honor `Retry-After` on `429` or `503`.
-
-The resource `requestHash` is the server's canonical idempotency digest. It is not the local SHA-256 of the exact HTTP
-body stored by the CLI.
-
-## Read status
-
-Read one resource with:
+V2 is the CLI default. Read one resource with:
 
 ```sh
 programmable-launch status REQUEST_UUID --watch --until authorized
 ```
 
-The command uses `GET /v1/custom-launches/{launchId}`. The path keeps a legacy name, but its value is the API request
-UUID returned as both `launchId` and `requestId`. `onchainLaunchId` is a separate Router bytes32 value. The list route
-can make a bounded best-effort reconciliation pass over pending rows, but it returns `output: null`; the single-resource
-GET is the precise status and full-output path.
+The list route may make a bounded best-effort reconciliation pass over pending rows, but it returns `output: null`.
+The single resource GET is the precise status and full output path.
 
 ```text
-received -> validating -> prepared -> authorized -> submitted -> finalized
+received -> validating -> simulating -> prepared -> authorized -> submitted -> finalized
 ```
 
 `failed` and `cancelled` are terminal alternatives. `prepared` has no wallet transaction. `authorized` contains the
-exact transaction for separate controller-wallet review, signing and broadcast. The CLI stops at that wallet handoff;
-it never signs or broadcasts. After broadcast, run:
+exact transaction for separate controller wallet review, signing and broadcast. The API and CLI never sign or
+broadcast. After the wallet broadcasts, run:
 
 ```sh
 programmable-launch status REQUEST_UUID --watch --until finalized
 ```
 
-## Exact-source verification
+## Exact source verification and discovery
 
 Finality is independent from explorer availability. After a bundled request is finalized, the server enqueues
-idempotent verification work for each exclusive component. Optional `sourceVerification` is server-authored and uses
-`queued`, `retrying`, `exact_match` or `needs_attention`. Only literal `exact_match` for every component is Source
-verified. A client must never submit or infer this state. Legacy or unbundled requests remain compatible and unverified.
+idempotent verification work for each exclusive component. Optional `sourceVerification` is server authored and uses
+`queued`, `retrying`, `exact_match` or `needs_attention`. Only literal `exact_match` for every component means Source
+verified. A client must never submit or infer this state. Legacy or unbundled requests remain compatible and
+unverified.
 
-Finalized Router identities remain eligible for Explore and Profile after discovery refreshes even when optional market
-enrichment or an explorer is unavailable. Provenance is not an audit, safety claim, liquidity guarantee or endorsement.
+Finalized Router identities remain eligible for Explore and Profile after discovery refreshes even when optional
+market enrichment or an explorer is unavailable. Provenance is not an audit, liquidity guarantee or endorsement.
 
 ## Errors and support
 
-For V1 POST, `409 CUSTOM_LAUNCH_V1_READ_ONLY` is permanent and non-retryable. The held V2 release candidate returns
-`503 CUSTOM_LAUNCH_V2_UNAVAILABLE` with `Retry-After` until canary and public activation. For live V1 reads, honor
-`Retry-After` on `429` and `503`. For support, send only `error.requestId`, HTTP status, UTC time and the public error
-code. Never send the API key.
+Fix nonretryable `400`, `403`, `409`, `413`, `415` and `422` responses before sending a new request. Preserve the
+exact journal binding for retryable `429`, `503` and ambiguous transport results. For support, send only
+`error.requestId`, HTTP status, UTC time and the public error code. Never send the API key.
 
 Generic fee claiming and buyback management for arbitrary hooks are not live. FADE uses a specifically bound adapter.
 The reserved `fees:claim` and `buybacks:manage` scopes are disabled and promise no future behavior. Public Hookbuilder
-and reusable-template intake are not part of V1.
+and reusable template intake are not part of the Custom Launch API.

--- a/public/openapi/custom-launch-v1.json
+++ b/public/openapi/custom-launch-v1.json
@@ -4,7 +4,7 @@
     "title": "Programmable Custom Launch API",
     "version": "1.4.0",
     "summary": "Read existing wallet-bound V1 Custom launch history on Ethereum Mainnet.",
-    "description": "V1 list and single-resource reads remain live for existing wallet-bound launch requests. V1 creation is write-fenced: every authenticated POST /v1/custom-launches returns 409 CUSTOM_LAUNCH_V1_READ_ONLY and must not be retried. The fee-enforced V2 release candidate is held until canary and explicit public activation; unavailable V2 requests return 503 CUSTOM_LAUNCH_V2_UNAVAILABLE with Retry-After. Legacy Registry and GitHub submission intake is closed. Existing finalized resources and server-authored exact-source verification remain readable. An API key is not wallet signing authority."
+    "description": "V1 list and single-resource reads remain live for existing wallet-bound launch requests. V1 creation is write-fenced: every authenticated POST /v1/custom-launches returns 409 CUSTOM_LAUNCH_V1_READ_ONLY and must not be retried. Public V2 creation and lifecycle reads are defined by the separate V2 contract. Legacy Registry and GitHub submission intake is closed. Existing finalized resources and server-authored exact-source verification remain readable. An API key is not wallet signing authority."
   },
   "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
   "servers": [
@@ -83,7 +83,7 @@
         "operationId": "createCustomLaunch",
         "deprecated": true,
         "summary": "V1 launch creation is read-only",
-        "description": "The V1 creation route is retained only as an explicit write fence. After successful API-key authentication and scope checks it returns 409 CUSTOM_LAUNCH_V1_READ_ONLY before reading an idempotency key or request body. This response is non-retryable. Use the live V1 GET operations for existing history. No public V2 create contract is advertised by this V1 document.",
+        "description": "The V1 creation route is retained only as an explicit write fence. After successful API-key authentication and scope checks it returns 409 CUSTOM_LAUNCH_V1_READ_ONLY before reading an idempotency key or request body. This response is non-retryable. Use the live V1 GET operations for existing history and the separate public V2 contract for new launches.",
         "responses": {
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -1774,10 +1774,17 @@
       "retryable": false
     },
     "v2ReleaseCandidate": {
-      "status": "held",
-      "httpStatus": 503,
-      "errorCode": "CUSTOM_LAUNCH_V2_UNAVAILABLE",
-      "retryAfter": "honor-until-canary-and-public-activation"
+      "status": "promoted-to-public",
+      "release": "2.0.0",
+      "publicAuthorization": true,
+      "openApiUrl": "https://programmable.market/openapi/custom-launch-v2.json"
+    },
+    "v2": {
+      "status": "live",
+      "createHttpStatus": 202,
+      "replayHttpStatus": 200,
+      "retryAfter": "honor-on-429-or-503",
+      "openApiUrl": "https://programmable.market/openapi/custom-launch-v2.json"
     },
     "legacyIntake": {
       "registry": "closed",

--- a/public/openapi/custom-launch-v2.json
+++ b/public/openapi/custom-launch-v2.json
@@ -1,16 +1,16 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "Programmable Custom Launch API V2 release candidate",
-    "version": "2.0.0-rc.2",
-    "summary": "Held fee-enforced V2 Custom launch contract for private canary integration.",
-    "description": "This machine contract describes the immutable 2.0.0-rc.2 request, lifecycle and wallet-handoff shapes. It does not activate public V2 launch creation. Public V2 requests currently receive 503 CUSTOM_LAUNCH_V2_UNAVAILABLE with Retry-After until an explicit canary and public activation. V1 history reads remain governed by the separate V1 contract. An API key never signs or broadcasts a controller-wallet transaction."
+    "title": "Programmable Custom Launch API V2",
+    "version": "2.0.0",
+    "summary": "Public fee-enforced Custom launch creation and wallet-owned lifecycle reads.",
+    "description": "This machine contract describes the immutable 2.0.0 request, lifecycle and wallet-handoff shapes for public Ethereum Mainnet launch creation. V1 history reads remain governed by the separate V1 contract. An API key never signs or broadcasts a controller-wallet transaction."
   },
   "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
   "servers": [
     {
       "url": "https://api.programmable.market",
-      "description": "Programmable Custom Launch API; V2 public access is held"
+      "description": "Programmable Custom Launch API production"
     }
   ],
   "externalDocs": {
@@ -23,34 +23,42 @@
     }
   ],
   "x-programmable-availability": {
-    "status": "release-candidate-held",
-    "release": "2.0.0-rc.2",
-    "publicAuthorized": false,
-    "privateCanaryOnly": true,
+    "status": "live",
+    "release": "2.0.0",
+    "publicAuthorized": true,
+    "privateCanaryOnly": false,
     "publicCreate": {
-      "status": "held",
-      "httpStatus": 503,
-      "errorCode": "CUSTOM_LAUNCH_V2_UNAVAILABLE",
-      "retryAfterSeconds": 30
+      "status": "live"
     },
-    "activationRule": "A published profile allowlist, canary evidence and explicit public activation are required. This document or a successful local pack does not satisfy that rule.",
+    "activationRule": "Only the exact published Rev3 production profile is accepted. API authorization never replaces separate controller-wallet review and signing.",
     "v1Contract": "https://programmable.market/openapi/custom-launch-v1.json"
   },
   "x-programmable-release-candidate": {
+    "status": "promoted-to-public",
     "packageName": "@programmable/launch",
     "binary": "programmable-launch",
-    "version": "2.0.0-rc.2",
-    "tag": "programmable-launch-v2.0.0-rc.2",
-    "releaseUrl": "https://github.com/0xprogrammable/PROGRAMMABLE/releases/tag/programmable-launch-v2.0.0-rc.2",
-    "tarballUrl": "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0-rc.2/programmable-launch-2.0.0-rc.2.tgz",
-    "launchProfileHash": "sha256:1eca209637922b9a8627d073a6d92fede0ae355fb5bd2dfebe3e5382f12f55f8",
-    "productionLaunchAuthorized": false
+    "version": "2.0.0",
+    "tag": "programmable-launch-v2.0.0",
+    "releaseUrl": "https://github.com/0xprogrammable/PROGRAMMABLE/releases/tag/programmable-launch-v2.0.0",
+    "tarballUrl": "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz",
+    "launchProfileHash": "sha256:fd2d738117c4c69304efb49c75d402d2e8b8968832fd2e27548c3d9814c5c9ee",
+    "productionLaunchAuthorized": true
+  },
+  "x-programmable-release": {
+    "packageName": "@programmable/launch",
+    "binary": "programmable-launch",
+    "version": "2.0.0",
+    "tag": "programmable-launch-v2.0.0",
+    "releaseUrl": "https://github.com/0xprogrammable/PROGRAMMABLE/releases/tag/programmable-launch-v2.0.0",
+    "tarballUrl": "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz",
+    "launchProfileHash": "sha256:fd2d738117c4c69304efb49c75d402d2e8b8968832fd2e27548c3d9814c5c9ee",
+    "productionLaunchAuthorized": true
   },
   "x-programmable-fee-policy": {
     "profileId": "programmable.fee-enforced-isolated-after-swap.zero-delta.v1",
-    "profileRevision": 2,
-    "launchProfileHash": "sha256:1eca209637922b9a8627d073a6d92fede0ae355fb5bd2dfebe3e5382f12f55f8",
-    "productionLaunchAuthorized": false,
+    "profileRevision": 3,
+    "launchProfileHash": "sha256:fd2d738117c4c69304efb49c75d402d2e8b8968832fd2e27548c3d9814c5c9ee",
+    "productionLaunchAuthorized": true,
     "chainId": "1",
     "network": "Ethereum Mainnet",
     "chargeTrigger": "successful-swap",
@@ -119,13 +127,20 @@
       "INTERNAL_ERROR"
     ]
   },
+  "x-programmable-admission": {
+    "scope": "global-v2-created-requests",
+    "hourlyLimit": 120,
+    "dailyLimit": 500,
+    "exactIdempotentReplayConsumesCapacity": false,
+    "enforcement": "durable-transactional"
+  },
   "paths": {
     "/v2/custom-launches": {
       "get": {
         "operationId": "listCustomLaunchesV2",
         "summary": "List wallet-owned V2 launch requests",
-        "description": "Private-canary contract. Returns newest-first compact rows for the wallet bound to the API key. List output is always null; use the version-matched single-resource route for a full handoff. Public availability remains held and can return 503 with Retry-After.",
-        "x-programmable-public-availability": "held",
+        "description": "Returns newest-first compact rows for the wallet bound to the API key. List output is always null; use the version-matched single-resource route for a full handoff.",
+        "x-programmable-public-availability": "live",
         "parameters": [
           {
             "name": "limit",
@@ -182,9 +197,9 @@
       },
       "post": {
         "operationId": "createCustomLaunchV2",
-        "summary": "Prepare a fee-enforced V2 launch (held/private canary)",
-        "description": "The request is byte- and hash-bound to the frozen fee-enforced profile, five-target graph, exact source, runtime materialization and agent attestation. Public authorization is held. Approved private-canary traffic may receive 202, or 200 only when replaying the same Idempotency-Key with byte-identical request bytes. Public traffic receives 503 CUSTOM_LAUNCH_V2_UNAVAILABLE with Retry-After. Never mutate request bytes when retrying a transient response.",
-        "x-programmable-public-availability": "held",
+        "summary": "Prepare a fee-enforced V2 launch",
+        "description": "The request is byte- and hash-bound to the frozen Rev3 production profile, five-target graph, exact source, runtime materialization and agent attestation. A new durable request returns 202; an exact Idempotency-Key replay can return 200. Never mutate request bytes when retrying a transient response.",
+        "x-programmable-public-availability": "live",
         "parameters": [
           {
             "name": "Idempotency-Key",
@@ -227,7 +242,7 @@
             }
           },
           "202": {
-            "description": "Private-canary request durably accepted. Poll the Location resource. This response is not available to public traffic while held.",
+            "description": "New public V2 request durably accepted. Poll the Location resource.",
             "headers": {
               "Location": {
                 "$ref": "#/components/headers/ResourceLocation"
@@ -278,8 +293,8 @@
       "get": {
         "operationId": "getCustomLaunchV2",
         "summary": "Read one wallet-owned V2 launch request",
-        "description": "Private-canary single-resource polling contract. The simulating state exposes no output. Only an authorized resource can contain the exact simulation-passed wallet transaction for separate wallet review. The service never signs or broadcasts for the controller wallet. A missing launch and another principal's launch both return 404. Public availability remains held and can return 503 with Retry-After.",
-        "x-programmable-public-availability": "held",
+        "description": "Public V2 single-resource polling contract. The simulating state exposes no output. Only an authorized resource can contain the exact simulation-passed wallet transaction for separate wallet review. The service never signs or broadcasts for the controller wallet. A missing launch and another principal's launch both return 404.",
+        "x-programmable-public-availability": "live",
         "parameters": [
           {
             "name": "launchId",
@@ -296,7 +311,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Current durable private-canary V2 resource.",
+            "description": "Current durable public V2 resource.",
             "content": {
               "application/json": {
                 "schema": {
@@ -330,12 +345,12 @@
         "type": "http",
         "scheme": "bearer",
         "bearerFormat": "pm_live_<22-char-key-id>_<43-char-secret>",
-        "description": "Wallet-bound key created at https://programmable.market/developers/api-keys. Private-canary V2 requires the route scope and an approved wallet/profile grant. Possessing a key or scope does not activate public V2 and never grants wallet signing authority."
+        "description": "Wallet-bound key created at https://programmable.market/developers/api-keys. The key requires the V2 route scope, is limited to its bound wallet and never grants wallet signing authority."
       }
     },
     "headers": {
       "RetryAfterSeconds": {
-        "description": "Whole seconds to wait before retrying the identical request. Current V2 held responses use 30.",
+        "description": "Whole seconds to wait before retrying the identical request.",
         "schema": {
           "type": "string",
           "pattern": "^[0-9]+$",
@@ -380,7 +395,7 @@
         }
       },
       "Forbidden": {
-        "description": "Required route scope or linked-wallet binding is missing. A held or unavailable V2 profile is reported as 503 instead.",
+        "description": "Required route scope or linked-wallet binding is missing.",
         "content": {
           "application/json": {
             "schema": {
@@ -471,7 +486,7 @@
         }
       },
       "V2Unavailable": {
-        "description": "V2 is held, unavailable or awaiting a retryable simulation dependency. Preserve exact request bytes. Honor Retry-After when present: CUSTOM_LAUNCH_V2_UNAVAILABLE and SIMULATION_UNAVAILABLE include it, while generic LAUNCH_UNAVAILABLE can omit it. CUSTOM_LAUNCH_V2_UNAVAILABLE is the expected public response while held.",
+        "description": "The launch service or a simulation dependency is temporarily unavailable. Preserve exact request bytes and honor Retry-After when present.",
         "headers": {
           "Retry-After": {
             "$ref": "#/components/headers/RetryAfterSeconds"
@@ -485,8 +500,8 @@
             "example": {
               "schemaVersion": "programmable.api-error.v1",
               "error": {
-                "code": "CUSTOM_LAUNCH_V2_UNAVAILABLE",
-                "message": "The fee-enforced V2 profile is held until its production security commitments are activated",
+                "code": "LAUNCH_UNAVAILABLE",
+                "message": "The Custom launch service is temporarily unavailable",
                 "requestId": "018f1f8e-7d93-7c2f-8d7f-e114942e7f25",
                 "details": {
                   "retryAfterSeconds": 30
@@ -607,7 +622,7 @@
       },
       "FeeEnforcedLaunchProfileV2": {
         "type": "object",
-        "description": "Frozen server-allowlisted profile. The server requires the canonical JSON to match the private durable profile byte for byte; the 2.0.0-rc.2 public package carries a non-production-authorized candidate for offline pack and validation.",
+        "description": "Frozen Rev3 production profile. The server requires the canonical JSON to match the durable public profile byte for byte; the 2.0.0 package derives it from the exact distributed assets.",
         "required": [
           "schemaVersion",
           "profileId",
@@ -635,19 +650,16 @@
             "const": "programmable.fee-enforced-launch-profile.v1"
           },
           "profileId": {
-            "type": "string",
-            "pattern": "^[a-z][a-z0-9.-]{2,127}$"
+            "const": "programmable.fee-enforced-isolated-after-swap.zero-delta.v1"
           },
           "profileRevision": {
-            "type": "integer",
-            "minimum": 1
+            "const": 3
           },
           "profileVersion": {
-            "type": "string",
-            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?$"
+            "const": "2.0.0"
           },
           "productionLaunchAuthorized": {
-            "type": "boolean"
+            "const": true
           },
           "chainId": {
             "const": "1"
@@ -811,12 +823,10 @@
             "const": "programmable.fee-enforced-launch-profile-binding.v1"
           },
           "profileId": {
-            "type": "string",
-            "pattern": "^[a-z][a-z0-9.-]{2,127}$"
+            "const": "programmable.fee-enforced-isolated-after-swap.zero-delta.v1"
           },
           "profileRevision": {
-            "type": "integer",
-            "minimum": 1
+            "const": 3
           },
           "targetRoles": {
             "$ref": "#/components/schemas/FeeEnforcedLaunchTargetRolesV2"

--- a/tests/agent-readiness.test.ts
+++ b/tests/agent-readiness.test.ts
@@ -154,7 +154,7 @@ describe("agent-readable public surface", () => {
       ),
     ).toEqual(["get"]);
     expect(programmablePublicOpenApi["x-programmable-api-scopes"]).toMatchObject({
-      "custom-launch:create": { state: "write-fenced" },
+      "custom-launch:create": { state: "v1-write-fenced-v2-live" },
       "fees:claim": { state: "reserved-disabled" },
       "buybacks:manage": { state: "reserved-disabled" },
     });

--- a/tests/custom-launch-cli-public-surface.test.ts
+++ b/tests/custom-launch-cli-public-surface.test.ts
@@ -13,7 +13,7 @@ import { programmableWellKnownDocumentV1 } from
 const root = process.cwd();
 
 describe("public Custom Launch CLI surface", () => {
-  it("advertises live V1 reads and the fail-closed public write cutover", () => {
+  it("advertises public V2 creation and retained V1 reads", () => {
     const document = programmableWellKnownDocumentV1(
       PRELAUNCH_CUSTOM_REGISTRY_PUBLIC_MANIFEST_V1,
     );
@@ -21,7 +21,7 @@ describe("public Custom Launch CLI surface", () => {
       "https://programmable.market/api/indexers/v1/router-custom-identities",
     );
     expect(document.customLaunchApi).toMatchObject({
-      status: "read-only",
+      status: "live",
       readStatus: "live",
       readyzUrl: "https://api.programmable.market/readyz",
       openApiUrl: "https://programmable.market/openapi/custom-launch-v1.json",
@@ -33,22 +33,37 @@ describe("public Custom Launch CLI surface", () => {
         tarballUrl:
           "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz",
       },
+      publicRelease: {
+        status: "live",
+        apiVersion: "2",
+        guideUrl: "https://programmable.market/docs/developers/custom-launch",
+        openApiUrl: "https://programmable.market/openapi/custom-launch-v2.json",
+        authentication: "wallet-bound-api-key",
+        walletBoundary: "separate-wallet-signature",
+        cli: {
+          packageName: "@programmable/launch",
+          binary: "programmable-launch",
+          releaseVersion: "2.0.0",
+          tarballUrl:
+            "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz",
+        },
+      },
       releaseCandidate: {
-        status: "private-canary-held",
-        publicAuthorization: false,
-        releaseVersion: "2.0.0-rc.2",
-        releaseTag: "programmable-launch-v2.0.0-rc.2",
+        status: "promoted-to-public",
+        publicAuthorization: true,
+        releaseVersion: "2.0.0",
+        releaseTag: "programmable-launch-v2.0.0",
         tarballUrl:
-          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0-rc.2/programmable-launch-2.0.0-rc.2.tgz",
+          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz",
         openApiUrl:
           "https://programmable.market/openapi/custom-launch-v2.json",
         feePolicy: {
           profileId:
             "programmable.fee-enforced-isolated-after-swap.zero-delta.v1",
-          profileRevision: 2,
+          profileRevision: 3,
           launchProfileHash:
-            "sha256:1eca209637922b9a8627d073a6d92fede0ae355fb5bd2dfebe3e5382f12f55f8",
-          productionLaunchAuthorized: false,
+            "sha256:fd2d738117c4c69304efb49c75d402d2e8b8968832fd2e27548c3d9814c5c9ee",
+          productionLaunchAuthorized: true,
           chainId: "1",
           network: "Ethereum Mainnet",
           chargeTrigger: "successful-swap",
@@ -78,16 +93,17 @@ describe("public Custom Launch CLI surface", () => {
           retryable: false,
         },
         v2: {
-          status: "release-candidate-held",
-          createHttpStatus: 503,
-          createErrorCode: "CUSTOM_LAUNCH_V2_UNAVAILABLE",
-          retryAfter: "honor",
+          status: "live",
+          createHttpStatus: 202,
+          replayHttpStatus: 200,
+          retryAfter: "honor-on-429-or-503",
         },
       },
     });
     expect(document.publicCategories.custom).toMatchObject({
       discoveryStatus: "live",
-      publicSubmissionStatus: "release-candidate-held",
+      publicSubmissionStatus: "closed",
+      customLaunchApiStatus: "live",
       registryDiscoveryStatus: "prelaunch",
       legacyRegistrySubmissionStatus: "closed",
       legacyGithubSubmissionStatus: "closed",
@@ -95,7 +111,7 @@ describe("public Custom Launch CLI surface", () => {
     expect(JSON.stringify(document)).not.toContain("api-live");
   });
 
-  it("publishes a held, reference-complete V2 release-candidate contract", () => {
+  it("publishes a public, reference-complete V2 contract", () => {
     const v1 = JSON.parse(readFileSync(
       join(root, "public/openapi/custom-launch-v1.json"),
       "utf8",
@@ -106,17 +122,21 @@ describe("public Custom Launch CLI surface", () => {
     ));
 
     expect(v2.openapi).toBe("3.1.0");
-    expect(v2.info.version).toBe("2.0.0-rc.2");
+    expect(v2.info.version).toBe("2.0.0");
     expect(v2["x-programmable-availability"]).toMatchObject({
-      status: "release-candidate-held",
-      publicAuthorized: false,
-      privateCanaryOnly: true,
+      status: "live",
+      publicAuthorized: true,
+      privateCanaryOnly: false,
       publicCreate: {
-        status: "held",
-        httpStatus: 503,
-        errorCode: "CUSTOM_LAUNCH_V2_UNAVAILABLE",
-        retryAfterSeconds: 30,
+        status: "live",
       },
+    });
+    expect(v2["x-programmable-release-candidate"]).toMatchObject({
+      status: "promoted-to-public",
+      version: "2.0.0",
+      launchProfileHash:
+        "sha256:fd2d738117c4c69304efb49c75d402d2e8b8968832fd2e27548c3d9814c5c9ee",
+      productionLaunchAuthorized: true,
     });
     expect(Object.keys(v2.paths).sort()).toEqual([
       "/v2/custom-launches",
@@ -129,7 +149,7 @@ describe("public Custom Launch CLI surface", () => {
     expect(new Set(operationIds).size).toBe(operationIds.length);
 
     const create = v2.paths["/v2/custom-launches"].post;
-    expect(create["x-programmable-public-availability"]).toBe("held");
+    expect(create["x-programmable-public-availability"]).toBe("live");
     expect(Object.keys(create.responses)).toEqual([
       "200", "202", "400", "401", "403", "409", "413", "415", "422", "429", "500", "503",
     ]);
@@ -146,7 +166,7 @@ describe("public Custom Launch CLI surface", () => {
     expect(
       v2.components.responses.V2Unavailable.content["application/json"]
         .example.error.code,
-    ).toBe("CUSTOM_LAUNCH_V2_UNAVAILABLE");
+    ).toBe("LAUNCH_UNAVAILABLE");
 
     const request = v2.components.schemas.CustomLaunchCreateRequestV2;
     expect(request.additionalProperties).toBe(false);
@@ -168,6 +188,25 @@ describe("public Custom Launch CLI surface", () => {
     expect(request.properties.verificationBundle).toEqual({
       $ref: "#/components/schemas/ExactSourceVerificationBundleV2",
     });
+    expect(v2.components.schemas.FeeEnforcedLaunchProfileV2.properties)
+      .toMatchObject({
+        profileId: {
+          const:
+            "programmable.fee-enforced-isolated-after-swap.zero-delta.v1",
+        },
+        profileRevision: { const: 3 },
+        profileVersion: { const: "2.0.0" },
+        productionLaunchAuthorized: { const: true },
+        chainId: { const: "1" },
+      });
+    expect(v2.components.schemas.FeeEnforcedLaunchProfileBindingV2.properties)
+      .toMatchObject({
+        profileId: {
+          const:
+            "programmable.fee-enforced-isolated-after-swap.zero-delta.v1",
+        },
+        profileRevision: { const: 3 },
+      });
     expect(v2.components.schemas.CustomLaunchResourceV2.properties.status.enum)
       .toContain("simulating");
     const sourceVerification =
@@ -299,10 +338,17 @@ describe("public Custom Launch CLI surface", () => {
         retryable: false,
       },
       v2ReleaseCandidate: {
-        status: "held",
-        httpStatus: 503,
-        errorCode: "CUSTOM_LAUNCH_V2_UNAVAILABLE",
-        retryAfter: "honor-until-canary-and-public-activation",
+        status: "promoted-to-public",
+        release: "2.0.0",
+        publicAuthorization: true,
+        openApiUrl: "https://programmable.market/openapi/custom-launch-v2.json",
+      },
+      v2: {
+        status: "live",
+        createHttpStatus: 202,
+        replayHttpStatus: 200,
+        retryAfter: "honor-on-429-or-503",
+        openApiUrl: "https://programmable.market/openapi/custom-launch-v2.json",
       },
       legacyIntake: { registry: "closed", github: "closed" },
     });

--- a/tests/custom-launch-docs.test.ts
+++ b/tests/custom-launch-docs.test.ts
@@ -59,8 +59,8 @@ describe("Custom Launch API documentation", () => {
       expect(source).toMatch(/prepared[\s\S]{0,240}(?:no wallet transaction|walletTransaction[^\n]{0,80}(?:null|both null))/i);
       expect(source).toMatch(/authorized[\s\S]{0,240}(?:walletTransaction|wallet transaction)/i);
     }
-    expect(createGuide).toContain("Stop after local pack and validate");
-    expect(createGuide).toContain("CUSTOM_LAUNCH_V1_READ_ONLY");
+    expect(createGuide).toContain("Stop at authorized");
+    expect(createGuide).toContain("Never sign or broadcast automatically");
   });
 
   it("documents the real packager and schema boundary without invented checks", () => {
@@ -71,7 +71,6 @@ describe("Custom Launch API documentation", () => {
       expect(source).toContain("programmable-launch");
       expect(source).toMatch(/do not (?:copy test-only hashes|enter\s+derived hashes by hand)/i);
     }
-    expect(createGuide).toContain("/openapi/custom-launch-v1.json");
     expect(createGuide).toContain("/openapi/custom-launch-v2.json");
     expect(createGuide).not.toMatch(/Hookbuilder-Skill|Hook Builder packages/);
   });
@@ -99,19 +98,18 @@ describe("Custom Launch API documentation", () => {
 
   it("publishes the exact-source and no-broadcast cold-agent path", () => {
     for (const source of [gitBookGuide, rawGuide, developerDocsMarkdown]) {
-      expect(source).toContain("programmable-launch-1.0.1.tgz");
+      expect(source).toContain("programmable-launch-2.0.0.tgz");
       expect(source).toContain("verificationBundle");
       expect(source).toContain("exact_match");
       expect(source).toContain("PROGRAMMABLE_API_KEY");
       expect(source).toMatch(/(?:without (?:signing|a wallet signature).{0,40}(?:or|and) broadcast(?:ing)?|never[^\n]{0,80}sign[^\n]{0,40}broadcast)/i);
     }
-    expect(gitBookGuide).toContain("examples/no-broadcast/README.md");
+    expect(gitBookGuide).toContain("examples/fee-enforced-v2-no-broadcast/README.md");
     expect(gitBookGuide).toContain("deterministic-hook-permission-grind-v1");
-    expect(gitBookGuide).toContain("Do not run `submit` against V1");
-    expect(gitBookGuide).not.toMatch(/programmable-launch submit\s+\.\/launch\.json/);
+    expect(gitBookGuide).toContain("programmable-launch submit launch.json");
   });
 
-  it("publishes the exact dark-cutover contract without claiming a live write path", () => {
+  it("publishes public V2 while retaining the exact V1 write fence", () => {
     for (const source of [
       gitBookGuide,
       websiteGuide,
@@ -119,15 +117,13 @@ describe("Custom Launch API documentation", () => {
       developerDocsMarkdown,
     ]) {
       expect(source).toContain("CUSTOM_LAUNCH_V1_READ_ONLY");
-      expect(source).toMatch(/V1[^\n]{0,100}(?:read-only|write fence)/i);
-      expect(source).not.toContain("The Custom Launch API is live");
+      expect(source).toMatch(/V1[\s\S]{0,200}(?:read-only|read only|write fence)/i);
+      expect(source).toMatch(/Public V2/i);
     }
-    expect(createGuide).toContain("CUSTOM_LAUNCH_V1_READ_ONLY");
-    expect(createGuide).toContain("Do not submit");
+    expect(createGuide).toContain("submit the byte-identical request");
     for (const source of [gitBookGuide, websiteGuide, rawGuide, developerDocsMarkdown]) {
-      expect(source).toContain("CUSTOM_LAUNCH_V2_UNAVAILABLE");
       expect(source).toContain("Retry-After");
-      expect(source).toMatch(/V2[^\n]{0,120}held/i);
+      expect(source).toMatch(/V2[^\n]{0,120}(?:public|live)/i);
       expect(source).toContain("/openapi/custom-launch-v2.json");
     }
 
@@ -147,36 +143,35 @@ describe("Custom Launch API documentation", () => {
           errorCode: "CUSTOM_LAUNCH_V1_READ_ONLY",
           retryable: false,
         },
-        v2ReleaseCandidate: {
-          status: "held",
-          httpStatus: 503,
-          errorCode: "CUSTOM_LAUNCH_V2_UNAVAILABLE",
+        v2: {
+          status: "live",
+          createHttpStatus: 202,
+          replayHttpStatus: 200,
         },
         legacyIntake: { registry: "closed", github: "closed" },
       });
   });
 
-  it("discloses the exact held RC2 fee without conflating LP fees or future operations", () => {
+  it("discloses the exact public Rev3 fee without conflating LP fees or future operations", () => {
     for (const source of [gitBookGuide, websiteGuide, rawGuide, cliGuide]) {
       expect(source).toContain("Ethereum Mainnet");
-      expect(source).toContain("productionLaunchAuthorized: false");
+      expect(source).toContain("productionLaunchAuthorized: true");
       expect(source).toContain("gross-unspecified-pool-currency-amount");
       expect(source).toContain("1,000 ppm = 0.10% = 10 bps");
       expect(source).toContain("0x4957f49620AFf3Adbbe8195a4f633E49cc93376c");
       expect(source).toContain("cannot reduce or redirect");
       expect(source).toContain("LP fee is separate");
       expect(source).toMatch(/Generic fee claiming and\s+buyback/);
-      expect(source).toMatch(/private[- ]canary/i);
-      expect(source).not.toContain("public V2 is active");
+      expect(source).toMatch(/Rev3/i);
     }
 
     expect(v2OpenApi["x-programmable-fee-policy"]).toEqual({
       profileId:
         "programmable.fee-enforced-isolated-after-swap.zero-delta.v1",
-      profileRevision: 2,
+      profileRevision: 3,
       launchProfileHash:
-        "sha256:1eca209637922b9a8627d073a6d92fede0ae355fb5bd2dfebe3e5382f12f55f8",
-      productionLaunchAuthorized: false,
+        "sha256:fd2d738117c4c69304efb49c75d402d2e8b8968832fd2e27548c3d9814c5c9ee",
+      productionLaunchAuthorized: true,
       chainId: "1",
       network: "Ethereum Mainnet",
       chargeTrigger: "successful-swap",

--- a/tests/custom-launch-docs.test.ts
+++ b/tests/custom-launch-docs.test.ts
@@ -106,7 +106,7 @@ describe("Custom Launch API documentation", () => {
     }
     expect(gitBookGuide).toContain("examples/fee-enforced-v2-no-broadcast/README.md");
     expect(gitBookGuide).toContain("deterministic-hook-permission-grind-v1");
-    expect(gitBookGuide).toContain("programmable-launch submit launch.json");
+    expect(gitBookGuide).toContain("programmable-launch submit ./launch.json");
   });
 
   it("publishes public V2 while retaining the exact V1 write fence", () => {

--- a/tests/developer-api-keys-ui.test.ts
+++ b/tests/developer-api-keys-ui.test.ts
@@ -155,13 +155,10 @@ describe("developer API key interface", () => {
       PROGRAMMABLE_AGENT_SETUP_LINKS_V1.openApi,
     );
     expect(PROGRAMMABLE_AGENT_SETUP_TEXT_V1).toContain(
-      PROGRAMMABLE_AGENT_SETUP_LINKS_V1.openApiV2ReleaseCandidate,
+      PROGRAMMABLE_AGENT_SETUP_LINKS_V1.openApiV1Compatibility,
     );
     expect(PROGRAMMABLE_AGENT_SETUP_TEXT_V1).toContain(
-      PROGRAMMABLE_AGENT_SETUP_LINKS_V1.cliV2ReleaseCandidate,
-    );
-    expect(PROGRAMMABLE_AGENT_SETUP_TEXT_V1).toContain(
-      "V2 is held for private canary",
+      "Stop at authorized",
     );
     expect(PROGRAMMABLE_AGENT_SETUP_TEXT_V1).not.toContain("pm_live_");
   });

--- a/tests/launch-model-gating.test.ts
+++ b/tests/launch-model-gating.test.ts
@@ -202,8 +202,8 @@ describe("unreleased launch model gating", () => {
     const customCard = html.match(
       /<a[^>]*data-launch-model-option="custom"[^>]*>/,
     )?.[0];
-    expect(customCard).toContain('data-launch-model-available="false"');
-    expect(customCard).toContain('data-launch-model-entry="release-held"');
+    expect(customCard).toContain('data-launch-model-available="true"');
+    expect(customCard).toContain('data-launch-model-entry="public-api"');
     expect(customCard).toContain('data-launch-model-launchable="false"');
     expect(customCard).toContain('href="/docs/developers/custom-launch"');
     expect(customCard).not.toContain("disabled");
@@ -211,11 +211,11 @@ describe("unreleased launch model gating", () => {
       'id="launch-model-custom-title">Custom</strong>',
     );
     expect(html).toContain("Create a Classic coin");
-    expect(html).toContain('data-status="held">Held</small>');
+    expect(html).toContain('data-status="live">Live API</small>');
     expect(html).toContain(
-      "Package and validate a deterministic bundle locally. Public Custom creation remains held until the fee-enforced V2 release is activated.",
+      "Package, validate and submit a deterministic Custom launch through the public V2 API. Your connected wallet reviews and signs separately.",
     );
-    expect(html).toContain("Read API availability");
+    expect(html).toContain("Launch with the API");
     expect(html).not.toContain("approved GitHub revision");
     expect(html.indexOf('data-launch-model-option="classic"')).toBeLessThan(
       html.indexOf('data-launch-model-option="custom"'),
@@ -240,7 +240,7 @@ describe("unreleased launch model gating", () => {
     expect(html).not.toContain("Liquidity Growth");
   });
 
-  it("keeps the held Custom entry independent of the legacy gate", () => {
+  it("keeps the public Custom API entry independent of the legacy gate", () => {
     const html = renderToStaticMarkup(
       createElement(LaunchModelPicker, {
         onChoose: () => undefined,
@@ -250,12 +250,12 @@ describe("unreleased launch model gating", () => {
     expect(html).toContain('data-launch-model-option="prediction"');
     expect(html).toContain('data-launch-model-option="custom"');
     expect(html).toContain('id="launch-model-custom-title"');
-    expect(html).toContain('data-launch-model-available="false"');
-    expect(html).toContain('data-launch-model-entry="release-held"');
+    expect(html).toContain('data-launch-model-available="true"');
+    expect(html).toContain('data-launch-model-entry="public-api"');
     expect(html).toContain('data-launch-model-launchable="false"');
-    expect(html).toContain('data-status="held">Held</small>');
+    expect(html).toContain('data-status="live">Live API</small>');
     expect(html).toContain('href="/docs/developers/custom-launch"');
-    expect(html).toContain("Read API availability");
+    expect(html).toContain("Launch with the API");
     expect(html).not.toContain("approved GitHub revision");
     expect(html).not.toContain("Build or resume");
   });

--- a/tests/launch-model-motion.test.ts
+++ b/tests/launch-model-motion.test.ts
@@ -71,8 +71,8 @@ describe("launch model artwork", () => {
       'aria-describedby="launch-model-custom-description"',
     );
     expect(source).toContain('data-launch-model-option="custom"');
-    expect(source).toContain('data-launch-model-available="false"');
-    expect(source).toContain('data-launch-model-entry="release-held"');
+    expect(source).toContain('data-launch-model-available="true"');
+    expect(source).toContain('data-launch-model-entry="public-api"');
     expect(source).toContain('href="/docs/developers/custom-launch"');
     expect(source).not.toContain('onChoose("custom")');
     expect(source).not.toContain("customLaunchPublicEnabled");


### PR DESCRIPTION
## Summary
- publish the public GA 2.0.0 CLI surface and exact Rev3 profile identity
- expose public V2 OpenAPI, well-known discovery, and agent handoff while preserving V1 compatibility
- update canonical docs and Launch UI with Mainnet-only, fixed 10 bps treasury, separate wallet review/signing, and honest claim/buyback boundaries

## Exact identity
- profile hash: sha256:fd2d738117c4c69304efb49c75d402d2e8b8968832fd2e27548c3d9814c5c9ee
- policy repository: https://github.com/0xprogrammable/Launch-Policy
- policy source commit: 5f8b633dc8e43b3300bc9e05cb32d7d7b7ac406d
- canonical profile bytes: 8113

## Checks
- package tests: 23/23
- focused Vitest: 53/53
- typecheck: passed
- lint: 0 errors (35 existing warnings)
- production build plus neutrality and bundle scans: passed
- package dry-run: 42 files, programmable-launch-2.0.0.tgz
- OpenAPI JSON validation and git diff check: passed

## Release gate
Do not deploy this Website change until backend PR #114 is merged, deployed, and read back, and GitHub Release programmable-launch-v2.0.0 plus its tarball/checksum exist and are read back. No wallet signing or broadcast is included.