### PR TITLE
Fix stale V3 launch copy before production promotion

### DIFF
--- a/app/docs/creators/launch/page.tsx
+++ b/app/docs/creators/launch/page.tsx
@@ -61,7 +61,7 @@ export default function CreatorLaunchDocsPage() {
             <span>
               Keep contracts, tests, deployment logic and public project data
               together in the bundle described by the V3 API schema. The CLI
-              release includes the exact rev2 no-broadcast example at{" "}
+              release includes the exact V3 no-broadcast example at{" "}
               <code>examples/direct-native-v3-no-broadcast/README.md</code>.
             </span>
           </li>
@@ -69,8 +69,8 @@ export default function CreatorLaunchDocsPage() {
             <strong>Run the project checks.</strong>
             <span>
               Compile, test and verify the graph bundle before sending it to the
-              API. The API rechecks the declared manifest digest and exact graph
-              bindings, but does not reproduce your build.
+              API. The API rebuilds and binds the exact source and compilation
+              outputs, but does not reproduce project-specific tests.
             </span>
           </li>
           <li>

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -112,7 +112,7 @@ export default function DocsIndexPage() {
             <h3>Creators</h3>
             <p>
               Build and package a concrete project locally, then use the public
-              V2 API for a wallet-owned Custom launch on Ethereum Mainnet.
+              V3 API for a wallet-owned Custom launch on Ethereum Mainnet.
             </p>
           </div>
           <div>

--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -302,7 +302,7 @@ export function LaunchModelPicker({
           id="launch-model-custom-description"
         >
           Package, validate and submit a deterministic Custom launch through
-          the public V2 API. Your connected wallet reviews and signs separately.
+          the public V3 API. Your connected wallet reviews and signs separately.
         </span>
         <span
           className={`launch-model-action ${launchExperience.modelAction}`}

--- a/tests/docs-information-architecture.test.ts
+++ b/tests/docs-information-architecture.test.ts
@@ -246,7 +246,9 @@ describe("Docs information architecture", () => {
     expect(creatorLaunchPage).toContain("The API does not control your wallet");
     expect(creatorLaunchPage).toContain("Manage Custom launch API keys");
     expect(creatorLaunchPage).toContain("CUSTOM_LAUNCH_V1_READ_ONLY");
-    expect(creatorLaunchPage).toContain("does not reproduce your build");
+    expect(creatorLaunchPage).toContain(
+      "does not reproduce project-specific tests",
+    );
     expect(creatorLaunchPage).not.toContain(
       "Open public wallet self-service is not active",
     );

--- a/tests/launch-model-gating.test.ts
+++ b/tests/launch-model-gating.test.ts
@@ -213,7 +213,7 @@ describe("unreleased launch model gating", () => {
     expect(html).toContain("Create a Classic coin");
     expect(html).toContain('data-status="live">Live API</small>');
     expect(html).toContain(
-      "Package, validate and submit a deterministic Custom launch through the public V2 API. Your connected wallet reviews and signs separately.",
+      "Package, validate and submit a deterministic Custom launch through the public V3 API. Your connected wallet reviews and signs separately.",
     );
     expect(html).toContain("Launch with the API");
     expect(html).not.toContain("approved GitHub revision");


### PR DESCRIPTION
## Outcome\n\nAligns the visible Custom launch and creator documentation copy with the already merged V3 public contract.\n\n## Changes\n\n- names the live Custom surface as V3 in the launch picker and docs index\n- names the packaged no-broadcast example as V3\n- states the exact-source rebuild boundary accurately without claiming project-specific tests are reproduced\n\n## Validation\n\n- focused ESLint on all three changed files\n- stale-copy search\n- git diff --check\n\nNo API, CLI, contract, deployment, secret, wallet or onchain behavior changes.