### PR TITLE
Fix Router Custom cold-start identity conflicts

### DIFF
--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -160,7 +160,7 @@
     },
     "publicSnapshot": {
       "path": "lib/alchemy/router-custom-public.server.ts",
-      "sha256": "e8d75b9ed722bac43833562eae6a77e45d612a61e71fd8c018719c374d2977a1"
+      "sha256": "a2fdc5c675e31f062908038499586fd958e990c8add4d031d518f83c7df0331a"
     }
   },
   "workers": [

--- a/lib/alchemy/router-custom-public.server.ts
+++ b/lib/alchemy/router-custom-public.server.ts
@@ -317,6 +317,16 @@ export function routerCustomSnapshotPreservesFinalizedIdentitiesV1(
   }
 }
 
+function routerCustomSnapshotsShareFinalizedIdentityBoundaryV1(
+  left: RouterCustomIdentitySnapshotV1,
+  right: RouterCustomIdentitySnapshotV1,
+) {
+  return left.asOfBlock === right.asOfBlock &&
+    left.asOfBlockHash.toLowerCase() === right.asOfBlockHash.toLowerCase() &&
+    routerCustomSnapshotPreservesFinalizedIdentitiesV1(left, right) &&
+    routerCustomSnapshotPreservesFinalizedIdentitiesV1(right, left);
+}
+
 function jsonRecord(
   value: JsonValue | undefined,
 ): Readonly<Record<string, JsonValue>> {
@@ -457,7 +467,13 @@ async function persistDurableRouterCustomIdentitySnapshotV1(
       return;
     }
     if (previousBlock === nextBlock) {
-      if (existing.snapshot.identityCommitment !== snapshot.identityCommitment) {
+      if (
+        existing.snapshot.identityCommitment !== snapshot.identityCommitment &&
+        !routerCustomSnapshotsShareFinalizedIdentityBoundaryV1(
+          existing.snapshot,
+          snapshot,
+        )
+      ) {
         throw new RouterCustomSnapshotConflictError(
           "Router Custom durable snapshot conflicts at one block",
         );
@@ -572,9 +588,18 @@ export function createRouterCustomIdentitySnapshotReaderV1(
                 durable.asOfBlockHash.toLowerCase() ||
               previous.identityCommitment !== durable.identityCommitment)
           ) {
-            throw new RouterCustomSnapshotConflictError(
-              "Router Custom cached and durable snapshots conflict",
-            );
+            if (!routerCustomSnapshotsShareFinalizedIdentityBoundaryV1(
+              previous,
+              durable,
+            )) {
+              throw new RouterCustomSnapshotConflictError(
+                "Router Custom cached and durable snapshots conflict",
+              );
+            }
+            // Observation-only finality fields can be rehydrated at a later
+            // head without changing launch identity. Prefer the shared durable
+            // bytes so cold serverless instances publish one stable boundary.
+            previous = durable;
           }
           if (
             durableBlock > previousBlock &&
@@ -606,8 +631,16 @@ export function createRouterCustomIdentitySnapshotReaderV1(
               snapshot.asOfBlockHash.toLowerCase() ||
             previous.identityCommitment !== snapshot.identityCommitment)
         ) {
-          throw new RouterCustomSnapshotConflictError(
-            "Router Custom snapshots conflict at one boundary",
+          if (!routerCustomSnapshotsShareFinalizedIdentityBoundaryV1(
+            previous,
+            snapshot,
+          )) {
+            throw new RouterCustomSnapshotConflictError(
+              "Router Custom snapshots conflict at one boundary",
+            );
+          }
+          return cacheSnapshot(
+            lastKnownGoodRouterCustomSnapshotV1(previous),
           );
         }
         if (

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -188,7 +188,7 @@ const APPROVED_OPERATIONS = Object.freeze({
     publicSnapshot: Object.freeze({
       path: "lib/alchemy/router-custom-public.server.ts",
       sha256:
-        "e8d75b9ed722bac43833562eae6a77e45d612a61e71fd8c018719c374d2977a1",
+        "a2fdc5c675e31f062908038499586fd958e990c8add4d031d518f83c7df0331a",
     }),
   }),
   independentCrons: Object.freeze([

--- a/tests/router-custom-public.test.ts
+++ b/tests/router-custom-public.test.ts
@@ -3,9 +3,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => ({
+  blobGet: vi.fn(),
+  blobPut: vi.fn(),
   readAlchemyExploreModel: vi.fn(),
   readAlchemyRouterCustomIdentitySourceV1: vi.fn(),
   enrichRouterCustomSnapshotWithFinalizedMetadataV1: vi.fn(),
+}));
+
+vi.mock("@vercel/blob", () => ({
+  get: mocks.blobGet,
+  put: mocks.blobPut,
 }));
 
 vi.mock("../lib/alchemy/explore.server", () => ({
@@ -28,6 +35,7 @@ import {
   mergeRouterCustomCreatorProfileV1,
   mergeRouterCustomExploreEntriesV1,
   normalizeRouterCustomSnapshotBlobEtagV1,
+  persistRouterCustomIdentitySnapshotFromSourceV1,
   publicLaunchSourceV1,
   readFinalizedRouterCustomExploreEntriesV1,
   ROUTER_CUSTOM_SNAPSHOT_CACHE_TTL_MS,
@@ -131,6 +139,7 @@ function profile(blockNumber = "25740000"): CreatorProfile {
 describe("finalized Router Custom public projection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
     mocks.readAlchemyExploreModel.mockResolvedValue(model());
     mocks.readAlchemyRouterCustomIdentitySourceV1.mockResolvedValue(source());
     mocks.enrichRouterCustomSnapshotWithFinalizedMetadataV1
@@ -320,6 +329,85 @@ describe("finalized Router Custom public projection", () => {
       asOfBlock: "25740001",
       entries: [customGraphExploreEntry],
     });
+  });
+
+  it("keeps one durable boundary when only finality observation fields drift", async () => {
+    const durable = routerCustomIdentitySnapshotFromSourceV1(source());
+    const reobservedSource = source([
+      {
+        ...customGraphToken,
+        launchStampProvenance: {
+          ...customGraphToken.launchStampProvenance!,
+          finalizedAtBlockNumber: "25740123",
+          finalizedAtBlockHash: `0x${"df".repeat(32)}` as `0x${string}`,
+        },
+      },
+      stampedClassicToken,
+    ]);
+    const reobserved = routerCustomIdentitySnapshotFromSourceV1(
+      reobservedSource,
+    );
+    const persistDurableSnapshot = vi.fn().mockResolvedValue(undefined);
+    const reader = createRouterCustomIdentitySnapshotReaderV1({
+      now: () => Date.parse("2026-08-25T06:01:00.000Z"),
+      readCurrentSource: vi.fn().mockResolvedValue(reobservedSource),
+      readDurableSnapshot: vi.fn().mockResolvedValue(durable),
+      persistDurableSnapshot,
+    });
+
+    expect(reobserved.identityCommitment).not.toBe(durable.identityCommitment);
+    expect(routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+      durable,
+      reobserved,
+    )).toBe(true);
+    expect(routerCustomSnapshotPreservesFinalizedIdentitiesV1(
+      reobserved,
+      durable,
+    )).toBe(true);
+    await expect(reader()).resolves.toMatchObject({
+      status: "last-known-good",
+      identityCommitment: durable.identityCommitment,
+      entries: [customGraphExploreEntry],
+    });
+    expect(persistDurableSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("does not overwrite the durable Blob for observation-only same-block drift", async () => {
+    const durable = routerCustomIdentitySnapshotFromSourceV1(source());
+    const reobservedSource = source([
+      {
+        ...customGraphToken,
+        launchStampProvenance: {
+          ...customGraphToken.launchStampProvenance!,
+          finalizedAtBlockNumber: "25740123",
+          finalizedAtBlockHash: `0x${"df".repeat(32)}` as `0x${string}`,
+        },
+      },
+      stampedClassicToken,
+    ]);
+    const body = JSON.stringify({
+      schemaVersion:
+        "programmable.router-custom-identity-snapshot-envelope.v1",
+      binding: LAUNCH_STAMP_ROUTER_BINDING,
+      snapshot: durable,
+    });
+    mocks.blobGet.mockResolvedValue({
+      statusCode: 200,
+      stream: new Response(body).body,
+      blob: {
+        size: Buffer.byteLength(body, "utf8"),
+        etag: `W/"${"ab".repeat(16)}"`,
+      },
+    });
+    vi.stubEnv("OPS_BLOB_READ_WRITE_TOKEN", "vercel_blob_rw_test");
+
+    await expect(
+      persistRouterCustomIdentitySnapshotFromSourceV1(reobservedSource),
+    ).resolves.toMatchObject({
+      asOfBlock: durable.asOfBlock,
+    });
+    expect(mocks.blobGet).toHaveBeenCalledOnce();
+    expect(mocks.blobPut).not.toHaveBeenCalled();
   });
 
   it("accepts a newer boundary only when every finalized identity is unchanged", () => {


### PR DESCRIPTION
## Outcome

Keeps finalized Router Custom identities available across cold serverless starts when only observation-time finality fields are rehydrated at the same router block boundary.

## Safety boundary

- accepts only bidirectionally identical immutable identity sets at the same block/hash
- retains the durable last-known-good bytes for a stable public boundary
- preserves fail-closed behavior for real identity, set, block, or block-hash conflicts
- avoids rewriting the durable Blob for observation-only drift
- updates the reviewed operations source-digest binding for the changed snapshot reader

## Verification

- `npx vitest run tests/router-custom-public.test.ts tests/data-pipeline/read-model-ops-contract.test.ts` — 119/119 passed
- `git diff --check` — passed
- commit signature — GitHub verified
