### PR TITLE
Keep SHARD trading across finality rehydration

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1347,6 +1347,7 @@ jobs:
         env:
           STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          PROGRAMMABLE_REQUIRE_SHARD_ROUTER_TRADE: "true"
         run: |
           node scripts/smoke-static-dexscreener-public-apis.mjs
 
@@ -1374,6 +1375,7 @@ jobs:
           CUSTOM_LAUNCH_V3_RELEASE: ${{ inputs.custom_launch_v3_release }}
           MARKET_READ_STATUS: ${{ steps.public-provider-smoke.outputs.market_read_status }}
           DETAIL_SMOKE_STATUS: ${{ steps.public-provider-smoke.outputs.detail_status }}
+          SHARD_TRADE_STATUS: ${{ steps.public-provider-smoke.outputs.shard_trade_status }}
           CHART_SMOKE_STATUS: ${{ steps.public-provider-smoke.outputs.chart_status }}
           CATALOG_BLOCK_NUMBER: ${{ steps.envio-catalog-probe.outputs.block_number }}
           CATALOG_TOKEN_COUNT: ${{ steps.envio-catalog-probe.outputs.token_count }}
@@ -1392,6 +1394,7 @@ jobs:
             echo "- Market data provider: Dexscreener (optional enrichment)"
             echo "- Explore market read status: \`${MARKET_READ_STATUS:-not-run}\`"
             echo "- Token detail smoke: \`${DETAIL_SMOKE_STATUS:-not-run}\`"
+            echo "- SHARD trade adapter smoke: \`${SHARD_TRADE_STATUS:-not-run}\`"
             echo "- Market chart smoke: \`${CHART_SMOKE_STATUS:-not-run}\`"
             echo "- Custom V2 verification required by this commit: \`$CUSTOM_V2_REQUIRED\`"
             if [ "$CUSTOM_V2_REQUIRED" = true ]; then

--- a/lib/custom-launch/router-trade-adapters-v1.ts
+++ b/lib/custom-launch/router-trade-adapters-v1.ts
@@ -750,11 +750,9 @@ function resolveShardRouterTradeAdapterV1(
     || stamp.transactionIndex !== 25
     || stamp.routeLogIndex !== 266
     || stamp.launchLogIndex !== 267
-    || stamp.finalizedAtBlockNumber !== "25845472"
-    || !sameHex(
-      stamp.finalizedAtBlockHash,
-      "0x27a50f4ef518dd04bfe23cb666f633436fe4b6ed684f168c1b95fa1e7741c16a",
-    )
+    // These two finality fields identify the later observation head, not the
+    // immutable launch. The provenance validator above still requires a
+    // bytes32 block hash and at least 64 confirmations.
     || !sameHex(
       stamp.poolManagerAddress,
       "0x000000000004444c5dc75cb358380d2e3de08a90",

--- a/scripts/smoke-static-dexscreener-public-apis.mjs
+++ b/scripts/smoke-static-dexscreener-public-apis.mjs
@@ -10,6 +10,16 @@ const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
 const CATALOG_SOURCES = new Set(["envio-classic-v3"]);
 const PROGRAMMABLE_MAIN_ASSET_ADDRESS =
   "0x7987f03462200b3d8a072e02c89a8a41dcb124ee";
+const SHARD_TOKEN_ADDRESS = [
+  "0xface73b63787960282f2",
+  "d4682d3752beb25271ad",
+].join("");
+const SHARD_POOL_ID =
+  "0x9c74d6183b1ee526a62db562a81da3bf579b5bd6bff5066ae985265a7028e010";
+const SHARD_ROUTER_TRADE_PROJECT_ID =
+  "sha256:98f170ed0fa4e98f5b7e1901905132c24082f54f37f6176133be54fd039959a3";
+const SHARD_ROUTER_TRADE_CAPABILITY_HASH =
+  "sha256:6c562e4c2f52829d6c5fdf806ab7deb5a9a37ac549e8137a17160d0dd8436e6a";
 const CATALOG_STATUSES = new Set([
   "current",
   "last-known-good",
@@ -106,6 +116,36 @@ function exactExplorePage(response, tokens, expected = { page: 1, pageSize: 20 }
     tokens.length === Math.min(expected.pageSize, Math.max(0, total - offset)) &&
     Number.isSafeInteger(totalPages) &&
     totalPages === Math.ceil(total / expected.pageSize);
+}
+
+function exactShardRouterTradeDetail(response) {
+  const project = response.body?.routerTradeProject;
+  const market = Array.isArray(project?.markets) && project.markets.length === 1
+    ? project.markets[0]
+    : null;
+  const capability = market?.tradeCapability;
+  return response.status === 200 &&
+    response.body?.status === "ready" &&
+    response.body?.customProject === null &&
+    String(response.body?.token?.tokenAddress ?? "").toLowerCase() ===
+      SHARD_TOKEN_ADDRESS &&
+    project?.customProjectId === SHARD_ROUTER_TRADE_PROJECT_ID &&
+    market?.marketId === "shard-eth-v4" &&
+    market?.kind === "uniswap-v4-hooked-pool" &&
+    market?.status === "active" &&
+    String(market?.poolId ?? "").toLowerCase() === SHARD_POOL_ID &&
+    market?.baseAsset?.symbol === "SHARD" &&
+    String(market?.baseAsset?.identity?.value ?? "").toLowerCase() ===
+      SHARD_TOKEN_ADDRESS &&
+    market?.quoteAsset?.symbol === "ETH" &&
+    String(market?.quoteAsset?.identity?.value ?? "").toLowerCase() ===
+      "0x0000000000000000000000000000000000000000" &&
+    JSON.stringify(capability?.supportedSides) ===
+      JSON.stringify(["base-to-quote", "quote-to-base"]) &&
+    capability?.hookDataPolicy?.kind === "empty" &&
+    capability?.hookDataPolicy?.data === "0x" &&
+    capability?.tradeCapabilityBindingHash ===
+      SHARD_ROUTER_TRADE_CAPABILITY_HASH;
 }
 
 function exactIdentity(token) {
@@ -572,6 +612,8 @@ export async function runStagedStaticDexscreenerSmokeV1(input = {}) {
     : {};
   const request = (path, acceptedStatuses) =>
     requestJson(target, headers, path, fetchImpl, acceptedStatuses);
+  const requireShardRouterTrade =
+    environment.PROGRAMMABLE_REQUIRE_SHARD_ROUTER_TRADE === "true";
 
   const health = await request("/api/ops/health");
   if (!exactInformationalHealth(health)) {
@@ -740,12 +782,39 @@ export async function runStagedStaticDexscreenerSmokeV1(input = {}) {
       const detailStatus = qualifiedDexscreenerFdv(detailToken)
         ? "verified-dexscreener-market"
         : "verified-identity-market-unavailable";
+      let shardTradeStatus = "not-required";
+      if (requireShardRouterTrade) {
+        const shardDetail = await request(
+          "/api/explore/token?address=" +
+            encodeURIComponent(SHARD_TOKEN_ADDRESS),
+        );
+        const shardCatalog = exactCatalogSnapshot(
+          { ...shardDetail, body: {
+            ...shardDetail.body,
+            total: shardDetail.body?.catalog?.identityCount,
+          } },
+          { requireLaunchIdentity: false },
+        );
+        if (shardCatalog === null) {
+          throw new Error("SHARD trade detail catalog is invalid");
+        }
+        if (shardCatalog !== highestCatalog) {
+          throw new ExploreCatalogBoundaryDriftError(
+            "Explore catalog changed before SHARD trade detail read",
+          );
+        }
+        if (!exactShardRouterTradeDetail(shardDetail)) {
+          throw new Error("SHARD Router trade project is unavailable or invalid");
+        }
+        shardTradeStatus = "verified";
+      }
 
       exploreSnapshot = {
         catalogBoundary,
         detailStatus,
         highest,
         newestTokens,
+        shardTradeStatus,
         tokenAddress,
       };
       break;
@@ -768,6 +837,7 @@ export async function runStagedStaticDexscreenerSmokeV1(input = {}) {
     detailStatus,
     highest,
     newestTokens,
+    shardTradeStatus,
     tokenAddress,
   } = exploreSnapshot;
 
@@ -943,6 +1013,7 @@ export async function runStagedStaticDexscreenerSmokeV1(input = {}) {
       [
         `market_read_status=${marketReadStatus}`,
         `detail_status=${detailStatus}`,
+        `shard_trade_status=${shardTradeStatus}`,
         `chart_status=${chartStatus}`,
       ].join("\n") + "\n",
       "utf8",
@@ -961,6 +1032,7 @@ export async function runStagedStaticDexscreenerSmokeV1(input = {}) {
     profileAccount,
     profileStatus,
     detailStatus,
+    shardTradeStatus,
     chartStatus,
     creatorClaimPrepare: "separate-live-probe-required",
     tradePrepare: "separate-live-probe-required",
@@ -976,6 +1048,7 @@ export function runProductionStaticDexscreenerSmokeV1(input = {}) {
     environment: {
       ...(input.environment ?? process.env),
       STAGED_TARGET_URL: "https://programmable.market/",
+      PROGRAMMABLE_REQUIRE_SHARD_ROUTER_TRADE: "true",
     },
   });
 }

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -314,6 +314,7 @@ test("every staged candidate proves the Envio catalog before public data smoke",
     smoke,
     /node scripts\/smoke-static-dexscreener-public-apis\.mjs/u,
   );
+  assert.match(smoke, /PROGRAMMABLE_REQUIRE_SHARD_ROUTER_TRADE: "true"/u);
   assert.equal(
     smoke.match(/smoke-static-dexscreener-public-apis\.mjs/gu)?.length,
     1,
@@ -334,6 +335,7 @@ test("every staged candidate proves the Envio catalog before public data smoke",
   );
   assert.match(handoff, /Explore market read status:/u);
   assert.match(handoff, /Token detail smoke:/u);
+  assert.match(handoff, /SHARD trade adapter smoke:/u);
   assert.match(handoff, /Market chart smoke:/u);
 
   for (const retired of [

--- a/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
+++ b/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
@@ -16,6 +16,16 @@ const ROUTER_TOKEN = "0x6969696969696969696969696969696969696969";
 const ROUTER_LAUNCH_ID = `0x${"ab".repeat(32)}`;
 const ROUTER_STAMP_HASH = `0x${"cd".repeat(32)}`;
 const POOL_MANAGER = "0x000000000004444c5dc75cb358380d2e3de08a90";
+const SHARD_TOKEN = [
+  "0xface73b63787960282f2",
+  "d4682d3752beb25271ad",
+].join("");
+const SHARD_POOL =
+  "0x9c74d6183b1ee526a62db562a81da3bf579b5bd6bff5066ae985265a7028e010";
+const SHARD_PROJECT =
+  "sha256:98f170ed0fa4e98f5b7e1901905132c24082f54f37f6176133be54fd039959a3";
+const SHARD_CAPABILITY =
+  "sha256:6c562e4c2f52829d6c5fdf806ab7deb5a9a37ac549e8137a17160d0dd8436e6a";
 
 function entry(index) {
   const tokenAddress = index === 0
@@ -235,6 +245,39 @@ function explore(sort) {
   };
 }
 
+function shardTradeDetail() {
+  return {
+    status: "ready",
+    token: { tokenAddress: SHARD_TOKEN },
+    customProject: null,
+    routerTradeProject: {
+      customProjectId: SHARD_PROJECT,
+      markets: [{
+        marketId: "shard-eth-v4",
+        kind: "uniswap-v4-hooked-pool",
+        status: "active",
+        poolId: SHARD_POOL,
+        baseAsset: {
+          symbol: "SHARD",
+          identity: { value: SHARD_TOKEN },
+        },
+        quoteAsset: {
+          symbol: "ETH",
+          identity: {
+            value: "0x0000000000000000000000000000000000000000",
+          },
+        },
+        tradeCapability: {
+          supportedSides: ["base-to-quote", "quote-to-base"],
+          hookDataPolicy: { kind: "empty", data: "0x" },
+          tradeCapabilityBindingHash: SHARD_CAPABILITY,
+        },
+      }],
+    },
+    catalog: catalog(),
+  };
+}
+
 function response(body, extraHeaders = {}, omittedHeaders = []) {
   const headers = new Headers({
     "content-type": "application/json",
@@ -270,12 +313,14 @@ function stagedFetch(
     } else if (url.pathname === "/api/explore") {
       body = explore(url.searchParams.get("sort"));
     } else if (url.pathname === "/api/explore/token") {
-      body = {
-        status: "ready",
-        token: entry(0),
-        customProject: null,
-        catalog: catalog(),
-      };
+      body = url.searchParams.get("address")?.toLowerCase() === SHARD_TOKEN
+        ? shardTradeDetail()
+        : {
+            status: "ready",
+            token: entry(0),
+            customProject: null,
+            catalog: catalog(),
+          };
     } else if (url.pathname === "/api/explore/token/chart") {
       body = {
         schemaVersion: "programmable.market-chart.v1",
@@ -607,6 +652,23 @@ test("staged smoke accepts an exact Router Custom token identity", async () => {
 
   assert.equal(result.tokenAddress, ROUTER_TOKEN);
   assert.equal(result.detailStatus, "verified-identity-market-unavailable");
+});
+
+test("staged smoke requires the exact SHARD Router trade project", async () => {
+  const output = [];
+  const result = await runStagedStaticDexscreenerSmokeV1({
+    environment: {
+      STAGED_TARGET_URL: "https://candidate.vercel.app/",
+      VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+      PROGRAMMABLE_REQUIRE_SHARD_ROUTER_TRADE: "true",
+      GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+    },
+    fetchImpl: stagedFetch(),
+    appendOutput: (...args) => output.push(args),
+  });
+
+  assert.equal(result.shardTradeStatus, "verified");
+  assert.match(output[0][1], /shard_trade_status=verified/u);
 });
 
 test("staged smoke accepts a bounded Router last-known-good identity", async () => {

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -1010,7 +1010,7 @@ describe("read-model operations source contract", () => {
     const smoke = readFileSync(resolve(ROOT, path), "utf8");
     expect(smoke).toContain(needle);
     const result = evaluateReadModelOperationsSourceContracts(ROOT, {
-      sourceOverrides: { [path]: smoke.replace(needle, replacement) },
+      sourceOverrides: { [path]: smoke.replaceAll(needle, replacement) },
     });
     expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
       "ops-protected-public-provider-stage-smoke",

--- a/tests/router-trade-adapters-v1.test.ts
+++ b/tests/router-trade-adapters-v1.test.ts
@@ -72,6 +72,33 @@ describe("reviewed Router trade adapter registry v1", () => {
     });
   });
 
+  it("accepts a later valid SHARD finality observation", () => {
+    const rehydratedEntry = {
+      ...shardRouterTradeEntry,
+      launchStampProvenance: {
+        ...shardRouterTradeStamp,
+        finalizedAtBlockNumber: "25846576",
+        finalizedAtBlockHash:
+          "0x1284240707b04c1c4472bbf708d232a104d05ecd2364ef8ddfac8a3606bb4750",
+      },
+    } as CanonicalTokenExploreEntry;
+    const underFinalizedEntry = {
+      ...shardRouterTradeEntry,
+      launchStampProvenance: {
+        ...shardRouterTradeStamp,
+        finalizedAtBlockNumber: "25845471",
+        finalizedAtBlockHash: `0x${"f".repeat(64)}`,
+      },
+    } as CanonicalTokenExploreEntry;
+
+    expect(resolveRouterTradeAdapterV1(rehydratedEntry)).toBe(
+      SHARD_ROUTER_TRADE_ADAPTER_V1,
+    );
+    expect(routerTradeProjectForEntryV1(rehydratedEntry)?.customProjectId)
+      .toBe(SHARD_ROUTER_TRADE_PROJECT_ID);
+    expect(resolveRouterTradeAdapterV1(underFinalizedEntry)).toBeNull();
+  });
+
   it("builds SHARD with the canonical capability binding and exact PoolKey", () => {
     expect(parseDiscoverableMarketTradeCapabilityV1({
       value: SHARD_ROUTER_TRADE_CAPABILITY_V1,


### PR DESCRIPTION
## Outcome

- keep the exact reviewed SHARD trade adapter available when the Router snapshot is rehydrated at a later valid 64-confirmation observation head
- retain every immutable launch, PoolKey, runtime, component, transaction, stamp, and category binding
- reject under-finalized observations
- make Stage and post-promotion smoke fail unless the exact SHARD project, pool, bidirectional sides, hook-data policy, and capability hash are present

## Focused verification

- `npx vitest run tests/router-trade-adapters-v1.test.ts tests/token-detail-api.test.ts` — 28 passed
- `node --test scripts/test/smoke-static-dexscreener-public-apis.test.mjs` — 32 passed
- `node --test scripts/test/custom-v2-production-workflow-contract.test.mjs` — 9 passed
- scoped ESLint — passed
- `node --check scripts/smoke-static-dexscreener-public-apis.mjs` — passed
- `git diff --check` — passed

The local full TypeScript check reaches the same pre-existing `Uint8Array<ArrayBufferLike>` / Vercel Blob `PutBody` mismatch in `lib/server/creator-article/media-api.server.ts:144` on the unchanged base checkout. This PR does not touch that path; protected CI remains authoritative.
