### PR TITLE
Bind custom launch release gate to profile 3.2

### DIFF
--- a/docs/operations/releases/custom-launch-v2/backend-release-binding.schema.json
+++ b/docs/operations/releases/custom-launch-v2/backend-release-binding.schema.json
@@ -64,7 +64,8 @@
           "enum": [
             "migrations/0007_direct_native_hook_profile_v3.sql",
             "migrations/0008_direct_native_platform_admission_v3.sql",
-            "migrations/0010_durable_launch_lifecycle_queue_v3.sql"
+            "migrations/0010_durable_launch_lifecycle_queue_v3.sql",
+            "migrations/0011_custom_launch_project_metadata_v3.sql"
           ]
         },
         "schemaEvidenceSha256": { "$ref": "#/$defs/sha256" }
@@ -79,7 +80,7 @@
         "readinessIdentitySha256": { "$ref": "#/$defs/sha256" },
         "apiContractSha256": { "$ref": "#/$defs/sha256" },
         "profileId": { "const": "programmable.direct-native-hook-graph.v1" },
-        "profileVersion": { "enum": ["2.0.0", "3.0.0", "3.1.0"] },
+        "profileVersion": { "enum": ["2.0.0", "3.0.0", "3.1.0", "3.2.0"] },
         "publicProfilePath": {
           "enum": [
             "services/custom-launch-api-v1/release/direct-native-hook-graph-admission-profile.v2.json",
@@ -157,6 +158,28 @@
               "type": "object",
               "properties": {
                 "profileVersion": { "const": "3.1.0" },
+                "publicProfilePath": {
+                  "const": "services/custom-launch-api-v1/release/direct-native-hook-graph-admission-profile.v3.json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "database": {
+              "type": "object",
+              "properties": {
+                "lastMigration": {
+                  "const": "migrations/0011_custom_launch_project_metadata_v3.sql"
+                }
+              }
+            },
+            "api": {
+              "type": "object",
+              "properties": {
+                "profileVersion": { "const": "3.2.0" },
                 "publicProfilePath": {
                   "const": "services/custom-launch-api-v1/release/direct-native-hook-graph-admission-profile.v3.json"
                 }

--- a/docs/operations/releases/custom-launch-v2/backend-release-binding.template.json
+++ b/docs/operations/releases/custom-launch-v2/backend-release-binding.template.json
@@ -25,7 +25,7 @@
   },
   "database": {
     "migrationInventorySha256": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-    "lastMigration": "migrations/0010_durable_launch_lifecycle_queue_v3.sql",
+    "lastMigration": "migrations/0011_custom_launch_project_metadata_v3.sql",
     "schemaEvidenceSha256": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
   },
   "api": {
@@ -33,7 +33,7 @@
     "readinessIdentitySha256": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     "apiContractSha256": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     "profileId": "programmable.direct-native-hook-graph.v1",
-    "profileVersion": "3.1.0",
+    "profileVersion": "3.2.0",
     "publicProfilePath": "services/custom-launch-api-v1/release/direct-native-hook-graph-admission-profile.v3.json",
     "publicProfileSha256": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
   },

--- a/scripts/generate-custom-launch-api-release-binding-v1.mjs
+++ b/scripts/generate-custom-launch-api-release-binding-v1.mjs
@@ -33,8 +33,8 @@ const LAUNCH_PACKAGE_MANIFEST_PATH = "packages/launch/package.json";
 const PUBLIC_PROFILE_SCHEMA_VERSION =
   "programmable.direct-native-hook-graph-admission-profile.v3";
 const PUBLIC_PROFILE_ID = "programmable.direct-native-hook-graph.v1";
-const PUBLIC_PROFILE_VERSION = "3.1.0";
-const LAUNCH_PACKAGE_VERSION = "3.3.1";
+const PUBLIC_PROFILE_VERSION = "3.2.0";
+const LAUNCH_PACKAGE_VERSION = "3.3.2";
 const PLATFORM_ADMISSION_POLICY = Object.freeze({
   schemaVersion: "programmable.direct-native-platform-admission-policy.v1",
   mode: "deterministic-exact-source-graph-static-baseline-v1",
@@ -93,6 +93,7 @@ const EXPECTED_MIGRATIONS = Object.freeze([
   "0008_direct_native_platform_admission_v3.sql",
   "0009_admit_eip3009_authorization_patch_v2.sql",
   "0010_durable_launch_lifecycle_queue_v3.sql",
+  "0011_custom_launch_project_metadata_v3.sql",
 ]);
 const EXPECTED_SUPABASE_MIGRATIONS = Object.freeze([
   "20260824110842_programmable_custom_launch_api_private_schema_v1.sql",
@@ -105,11 +106,13 @@ const EXPECTED_SUPABASE_MIGRATIONS = Object.freeze([
   "20260826045034_direct_native_platform_admission_v3.sql",
   "20260826105310_admit_eip3009_authorization_patch_v2.sql",
   "20260826135927_durable_launch_lifecycle_queue_v3.sql",
+  "20260826175335_custom_launch_project_metadata_v3.sql",
 ]);
 const EXPECTED_API_ROUTES = Object.freeze([
   Object.freeze({ method: "GET", path: "/v3/capabilities" }),
   Object.freeze({ method: "GET", path: "/v3/custom-launches" }),
   Object.freeze({ method: "GET", path: "/v3/custom-launches/{id}" }),
+  Object.freeze({ method: "GET", path: "/v3/finalized-custom-launches" }),
   Object.freeze({ method: "GET", path: "/v3/wallet-admin/custom-launches" }),
   Object.freeze({ method: "GET", path: "/v3/wallet-admin/custom-launches/{id}" }),
   Object.freeze({ method: "POST", path: "/v3/custom-launches" }),
@@ -401,7 +404,7 @@ function validateWebsiteArtifacts(publicOpenApiBytes, launchPackageManifestBytes
     || openApi?.["x-programmable-admission-policy"]?.currentProfileVersion
       !== PUBLIC_PROFILE_VERSION
     || canonicalize(openApi?.["x-programmable-admission-policy"]
-      ?.legacyExactProfileVersions) !== canonicalize(["3.0.0"])
+      ?.legacyExactProfileVersions) !== canonicalize(["3.1.0", "3.0.0"])
     || openApi?.["x-programmable-admission-policy"]?.manualProjectAllowlist !== false
     || canonicalize(openApi?.["x-programmable-admission-policy"]
       ?.hardBlockFindingRules) !== canonicalize(
@@ -411,7 +414,7 @@ function validateWebsiteArtifacts(publicOpenApiBytes, launchPackageManifestBytes
   }
   if (launchPackage?.name !== "@programmable/launch"
     || launchPackage?.version !== LAUNCH_PACKAGE_VERSION) {
-    throw new Error("launch package manifest is not the 3.3.1 public CLI contract");
+    throw new Error("launch package manifest is not the 3.3.2 public CLI contract");
   }
 }
 

--- a/scripts/test/custom-launch-v2-release-gate.test.mjs
+++ b/scripts/test/custom-launch-v2-release-gate.test.mjs
@@ -133,7 +133,7 @@ async function stagingFixture() {
     },
     database: {
       migrationInventorySha256: record.subject.apiService.migrationInventorySha256,
-      lastMigration: "migrations/0010_durable_launch_lifecycle_queue_v3.sql",
+      lastMigration: "migrations/0011_custom_launch_project_metadata_v3.sql",
       schemaEvidenceSha256: hashes.nine,
     },
     api: {
@@ -175,15 +175,25 @@ test("V2 template validates without granting staging authority", async () => {
   assert.equal(record.recordStatus, "draft");
 });
 
-test("backend binding schema pairs current 3.1 and compatible 3.0/2.0 evidence", async () => {
+test("backend binding schema pairs current 3.2 and compatible 3.1/3.0/2.0 evidence", async () => {
   const currentBytes = await readFile(new URL(
     "../../docs/operations/releases/custom-launch-v2/backend-release-binding.template.json",
     import.meta.url,
   ));
   const current = parseDeterministicCustomLaunchApiReleaseBindingV1(currentBytes);
-  assert.equal(current.api.profileVersion, "3.1.0");
+  assert.equal(current.api.profileVersion, "3.2.0");
   assert.match(current.api.publicProfilePath, /admission-profile\.v3\.json$/u);
-  assert.match(current.database.lastMigration, /0010_durable_launch_lifecycle_queue_v3/u);
+  assert.match(current.database.lastMigration, /0011_custom_launch_project_metadata_v3/u);
+
+  const prior = clone(current);
+  prior.api.profileVersion = "3.1.0";
+  prior.database.lastMigration =
+    "migrations/0010_durable_launch_lifecycle_queue_v3.sql";
+  const priorBytes = Buffer.from(`${JSON.stringify(prior, null, 2)}\n`);
+  assert.equal(
+    parseDeterministicCustomLaunchApiReleaseBindingV1(priorBytes).api.profileVersion,
+    "3.1.0",
+  );
 
   const compatible = clone(current);
   compatible.api.profileVersion = "3.0.0";

--- a/scripts/test/custom-launch-v3-release-generators.test.mjs
+++ b/scripts/test/custom-launch-v3-release-generators.test.mjs
@@ -35,6 +35,7 @@ const runtimeMigrations = Object.freeze([
   "0008_direct_native_platform_admission_v3.sql",
   "0009_admit_eip3009_authorization_patch_v2.sql",
   "0010_durable_launch_lifecycle_queue_v3.sql",
+  "0011_custom_launch_project_metadata_v3.sql",
 ]);
 const supabaseMigrations = Object.freeze([
   "20260824110842_programmable_custom_launch_api_private_schema_v1.sql",
@@ -47,11 +48,13 @@ const supabaseMigrations = Object.freeze([
   "20260826045034_direct_native_platform_admission_v3.sql",
   "20260826105310_admit_eip3009_authorization_patch_v2.sql",
   "20260826135927_durable_launch_lifecycle_queue_v3.sql",
+  "20260826175335_custom_launch_project_metadata_v3.sql",
 ]);
 const apiRoutes = Object.freeze([
   Object.freeze({ method: "GET", path: "/v3/capabilities" }),
   Object.freeze({ method: "GET", path: "/v3/custom-launches" }),
   Object.freeze({ method: "GET", path: "/v3/custom-launches/{id}" }),
+  Object.freeze({ method: "GET", path: "/v3/finalized-custom-launches" }),
   Object.freeze({ method: "GET", path: "/v3/wallet-admin/custom-launches" }),
   Object.freeze({ method: "GET", path: "/v3/wallet-admin/custom-launches/{id}" }),
   Object.freeze({ method: "POST", path: "/v3/custom-launches" }),
@@ -133,28 +136,28 @@ async function releaseFixture(t) {
   const backendRoot = join(root, "backend");
   await json(join(websiteRoot, "public/openapi/custom-launch-v3.json"), {
     openapi: "3.1.0",
-    info: { title: "fixture", version: "3.3.1" },
+    info: { title: "fixture", version: "3.3.2" },
     "x-programmable-profile": {
       profileId: "programmable.direct-native-hook-graph.v1",
-      profileVersion: "3.1.0",
+      profileVersion: "3.2.0",
       profileRevision: 3,
       productionLaunchAuthorized: true,
     },
     "x-programmable-admission-policy": {
-      currentProfileVersion: "3.1.0",
-      legacyExactProfileVersions: ["3.0.0"],
+      currentProfileVersion: "3.2.0",
+      legacyExactProfileVersions: ["3.1.0", "3.0.0"],
       manualProjectAllowlist: false,
       hardBlockFindingRules: platformAdmissionPolicy.blockingFindingRules,
     },
   });
   await json(join(websiteRoot, "packages/launch/package.json"), {
     name: "@programmable/launch",
-    version: "3.3.1",
+    version: "3.3.2",
   });
   const profile = {
     schemaVersion: "programmable.direct-native-hook-graph-admission-profile.v3",
     profileId: "programmable.direct-native-hook-graph.v1",
-    profileVersion: "3.1.0",
+    profileVersion: "3.2.0",
     profileRevision: 3,
     productionLaunchAuthorized: true,
     platformAdmissionPolicy,
@@ -164,7 +167,7 @@ async function releaseFixture(t) {
     schemaVersion: "programmable.custom-launch-api-contract.v3",
     requestSchemaVersion: "programmable.custom-launch-create-request.v3",
     profileId: "programmable.direct-native-hook-graph.v1",
-    profileVersion: "3.1.0",
+    profileVersion: "3.2.0",
     routes: apiRoutes,
   };
   await json(join(
@@ -301,7 +304,7 @@ test("binding generator derives exact revision 3 artifacts and retained database
   assert.equal(binding.backend.candidateTreeSha, fixture.backend.tree);
   assert.equal(binding.website.candidateCommitSha, fixture.website.commit);
   assert.equal(binding.website.candidateTreeSha, fixture.website.tree);
-  assert.equal(binding.api.profileVersion, "3.1.0");
+  assert.equal(binding.api.profileVersion, "3.2.0");
   assert.match(binding.api.publicProfilePath, /admission-profile\.v3\.json$/u);
   assert.equal(binding.fly.imageTag, `main-${fixture.backend.commit.slice(0, 12)}`);
   assert.equal(binding.fly.imageDigest, `sha256:${"9".repeat(64)}`);
@@ -310,9 +313,9 @@ test("binding generator derives exact revision 3 artifacts and retained database
   assert.equal(binding.database.schemaEvidenceSha256, sha256(databaseEvidenceBytes));
   assert.equal(databaseEvidence.status, "passed");
   assert.equal(binding.database.lastMigration,
-    "migrations/0010_durable_launch_lifecycle_queue_v3.sql");
-  assert.equal(databaseEvidence.supabaseMigrationList.migrations.length, 10);
-  assert.equal(databaseEvidence.mirrorByteChecks.length, 10);
+    "migrations/0011_custom_launch_project_metadata_v3.sql");
+  assert.equal(databaseEvidence.supabaseMigrationList.migrations.length, 11);
+  assert.equal(databaseEvidence.mirrorByteChecks.length, 11);
   assert.ok(databaseEvidence.mirrorByteChecks.every((check) => check.byteEqual));
   assert.equal((await stat(result.outputPath)).mode & 0o777, 0o600);
   const beforeRetry = Buffer.from(bindingBytes);


### PR DESCRIPTION
Updates the signed Custom Launch API release binder to the already-published profile 3.2 / CLI 3.3.2 contract, adds the metadata migration and finalized metadata route, and preserves historical 2.0/3.0/3.1 binding validation.\n\nFocused checks:\n- node --test scripts/test/custom-launch-v3-release-generators.test.mjs\n- node --test scripts/test/custom-launch-v2-release-gate.test.mjs\n- git diff --check