### PR TITLE
Bind wallet admin readiness identity

### DIFF
--- a/scripts/generate-custom-launch-api-release-binding-v1.mjs
+++ b/scripts/generate-custom-launch-api-release-binding-v1.mjs
@@ -132,8 +132,14 @@ const READINESS_KEYS = Object.freeze([
   "sourceTree",
   "migrationInventorySha256",
   "apiContractSha256",
+  "walletAdminSecurity",
   "publicProfile",
   "chain",
+]);
+const WALLET_ADMIN_SECURITY_KEYS = Object.freeze([
+  "assertionVersion",
+  "assertionMode",
+  "legacyBearerRequestsAccepted",
 ]);
 const PUBLIC_PROFILE_KEYS = Object.freeze([
   "profileId",
@@ -432,6 +438,10 @@ function validateReadiness(readiness, backend, inventory, contract, profile) {
     || readiness.sourceTree !== backend.treeSha
     || readiness.migrationInventorySha256 !== migrationInventorySha256
     || readiness.apiContractSha256 !== apiContractSha256
+    || !exactKeys(readiness.walletAdminSecurity, WALLET_ADMIN_SECURITY_KEYS)
+    || readiness.walletAdminSecurity.assertionVersion !== "2"
+    || readiness.walletAdminSecurity.assertionMode !== "compatibility"
+    || readiness.walletAdminSecurity.legacyBearerRequestsAccepted !== true
     || !exactKeys(readiness.publicProfile, PUBLIC_PROFILE_KEYS)
     || readiness.publicProfile.profileId !== profile.profileId
     || readiness.publicProfile.profileVersion !== profile.profileVersion

--- a/scripts/test/custom-launch-v3-release-generators.test.mjs
+++ b/scripts/test/custom-launch-v3-release-generators.test.mjs
@@ -224,6 +224,11 @@ async function releaseFixture(t) {
     sourceTree: backend.tree,
     migrationInventorySha256: prettySha256(inventory),
     apiContractSha256: prettySha256(contract),
+    walletAdminSecurity: {
+      assertionVersion: "2",
+      assertionMode: "compatibility",
+      legacyBearerRequestsAccepted: true,
+    },
     publicProfile: {
       profileId: profile.profileId,
       profileVersion: profile.profileVersion,
@@ -307,6 +312,10 @@ test("binding generator derives exact revision 3 artifacts and retained database
   assert.equal(binding.website.candidateCommitSha, fixture.website.commit);
   assert.equal(binding.website.candidateTreeSha, fixture.website.tree);
   assert.equal(binding.api.profileVersion, "3.2.0");
+  assert.equal(
+    binding.api.readinessIdentitySha256,
+    sha256(Buffer.from(canonicalize(fixture.readiness), "utf8")),
+  );
   assert.match(binding.api.publicProfilePath, /admission-profile\.v3\.json$/u);
   assert.equal(binding.fly.imageTag, `main-${fixture.backend.commit.slice(0, 12)}`);
   assert.equal(binding.fly.imageDigest, `sha256:${"9".repeat(64)}`);
@@ -326,6 +335,36 @@ test("binding generator derives exact revision 3 artifacts and retained database
     /repository is not clean|output already exists/u,
   );
   assert.deepEqual(await readFile(result.outputPath), beforeRetry);
+});
+
+test("binding generator requires the exact compatibility wallet-admin security identity", async (t) => {
+  const mutations = Object.freeze([
+    (readiness) => { delete readiness.walletAdminSecurity; },
+    (readiness) => { readiness.walletAdminSecurity.assertionVersion = "1"; },
+    (readiness) => { readiness.walletAdminSecurity.assertionMode = "enforced"; },
+    (readiness) => { readiness.walletAdminSecurity.legacyBearerRequestsAccepted = false; },
+    (readiness) => { readiness.walletAdminSecurity.unexpected = true; },
+  ]);
+
+  for (const mutate of mutations) {
+    const fixture = await releaseFixture(t);
+    const mutatedReadiness = structuredClone(fixture.readiness);
+    mutate(mutatedReadiness);
+    await json(fixture.paths.readiness, mutatedReadiness);
+    await assert.rejects(
+      materializeCustomLaunchApiReleaseBindingV1({
+        websiteRoot: fixture.websiteRoot,
+        backendRoot: fixture.backendRoot,
+        flyReleases: fixture.paths.releases,
+        flyMachines: fixture.paths.machines,
+        flyImages: fixture.paths.images,
+        apiReadiness: fixture.paths.readiness,
+        supabaseMigrationList: fixture.paths.migrationList,
+        databaseSchemaEvidenceOutput: fixture.paths.databaseEvidence,
+      }),
+      /readiness differs from the exact backend artifacts/u,
+    );
+  }
 });
 
 test("rollback snapshot retains only exact deployment and env metadata", async (t) => {


### PR DESCRIPTION
Summary

- require the exact walletAdminSecurity compatibility object in the Custom Launch API release-binding generator
- retain the complete readiness document, including wallet-admin security mode, in the canonical readiness identity digest
- fail closed on missing, mutated, or additive wallet-admin security fields

Verification

- node --test scripts/test/custom-launch-v3-release-generators.test.mjs: 3 passed
- git diff --check

No other release checks, product files, merge, or deployment are included.