### PR TITLE
Fix public Custom discovery and CLI API errors

### DIFF
--- a/docs/public/developers/custom-launch.md
+++ b/docs/public/developers/custom-launch.md
@@ -37,7 +37,7 @@ Install the pinned public GitHub Release asset. Do not substitute an unverified 
 
 ```bash
 npm install --global \
-  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz
+  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.1/programmable-launch-2.0.1.tgz
 programmable-launch --version
 ```
 

--- a/docs/public/reference/official-links.md
+++ b/docs/public/reference/official-links.md
@@ -18,7 +18,7 @@ description: Official Programmable product, source, community and analytics link
 | Custom Launch V2 OpenAPI | [public creation and lifecycle contract](https://programmable.market/openapi/custom-launch-v2.json)               |
 | Custom Launch API      | [api.programmable.market](https://api.programmable.market)                                                         |
 | Custom API readiness    | [api.programmable.market/readyz](https://api.programmable.market/readyz)                                           |
-| Custom Launch CLI 2.0.0 | [public V2 GitHub Release asset](https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz) |
+| Custom Launch CLI 2.0.1 | [public V2 GitHub Release asset](https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.1/programmable-launch-2.0.1.tgz) |
 | Custom Launch CLI 1.0.1 | [V1 compatibility asset](https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz) |
 | Launch policy           | [github.com/0xprogrammable/launch-policy](https://github.com/0xprogrammable/launch-policy)                         |
 | Read-only developer API | [developers.programmable.family](https://developers.programmable.family)                                           |

--- a/lib/custom-launch/agent-setup-v1.ts
+++ b/lib/custom-launch/agent-setup-v1.ts
@@ -1,5 +1,5 @@
 export const PROGRAMMABLE_AGENT_SETUP_LINKS_V1 = Object.freeze({
-  cli: "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz",
+  cli: "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.1/programmable-launch-2.0.1.tgz",
   guide: "https://programmable.market/docs/developers/custom-launch",
   openApi: "https://programmable.market/openapi/custom-launch-v2.json",
   openApiV1Compatibility:

--- a/lib/developer-docs-content.ts
+++ b/lib/developer-docs-content.ts
@@ -23,7 +23,7 @@ const customLaunchHumanGuideUrl =
   "https://programmable.market/docs/developers/custom-launch";
 const customLaunchReadyzUrl = "https://api.programmable.market/readyz";
 const customLaunchCliReleaseUrl =
-  "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz";
+  "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.1/programmable-launch-2.0.1.tgz";
 
 const manifest = PROGRAMMABLE_LAUNCH_STAMP_MANIFEST;
 const router = manifest.launchStampRouter;

--- a/lib/server/custom-launch/well-known-v1.ts
+++ b/lib/server/custom-launch/well-known-v1.ts
@@ -59,11 +59,11 @@ export function programmableWellKnownDocumentV1(
         cli: Object.freeze({
           packageName: "@programmable/launch",
           binary: "programmable-launch",
-          releaseVersion: "2.0.0",
+          releaseVersion: "2.0.1",
           releaseUrl:
-            "https://github.com/0xprogrammable/PROGRAMMABLE/releases/tag/programmable-launch-v2.0.0",
+            "https://github.com/0xprogrammable/PROGRAMMABLE/releases/tag/programmable-launch-v2.0.1",
           tarballUrl:
-            "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz",
+            "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.1/programmable-launch-2.0.1.tgz",
         }),
       }),
       releaseCandidate: Object.freeze({
@@ -71,12 +71,12 @@ export function programmableWellKnownDocumentV1(
         publicAuthorization: true as const,
         packageName: "@programmable/launch",
         binary: "programmable-launch",
-        releaseVersion: "2.0.0",
-        releaseTag: "programmable-launch-v2.0.0",
+        releaseVersion: "2.0.1",
+        releaseTag: "programmable-launch-v2.0.1",
         releaseUrl:
-          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/tag/programmable-launch-v2.0.0",
+          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/tag/programmable-launch-v2.0.1",
         tarballUrl:
-          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz",
+          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.1/programmable-launch-2.0.1.tgz",
         openApiUrl:
           "https://programmable.market/openapi/custom-launch-v2.json",
         feePolicy: Object.freeze({
@@ -141,7 +141,9 @@ export function programmableWellKnownDocumentV1(
         discoveryStatus: "live" as const,
         publicSubmissionStatus: "closed" as const,
         customLaunchApiStatus: "live" as const,
-        registryDiscoveryStatus: manifest.status,
+        registryDiscoveryStatus: manifest.status === "live"
+          ? "live" as const
+          : "legacy-closed" as const,
         legacyRegistrySubmissionStatus: "closed" as const,
         legacyGithubSubmissionStatus: "closed" as const,
         registryAddress: manifest.contracts.registry.address?.toLowerCase() ?? null,

--- a/packages/launch/README.md
+++ b/packages/launch/README.md
@@ -15,12 +15,12 @@ programmable-launch --version
 That immutable release remains the V1 compatibility package. V1 request preparation and status reads remain valid,
 but new V1 submissions are read-only fenced with non-retryable `CUSTOM_LAUNCH_V1_READ_ONLY`.
 
-For public V2 preparation and submission, install the immutable `2.0.0` GitHub Release asset rather than an
+For public V2 preparation and submission, install the immutable `2.0.1` GitHub Release asset rather than an
 unverified npm-registry package with the same name:
 
 ```sh
 npm install --global \
-  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz
+  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.1/programmable-launch-2.0.1.tgz
 programmable-launch --version
 ```
 

--- a/packages/launch/bin/programmable-launch.mjs
+++ b/packages/launch/bin/programmable-launch.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 
-import { main } from "../src/cli.mjs";
+import { formatCliError, main } from "../src/cli.mjs";
 
 main(process.argv.slice(2)).catch((error) => {
-  const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`${message}\n`);
+  process.stderr.write(`${formatCliError(error)}\n`);
   process.exitCode = 1;
 });

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@programmable/launch",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Deterministic pack, validation, submission, and status tooling for the Programmable Custom Launch API",
   "type": "module",
   "bin": {

--- a/packages/launch/src/api-client.mjs
+++ b/packages/launch/src/api-client.mjs
@@ -24,6 +24,7 @@ import { validateLaunchFile } from "./validate.mjs";
 
 const IDEMPOTENCY_KEY = /^[A-Za-z0-9._:-]{16,128}$/;
 const REQUEST_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SAFE_API_CODE = /^[A-Z][A-Z0-9_]{0,63}$/;
 const MAX_SUBMISSION_JOURNAL_BYTES = 12_582_912;
 
 export class ProgrammableApiError extends Error {
@@ -260,14 +261,29 @@ function parseResponseBody(bytes, status) {
 function apiError(status, body, retryAfter) {
   const error = body?.error ?? body;
   return new ProgrammableApiError(
-    typeof error?.message === "string" ? error.message : `Custom Launch API returned HTTP ${status}`,
+    `Custom Launch API returned HTTP ${status}`,
     {
       httpStatus: status,
-      code: typeof error?.code === "string" ? error.code : null,
-      requestId: typeof error?.requestId === "string" ? error.requestId : null,
-      retryAfter,
+      code: safeApiCode(error?.code),
+      requestId: safeErrorRequestId(error?.requestId),
+      retryAfter: safeRetryAfter(retryAfter),
     },
   );
+}
+
+function safeApiCode(value) {
+  return typeof value === "string" && SAFE_API_CODE.test(value) ? value : null;
+}
+
+function safeErrorRequestId(value) {
+  return typeof value === "string" && REQUEST_ID.test(value) ? value : null;
+}
+
+function safeRetryAfter(value) {
+  if (typeof value !== "string") return null;
+  if (/^[0-9]{1,10}$/.test(value)) return value;
+  const when = Date.parse(value);
+  return Number.isFinite(when) ? new Date(when).toUTCString() : null;
 }
 
 function retryDelayMs(retryAfter, attempt) {

--- a/packages/launch/src/cli.mjs
+++ b/packages/launch/src/cli.mjs
@@ -8,7 +8,42 @@ import {
 } from "./constants.mjs";
 import { packLaunch } from "./pack.mjs";
 import { validateLaunchFile } from "./validate.mjs";
-import { statusLaunch, submitLaunch } from "./api-client.mjs";
+import { ProgrammableApiError, statusLaunch, submitLaunch } from "./api-client.mjs";
+
+const SAFE_API_CODE = /^[A-Z][A-Z0-9_]{0,63}$/;
+const SAFE_ERROR_REQUEST_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function formatCliError(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!(error instanceof ProgrammableApiError)) return message;
+  const details = error.details && typeof error.details === "object"
+    ? error.details
+    : {};
+  const safeDetails = {};
+  if (typeof details.code === "string" && SAFE_API_CODE.test(details.code)) {
+    safeDetails.code = details.code;
+  }
+  if (Number.isInteger(details.httpStatus)
+    && details.httpStatus >= 100
+    && details.httpStatus <= 599) {
+    safeDetails.httpStatus = details.httpStatus;
+  }
+  if (typeof details.requestId === "string"
+    && SAFE_ERROR_REQUEST_ID.test(details.requestId)) {
+    safeDetails.requestId = details.requestId;
+  }
+  if (typeof details.retryAfter === "string") {
+    if (/^[0-9]{1,10}$/.test(details.retryAfter)) {
+      safeDetails.retryAfter = details.retryAfter;
+    } else {
+      const retryAt = Date.parse(details.retryAfter);
+      if (Number.isFinite(retryAt)) safeDetails.retryAfter = new Date(retryAt).toUTCString();
+    }
+  }
+  return Object.keys(safeDetails).length === 0
+    ? message
+    : `${message}\nProgrammable API error details: ${JSON.stringify(safeDetails)}`;
+}
 
 export async function main(argv) {
   if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") {

--- a/packages/launch/src/constants.mjs
+++ b/packages/launch/src/constants.mjs
@@ -1,4 +1,4 @@
-export const PACKAGE_VERSION = "2.0.0";
+export const PACKAGE_VERSION = "2.0.1";
 export const PACK_CONFIG_SCHEMA_V1 = "programmable.launch-pack-config.v1";
 export const PACK_CONFIG_SCHEMA_V2 = "programmable.launch-pack-config.v2";
 export const PACK_CONFIG_SCHEMA = PACK_CONFIG_SCHEMA_V1;
@@ -38,8 +38,8 @@ export const RELEASE_TAG_V1 = "programmable-launch-v1.0.1";
 export const RELEASE_TARBALL_V1 = "programmable-launch-1.0.1.tgz";
 export const RELEASE_URL_V1 =
   `https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/${RELEASE_TAG_V1}/${RELEASE_TARBALL_V1}`;
-export const RELEASE_TAG = "programmable-launch-v2.0.0";
-export const RELEASE_TARBALL = "programmable-launch-2.0.0.tgz";
+export const RELEASE_TAG = "programmable-launch-v2.0.1";
+export const RELEASE_TARBALL = "programmable-launch-2.0.1.tgz";
 export const RELEASE_URL =
   `https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/${RELEASE_TAG}/${RELEASE_TARBALL}`;
 

--- a/packages/launch/test/launch.test.mjs
+++ b/packages/launch/test/launch.test.mjs
@@ -9,7 +9,12 @@ import test from "node:test";
 import solc from "solc";
 import { encodeAbiParameters, keccak256 } from "viem";
 
-import { statusLaunch, submitLaunch } from "../src/api-client.mjs";
+import {
+  ProgrammableApiError,
+  statusLaunch,
+  submitLaunch,
+} from "../src/api-client.mjs";
+import { formatCliError } from "../src/cli.mjs";
 import {
   HOOK_PERMISSION_BITS,
   HOOK_PERMISSIONS,
@@ -259,7 +264,7 @@ test("submit treats the V1 read-only 409 as non-retryable", async () => {
         error: {
           code: "CUSTOM_LAUNCH_V1_READ_ONLY",
           message: "V1 launch creation is read-only",
-          requestId: "v1-read-only-request",
+          requestId: "9be43bed-a5f2-4c15-b0d0-2f0f0ae942f0",
         },
       }), { status: 409, headers: { "content-type": "application/json" } });
     },
@@ -268,10 +273,59 @@ test("submit treats the V1 read-only 409 as non-retryable", async () => {
   }), (error) => {
     assert.equal(error.details.httpStatus, 409);
     assert.equal(error.details.code, "CUSTOM_LAUNCH_V1_READ_ONLY");
-    assert.equal(error.details.requestId, "v1-read-only-request");
+    assert.equal(error.details.requestId, "9be43bed-a5f2-4c15-b0d0-2f0f0ae942f0");
     return true;
   });
   assert.equal(networkCalls, 1);
+});
+
+test("CLI renders only safe API error details", async () => {
+  const apiKey = "pm_live_must_never_be_rendered";
+  const requestBytes = '{"sourceDescriptor":"must-never-be-rendered"}';
+  let caught;
+  try {
+    await statusLaunch({
+      requestId: "836b6989-bac4-4f39-98ab-828c7231fbf1",
+      maxAttempts: 1,
+      apiOrigin: "http://127.0.0.1:43197",
+      fetchImpl: async () => new Response(JSON.stringify({
+        error: {
+          code: "RATE_LIMITED",
+          message: `unsafe echo ${apiKey} ${requestBytes}`,
+          requestId: "af9c0ec0-ff27-4a48-9ff5-8d99bc11e667",
+          authorization: apiKey,
+          requestBody: requestBytes,
+        },
+      }), {
+        status: 429,
+        headers: { "retry-after": "17", "content-type": "application/json" },
+      }),
+      loadApiKeyImpl: async () => apiKey,
+    });
+  } catch (error) {
+    caught = error;
+  }
+  const rendered = formatCliError(caught);
+  assert.equal(
+    rendered,
+    'Custom Launch API returned HTTP 429\nProgrammable API error details: {"code":"RATE_LIMITED","httpStatus":429,"requestId":"af9c0ec0-ff27-4a48-9ff5-8d99bc11e667","retryAfter":"17"}',
+  );
+  assert.ok(!rendered.includes(apiKey));
+  assert.ok(!rendered.includes(requestBytes));
+  assert.ok(!rendered.includes("authorization"));
+  assert.ok(!rendered.includes("requestBody"));
+
+  const rejectedDetails = formatCliError(new ProgrammableApiError(
+    "Custom Launch API request failed",
+    {
+      code: apiKey,
+      httpStatus: 999,
+      requestId: apiKey,
+      retryAfter: requestBytes,
+      requestBody: requestBytes,
+    },
+  ));
+  assert.equal(rejectedDetails, "Custom Launch API request failed");
 });
 
 test("status honors Retry-After and stops at the wallet handoff", async () => {

--- a/public/developers/custom-launch-api-v1.md
+++ b/public/developers/custom-launch-api-v1.md
@@ -34,7 +34,7 @@ Install only the immutable GitHub Release asset:
 
 ```sh
 npm install --global \
-  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz
+  https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.1/programmable-launch-2.0.1.tgz
 programmable-launch --version
 ```
 

--- a/public/openapi/custom-launch-v2.json
+++ b/public/openapi/custom-launch-v2.json
@@ -37,20 +37,20 @@
     "status": "promoted-to-public",
     "packageName": "@programmable/launch",
     "binary": "programmable-launch",
-    "version": "2.0.0",
-    "tag": "programmable-launch-v2.0.0",
-    "releaseUrl": "https://github.com/0xprogrammable/PROGRAMMABLE/releases/tag/programmable-launch-v2.0.0",
-    "tarballUrl": "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz",
+    "version": "2.0.1",
+    "tag": "programmable-launch-v2.0.1",
+    "releaseUrl": "https://github.com/0xprogrammable/PROGRAMMABLE/releases/tag/programmable-launch-v2.0.1",
+    "tarballUrl": "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.1/programmable-launch-2.0.1.tgz",
     "launchProfileHash": "sha256:fd2d738117c4c69304efb49c75d402d2e8b8968832fd2e27548c3d9814c5c9ee",
     "productionLaunchAuthorized": true
   },
   "x-programmable-release": {
     "packageName": "@programmable/launch",
     "binary": "programmable-launch",
-    "version": "2.0.0",
-    "tag": "programmable-launch-v2.0.0",
-    "releaseUrl": "https://github.com/0xprogrammable/PROGRAMMABLE/releases/tag/programmable-launch-v2.0.0",
-    "tarballUrl": "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz",
+    "version": "2.0.1",
+    "tag": "programmable-launch-v2.0.1",
+    "releaseUrl": "https://github.com/0xprogrammable/PROGRAMMABLE/releases/tag/programmable-launch-v2.0.1",
+    "tarballUrl": "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.1/programmable-launch-2.0.1.tgz",
     "launchProfileHash": "sha256:fd2d738117c4c69304efb49c75d402d2e8b8968832fd2e27548c3d9814c5c9ee",
     "productionLaunchAuthorized": true
   },
@@ -622,7 +622,7 @@
       },
       "FeeEnforcedLaunchProfileV2": {
         "type": "object",
-        "description": "Frozen Rev3 production profile. The server requires the canonical JSON to match the durable public profile byte for byte; the 2.0.0 package derives it from the exact distributed assets.",
+        "description": "Frozen Rev3 production profile. The server requires the canonical JSON to match the durable public profile byte for byte; the 2.0.1 package derives it from the exact distributed assets.",
         "required": [
           "schemaVersion",
           "profileId",

--- a/tests/custom-launch-cli-public-surface.test.ts
+++ b/tests/custom-launch-cli-public-surface.test.ts
@@ -43,18 +43,18 @@ describe("public Custom Launch CLI surface", () => {
         cli: {
           packageName: "@programmable/launch",
           binary: "programmable-launch",
-          releaseVersion: "2.0.0",
+          releaseVersion: "2.0.1",
           tarballUrl:
-            "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz",
+            "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.1/programmable-launch-2.0.1.tgz",
         },
       },
       releaseCandidate: {
         status: "promoted-to-public",
         publicAuthorization: true,
-        releaseVersion: "2.0.0",
-        releaseTag: "programmable-launch-v2.0.0",
+        releaseVersion: "2.0.1",
+        releaseTag: "programmable-launch-v2.0.1",
         tarballUrl:
-          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.0/programmable-launch-2.0.0.tgz",
+          "https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v2.0.1/programmable-launch-2.0.1.tgz",
         openApiUrl:
           "https://programmable.market/openapi/custom-launch-v2.json",
         feePolicy: {
@@ -104,11 +104,12 @@ describe("public Custom Launch CLI surface", () => {
       discoveryStatus: "live",
       publicSubmissionStatus: "closed",
       customLaunchApiStatus: "live",
-      registryDiscoveryStatus: "prelaunch",
+      registryDiscoveryStatus: "legacy-closed",
       legacyRegistrySubmissionStatus: "closed",
       legacyGithubSubmissionStatus: "closed",
     });
     expect(JSON.stringify(document)).not.toContain("api-live");
+    expect(JSON.stringify(document)).not.toContain("prelaunch");
   });
 
   it("publishes a public, reference-complete V2 contract", () => {
@@ -133,7 +134,7 @@ describe("public Custom Launch CLI surface", () => {
     });
     expect(v2["x-programmable-release-candidate"]).toMatchObject({
       status: "promoted-to-public",
-      version: "2.0.0",
+      version: "2.0.1",
       launchProfileHash:
         "sha256:fd2d738117c4c69304efb49c75d402d2e8b8968832fd2e27548c3d9814c5c9ee",
       productionLaunchAuthorized: true,

--- a/tests/custom-launch-docs.test.ts
+++ b/tests/custom-launch-docs.test.ts
@@ -98,7 +98,7 @@ describe("Custom Launch API documentation", () => {
 
   it("publishes the exact-source and no-broadcast cold-agent path", () => {
     for (const source of [gitBookGuide, rawGuide, developerDocsMarkdown]) {
-      expect(source).toContain("programmable-launch-2.0.0.tgz");
+      expect(source).toContain("programmable-launch-2.0.1.tgz");
       expect(source).toContain("verificationBundle");
       expect(source).toContain("exact_match");
       expect(source).toContain("PROGRAMMABLE_API_KEY");


### PR DESCRIPTION
## Outcome
- report an absent legacy Custom Registry as `legacy-closed`, never `prelaunch`, while public V2 Custom discovery remains live
- render only whitelisted API error code, HTTP status, UUID request ID, and normalized Retry-After in the CLI
- stop reflecting server error messages so echoed API keys or request bytes cannot reach stderr
- ship the CLI-only fix as immutable version 2.0.1 while retaining API and Rev3 profile schema version 2.0.0

## Focused verification
- `npm test` in `packages/launch`: 24/24 passed
- `vitest` public CLI surface, docs, and API-key setup: 24/24 passed
- `npm run pack:dry-run`: 42 files, package 2.0.1
- targeted ESLint: zero errors (one pre-existing unused-variable warning in the package test)
- `git diff --check`: passed

No wallet action, broadcast, provider mutation, or secret output was performed.