### PR TITLE
Bound prediction market cold loads

### DIFF
--- a/components/prediction-market-directory.tsx
+++ b/components/prediction-market-directory.tsx
@@ -1,14 +1,23 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowRight, Plus } from "lucide-react";
+import { ArrowRight, Plus, RotateCw } from "lucide-react";
 import type { CSSProperties } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { ExploreModeSwitch } from "@/components/explore-mode-switch";
 import styles from "@/components/prediction-market-experience.module.css";
 import { predictionPreviewMarkets } from "@/components/prediction-market-preview";
-import { getPredictionMarketReleaseConfig } from "@/lib/prediction-market-chain";
+import {
+  createPredictionMarketPublicClients,
+  getPredictionMarketReleaseConfig,
+} from "@/lib/prediction-market-chain";
+import {
+  PREDICTION_DIRECTORY_LOAD_DEADLINE_MS,
+  PREDICTION_DIRECTORY_PAGE_SIZE,
+  PredictionDirectoryReadTimeoutError,
+  readPredictionDirectoryWithinDeadline,
+} from "@/lib/prediction-directory-load-policy";
 import { predictionMarketErrorMessage } from "@/lib/prediction-market-errors";
 import {
   formatPredictionPriceAtoms,
@@ -26,7 +35,10 @@ type DirectoryState =
     }
   | { kind: "error"; message: string };
 
-const DIRECTORY_PAGE_SIZE = 12;
+const DIRECTORY_TIMEOUT_MESSAGE =
+  "Two-provider verification did not finish in time. No unverified market data was shown.";
+const DIRECTORY_UNAVAILABLE_MESSAGE =
+  "The verified market list could not be loaded. No unverified market data was shown.";
 
 function errorMessage(error: unknown) {
   return predictionMarketErrorMessage(
@@ -127,10 +139,14 @@ export function PredictionMarketDirectoryView() {
   const [state, setState] = useState<DirectoryState>({ kind: "loading" });
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [olderError, setOlderError] = useState("");
+  const [retryGeneration, setRetryGeneration] = useState(0);
+  const olderRequestRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     let active = true;
-    if (!release.config) {
+    const controller = new AbortController();
+    const config = release.config;
+    if (!config) {
       const timer = window.setTimeout(() => {
         if (!active) return;
         setState({
@@ -143,9 +159,14 @@ export function PredictionMarketDirectoryView() {
         window.clearTimeout(timer);
       };
     }
-    void readPredictionMarketDirectory({
-      config: release.config,
-      limit: DIRECTORY_PAGE_SIZE,
+    void readPredictionDirectoryWithinDeadline({
+      read: (signal) => readPredictionMarketDirectory({
+        clients: createPredictionMarketPublicClients(config, { signal }),
+        config,
+        limit: PREDICTION_DIRECTORY_PAGE_SIZE,
+      }),
+      signal: controller.signal,
+      timeoutMs: PREDICTION_DIRECTORY_LOAD_DEADLINE_MS,
     })
       .then((directory) => {
         if (active) {
@@ -157,29 +178,48 @@ export function PredictionMarketDirectoryView() {
         }
       })
       .catch((error) => {
-        if (active) setState({ kind: "error", message: errorMessage(error) });
+        if (!active || controller.signal.aborted) return;
+        setState({
+          kind: "error",
+          message: error instanceof PredictionDirectoryReadTimeoutError
+            ? DIRECTORY_TIMEOUT_MESSAGE
+            : DIRECTORY_UNAVAILABLE_MESSAGE,
+        });
       });
     return () => {
       active = false;
+      controller.abort();
+      olderRequestRef.current?.abort();
+      olderRequestRef.current = null;
     };
-  }, [release.config]);
+  }, [release.config, retryGeneration]);
 
   async function loadOlderMarkets() {
+    const config = release.config;
     if (
-      !release.config ||
+      !config ||
       state.kind !== "live" ||
       state.nextCursor === 0n ||
       loadingOlder
     )
       return;
+    const controller = new AbortController();
+    olderRequestRef.current?.abort();
+    olderRequestRef.current = controller;
     setLoadingOlder(true);
     setOlderError("");
     try {
-      const directory = await readPredictionMarketDirectory({
-        config: release.config,
-        cursor: state.nextCursor,
-        limit: DIRECTORY_PAGE_SIZE,
+      const directory = await readPredictionDirectoryWithinDeadline({
+        read: (signal) => readPredictionMarketDirectory({
+          clients: createPredictionMarketPublicClients(config, { signal }),
+          config,
+          cursor: state.nextCursor,
+          limit: PREDICTION_DIRECTORY_PAGE_SIZE,
+        }),
+        signal: controller.signal,
+        timeoutMs: PREDICTION_DIRECTORY_LOAD_DEADLINE_MS,
       });
+      if (controller.signal.aborted) return;
       setState((current) => {
         if (current.kind !== "live") return current;
         const known = new Set(
@@ -197,13 +237,26 @@ export function PredictionMarketDirectoryView() {
         };
       });
     } catch (error) {
-      setOlderError(errorMessage(error));
+      if (controller.signal.aborted) return;
+      setOlderError(
+        error instanceof PredictionDirectoryReadTimeoutError
+          ? DIRECTORY_TIMEOUT_MESSAGE
+          : DIRECTORY_UNAVAILABLE_MESSAGE,
+      );
     } finally {
-      setLoadingOlder(false);
+      if (olderRequestRef.current === controller) {
+        olderRequestRef.current = null;
+        setLoadingOlder(false);
+      }
     }
   }
 
   const markets = "markets" in state ? state.markets : [];
+
+  function retryDirectory() {
+    setState({ kind: "loading" });
+    setRetryGeneration((current) => current + 1);
+  }
 
   return (
     <main className={`page-width ${styles.directoryPage}`}>
@@ -228,16 +281,27 @@ export function PredictionMarketDirectoryView() {
       {release.error ? (
         <p className={styles.errorBanner}>{release.error}</p>
       ) : null}
-      {state.kind === "error" ? (
-        <p className={styles.errorBanner} role="alert">
-          {state.message}
-        </p>
-      ) : null}
-
-      <section className={styles.directoryList} aria-label="Prediction markets">
+      <section
+        aria-busy={state.kind === "loading" || loadingOlder || undefined}
+        className={styles.directoryList}
+        aria-label="Prediction markets"
+      >
         {state.kind === "loading" ? (
           <div className={styles.marketLoading} aria-live="polite">
             Loading predictions…
+          </div>
+        ) : state.kind === "error" ? (
+          <div className={styles.marketLoading} aria-live="polite">
+            <strong>Predictions are temporarily unavailable</strong>
+            <span>{state.message}</span>
+            <button
+              className={`${styles.loadMoreMarkets} ${styles.retryMarkets}`}
+              onClick={retryDirectory}
+              type="button"
+            >
+              <RotateCw aria-hidden="true" size={15} />
+              Retry
+            </button>
           </div>
         ) : markets.length ? (
           <div className={styles.marketGrid}>

--- a/components/prediction-market-experience.module.css
+++ b/components/prediction-market-experience.module.css
@@ -189,6 +189,15 @@
   z-index: 1;
 }
 
+.marketCardPrices > span {
+  min-width: 0;
+  width: 50%;
+}
+
+.marketCardPrices > span:last-child {
+  text-align: right;
+}
+
 .marketCardBody {
   display: block;
   min-height: 118px;
@@ -293,6 +302,14 @@
   cursor: wait;
 }
 
+.retryMarkets {
+  align-items: center;
+  display: inline-flex;
+  gap: 7px;
+  justify-content: center;
+  margin-top: 14px;
+}
+
 .detailBack {
   align-items: center;
   color: var(--webde-muted);
@@ -370,6 +387,7 @@
 }
 
 .heroProbability > div {
+  align-content: center;
   background: color-mix(in srgb, var(--market-green) 10%, var(--webde-surface));
   border: 1px solid
     color-mix(in srgb, var(--market-green) 28%, var(--webde-line));
@@ -1849,13 +1867,7 @@
   }
 
   .heroProbability > div {
-    align-items: flex-start;
-    flex-direction: column;
     gap: 5px;
-  }
-
-  .heroProbability > div:nth-child(2) {
-    align-items: flex-end;
   }
 
   .tradeTerminal {

--- a/lib/prediction-directory-load-policy.ts
+++ b/lib/prediction-directory-load-policy.ts
@@ -1,0 +1,63 @@
+export const PREDICTION_DIRECTORY_PAGE_SIZE = 4;
+export const PREDICTION_DIRECTORY_LOAD_DEADLINE_MS = 8_000;
+
+export class PredictionDirectoryReadTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Prediction directory read exceeded ${timeoutMs}ms`);
+    this.name = "PredictionDirectoryReadTimeoutError";
+  }
+}
+type PredictionDirectoryReadInput<Result> = Readonly<{
+  read: (signal: AbortSignal) => Promise<Result>;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}>;
+
+function supersededError() {
+  return new DOMException(
+    "Prediction directory read was superseded",
+    "AbortError",
+  );
+}
+
+export async function readPredictionDirectoryWithinDeadline<Result>({
+  read,
+  signal,
+  timeoutMs = PREDICTION_DIRECTORY_LOAD_DEADLINE_MS,
+}: PredictionDirectoryReadInput<Result>): Promise<Result> {
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 1) {
+    throw new TypeError("Prediction directory timeout must be a positive integer");
+  }
+  if (signal?.aborted) throw signal.reason ?? supersededError();
+
+  const controller = new AbortController();
+  const timeoutError = new PredictionDirectoryReadTimeoutError(timeoutMs);
+  const abortFromParent = () => {
+    controller.abort(signal?.reason ?? supersededError());
+  };
+  signal?.addEventListener("abort", abortFromParent, { once: true });
+
+  let rejectAbort: ((reason: unknown) => void) | undefined;
+  const abortResult = new Promise<never>((_resolve, reject) => {
+    rejectAbort = reject;
+  });
+  const rejectOnAbort = () => {
+    rejectAbort?.(controller.signal.reason ?? supersededError());
+  };
+  controller.signal.addEventListener("abort", rejectOnAbort, { once: true });
+
+  const timeout = globalThis.setTimeout(() => {
+    controller.abort(timeoutError);
+  }, timeoutMs);
+
+  try {
+    return await Promise.race([
+      Promise.resolve().then(() => read(controller.signal)),
+      abortResult,
+    ]);
+  } finally {
+    globalThis.clearTimeout(timeout);
+    signal?.removeEventListener("abort", abortFromParent);
+    controller.signal.removeEventListener("abort", rejectOnAbort);
+  }
+}

--- a/lib/prediction-market-chain.ts
+++ b/lib/prediction-market-chain.ts
@@ -36,6 +36,7 @@ const PREDICTION_MAX_RPC_HEAD_DIVERGENCE = 300n;
 const PREDICTION_GAS_BUFFER_PERCENT = 120n;
 const PREDICTION_MAX_GAS_LIMIT = 10_000_000n;
 const PREDICTION_MULTICALL_BATCH_SIZE = 64;
+const PREDICTION_RPC_HTTP_BATCH_SIZE = 64;
 const PREDICTION_SECONDARY_RPC_HOST = "robinhood-mainnet.g.alchemy.com";
 const UINT256_MAX = (1n << 256n) - 1n;
 
@@ -454,10 +455,21 @@ export function getPredictionMarketReleaseConfig() {
 
 export function createPredictionMarketPublicClients(
   config = getPredictionMarketReleaseConfig(),
+  options: Readonly<{
+    signal?: AbortSignal;
+    timeoutMs?: number;
+  }> = {},
 ) {
   if (!config) {
     throw new Error("The prediction market release is not configured");
   }
+  const timeout = options.timeoutMs ?? 10_000;
+  if (!Number.isInteger(timeout) || timeout < 1) {
+    throw new TypeError("The prediction RPC timeout must be a positive integer");
+  }
+  const fetchOptions = options.signal
+    ? { fetchOptions: { signal: options.signal } }
+    : {};
   return [
     createPublicClient({
       batch: {
@@ -468,8 +480,10 @@ export function createPredictionMarketPublicClients(
       },
       chain: robinhoodChain,
       transport: http(ROBINHOOD_MAINNET_RPC_URL, {
+        ...fetchOptions,
+        batch: { batchSize: PREDICTION_RPC_HTTP_BATCH_SIZE, wait: 0 },
         retryCount: 1,
-        timeout: 10_000,
+        timeout,
       }),
     }),
     createPublicClient({
@@ -481,8 +495,10 @@ export function createPredictionMarketPublicClients(
       },
       chain: robinhoodChain,
       transport: http(config.secondaryRpcUrl, {
+        ...fetchOptions,
+        batch: { batchSize: PREDICTION_RPC_HTTP_BATCH_SIZE, wait: 0 },
         retryCount: 1,
-        timeout: 10_000,
+        timeout,
       }),
     }),
   ] as const;

--- a/tests/prediction-directory-load-policy.test.ts
+++ b/tests/prediction-directory-load-policy.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  PREDICTION_DIRECTORY_PAGE_SIZE,
+  PredictionDirectoryReadTimeoutError,
+  readPredictionDirectoryWithinDeadline,
+} from "../lib/prediction-directory-load-policy";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("prediction directory cold-load policy", () => {
+  it("keeps the first settled quorum page to one four-market batch", () => {
+    expect(PREDICTION_DIRECTORY_PAGE_SIZE).toBe(4);
+  });
+
+  it("aborts and settles a reader that ignores its own transport timeout", async () => {
+    vi.useFakeTimers();
+    let readSignal: AbortSignal | undefined;
+    const result = readPredictionDirectoryWithinDeadline({
+      read: async (signal) => {
+        readSignal = signal;
+        return await new Promise<never>(() => undefined);
+      },
+      timeoutMs: 25,
+    });
+    const observed = result.catch((error: unknown) => error);
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(await observed).toBeInstanceOf(
+      PredictionDirectoryReadTimeoutError,
+    );
+    expect(readSignal?.aborted).toBe(true);
+  });
+
+  it("returns only a reader result that settled before the deadline", async () => {
+    vi.useFakeTimers();
+    const result = readPredictionDirectoryWithinDeadline({
+      read: async (signal) => {
+        expect(signal.aborted).toBe(false);
+        return "quorum-valid" as const;
+      },
+      timeoutMs: 25,
+    });
+
+    await expect(result).resolves.toBe("quorum-valid");
+    await vi.advanceTimersByTimeAsync(25);
+  });
+
+  it("aborts a superseded read without turning it into a timeout", async () => {
+    const controller = new AbortController();
+    const reason = new DOMException("superseded", "AbortError");
+    let readSignal: AbortSignal | undefined;
+    const result = readPredictionDirectoryWithinDeadline({
+      read: async (signal) => {
+        readSignal = signal;
+        return await new Promise<never>(() => undefined);
+      },
+      signal: controller.signal,
+      timeoutMs: 25,
+    }).catch((error: unknown) => error);
+
+    controller.abort(reason);
+
+    expect(await result).toBe(reason);
+    expect(readSignal?.aborted).toBe(true);
+  });
+
+  it("binds retry copy and equal mobile YES/NO alignment in the UI source", () => {
+    const component = readFileSync(
+      join(process.cwd(), "components/prediction-market-directory.tsx"),
+      "utf8",
+    );
+    const styles = readFileSync(
+      join(process.cwd(), "components/prediction-market-experience.module.css"),
+      "utf8",
+    );
+
+    expect(component).toContain("No unverified market data was shown.");
+    expect(component).toContain("onClick={retryDirectory}");
+    expect(styles).toMatch(
+      /\.heroProbability > div\s*\{[^}]*align-content:\s*center;/su,
+    );
+    expect(styles).toMatch(
+      /\.marketCardPrices > span\s*\{[^}]*width:\s*50%;/su,
+    );
+    expect(styles).toMatch(
+      /\.marketCardPrices > span:last-child\s*\{[^}]*text-align:\s*right;/su,
+    );
+  });
+});

--- a/tests/prediction-market-chain.test.ts
+++ b/tests/prediction-market-chain.test.ts
@@ -31,14 +31,51 @@ describe("prediction market RPC policy", () => {
     expect(secondary.batch?.multicall).toEqual({ batchSize: 64, wait: 0 });
   });
 
+  it("coalesces concurrent JSON-RPC reads into one bounded provider request", async () => {
+    const requestBodies: unknown[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input, init) => {
+        const body = JSON.parse(String(init?.body)) as
+          | Readonly<{ id: number; method: string }>
+          | readonly Readonly<{ id: number; method: string }>[];
+        requestBodies.push(body);
+        const requests = Array.isArray(body) ? body : [body];
+        return new Response(
+          JSON.stringify(requests.map((request) => ({
+            id: request.id,
+            jsonrpc: "2.0",
+            result: request.method === "eth_chainId" ? "0x1237" : "0x1",
+          }))),
+          { headers: { "content-type": "application/json" }, status: 200 },
+        );
+      }),
+    );
+    const primary = createPredictionMarketPublicClients(config)[0];
+
+    await Promise.all([primary.getBlockNumber(), primary.getChainId()]);
+
+    expect(requestBodies).toHaveLength(1);
+    expect(requestBodies[0]).toBeInstanceOf(Array);
+    expect(requestBodies[0]).toHaveLength(2);
+  });
+
   it("binds the secondary client to the configured Alchemy endpoint", async () => {
     const requests: string[] = [];
     vi.stubGlobal(
       "fetch",
-      vi.fn(async (input) => {
+      vi.fn(async (input, init) => {
         requests.push(String(input));
+        const body = JSON.parse(String(init?.body)) as
+          | Readonly<{ id: number }>
+          | readonly Readonly<{ id: number }>[];
+        const batch = Array.isArray(body) ? body : [body];
         return new Response(
-          JSON.stringify({ id: 0, jsonrpc: "2.0", result: "0x1" }),
+          JSON.stringify(batch.map((request) => ({
+            id: request.id,
+            jsonrpc: "2.0",
+            result: "0x1",
+          }))),
           { headers: { "content-type": "application/json" }, status: 200 },
         );
       }),


### PR DESCRIPTION
## Outcome

- Coalesces simultaneous JSON-RPC calls into bounded HTTP batches on each independent provider.
- Reduces the first verified directory page from twelve markets to one four-market batch; older markets remain available through Show more.
- Applies one abortable eight-second wall-clock deadline to initial and pagination reads.
- Replaces indefinite loading with a neutral Retry state and never renders partial or unverified market data.
- Makes mobile YES and NO alignment explicit and removes ineffective flex declarations from grid cells.

## Safety boundary

- Strict two-provider quorum and all existing release, block, market, pool, and contract reconciliation remain unchanged.
- The disabled Prediction V2 release remains disabled.
- No fallback data, preview identity, or invented market state is introduced.

## Focused evidence

- 49 focused Vitest checks passed.
- TypeScript passed.
- Changed TypeScript ESLint passed.
- git diff --check passed.
- A read-only live probe confirmed the public primary provider accepts the bounded JSON-RPC batch and reports chain 4663.