### PR TITLE
Repair MetaMask fee claim console

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -98,6 +98,16 @@ paths = ['''public/policies/custom-launch-agent-remediation-v1\.json''']
 regexes = ['''(?i)0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48''']
 
 [[allowlists]]
+description = "Private claim console demo pins public FADE and PCAN token addresses"
+condition = "AND"
+regexTarget = "match"
+paths = ['''ops/protocol-fee-claim/app\.js''']
+regexes = [
+  '''(?i)0x69d278968abf120f878f2e1e016ab615d3686c19''',
+  '''(?i)0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce''',
+]
+
+[[allowlists]]
 description = "FADE trade capability pins public onchain identifiers and runtime hashes"
 condition = "AND"
 regexTarget = "match"
@@ -214,4 +224,18 @@ paths = [
 regexes = [
   '''(?i)0x06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9''',
   '''(?i)0x06ddf6e1ee758fde18425dbce46ccddab61afc4d83b90d27febdf928d8a18bfc''',
+]
+
+[[allowlists]]
+description = "Fee claim console pins reviewed public SHARD and PCR2 token addresses"
+condition = "AND"
+regexTarget = "match"
+paths = [
+  '''ops/protocol-fee-claim/claim-discovery\.json''',
+  '''ops/protocol-fee-claim/logic\.mjs''',
+  '''ops/protocol-fee-claim/logic\.test\.mjs''',
+]
+regexes = [
+  '''(?i)0xface73b63787960282f2d4682d3752beb25271ad''',
+  '''(?i)0xd0f3e1e5c985d2b37a66cf07fecb0d8191c0445f''',
 ]

--- a/app/docs/developers/indexing/page.tsx
+++ b/app/docs/developers/indexing/page.tsx
@@ -21,6 +21,7 @@ const manifest = PROGRAMMABLE_LAUNCH_STAMP_MANIFEST;
 const router = manifest.launchStampRouter;
 const reads = PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI;
 const events = Object.values(router.events);
+const CLAIM_CONSOLE_MAX_FINALIZED_SPREAD_BLOCKS = 32;
 
 const indexingSections = [
   { id: "scope", label: "When to index" },
@@ -178,6 +179,13 @@ export default function IndexLaunchesPage() {
           <li>
             Read bounded <code>eth_getLogs</code> chunks from{" "}
             <code>{router.startBlock}</code> through a finalized boundary.
+            For a fee-claim inventory, require the Wallet RPC and two
+            independent public RPCs to report finalized views no more than{" "}
+            <code>{CLAIM_CONSOLE_MAX_FINALIZED_SPREAD_BLOCKS}</code> blocks apart.
+            Use the oldest view as the safe boundary, require all three RPCs to
+            return its exact block hash, then compare the complete raw log
+            tuples through that boundary. Any disagreement is{" "}
+            <code>INDETERMINATE</code> and must block execution.
           </li>
           <li>
             Require the exact Router emitter and published topic signatures,
@@ -291,19 +299,42 @@ export default function IndexLaunchesPage() {
             version hook; the legacy V1 aggregate hook remains a separate row.
           </li>
           <li>
-            Custom V1 replays the complete Registry history, then verifies each
-            current launch state, runtime, recipient, fee policy and accrued
-            amount at one block. Every future finalized standard 5 or 10 bps
-            source is discovered without editing a coin list.
+            A Router-stamped Classic launch is covered automatically only when
+            its exact hook matches a known verified aggregate hook. An unknown
+            Classic hook remains visible and blocks the combined claim.
+          </li>
+          <li>
+            The complete Registry history remains available for audit, but
+            Custom Registry V1 is retired as a live discovery or claim source.
+          </li>
+          <li>
+            Router-stamped Custom launches come from a bounded common
+            consensus-finalized checkpoint and raw-log replay agreed by the
+            Wallet RPC and two independent public RPCs. Each candidate is
+            reproduced through the Router record, identity lookup, component
+            proof, runtime and displayed claim balance at that same checkpoint.
+          </li>
+          <li>
+            A Custom claim requires an exact reviewed profile bound to its
+            launch ID, token, fee source and runtime. FADE uses its native
+            accumulator, SHARD uses a direct launcher-fee claim, PCAN redeems
+            both PoolManager currencies in one call and PCR2 claims its native
+            and token balances as two independent fee-Vault calls. Only positive
+            balances enter the batch. Future Router-stamped Custom launches are
+            discovered and stay visible, but a new or unknown ABI blocks the
+            combined claim until its exact profile is reviewed. The console
+            does not offer universal arbitrary Custom support and never guesses
+            calldata.
           </li>
           <li>
             Stock claims use the published fixed release asset set. New Stock
             assets are not inferred or silently added.
           </li>
           <li>
-            Custom V2 sources remain unavailable until an exact deployed,
-            finalized release binding exists. Unknown, revoked, mismatched or
-            unverified sources block execution instead of being omitted.
+            Custom V2 remains unavailable until an exact deployed, finalized
+            release binding exists. Unknown, mismatched or unverified bindings
+            block execution. Quarantined sources remain visible and
+            non-executable.
           </li>
         </ul>
 
@@ -314,7 +345,17 @@ export default function IndexLaunchesPage() {
           </a>
           . The page rescans before every claim and sends positive verified
           entries only as one wallet-declared atomic batch from the fixed reward
-          wallet.
+          wallet. Its immediate latest simulation can include fees accrued after
+          the displayed finalized balance. The current safe limit is 64 calls;
+          overflow blocks instead of silently dropping a claim. Before the
+          wallet opens, the console persists an app-defined batch ID under an
+          origin-wide tab lock. A confirmed batch stays locked across reloads
+          until its exact transaction and block receipts agree across all three
+          RPCs and the Router checkpoint has finalized them. Partial or
+          ambiguous outcomes remain locked for manual reconciliation. If the
+          page closes during wallet submission, the saved call set can only be
+          resumed with the same app-defined ID; it is never rebuilt as a second
+          batch.
         </p>
       </section>
 

--- a/docs/public/developers/indexing.md
+++ b/docs/public/developers/indexing.md
@@ -22,17 +22,45 @@ inventory follows the exact execution contracts:
 - Classic V2 and V3 coin rows come from complete canonical Launcher event
   scans. Fee execution remains one aggregate claim per verified version hook;
   the legacy V1 aggregate hook remains a separate row.
-- Custom V1 replays the complete Registry history and verifies every current
-  source state, runtime, reward wallet, fee policy and accrued amount at one
-  block. Future finalized standard 5 or 10 bps sources are discovered without
-  editing a static coin list.
+- A Router-stamped Classic launch is covered automatically only when its exact
+  hook matches a known verified aggregate hook. An unknown Classic hook remains
+  visible and blocks the combined claim.
+- The complete Registry history remains available for audit, but Custom
+  Registry V1 is retired as a live discovery or claim source.
+- Router-stamped Custom launches come from a consensus-finalized Router event
+  replay. The claim console requires the Wallet RPC and two independent public
+  RPCs to report `finalized` views no more than 32 blocks apart. It uses the
+  oldest view as the safe boundary, requires all three RPCs to return its exact
+  block hash, then requires the exact same complete raw log tuples through that
+  checkpoint. It then verifies every launch record, token or pool lookup,
+  component proof, runtime and displayed claim balance at that same checkpoint.
+- A Custom claim is executable only through an exact reviewed profile bound to
+  its launch ID, token, fee source and runtime. The current profiles cover
+  FADE's native accumulator, SHARD's direct launcher-fee claim, PCAN's
+  dual-currency PoolManager redemption and PCR2's two-currency fee Vault.
+  PCR2's native and token balances are independent claim calls, and only
+  positive balances enter the batch. Future Router-stamped Custom launches are
+  discovered and remain visible, but a new or unknown claim ABI blocks the
+  combined claim until an exact profile is reviewed. The console does not
+  provide universal arbitrary Custom support and never guesses calldata from
+  selectors or bytecode shape.
 - Stock claims use the published fixed release asset set. New Stock assets are
   not inferred or silently added.
 - Custom V2 remains unavailable until an exact deployed and finalized release
-  binding exists. Unknown, revoked, mismatched or unverified sources block the
-  combined claim instead of disappearing from the result.
+  binding exists. Unknown, mismatched or unverified bindings block the combined
+  claim. Quarantined sources remain visible and non-executable.
 
 The live console publishes this boundary at
 [`claimhazard.vercel.app/claim-discovery.json`](https://claimhazard.vercel.app/claim-discovery.json).
 It rescans before every claim and includes only positive verified entries in one
-wallet-declared atomic batch from the fixed reward wallet.
+wallet-declared atomic batch from the fixed reward wallet. Its immediate latest
+simulation can include fees accrued after the displayed finalized balance. The
+current safe limit is 64 calls; overflow blocks execution instead of silently
+omitting a claim. Before opening the wallet, the console persists an app-defined
+batch ID under an origin-wide tab lock. A confirmed batch remains locked across
+reloads until its exact transaction and block receipts agree across all three
+RPCs and the Router checkpoint has finalized them. Off-chain failures and full
+reverts may unlock automatically; partial or ambiguous outcomes remain locked
+for manual reconciliation. If the page closes during wallet submission, the
+saved call set can only be resumed with the same app-defined ID; it is never
+rebuilt as a second batch.

--- a/ops/protocol-fee-claim/app.js
+++ b/ops/protocol-fee-claim/app.js
@@ -7,45 +7,249 @@ import {
   CUSTOM_V2_RELEASE_PATH,
   CUSTOM_V2_SELECTORS,
   HOOKS,
+  LAUNCH_STAMP_ROUTER,
+  LAUNCH_STAMP_SELECTORS,
+  LAUNCH_STAMP_TOPICS,
   MAINNET_CHAIN_ID,
+  ROUTER_CUSTOM_CLAIM_PROFILES,
   SELECTORS,
-  TOKEN_SELECTORS,
   TREASURY,
   atomicCapabilityStatus,
   buildWalletSendCalls,
+  confirmedBatchReceiptProof,
+  confirmedTransactionReceiptMatches,
+  createRefreshQueue,
   customClaimDefinitionClassification,
   customLaunchClassification,
   customLaunchStateData,
   customV2Bytes32ReadData,
   customV2IndexedReadData,
   customV2SourceClassification,
-  decodeAbiString,
   decodeAddress,
   decodeBool,
   decodeBytes4,
   decodeBytes32,
   decodeCustomLaunchState,
   decodeCustomV2SourceState,
+  decodeLaunchStampProof,
+  decodeLaunchStampRecord,
   decodeUint256,
+  encodeAddressArgument,
+  exactRouterFinalizedCheckpoint,
   formatEth,
   formatUnits,
   isTreasury,
   keccak256Hex,
+  launchStampAddressReadData,
+  launchStampBytes32ReadData,
+  launchStampLogSetFingerprint,
+  launchStampPoolReadData,
   normalizeBatchId,
+  metaMaskProviderFrom,
   parseCustomV2Release,
+  poolManagerBalanceOfData,
   readAccruedData,
   reduceClassicLaunchLogs,
   reduceCustomRegistryLogs,
+  reduceLaunchStampLogs,
   requireAtomicClaimCapability,
+  routerFinalizedBoundary,
   shortAddress,
   toQuantityHex,
+  routerCustomClaimClassification,
+  validatedAtomicBatchStatus,
+  walletSendDefinitelyNotSubmitted,
+  walletSendDuplicateBatchId,
+  withTimeout,
 } from "./logic.mjs";
+
+const DEMO_MODE = new URLSearchParams(window.location.search).has("demo");
+const EVENT_LOG_CHUNK_SIZE = 10_000n;
+const MAX_ROUTER_LAUNCHES = 4_096;
+const MAX_BATCH_CALLS = 64;
+const ROUTER_QUORUM_RPC_GROUPS = Object.freeze([
+  Object.freeze([
+    "https://mainnet.gateway.tenderly.co",
+    "https://eth.drpc.org",
+  ]),
+  Object.freeze(["https://rpc.mevblocker.io"]),
+]);
+const ROUTER_QUORUM_TIMEOUT_MS = 20_000;
+const WALLET_DISCOVERY_TIMEOUT_MS = 1_500;
+const CONFIRMED_BATCH_STORAGE_KEY =
+  "programmable.fee-claim.confirmed-batch.v2";
+const CONFIRMED_BATCH_SCHEMA = "programmable.confirmed-claim-batch.v2";
+const CLAIM_SUBMISSION_LEASE = "programmable-fee-claim-submission";
+const INTERACTIVE_WALLET_METHODS = new Set([
+  "eth_requestAccounts",
+  "wallet_requestPermissions",
+  "wallet_switchEthereumChain",
+  "wallet_sendCalls",
+]);
+
+const announcedWalletProviders = new Map();
+let boundWalletProvider = null;
+let walletAuthorizationRevision = 0;
+
+function rememberAnnouncedWalletProvider(event) {
+  const detail = event?.detail;
+  if (
+    typeof detail?.info?.uuid !== "string" ||
+    typeof detail?.provider?.request !== "function"
+  )
+    return;
+  announcedWalletProviders.set(detail.info.uuid, detail);
+}
+
+window.addEventListener(
+  "eip6963:announceProvider",
+  rememberAnnouncedWalletProvider,
+);
+window.dispatchEvent(new Event("eip6963:requestProvider"));
+
+function invalidConfirmedBatchLock() {
+  return {
+    schema: CONFIRMED_BATCH_SCHEMA,
+    account: TREASURY.toLowerCase(),
+    chainId: MAINNET_CHAIN_ID,
+    batchId: null,
+    batch: null,
+    phase: "manual",
+    receipts: null,
+    failureStatus: null,
+    invalid: true,
+  };
+}
+
+function normalizeStoredBatch(batch, expectedBatchId) {
+  const id = normalizeBatchId(batch?.id);
+  if (
+    id.toLowerCase() !== expectedBatchId.toLowerCase() ||
+    batch?.version !== "2.0.0" ||
+    !isTreasury(batch?.from) ||
+    batch?.chainId !== MAINNET_CHAIN_ID ||
+    batch?.atomicRequired !== true ||
+    !Array.isArray(batch?.calls) ||
+    batch.calls.length === 0 ||
+    batch.calls.length > MAX_BATCH_CALLS
+  ) {
+    throw new Error("Ungültiger gespeicherter Claim-Batch");
+  }
+  const calls = batch.calls.map((call) => {
+    if (
+      typeof call?.to !== "string" ||
+      !/^0x[0-9a-fA-F]{40}$/.test(call.to) ||
+      typeof call?.data !== "string" ||
+      !/^0x[0-9a-fA-F]{8}(?:[0-9a-fA-F]{64})*$/.test(call.data) ||
+      call?.value !== "0x0"
+    ) {
+      throw new Error("Ungültiger gespeicherter Claim-Call");
+    }
+    return {
+      to: call.to,
+      data: call.data.toLowerCase(),
+      value: "0x0",
+    };
+  });
+  const callKeys = calls.map(
+    ({ to, data }) => `${to.toLowerCase()}:${data}`,
+  );
+  if (new Set(callKeys).size !== callKeys.length)
+    throw new Error("Doppelter gespeicherter Claim-Call");
+  return {
+    version: "2.0.0",
+    id,
+    from: batch.from,
+    chainId: MAINNET_CHAIN_ID,
+    atomicRequired: true,
+    calls,
+  };
+}
+
+function normalizeStoredReceipt(receipt) {
+  const blockNumber = BigInt(receipt?.blockNumber);
+  if (
+    blockNumber <= 0n ||
+    typeof receipt?.blockHash !== "string" ||
+    !/^0x[0-9a-fA-F]{64}$/.test(receipt.blockHash) ||
+    typeof receipt?.transactionHash !== "string" ||
+    !/^0x[0-9a-fA-F]{64}$/.test(receipt.transactionHash)
+  ) {
+    throw new Error("Ungültiger gespeicherter Receipt");
+  }
+  return {
+    blockNumber: blockNumber.toString(),
+    blockHash: receipt.blockHash.toLowerCase(),
+    transactionHash: receipt.transactionHash.toLowerCase(),
+  };
+}
+
+function loadConfirmedBatchLock() {
+  let stored;
+  try {
+    stored = window.localStorage.getItem(CONFIRMED_BATCH_STORAGE_KEY);
+  } catch {
+    return invalidConfirmedBatchLock();
+  }
+  if (stored === null) return null;
+
+  try {
+    const parsed = JSON.parse(stored);
+    const batchId = normalizeBatchId(parsed.batchId);
+    const batch = normalizeStoredBatch(parsed.batch, batchId);
+    const receipts =
+      parsed.receipts === null
+        ? null
+        : parsed.receipts.map(normalizeStoredReceipt);
+    if (
+      parsed.schema !== CONFIRMED_BATCH_SCHEMA ||
+      !isTreasury(parsed.account) ||
+      parsed.chainId !== MAINNET_CHAIN_ID ||
+      batchId !== parsed.batchId ||
+      !["submitting", "pending", "confirmed", "manual"].includes(
+        parsed.phase,
+      ) ||
+      (parsed.phase === "confirmed" &&
+        (!Array.isArray(receipts) || receipts.length === 0)) ||
+      (parsed.failureStatus !== null &&
+        !Number.isInteger(parsed.failureStatus))
+    ) {
+      throw new Error("Ungültige Claim-Sperre");
+    }
+    return {
+      schema: CONFIRMED_BATCH_SCHEMA,
+      account: parsed.account.toLowerCase(),
+      chainId: MAINNET_CHAIN_ID,
+      batchId,
+      batch,
+      phase: parsed.phase,
+      receipts,
+      failureStatus: parsed.failureStatus,
+    };
+  } catch {
+    return invalidConfirmedBatchLock();
+  }
+}
+
+function requireConfirmedBatchStorage() {
+  const probeKey = `${CONFIRMED_BATCH_STORAGE_KEY}.probe`;
+  try {
+    window.localStorage.setItem(probeKey, "1");
+    window.localStorage.removeItem(probeKey);
+  } catch {
+    throw new Error(
+      "Der sichere Claim-Status kann in diesem Browser nicht gespeichert werden. Es wurde nichts gesendet.",
+    );
+  }
+}
 
 const state = {
   account: null,
   chainId: null,
   blockTag: null,
   capability: null,
+  walletMissing: false,
+  confirmedBatch: DEMO_MODE ? null : loadConfirmedBatchLock(),
   claims: new Map(),
   hooks: new Map(),
   custom: {
@@ -60,6 +264,13 @@ const state = {
     sources: [],
     error: null,
   },
+  router: {
+    status: "idle",
+    verified: false,
+    finalizedBlock: null,
+    launches: [],
+    error: null,
+  },
   classic: {
     status: "idle",
     launchersVerified: false,
@@ -69,6 +280,136 @@ const state = {
   busy: false,
 };
 
+function saveConfirmedBatchLock(
+  lock,
+  { expectedBatchId = null, requireEmpty = false } = {},
+) {
+  try {
+    const stored = loadConfirmedBatchLock();
+    if (
+      stored?.invalid ||
+      (requireEmpty && stored !== null) ||
+      (expectedBatchId !== null &&
+        stored?.batchId?.toLowerCase() !== expectedBatchId.toLowerCase())
+    ) {
+      state.confirmedBatch = stored;
+      return false;
+    }
+    const serialized = JSON.stringify(lock);
+    window.localStorage.setItem(CONFIRMED_BATCH_STORAGE_KEY, serialized);
+    if (window.localStorage.getItem(CONFIRMED_BATCH_STORAGE_KEY) !== serialized)
+      return false;
+    state.confirmedBatch = lock;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function clearConfirmedBatchLock(expectedBatchId) {
+  try {
+    const stored = loadConfirmedBatchLock();
+    if (
+      stored &&
+      (!expectedBatchId ||
+        stored.batchId?.toLowerCase() !== expectedBatchId.toLowerCase())
+    ) {
+      state.confirmedBatch = stored;
+      return false;
+    }
+    window.localStorage.removeItem(CONFIRMED_BATCH_STORAGE_KEY);
+    if (window.localStorage.getItem(CONFIRMED_BATCH_STORAGE_KEY) !== null)
+      return false;
+    state.confirmedBatch = null;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function highestConfirmedReceiptBlock(lock = state.confirmedBatch) {
+  if (!Array.isArray(lock?.receipts) || lock.receipts.length === 0) return null;
+  return lock.receipts.reduce((highest, receipt) => {
+    const blockNumber = BigInt(receipt.blockNumber);
+    return blockNumber > highest ? blockNumber : highest;
+  }, 0n);
+}
+
+function confirmedBatchStatus() {
+  if (state.confirmedBatch?.invalid)
+    return "Lokaler Claim-Status ist unvollständig · Claims bleiben gesperrt";
+  if ((state.confirmedBatch?.failureStatus ?? 0) >= 600)
+    return "Wallet meldet mögliche Teil-Ausführung · Claims bleiben gesperrt";
+  if (state.confirmedBatch?.phase === "submitting")
+    return "Wallet-Antwort wird wiederhergestellt · kein neuer Claim möglich";
+  if (state.confirmedBatch?.phase !== "confirmed")
+    return "MetaMask-Batch wird bestätigt · kein neuer Claim möglich";
+  return `Claim bestätigt · wartet auf finalisierten Block ${highestConfirmedReceiptBlock()?.toString()}`;
+}
+
+function createAppBatchId() {
+  const bytes = new Uint8Array(32);
+  window.crypto.getRandomValues(bytes);
+  return `0x${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+}
+
+async function withExclusiveClaimLease(callback) {
+  if (!window.navigator.locks?.request)
+    throw new Error(
+      "Dieser Browser kann parallele Claim-Tabs nicht sicher koordinieren. Es wurde nichts gesendet.",
+    );
+  return window.navigator.locks.request(
+    CLAIM_SUBMISSION_LEASE,
+    { mode: "exclusive", ifAvailable: true },
+    async (lease) => {
+      if (!lease)
+        throw new Error(
+          "Ein anderer Tab bereitet bereits einen Claim vor. Es wurde nichts gesendet.",
+        );
+      const stored = loadConfirmedBatchLock();
+      if (stored) {
+        state.confirmedBatch = stored;
+        renderSummary();
+        throw new Error(
+          "Ein bestehender Claim-Batch muss zuerst finalisiert werden",
+        );
+      }
+      return callback();
+    },
+  );
+}
+
+async function withExistingClaimLease(callback) {
+  if (!window.navigator.locks?.request)
+    throw new Error(
+      "Dieser Browser kann parallele Claim-Tabs nicht sicher koordinieren. Es wurde nichts gesendet.",
+    );
+  return window.navigator.locks.request(
+    CLAIM_SUBMISSION_LEASE,
+    { mode: "exclusive", ifAvailable: true },
+    async (lease) => {
+      if (!lease)
+        throw new Error(
+          "Ein anderer Tab prüft bereits diesen Claim-Batch. Es wurde nichts erneut gesendet.",
+        );
+      const stored = loadConfirmedBatchLock();
+      if (!stored || stored.invalid)
+        throw new Error("Der gespeicherte Claim-Batch ist nicht wiederherstellbar");
+      state.confirmedBatch = stored;
+      return callback(stored);
+    },
+  );
+}
+
+async function withAvailableClaimStateLease(callback) {
+  if (!window.navigator.locks?.request) return null;
+  return window.navigator.locks.request(
+    CLAIM_SUBMISSION_LEASE,
+    { mode: "exclusive", ifAvailable: true },
+    (lease) => (lease ? callback() : null),
+  );
+}
+
 const elements = {
   action: document.querySelector("[data-action]"),
   actionLabel: document.querySelector("[data-action-label]"),
@@ -77,21 +418,202 @@ const elements = {
   batchMode: document.querySelector("[data-batch-mode]"),
   claimCount: document.querySelector("[data-claim-count]"),
   claimRows: document.querySelector("[data-claim-rows]"),
+  content: document.querySelector(".content"),
   error: document.querySelector("[data-error]"),
+  metamaskOpen: document.querySelector("[data-metamask-open]"),
   network: document.querySelector("[data-network]"),
   refresh: document.querySelector("[data-refresh]"),
   status: document.querySelector("[data-status]"),
   total: document.querySelector("[data-total]"),
 };
 
-function provider() {
-  if (!window.ethereum?.request)
-    throw new Error("MetaMask wurde in diesem Browser nicht gefunden");
-  return window.ethereum;
+function clearWalletAuthorizationState() {
+  state.account = null;
+  state.chainId = null;
+  state.capability = null;
+}
+
+function invalidateWalletAuthorizationState() {
+  walletAuthorizationRevision += 1;
+  clearWalletAuthorizationState();
+  return walletAuthorizationRevision;
+}
+
+async function syncAfterWalletEvent() {
+  const revision = invalidateWalletAuthorizationState();
+  setError();
+  setStatus("Wallet wird aktualisiert");
+  renderSummary();
+  try {
+    await syncWallet({ expectedRevision: revision });
+  } catch {
+    if (revision !== walletAuthorizationRevision) return;
+    clearWalletAuthorizationState();
+    setError("Wallet-Status konnte nicht aktualisiert werden");
+    setStatus("MetaMask erneut verbinden");
+    renderSummary();
+  }
+}
+
+function failClosedAfterWalletDisconnect() {
+  invalidateWalletAuthorizationState();
+  setError("MetaMask wurde getrennt");
+  setStatus("MetaMask verbinden");
+  renderSummary();
+}
+
+function bindWalletProviderEvents(walletProvider) {
+  if (boundWalletProvider === walletProvider) return;
+  boundWalletProvider?.removeListener?.(
+    "accountsChanged",
+    syncAfterWalletEvent,
+  );
+  boundWalletProvider?.removeListener?.("chainChanged", syncAfterWalletEvent);
+  boundWalletProvider?.removeListener?.(
+    "disconnect",
+    failClosedAfterWalletDisconnect,
+  );
+  boundWalletProvider = walletProvider;
+  boundWalletProvider.on?.("accountsChanged", syncAfterWalletEvent);
+  boundWalletProvider.on?.("chainChanged", syncAfterWalletEvent);
+  boundWalletProvider.on?.("disconnect", failClosedAfterWalletDisconnect);
+}
+
+function selectedMetaMaskProvider({ allowLegacy = false } = {}) {
+  const selected = metaMaskProviderFrom(
+    [...announcedWalletProviders.values()],
+    allowLegacy ? window.ethereum : null,
+  );
+  if (!selected) return null;
+  bindWalletProviderEvents(selected);
+  return selected;
+}
+
+async function requireMetaMaskProvider() {
+  let selected = selectedMetaMaskProvider();
+  if (selected) {
+    state.walletMissing = false;
+    return selected;
+  }
+  if (boundWalletProvider) {
+    state.walletMissing = false;
+    return boundWalletProvider;
+  }
+
+  window.dispatchEvent(new Event("eip6963:requestProvider"));
+  selected = selectedMetaMaskProvider();
+  if (selected) {
+    state.walletMissing = false;
+    return selected;
+  }
+
+  await new Promise((resolve) => {
+    let settled = false;
+    const cleanup = () => {
+      window.removeEventListener("eip6963:announceProvider", finish);
+      window.removeEventListener("ethereum#initialized", retry);
+    };
+    const settle = () => {
+      settled = true;
+      window.clearTimeout(timeout);
+      cleanup();
+      resolve();
+    };
+    const finish = () => {
+      if (settled || !selectedMetaMaskProvider()) return;
+      settle();
+    };
+    const retry = () => {
+      if (settled) return;
+      window.dispatchEvent(new Event("eip6963:requestProvider"));
+      finish();
+    };
+    const timeout = window.setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve();
+    }, WALLET_DISCOVERY_TIMEOUT_MS);
+    window.addEventListener("eip6963:announceProvider", finish);
+    window.addEventListener("ethereum#initialized", retry);
+  });
+
+  selected = selectedMetaMaskProvider({ allowLegacy: true });
+  if (!selected) {
+    state.walletMissing = true;
+    const error = new Error(
+      "MetaMask wurde nicht gefunden. Erweiterung entsperren, Seite neu laden und erneut verbinden.",
+    );
+    error.code = "METAMASK_NOT_FOUND";
+    throw error;
+  }
+  state.walletMissing = false;
+  return selected;
 }
 
 async function request(method, params = []) {
-  return provider().request({ method, params });
+  const walletProvider = await requireMetaMaskProvider();
+  const operation = walletProvider.request({ method, params });
+  if (INTERACTIVE_WALLET_METHODS.has(method)) return operation;
+  return withTimeout(
+    operation,
+    ROUTER_QUORUM_TIMEOUT_MS,
+    `Wallet-RPC-Zeitlimit bei ${method} überschritten`,
+  );
+}
+
+let publicRpcId = 1;
+
+async function publicRpcRequest(url, method, params = []) {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(
+    () => controller.abort(),
+    ROUTER_QUORUM_TIMEOUT_MS,
+  );
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: publicRpcId++,
+        method,
+        params,
+      }),
+      signal: controller.signal,
+    });
+    if (!response.ok)
+      throw new Error(`Router-Quorum-RPC antwortet mit HTTP ${response.status}`);
+    const payload = await response.json();
+    if (payload?.error || payload?.result === undefined)
+      throw new Error(
+        payload?.error?.message ?? "Router-Quorum-RPC-Antwort ist ungültig",
+      );
+    return payload.result;
+  } finally {
+    window.clearTimeout(timeout);
+  }
+}
+
+async function publicRpcGroupRequest(urls, method, params = []) {
+  let lastError;
+  for (const url of urls) {
+    try {
+      return await publicRpcRequest(url, method, params);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError ?? new Error("Router-Quorum-RPC-Gruppe ist nicht verfügbar");
+}
+
+async function routerQuorumRequest(method, params = []) {
+  return Promise.all([
+    request(method, params),
+    ...ROUTER_QUORUM_RPC_GROUPS.map((urls) =>
+      publicRpcGroupRequest(urls, method, params),
+    ),
+  ]);
 }
 
 function setError(message = "") {
@@ -111,8 +633,24 @@ function disclosureIndicator() {
 }
 
 function hookVerified(claim) {
-  if (claim.kind === "custom") return claim.bindingVerified === true;
+  if (claim.kind === "custom") {
+    if (claim.origin === "launch-stamp-router")
+      return (
+        claim.provenanceVerified === true &&
+        claim.runtimeVerified === true &&
+        claim.claimBindingVerified === true
+      );
+    return claim.bindingVerified === true;
+  }
   return state.hooks.get(claim.hookId)?.verified === true;
+}
+
+function claimHasOpenAmount(claim) {
+  return (
+    (typeof claim?.amount === "bigint" && claim.amount > 0n) ||
+    (typeof claim?.secondaryAmount === "bigint" &&
+      claim.secondaryAmount > 0n)
+  );
 }
 
 function statusLabel(claim) {
@@ -122,9 +660,11 @@ function statusLabel(claim) {
   if (claim.status === "pending") return "Wird bestätigt";
   if (claim.status === "claimed") return "Geclaimt";
   if (claim.status === "failed") return "Nicht verfügbar";
+  if (state.confirmedBatch && claimHasOpenAmount(claim))
+    return "Bestätigt · Finalität ausstehend";
   if (!hookVerified(claim)) return "Contract nicht verifiziert";
   if (!claim.recipientMatches) return "Falscher Empfänger";
-  if (claim.amount === 0n) return "Nichts offen";
+  if (!claimHasOpenAmount(claim)) return "Nichts offen";
   return "Bereit";
 }
 
@@ -158,6 +698,8 @@ function customStatusLabel(launch) {
   if (launch.status === "pending") return "Wird bestätigt";
   if (launch.status === "claimed") return "Geclaimt";
   if (launch.status === "failed") return "Nicht verfügbar";
+  if (state.confirmedBatch && classification === "ready")
+    return "Bestätigt · Finalität ausstehend";
   if (classification === "ready") return "Bereit";
   if (classification === "empty") return "Nichts offen";
   if (classification === "no-market") return "Kein Fee-Markt";
@@ -207,6 +749,8 @@ function customV2StatusLabel(source) {
   if (source.status === "claimed") return "Geclaimt";
   if (source.status === "failed") return "Nicht verfügbar";
   const classification = customV2SourceClassification(source);
+  if (state.confirmedBatch && classification === "ready")
+    return "Bestätigt · Finalität ausstehend";
   if (classification === "ready") return "Bereit";
   if (classification === "empty") return "Nichts offen";
   if (classification === "quarantined") return "Nicht ausführbar";
@@ -242,7 +786,72 @@ function buildCustomV2Row(source) {
   return row;
 }
 
+function routerCustomStatusLabel(source) {
+  const current = state.claims.get(source.id) ?? source;
+  if (current.status === "claiming") return "In MetaMask bestätigen";
+  if (current.status === "pending") return "Wird bestätigt";
+  if (current.status === "claimed") return "Geclaimt";
+  const classification = routerCustomClaimClassification({
+    ...source,
+    ...current,
+  });
+  if (state.confirmedBatch && classification === "ready")
+    return "Bestätigt · Finalität ausstehend";
+  if (classification === "ready") return "Bereit";
+  if (classification === "empty") return "Nichts offen";
+  if (classification === "no-manual-claim")
+    return "Gebühren werden direkt ausgezahlt";
+  return "Claim-Profil fehlt · alles gesperrt";
+}
+
+function buildRouterCustomRow(source) {
+  const current = state.claims.get(source.id) ?? source;
+  const rendered = { ...source, ...current };
+  const classification = routerCustomClaimClassification(rendered);
+  const row = document.createElement("li");
+  row.className = "claim-row custom-row router-custom-row";
+  row.dataset.state = ["claiming", "pending", "claimed"].includes(
+    rendered.status,
+  )
+    ? rendered.status
+    : classification;
+
+  const identity = document.createElement("div");
+  identity.className = "claim-identity";
+  const name = document.createElement("strong");
+  name.textContent = `Custom · ${shortAddress(source.token)}`;
+  const detail = document.createElement("span");
+  detail.textContent = `Launch Router · ${shortAddress(source.hook)}`;
+  identity.append(name, detail);
+
+  const value = document.createElement("div");
+  value.className = "claim-value";
+  const amount = document.createElement("strong");
+  if (classification === "no-manual-claim") {
+    amount.textContent = "Direkt";
+  } else if (classification === "blocked") {
+    amount.textContent = "—";
+  } else {
+    const amounts = [];
+    if ((rendered.amount ?? 0n) > 0n)
+      amounts.push(`${formatEth(rendered.amount)} ETH`);
+    if ((rendered.secondaryAmount ?? 0n) > 0n)
+      amounts.push(
+        `${formatUnits(rendered.secondaryAmount, rendered.secondaryDecimals)} ${rendered.secondaryUnit}`,
+      );
+    amount.textContent = amounts.length > 0 ? amounts.join(" + ") : "0 ETH";
+  }
+  const status = document.createElement("span");
+  status.textContent = routerCustomStatusLabel(rendered);
+  value.append(amount, status);
+  row.append(identity, value);
+  return row;
+}
+
 function buildCustomGroup() {
+  const routerCustoms = state.router.launches.filter(
+    ({ launchKind }) => launchKind === 1,
+  );
   const group = document.createElement("li");
   group.className = "asset-group custom-group";
   const details = document.createElement("details");
@@ -252,7 +861,7 @@ function buildCustomGroup() {
   const name = document.createElement("strong");
   name.textContent = "Custom-v4-Gebühren";
   const detail = document.createElement("span");
-  detail.textContent = "Automatisch aus der Mainnet Registry";
+  detail.textContent = "Retired V1 + offizieller Launch Router";
   identity.append(name, detail);
 
   const value = document.createElement("span");
@@ -264,11 +873,12 @@ function buildCustomGroup() {
     hint.textContent = "Nach Verbindung";
   } else if (
     state.custom.status === "loading" ||
-    state.customV2.status === "loading"
+    state.customV2.status === "loading" ||
+    state.router.status === "loading"
   ) {
     count.textContent = "Wird gelesen";
     hint.textContent = "Finalisierte Launches";
-  } else if (state.custom.error) {
+  } else if (state.custom.error || state.router.error) {
     count.textContent = "Nicht verfügbar";
     hint.textContent = "Claims gesperrt";
   } else {
@@ -279,11 +889,22 @@ function buildCustomGroup() {
       (launch) => customLaunchClassification(launch) === "ready",
     ).length;
     const sourceCount = state.customV2.sources.length;
-    const readyCount = readyV1Count + state.customV2.sources.filter(
-      (source) => customV2SourceClassification(source) === "ready",
+    const routerReadyCount = routerCustoms.filter(
+      (source) => routerCustomClaimClassification(source) === "ready",
     ).length;
-    count.textContent = `${state.custom.launches.length + sourceCount} erkannt`;
+    const routerBlockedCount = routerCustoms.filter(
+      (source) => routerCustomClaimClassification(source) === "blocked",
+    ).length;
+    const readyCount =
+      readyV1Count +
+      routerReadyCount +
+      state.customV2.sources.filter(
+        (source) => customV2SourceClassification(source) === "ready",
+      ).length;
+    count.textContent = `${state.custom.launches.length + sourceCount + routerCustoms.length} erkannt`;
     if (state.customV2.error) hint.textContent = "V2-Release gesperrt";
+    else if (routerBlockedCount > 0)
+      hint.textContent = `${routerBlockedCount} unbekanntes Claim-Profil gesperrt`;
     else if (readyCount > 0)
       hint.textContent = `${readyCount} Custom-Claim${readyCount === 1 ? "" : "s"} offen`;
     else if (feeBearing > 0)
@@ -296,11 +917,16 @@ function buildCustomGroup() {
   summary.append(identity, value, disclosureIndicator());
   details.append(summary);
 
-  if (state.custom.launches.length > 0 || state.customV2.sources.length > 0) {
+  if (
+    state.custom.launches.length > 0 ||
+    state.customV2.sources.length > 0 ||
+    routerCustoms.length > 0
+  ) {
     const list = document.createElement("ul");
     list.className = "asset-list";
     list.replaceChildren(
       ...state.customV2.sources.map(buildCustomV2Row),
+      ...routerCustoms.map(buildRouterCustomRow),
       ...state.custom.launches.map(buildCustomRow),
     );
     details.append(list);
@@ -312,28 +938,36 @@ function buildCustomGroup() {
 function buildClassicLaunchRow(launch) {
   const row = document.createElement("li");
   row.className = "claim-row classic-launch-row";
-  row.dataset.state = "covered";
+  const releaseName = launch.releaseName ?? "Launch Router";
+  const covered = launch.claimMode !== "unsupported";
+  row.dataset.state = covered ? "covered" : "blocked";
 
   const identity = document.createElement("div");
   identity.className = "claim-identity";
   const name = document.createElement("strong");
   name.textContent = launch.symbol || launch.name || "Classic Token";
   const detail = document.createElement("span");
-  detail.textContent = `${launch.releaseName} · ${shortAddress(launch.token)}`;
+  detail.textContent = `${releaseName} · ${shortAddress(launch.token)}`;
   identity.append(name, detail);
 
   const value = document.createElement("div");
   value.className = "claim-value";
   const coverage = document.createElement("strong");
-  coverage.textContent = "Enthalten";
+  coverage.textContent = covered ? "Enthalten" : "Gesperrt";
   const status = document.createElement("span");
-  status.textContent = `Im ${launch.releaseName}-Claim`;
+  status.textContent = covered
+    ? `Im ${launch.claimProfile ?? releaseName}-Claim`
+    : "Unbekannter Classic-Hook";
   value.append(coverage, status);
   row.append(identity, value);
   return row;
 }
 
 function buildClassicLaunchGroup() {
+  const routerClassic = state.router.launches.filter(
+    ({ launchKind }) => launchKind === 2,
+  );
+  const launches = [...routerClassic, ...state.classic.launches];
   const group = document.createElement("li");
   group.className = "asset-group classic-launch-group";
   const details = document.createElement("details");
@@ -343,7 +977,7 @@ function buildClassicLaunchGroup() {
   const name = document.createElement("strong");
   name.textContent = "Classic Launches";
   const detail = document.createElement("span");
-  detail.textContent = "Neue Coins automatisch aus den Launchern";
+  detail.textContent = "Launcher-Historie + offizieller Launch Router";
   identity.append(name, detail);
 
   const value = document.createElement("span");
@@ -353,24 +987,32 @@ function buildClassicLaunchGroup() {
   if (state.account === null) {
     count.textContent = "Onchain";
     hint.textContent = "Nach Verbindung";
-  } else if (state.classic.status === "loading") {
+  } else if (
+    state.classic.status === "loading" ||
+    state.router.status === "loading"
+  ) {
     count.textContent = "Wird gelesen";
     hint.textContent = "V2 und V3";
-  } else if (state.classic.error) {
+  } else if (state.classic.error || state.router.error) {
     count.textContent = "Nicht verfügbar";
     hint.textContent = "Hook-Claim bleibt aktiv";
   } else {
-    count.textContent = `${state.classic.launches.length} erkannt`;
-    hint.textContent = "Alle über Classic-Hooks abgedeckt";
+    const unsupported = routerClassic.filter(
+      ({ claimMode }) => claimMode === "unsupported",
+    ).length;
+    count.textContent = `${launches.length} erkannt`;
+    hint.textContent = unsupported
+      ? `${unsupported} neuer Hook gesperrt`
+      : "Alle über Classic-Hooks abgedeckt";
   }
   value.append(count, hint);
   summary.append(identity, value, disclosureIndicator());
   details.append(summary);
 
-  if (state.classic.launches.length > 0) {
+  if (launches.length > 0) {
     const list = document.createElement("ul");
     list.className = "asset-list";
-    list.replaceChildren(...state.classic.launches.map(buildClassicLaunchRow));
+    list.replaceChildren(...launches.map(buildClassicLaunchRow));
     details.append(list);
   }
   group.append(details);
@@ -452,10 +1094,17 @@ function allClaimDefinitions() {
         standardClaimBindingVerified === true,
     ),
     ...state.customV2.sources,
+    ...state.router.launches.flatMap((launch) => {
+      if (launch.launchKind !== 1 || launch.claimMode !== "manual") return [];
+      return Array.isArray(launch.claimDefinitions)
+        ? launch.claimDefinitions
+        : [launch];
+    }),
   ];
 }
 
-function claimableClaims() {
+function claimableClaims({ ignoreConfirmedBatch = false } = {}) {
+  if (state.confirmedBatch && !ignoreConfirmedBatch) return [];
   return allClaimDefinitions().filter((claim) => {
     const current = state.claims.get(claim.id);
     if (claim.kind === "custom") {
@@ -468,14 +1117,18 @@ function claimableClaims() {
     return (
       hookVerified(claim) &&
       current?.recipientMatches === true &&
-      current.amount > 0n
+      claimHasOpenAmount(current)
     );
-  });
+  }).sort((left, right) => left.id.localeCompare(right.id));
 }
 
-function claimSafetyError() {
+function claimSafetyError({ ignoreConfirmedBatch = false } = {}) {
+  if (state.confirmedBatch && !ignoreConfirmedBatch)
+    return "Ein bestätigter Claim-Batch wartet noch auf einen finalisierten Onchain-Stand";
+  if (state.router.status !== "ready" || state.router.verified !== true)
+    return "Der Launch-Stamp-Router ist nicht vollständig verifiziert";
   if (
-    state.custom.status !== "ready" ||
+    !["ready", "retired"].includes(state.custom.status) ||
     state.custom.registryVerified !== true
   )
     return "Die Custom Registry ist nicht vollständig verifiziert";
@@ -495,20 +1148,41 @@ function claimSafetyError() {
     )
   )
     return "Mindestens eine Custom-V2-Source-Bindung stimmt nicht";
+  if (
+    state.router.launches.some(
+      (launch) =>
+        (launch.launchKind === 1 &&
+          routerCustomClaimClassification(launch) === "blocked") ||
+        (launch.launchKind === 2 && launch.claimMode === "unsupported"),
+    )
+  )
+    return "Mindestens ein Router-Launch hat noch kein freigegebenes Claim-Profil";
   if (HOOKS.some(({ id }) => state.hooks.get(id)?.verified !== true))
     return "Mindestens eine Classic- oder Stock-Bindung stimmt nicht";
+  if (claimableClaims({ ignoreConfirmedBatch }).length > MAX_BATCH_CALLS)
+    return `Mehr als ${MAX_BATCH_CALLS} offene Claims passen nicht sicher in einen atomaren Batch`;
   return null;
 }
 
 function renderSummary() {
   const claimable = claimableClaims();
   const nativeTotal = claimable
-    .filter(({ kind }) => kind === "native" || kind === "custom")
+    .filter(
+      ({ kind, unit }) =>
+        kind === "native" || (kind === "custom" && unit === "ETH"),
+    )
     .reduce(
       (sum, claim) => sum + (state.claims.get(claim.id)?.amount ?? 0n),
       0n,
     );
-  const assetCount = claimable.filter(({ kind }) => kind === "asset").length;
+  const assetCount =
+    claimable.filter(
+      ({ kind, unit }) =>
+        kind === "asset" || (kind === "custom" && unit !== "ETH"),
+    ).length +
+    claimable.filter(
+      (claim) => (state.claims.get(claim.id)?.secondaryAmount ?? 0n) > 0n,
+    ).length;
   const verifiedHooks = HOOKS.filter(
     ({ id }) => state.hooks.get(id)?.verified === true,
   ).length;
@@ -521,14 +1195,25 @@ function renderSummary() {
   const customV2BindingBlockers = state.customV2.sources.filter(
     (source) => customV2SourceClassification(source) === "blocked",
   );
+  const routerBindingBlockers = state.router.launches.filter(
+    (launch) =>
+      (launch.launchKind === 1 &&
+        routerCustomClaimClassification(launch) === "blocked") ||
+      (launch.launchKind === 2 && launch.claimMode === "unsupported"),
+  );
 
-  elements.total.textContent = `${formatEth(nativeTotal)} ETH${assetCount > 0 ? ` + ${assetCount} Assets` : ""}`;
-  elements.claimCount.textContent = `${claimable.length} ${claimable.length === 1 ? "Claim" : "Claims"}`;
+  elements.total.textContent = state.account
+    ? `${formatEth(nativeTotal)} ETH`
+    : "—";
+  elements.claimCount.textContent = state.account
+    ? `${claimable.length} ${claimable.length === 1 ? "Claim" : "Claims"}${assetCount > 0 ? ` · +${assetCount} Assets` : ""}`
+    : "Noch nicht geprüft";
   elements.account.textContent = state.account
     ? shortAddress(state.account)
     : "Nicht verbunden";
-  elements.network.textContent =
-    state.chainId === MAINNET_CHAIN_ID
+  elements.network.textContent = DEMO_MODE
+    ? "Ethereum · QA"
+    : state.chainId === MAINNET_CHAIN_ID
       ? "Ethereum"
       : state.account
         ? "Falsches Netzwerk"
@@ -542,63 +1227,110 @@ function renderSummary() {
   const connected = state.account !== null;
   const correctWallet = connected && isTreasury(state.account);
   const correctNetwork = state.chainId === MAINNET_CHAIN_ID;
+  const loading =
+    state.custom.status === "loading" ||
+    state.customV2.status === "loading" ||
+    state.classic.status === "loading" ||
+    state.router.status === "loading";
+  elements.content.setAttribute("aria-busy", String(state.busy || loading));
+  elements.network.dataset.state = !connected
+    ? "idle"
+    : correctNetwork
+      ? "ready"
+      : "wrong";
+  elements.refresh.hidden = !correctWallet || !correctNetwork;
+  elements.metamaskOpen.hidden = !state.walletMissing;
 
   if (!connected) {
-    elements.actionLabel.textContent = "Wallet verbinden";
-    elements.actionDetail.textContent = "MetaMask · Programmable Treasury";
+    elements.actionLabel.textContent = state.walletMissing
+      ? "MetaMask erneut suchen"
+      : "MetaMask verbinden";
+    elements.actionDetail.textContent = "Reward Wallet · endet 376C";
     elements.action.disabled = state.busy;
   } else if (!correctNetwork) {
     elements.actionLabel.textContent = "Zu Ethereum wechseln";
-    elements.actionDetail.textContent = "Mainnet erforderlich";
+    elements.actionDetail.textContent = "Ein Klick";
     elements.action.disabled = state.busy;
   } else if (!correctWallet) {
-    elements.actionLabel.textContent = "Treasury-Wallet verwenden";
-    elements.actionDetail.textContent = shortAddress(TREASURY);
+    elements.actionLabel.textContent = "MetaMask-Konto wechseln";
+    elements.actionDetail.textContent = "Wallet · endet 376C";
+    elements.action.disabled = state.busy;
+  } else if (loading) {
+    elements.actionLabel.textContent = "Fees werden gesucht";
+    elements.actionDetail.textContent = "Einen Moment";
     elements.action.disabled = true;
+  } else if (state.confirmedBatch) {
+    const resumable =
+      !state.confirmedBatch.invalid &&
+      ["submitting", "pending"].includes(state.confirmedBatch.phase);
+    elements.actionLabel.textContent = state.confirmedBatch.invalid
+      ? "Claim-Status prüfen"
+      : resumable
+        ? "Claim-Batch sicher fortsetzen"
+        : "Claim bereits bestätigt";
+    elements.actionDetail.textContent = state.confirmedBatch.invalid
+      ? "Lokale Sperre unvollständig · nichts erneut senden"
+      : (state.confirmedBatch.failureStatus ?? 0) >= 600
+        ? "Mögliche Teil-Ausführung muss onchain geprüft werden"
+        : resumable
+          ? "Exakt dieselbe Batch-ID · kein zweiter Claim"
+          : `Neuer Scan erst nach finalisiertem Block ${highestConfirmedReceiptBlock()?.toString()}`;
+    elements.action.disabled = state.busy || !resumable;
   } else if (
     state.custom.status === "failed" ||
     state.custom.registryVerified !== true
   ) {
-    elements.actionLabel.textContent = "Custom Registry nicht verifiziert";
-    elements.actionDetail.textContent = "Neu laden oder RPC-Verbindung prüfen";
+    elements.actionLabel.textContent = "Scan fehlgeschlagen";
+    elements.actionDetail.textContent = "Bitte neu scannen";
     elements.action.disabled = true;
   } else if (state.customV2.status === "failed") {
-    elements.actionLabel.textContent = "Custom V2 nicht verifiziert";
-    elements.actionDetail.textContent = "Release-Bindung oder RPC-Verbindung prüfen";
+    elements.actionLabel.textContent = "Scan fehlgeschlagen";
+    elements.actionDetail.textContent = "Bitte neu scannen";
+    elements.action.disabled = true;
+  } else if (state.router.status === "failed" || state.router.verified !== true) {
+    elements.actionLabel.textContent = "Scan fehlgeschlagen";
+    elements.actionDetail.textContent = "Bitte neu scannen";
     elements.action.disabled = true;
   } else if (customBindingBlockers.length > 0) {
-    elements.actionLabel.textContent = "Custom-Quelle nicht verifiziert";
-    elements.actionDetail.textContent = `${customBindingBlockers.length} Onchain-Bindung${customBindingBlockers.length === 1 ? "" : "en"} gesperrt`;
+    elements.actionLabel.textContent = "Neue Quelle prüfen";
+    elements.actionDetail.textContent = "Claim bleibt sicher gesperrt";
     elements.action.disabled = true;
   } else if (customV2BindingBlockers.length > 0) {
-    elements.actionLabel.textContent = "Custom-V2-Quelle nicht verifiziert";
-    elements.actionDetail.textContent = `${customV2BindingBlockers.length} Source-Bindung${customV2BindingBlockers.length === 1 ? "" : "en"} gesperrt`;
+    elements.actionLabel.textContent = "Neue Quelle prüfen";
+    elements.actionDetail.textContent = "Claim bleibt sicher gesperrt";
     elements.action.disabled = true;
   } else if (customAdapterBlockers.length > 0) {
-    elements.actionLabel.textContent = "Custom-Claimadapter fehlt";
-    elements.actionDetail.textContent = `${customAdapterBlockers.length} finalisierte Feequelle${customAdapterBlockers.length === 1 ? "" : "n"} gesperrt`;
+    elements.actionLabel.textContent = "Neue Quelle prüfen";
+    elements.actionDetail.textContent = "Claim bleibt sicher gesperrt";
+    elements.action.disabled = true;
+  } else if (routerBindingBlockers.length > 0) {
+    elements.actionLabel.textContent = "Neue Quelle prüfen";
+    elements.actionDetail.textContent = "Claim bleibt sicher gesperrt";
     elements.action.disabled = true;
   } else if (verifiedHooks !== HOOKS.length) {
-    elements.actionLabel.textContent = "Contract-Prüfung fehlgeschlagen";
-    elements.actionDetail.textContent = `${verifiedHooks} von ${HOOKS.length} verifiziert`;
+    elements.actionLabel.textContent = "Scan fehlgeschlagen";
+    elements.actionDetail.textContent = "Bitte neu scannen";
+    elements.action.disabled = true;
+  } else if (claimable.length > MAX_BATCH_CALLS) {
+    elements.actionLabel.textContent = "Zu viele offene Claims";
+    elements.actionDetail.textContent = "Details prüfen";
     elements.action.disabled = true;
   } else if (claimable.length === 0) {
-    elements.actionLabel.textContent = "Alles geclaimt";
-    elements.actionDetail.textContent = "Aktuell sind keine Fees offen";
+    elements.actionLabel.textContent = "Nichts offen";
+    elements.actionDetail.textContent = "Später erneut scannen";
     elements.action.disabled = true;
   } else if (!state.capability) {
-    elements.actionLabel.textContent = "Gemeinsamer Claim nicht verfügbar";
-    elements.actionDetail.textContent =
-      "MetaMask unterstützt keinen atomaren Batch";
+    elements.actionLabel.textContent = "MetaMask aktualisieren";
+    elements.actionDetail.textContent = "Gemeinsamer Claim nicht verfügbar";
     elements.action.disabled = true;
   } else {
-    elements.actionLabel.textContent = "Scannen & alles claimen";
+    elements.actionLabel.textContent = "Alles claimen";
     const claimLabel = `${claimable.length} ${claimable.length === 1 ? "Claim" : "Claims"}`;
-    elements.actionDetail.textContent = `${claimLabel} · 1 MetaMask-Bestätigung`;
+    elements.actionDetail.textContent = `${claimLabel} · eine Bestätigung`;
     elements.action.disabled = state.busy;
   }
 
-  elements.refresh.disabled = state.busy || !connected;
+  elements.refresh.disabled = state.busy || !correctWallet || !correctNetwork;
   renderRows();
 }
 
@@ -609,9 +1341,12 @@ async function readCustomRegistryLogs(blockTag) {
   for (
     let fromBlock = CUSTOM_REGISTRY.startBlock;
     fromBlock <= latest;
-    fromBlock += 4_000n
+    fromBlock += EVENT_LOG_CHUNK_SIZE
   ) {
-    const toBlock = fromBlock + 3_999n < latest ? fromBlock + 3_999n : latest;
+    const toBlock =
+      fromBlock + EVENT_LOG_CHUNK_SIZE - 1n < latest
+        ? fromBlock + EVENT_LOG_CHUNK_SIZE - 1n
+        : latest;
     logs.push(
       ...(await request("eth_getLogs", [
         {
@@ -632,9 +1367,12 @@ async function readClassicLauncherLogs(launcher, blockTag) {
   for (
     let fromBlock = launcher.startBlock;
     fromBlock <= latest;
-    fromBlock += 4_000n
+    fromBlock += EVENT_LOG_CHUNK_SIZE
   ) {
-    const toBlock = fromBlock + 3_999n < latest ? fromBlock + 3_999n : latest;
+    const toBlock =
+      fromBlock + EVENT_LOG_CHUNK_SIZE - 1n < latest
+        ? fromBlock + EVENT_LOG_CHUNK_SIZE - 1n
+        : latest;
     logs.push(
       ...(await request("eth_getLogs", [
         {
@@ -647,24 +1385,6 @@ async function readClassicLauncherLogs(launcher, blockTag) {
     );
   }
   return logs;
-}
-
-async function readTokenText(token, selector, blockTag) {
-  return decodeAbiString(
-    await request("eth_call", [{ to: token, data: selector }, blockTag]),
-  );
-}
-
-async function readClassicLaunchMetadata(launch, blockTag) {
-  const [name, symbol] = await Promise.allSettled([
-    readTokenText(launch.token, TOKEN_SELECTORS.name, blockTag),
-    readTokenText(launch.token, TOKEN_SELECTORS.symbol, blockTag),
-  ]);
-  return {
-    ...launch,
-    name: name.status === "fulfilled" ? name.value : null,
-    symbol: symbol.status === "fulfilled" ? symbol.value : null,
-  };
 }
 
 async function readClassicLaunches(blockTag) {
@@ -691,13 +1411,10 @@ async function readClassicLaunches(blockTag) {
       }),
     );
     const launches = reduceClassicLaunchLogs(launcherResults.flat());
-    const hydrated = await Promise.all(
-      launches.map((launch) => readClassicLaunchMetadata(launch, blockTag)),
-    );
     state.classic = {
       status: "ready",
       launchersVerified: true,
-      launches: hydrated,
+      launches,
       error: null,
     };
   } catch (error) {
@@ -709,6 +1426,759 @@ async function readClassicLaunches(blockTag) {
         error instanceof Error
           ? error.message
           : "Classic Launches konnten nicht gelesen werden",
+    };
+  }
+}
+
+async function readLaunchStampLogs(toBlock) {
+  const logs = [];
+  for (
+    let fromBlock = LAUNCH_STAMP_ROUTER.startBlock;
+    fromBlock <= toBlock;
+    fromBlock += EVENT_LOG_CHUNK_SIZE
+  ) {
+    const chunkEnd =
+      fromBlock + EVENT_LOG_CHUNK_SIZE - 1n < toBlock
+        ? fromBlock + EVENT_LOG_CHUNK_SIZE - 1n
+        : toBlock;
+    const filter = {
+      address: LAUNCH_STAMP_ROUTER.address,
+      fromBlock: toQuantityHex(fromBlock),
+      toBlock: toQuantityHex(chunkEnd),
+      topics: [LAUNCH_STAMP_TOPICS.launchStamped],
+    };
+    const responses = await routerQuorumRequest("eth_getLogs", [filter]);
+    const fingerprints = responses.map(launchStampLogSetFingerprint);
+    if (new Set(fingerprints).size !== 1)
+      throw new Error("Die Router-Loghistorie stimmt im RPC-Quorum nicht überein");
+    logs.push(...responses[0]);
+    if (logs.length > MAX_ROUTER_LAUNCHES)
+      throw new Error("Die Router-Launchliste überschreitet das sichere Scan-Limit");
+  }
+  return logs;
+}
+
+async function readRouterQuorumBlock(blockTag) {
+  const blocks = await routerQuorumRequest("eth_getBlockByNumber", [
+    blockTag,
+    false,
+  ]);
+  return exactRouterFinalizedCheckpoint(
+    blocks,
+    LAUNCH_STAMP_ROUTER.startBlock,
+  );
+}
+
+async function readRouterFinalizedBoundary() {
+  const blocks = await routerQuorumRequest("eth_getBlockByNumber", [
+    LAUNCH_STAMP_ROUTER.finalizedTag,
+    false,
+  ]);
+  return routerFinalizedBoundary(
+    blocks,
+    LAUNCH_STAMP_ROUTER.startBlock,
+    LAUNCH_STAMP_ROUTER.maximumFinalizedSpread,
+  );
+}
+
+async function verifyLaunchStampInfrastructure(blockTag) {
+  const [
+    routerCode,
+    chainIdWord,
+    permitAuthorityWord,
+    permitAuthorityRuntimeWord,
+    graphFactoryWord,
+    graphFactoryRuntimeWord,
+    poolManagerWord,
+    poolManagerRuntimeWord,
+  ] = await Promise.all([
+    request("eth_getCode", [LAUNCH_STAMP_ROUTER.address, blockTag]),
+    readContractWord(
+      LAUNCH_STAMP_ROUTER.address,
+      LAUNCH_STAMP_SELECTORS.chainId,
+      blockTag,
+    ),
+    readContractWord(
+      LAUNCH_STAMP_ROUTER.address,
+      LAUNCH_STAMP_SELECTORS.permitAuthority,
+      blockTag,
+    ),
+    readContractWord(
+      LAUNCH_STAMP_ROUTER.address,
+      LAUNCH_STAMP_SELECTORS.permitAuthorityRuntimeCodeHash,
+      blockTag,
+    ),
+    readContractWord(
+      LAUNCH_STAMP_ROUTER.address,
+      LAUNCH_STAMP_SELECTORS.graphFactory,
+      blockTag,
+    ),
+    readContractWord(
+      LAUNCH_STAMP_ROUTER.address,
+      LAUNCH_STAMP_SELECTORS.graphFactoryRuntimeCodeHash,
+      blockTag,
+    ),
+    readContractWord(
+      LAUNCH_STAMP_ROUTER.address,
+      LAUNCH_STAMP_SELECTORS.poolManager,
+      blockTag,
+    ),
+    readContractWord(
+      LAUNCH_STAMP_ROUTER.address,
+      LAUNCH_STAMP_SELECTORS.poolManagerRuntimeCodeHash,
+      blockTag,
+    ),
+  ]);
+  const permitAuthority = decodeAddress(permitAuthorityWord);
+  const graphFactory = decodeAddress(graphFactoryWord);
+  const poolManager = decodeAddress(poolManagerWord);
+  if (
+    keccak256Hex(routerCode).toLowerCase() !==
+      LAUNCH_STAMP_ROUTER.runtimeCodeHash ||
+    decodeUint256(chainIdWord) !== 1n ||
+    permitAuthority.toLowerCase() !==
+      LAUNCH_STAMP_ROUTER.permitAuthority.address.toLowerCase() ||
+    decodeBytes32(permitAuthorityRuntimeWord) !==
+      LAUNCH_STAMP_ROUTER.permitAuthority.runtimeCodeHash ||
+    graphFactory.toLowerCase() !==
+      LAUNCH_STAMP_ROUTER.graphFactory.address.toLowerCase() ||
+    decodeBytes32(graphFactoryRuntimeWord) !==
+      LAUNCH_STAMP_ROUTER.graphFactory.runtimeCodeHash ||
+    poolManager.toLowerCase() !==
+      LAUNCH_STAMP_ROUTER.poolManager.address.toLowerCase() ||
+    decodeBytes32(poolManagerRuntimeWord) !==
+      LAUNCH_STAMP_ROUTER.poolManager.runtimeCodeHash
+  )
+    throw new Error("Launch-Stamp-Router-Bindung stimmt nicht");
+
+  const [permitCode, graphCode, poolManagerCode] = await Promise.all([
+    request("eth_getCode", [permitAuthority, blockTag]),
+    request("eth_getCode", [graphFactory, blockTag]),
+    request("eth_getCode", [poolManager, blockTag]),
+  ]);
+  if (
+    keccak256Hex(permitCode).toLowerCase() !==
+      LAUNCH_STAMP_ROUTER.permitAuthority.runtimeCodeHash ||
+    keccak256Hex(graphCode).toLowerCase() !==
+      LAUNCH_STAMP_ROUTER.graphFactory.runtimeCodeHash ||
+    keccak256Hex(poolManagerCode).toLowerCase() !==
+      LAUNCH_STAMP_ROUTER.poolManager.runtimeCodeHash
+  )
+    throw new Error("Launch-Stamp-Infrastruktur-Runtime stimmt nicht");
+}
+
+function routerProfileBindingMatches(launch, profile) {
+  return profile.bindings.some(
+    ({ launchId, token, source, runtimeCodeHash }) =>
+      launch.launchId === launchId &&
+      (!token || launch.token.toLowerCase() === token.toLowerCase()) &&
+      launch.hook.toLowerCase() === source.toLowerCase() &&
+      launch.runtimeCodeHash === runtimeCodeHash,
+  );
+}
+
+function routerFeeVaultBinding(launch, profile) {
+  return profile.bindings.find(
+    ({ launchId, token, hook, hookRuntimeCodeHash }) =>
+      launch.launchId === launchId &&
+      launch.token.toLowerCase() === token.toLowerCase() &&
+      launch.hook.toLowerCase() === hook.toLowerCase() &&
+      launch.runtimeCodeHash === hookRuntimeCodeHash,
+  );
+}
+
+async function verifyRouterProfileComponent(launch, binding, blockTag) {
+  const [launchIdWord, proofValue, runtimeWord, runtimeCode] =
+    await Promise.all([
+      readContractWord(
+        LAUNCH_STAMP_ROUTER.address,
+        launchStampAddressReadData(
+          LAUNCH_STAMP_SELECTORS.launchIdByComponent,
+          binding.source,
+        ),
+        blockTag,
+      ),
+      request("eth_call", [
+        {
+          to: LAUNCH_STAMP_ROUTER.address,
+          data: launchStampAddressReadData(
+            LAUNCH_STAMP_SELECTORS.stampProof,
+            binding.source,
+          ),
+        },
+        blockTag,
+      ]),
+      readContractWord(
+        LAUNCH_STAMP_ROUTER.address,
+        launchStampAddressReadData(
+          LAUNCH_STAMP_SELECTORS.componentRuntimeCodeHash,
+          binding.source,
+        ),
+        blockTag,
+      ),
+      request("eth_getCode", [binding.source, blockTag]),
+    ]);
+  const proof = decodeLaunchStampProof(proofValue);
+  const runtimeCodeHash = decodeBytes32(runtimeWord);
+  if (
+    decodeBytes32(launchIdWord) !== launch.launchId ||
+    proof.launchId !== launch.launchId ||
+    proof.stampHash !== launch.stampHash ||
+    runtimeCodeHash !== binding.sourceRuntimeCodeHash ||
+    keccak256Hex(runtimeCode).toLowerCase() !==
+      binding.sourceRuntimeCodeHash.toLowerCase()
+  )
+    throw new Error("Custom-Vault-Stamp oder Runtime stimmt nicht");
+}
+
+async function tryRouterClaimProfile(
+  launch,
+  runtimeCode,
+  profile,
+  blockTag,
+) {
+  if (!routerProfileBindingMatches(launch, profile)) return null;
+  try {
+    const [
+      recipientWord,
+      feeWord,
+      accruedWord,
+      feeDenominatorWord,
+      poolManagerWord,
+      boundTokenWord,
+      nftWord,
+      initializedWord,
+    ] = await Promise.all([
+      readContractWord(launch.hook, profile.recipient, blockTag),
+      readContractWord(launch.hook, profile.feeBps, blockTag),
+      readContractWord(launch.hook, profile.accrued, blockTag),
+      profile.feeDenominatorBps
+        ? readContractWord(launch.hook, profile.feeDenominatorBps, blockTag)
+        : null,
+      profile.poolManager
+        ? readContractWord(launch.hook, profile.poolManager, blockTag)
+        : null,
+      profile.boundToken
+        ? readContractWord(launch.hook, profile.boundToken, blockTag)
+        : null,
+      profile.nft ? readContractWord(launch.hook, profile.nft, blockTag) : null,
+      profile.initialized
+        ? readContractWord(launch.hook, profile.initialized, blockTag)
+        : null,
+    ]);
+    const amount = decodeUint256(accruedWord);
+    if (
+      !isTreasury(decodeAddress(recipientWord)) ||
+      decodeUint256(feeWord) !== profile.expectedFeeBps ||
+      (feeDenominatorWord !== null &&
+        decodeUint256(feeDenominatorWord) !==
+          profile.expectedFeeDenominatorBps) ||
+      (poolManagerWord !== null &&
+        decodeAddress(poolManagerWord).toLowerCase() !==
+          LAUNCH_STAMP_ROUTER.poolManager.address.toLowerCase()) ||
+      (boundTokenWord !== null &&
+        decodeAddress(boundTokenWord).toLowerCase() !==
+          launch.token.toLowerCase()) ||
+      (nftWord !== null &&
+        decodeAddress(nftWord).toLowerCase() !==
+          profile.expectedNft.toLowerCase()) ||
+      (initializedWord !== null && !decodeBool(initializedWord))
+    )
+      return null;
+    if (amount > 0n) {
+      const simulated = await readContractWord(
+        launch.hook,
+        profile.claim,
+        blockTag,
+        TREASURY,
+      );
+      if (decodeUint256(simulated) !== amount)
+        throw new Error("Custom-Claim-Simulation stimmt nicht");
+    }
+    return {
+      ...launch,
+      id: `router-custom:${launch.launchId}`,
+      name: "Custom · Router",
+      detail: shortAddress(launch.token),
+      unit: "ETH",
+      decimals: 18,
+      kind: "custom",
+      origin: "launch-stamp-router",
+      address: launch.hook,
+      claimMode: "manual",
+      claimProfile: profile.id,
+      readData: profile.accrued,
+      claimData: profile.claim,
+      claimBindingVerified: true,
+      recipientMatches: true,
+      amount,
+      status: "ready",
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function tryRouterFeeVaultProfile(launch, profile, blockTag) {
+  const binding = routerFeeVaultBinding(launch, profile);
+  if (!binding) return null;
+  try {
+    await verifyRouterProfileComponent(launch, binding, blockTag);
+    const nativeAsset = CUSTOM_V2_POLICY.nativeAsset;
+    const nativeReadData = `${profile.accrued}${encodeAddressArgument(nativeAsset)}`;
+    const tokenReadData = `${profile.accrued}${encodeAddressArgument(launch.token)}`;
+    const nativeClaimData = `${profile.claim}${encodeAddressArgument(nativeAsset)}`;
+    const tokenClaimData = `${profile.claim}${encodeAddressArgument(launch.token)}`;
+    const [
+      hookVaultWord,
+      recipientWord,
+      feePpmWord,
+      feeDenominatorWord,
+      poolManagerWord,
+      authorizedAdapterWord,
+      authorizedAdapterCodeHashWord,
+      bindingAuthorityWord,
+      nativeAmountWord,
+      tokenAmountWord,
+    ] = await Promise.all([
+      readContractWord(launch.hook, profile.hookFeeVault, blockTag),
+      readContractWord(binding.source, profile.recipient, blockTag),
+      readContractWord(binding.source, profile.feePpm, blockTag),
+      readContractWord(binding.source, profile.feeDenominatorPpm, blockTag),
+      readContractWord(binding.source, profile.poolManager, blockTag),
+      readContractWord(binding.source, profile.authorizedAdapter, blockTag),
+      readContractWord(
+        binding.source,
+        profile.authorizedAdapterCodeHash,
+        blockTag,
+      ),
+      readContractWord(binding.source, profile.bindingAuthority, blockTag),
+      readContractWord(binding.source, nativeReadData, blockTag),
+      readContractWord(binding.source, tokenReadData, blockTag),
+    ]);
+    if (
+      decodeAddress(hookVaultWord).toLowerCase() !==
+        binding.source.toLowerCase() ||
+      !isTreasury(decodeAddress(recipientWord)) ||
+      decodeUint256(feePpmWord) !== profile.expectedFeePpm ||
+      decodeUint256(feeDenominatorWord) !==
+        profile.expectedFeeDenominatorPpm ||
+      decodeAddress(poolManagerWord).toLowerCase() !==
+        LAUNCH_STAMP_ROUTER.poolManager.address.toLowerCase() ||
+      decodeAddress(authorizedAdapterWord).toLowerCase() !==
+        launch.hook.toLowerCase() ||
+      decodeBytes32(authorizedAdapterCodeHashWord) !==
+        binding.hookRuntimeCodeHash ||
+      decodeAddress(bindingAuthorityWord) !== nativeAsset
+    )
+      throw new Error("Custom-Vault-Claim-Bindung stimmt nicht");
+
+    const amount = decodeUint256(nativeAmountWord);
+    const secondaryAmount = decodeUint256(tokenAmountWord);
+    await Promise.all(
+      [
+        { amount, claimData: nativeClaimData },
+        { amount: secondaryAmount, claimData: tokenClaimData },
+      ].map(async (leg) => {
+        if (leg.amount === 0n) return;
+        const simulated = await readContractWord(
+          binding.source,
+          leg.claimData,
+          blockTag,
+          TREASURY,
+        );
+        if (decodeUint256(simulated) !== leg.amount)
+          throw new Error("Custom-Vault-Claim-Simulation stimmt nicht");
+      }),
+    );
+
+    const id = `router-custom:${launch.launchId}`;
+    const common = {
+      launchId: launch.launchId,
+      token: launch.token,
+      hook: launch.hook,
+      launchKind: launch.launchKind,
+      kind: "custom",
+      origin: "launch-stamp-router",
+      address: binding.source,
+      provenanceVerified: true,
+      runtimeVerified: true,
+      sourceRuntimeVerified: true,
+      claimMode: "manual",
+      claimProfile: profile.id,
+      claimBindingVerified: true,
+      recipientMatches: true,
+      status: "ready",
+    };
+    const claimDefinitions = [
+      {
+        ...common,
+        id: `${id}:native`,
+        name: "Custom · Router",
+        detail: `${shortAddress(launch.token)} · ETH`,
+        unit: "ETH",
+        decimals: 18,
+        readData: nativeReadData,
+        claimData: nativeClaimData,
+        amount,
+      },
+      {
+        ...common,
+        id: `${id}:${launch.token.toLowerCase()}`,
+        name: "Custom · Router",
+        detail: `${shortAddress(launch.token)} · ${profile.secondaryUnit}`,
+        asset: launch.token,
+        unit: profile.secondaryUnit,
+        decimals: profile.secondaryDecimals,
+        readData: tokenReadData,
+        claimData: tokenClaimData,
+        amount: secondaryAmount,
+      },
+    ];
+    return {
+      ...launch,
+      ...common,
+      id,
+      name: "Custom · Router",
+      detail: shortAddress(launch.token),
+      unit: "ETH",
+      decimals: 18,
+      secondaryAsset: launch.token,
+      secondaryUnit: profile.secondaryUnit,
+      secondaryDecimals: profile.secondaryDecimals,
+      amount,
+      secondaryAmount,
+      claimDefinitions,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function readRouterCustomClaim(launch, runtimeCode, blockTag) {
+  for (const profile of [
+    ROUTER_CUSTOM_CLAIM_PROFILES.nativeAccumulatorV1,
+    ROUTER_CUSTOM_CLAIM_PROFILES.shardLauncherFeesV1,
+    ROUTER_CUSTOM_CLAIM_PROFILES.protocolFeeSourceV1,
+  ]) {
+    const claim = await tryRouterClaimProfile(
+      launch,
+      runtimeCode,
+      profile,
+      blockTag,
+    );
+    if (claim) return claim;
+  }
+
+  const feeVaultClaim = await tryRouterFeeVaultProfile(
+    launch,
+    ROUTER_CUSTOM_CLAIM_PROFILES.isolatedAfterSwapFeeVaultV2,
+    blockTag,
+  );
+  if (feeVaultClaim) return feeVaultClaim;
+
+  const redeemer = ROUTER_CUSTOM_CLAIM_PROFILES.dualCurrencyRedeemerV1;
+  try {
+    if (!routerProfileBindingMatches(launch, redeemer))
+      throw new Error("Kein freigegebenes Mehrwährungs-Claim-Profil");
+    const [
+      recipientWord,
+      feePipsWord,
+      poolManagerWord,
+      currency0Word,
+      currency1Word,
+      poolIdWord,
+      nativeAmountWord,
+      tokenAmountWord,
+    ] = await Promise.all([
+      readContractWord(launch.hook, redeemer.recipient, blockTag),
+      readContractWord(launch.hook, redeemer.feePips, blockTag),
+      readContractWord(launch.hook, redeemer.poolManager, blockTag),
+      readContractWord(launch.hook, redeemer.currency0, blockTag),
+      readContractWord(launch.hook, redeemer.currency1, blockTag),
+      readContractWord(launch.hook, redeemer.poolId, blockTag),
+      readContractWord(
+        LAUNCH_STAMP_ROUTER.poolManager.address,
+        poolManagerBalanceOfData(
+          redeemer.balanceOf,
+          launch.hook,
+          CUSTOM_V2_POLICY.nativeAsset,
+        ),
+        blockTag,
+      ),
+      readContractWord(
+        LAUNCH_STAMP_ROUTER.poolManager.address,
+        poolManagerBalanceOfData(
+          redeemer.balanceOf,
+          launch.hook,
+          launch.token,
+        ),
+        blockTag,
+      ),
+    ]);
+    if (
+      !isTreasury(decodeAddress(recipientWord)) ||
+      decodeUint256(feePipsWord) !== redeemer.expectedFeePips ||
+      decodeAddress(poolManagerWord).toLowerCase() !==
+        LAUNCH_STAMP_ROUTER.poolManager.address.toLowerCase() ||
+      decodeAddress(currency0Word).toLowerCase() !==
+        CUSTOM_V2_POLICY.nativeAsset.toLowerCase() ||
+      decodeAddress(currency1Word).toLowerCase() !==
+        launch.token.toLowerCase() ||
+      decodeBytes32(poolIdWord) !== launch.poolId
+    )
+      throw new Error("Mehrwährungs-Claim-Bindung stimmt nicht");
+    const amount = decodeUint256(nativeAmountWord);
+    const secondaryAmount = decodeUint256(tokenAmountWord);
+    if (amount > 0n || secondaryAmount > 0n) {
+      const simulated = await request("eth_call", [
+        { from: TREASURY, to: launch.hook, data: redeemer.claim },
+        blockTag,
+      ]);
+      if (simulated !== "0x")
+        throw new Error("Mehrwährungs-Claim-Simulation stimmt nicht");
+    }
+    return {
+      ...launch,
+      id: `router-custom:${launch.launchId}`,
+      name: "Custom · Router",
+      detail: shortAddress(launch.token),
+      unit: "ETH",
+      decimals: 18,
+      secondaryAsset: launch.token,
+      secondaryUnit: redeemer.secondaryUnit,
+      secondaryDecimals: redeemer.secondaryDecimals,
+      kind: "custom",
+      origin: "launch-stamp-router",
+      address: launch.hook,
+      claimMode: "manual",
+      claimProfile: redeemer.id,
+      claimData: redeemer.claim,
+      claimBindingVerified: true,
+      recipientMatches: true,
+      amount,
+      secondaryAmount,
+      status: "ready",
+    };
+  } catch {
+    // Continue to the explicit unsupported disposition below.
+  }
+
+  return {
+    ...launch,
+    id: `router-custom:${launch.launchId}`,
+    name: "Custom · Router",
+    detail: shortAddress(launch.token),
+    unit: "ETH",
+    decimals: 18,
+    kind: "custom",
+    origin: "launch-stamp-router",
+    address: launch.hook,
+    claimMode: "unsupported",
+    claimProfile: null,
+    claimBindingVerified: false,
+    recipientMatches: false,
+    amount: 0n,
+    status: "failed",
+  };
+}
+
+async function readVerifiedRouterLaunch(candidate, finalizedTag) {
+  const [recordValue, tokenLaunchIdWord, poolLaunchIdWord, tokenProofValue] =
+    await Promise.all([
+    request("eth_call", [
+      {
+        to: LAUNCH_STAMP_ROUTER.address,
+        data: launchStampBytes32ReadData(
+          LAUNCH_STAMP_SELECTORS.launchStamp,
+          candidate.launchId,
+        ),
+      },
+      finalizedTag,
+    ]),
+    readContractWord(
+      LAUNCH_STAMP_ROUTER.address,
+      launchStampAddressReadData(
+        LAUNCH_STAMP_SELECTORS.launchIdByToken,
+        candidate.token,
+      ),
+      finalizedTag,
+    ),
+    readContractWord(
+      LAUNCH_STAMP_ROUTER.address,
+      launchStampPoolReadData(
+        LAUNCH_STAMP_SELECTORS.launchIdByPool,
+        candidate.poolManager,
+        candidate.poolId,
+      ),
+      finalizedTag,
+    ),
+    request("eth_call", [
+      {
+        to: LAUNCH_STAMP_ROUTER.address,
+        data: launchStampAddressReadData(
+          LAUNCH_STAMP_SELECTORS.stampProof,
+          candidate.token,
+        ),
+      },
+      finalizedTag,
+    ]),
+  ]);
+  const record = decodeLaunchStampRecord(recordValue);
+  const tokenProof = decodeLaunchStampProof(tokenProofValue);
+  if (
+    decodeBytes32(tokenLaunchIdWord) !== candidate.launchId ||
+    decodeBytes32(poolLaunchIdWord) !== candidate.launchId ||
+    tokenProof.launchId !== candidate.launchId ||
+    tokenProof.stampHash !== candidate.stampHash ||
+    record.token.toLowerCase() !== candidate.token.toLowerCase() ||
+    record.hook.toLowerCase() !== candidate.hook.toLowerCase() ||
+    record.poolManager.toLowerCase() !== candidate.poolManager.toLowerCase() ||
+    record.poolId !== candidate.poolId ||
+    record.stampHash !== candidate.stampHash
+  )
+    throw new Error("Launch-Stamp-Record stimmt nicht mit dem Event überein");
+
+  const routeCode = await request("eth_getCode", [
+    record.routeLauncher,
+    finalizedTag,
+  ]);
+  if (
+    keccak256Hex(routeCode).toLowerCase() !==
+    record.routeLauncherRuntimeCodeHash
+  )
+    throw new Error("Launch-Route-Runtime ist gedriftet");
+
+  const verified = {
+    ...candidate,
+    ...record,
+    launchKind: record.kind,
+    provenanceVerified: true,
+    runtimeVerified: true,
+  };
+  if (record.kind === 2) {
+    const knownHook = HOOKS.find(
+      ({ address }) => address.toLowerCase() === record.hook.toLowerCase(),
+    );
+    return {
+      ...verified,
+      claimMode: knownHook ? "covered-by-known-hook" : "unsupported",
+      claimProfile: knownHook?.id ?? null,
+      claimBindingVerified: Boolean(knownHook),
+      amount: 0n,
+    };
+  }
+
+  const [hookLaunchIdWord, hookProofValue, recordedRuntimeWord, hookCode] =
+    await Promise.all([
+      readContractWord(
+        LAUNCH_STAMP_ROUTER.address,
+        launchStampAddressReadData(
+          LAUNCH_STAMP_SELECTORS.launchIdByComponent,
+          record.hook,
+        ),
+        finalizedTag,
+      ),
+      request("eth_call", [
+        {
+          to: LAUNCH_STAMP_ROUTER.address,
+          data: launchStampAddressReadData(
+            LAUNCH_STAMP_SELECTORS.stampProof,
+            record.hook,
+          ),
+        },
+        finalizedTag,
+      ]),
+      readContractWord(
+        LAUNCH_STAMP_ROUTER.address,
+        launchStampAddressReadData(
+          LAUNCH_STAMP_SELECTORS.componentRuntimeCodeHash,
+          record.hook,
+        ),
+        finalizedTag,
+      ),
+      request("eth_getCode", [record.hook, finalizedTag]),
+    ]);
+  const hookProof = decodeLaunchStampProof(hookProofValue);
+  const recordedRuntime = decodeBytes32(recordedRuntimeWord);
+  if (
+    decodeBytes32(hookLaunchIdWord) !== candidate.launchId ||
+    hookProof.launchId !== candidate.launchId ||
+    hookProof.stampHash !== candidate.stampHash ||
+    /^0x0{64}$/i.test(recordedRuntime) ||
+    keccak256Hex(hookCode).toLowerCase() !== recordedRuntime
+  )
+    throw new Error("Custom-Hook-Stamp oder Runtime stimmt nicht");
+
+  return readRouterCustomClaim(
+    { ...verified, runtimeCodeHash: recordedRuntime },
+    hookCode,
+    finalizedTag,
+  );
+}
+
+async function readLaunchStampRouter() {
+  for (const key of state.claims.keys()) {
+    if (key.startsWith("router-custom:")) state.claims.delete(key);
+  }
+  state.router = {
+    status: "loading",
+    verified: false,
+    finalizedBlock: null,
+    launches: [],
+    error: null,
+  };
+  renderSummary();
+  try {
+    const finalizedBlock = await readRouterFinalizedBoundary();
+    const finalizedTag = toQuantityHex(finalizedBlock);
+    const openingBlock = await readRouterQuorumBlock(finalizedTag);
+    await verifyLaunchStampInfrastructure(finalizedTag);
+    const candidates = reduceLaunchStampLogs(
+      await readLaunchStampLogs(finalizedBlock),
+    );
+    const launches = await mapWithConcurrency(candidates, 8, (candidate) =>
+      readVerifiedRouterLaunch(candidate, finalizedTag),
+    );
+    const closingBlock = await readRouterQuorumBlock(finalizedTag);
+    if (
+      closingBlock.number !== openingBlock.number ||
+      closingBlock.hash !== openingBlock.hash
+    )
+      throw new Error("Finalisierter Router-Block hat sich während des Scans geändert");
+    for (const launch of launches) {
+      if (launch.launchKind !== 1 || launch.claimMode !== "manual") continue;
+      state.claims.set(launch.id, {
+        amount: launch.amount,
+        secondaryAmount: launch.secondaryAmount,
+        recipientMatches: launch.recipientMatches,
+        status: launch.status,
+      });
+      for (const claim of launch.claimDefinitions ?? []) {
+        state.claims.set(claim.id, {
+          amount: claim.amount,
+          recipientMatches: claim.recipientMatches,
+          status: claim.status,
+        });
+      }
+    }
+    state.router = {
+      status: "ready",
+      verified: true,
+      finalizedBlock,
+      launches,
+      error: null,
+    };
+  } catch (error) {
+    state.router = {
+      status: "failed",
+      verified: false,
+      finalizedBlock: null,
+      launches: [],
+      error:
+        error instanceof Error
+          ? error.message
+          : "Launch-Stamp-Router konnte nicht gelesen werden",
     };
   }
 }
@@ -810,16 +2280,18 @@ async function readCustomRegistry(blockTag) {
     if (key.startsWith("custom-v1-standard:")) state.claims.delete(key);
   }
   state.custom = {
-    status: "failed",
-    registryVerified: false,
+    status: "retired",
+    registryVerified: true,
     launches: [],
-    error: "Custom Registry V1 ist außer Betrieb",
+    error: null,
   };
   renderSummary();
 }
 
-async function readContractWord(address, data, blockTag) {
-  const value = await request("eth_call", [{ to: address, data }, blockTag]);
+async function readContractWord(address, data, blockTag, from = null) {
+  const call = { to: address, data };
+  if (from) call.from = from;
+  const value = await request("eth_call", [call, blockTag]);
   if (typeof value !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(value))
     throw new Error(`Ungültige Contract-Antwort von ${shortAddress(address)}`);
   return value;
@@ -1075,6 +2547,9 @@ async function readCustomV2Source(release, indexed, blockTag) {
 }
 
 async function readCustomV2(blockTag) {
+  for (const key of state.claims.keys()) {
+    if (key.startsWith("custom-v2:")) state.claims.delete(key);
+  }
   state.customV2 = {
     status: "loading",
     release: null,
@@ -1217,11 +2692,160 @@ async function readCapabilities() {
   }
 }
 
-async function refreshClaims() {
+async function verifyCanonicalConfirmedBatchReceipts(receipts) {
+  await Promise.all(
+    receipts.map(async (storedReceipt) => {
+      const proof = {
+        blockNumber: BigInt(storedReceipt.blockNumber),
+        blockHash: storedReceipt.blockHash,
+        transactionHash: storedReceipt.transactionHash,
+      };
+      const [checkpoint, rpcReceipts] = await Promise.all([
+        readRouterQuorumBlock(toQuantityHex(proof.blockNumber)),
+        routerQuorumRequest("eth_getTransactionReceipt", [
+          proof.transactionHash,
+        ]),
+      ]);
+      if (
+        checkpoint.number !== proof.blockNumber ||
+        checkpoint.hash.toLowerCase() !== proof.blockHash.toLowerCase() ||
+        rpcReceipts.length !== 3 ||
+        rpcReceipts.some(
+          (receipt) => !confirmedTransactionReceiptMatches(proof, receipt),
+        )
+      ) {
+        throw new Error(
+          "Der bestätigte Claim-Receipt ist noch nicht kanonisch finalisiert",
+        );
+      }
+    }),
+  );
+}
+
+async function reconcileConfirmedBatchLock() {
+  return withAvailableClaimStateLease(async () => {
+    let lock = loadConfirmedBatchLock();
+    state.confirmedBatch = lock;
+    if (
+      !lock ||
+      lock.invalid ||
+      !state.account ||
+      state.chainId !== MAINNET_CHAIN_ID ||
+      state.account.toLowerCase() !== lock.account ||
+      lock.phase === "manual"
+    ) {
+      return;
+    }
+
+    if (lock.phase !== "confirmed") {
+      let result;
+      try {
+        result = await request("wallet_getCallsStatus", [lock.batchId]);
+      } catch {
+        return;
+      }
+
+      let status;
+      try {
+        status = validatedAtomicBatchStatus(
+          result,
+          lock.batchId,
+          MAINNET_CHAIN_ID,
+        );
+      } catch {
+        return;
+      }
+
+      if (status === 400 || status === 500) {
+        clearConfirmedBatchLock(lock.batchId);
+        return;
+      }
+      if (status >= 600) {
+        saveConfirmedBatchLock(
+          {
+            ...lock,
+            phase: "manual",
+            failureStatus: status,
+          },
+          { expectedBatchId: lock.batchId },
+        );
+        return;
+      }
+      if (status !== 200) {
+        if (status >= 100 && status < 200)
+          saveConfirmedBatchLock(
+            { ...lock, phase: "pending" },
+            { expectedBatchId: lock.batchId },
+          );
+        return;
+      }
+
+      try {
+        const proof = confirmedBatchReceiptProof(
+          result,
+          lock.batchId,
+          MAINNET_CHAIN_ID,
+        );
+        lock = {
+          ...lock,
+          phase: "confirmed",
+          receipts: proof.receipts.map((receipt) => ({
+            blockNumber: receipt.blockNumber.toString(),
+            blockHash: receipt.blockHash,
+            transactionHash: receipt.transactionHash,
+          })),
+          failureStatus: null,
+        };
+        if (
+          !saveConfirmedBatchLock(lock, {
+            expectedBatchId: lock.batchId,
+          })
+        )
+          return;
+      } catch {
+        return;
+      }
+    }
+
+    const highestBlock = highestConfirmedReceiptBlock(lock);
+    let inventoryBlock = null;
+    try {
+      inventoryBlock = BigInt(state.blockTag);
+    } catch {
+      // The fee inventory is not bound to a usable post-receipt checkpoint.
+    }
+    if (
+      highestBlock === null ||
+      inventoryBlock === null ||
+      inventoryBlock < highestBlock ||
+      state.router.status !== "ready" ||
+      state.router.verified !== true ||
+      typeof state.router.finalizedBlock !== "bigint" ||
+      state.router.finalizedBlock < highestBlock
+    ) {
+      return;
+    }
+
+    try {
+      await verifyCanonicalConfirmedBatchReceipts(lock.receipts);
+      clearConfirmedBatchLock(lock.batchId);
+    } catch {
+      // A reorged, missing or divergent receipt remains locked until a later scan.
+    }
+  });
+}
+
+async function refreshClaimsOnce() {
   if (!state.account || state.chainId !== MAINNET_CHAIN_ID) return;
   setError();
   setStatus("Contract-Bindungen und Guthaben werden geprüft");
-  const blockTag = await request("eth_blockNumber");
+  await readLaunchStampRouter();
+  const blockTag =
+    state.router.status === "ready" &&
+    state.router.verified === true &&
+    typeof state.router.finalizedBlock === "bigint"
+      ? toQuantityHex(state.router.finalizedBlock)
+      : await request("eth_blockNumber");
   state.blockTag = blockTag;
 
   await Promise.all([
@@ -1230,9 +2854,13 @@ async function refreshClaims() {
     readClassicLaunches(blockTag),
   ]);
 
-  const hookResults = await Promise.allSettled(
-    HOOKS.map((hook) => readHook(hook, blockTag)),
-  );
+  const hookResults = await mapWithConcurrency(HOOKS, 4, async (hook) => {
+    try {
+      return { status: "fulfilled", value: await readHook(hook, blockTag) };
+    } catch (reason) {
+      return { status: "rejected", reason };
+    }
+  });
   hookResults.forEach((result, index) => {
     const hook = HOOKS[index];
     state.hooks.set(
@@ -1241,9 +2869,13 @@ async function refreshClaims() {
     );
   });
 
-  const claimResults = await Promise.allSettled(
-    CLAIMS.map((claim) => readClaim(claim, blockTag)),
-  );
+  const claimResults = await mapWithConcurrency(CLAIMS, 4, async (claim) => {
+    try {
+      return { status: "fulfilled", value: await readClaim(claim, blockTag) };
+    } catch (reason) {
+      return { status: "rejected", reason };
+    }
+  });
   claimResults.forEach((result, index) => {
     const claim = CLAIMS[index];
     state.claims.set(
@@ -1255,6 +2887,7 @@ async function refreshClaims() {
   });
 
   await readCapabilities();
+  await reconcileConfirmedBatchLock();
   const verified = hookResults.filter(
     ({ status }, index) =>
       status === "fulfilled" && state.hooks.get(HOOKS[index].id)?.verified,
@@ -1279,53 +2912,146 @@ async function refreshClaims() {
     errors.push(
       "Die Classic-Launchliste konnte nicht vollständig gelesen werden. Der verifizierte gemeinsame Hook-Claim bleibt verfügbar.",
     );
+  if (state.router.error)
+    errors.push(
+      "Der offizielle Launch-Stamp-Router konnte nicht vollständig verifiziert werden. Alle Claims bleiben gesperrt.",
+    );
   setError(errors.join(" "));
   setStatus(
-    state.custom.error || state.customV2.error
-      ? "Custom Registry konnte nicht vollständig gelesen werden"
-      : failedClaims === 0
-        ? `Stand Block ${BigInt(blockTag).toString()} · ${state.classic.launches.length} Classic · ${state.custom.launches.length + state.customV2.sources.length} Custom`
-        : `${failedClaims} Guthaben konnten nicht gelesen werden`,
+    state.confirmedBatch
+      ? confirmedBatchStatus()
+      : state.custom.error || state.customV2.error || state.router.error
+        ? "Ecosystem-Scan konnte nicht vollständig gelesen werden"
+        : failedClaims === 0
+          ? `Stand Block ${BigInt(blockTag).toString()} · ${state.classic.launches.length + state.router.launches.filter(({ launchKind }) => launchKind === 2).length} Classic · ${state.custom.launches.length + state.customV2.sources.length + state.router.launches.filter(({ launchKind }) => launchKind === 1).length} Custom`
+          : `${failedClaims} Guthaben konnten nicht gelesen werden`,
   );
   renderSummary();
 }
 
-async function syncWallet({ requestAccounts = false } = {}) {
+const refreshClaims = createRefreshQueue(refreshClaimsOnce);
+
+async function syncWallet({
+  requestAccounts = false,
+  expectedRevision = walletAuthorizationRevision,
+} = {}) {
   const method = requestAccounts ? "eth_requestAccounts" : "eth_accounts";
   const [accounts, chainId] = await Promise.all([
     request(method),
     request("eth_chainId"),
   ]);
-  state.account =
-    Array.isArray(accounts) && accounts.length > 0 ? accounts[0] : null;
+  if (expectedRevision !== walletAuthorizationRevision) return;
+  state.account = Array.isArray(accounts) ? accounts[0] ?? null : null;
   state.chainId = chainId;
   renderSummary();
-  if (state.account && chainId === MAINNET_CHAIN_ID) await refreshClaims();
+  if (requestAccounts && state.account) {
+    setStatus(
+      isTreasury(state.account)
+        ? "Wallet verbunden · Fees werden gesucht"
+        : "Reward Wallet auswählen",
+    );
+  }
+  if (
+    !state.account ||
+    state.chainId !== MAINNET_CHAIN_ID ||
+    !isTreasury(state.account)
+  )
+    return;
+  await refreshClaims();
+}
+
+async function chooseRewardWallet() {
+  setStatus("Reward Wallet in MetaMask auswählen");
+  await request("wallet_requestPermissions", [{ eth_accounts: {} }]);
+  await syncWallet();
+}
+
+async function requireActiveRewardWallet(expectedAccount = null) {
+  const revision = walletAuthorizationRevision;
+  const [accounts, chainId] = await Promise.all([
+    request("eth_accounts"),
+    request("eth_chainId"),
+  ]);
+  if (revision !== walletAuthorizationRevision)
+    throw new Error(
+      "Wallet oder Netzwerk wurde während der Prüfung geändert. Es wurde nichts gesendet.",
+    );
+  const activeAccount = Array.isArray(accounts) ? accounts[0] ?? null : null;
+  state.account = activeAccount;
+  state.chainId = chainId;
+  renderSummary();
+  if (
+    chainId !== MAINNET_CHAIN_ID ||
+    !activeAccount ||
+    !isTreasury(activeAccount) ||
+    (expectedAccount !== null &&
+      activeAccount.toLowerCase() !== expectedAccount.toLowerCase())
+  )
+    throw new Error(
+      "Aktive Reward Wallet oder Netzwerk hat sich geändert. Es wurde nichts gesendet.",
+    );
+  return activeAccount.toLowerCase();
 }
 
 async function switchToMainnet() {
   await request("wallet_switchEthereumChain", [{ chainId: MAINNET_CHAIN_ID }]);
-  state.chainId = await request("eth_chainId");
-  renderSummary();
-  await refreshClaims();
+  await syncWallet();
+  if (!state.account || !isTreasury(state.account))
+    setStatus("Reward Wallet auswählen");
 }
 
-async function waitForBatch(id) {
+async function waitForBatch(initialLock) {
+  let lock = initialLock;
+  const id = lock.batchId;
   const startedAt = Date.now();
   while (Date.now() - startedAt < 5 * 60 * 1000) {
-    const result = await request("wallet_getCallsStatus", [id]);
-    if (result?.status === 200) {
-      if (
-        result.atomic !== true ||
-        !Array.isArray(result.receipts) ||
-        result.receipts.some(({ status }) => status !== "0x1")
-      ) {
-        throw new Error("Der atomare Claim-Batch ist fehlgeschlagen");
-      }
-      return result;
+    let result;
+    try {
+      result = await request("wallet_getCallsStatus", [id]);
+    } catch {
+      await new Promise((resolve) => window.setTimeout(resolve, 3000));
+      continue;
     }
-    if (typeof result?.status === "number" && result.status >= 400)
+    let status;
+    try {
+      status = validatedAtomicBatchStatus(result, id, MAINNET_CHAIN_ID);
+    } catch {
+      await new Promise((resolve) => window.setTimeout(resolve, 3000));
+      continue;
+    }
+    if (status === 200) {
+      const proof = confirmedBatchReceiptProof(result, id, MAINNET_CHAIN_ID);
+      lock = {
+        ...lock,
+        phase: "confirmed",
+        receipts: proof.receipts.map((receipt) => ({
+          blockNumber: receipt.blockNumber.toString(),
+          blockHash: receipt.blockHash,
+          transactionHash: receipt.transactionHash,
+        })),
+        failureStatus: null,
+      };
+      if (!saveConfirmedBatchLock(lock, { expectedBatchId: id }))
+        throw new Error(
+          "Der bestätigte Claim-Batch konnte nicht sicher gespeichert werden. Claims bleiben gesperrt.",
+        );
+      return lock;
+    }
+    if (status === 400 || status === 500) {
+      clearConfirmedBatchLock(id);
       throw new Error("Der Claim-Batch wurde abgelehnt");
+    }
+    if (status >= 600) {
+      lock = {
+        ...lock,
+        phase: "manual",
+        failureStatus: status,
+      };
+      saveConfirmedBatchLock(lock, { expectedBatchId: id });
+      throw new Error(
+        "Der Wallet-Batch kann teilweise ausgeführt worden sein. Claims bleiben gesperrt.",
+      );
+    }
     await new Promise((resolve) => window.setTimeout(resolve, 3000));
   }
   throw new Error(
@@ -1333,8 +3059,92 @@ async function waitForBatch(id) {
   );
 }
 
-async function claimAll() {
+async function submitStoredBatchAndWait(initialLock) {
+  let lock = initialLock;
+  const id = lock.batchId;
+  try {
+    const result = await request("wallet_sendCalls", [lock.batch]);
+    const returnedId = normalizeBatchId(result);
+    if (returnedId.toLowerCase() !== id.toLowerCase())
+      throw new Error(
+        "MetaMask hat eine abweichende Batch-ID geliefert. Claims bleiben gesperrt.",
+      );
+  } catch (error) {
+    if (walletSendDefinitelyNotSubmitted(error)) {
+      clearConfirmedBatchLock(id);
+      throw error;
+    }
+    if (!walletSendDuplicateBatchId(error)) throw error;
+  }
+
+  lock = { ...lock, phase: "pending" };
+  if (!saveConfirmedBatchLock(lock, { expectedBatchId: id }))
+    throw new Error(
+      "Der Claim-Batch konnte nach der Wallet-Antwort nicht sicher gespeichert werden. Claims bleiben gesperrt.",
+    );
+  return waitForBatch(lock);
+}
+
+async function preflightWalletBatch(batch) {
+  await Promise.all(
+    batch.calls.map(({ to, data, value }) =>
+      request("eth_call", [
+        { from: batch.from, to, data, value },
+        "latest",
+      ]),
+    ),
+  );
+}
+
+async function preflightClaimBatch(claims) {
+  if (claims.length > MAX_BATCH_CALLS)
+    throw new Error(
+      `Mehr als ${MAX_BATCH_CALLS} offene Claims passen nicht sicher in einen atomaren Batch`,
+    );
+  const batch = buildWalletSendCalls(state.account, claims);
+  await preflightWalletBatch(batch);
+  return batch;
+}
+
+function walletCallKey({ to, data, value }) {
+  return `${to.toLowerCase()}:${data.toLowerCase()}:${value.toLowerCase()}`;
+}
+
+async function walletRecognizesStoredBatch(lock) {
+  try {
+    const result = await request("wallet_getCallsStatus", [lock.batchId]);
+    validatedAtomicBatchStatus(result, lock.batchId, MAINNET_CHAIN_ID);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function validateStoredBatchForResubmission(lock) {
   await refreshClaims();
+  await requireActiveRewardWallet(lock.account);
+  const safetyError = claimSafetyError({ ignoreConfirmedBatch: true });
+  if (safetyError) throw new Error(`${safetyError}. Claims bleiben gesperrt.`);
+
+  const currentClaims = claimableClaims({ ignoreConfirmedBatch: true });
+  const currentCalls =
+    currentClaims.length === 0
+      ? []
+      : buildWalletSendCalls(lock.account, currentClaims).calls;
+  const currentCallKeys = new Set(currentCalls.map(walletCallKey));
+  if (lock.batch.calls.some((call) => !currentCallKeys.has(walletCallKey(call))))
+    throw new Error(
+      "Der gespeicherte Claim ist nicht mehr Teil des aktuell verifizierten Fee-Inventars. Es wurde nichts gesendet.",
+    );
+
+  await preflightWalletBatch(lock.batch);
+  await requireActiveRewardWallet(lock.account);
+}
+
+async function claimAll() {
+  const expectedAccount = await requireActiveRewardWallet();
+  await refreshClaims();
+  await requireActiveRewardWallet(expectedAccount);
   const safetyError = claimSafetyError();
   if (safetyError) throw new Error(`${safetyError}. Claims bleiben gesperrt.`);
   const claims = claimableClaims();
@@ -1345,13 +3155,34 @@ async function claimAll() {
   renderSummary();
 
   try {
-    setStatus(
-      `${claims.length} Claims werden in einer MetaMask-Bestätigung vorbereitet`,
-    );
-    const result = await request("wallet_sendCalls", [
-      buildWalletSendCalls(state.account, claims),
-    ]);
-    await waitForBatch(normalizeBatchId(result));
+    await withExclusiveClaimLease(async () => {
+      setStatus(
+        `${claims.length} Claims werden direkt vor MetaMask erneut simuliert`,
+      );
+      const batch = await preflightClaimBatch(claims);
+      await requireActiveRewardWallet(expectedAccount);
+      requireConfirmedBatchStorage();
+      const id = createAppBatchId();
+      const exactBatch = { ...batch, id };
+      const submissionLock = {
+        schema: CONFIRMED_BATCH_SCHEMA,
+        account: expectedAccount,
+        chainId: MAINNET_CHAIN_ID,
+        batchId: id,
+        batch: exactBatch,
+        phase: "submitting",
+        receipts: null,
+        failureStatus: null,
+      };
+      if (!saveConfirmedBatchLock(submissionLock, { requireEmpty: true }))
+        throw new Error(
+          "Die tabübergreifende Claim-Sperre konnte nicht gespeichert werden. Es wurde nichts gesendet.",
+        );
+      setStatus(
+        `${claims.length} Claims werden in einer MetaMask-Bestätigung vorbereitet`,
+      );
+      return submitStoredBatchAndWait(submissionLock);
+    });
     setStatus("Alle verfügbaren Fees wurden geclaimt");
     await refreshClaims();
   } catch (error) {
@@ -1371,14 +3202,63 @@ async function claimAll() {
   }
 }
 
+async function resumeStoredBatch() {
+  state.busy = true;
+  setError();
+  renderSummary();
+  try {
+    await withExistingClaimLease(async (lock) => {
+      if (!["submitting", "pending"].includes(lock.phase))
+        throw new Error("Dieser Claim-Batch kann nicht erneut eingereicht werden");
+      await requireActiveRewardWallet(lock.account);
+      if (lock.phase === "pending" || (await walletRecognizesStoredBatch(lock)))
+        return waitForBatch(lock);
+      await validateStoredBatchForResubmission(lock);
+      setStatus("Der gespeicherte Claim-Batch wird mit derselben ID fortgesetzt");
+      return submitStoredBatchAndWait(lock);
+    });
+    setStatus("Alle verfügbaren Fees wurden geclaimt");
+    await refreshClaims();
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Der gespeicherte Claim-Batch konnte nicht fortgesetzt werden";
+    setError(
+      /reject|denied|cancel/i.test(message)
+        ? "Claim in MetaMask abgebrochen"
+        : message,
+    );
+    setStatus("Claims wurden sicher gestoppt");
+  } finally {
+    state.busy = false;
+    renderSummary();
+  }
+}
+
 async function handlePrimaryAction() {
   try {
     setError();
+    if (DEMO_MODE) {
+      setStatus(
+        "QA-Vorschau: In der echten Ansicht öffnet dieser Button genau eine MetaMask-Bestätigung",
+      );
+      return;
+    }
     state.busy = true;
     renderSummary();
     if (!state.account) await syncWallet({ requestAccounts: true });
     else if (state.chainId !== MAINNET_CHAIN_ID) await switchToMainnet();
-    else if (isTreasury(state.account)) await claimAll();
+    else if (!isTreasury(state.account)) await chooseRewardWallet();
+    else if (isTreasury(state.account)) {
+      if (
+        state.confirmedBatch &&
+        !state.confirmedBatch.invalid &&
+        ["submitting", "pending"].includes(state.confirmedBatch.phase)
+      )
+        await resumeStoredBatch();
+      else await claimAll();
+    }
   } catch (error) {
     const message =
       error instanceof Error
@@ -1395,8 +3275,31 @@ async function handlePrimaryAction() {
   }
 }
 
+window.addEventListener("storage", (event) => {
+  if (DEMO_MODE || event.key !== CONFIRMED_BATCH_STORAGE_KEY) return;
+  const stored = loadConfirmedBatchLock();
+  if (stored) {
+    state.confirmedBatch = stored;
+    renderSummary();
+    return;
+  }
+  state.confirmedBatch = null;
+  state.busy = true;
+  renderSummary();
+  refreshClaims()
+    .catch(() => undefined)
+    .finally(() => {
+      state.busy = false;
+      renderSummary();
+    });
+});
+
 elements.action.addEventListener("click", handlePrimaryAction);
 elements.refresh.addEventListener("click", async () => {
+  if (DEMO_MODE) {
+    setStatus("QA-Vorschau wurde neu geladen · keine Wallet-Aktion");
+    return;
+  }
   state.busy = true;
   renderSummary();
   try {
@@ -1411,15 +3314,132 @@ elements.refresh.addEventListener("click", async () => {
   }
 });
 
-window.ethereum?.on?.("accountsChanged", () =>
-  syncWallet().catch(() => undefined),
-);
-window.ethereum?.on?.("chainChanged", () =>
-  syncWallet().catch(() => undefined),
-);
-
-renderSummary();
-syncWallet().catch(() => {
-  setStatus("MetaMask verbinden, um offene Fees zu lesen");
+function seedDemoState() {
+  state.account = TREASURY;
+  state.chainId = MAINNET_CHAIN_ID;
+  state.blockTag = "0x189f510";
+  state.capability = "ready";
+  for (const hook of HOOKS) {
+    state.hooks.set(hook.id, {
+      actualCodeHash: hook.runtimeCodeHash,
+      recipient: TREASURY,
+      verified: true,
+    });
+  }
+  const demoAmounts = new Map([
+    ["classic-v3", 3_831_314_566_506_772n],
+    ["classic-v2", 227_307_871_565_013_620n],
+    ["classic-v1", 46_446_511_178_969n],
+    ["stock-current-nvdaon", 84_200_000_000_000_000n],
+  ]);
+  for (const claim of CLAIMS) {
+    state.claims.set(claim.id, {
+      amount: demoAmounts.get(claim.id) ?? 0n,
+      recipient: TREASURY,
+      recipientMatches: true,
+      status: "ready",
+    });
+  }
+  state.custom = {
+    status: "retired",
+    registryVerified: true,
+    launches: [],
+    error: null,
+  };
+  state.customV2 = {
+    status: "hold",
+    release: null,
+    sources: [],
+    error: null,
+  };
+  state.classic = {
+    status: "ready",
+    launchersVerified: true,
+    launches: [],
+    error: null,
+  };
+  const fadeProfile = ROUTER_CUSTOM_CLAIM_PROFILES.nativeAccumulatorV1;
+  const fadeBinding = fadeProfile.bindings[0];
+  const fadeClaim = {
+    id: `router-custom:${fadeBinding.launchId}`,
+    launchId: fadeBinding.launchId,
+    token: "0x69d278968abf120f878f2e1e016ab615d3686c19",
+    hook: fadeBinding.source,
+    runtimeCodeHash: fadeBinding.runtimeCodeHash,
+    launchKind: 1,
+    kind: "custom",
+    origin: "launch-stamp-router",
+    address: fadeBinding.source,
+    unit: "ETH",
+    decimals: 18,
+    provenanceVerified: true,
+    runtimeVerified: true,
+    claimMode: "manual",
+    claimProfile: fadeProfile.id,
+    readData: fadeProfile.accrued,
+    claimData: fadeProfile.claim,
+    claimBindingVerified: true,
+    recipientMatches: true,
+    amount: 28_054_452_170_132_560n,
+    status: "ready",
+  };
+  const pcanProfile = ROUTER_CUSTOM_CLAIM_PROFILES.dualCurrencyRedeemerV1;
+  const pcanBinding = pcanProfile.bindings[0];
+  const pcanClaim = {
+    id: `router-custom:${pcanBinding.launchId}`,
+    launchId: pcanBinding.launchId,
+    token: "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce",
+    hook: pcanBinding.source,
+    runtimeCodeHash: pcanBinding.runtimeCodeHash,
+    launchKind: 1,
+    kind: "custom",
+    origin: "launch-stamp-router",
+    address: pcanBinding.source,
+    unit: "ETH",
+    decimals: 18,
+    provenanceVerified: true,
+    runtimeVerified: true,
+    claimMode: "manual",
+    claimProfile: pcanProfile.id,
+    claimData: pcanProfile.claim,
+    claimBindingVerified: true,
+    recipientMatches: true,
+    amount: 500_802_908_283_517n,
+    secondaryAsset: "0x9deeb39d2590b0cad5fc473f755c5f97dcc8f7ce",
+    secondaryAmount: 2_740_004_896_936_423_458_238n,
+    secondaryUnit: pcanProfile.secondaryUnit,
+    secondaryDecimals: pcanProfile.secondaryDecimals,
+    status: "ready",
+  };
+  state.router = {
+    status: "ready",
+    verified: true,
+    finalizedBlock: 25_827_076n,
+    launches: [fadeClaim, pcanClaim],
+    error: null,
+  };
+  state.claims.set(fadeClaim.id, {
+    amount: fadeClaim.amount,
+    recipientMatches: true,
+    status: "ready",
+  });
+  state.claims.set(pcanClaim.id, {
+    amount: pcanClaim.amount,
+    secondaryAmount: pcanClaim.secondaryAmount,
+    recipientMatches: true,
+    status: "ready",
+  });
   renderSummary();
-});
+  elements.status.textContent =
+    "Sichere QA-Vorschau · Werte sind Testdaten · keine Wallet-Aktion";
+}
+
+if (DEMO_MODE) {
+  seedDemoState();
+} else {
+  renderSummary();
+  syncWallet().catch(() => {
+    setStatus("MetaMask verbinden");
+    renderSummary();
+  });
+}

--- a/ops/protocol-fee-claim/claim-discovery.json
+++ b/ops/protocol-fee-claim/claim-discovery.json
@@ -1,11 +1,166 @@
 {
-  "schemaVersion": "programmable.fee-claim-discovery.v1",
+  "schemaVersion": "programmable.fee-claim-discovery.v2",
   "chainId": "1",
   "rewardWallet": "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c",
   "execution": {
     "method": "wallet_sendCalls",
     "atomicRequired": true,
-    "unsupportedWalletBehavior": "fail_closed"
+    "preflightEveryCallImmediatelyBeforeWallet": true,
+    "maximumCallsPerAtomicBatch": 64,
+    "unsupportedWalletBehavior": "fail_closed",
+    "appProvidedBatchId": true,
+    "crossTabSubmissionLease": "web_locks_exclusive",
+    "ambiguousSubmissionRecovery": "resubmit_exact_same_batch_with_exact_same_app_id",
+    "postConfirmationReconciliation": "persist_until_three_provider_canonical_receipts_and_finalized_router_snapshot",
+    "partialFailureBehavior": "fail_closed_manual_reconciliation"
+  },
+  "launchStampRouter": {
+    "discoveryMode": "complete_consensus_finalized_event_replay_plus_onchain_stamp_verification",
+    "address": "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
+    "startBlock": "25717612",
+    "finality": {
+      "blockTag": "finalized",
+      "maximumProviderSpreadBlocks": "32",
+      "policy": "bounded_three_provider_finalized_views_then_exact_common_block_hash_or_block"
+    },
+    "runtimeCodeHash": "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
+    "eventTopic": "0x6cf479a102f1eebc9244f48f8d68f6aa52b4c5a4516318df58ba46614a5b14f2",
+    "futureRouterLaunchesAutoDiscovered": true,
+    "classicClaimPolicy": {
+      "knownHook": "covered_by_verified_aggregate_hook",
+      "unknownHook": "visible_and_block_all_claims"
+    },
+    "maximumScannedLaunches": 4096,
+    "logQuorum": {
+      "policy": "wallet_plus_two_independent_rpc_exact_raw_match_or_block",
+      "publicRpcEndpoints": [
+        "https://mainnet.gateway.tenderly.co",
+        "https://eth.drpc.org",
+        "https://rpc.mevblocker.io"
+      ],
+      "publicRpcProviderGroups": [
+        [
+          "https://mainnet.gateway.tenderly.co",
+          "https://eth.drpc.org"
+        ],
+        [
+          "https://rpc.mevblocker.io"
+        ]
+      ],
+      "canonicalTuple": [
+        "address",
+        "blockHash",
+        "blockNumber",
+        "transactionHash",
+        "transactionIndex",
+        "logIndex",
+        "topics",
+        "data"
+      ]
+    },
+    "verification": [
+      "router_and_trust_root_runtime_hashes",
+      "exact_consensus_finalized_checkpoint_quorum",
+      "independent_rpc_log_quorum",
+      "router_claim_bindings_and_displayed_balances_at_finalized_checkpoint",
+      "launch_id_by_token",
+      "launch_id_by_pool_manager_and_pool_id",
+      "launch_stamp_record_and_component_proofs",
+      "route_and_hook_runtime_hashes_at_finalized_checkpoint"
+    ],
+    "trustRoots": {
+      "permitAuthority": {
+        "address": "0x755509eA6e3F5Ec1aA2E797bb68f1B87DD8b886b",
+        "runtimeCodeHash": "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c"
+      },
+      "graphFactory": {
+        "address": "0xB012e4A8F2c5FC4E8E4faCA9D5Ad6FfF13FBA887",
+        "runtimeCodeHash": "0xd23692fae59331592048e71a96d4963e170ee56e449683dc9f7fa3f9470018b8"
+      },
+      "poolManager": {
+        "address": "0x000000000004444c5dc75cB358380D2e3dE08A90",
+        "runtimeCodeHash": "0x785f1014552b7ce7d5fb7d0c970ca60edee94fd00425d7ca21609acac7ce1293"
+      }
+    },
+    "claimProfiles": [
+      {
+        "id": "native-accumulator-v1",
+        "launchId": "0x6d6ed0e1e69a7cd6afa177e3454c9e32eed61cbd3f855ee56aff1915a6776fc2",
+        "source": "0xd7451a039373f54e493deE42A751fEcBfAFBa0cc",
+        "runtimeCodeHash": "0xff70a4d3d889b730a064b270fc187f0cba40582f1fa6f5875893066b17a1257b",
+        "accruedSelector": "0x0986bdb6",
+        "claimSelector": "0xa95e4f21"
+      },
+      {
+        "id": "shard-launcher-fees-v1",
+        "launchId": "0xe253f3bd22fcb3d6cb20b9d408287e30f0f1aeeb56426b779425c35fd6411de9",
+        "token": "0xFAce73B63787960282f2d4682d3752Beb25271Ad",
+        "source": "0x07a16735325723fEa4f4a52ED5E9da687766A0Cc",
+        "runtimeCodeHash": "0x168f82b0d458a35676522562489b2fec71929e4717c3d98b4893ef63e69e8da6",
+        "recipientSelector": "0x4c50e2c4",
+        "expectedRecipient": "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c",
+        "feeBpsSelector": "0x89223381",
+        "expectedFeeBps": 1000,
+        "feeDenominatorBpsSelector": "0xe1a45218",
+        "expectedFeeDenominatorBps": 10000,
+        "poolManagerSelector": "0xdc4c90d3",
+        "expectedPoolManager": "0x000000000004444c5dc75cb358380d2e3de08a90",
+        "boundTokenSelector": "0x996373c3",
+        "expectedBoundToken": "0xFAce73B63787960282f2d4682d3752Beb25271Ad",
+        "nftSelector": "0x47ccca02",
+        "expectedNft": "0x92822e03D9cc1b2b497647B159ce5207Cd721527",
+        "initializedSelector": "0x07003bb4",
+        "expectedInitialized": true,
+        "accruedSelector": "0x1497233e",
+        "claimSelector": "0x64d46b85",
+        "claimCalldata": "0x64d46b85"
+      },
+      {
+        "id": "dual-currency-redeemer-v1",
+        "launchId": "0x5a52180427785716bff0a36218dde89f0459db265d0c2bdfcfde81a8fe733c92",
+        "source": "0xEBa46F25dff528141DE5317109aCB5a989296044",
+        "runtimeCodeHash": "0xd59d31add7a3b206972725889dbb726782c0fbd82514710cf2d645749dc3fa25",
+        "claimSelector": "0xfc656ac5",
+        "claimCalldata": "0xfc656ac500000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
+        "balanceSelector": "0x00fdd58e",
+        "currencies": [
+          "0x0000000000000000000000000000000000000000",
+          "0x9DEeB39D2590b0cAD5fc473F755C5F97Dcc8f7cE"
+        ]
+      },
+      {
+        "id": "isolated-after-swap-fee-vault-v2",
+        "launchId": "0x786d3d5cdd0c6ba81621eb01fbcc6b5912556a2d7dbe886431346460afeee197",
+        "token": "0xD0f3E1e5C985D2b37a66Cf07feCB0d8191c0445F",
+        "hook": "0xce6f22c5ccf06aad50dd2bc681fa7c30ce55e044",
+        "hookRuntimeCodeHash": "0x0a461fa65d04305fa2e583d9a6fba369b3b2ff66aa5856f56d0782c2ff72e19c",
+        "source": "0x97875d30DFE562e290Eb5646D907F8e775645f66",
+        "sourceRuntimeCodeHash": "0xf2cbc21a3f07c05909d664ba8d8b66fe6576eb8a5d016faa53e31e73ed6acbd4",
+        "hookFeeVaultSelector": "0x5517476a",
+        "expectedHookFeeVault": "0x97875d30DFE562e290Eb5646D907F8e775645f66",
+        "bindingAuthoritySelector": "0x2028d39b",
+        "expectedBindingAuthority": "0x0000000000000000000000000000000000000000",
+        "recipientSelector": "0xc6fd9bd8",
+        "expectedRecipient": "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c",
+        "feePpmSelector": "0x6cf9ca81",
+        "expectedFeePpm": 1000,
+        "feeDenominatorPpmSelector": "0x1bd7398b",
+        "expectedFeeDenominatorPpm": 1000000,
+        "poolManagerSelector": "0xdc4c90d3",
+        "expectedPoolManager": "0x000000000004444c5dc75cb358380d2e3de08a90",
+        "authorizedAdapterSelector": "0x54a1b628",
+        "expectedAuthorizedAdapter": "0xce6f22c5ccf06aad50dd2bc681fa7c30ce55e044",
+        "authorizedAdapterCodeHashSelector": "0x18903320",
+        "expectedAuthorizedAdapterCodeHash": "0x0a461fa65d04305fa2e583d9a6fba369b3b2ff66aa5856f56d0782c2ff72e19c",
+        "accruedSelector": "0x87d4d28c",
+        "claimSelector": "0x5fa65a04",
+        "currencies": [
+          "0x0000000000000000000000000000000000000000",
+          "0xD0f3E1e5C985D2b37a66Cf07feCB0d8191c0445F"
+        ]
+      }
+    ],
+    "unknownClaimProfile": "visible_and_block_all_claims"
   },
   "classic": {
     "claimMode": "one_aggregate_claim_per_hook_version",
@@ -45,6 +200,6 @@
   "customV2": {
     "status": "HOLD",
     "futureFinalizedStandardSourcesAutoAdded": false,
-    "reason": "No exact Mainnet deployment and finalized release binding exists yet."
+    "reason": "The proposed universal revenue registry is not deployed. Official future launches are discovered through the Launch Stamp Router and require an exact approved claim profile."
   }
 }

--- a/ops/protocol-fee-claim/index.html
+++ b/ops/protocol-fee-claim/index.html
@@ -25,63 +25,74 @@
       </header>
 
       <section class="content" aria-labelledby="claim-title">
-        <div class="intro-grid">
-          <div>
-            <p class="eyebrow">Privates Claim-Fenster</p>
-            <h1 id="claim-title">Alle Fees<br />claimen</h1>
-          </div>
+        <div class="hero">
+          <p class="eyebrow">Fee Claim</p>
+          <h1 id="claim-title">Alles claimen.</h1>
           <p class="intro">
-            Neue Classic- und Custom-Launches erscheinen bei jedem Scan
-            automatisch. Stock bleibt auf den bestehenden Assets.
+            Reward Wallet verbinden. Offene Fees werden automatisch gefunden.
           </p>
         </div>
 
         <div class="total-line" aria-label="Offene Gebühren">
-          <span data-claim-count>0 Claims</span>
+          <span>Offen</span>
           <strong data-total>0 ETH</strong>
-        </div>
-
-        <ul
-          class="claim-list"
-          data-claim-rows
-          aria-label="Programmable Feequellen"
-        ></ul>
-
-        <div class="meta-grid">
-          <div>
-            <span>Wallet</span>
-            <strong data-account>Nicht verbunden</strong>
-          </div>
-          <div>
-            <span>Bestätigung</span>
-            <strong data-batch-mode>Batch wird geprüft</strong>
-          </div>
-          <button class="refresh" type="button" data-refresh disabled>
-            Nur scannen
-          </button>
+          <small data-claim-count>Noch nicht gescannt</small>
         </div>
 
         <button class="primary" type="button" data-action>
-          <strong data-action-label>Wallet verbinden</strong>
-          <span data-action-detail>MetaMask · Programmable Treasury</span>
+          <strong data-action-label>MetaMask verbinden</strong>
+          <span data-action-detail>Reward Wallet · endet 376C</span>
         </button>
 
         <p class="status" role="status" aria-live="polite" data-status>
-          MetaMask verbinden, um offene Fees zu lesen
+          Bereit
         </p>
         <p class="error" role="alert" data-error hidden></p>
 
-        <footer class="trust">
-          <span class="trust-mark" aria-hidden="true"></span>
-          <p>
-            Lokal und ohne Private Key. Vor jedem Claim werden Contract-Code,
-            Treasury-Empfänger und Guthaben am selben Ethereum-Block geprüft.
-            Classic-Launches laufen gesammelt über ihren gemeinsamen Hook.
-            Standardisierte Custom-Quellen werden aus der Registry erkannt und
-            im selben Wallet-Batch geclaimt. Unbekannte Quellen bleiben
-            gesperrt. Ohne atomaren MetaMask-Batch wird nichts gesendet.
-          </p>
-        </footer>
+        <div class="quick-actions">
+          <button class="refresh" type="button" data-refresh hidden disabled>
+            Neu scannen
+          </button>
+          <a
+            href="https://link.metamask.io/dapp/claimhazard.vercel.app/"
+            data-metamask-open
+            hidden
+          >
+            In MetaMask öffnen
+          </a>
+          <span>Nur die Reward Wallet kann claimen</span>
+        </div>
+
+        <details class="details">
+          <summary>Details</summary>
+          <div class="details-body">
+            <div class="meta-grid">
+              <div>
+                <span>Wallet</span>
+                <strong data-account>Nicht verbunden</strong>
+              </div>
+              <div>
+                <span>Bestätigung</span>
+                <strong data-batch-mode>Wird geprüft</strong>
+              </div>
+            </div>
+
+            <ul
+              class="claim-list"
+              data-claim-rows
+              aria-label="Programmable Feequellen"
+            ></ul>
+
+            <footer class="trust">
+              <span class="trust-mark" aria-hidden="true"></span>
+              <p>
+                Vor jeder Wallet-Bestätigung werden Empfänger, Contracts und
+                offene Beträge erneut geprüft. Unbekannte Quellen werden nicht
+                gesendet.
+              </p>
+            </footer>
+          </div>
+        </details>
       </section>
     </main>
 

--- a/ops/protocol-fee-claim/logic.mjs
+++ b/ops/protocol-fee-claim/logic.mjs
@@ -51,6 +51,168 @@ export const CUSTOM_V2_POLICY = Object.freeze({
 
 export const CUSTOM_V2_RELEASE_PATH = "./custom-v2-release.json";
 
+export const LAUNCH_STAMP_ROUTER = Object.freeze({
+  address: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
+  startBlock: 25_717_612n,
+  endBlock: null,
+  finalizedTag: "finalized",
+  maximumFinalizedSpread: 32n,
+  runtimeCodeHash:
+    "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
+  sourceCommit: "0a7134bbb912222639627fb9078df2f8dd3a6c38",
+  sourceTree: "24ffb0c6b04af7993254560b4f03608de8f52231",
+  abiSha256:
+    "sha256:bb4e728e9f9c850eb01f928e8a798ac206a82e241a8d93b3b3c686635c88ed86",
+  permitAuthority: Object.freeze({
+    address: "0x755509eA6e3F5Ec1aA2E797bb68f1B87DD8b886b",
+    runtimeCodeHash:
+      "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c",
+  }),
+  graphFactory: Object.freeze({
+    address: "0xB012e4A8F2c5FC4E8E4faCA9D5Ad6FfF13FBA887",
+    runtimeCodeHash:
+      "0xd23692fae59331592048e71a96d4963e170ee56e449683dc9f7fa3f9470018b8",
+  }),
+  poolManager: Object.freeze({
+    address: "0x000000000004444c5dc75cB358380D2e3dE08A90",
+    runtimeCodeHash:
+      "0x785f1014552b7ce7d5fb7d0c970ca60edee94fd00425d7ca21609acac7ce1293",
+  }),
+});
+
+export const LAUNCH_STAMP_TOPICS = Object.freeze({
+  launchStamped:
+    "0x6cf479a102f1eebc9244f48f8d68f6aa52b4c5a4516318df58ba46614a5b14f2",
+  launchRouteStamped:
+    "0x45e7cc355b63ca67d6278a0d8d23470ce2a0741a9c60283d7dee712df7a877a5",
+  componentStamped:
+    "0x8147265e7396d6400cee8d049456a1f7438fdfbe2a7c81c976d51ba67e52ff4b",
+});
+
+export const LAUNCH_STAMP_SELECTORS = Object.freeze({
+  chainId: "0x85e1f4d0",
+  permitAuthority: "0xc3a3d03c",
+  permitAuthorityRuntimeCodeHash: "0xa497c61c",
+  graphFactory: "0x1cc9e5ce",
+  graphFactoryRuntimeCodeHash: "0x92989a00",
+  poolManager: "0x62308e85",
+  poolManagerRuntimeCodeHash: "0x38d831c4",
+  launchIdByToken: "0x1dad847c",
+  launchIdByPool: "0x361df6f3",
+  launchIdByComponent: "0x58c5e373",
+  componentRuntimeCodeHash: "0xc892d353",
+  launchStamp: "0x4c9e4764",
+  stampProof: "0x174b9f9d",
+});
+
+export const ROUTER_CUSTOM_CLAIM_PROFILES = Object.freeze({
+  nativeAccumulatorV1: Object.freeze({
+    id: "native-accumulator-v1",
+    bindings: Object.freeze([
+      Object.freeze({
+        launchId:
+          "0x6d6ed0e1e69a7cd6afa177e3454c9e32eed61cbd3f855ee56aff1915a6776fc2",
+        source: "0xd7451a039373f54e493deE42A751fEcBfAFBa0cc",
+        runtimeCodeHash:
+          "0xff70a4d3d889b730a064b270fc187f0cba40582f1fa6f5875893066b17a1257b",
+      }),
+    ]),
+    recipient: "0x4968150a",
+    feeBps: "0xb6c7448d",
+    accrued: "0x0986bdb6",
+    claim: "0xa95e4f21",
+    expectedFeeBps: 10n,
+  }),
+  shardLauncherFeesV1: Object.freeze({
+    id: "shard-launcher-fees-v1",
+    bindings: Object.freeze([
+      Object.freeze({
+        launchId:
+          "0xe253f3bd22fcb3d6cb20b9d408287e30f0f1aeeb56426b779425c35fd6411de9",
+        token: "0xFAce73B63787960282f2d4682d3752Beb25271Ad",
+        source: "0x07a16735325723fEa4f4a52ED5E9da687766A0Cc",
+        runtimeCodeHash:
+          "0x168f82b0d458a35676522562489b2fec71929e4717c3d98b4893ef63e69e8da6",
+      }),
+    ]),
+    recipient: "0x4c50e2c4",
+    feeBps: "0x89223381",
+    feeDenominatorBps: "0xe1a45218",
+    poolManager: "0xdc4c90d3",
+    boundToken: "0x996373c3",
+    nft: "0x47ccca02",
+    initialized: "0x07003bb4",
+    accrued: "0x1497233e",
+    claim: "0x64d46b85",
+    expectedFeeBps: 1_000n,
+    expectedFeeDenominatorBps: 10_000n,
+    expectedNft: "0x92822e03D9cc1b2b497647B159ce5207Cd721527",
+  }),
+  protocolFeeSourceV1: Object.freeze({
+    id: "protocol-fee-source-v1",
+    bindings: Object.freeze([]),
+    recipient: CUSTOM_V2_SELECTORS.programmableFeeRecipient,
+    feeBps: `${CUSTOM_V2_SELECTORS.programmableFeeBps}${"0".repeat(64)}`,
+    accrued: `${CUSTOM_V2_SELECTORS.accruedProgrammableFees}${"0".repeat(64)}`,
+    claim: `${CUSTOM_V2_SELECTORS.claimProgrammableFees}${"0".repeat(64)}`,
+    expectedFeeBps: 10n,
+  }),
+  isolatedAfterSwapFeeVaultV2: Object.freeze({
+    id: "isolated-after-swap-fee-vault-v2",
+    bindings: Object.freeze([
+      Object.freeze({
+        launchId:
+          "0x786d3d5cdd0c6ba81621eb01fbcc6b5912556a2d7dbe886431346460afeee197",
+        token: "0xD0f3E1e5C985D2b37a66Cf07feCB0d8191c0445F",
+        hook: "0xce6f22c5ccf06aad50dd2bc681fa7c30ce55e044",
+        hookRuntimeCodeHash:
+          "0x0a461fa65d04305fa2e583d9a6fba369b3b2ff66aa5856f56d0782c2ff72e19c",
+        source: "0x97875d30DFE562e290Eb5646D907F8e775645f66",
+        sourceRuntimeCodeHash:
+          "0xf2cbc21a3f07c05909d664ba8d8b66fe6576eb8a5d016faa53e31e73ed6acbd4",
+      }),
+    ]),
+    hookFeeVault: "0x5517476a",
+    recipient: "0xc6fd9bd8",
+    feePpm: "0x6cf9ca81",
+    feeDenominatorPpm: "0x1bd7398b",
+    poolManager: "0xdc4c90d3",
+    authorizedAdapter: "0x54a1b628",
+    authorizedAdapterCodeHash: "0x18903320",
+    bindingAuthority: "0x2028d39b",
+    accrued: "0x87d4d28c",
+    claim: "0x5fa65a04",
+    expectedFeePpm: 1_000n,
+    expectedFeeDenominatorPpm: 1_000_000n,
+    secondaryUnit: "PCR2",
+    secondaryDecimals: 18,
+  }),
+  dualCurrencyRedeemerV1: Object.freeze({
+    id: "dual-currency-redeemer-v1",
+    bindings: Object.freeze([
+      Object.freeze({
+        launchId:
+          "0x5a52180427785716bff0a36218dde89f0459db265d0c2bdfcfde81a8fe733c92",
+        source: "0xEBa46F25dff528141DE5317109aCB5a989296044",
+        runtimeCodeHash:
+          "0xd59d31add7a3b206972725889dbb726782c0fbd82514710cf2d645749dc3fa25",
+      }),
+    ]),
+    recipient: "0x46904840",
+    feePips: "0x9fa59765",
+    poolManager: "0xdc4c90d3",
+    currency0: "0x79f1232b",
+    currency1: "0x10d737b8",
+    poolId: "0x3e0dc34e",
+    balanceOf: "0x00fdd58e",
+    claim:
+      "0xfc656ac500000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
+    expectedFeePips: 1_000n,
+    secondaryUnit: "PCAN",
+    secondaryDecimals: 18,
+  }),
+});
+
 export const CUSTOM_REGISTRY = Object.freeze({
   status: "retired",
   address: "0x0000000000000000000000000000000000000000",
@@ -328,6 +490,25 @@ export function normalizeAddress(value) {
   return typeof value === "string" ? value.toLowerCase() : "";
 }
 
+export async function withTimeout(promise, timeoutMs, message) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0)
+    throw new Error("Ungültiges RPC-Zeitlimit");
+  let timeout;
+  try {
+    return await Promise.race([
+      Promise.resolve(promise),
+      new Promise((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(message || "RPC-Zeitlimit überschritten")),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 export function isTreasury(value) {
   return normalizeAddress(value) === normalizeAddress(TREASURY);
 }
@@ -464,8 +645,197 @@ export function reduceClassicLaunchLogs(entries) {
   });
 }
 
+export function decodeLaunchStampLog(log) {
+  if (
+    !log ||
+    log.removed === true ||
+    normalizeAddress(log.address) !== normalizeAddress(LAUNCH_STAMP_ROUTER.address) ||
+    !Array.isArray(log.topics) ||
+    log.topics.length !== 4 ||
+    log.topics[0]?.toLowerCase() !== LAUNCH_STAMP_TOPICS.launchStamped ||
+    typeof log.data !== "string" ||
+    !/^0x[0-9a-fA-F]{192}$/.test(log.data)
+  )
+    throw new Error("Launch-Stamp-Event ist nicht kanonisch");
+
+  const launchId = decodeBytes32(log.topics[1]);
+  const token = topicAddress(log.topics[2]);
+  const hook = topicAddress(log.topics[3]);
+  requireAbiWords(log.data, 3, "Launch-Stamp-Event");
+  const poolManager = wordAddress(abiWord(log.data, 0));
+  const poolId = decodeBytes32(abiWord(log.data, 1));
+  const stampHash = decodeBytes32(abiWord(log.data, 2));
+  if (
+    normalizeAddress(token) === normalizeAddress("0x0000000000000000000000000000000000000000") ||
+    normalizeAddress(poolManager) !== normalizeAddress(LAUNCH_STAMP_ROUTER.poolManager.address) ||
+    /^0x0{64}$/i.test(launchId) ||
+    /^0x0{64}$/i.test(poolId) ||
+    /^0x0{64}$/i.test(stampHash) ||
+    !/^0x[0-9a-fA-F]{64}$/.test(log.blockHash ?? "") ||
+    !/^0x[0-9a-fA-F]{64}$/.test(log.transactionHash ?? "")
+  )
+    throw new Error("Launch-Stamp-Identität ist unvollständig");
+
+  return Object.freeze({
+    launchId,
+    token,
+    hook,
+    poolManager,
+    poolId,
+    stampHash,
+    blockHash: log.blockHash.toLowerCase(),
+    blockNumber: BigInt(log.blockNumber),
+    transactionIndex: BigInt(log.transactionIndex),
+    logIndex: BigInt(log.logIndex),
+    transactionHash: log.transactionHash.toLowerCase(),
+  });
+}
+
+export function reduceLaunchStampLogs(logs) {
+  if (!Array.isArray(logs)) throw new Error("Launch-Stamp-Events fehlen");
+  const launches = new Map();
+  for (const log of logs) {
+    const launch = decodeLaunchStampLog(log);
+    if (launches.has(launch.launchId))
+      throw new Error("Doppelter Launch-Stamp");
+    launches.set(launch.launchId, launch);
+  }
+  return [...launches.values()].sort((left, right) => {
+    if (left.blockNumber !== right.blockNumber)
+      return left.blockNumber > right.blockNumber ? -1 : 1;
+    if (left.logIndex !== right.logIndex)
+      return left.logIndex > right.logIndex ? -1 : 1;
+    return left.launchId.localeCompare(right.launchId);
+  });
+}
+
+export function launchStampLogSetFingerprint(logs) {
+  if (!Array.isArray(logs)) throw new Error("Launch-Stamp-Events fehlen");
+  const tuples = logs.map((log) => {
+    const decoded = decodeLaunchStampLog(log);
+    return {
+      address: log.address.toLowerCase(),
+      blockHash: decoded.blockHash,
+      blockNumber: decoded.blockNumber.toString(),
+      transactionHash: decoded.transactionHash,
+      transactionIndex: decoded.transactionIndex.toString(),
+      logIndex: decoded.logIndex.toString(),
+      topics: log.topics.map((topic) => topic.toLowerCase()),
+      data: log.data.toLowerCase(),
+    };
+  });
+  tuples.sort((left, right) =>
+    JSON.stringify(left).localeCompare(JSON.stringify(right)),
+  );
+  return JSON.stringify(tuples);
+}
+
+function parseRouterCheckpoints(blocks) {
+  if (!Array.isArray(blocks) || blocks.length !== 3)
+    throw new Error("Finalisierter Router-Block fehlt im RPC-Quorum");
+  return blocks.map((block) => {
+    if (
+      !block ||
+      typeof block.number !== "string" ||
+      !/^0x(?:0|[1-9a-fA-F][0-9a-fA-F]*)$/.test(block.number) ||
+      typeof block.hash !== "string" ||
+      !/^0x[0-9a-fA-F]{64}$/.test(block.hash)
+    )
+      throw new Error("Finalisierter Router-Block fehlt im RPC-Quorum");
+    return Object.freeze({
+      number: BigInt(block.number),
+      hash: block.hash.toLowerCase(),
+    });
+  });
+}
+
+export function routerFinalizedBoundary(
+  blocks,
+  minimumBlock = 0n,
+  maximumSpread = 32n,
+) {
+  const checkpoints = parseRouterCheckpoints(blocks);
+  const numbers = checkpoints.map(({ number }) => number);
+  const first = numbers.reduce((minimum, number) =>
+    number < minimum ? number : minimum,
+  );
+  const last = numbers.reduce((maximum, number) =>
+    number > maximum ? number : maximum,
+  );
+  if (maximumSpread < 0n || last - first > maximumSpread)
+    throw new Error(
+      "Finalisierte Router-Stände liegen im RPC-Quorum zu weit auseinander",
+    );
+  if (first < BigInt(minimumBlock))
+    throw new Error("Launch-Stamp-Router hat noch keinen finalisierten Bereich");
+  return first;
+}
+
+export function exactRouterFinalizedCheckpoint(blocks, minimumBlock = 0n) {
+  const checkpoints = parseRouterCheckpoints(blocks);
+  if (
+    new Set(
+      checkpoints.map(({ number, hash }) => `${number.toString()}:${hash}`),
+    ).size !== 1
+  )
+    throw new Error(
+      "Finalisierter Router-Block stimmt im RPC-Quorum nicht überein",
+    );
+  if (checkpoints[0].number < BigInt(minimumBlock))
+    throw new Error("Launch-Stamp-Router hat noch keinen finalisierten Bereich");
+  return checkpoints[0];
+}
+
+export function decodeLaunchStampRecord(value) {
+  requireAbiWords(value, 14, "Launch-Stamp-Record");
+  const kind = Number(decodeUint256(abiWord(value, 0)));
+  if (kind !== 1 && kind !== 2)
+    throw new Error("Launch-Stamp-Art wird nicht unterstützt");
+  const record = {
+    kind,
+    launchWallet: wordAddress(abiWord(value, 1)),
+    token: wordAddress(abiWord(value, 2)),
+    hook: wordAddress(abiWord(value, 3)),
+    poolManager: wordAddress(abiWord(value, 4)),
+    poolId: decodeBytes32(abiWord(value, 5)),
+    poolKeyHash: decodeBytes32(abiWord(value, 6)),
+    componentSetHash: decodeBytes32(abiWord(value, 7)),
+    routePayloadHash: decodeBytes32(abiWord(value, 8)),
+    routeLauncher: wordAddress(abiWord(value, 9)),
+    routeLauncherRuntimeCodeHash: decodeBytes32(abiWord(value, 10)),
+    expectedResultHash: decodeBytes32(abiWord(value, 11)),
+    permitDigest: decodeBytes32(abiWord(value, 12)),
+    stampHash: decodeBytes32(abiWord(value, 13)),
+  };
+  for (const key of [
+    "poolId",
+    "poolKeyHash",
+    "componentSetHash",
+    "routePayloadHash",
+    "routeLauncherRuntimeCodeHash",
+    "expectedResultHash",
+    "permitDigest",
+    "stampHash",
+  ]) {
+    if (/^0x0{64}$/i.test(record[key]))
+      throw new Error(`Launch-Stamp ${key} ist null`);
+  }
+  return Object.freeze(record);
+}
+
+export function decodeLaunchStampProof(value) {
+  requireAbiWords(value, 2, "Launch-Stamp-Proof");
+  return Object.freeze({
+    launchId: decodeBytes32(abiWord(value, 0)),
+    stampHash: decodeBytes32(abiWord(value, 1)),
+  });
+}
+
 function topicAddress(topic) {
-  if (typeof topic !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(topic))
+  if (
+    typeof topic !== "string" ||
+    !/^0x0{24}[0-9a-fA-F]{40}$/.test(topic)
+  )
     throw new Error("Ungültige Custom-Eventadresse");
   return `0x${topic.slice(-40)}`;
 }
@@ -733,15 +1103,69 @@ export function customV2SourceClassification(source) {
   if (!source || source.bindingVerified !== true) return "blocked";
   if (!source.registered || source.quarantined || !source.executable)
     return "quarantined";
+  if (typeof source.amount !== "bigint" || source.amount < 0n) return "blocked";
   if (source.amount === 0n) return "empty";
   return "ready";
 }
 
+export function routerCustomClaimClassification(source) {
+  if (
+    !source ||
+    source.origin !== "launch-stamp-router" ||
+    source.provenanceVerified !== true ||
+    source.runtimeVerified !== true
+  )
+    return "blocked";
+  if (source.claimMode === "no-manual-claim") return "no-manual-claim";
+  if (
+    source.claimMode !== "manual" ||
+    source.claimBindingVerified !== true ||
+    typeof source.amount !== "bigint" ||
+    source.amount < 0n ||
+    (source.secondaryAmount !== undefined &&
+      (typeof source.secondaryAmount !== "bigint" ||
+        source.secondaryAmount < 0n))
+  )
+    return "blocked";
+  return source.amount === 0n && (source.secondaryAmount ?? 0n) === 0n
+    ? "empty"
+    : "ready";
+}
+
 export function customClaimDefinitionClassification(claim, current = {}) {
   const source = { ...claim, ...current };
+  if (claim?.origin === "launch-stamp-router")
+    return routerCustomClaimClassification(source);
   return claim?.standardClaimBindingVerified === true
     ? customLaunchClassification(source)
     : customV2SourceClassification(source);
+}
+
+export function createRefreshQueue(run) {
+  if (typeof run !== "function")
+    throw new Error("Refresh-Runner fehlt");
+  let requested = false;
+  let active = null;
+
+  return async function requestRefresh() {
+    requested = true;
+    while (true) {
+      if (!active) {
+        active = (async () => {
+          try {
+            while (requested) {
+              requested = false;
+              await run();
+            }
+          } finally {
+            active = null;
+          }
+        })();
+      }
+      await active;
+      if (!requested && active === null) return;
+    }
+  };
 }
 
 export function formatEth(value, maximumFractionDigits = 6) {
@@ -786,7 +1210,42 @@ export function customV2Bytes32ReadData(selector, value) {
   return `${selector}${encodeBytes32Argument(value)}`;
 }
 
+export function launchStampBytes32ReadData(selector, value) {
+  if (typeof selector !== "string" || !/^0x[0-9a-fA-F]{8}$/.test(selector))
+    throw new Error("Launch-Stamp-Selector ist ungültig");
+  return `${selector.toLowerCase()}${encodeBytes32Argument(value)}`;
+}
+
+export function launchStampAddressReadData(selector, value) {
+  if (typeof selector !== "string" || !/^0x[0-9a-fA-F]{8}$/.test(selector))
+    throw new Error("Launch-Stamp-Selector ist ungültig");
+  return `${selector.toLowerCase()}${encodeAddressArgument(value)}`;
+}
+
+export function launchStampPoolReadData(selector, poolManager, poolId) {
+  if (typeof selector !== "string" || !/^0x[0-9a-fA-F]{8}$/.test(selector))
+    throw new Error("Launch-Stamp-Selector ist ungültig");
+  return `${selector.toLowerCase()}${encodeAddressArgument(poolManager)}${encodeBytes32Argument(poolId)}`;
+}
+
+export function poolManagerBalanceOfData(selector, owner, currency) {
+  if (typeof selector !== "string" || !/^0x[0-9a-fA-F]{8}$/.test(selector))
+    throw new Error("PoolManager-Selector ist ungültig");
+  return `${selector.toLowerCase()}${encodeAddressArgument(owner)}${encodeAddressArgument(currency)}`;
+}
+
+function exactCallData(value, label) {
+  if (
+    typeof value !== "string" ||
+    !/^0x[0-9a-fA-F]{8}(?:[0-9a-fA-F]{64})*$/.test(value)
+  )
+    throw new Error(`${label} ist ungültig`);
+  return value.toLowerCase();
+}
+
 export function readAccruedData(claim) {
+  if (claim?.readData !== undefined)
+    return exactCallData(claim.readData, "Claim-Lesedaten");
   if (claim.kind === "custom")
     return `${CUSTOM_V2_SELECTORS.accruedProgrammableFees}${encodeAddressArgument(CUSTOM_V2_POLICY.nativeAsset)}`;
   return claim.kind === "asset"
@@ -795,6 +1254,8 @@ export function readAccruedData(claim) {
 }
 
 export function claimData(claim) {
+  if (claim?.claimData !== undefined)
+    return exactCallData(claim.claimData, "Claim-Calldata");
   if (claim.kind === "custom")
     return `${CUSTOM_V2_SELECTORS.claimProgrammableFees}${encodeAddressArgument(CUSTOM_V2_POLICY.nativeAsset)}`;
   return claim.kind === "asset"
@@ -811,6 +1272,39 @@ export function toQuantityHex(value) {
 export function shortAddress(value) {
   if (typeof value !== "string" || value.length < 12) return value;
   return `${value.slice(0, 6)}…${value.slice(-4)}`;
+}
+
+function usableWalletProvider(provider) {
+  return provider !== null && typeof provider?.request === "function";
+}
+
+export function metaMaskProviderFrom(
+  announcedProviderDetails = [],
+  legacyProvider = null,
+) {
+  const announced = Array.isArray(announcedProviderDetails)
+    ? announcedProviderDetails.filter(({ provider }) =>
+        usableWalletProvider(provider),
+      )
+    : [];
+  const exact = announced.find(
+    ({ info }) =>
+      typeof info?.rdns === "string" &&
+      info.rdns.toLowerCase() === "io.metamask",
+  );
+  if (exact) return exact.provider;
+
+  const legacyCandidates = Array.isArray(legacyProvider?.providers)
+    ? legacyProvider.providers
+    : [legacyProvider];
+  return (
+    legacyCandidates.find(
+      (provider) =>
+        usableWalletProvider(provider) &&
+        provider.isMetaMask === true &&
+        provider.isBraveWallet !== true,
+    ) ?? null
+  );
 }
 
 export function atomicCapabilityStatus(
@@ -835,16 +1329,22 @@ export function buildWalletSendCalls(account, claims) {
     throw new Error("Die Treasury-Wallet muss verbunden sein");
   if (!Array.isArray(claims) || claims.length === 0)
     throw new Error("Keine Claims verfügbar");
+  const calls = claims.map((claim) => ({
+    to: claim.address,
+    data: claimData(claim),
+    value: "0x0",
+  }));
+  const callKeys = calls.map(
+    ({ to, data }) => `${normalizeAddress(to)}:${data.toLowerCase()}`,
+  );
+  if (new Set(callKeys).size !== callKeys.length)
+    throw new Error("Doppelter Claim im atomaren Batch");
   return {
     version: "2.0.0",
     from: account,
     chainId: MAINNET_CHAIN_ID,
     atomicRequired: true,
-    calls: claims.map((claim) => ({
-      to: claim.address,
-      data: claimData(claim),
-      value: "0x0",
-    })),
+    calls,
   };
 }
 
@@ -853,4 +1353,104 @@ export function normalizeBatchId(result) {
   if (typeof id !== "string" || !/^0x[0-9a-fA-F]+$/.test(id))
     throw new Error("MetaMask hat keine gültige Batch-ID geliefert");
   return id;
+}
+
+export function walletSendDefinitelyNotSubmitted(error) {
+  return [-32602, 4001, 4100, 5700, 5710, 5740, 5750, 5760].includes(
+    error?.code,
+  );
+}
+
+export function walletSendDuplicateBatchId(error) {
+  return error?.code === 5720;
+}
+
+export function validatedAtomicBatchStatus(
+  result,
+  expectedId,
+  expectedChainId = MAINNET_CHAIN_ID,
+) {
+  const resultId = normalizeBatchId(result?.id);
+  const normalizedExpectedId = normalizeBatchId(expectedId);
+  if (
+    result?.version !== "2.0.0" ||
+    resultId.toLowerCase() !== normalizedExpectedId.toLowerCase() ||
+    typeof result?.chainId !== "string" ||
+    !/^0x[0-9a-fA-F]+$/.test(result.chainId) ||
+    BigInt(result.chainId) !== BigInt(expectedChainId) ||
+    !Number.isInteger(result?.status) ||
+    result?.atomic !== true
+  ) {
+    throw new Error("Der Wallet-Batchstatus stimmt nicht mit dem Claim überein");
+  }
+  return result.status;
+}
+
+export function confirmedBatchReceiptProof(
+  result,
+  expectedId,
+  expectedChainId = MAINNET_CHAIN_ID,
+) {
+  if (
+    validatedAtomicBatchStatus(result, expectedId, expectedChainId) !== 200 ||
+    !Array.isArray(result.receipts) ||
+    result.receipts.length === 0
+  )
+    throw new Error("Der atomare Claim-Batch ist nicht vollständig bestätigt");
+
+  let highestBlock = 0n;
+  const transactionHashes = new Set();
+  const receipts = [];
+  for (const receipt of result.receipts) {
+    if (receipt?.status !== "0x1")
+      throw new Error("Der atomare Claim-Batch ist fehlgeschlagen");
+    if (
+      typeof receipt.blockNumber !== "string" ||
+      !/^0x[0-9a-fA-F]+$/.test(receipt.blockNumber)
+    ) {
+      throw new Error("Dem bestätigten Claim-Batch fehlt der Receipt-Block");
+    }
+    const blockNumber = BigInt(receipt.blockNumber);
+    if (blockNumber <= 0n)
+      throw new Error("Der Receipt-Block des Claim-Batches ist ungültig");
+    if (
+      typeof receipt.blockHash !== "string" ||
+      !/^0x[0-9a-fA-F]{64}$/.test(receipt.blockHash) ||
+      typeof receipt.transactionHash !== "string" ||
+      !/^0x[0-9a-fA-F]{64}$/.test(receipt.transactionHash)
+    ) {
+      throw new Error("Dem bestätigten Claim-Batch fehlt die Receipt-Identität");
+    }
+    const transactionHash = receipt.transactionHash.toLowerCase();
+    if (transactionHashes.has(transactionHash))
+      throw new Error("Der Claim-Batch enthält einen doppelten Receipt");
+    transactionHashes.add(transactionHash);
+    receipts.push({
+      blockNumber,
+      blockHash: receipt.blockHash.toLowerCase(),
+      transactionHash,
+    });
+    if (blockNumber > highestBlock) highestBlock = blockNumber;
+  }
+  return { highestBlock, receipts };
+}
+
+export function confirmedTransactionReceiptMatches(proof, receipt) {
+  if (
+    typeof proof?.blockNumber !== "bigint" ||
+    proof.blockNumber <= 0n ||
+    typeof proof?.blockHash !== "string" ||
+    typeof proof?.transactionHash !== "string" ||
+    receipt?.status !== "0x1" ||
+    typeof receipt?.blockNumber !== "string" ||
+    !/^0x[0-9a-fA-F]+$/.test(receipt.blockNumber)
+  ) {
+    return false;
+  }
+  return (
+    BigInt(receipt.blockNumber) === proof.blockNumber &&
+    receipt.blockHash?.toLowerCase() === proof.blockHash.toLowerCase() &&
+    receipt.transactionHash?.toLowerCase() ===
+      proof.transactionHash.toLowerCase()
+  );
 }

--- a/ops/protocol-fee-claim/logic.test.mjs
+++ b/ops/protocol-fee-claim/logic.test.mjs
@@ -10,13 +10,20 @@ import {
   CUSTOM_V2_POLICY,
   CUSTOM_V2_SELECTORS,
   HOOKS,
+  LAUNCH_STAMP_ROUTER,
+  LAUNCH_STAMP_SELECTORS,
+  LAUNCH_STAMP_TOPICS,
   MAINNET_CHAIN_ID,
+  ROUTER_CUSTOM_CLAIM_PROFILES,
   SELECTORS,
   TREASURY,
   TOKEN_SELECTORS,
   atomicCapabilityStatus,
   buildWalletSendCalls,
+  confirmedBatchReceiptProof,
+  confirmedTransactionReceiptMatches,
   claimData,
+  createRefreshQueue,
   customClaimDefinitionClassification,
   customLaunchClassification,
   customLaunchStateData,
@@ -28,21 +35,38 @@ import {
   decodeCustomLaunchState,
   decodeCustomV2SourceState,
   decodeCustomRegistryLog,
+  decodeLaunchStampLog,
+  decodeLaunchStampProof,
+  decodeLaunchStampRecord,
   decodeAddress,
   decodeUint256,
   encodeAddressArgument,
+  exactRouterFinalizedCheckpoint,
   formatEth,
   formatUnits,
   isTreasury,
   keccak256Hex,
+  launchStampAddressReadData,
+  launchStampBytes32ReadData,
+  launchStampLogSetFingerprint,
+  launchStampPoolReadData,
+  metaMaskProviderFrom,
   normalizeBatchId,
   parseCustomV2Release,
+  poolManagerBalanceOfData,
   readAccruedData,
   reduceClassicLaunchLogs,
   reduceCustomRegistryLogs,
+  reduceLaunchStampLogs,
   requireAtomicClaimCapability,
+  routerFinalizedBoundary,
+  routerCustomClaimClassification,
   shortAddress,
   toQuantityHex,
+  validatedAtomicBatchStatus,
+  walletSendDefinitelyNotSubmitted,
+  walletSendDuplicateBatchId,
+  withTimeout,
 } from "./logic.mjs";
 
 test("binds exactly Classic and deployed Stock fee sources", () => {
@@ -61,6 +85,7 @@ test("binds exactly Classic and deployed Stock fee sources", () => {
     false,
   );
 });
+
 
 test("keeps the public claim discovery manifest aligned with the scanner", () => {
   const manifest = JSON.parse(
@@ -94,8 +119,471 @@ test("keeps the public claim discovery manifest aligned with the scanner", () =>
   );
   assert.equal(manifest.customV1.status, "HOLD");
   assert.equal(manifest.customV1.futureFinalizedStandardSourcesAutoAdded, false);
+  assert.equal(
+    manifest.schemaVersion,
+    "programmable.fee-claim-discovery.v2",
+  );
+  assert.equal(
+    manifest.launchStampRouter.address.toLowerCase(),
+    LAUNCH_STAMP_ROUTER.address.toLowerCase(),
+  );
+  assert.equal(
+    manifest.launchStampRouter.startBlock,
+    LAUNCH_STAMP_ROUTER.startBlock.toString(),
+  );
+  assert.equal(
+    manifest.launchStampRouter.runtimeCodeHash,
+    LAUNCH_STAMP_ROUTER.runtimeCodeHash,
+  );
+  assert.equal(
+    manifest.launchStampRouter.eventTopic,
+    LAUNCH_STAMP_TOPICS.launchStamped,
+  );
+  assert.deepEqual(manifest.launchStampRouter.finality, {
+    blockTag: LAUNCH_STAMP_ROUTER.finalizedTag,
+    maximumProviderSpreadBlocks:
+      LAUNCH_STAMP_ROUTER.maximumFinalizedSpread.toString(),
+    policy:
+      "bounded_three_provider_finalized_views_then_exact_common_block_hash_or_block",
+  });
+  assert.equal(
+    manifest.launchStampRouter.futureRouterLaunchesAutoDiscovered,
+    true,
+  );
+  assert.deepEqual(manifest.launchStampRouter.classicClaimPolicy, {
+    knownHook: "covered_by_verified_aggregate_hook",
+    unknownHook: "visible_and_block_all_claims",
+  });
+  assert.equal(
+    manifest.launchStampRouter.unknownClaimProfile,
+    "visible_and_block_all_claims",
+  );
+  assert.deepEqual(manifest.launchStampRouter.verification, [
+    "router_and_trust_root_runtime_hashes",
+    "exact_consensus_finalized_checkpoint_quorum",
+    "independent_rpc_log_quorum",
+    "router_claim_bindings_and_displayed_balances_at_finalized_checkpoint",
+    "launch_id_by_token",
+    "launch_id_by_pool_manager_and_pool_id",
+    "launch_stamp_record_and_component_proofs",
+    "route_and_hook_runtime_hashes_at_finalized_checkpoint",
+  ]);
+  assert.deepEqual(manifest.launchStampRouter.logQuorum.publicRpcEndpoints, [
+    "https://mainnet.gateway.tenderly.co",
+    "https://eth.drpc.org",
+    "https://rpc.mevblocker.io",
+  ]);
+  assert.deepEqual(manifest.launchStampRouter.logQuorum.publicRpcProviderGroups, [
+    ["https://mainnet.gateway.tenderly.co", "https://eth.drpc.org"],
+    ["https://rpc.mevblocker.io"],
+  ]);
+  assert.deepEqual(
+    manifest.launchStampRouter.claimProfiles
+      .map(
+        ({ id, launchId, source, runtimeCodeHash, sourceRuntimeCodeHash }) => ({
+          id,
+          launchId,
+          source: source.toLowerCase(),
+          runtimeCodeHash: runtimeCodeHash ?? sourceRuntimeCodeHash,
+        }),
+      )
+      .sort((left, right) => left.id.localeCompare(right.id)),
+    [
+      ROUTER_CUSTOM_CLAIM_PROFILES.nativeAccumulatorV1,
+      ROUTER_CUSTOM_CLAIM_PROFILES.shardLauncherFeesV1,
+      ROUTER_CUSTOM_CLAIM_PROFILES.isolatedAfterSwapFeeVaultV2,
+      ROUTER_CUSTOM_CLAIM_PROFILES.dualCurrencyRedeemerV1,
+    ]
+      .map(({ id, bindings: [binding] }) => ({
+        id,
+        launchId: binding.launchId,
+        source: binding.source.toLowerCase(),
+        runtimeCodeHash:
+          binding.runtimeCodeHash ?? binding.sourceRuntimeCodeHash,
+      }))
+      .sort((left, right) => left.id.localeCompare(right.id)),
+  );
+  const vaultManifest = manifest.launchStampRouter.claimProfiles.find(
+    ({ id }) =>
+      id === ROUTER_CUSTOM_CLAIM_PROFILES.isolatedAfterSwapFeeVaultV2.id,
+  );
+  const vaultProfile =
+    ROUTER_CUSTOM_CLAIM_PROFILES.isolatedAfterSwapFeeVaultV2;
+  assert.deepEqual(
+    {
+      hookFeeVaultSelector: vaultManifest.hookFeeVaultSelector,
+      expectedHookFeeVault: vaultManifest.expectedHookFeeVault.toLowerCase(),
+      bindingAuthoritySelector: vaultManifest.bindingAuthoritySelector,
+      expectedBindingAuthority:
+        vaultManifest.expectedBindingAuthority.toLowerCase(),
+    },
+    {
+      hookFeeVaultSelector: vaultProfile.hookFeeVault,
+      expectedHookFeeVault: vaultProfile.bindings[0].source.toLowerCase(),
+      bindingAuthoritySelector: vaultProfile.bindingAuthority,
+      expectedBindingAuthority: CUSTOM_V2_POLICY.nativeAsset.toLowerCase(),
+    },
+  );
   assert.equal(manifest.execution.atomicRequired, true);
+  assert.equal(manifest.execution.maximumCallsPerAtomicBatch, 64);
+  assert.equal(
+    manifest.execution.preflightEveryCallImmediatelyBeforeWallet,
+    true,
+  );
   assert.equal(manifest.execution.unsupportedWalletBehavior, "fail_closed");
+  assert.equal(manifest.execution.appProvidedBatchId, true);
+  assert.equal(
+    manifest.execution.crossTabSubmissionLease,
+    "web_locks_exclusive",
+  );
+  assert.equal(
+    manifest.execution.ambiguousSubmissionRecovery,
+    "resubmit_exact_same_batch_with_exact_same_app_id",
+  );
+  assert.equal(
+    manifest.execution.postConfirmationReconciliation,
+    "persist_until_three_provider_canonical_receipts_and_finalized_router_snapshot",
+  );
+  assert.equal(
+    manifest.execution.partialFailureBehavior,
+    "fail_closed_manual_reconciliation",
+  );
+});
+
+test("clears a pre-send lock only for wallet errors that prove no calls were sent", () => {
+  assert.equal(walletSendDefinitelyNotSubmitted({ code: 4001 }), true);
+  assert.equal(walletSendDefinitelyNotSubmitted({ code: 5750 }), true);
+  assert.equal(walletSendDefinitelyNotSubmitted({ code: -32602 }), true);
+  assert.equal(walletSendDefinitelyNotSubmitted({ code: 5760 }), true);
+  assert.equal(walletSendDefinitelyNotSubmitted({ code: 5720 }), false);
+  assert.equal(
+    walletSendDefinitelyNotSubmitted({
+      code: -32603,
+      message: "request canceled after provider transport failure",
+    }),
+    false,
+  );
+  assert.equal(walletSendDefinitelyNotSubmitted(new Error("user rejected")), false);
+  assert.equal(walletSendDuplicateBatchId({ code: 5720 }), true);
+  assert.equal(walletSendDuplicateBatchId({ code: 4001 }), false);
+});
+
+test("discovers MetaMask with EIP-6963 and safe legacy fallbacks", () => {
+  const other = { request() {} };
+  const brave = { isMetaMask: true, isBraveWallet: true, request() {} };
+  const legacyMetaMask = { isMetaMask: true, request() {} };
+  const announcedMetaMask = { request() {} };
+
+  assert.equal(
+    metaMaskProviderFrom(
+      [
+        { info: { rdns: "com.example.wallet" }, provider: other },
+        { info: { rdns: "io.metamask" }, provider: announcedMetaMask },
+      ],
+      { providers: [brave, legacyMetaMask] },
+    ),
+    announcedMetaMask,
+  );
+  assert.equal(
+    metaMaskProviderFrom([], { providers: [brave, legacyMetaMask] }),
+    legacyMetaMask,
+  );
+  assert.equal(metaMaskProviderFrom([], brave), null);
+  assert.equal(metaMaskProviderFrom([{ info: {}, provider: other }], other), null);
+  assert.equal(
+    metaMaskProviderFrom(
+      [{ info: { rdns: { malformed: true } }, provider: other }],
+      legacyMetaMask,
+    ),
+    legacyMetaMask,
+  );
+  assert.equal(
+    metaMaskProviderFrom(
+      [
+        {
+          info: { rdns: "io.rabby" },
+          provider: { isMetaMask: true, request() {} },
+        },
+      ],
+      legacyMetaMask,
+    ),
+    legacyMetaMask,
+  );
+  assert.equal(
+    metaMaskProviderFrom(
+      [
+        {
+          info: { rdns: "io.rabby" },
+          provider: { isMetaMask: true, request() {} },
+        },
+      ],
+      null,
+    ),
+    null,
+  );
+});
+
+test("keeps the static Vercel scanner on wallet RPC and serializes refreshes", () => {
+  const app = readFileSync(new URL("./app.js", import.meta.url), "utf8");
+  assert.match(
+    app,
+    /const walletProvider = await requireMetaMaskProvider\(\);\s*const operation = walletProvider\.request\(\{ method, params \}\);/,
+  );
+  assert.match(app, /"eip6963:announceProvider"/);
+  assert.match(app, /new Event\("eip6963:requestProvider"\)/);
+  assert.match(app, /"ethereum#initialized"/);
+  assert.match(app, /"disconnect",\s*failClosedAfterWalletDisconnect/);
+  const discoveryStart = app.indexOf(
+    "async function requireMetaMaskProvider",
+  );
+  const discovery = app.slice(
+    discoveryStart,
+    app.indexOf("async function request", discoveryStart),
+  );
+  assert.ok(
+    discovery.indexOf("await new Promise") <
+      discovery.indexOf("selectedMetaMaskProvider({ allowLegacy: true })"),
+    "legacy provider fallback must happen only after waiting for exact EIP-6963 MetaMask",
+  );
+  assert.match(
+    app,
+    /async function syncAfterWalletEvent\(\) \{\s*const revision = invalidateWalletAuthorizationState\(\);[\s\S]*await syncWallet\(\{ expectedRevision: revision \}\);\s*\} catch \{\s*if \(revision !== walletAuthorizationRevision\) return;\s*clearWalletAuthorizationState\(\);/,
+  );
+  assert.match(
+    app,
+    /if \(expectedRevision !== walletAuthorizationRevision\) return;\s*state\.account =/,
+  );
+  assert.match(
+    app,
+    /request\("wallet_requestPermissions", \[\{ eth_accounts: \{\} \}\]\)/,
+  );
+  assert.match(
+    app,
+    /else if \(!isTreasury\(state\.account\)\) await chooseRewardWallet\(\);/,
+  );
+  assert.match(
+    app,
+    /const expectedAccount = await requireActiveRewardWallet\(\);[\s\S]*await refreshClaims\(\);[\s\S]*await requireActiveRewardWallet\(expectedAccount\);/,
+  );
+  assert.match(
+    app,
+    /const batch = await preflightClaimBatch\(claims\);\s*await requireActiveRewardWallet\(expectedAccount\);\s*requireConfirmedBatchStorage\(\);/,
+  );
+  assert.doesNotMatch(app, /fetch\(["']\/rpc/);
+  assert.match(app, /const refreshClaims = createRefreshQueue\(refreshClaimsOnce\);/);
+  assert.match(app, /await refreshClaims\(\);/);
+  assert.match(app, /async function preflightClaimBatch\(claims\)/);
+  assert.match(app, /\{ from: batch\.from, to, data, value \}/);
+  assert.match(app, /launchStampPoolReadData\(/);
+  assert.match(app, /status: "retired",\s*registryVerified: true/);
+  assert.match(
+    app,
+    /const finalizedBlock = await readRouterFinalizedBoundary\(\);/,
+  );
+  assert.match(
+    app,
+    /readVerifiedRouterLaunch\(candidate, finalizedTag\)/,
+  );
+  assert.doesNotMatch(
+    app,
+    /readVerifiedRouterLaunch\(candidate, finalizedTag, blockTag\)/,
+  );
+  assert.match(app, /withTimeout\(\s*operation,/);
+});
+
+test("expands exact Router Vault legs and counts the actual wallet calls", () => {
+  const app = readFileSync(new URL("./app.js", import.meta.url), "utf8");
+  const section = (start, end) => {
+    const startIndex = app.indexOf(start);
+    const endIndex = app.indexOf(end, startIndex + start.length);
+    assert.ok(startIndex >= 0, `missing app section: ${start}`);
+    assert.ok(endIndex > startIndex, `missing app section boundary: ${end}`);
+    return app.slice(startIndex, endIndex);
+  };
+
+  const routerClaimReader = section(
+    "async function readRouterCustomClaim",
+    "async function readVerifiedRouterLaunch",
+  );
+  assert.match(
+    routerClaimReader,
+    /ROUTER_CUSTOM_CLAIM_PROFILES\.shardLauncherFeesV1/,
+  );
+  assert.match(
+    routerClaimReader,
+    /tryRouterFeeVaultProfile\(\s*launch,\s*ROUTER_CUSTOM_CLAIM_PROFILES\.isolatedAfterSwapFeeVaultV2,\s*blockTag,?\s*\)/,
+  );
+
+  const componentVerification = section(
+    "async function verifyRouterProfileComponent",
+    "async function tryRouterClaimProfile",
+  );
+  assert.match(
+    componentVerification,
+    /LAUNCH_STAMP_SELECTORS\.launchIdByComponent/,
+  );
+  assert.match(componentVerification, /LAUNCH_STAMP_SELECTORS\.stampProof/);
+  assert.match(
+    componentVerification,
+    /LAUNCH_STAMP_SELECTORS\.componentRuntimeCodeHash/,
+  );
+  assert.match(
+    componentVerification,
+    /request\("eth_getCode", \[binding\.source, blockTag\]\)/,
+  );
+  assert.match(componentVerification, /proof\.stampHash !== launch\.stampHash/);
+  assert.match(
+    componentVerification,
+    /runtimeCodeHash !== binding\.sourceRuntimeCodeHash/,
+  );
+  assert.match(
+    componentVerification,
+    /keccak256Hex\(runtimeCode\)[\s\S]*binding\.sourceRuntimeCodeHash/,
+  );
+
+  const directProfileReader = section(
+    "async function tryRouterClaimProfile",
+    "async function tryRouterFeeVaultProfile",
+  );
+  for (const field of [
+    "feeDenominatorBps",
+    "poolManager",
+    "boundToken",
+    "nft",
+    "initialized",
+  ]) {
+    assert.match(directProfileReader, new RegExp(`profile\\.${field}`));
+  }
+  assert.match(
+    directProfileReader,
+    /decodeUint256\(feeDenominatorWord\)[\s\S]*profile\.expectedFeeDenominatorBps/,
+  );
+  assert.match(
+    directProfileReader,
+    /decodeAddress\(poolManagerWord\)[\s\S]*LAUNCH_STAMP_ROUTER\.poolManager\.address/,
+  );
+  assert.match(
+    directProfileReader,
+    /decodeAddress\(boundTokenWord\)[\s\S]*launch\.token/,
+  );
+  assert.match(
+    directProfileReader,
+    /decodeAddress\(nftWord\)[\s\S]*profile\.expectedNft/,
+  );
+  assert.match(directProfileReader, /decodeBool\(initializedWord\)/);
+
+  const vaultReader = section(
+    "async function tryRouterFeeVaultProfile",
+    "async function readRouterCustomClaim",
+  );
+  assert.match(vaultReader, /const claimDefinitions = \[/);
+  assert.match(vaultReader, /id: `\$\{id\}:native`/);
+  assert.match(
+    vaultReader,
+    /id: `\$\{id\}:\$\{launch\.token\.toLowerCase\(\)\}`/,
+  );
+  assert.match(vaultReader, /claimDefinitions,/);
+
+  const definitions = section(
+    "function allClaimDefinitions",
+    "function claimableClaims",
+  );
+  assert.match(definitions, /state\.router\.launches\.flatMap/);
+  assert.match(
+    definitions,
+    /Array\.isArray\(launch\.claimDefinitions\)[\s\S]*launch\.claimDefinitions[\s\S]*\[launch\]/,
+  );
+
+  const preflight = section(
+    "async function preflightClaimBatch",
+    "function walletCallKey",
+  );
+  assert.match(preflight, /claims\.length > MAX_BATCH_CALLS/);
+  assert.match(preflight, /buildWalletSendCalls\(state\.account, claims\)/);
+
+  const customRow = section(
+    "function buildRouterCustomRow",
+    "function buildCustomGroup",
+  );
+  assert.match(
+    customRow,
+    /classification === "blocked"\) \{\s*amount\.textContent = "—";/,
+  );
+});
+
+test("keeps a confirmed batch locked until the Router snapshot reaches its receipt", () => {
+  const app = readFileSync(new URL("./app.js", import.meta.url), "utf8");
+  assert.match(app, /requireConfirmedBatchStorage\(\);/);
+  assert.match(
+    app,
+    /batch: exactBatch,[\s\S]*saveConfirmedBatchLock\(submissionLock, \{ requireEmpty: true \}\)/,
+  );
+  assert.match(app, /const exactBatch = \{ \.\.\.batch, id \};/);
+  assert.match(app, /request\("wallet_sendCalls", \[lock\.batch\]\)/);
+  assert.match(app, /walletSendDuplicateBatchId\(error\)/);
+  assert.match(app, /withExclusiveClaimLease\(async \(\) =>/);
+  assert.match(app, /withExistingClaimLease\(async \(lock\) =>/);
+  assert.match(
+    app,
+    /lock\.phase === "pending" \|\| \(await walletRecognizesStoredBatch\(lock\)\)[\s\S]*return waitForBatch\(lock\);/,
+  );
+  assert.match(
+    app,
+    /await refreshClaims\(\);[\s\S]*claimSafetyError\(\{ ignoreConfirmedBatch: true \}\)[\s\S]*preflightWalletBatch\(lock\.batch\);[\s\S]*requireActiveRewardWallet\(lock\.account\);/,
+  );
+  assert.match(
+    app,
+    /await validateStoredBatchForResubmission\(lock\);[\s\S]*return submitStoredBatchAndWait\(lock\);/,
+  );
+  assert.match(
+    app,
+    /state\.router\.finalizedBlock < highestBlock/,
+  );
+  assert.match(app, /inventoryBlock < highestBlock/);
+  assert.match(app, /readRouterQuorumBlock\(toQuantityHex\(proof\.blockNumber\)\)/);
+  assert.match(app, /confirmedTransactionReceiptMatches\(proof, receipt\)/);
+  assert.match(app, /status === 400 \|\| status === 500/);
+  assert.match(app, /if \(status >= 600\)/);
+  assert.match(app, /lock\.phase === "manual"/);
+  assert.match(app, /if \(lock\.phase !== "confirmed"\)/);
+  assert.match(
+    app,
+    /if \(state\.confirmedBatch && !ignoreConfirmedBatch\) return \[\];/,
+  );
+  assert.match(
+    app,
+    /"Claim bereits bestätigt"[\s\S]*elements\.action\.disabled = true/,
+  );
+  assert.match(
+    app,
+    /await readCapabilities\(\);\s*await reconcileConfirmedBatchLock\(\);/,
+  );
+  assert.match(app, /window\.addEventListener\("storage"/);
+  assert.match(
+    app,
+    /await readLaunchStampRouter\(\);[\s\S]*state\.router\.finalizedBlock[\s\S]*state\.blockTag = blockTag;/,
+  );
+});
+
+test("queues one fresh scan when refresh is requested during an active scan", async () => {
+  let releaseFirst;
+  const firstGate = new Promise((resolve) => {
+    releaseFirst = resolve;
+  });
+  const runs = [];
+  const refresh = createRefreshQueue(async () => {
+    runs.push(runs.length + 1);
+    if (runs.length === 1) await firstGate;
+  });
+
+  const first = refresh();
+  await Promise.resolve();
+  const second = refresh();
+  const third = refresh();
+  releaseFirst();
+  await Promise.all([first, second, third]);
+
+  assert.deepEqual(runs, [1, 2]);
 });
 
 test("uses the deployed claim and read selectors", () => {
@@ -169,6 +657,36 @@ function classicLog(launcher, { block = 25_700_000n, index = 0n } = {}) {
   };
 }
 
+function launchStampLog({
+  launchId = `0x${"11".repeat(32)}`,
+  token = "0x1234567890123456789012345678901234567890",
+  hook = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+  poolId = `0x${"22".repeat(32)}`,
+  stampHash = `0x${"33".repeat(32)}`,
+  block = 25_827_140n,
+  index = 0n,
+} = {}) {
+  return {
+    address: LAUNCH_STAMP_ROUTER.address,
+    blockHash: `0x${"88".repeat(32)}`,
+    blockNumber: `0x${block.toString(16)}`,
+    transactionIndex: "0x1",
+    logIndex: `0x${index.toString(16)}`,
+    transactionHash: `0x${"44".repeat(32)}`,
+    topics: [
+      LAUNCH_STAMP_TOPICS.launchStamped,
+      launchId,
+      `0x${addressWord(token)}`,
+      `0x${addressWord(hook)}`,
+    ],
+    data: `0x${[
+      addressWord(LAUNCH_STAMP_ROUTER.poolManager.address),
+      poolId.slice(2),
+      stampHash.slice(2),
+    ].join("")}`,
+  };
+}
+
 function abiString(value) {
   const bytes = Buffer.from(value, "utf8").toString("hex");
   const padded = bytes.padEnd(Math.ceil(bytes.length / 64) * 64, "0");
@@ -220,9 +738,274 @@ test("reduces canonical Classic V2 and V3 launch events newest first", () => {
   );
 });
 
-test("keeps retired Custom Registry V1 out of claim discovery", () => {
+test("binds the canonical Mainnet Launch Stamp Router trust root", () => {
+  assert.deepEqual(LAUNCH_STAMP_ROUTER, {
+    address: "0x8622DD5bAb44185f2A458ac90384Ac99248f8d56",
+    startBlock: 25_717_612n,
+    endBlock: null,
+    finalizedTag: "finalized",
+    maximumFinalizedSpread: 32n,
+    runtimeCodeHash:
+      "0x40e27ecf201761d5eb66bc4f2d5c6124831ef078d7baf458ca5f41b1a8108546",
+    sourceCommit: "0a7134bbb912222639627fb9078df2f8dd3a6c38",
+    sourceTree: "24ffb0c6b04af7993254560b4f03608de8f52231",
+    abiSha256:
+      "sha256:bb4e728e9f9c850eb01f928e8a798ac206a82e241a8d93b3b3c686635c88ed86",
+    permitAuthority: {
+      address: "0x755509eA6e3F5Ec1aA2E797bb68f1B87DD8b886b",
+      runtimeCodeHash:
+        "0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c",
+    },
+    graphFactory: {
+      address: "0xB012e4A8F2c5FC4E8E4faCA9D5Ad6FfF13FBA887",
+      runtimeCodeHash:
+        "0xd23692fae59331592048e71a96d4963e170ee56e449683dc9f7fa3f9470018b8",
+    },
+    poolManager: {
+      address: "0x000000000004444c5dc75cB358380D2e3dE08A90",
+      runtimeCodeHash:
+        "0x785f1014552b7ce7d5fb7d0c970ca60edee94fd00425d7ca21609acac7ce1293",
+    },
+  });
+  assert.deepEqual(LAUNCH_STAMP_TOPICS, {
+    launchStamped:
+      "0x6cf479a102f1eebc9244f48f8d68f6aa52b4c5a4516318df58ba46614a5b14f2",
+    launchRouteStamped:
+      "0x45e7cc355b63ca67d6278a0d8d23470ce2a0741a9c60283d7dee712df7a877a5",
+    componentStamped:
+      "0x8147265e7396d6400cee8d049456a1f7438fdfbe2a7c81c976d51ba67e52ff4b",
+  });
+  assert.deepEqual(LAUNCH_STAMP_SELECTORS, {
+    chainId: "0x85e1f4d0",
+    permitAuthority: "0xc3a3d03c",
+    permitAuthorityRuntimeCodeHash: "0xa497c61c",
+    graphFactory: "0x1cc9e5ce",
+    graphFactoryRuntimeCodeHash: "0x92989a00",
+    poolManager: "0x62308e85",
+    poolManagerRuntimeCodeHash: "0x38d831c4",
+    launchIdByToken: "0x1dad847c",
+    launchIdByPool: "0x361df6f3",
+    launchIdByComponent: "0x58c5e373",
+    componentRuntimeCodeHash: "0xc892d353",
+    launchStamp: "0x4c9e4764",
+    stampProof: "0x174b9f9d",
+  });
+});
+
+test("decodes and reduces canonical Launch Stamp events", () => {
+  const older = launchStampLog({ block: 25_827_140n });
+  const newer = launchStampLog({
+    launchId: `0x${"55".repeat(32)}`,
+    poolId: `0x${"66".repeat(32)}`,
+    stampHash: `0x${"77".repeat(32)}`,
+    block: 25_827_141n,
+    index: 2n,
+  });
+  const decoded = decodeLaunchStampLog(older);
+  assert.equal(decoded.launchId, older.topics[1]);
+  assert.equal(decoded.token.toLowerCase(), `0x${older.topics[2].slice(-40)}`);
+  assert.equal(decoded.hook.toLowerCase(), `0x${older.topics[3].slice(-40)}`);
+  assert.equal(
+    decoded.poolManager.toLowerCase(),
+    LAUNCH_STAMP_ROUTER.poolManager.address.toLowerCase(),
+  );
+  assert.equal(decoded.poolId, `0x${"22".repeat(32)}`);
+  assert.equal(decoded.stampHash, `0x${"33".repeat(32)}`);
+
+  const launches = reduceLaunchStampLogs([older, newer]);
+  assert.deepEqual(
+    launches.map(({ launchId }) => launchId),
+    [newer.topics[1], older.topics[1]],
+  );
+  assert.throws(
+    () => reduceLaunchStampLogs([older, older]),
+    /Doppelter Launch-Stamp/,
+  );
+  assert.equal(
+    launchStampLogSetFingerprint([older, newer]),
+    launchStampLogSetFingerprint([newer, older]),
+  );
+  assert.notEqual(
+    launchStampLogSetFingerprint([older, newer]),
+    launchStampLogSetFingerprint([older]),
+  );
+  assert.notEqual(
+    launchStampLogSetFingerprint([older, newer]),
+    launchStampLogSetFingerprint([]),
+  );
+  const sameSizeRawDivergence = {
+    ...newer,
+    data: `${newer.data.slice(0, -1)}${newer.data.endsWith("0") ? "1" : "0"}`,
+  };
+  assert.notEqual(
+    launchStampLogSetFingerprint([older, newer]),
+    launchStampLogSetFingerprint([older, sameSizeRawDivergence]),
+  );
+  const malformedAddressPadding = {
+    ...older,
+    topics: [
+      older.topics[0],
+      older.topics[1],
+      `0x${"ff".repeat(12)}${older.topics[2].slice(-40)}`,
+      older.topics[3],
+    ],
+  };
+  assert.throws(
+    () => launchStampLogSetFingerprint([malformedAddressPadding]),
+    /Eventadresse/,
+  );
+  assert.throws(
+    () =>
+      decodeLaunchStampLog({
+        ...older,
+        data: `0x${[
+          addressWord("0x0000000000000000000000000000000000000001"),
+          "22".repeat(32),
+          "33".repeat(32),
+        ].join("")}`,
+      }),
+    /Identität ist unvollständig/,
+  );
+});
+
+test("uses a bounded common finalized Router boundary and rejects a stale wallet view", () => {
+  const older = {
+    number: "0x18a1b37",
+    hash: `0x${"ab".repeat(32)}`,
+  };
+  const newer = {
+    number: "0x18a1b57",
+    hash: `0x${"cd".repeat(32)}`,
+  };
+  assert.equal(
+    routerFinalizedBoundary([older, newer, { ...newer }], 1n, 32n),
+    BigInt(older.number),
+  );
+  assert.throws(
+    () =>
+      routerFinalizedBoundary(
+        [{ ...older, number: "0x18a1b36" }, newer, { ...newer }],
+        1n,
+        32n,
+      ),
+    /zu weit auseinander/,
+  );
+});
+
+test("requires one exact common Router checkpoint from all three RPCs", () => {
+  const hash = `0x${"ab".repeat(32)}`;
+  const block = { number: "0x18a1b17", hash };
+  assert.deepEqual(
+    exactRouterFinalizedCheckpoint([block, { ...block }, { ...block }], 1n),
+    { number: 25_828_119n, hash },
+  );
+  assert.throws(
+    () =>
+      exactRouterFinalizedCheckpoint(
+        [
+          { number: "0x18a1ad0", hash: `0x${"cd".repeat(32)}` },
+          block,
+          { ...block },
+        ],
+        1n,
+      ),
+    /stimmt im RPC-Quorum nicht überein/,
+  );
+  assert.throws(
+    () =>
+      exactRouterFinalizedCheckpoint(
+        [block, { ...block, hash: `0x${"ef".repeat(32)}` }, { ...block }],
+        1n,
+      ),
+    /stimmt im RPC-Quorum nicht überein/,
+  );
+  assert.throws(
+    () => exactRouterFinalizedCheckpoint([block, { ...block }], 1n),
+    /fehlt im RPC-Quorum/,
+  );
+});
+
+test("terminates a stalled scan RPC instead of occupying the refresh queue", async () => {
+  await assert.rejects(
+    withTimeout(
+      new Promise(() => {}),
+      5,
+      "Wallet-RPC-Zeitlimit im Test überschritten",
+    ),
+    /Wallet-RPC-Zeitlimit im Test überschritten/,
+  );
+});
+
+test("decodes exact Launch Stamp records, proofs and lookup calldata", () => {
+  const launchId = `0x${"11".repeat(32)}`;
+  const token = "0x1234567890123456789012345678901234567890";
+  const hook = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
+  const routeLauncher = "0x9876543210987654321098765432109876543210";
+  const hashes = Array.from({ length: 8 }, (_, index) =>
+    (index + 2).toString(16).padStart(2, "0").repeat(32),
+  );
+  const recordWords = [
+    word(1),
+    addressWord(TREASURY),
+    addressWord(token),
+    addressWord(hook),
+    addressWord(LAUNCH_STAMP_ROUTER.poolManager.address),
+    hashes[0],
+    hashes[1],
+    hashes[2],
+    hashes[3],
+    addressWord(routeLauncher),
+    hashes[4],
+    hashes[5],
+    hashes[6],
+    hashes[7],
+  ];
+  const poolId = `0x${hashes[0]}`;
+  const record = decodeLaunchStampRecord(`0x${recordWords.join("")}`);
+  assert.equal(record.kind, 1);
+  assert.equal(record.launchWallet.toLowerCase(), TREASURY.toLowerCase());
+  assert.equal(record.token.toLowerCase(), token.toLowerCase());
+  assert.equal(record.hook.toLowerCase(), hook.toLowerCase());
+  assert.equal(record.routeLauncher.toLowerCase(), routeLauncher.toLowerCase());
+  assert.equal(record.poolId, poolId);
+  assert.equal(record.stampHash, `0x${hashes[7]}`);
+
+  assert.deepEqual(
+    decodeLaunchStampProof(`0x${launchId.slice(2)}${hashes[7]}`),
+    { launchId, stampHash: `0x${hashes[7]}` },
+  );
+  assert.equal(
+    launchStampBytes32ReadData(LAUNCH_STAMP_SELECTORS.launchStamp, launchId),
+    `${LAUNCH_STAMP_SELECTORS.launchStamp}${launchId.slice(2)}`,
+  );
+  assert.equal(
+    launchStampAddressReadData(LAUNCH_STAMP_SELECTORS.launchIdByToken, token),
+    `${LAUNCH_STAMP_SELECTORS.launchIdByToken}${addressWord(token)}`,
+  );
+  assert.equal(
+    launchStampPoolReadData(
+      LAUNCH_STAMP_SELECTORS.launchIdByPool,
+      LAUNCH_STAMP_ROUTER.poolManager.address,
+      poolId,
+    ),
+    `${LAUNCH_STAMP_SELECTORS.launchIdByPool}${addressWord(LAUNCH_STAMP_ROUTER.poolManager.address)}${poolId.slice(2)}`,
+  );
+  assert.throws(
+    () => decodeLaunchStampRecord(`0x${[word(3), ...recordWords.slice(1)].join("")}`),
+    /Art wird nicht unterstützt/,
+  );
+  assert.throws(
+    () => decodeLaunchStampProof(`0x${launchId.slice(2)}`),
+    /ungültige ABI-Länge/,
+  );
+});
+
+test("keeps the retired Custom Registry V1 policy inert", () => {
   assert.equal(CUSTOM_REGISTRY.status, "retired");
-  assert.equal(CUSTOM_REGISTRY.address, "0x0000000000000000000000000000000000000000");
+  assert.equal(
+    CUSTOM_REGISTRY.address,
+    "0x0000000000000000000000000000000000000000",
+  );
   assert.equal(CUSTOM_REGISTRY.startBlock, 0n);
   assert.equal(CUSTOM_REGISTRY.runtimeCodeHash, null);
   assert.deepEqual(Object.keys(CUSTOM_EVENT_TOPICS), [
@@ -529,6 +1312,124 @@ test("normalizes MetaMask batch identifiers", () => {
   assert.throws(() => normalizeBatchId({}), /Batch-ID/);
 });
 
+test("binds a confirmed atomic batch to its exact receipt identities", () => {
+  const id = `0x${"12".repeat(32)}`;
+  const blockHashA = `0x${"ab".repeat(32)}`;
+  const blockHashB = `0x${"cd".repeat(32)}`;
+  const transactionHashA = `0x${"34".repeat(32)}`;
+  const transactionHashB = `0x${"56".repeat(32)}`;
+  const status = {
+    version: "2.0.0",
+    id,
+    chainId: MAINNET_CHAIN_ID,
+    status: 200,
+    atomic: true,
+    receipts: [
+      {
+        status: "0x1",
+        blockNumber: "0x18a1b57",
+        blockHash: blockHashA,
+        transactionHash: transactionHashA,
+      },
+      {
+        status: "0x1",
+        blockNumber: "0x18a1b58",
+        blockHash: blockHashB,
+        transactionHash: transactionHashB,
+      },
+    ],
+  };
+  assert.equal(validatedAtomicBatchStatus(status, id), 200);
+  assert.deepEqual(confirmedBatchReceiptProof(status, id), {
+    highestBlock: 25_828_184n,
+    receipts: [
+      {
+        blockNumber: 25_828_183n,
+        blockHash: blockHashA,
+        transactionHash: transactionHashA,
+      },
+      {
+        blockNumber: 25_828_184n,
+        blockHash: blockHashB,
+        transactionHash: transactionHashB,
+      },
+    ],
+  });
+  assert.equal(
+    confirmedTransactionReceiptMatches(
+      {
+        blockNumber: 25_828_183n,
+        blockHash: blockHashA,
+        transactionHash: transactionHashA,
+      },
+      status.receipts[0],
+    ),
+    true,
+  );
+  assert.equal(
+    confirmedTransactionReceiptMatches(
+      {
+        blockNumber: 25_828_183n,
+        blockHash: blockHashA,
+        transactionHash: transactionHashA,
+      },
+      { ...status.receipts[0], blockHash: blockHashB },
+    ),
+    false,
+  );
+  assert.throws(
+    () =>
+      confirmedBatchReceiptProof(
+        { ...status, id: `0x${"99".repeat(32)}` },
+        id,
+      ),
+    /stimmt nicht/,
+  );
+  assert.throws(
+    () => confirmedBatchReceiptProof({ ...status, chainId: "0x2" }, id),
+    /stimmt nicht/,
+  );
+  assert.throws(
+    () =>
+      confirmedBatchReceiptProof(
+        {
+          ...status,
+          receipts: [{ ...status.receipts[0], blockHash: "0xdead" }],
+        },
+        id,
+      ),
+    /Receipt-Identität/,
+  );
+  assert.throws(
+    () =>
+      confirmedBatchReceiptProof({
+        version: "2.0.0",
+        id,
+        chainId: MAINNET_CHAIN_ID,
+        status: 200,
+        atomic: true,
+        receipts: [{ status: "0x1" }],
+      }, id),
+    /Receipt-Block/,
+  );
+  assert.throws(
+    () =>
+      confirmedBatchReceiptProof(
+        {
+          ...status,
+          receipts: [{ ...status.receipts[0], status: "0x0" }],
+        },
+        id,
+      ),
+    /fehlgeschlagen/,
+  );
+  assert.throws(
+    () =>
+      confirmedBatchReceiptProof({ ...status, status: 100, receipts: [] }, id),
+    /nicht vollständig bestätigt/,
+  );
+});
+
 function activeCustomV2Release() {
   const contract = (suffix) => ({
     address: `0x${suffix.repeat(40)}`,
@@ -723,5 +1624,321 @@ test("builds direct permissionless Custom claims into the same wallet batch", ()
       executable: true,
     }),
     "empty",
+  );
+  assert.equal(
+    customV2SourceClassification({
+      ...custom,
+      registered: true,
+      quarantined: false,
+      executable: true,
+    }),
+    "blocked",
+  );
+});
+
+test("binds audited Router Custom profiles with exact read and claim calldata", () => {
+  assert.deepEqual(ROUTER_CUSTOM_CLAIM_PROFILES, {
+    nativeAccumulatorV1: {
+      id: "native-accumulator-v1",
+      bindings: [
+        {
+          launchId:
+            "0x6d6ed0e1e69a7cd6afa177e3454c9e32eed61cbd3f855ee56aff1915a6776fc2",
+          source: "0xd7451a039373f54e493deE42A751fEcBfAFBa0cc",
+          runtimeCodeHash:
+            "0xff70a4d3d889b730a064b270fc187f0cba40582f1fa6f5875893066b17a1257b",
+        },
+      ],
+      recipient: "0x4968150a",
+      feeBps: "0xb6c7448d",
+      accrued: "0x0986bdb6",
+      claim: "0xa95e4f21",
+      expectedFeeBps: 10n,
+    },
+    shardLauncherFeesV1: {
+      id: "shard-launcher-fees-v1",
+      bindings: [
+        {
+          launchId:
+            "0xe253f3bd22fcb3d6cb20b9d408287e30f0f1aeeb56426b779425c35fd6411de9",
+          token: "0xFAce73B63787960282f2d4682d3752Beb25271Ad",
+          source: "0x07a16735325723fEa4f4a52ED5E9da687766A0Cc",
+          runtimeCodeHash:
+            "0x168f82b0d458a35676522562489b2fec71929e4717c3d98b4893ef63e69e8da6",
+        },
+      ],
+      recipient: "0x4c50e2c4",
+      feeBps: "0x89223381",
+      feeDenominatorBps: "0xe1a45218",
+      poolManager: "0xdc4c90d3",
+      boundToken: "0x996373c3",
+      nft: "0x47ccca02",
+      initialized: "0x07003bb4",
+      accrued: "0x1497233e",
+      claim: "0x64d46b85",
+      expectedFeeBps: 1_000n,
+      expectedFeeDenominatorBps: 10_000n,
+      expectedNft: "0x92822e03D9cc1b2b497647B159ce5207Cd721527",
+    },
+    protocolFeeSourceV1: {
+      id: "protocol-fee-source-v1",
+      bindings: [],
+      recipient: CUSTOM_V2_SELECTORS.programmableFeeRecipient,
+      feeBps: `${CUSTOM_V2_SELECTORS.programmableFeeBps}${"0".repeat(64)}`,
+      accrued: `${CUSTOM_V2_SELECTORS.accruedProgrammableFees}${"0".repeat(64)}`,
+      claim: `${CUSTOM_V2_SELECTORS.claimProgrammableFees}${"0".repeat(64)}`,
+      expectedFeeBps: 10n,
+    },
+    isolatedAfterSwapFeeVaultV2: {
+      id: "isolated-after-swap-fee-vault-v2",
+      bindings: [
+        {
+          launchId:
+            "0x786d3d5cdd0c6ba81621eb01fbcc6b5912556a2d7dbe886431346460afeee197",
+          token: "0xD0f3E1e5C985D2b37a66Cf07feCB0d8191c0445F",
+          hook: "0xce6f22c5ccf06aad50dd2bc681fa7c30ce55e044",
+          hookRuntimeCodeHash:
+            "0x0a461fa65d04305fa2e583d9a6fba369b3b2ff66aa5856f56d0782c2ff72e19c",
+          source: "0x97875d30DFE562e290Eb5646D907F8e775645f66",
+          sourceRuntimeCodeHash:
+            "0xf2cbc21a3f07c05909d664ba8d8b66fe6576eb8a5d016faa53e31e73ed6acbd4",
+        },
+      ],
+      hookFeeVault: "0x5517476a",
+      recipient: "0xc6fd9bd8",
+      feePpm: "0x6cf9ca81",
+      feeDenominatorPpm: "0x1bd7398b",
+      poolManager: "0xdc4c90d3",
+      authorizedAdapter: "0x54a1b628",
+      authorizedAdapterCodeHash: "0x18903320",
+      bindingAuthority: "0x2028d39b",
+      accrued: "0x87d4d28c",
+      claim: "0x5fa65a04",
+      expectedFeePpm: 1_000n,
+      expectedFeeDenominatorPpm: 1_000_000n,
+      secondaryUnit: "PCR2",
+      secondaryDecimals: 18,
+    },
+    dualCurrencyRedeemerV1: {
+      id: "dual-currency-redeemer-v1",
+      bindings: [
+        {
+          launchId:
+            "0x5a52180427785716bff0a36218dde89f0459db265d0c2bdfcfde81a8fe733c92",
+          source: "0xEBa46F25dff528141DE5317109aCB5a989296044",
+          runtimeCodeHash:
+            "0xd59d31add7a3b206972725889dbb726782c0fbd82514710cf2d645749dc3fa25",
+        },
+      ],
+      recipient: "0x46904840",
+      feePips: "0x9fa59765",
+      poolManager: "0xdc4c90d3",
+      currency0: "0x79f1232b",
+      currency1: "0x10d737b8",
+      poolId: "0x3e0dc34e",
+      balanceOf: "0x00fdd58e",
+      claim:
+        "0xfc656ac500000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
+      expectedFeePips: 1_000n,
+      secondaryUnit: "PCAN",
+      secondaryDecimals: 18,
+    },
+  });
+
+  const nativeProfile = ROUTER_CUSTOM_CLAIM_PROFILES.nativeAccumulatorV1;
+  const protocolProfile = ROUTER_CUSTOM_CLAIM_PROFILES.protocolFeeSourceV1;
+  const nativeClaim = {
+    id: "launch-stamp:fade",
+    kind: "custom",
+    address: "0xd7451a039373f54e493dee42a751fecbfafba0cc",
+    readData: nativeProfile.accrued,
+    claimData: nativeProfile.claim,
+  };
+  assert.equal(readAccruedData(nativeClaim), nativeProfile.accrued);
+  assert.equal(claimData(nativeClaim), nativeProfile.claim);
+  assert.equal(
+    readAccruedData({ ...nativeClaim, readData: protocolProfile.accrued }),
+    protocolProfile.accrued,
+  );
+  assert.equal(
+    claimData({ ...nativeClaim, claimData: protocolProfile.claim }),
+    protocolProfile.claim,
+  );
+
+  const shardProfile = ROUTER_CUSTOM_CLAIM_PROFILES.shardLauncherFeesV1;
+  const shardClaim = {
+    id: "launch-stamp:shard",
+    kind: "custom",
+    address: shardProfile.bindings[0].source,
+    readData: shardProfile.accrued,
+    claimData: shardProfile.claim,
+  };
+  assert.equal(readAccruedData(shardClaim), "0x1497233e");
+  assert.equal(claimData(shardClaim), "0x64d46b85");
+
+  const vaultProfile =
+    ROUTER_CUSTOM_CLAIM_PROFILES.isolatedAfterSwapFeeVaultV2;
+  const pcr2Token = "0xD0f3E1e5C985D2b37a66Cf07feCB0d8191c0445F";
+  const vaultNativeClaim = {
+    id: "launch-stamp:pcr2:native",
+    kind: "custom",
+    address: vaultProfile.bindings[0].source,
+    unit: "ETH",
+    readData: `${vaultProfile.accrued}${encodeAddressArgument(CUSTOM_V2_POLICY.nativeAsset)}`,
+    claimData: `${vaultProfile.claim}${encodeAddressArgument(CUSTOM_V2_POLICY.nativeAsset)}`,
+  };
+  const vaultTokenClaim = {
+    id: "launch-stamp:pcr2:token",
+    kind: "custom",
+    address: vaultProfile.bindings[0].source,
+    unit: vaultProfile.secondaryUnit,
+    readData: `${vaultProfile.accrued}${encodeAddressArgument(pcr2Token)}`,
+    claimData: `${vaultProfile.claim}${encodeAddressArgument(pcr2Token)}`,
+  };
+  assert.equal(
+    readAccruedData(vaultNativeClaim),
+    `0x87d4d28c${"0".repeat(64)}`,
+  );
+  assert.equal(
+    claimData(vaultNativeClaim),
+    `0x5fa65a04${"0".repeat(64)}`,
+  );
+  assert.equal(
+    readAccruedData(vaultTokenClaim),
+    `0x87d4d28c${encodeAddressArgument(pcr2Token)}`,
+  );
+  assert.equal(
+    claimData(vaultTokenClaim),
+    `0x5fa65a04${encodeAddressArgument(pcr2Token)}`,
+  );
+  const vaultBatch = buildWalletSendCalls(TREASURY, [
+    vaultNativeClaim,
+    vaultTokenClaim,
+  ]);
+  assert.equal(vaultBatch.calls.length, 2);
+  assert.notDeepEqual(vaultBatch.calls[0], vaultBatch.calls[1]);
+  assert.deepEqual(
+    vaultBatch.calls.map(({ to, data }) => ({ to, data })),
+    [vaultNativeClaim, vaultTokenClaim].map(({ address, claimData: data }) => ({
+      to: address,
+      data,
+    })),
+  );
+
+  const pcanProfile = ROUTER_CUSTOM_CLAIM_PROFILES.dualCurrencyRedeemerV1;
+  const pcanClaim = {
+    id: "launch-stamp:pcan",
+    kind: "custom",
+    address: pcanProfile.bindings[0].source,
+    claimData: pcanProfile.claim,
+  };
+  assert.equal(claimData(pcanClaim), pcanProfile.claim);
+  assert.equal(
+    poolManagerBalanceOfData(
+      pcanProfile.balanceOf,
+      pcanClaim.address,
+      "0x9DEeB39D2590b0cAD5fc473F755C5F97Dcc8f7cE",
+    ),
+    `${pcanProfile.balanceOf}${encodeAddressArgument(pcanClaim.address)}${encodeAddressArgument("0x9DEeB39D2590b0cAD5fc473F755C5F97Dcc8f7cE")}`,
+  );
+
+  const batch = buildWalletSendCalls(TREASURY, [nativeClaim, pcanClaim]);
+  assert.deepEqual(batch.calls, [
+    {
+      to: nativeClaim.address,
+      data: nativeProfile.claim,
+      value: "0x0",
+    },
+    {
+      to: pcanClaim.address,
+      data: pcanProfile.claim,
+      value: "0x0",
+    },
+  ]);
+  assert.throws(
+    () => readAccruedData({ ...nativeClaim, readData: "0x1234" }),
+    /Claim-Lesedaten/,
+  );
+  assert.throws(
+    () => claimData({ ...nativeClaim, claimData: "0x1234" }),
+    /Claim-Calldata/,
+  );
+});
+
+test("classifies Router Custom claims fail-closed", () => {
+  const ready = {
+    id: "launch-stamp:fade",
+    kind: "custom",
+    origin: "launch-stamp-router",
+    provenanceVerified: true,
+    runtimeVerified: true,
+    claimMode: "manual",
+    claimBindingVerified: true,
+    amount: 1n,
+  };
+  assert.equal(routerCustomClaimClassification(ready), "ready");
+  assert.equal(
+    routerCustomClaimClassification({ ...ready, amount: 0n }),
+    "empty",
+  );
+  assert.equal(
+    routerCustomClaimClassification({
+      ...ready,
+      amount: 0n,
+      secondaryAmount: 1n,
+    }),
+    "ready",
+  );
+  assert.equal(
+    routerCustomClaimClassification({
+      ...ready,
+      amount: 0n,
+      secondaryAmount: undefined,
+    }),
+    "empty",
+  );
+  assert.equal(
+    routerCustomClaimClassification({
+      ...ready,
+      amount: 0n,
+      secondaryAmount: "1",
+    }),
+    "blocked",
+  );
+  assert.equal(
+    routerCustomClaimClassification({ ...ready, amount: undefined }),
+    "blocked",
+  );
+  assert.equal(
+    routerCustomClaimClassification({ ...ready, runtimeVerified: false }),
+    "blocked",
+  );
+  assert.equal(
+    routerCustomClaimClassification({
+      ...ready,
+      claimMode: "no-manual-claim",
+      claimBindingVerified: false,
+      amount: undefined,
+    }),
+    "no-manual-claim",
+  );
+  assert.equal(
+    customClaimDefinitionClassification(ready, { amount: 2n }),
+    "ready",
+  );
+});
+
+test("rejects duplicate onchain calls in one atomic batch", () => {
+  const profile = ROUTER_CUSTOM_CLAIM_PROFILES.nativeAccumulatorV1;
+  const first = {
+    id: "launch-stamp:first",
+    kind: "custom",
+    address: "0xd7451a039373f54e493dee42a751fecbfafba0cc",
+    claimData: profile.claim,
+  };
+  const duplicate = { ...first, id: "launch-stamp:second" };
+  assert.throws(
+    () => buildWalletSendCalls(TREASURY, [first, duplicate]),
+    /Doppelter Claim im atomaren Batch/,
   );
 });

--- a/ops/protocol-fee-claim/package.json
+++ b/ops/protocol-fee-claim/package.json
@@ -2,6 +2,8 @@
   "name": "programmable-fee-claim",
   "private": true,
   "scripts": {
-    "build": "node build.mjs"
+    "build": "node build.mjs",
+    "test": "node --test logic.test.mjs",
+    "check": "npm test && npm run build"
   }
 }

--- a/ops/protocol-fee-claim/styles.css
+++ b/ops/protocol-fee-claim/styles.css
@@ -64,9 +64,9 @@ summary:focus-visible {
 .shell {
   background: var(--paper);
   border: 1px solid var(--line);
-  border-radius: 18px;
+  border-radius: 20px;
   box-shadow: 0 18px 48px rgba(46, 29, 39, 0.08);
-  max-width: 760px;
+  max-width: 680px;
   overflow: hidden;
   width: 100%;
 }
@@ -112,17 +112,21 @@ summary:focus-visible {
   height: 7px;
   width: 7px;
 }
-
-.content {
-  padding: 36px 40px 32px;
+.network[data-state="idle"]::before {
+  background: var(--ink-soft);
+}
+.network[data-state="wrong"]::before {
+  background: var(--danger);
 }
 
-.intro-grid {
-  align-items: end;
-  display: grid;
-  gap: 32px;
-  grid-template-columns: 1fr 1fr;
-  margin-bottom: 34px;
+.content {
+  padding: 54px 52px 36px;
+}
+
+.hero {
+  margin: 0 auto 44px;
+  max-width: 520px;
+  text-align: center;
 }
 
 .eyebrow {
@@ -136,25 +140,32 @@ summary:focus-visible {
 }
 
 h1 {
-  font-size: clamp(40px, 7vw, 58px);
+  font-size: clamp(46px, 8vw, 66px);
   font-weight: 620;
-  letter-spacing: -0.065em;
-  line-height: 0.88;
+  letter-spacing: -0.07em;
+  line-height: 0.95;
   margin: 0;
 }
 
 .intro {
   color: var(--ink-soft);
-  font-size: 14px;
-  line-height: 1.55;
-  margin: 0 0 2px;
+  font-size: 15px;
+  line-height: 1.5;
+  margin: 18px auto 0;
+  max-width: 390px;
 }
 
 .total-line {
-  align-items: end;
+  align-items: center;
+  background: linear-gradient(180deg, #fff8fb 0%, var(--pink-soft) 100%);
+  border: 1px solid #efd8e3;
+  border-radius: 16px;
   display: flex;
-  justify-content: space-between;
-  margin-bottom: 12px;
+  flex-direction: column;
+  justify-content: center;
+  margin-bottom: 16px;
+  min-height: 160px;
+  padding: 26px;
 }
 
 .total-line span {
@@ -162,16 +173,23 @@ h1 {
   font:
     500 12px/1 "Geist Mono",
     monospace;
+  text-transform: uppercase;
 }
 .total-line strong {
-  font-size: 22px;
+  font-size: clamp(38px, 8vw, 54px);
   font-weight: 620;
-  letter-spacing: -0.04em;
+  letter-spacing: -0.065em;
+  line-height: 1;
+  margin: 12px 0 9px;
+}
+.total-line small {
+  color: var(--ink-soft);
+  font:
+    500 11px/1.3 "Geist Mono",
+    monospace;
 }
 
 .claim-list {
-  border-bottom: 1px solid var(--line);
-  border-top: 1px solid var(--line);
   list-style: none;
   margin: 0;
   padding: 0;
@@ -197,6 +215,10 @@ h1 {
 .asset-group-value {
   display: flex;
   flex-direction: column;
+}
+
+.asset-group-identity {
+  min-width: 0;
 }
 
 .claim-identity {
@@ -293,11 +315,10 @@ h1 {
 }
 
 .meta-grid {
-  align-items: end;
   display: grid;
-  gap: 18px;
-  grid-template-columns: 1fr 1fr auto;
-  margin: 18px 0;
+  gap: 24px;
+  grid-template-columns: 1fr 1fr;
+  margin: 0 0 18px;
 }
 
 .meta-grid > div {
@@ -327,7 +348,7 @@ h1 {
   border: 0;
   color: var(--pink-dark);
   min-height: 44px;
-  padding: 0 2px;
+  padding: 0 6px;
 }
 
 .refresh:disabled {
@@ -342,9 +363,11 @@ h1 {
   border-radius: 12px;
   color: #2d1723;
   display: flex;
-  justify-content: space-between;
-  min-height: 62px;
-  padding: 0 18px;
+  flex-direction: column;
+  gap: 5px;
+  justify-content: center;
+  min-height: 68px;
+  padding: 10px 18px;
   transition:
     background-color 140ms ease,
     transform 140ms ease;
@@ -362,7 +385,7 @@ h1 {
   opacity: 0.55;
 }
 .primary strong {
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 720;
 }
 .primary span {
@@ -377,7 +400,7 @@ h1 {
   font:
     500 11px/1.45 "Geist Mono",
     monospace;
-  margin: 13px 0 0;
+  margin: 14px 0 0;
   min-height: 16px;
   text-align: center;
 }
@@ -390,7 +413,60 @@ h1 {
   font-size: 12px;
   margin: 13px 0 0;
   padding: 10px 12px;
+  line-height: 1.45;
   text-align: center;
+}
+
+.quick-actions {
+  align-items: center;
+  color: var(--ink-soft);
+  display: flex;
+  font:
+    500 10px/1.4 "Geist Mono",
+    monospace;
+  justify-content: center;
+  margin: 10px 0 28px;
+  min-height: 44px;
+}
+.quick-actions a {
+  color: var(--pink-dark);
+  min-height: 44px;
+  padding: 14px 6px;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+.quick-actions > :not([hidden]) + span::before {
+  color: var(--line);
+  content: "·";
+  margin: 0 8px 0 4px;
+}
+
+.details {
+  border-top: 1px solid var(--line);
+}
+.details > summary {
+  align-items: center;
+  color: var(--ink-soft);
+  cursor: pointer;
+  display: flex;
+  font-size: 12px;
+  justify-content: space-between;
+  list-style: none;
+  min-height: 52px;
+}
+.details > summary::-webkit-details-marker {
+  display: none;
+}
+.details > summary::after {
+  color: var(--pink-dark);
+  content: "+";
+  font-size: 18px;
+}
+.details[open] > summary::after {
+  content: "−";
+}
+.details-body {
+  padding: 8px 0 0;
 }
 
 .trust {
@@ -399,8 +475,8 @@ h1 {
   color: var(--ink-soft);
   display: flex;
   gap: 10px;
-  margin-top: 24px;
-  padding-top: 18px;
+  margin-top: 18px;
+  padding: 16px 0 2px;
 }
 
 .trust-mark {
@@ -432,18 +508,20 @@ h1 {
     padding: 0 18px;
   }
   .content {
-    padding: 28px 18px 24px;
+    padding: 42px 18px 24px;
   }
-  .intro-grid {
-    gap: 18px;
-    grid-template-columns: 1fr;
-    margin-bottom: 28px;
+  .hero {
+    margin-bottom: 32px;
   }
   h1 {
-    font-size: 46px;
+    font-size: 48px;
   }
   .intro {
-    max-width: 360px;
+    font-size: 14px;
+    max-width: 330px;
+  }
+  .total-line {
+    min-height: 148px;
   }
   .meta-grid {
     grid-template-columns: 1fr 1fr;
@@ -454,18 +532,22 @@ h1 {
     text-overflow: clip;
     white-space: normal;
   }
-  .refresh {
-    grid-column: 1 / -1;
-    justify-self: start;
+  .asset-group summary {
+    align-items: start;
+    column-gap: 8px;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(92px, 42%) auto;
   }
-  .primary {
-    align-items: flex-start;
-    flex-direction: column;
-    justify-content: center;
-    gap: 5px;
+  .asset-group-value,
+  .disclosure-indicator {
+    margin-left: 0;
+  }
+  .quick-actions {
+    flex-wrap: wrap;
+    margin-bottom: 22px;
   }
   .trust {
-    margin-top: 20px;
+    margin-top: 16px;
   }
   .trust p {
     font-size: 10px;


### PR DESCRIPTION
## Outcome

- selects MetaMask through EIP-6963 and keeps wallet lifecycle fail-closed
- reduces the console to one scan/claim action with one atomic wallet confirmation
- discovers all finalized Router launches and binds exact FADE, PCAN, SHARD, and PCR2 claim profiles
- expands PCR2 into separate ETH/token Vault legs while counting actual batch calls
- keeps unknown Custom ABIs visible and blocks the full claim instead of guessing calldata

## Verification

- 39/39 fee-console tests and static build
- 68/68 developer-doc checks
- TypeScript and targeted ESLint: no errors
- gitleaks: no leaks across production..HEAD
- real finalized Mainnet browser scan: 0.087300937004258244 ETH, 6 claims + 2 assets, 319 Classic + 4 Custom
- desktop/mobile rendered QA, zero console errors, zero wallet_sendCalls/signature/transaction methods during QA