### PR TITLE
Fix Explore Classic and Custom filter races

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -46,6 +46,7 @@ const CLASSIC_EXCLUSIONS = Object.freeze([
 
 const EXPLORE_QUERY_PARAMETERS = new Set([
   "limit",
+  "model",
   "page",
   "q",
   "socials",
@@ -185,9 +186,14 @@ function filterExploreEntries(
   entries: readonly ExploreEntry[],
   query: string,
   socials: "yes" | "no" | null,
+  model: "classic" | "custom" | null,
 ): ExploreEntry[] {
   const normalized = query.trim().toLowerCase().replace(/^\$/u, "");
   return entries.filter((entry) => {
+    if (
+      model !== null &&
+      entry.launchCategoryProvenance.category !== model
+    ) return false;
     const hasSocials = entry.links?.some(
       (link) => link.kind === "x" || link.kind === "telegram",
     ) ?? false;
@@ -251,10 +257,16 @@ export function paginateExploreEntriesV1(
     pageSize: number;
     query: string;
     socials: "yes" | "no" | null;
+    model: "classic" | "custom" | null;
     sort: ExploreSort;
   }>,
 ) {
-  const filtered = filterExploreEntries(entries, input.query, input.socials);
+  const filtered = filterExploreEntries(
+    entries,
+    input.query,
+    input.socials,
+    input.model,
+  );
   return paginateEntries(sortExploreEntries(filtered, input.sort), input);
 }
 
@@ -285,6 +297,14 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  const model = search.get("model");
+  if (model !== null && model !== "classic" && model !== "custom") {
+    return NextResponse.json(
+      { error: "Unsupported launch model filter" },
+      { status: 400, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
   try {
     const options = {
       query: search.get("q")?.trim() ?? "",
@@ -292,6 +312,7 @@ export async function GET(request: NextRequest) {
       page: integerQuery(search.get("page"), 1),
       pageSize: integerQuery(search.get("limit"), 9),
       socials,
+      model,
     } as const;
     const catalogRead = readEnvioClassicV3CatalogV1({
       signal: readSignal,
@@ -454,6 +475,7 @@ export async function GET(request: NextRequest) {
         identityEntries,
         options.query,
         options.socials,
+        options.model,
       );
       const valued = await readDexscreenerExploreEntriesV1(filtered, {
         signal: readSignal,
@@ -467,6 +489,7 @@ export async function GET(request: NextRequest) {
         ...options,
         query: "",
         socials: null,
+        model: null,
       });
     } else {
       const identityPage = paginateExploreEntriesV1(identityEntries, options);

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -5,7 +5,10 @@ import { Suspense } from "react";
 
 import { GET as readExploreResponse } from "@/app/api/explore/route";
 import { ExploreView } from "@/components/explore-view";
-import type { ExploreInitialResponse } from "@/components/explore-view";
+import type {
+  ExploreInitialResponse,
+  ExploreModelFilter,
+} from "@/components/explore-view";
 import { DEFAULT_EXPLORE_VIEW_SORT } from "@/lib/explore-defaults";
 
 export const dynamic = "force-dynamic";
@@ -20,6 +23,29 @@ export const INITIAL_EXPLORE_QUERY = new URLSearchParams({
   page: "1",
   limit: "9",
 }).toString();
+
+type ExplorePageSearchParams = Promise<
+  Record<string, string | string[] | undefined>
+>;
+
+export function initialExploreModelFilter(
+  value: string | string[] | undefined,
+): ExploreModelFilter {
+  if (value === "classic") return "classic";
+  if (value === "custom") return "custom-hook";
+  return "all";
+}
+
+export function initialExploreQuery(modelFilter: ExploreModelFilter) {
+  const query = new URLSearchParams(INITIAL_EXPLORE_QUERY);
+  if (modelFilter !== "all") {
+    query.set(
+      "model",
+      modelFilter === "custom-hook" ? "custom" : "classic",
+    );
+  }
+  return query.toString();
+}
 
 function unavailableInitialExploreResponse(): ExploreInitialResponse {
   return {
@@ -67,17 +93,23 @@ function isLocalPreviewHost(host: string | null) {
   );
 }
 
-async function InitialExploreView() {
-  const requestHeaders = await headers();
+async function InitialExploreView({
+  searchParams,
+}: Readonly<{ searchParams: ExplorePageSearchParams }>) {
+  const [requestHeaders, resolvedSearchParams] = await Promise.all([
+    headers(),
+    searchParams,
+  ]);
+  const modelFilter = initialExploreModelFilter(resolvedSearchParams.model);
   if (isLocalPreviewHost(requestHeaders.get("host"))) {
-    return <ExploreView />;
+    return <ExploreView initialModelFilter={modelFilter} />;
   }
 
   const initialResponse = await readInitialExploreWithinDeadline(
     async (signal) => {
       // prettier-ignore
       const response = await readExploreResponse(new NextRequest(
-        `http://programmable.local/api/explore?${INITIAL_EXPLORE_QUERY}`,
+        `http://programmable.local/api/explore?${initialExploreQuery(modelFilter)}`,
         {
           headers: { Accept: "application/json" },
           signal,
@@ -88,13 +120,20 @@ async function InitialExploreView() {
     },
   );
 
-  return <ExploreView initialResponse={initialResponse} />;
+  return (
+    <ExploreView
+      initialResponse={initialResponse}
+      initialModelFilter={modelFilter}
+    />
+  );
 }
 
-export default function ExplorePage() {
+export default function ExplorePage({
+  searchParams,
+}: Readonly<{ searchParams: ExplorePageSearchParams }>) {
   return (
     <Suspense fallback={<ExploreView loadingOnly />}>
-      <InitialExploreView />
+      <InitialExploreView searchParams={searchParams} />
     </Suspense>
   );
 }

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -2178,10 +2178,12 @@ function resultRangeLabel(payload: ExplorePayload | null) {
 
 export function ExploreView({
   initialResponse,
+  initialModelFilter = "all",
   loadingOnly = false,
   embedded = false,
 }: Readonly<{
   initialResponse?: ExploreInitialResponse;
+  initialModelFilter?: ExploreModelFilter;
   loadingOnly?: boolean;
   embedded?: boolean;
 }> = {}) {
@@ -2194,7 +2196,9 @@ export function ExploreView({
   );
   const [ageSort, setAgeSort] = useState<ExploreAgeSort>("none");
   const [socialFilter, setSocialFilter] = useState<ExploreSocialFilter>("all");
-  const [modelFilter, setModelFilter] = useState<ExploreModelFilter>("all");
+  const [modelFilter, setModelFilter] = useState<ExploreModelFilter>(
+    initialModelFilter,
+  );
   const [currentPage, setCurrentPage] = useState(1);
   const pageSize = useExploreTokensPerPage();
   const [retryKey, setRetryKey] = useState(0);
@@ -2211,8 +2215,7 @@ export function ExploreView({
   const filterRef = useRef<HTMLDetailsElement>(null);
   const sort = resolveExploreServerSort(valuationSort, ageSort);
   const requiresCompleteDataset =
-    modelFilter !== "all" ||
-    (valuationSort !== "none" && ageSort !== "none");
+    valuationSort !== "none" && ageSort !== "none";
   const contentKey = `${debouncedQuery}\u0000${valuationSort}\u0000${ageSort}\u0000${socialFilter}\u0000${modelFilter}\u0000${currentPage}\u0000${pageSize}`;
   const requestKey = `${contentKey}\u0000${retryKey}`;
   const modelDatasetKey = `${debouncedQuery}\u0000${valuationSort}\u0000${ageSort}\u0000${socialFilter}\u0000${modelFilter}\u0000${retryKey}`;
@@ -2341,7 +2344,7 @@ export function ExploreView({
       valuationSort === initialValuationSort &&
       ageSort === "none" &&
       socialFilter === "all" &&
-      modelFilter === "all" &&
+      modelFilter === initialModelFilter &&
       currentPage === 1 &&
       retryKey === 0;
     const responsiveInitialState = createResponsiveExploreInitialState(
@@ -2369,17 +2372,6 @@ export function ExploreView({
       return;
     }
 
-    if (handledRequestKey.current === requestKey) {
-      activeExploreContentKey.current = activeRequestContentKey;
-      if (initialState?.phase === "ready") {
-        cacheResolvedExplorePayload(
-          activeRequestContentKey,
-          initialState.payload,
-        );
-      }
-      return;
-    }
-
     initialResponseReuseAvailable.current = false;
 
     let ignore = false;
@@ -2396,6 +2388,12 @@ export function ExploreView({
     });
     if (socialFilter !== "all") {
       search.set("socials", socialFilter);
+    }
+    if (modelFilter !== "all") {
+      search.set(
+        "model",
+        modelFilter === "custom-hook" ? "custom" : "classic",
+      );
     }
 
     async function loadTokens() {
@@ -2475,6 +2473,7 @@ export function ExploreView({
     modelFilter,
     pageSize,
     initialResponse,
+    initialModelFilter,
     initialState,
     loadingOnly,
     preview,
@@ -2581,10 +2580,26 @@ export function ExploreView({
     setRetryKey((value) => value + 1);
   }
 
+  function updateModelFilter(next: ExploreModelFilter) {
+    setModelFilter(next);
+    setCurrentPage(1);
+    const url = new URL(window.location.href);
+    if (next === "all") {
+      url.searchParams.delete("model");
+    } else {
+      url.searchParams.set(
+        "model",
+        next === "custom-hook" ? "custom" : "classic",
+      );
+    }
+    window.history.replaceState(window.history.state, "", url);
+  }
+
   function renderTokenState() {
     if (
       displayState.phase === "loading" ||
-      (displayState.phase === "error" && displayState.requestKey !== requestKey)
+      ("requestKey" in displayState &&
+        displayState.requestKey !== requestKey)
     ) {
       return (
         <div className={styles.loadingState} aria-busy="true">
@@ -2641,10 +2656,9 @@ export function ExploreView({
               onClick={() => {
                 setQuery("");
                 setSocialFilter("all");
-                setModelFilter("all");
+                updateModelFilter("all");
                 setValuationSort("highest");
                 setAgeSort("none");
-                setCurrentPage(1);
                 searchInputRef.current?.focus();
               }}
             >
@@ -2934,10 +2948,9 @@ export function ExploreView({
                             type="button"
                             aria-pressed={modelFilter === option.id}
                             onClick={() => {
-                              setModelFilter((current) =>
-                                current === option.id ? "all" : option.id,
+                              updateModelFilter(
+                                modelFilter === option.id ? "all" : option.id,
                               );
-                              setCurrentPage(1);
                             }}
                           >
                             <span>{option.label}</span>

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -299,6 +299,34 @@ describe("Explore static identity and Dexscreener market contract", () => {
     );
   });
 
+  it("filters Classic and Custom launch categories before pagination", async () => {
+    mocks.readRouter.mockResolvedValue([customGraphExploreEntry]);
+
+    const customResponse = await GET(
+      request("sort=market-cap&page=1&limit=9&model=custom"),
+    );
+    const customBody = await json(customResponse);
+    expect(customResponse.status).toBe(200);
+    expect(customBody.total).toBe(1);
+    expect(customBody.tokens).toHaveLength(1);
+    expect(customBody.tokens[0].launchCategoryProvenance.category).toBe(
+      "custom",
+    );
+    expect(mocks.readDex.mock.calls.at(-1)?.[0]).toHaveLength(1);
+
+    const classicResponse = await GET(
+      request("sort=newest&page=1&limit=9&model=classic"),
+    );
+    const classicBody = await json(classicResponse);
+    expect(classicResponse.status).toBe(200);
+    expect(classicBody.total).toBe(TOKEN_COUNT);
+    expect(classicBody.tokens).toHaveLength(9);
+    expect(classicBody.tokens.every((entry: ExploreEntry) =>
+      entry.launchCategoryProvenance.category === "classic"
+    )).toBe(true);
+    expect(mocks.readDex.mock.calls.at(-1)?.[0]).toHaveLength(9);
+  });
+
   it("keeps a finalized Router identity visible when Envio is unavailable", async () => {
     mocks.readCatalog.mockRejectedValue(new Error("Envio unavailable"));
     mocks.readRouter.mockResolvedValue([customGraphExploreEntry]);
@@ -605,7 +633,14 @@ describe("Explore static identity and Dexscreener market contract", () => {
     });
   });
 
-  it.each(["unknown=value", "page=0", "limit=abc", "q=a&q=b", "socials=maybe"])(
+  it.each([
+    "unknown=value",
+    "page=0",
+    "limit=abc",
+    "q=a&q=b",
+    "socials=maybe",
+    "model=anything",
+  ])(
     "rejects unsupported query shape: %s",
     async (query) => {
       const response = await GET(request(query));

--- a/tests/explore-page-ssr.test.ts
+++ b/tests/explore-page-ssr.test.ts
@@ -7,6 +7,8 @@ vi.mock("next/headers", () => ({ headers: vi.fn() }));
 import {
   INITIAL_EXPLORE_TIMEOUT_MS,
   INITIAL_EXPLORE_QUERY,
+  initialExploreModelFilter,
+  initialExploreQuery,
   readInitialExploreWithinDeadline,
 } from "../app/explore/page";
 import { DEFAULT_EXPLORE_VIEW_SORT } from "../lib/explore-defaults";
@@ -26,6 +28,21 @@ describe("Explore initial server read", () => {
 
     expect(DEFAULT_EXPLORE_VIEW_SORT).toBe("market-cap");
     expect(query.get("sort")).toBe(DEFAULT_EXPLORE_VIEW_SORT);
+  });
+
+  it("hydrates public Classic and Custom links into the matching API filter", () => {
+    expect(initialExploreModelFilter("classic")).toBe("classic");
+    expect(initialExploreModelFilter("custom")).toBe("custom-hook");
+    expect(initialExploreModelFilter("anything")).toBe("all");
+    expect(initialExploreModelFilter(["custom"])).toBe("all");
+
+    expect(new URLSearchParams(initialExploreQuery("classic")).get("model"))
+      .toBe("classic");
+    expect(
+      new URLSearchParams(initialExploreQuery("custom-hook")).get("model"),
+    ).toBe("custom");
+    expect(new URLSearchParams(initialExploreQuery("all")).has("model"))
+      .toBe(false);
   });
 
   it("returns at the total deadline and safely consumes the aborted read", async () => {

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -23,8 +23,11 @@ describe("Explore UI contract", () => {
     expect(page).toContain("controller.abort()");
     expect(page).not.toContain("AbortSignal.timeout(");
     expect(page).not.toContain('fetch("https://programmable.market');
-    expect(page).toContain("<ExploreView initialResponse={initialResponse} />");
-    expect(source).toContain("if (handledRequestKey.current === requestKey)");
+    expect(page).toContain("initialResponse={initialResponse}");
+    expect(page).toContain("initialModelFilter={modelFilter}");
+    expect(source).not.toContain(
+      "if (handledRequestKey.current === requestKey)",
+    );
     expect(source).toContain(
       "handledInitialExploreRequestKey(initialState, requestKey)",
     );
@@ -241,6 +244,13 @@ describe("Explore UI contract", () => {
     expect(source).toContain("ageSortOptions.map((option) => (");
     expect(source).toContain("setValuationSort((current) =>");
     expect(source).toContain("setAgeSort((current) =>");
+    expect(source).toContain('search.set(\n        "model",');
+    expect(source).toContain(
+      'modelFilter === "custom-hook" ? "custom" : "classic"',
+    );
+    expect(source).toContain("initialModelFilter = \"all\"");
+    expect(source).toContain("window.history.replaceState(");
+    expect(source.match(/setModelFilter\(/gu)).toHaveLength(1);
     expect(source).not.toContain("setSort(option.id)");
     expect(styles).toMatch(
       /\.runnersIntro :global\(\.token-filter\)\s*\{[^}]*flex:\s*0 0 122px;[^}]*width:\s*122px;/s,


### PR DESCRIPTION
## Summary
- filter Classic and Custom launches server-side before pagination and market enrichment
- hydrate and synchronize `?model=classic|custom` deep links
- replace stale-category cards with the existing loading state and remove the cache-poisoning request shortcut

## Verification
- `vitest`: 95 focused Explore tests passed; parallel audit ran 142 related tests passed
- `npm run typecheck`
- focused ESLint on changed files
- `git diff --check`
- rendered QA at 1440x900 and 390x844, including 25ms rapid filter alternation, keyboard-accessible controls, zero page errors, and zero horizontal overflow

## Production build
A local webpack fallback was not a valid release signal because existing CSS modules require the repository default Turbopack build; the fallback also hit local disk ENOSPC. The protected PR/Vercel Turbopack build is the authoritative build gate.