### PR TITLE
Fix Custom Launch V3 list release probe

### DIFF
--- a/scripts/probe-custom-launch-v3-release.mjs
+++ b/scripts/probe-custom-launch-v3-release.mjs
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 const MAX_JSON_BYTES = 2 * 1024 * 1024;
 const SHA256 = /^sha256:[0-9a-f]{64}$/u;
 const COMMIT = /^[0-9a-f]{40}$/u;
+const CURSOR = /^[A-Za-z0-9_-]{16,512}$/u;
 
 function canonicalize(value) {
   if (value === null || ["boolean", "number", "string"].includes(typeof value)) {
@@ -171,10 +172,17 @@ export async function probeCustomLaunchV3Release(input) {
     headers: headers(undefined, input.apiKey),
   }, fetchImpl);
   const list = parseJson(listResult.bytes, "Custom Launch API V3 list");
+  if (listResult.response.status !== 200) {
+    throw new Error("authenticated V3 list canary failed");
+  }
+  exactKeys(list, ["schemaVersion", "launches", "nextCursor"],
+    "Custom Launch API V3 list");
   if (
-    listResult.response.status !== 200
-    || list?.schemaVersion !== "programmable.custom-launch-list.v3"
-    || !Array.isArray(list.items)
+    list.schemaVersion !== "programmable.custom-launch-list.v3"
+    || !Array.isArray(list.launches)
+    || (list.nextCursor !== null && (
+      typeof list.nextCursor !== "string" || !CURSOR.test(list.nextCursor)
+    ))
   ) throw new Error("authenticated V3 list canary failed");
 
   return Object.freeze({

--- a/scripts/test/custom-launch-v2-release-gate.test.mjs
+++ b/scripts/test/custom-launch-v2-release-gate.test.mjs
@@ -489,6 +489,11 @@ test("stage probe is GET-only and returns redacted no-broadcast evidence", async
   };
   observation.api.readinessIdentitySha256 = digest(Buffer.from(canonicalize(readiness)));
   const calls = [];
+  let listBody = {
+    schemaVersion: "programmable.custom-launch-list.v3",
+    launches: [],
+    nextCursor: null,
+  };
   const fetchImpl = async (input, init) => {
     const url = new URL(input);
     calls.push({ url: url.href, method: init.method, authorization: init.headers.authorization });
@@ -502,9 +507,7 @@ test("stage probe is GET-only and returns redacted no-broadcast evidence", async
     if (url.pathname === "/readyz") return Response.json(readiness, {
       headers: { "cache-control": "no-store" },
     });
-    if (url.pathname === "/v3/custom-launches") return Response.json({
-      schemaVersion: "programmable.custom-launch-list.v3", items: [],
-    });
+    if (url.pathname === "/v3/custom-launches") return Response.json(listBody);
     return new Response("not found", { status: 404 });
   };
   const evidence = await probeCustomLaunchV3Release({
@@ -522,6 +525,21 @@ test("stage probe is GET-only and returns redacted no-broadcast evidence", async
   assert.equal(JSON.stringify(evidence).includes("canary-secret-value"), false);
   assert.deepEqual(new Set(calls.map((call) => call.method)), new Set(["GET"]));
   assert.equal(calls.at(-1).authorization, "Bearer canary-secret-value");
+
+  listBody = {
+    schemaVersion: "programmable.custom-launch-list.v3",
+    items: [],
+    nextCursor: null,
+  };
+  await assert.rejects(() => probeCustomLaunchV3Release({
+    websiteUrl: "https://launcher-candidate.vercel.app",
+    websiteDeploymentId: "dpl_candidateProduction123456789",
+    expectedWebsiteCommitSha: hashes.a,
+    apiReleaseObservation: observation,
+    apiKey: "canary-secret-value",
+    vercelBypassSecret: "bypass-secret-value",
+    fetchImpl,
+  }), /Custom Launch API V3 list has an unexpected shape/u);
 });
 
 test("production workflow has an additive V3 stage lane and no promotion mutation", async () => {


### PR DESCRIPTION
## Summary

- validate the live V3 list response as `{ schemaVersion, launches, nextCursor }`
- reject the obsolete `items` shape and malformed cursors
- cover both the production response contract and the regression case

## Focused verification

- `node --test scripts/test/custom-launch-v2-release-gate.test.mjs` (8/8)
- `node --check scripts/probe-custom-launch-v3-release.mjs`
- `node --check scripts/test/custom-launch-v2-release-gate.test.mjs`
- `git diff --check`

No deployment or production alias change is included.