### PR TITLE
Stabilize protected preview login and stage feed checks

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1365,10 +1365,51 @@ jobs:
           grep -Fx "deployment_id=$EXPECTED_DEPLOYMENT_ID" "$binding_output"
           grep -Fx "target_url=$STAGED_TARGET_URL" "$binding_output"
 
+      - name: Bind exact candidate to stable protected preview
+        id: stable-preview
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          EXPECTED_DEPLOYMENT_ID: ${{ steps.staged-deployment.outputs.deployment_id }}
+          EXPECTED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
+          STABLE_PREVIEW_HOST: launcher-v4-aficialais-projects.vercel.app
+        run: |
+          set -euo pipefail
+          test "$STABLE_PREVIEW_HOST" = launcher-v4-aficialais-projects.vercel.app
+          test "$STABLE_PREVIEW_HOST" != programmable.market
+          vercel alias set "$EXPECTED_DEPLOYMENT_ID" "$STABLE_PREVIEW_HOST" \
+            --token="$VERCEL_TOKEN"
+          inspect_output="$RUNNER_TEMP/stable-preview-inspect.json"
+          test ! -e "$inspect_output"
+          umask 077
+          vercel inspect "$STABLE_PREVIEW_HOST" --format=json \
+            --token="$VERCEL_TOKEN" > "$inspect_output"
+          INSPECT_OUTPUT="$inspect_output" node --input-type=module <<'NODE'
+          import { readFileSync } from "node:fs";
+
+          const expectedTarget = new URL(process.env.EXPECTED_TARGET_URL);
+          const inspected = JSON.parse(
+            readFileSync(process.env.INSPECT_OUTPUT, "utf8"),
+          );
+          if (
+            expectedTarget.protocol !== "https:" ||
+            expectedTarget.pathname !== "/" ||
+            !expectedTarget.hostname.endsWith(".vercel.app") ||
+            inspected.id !== process.env.EXPECTED_DEPLOYMENT_ID ||
+            inspected.url !== expectedTarget.hostname ||
+            inspected.readyState !== "READY"
+          ) {
+            throw new Error(
+              "stable preview alias is not bound to the exact staged deployment",
+            );
+          }
+          NODE
+          echo "stable_preview_url=https://$STABLE_PREVIEW_HOST/" >> "$GITHUB_OUTPUT"
+
       - name: Record staged candidate handoff
         env:
           DEPLOYMENT_ID: ${{ steps.staged-deployment.outputs.deployment_id }}
           STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
+          STABLE_PREVIEW_URL: ${{ steps.stable-preview.outputs.stable_preview_url }}
           PREVIOUS_DEPLOYMENT_ID: ${{ steps.production-before.outputs.deployment_id }}
           PREVIOUS_GIT_HEAD: ${{ steps.production-before.outputs.git_head }}
           CUSTOM_V2_REQUIRED: ${{ needs.release-gate.outputs.verified_custom_v2 }}
@@ -1386,6 +1427,7 @@ jobs:
             echo "- Commit: \`$GITHUB_SHA\`"
             echo "- Deployment ID: \`$DEPLOYMENT_ID\`"
             echo "- Target: $STAGED_TARGET_URL"
+            echo "- Stable protected preview: $STABLE_PREVIEW_URL"
             echo "- Previous production deployment: \`$PREVIOUS_DEPLOYMENT_ID\`"
             echo "- Previous production commit: \`$PREVIOUS_GIT_HEAD\`"
             echo "- Launch identities: validated Envio Classic V3 catalog"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1372,16 +1372,20 @@ jobs:
           EXPECTED_DEPLOYMENT_ID: ${{ steps.staged-deployment.outputs.deployment_id }}
           EXPECTED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
           STABLE_PREVIEW_HOST: launcher-v4-aficialais-projects.vercel.app
+          VERCEL_SCOPE: aficialais-projects
         run: |
           set -euo pipefail
           test "$STABLE_PREVIEW_HOST" = launcher-v4-aficialais-projects.vercel.app
           test "$STABLE_PREVIEW_HOST" != programmable.market
+          test "$VERCEL_SCOPE" = aficialais-projects
           vercel alias set "$EXPECTED_DEPLOYMENT_ID" "$STABLE_PREVIEW_HOST" \
+            --scope="$VERCEL_SCOPE" \
             --token="$VERCEL_TOKEN"
           inspect_output="$RUNNER_TEMP/stable-preview-inspect.json"
           test ! -e "$inspect_output"
           umask 077
           vercel inspect "$STABLE_PREVIEW_HOST" --format=json \
+            --scope="$VERCEL_SCOPE" \
             --token="$VERCEL_TOKEN" > "$inspect_output"
           INSPECT_OUTPUT="$inspect_output" node --input-type=module <<'NODE'
           import { readFileSync } from "node:fs";

--- a/scripts/smoke-static-dexscreener-public-apis.mjs
+++ b/scripts/smoke-static-dexscreener-public-apis.mjs
@@ -487,7 +487,7 @@ function exactCatalogSnapshot(
       launchSource: catalog.launchSource,
     });
   }
-  const expectedLaunchSource = [
+  const launchSource = [
     source,
     ...(registryCustomStatus === "current"
       ? ["registry.custom-launched"]
@@ -518,7 +518,7 @@ function exactCatalogSnapshot(
     ISO_TIMESTAMP.test(String(generatedAt ?? "")) &&
     new Date(Date.parse(generatedAt)).toISOString() === generatedAt &&
     catalog.identityCount === response.body?.total &&
-    catalog.launchSource === expectedLaunchSource &&
+    catalog.launchSource === launchSource &&
     ["current", "last-known-good"].includes(catalog.completeness?.classic) &&
     catalog.completeness?.stock === "excluded" &&
     customStatus === expectedCustomStatus &&
@@ -553,9 +553,9 @@ function exactCatalogSnapshot(
     POSITIVE_INTEGER.test(String(catalog.asOfBlock ?? "")) &&
     /^0x[0-9a-f]{64}$/u.test(String(catalog.asOfBlockHash ?? "")) &&
     response.headers.get("x-programmable-launch-source") ===
-      expectedLaunchSource &&
+      launchSource &&
     response.headers.get("x-programmable-read-source") ===
-      `${expectedLaunchSource}+dexscreener` &&
+      `${launchSource}+dexscreener` &&
     response.headers.get("x-programmable-identity-last-indexed-at") ===
       generatedAt &&
     (
@@ -579,7 +579,7 @@ function exactCatalogSnapshot(
     scope: catalog.scope,
     evidenceDeployment: catalog.evidence.deployment,
     evidenceSourceCommit: catalog.evidence.sourceCommit,
-    launchSource: expectedLaunchSource,
+    launchSource,
   });
 }
 

--- a/scripts/smoke-static-dexscreener-public-apis.mjs
+++ b/scripts/smoke-static-dexscreener-public-apis.mjs
@@ -404,7 +404,90 @@ function exactCatalogSnapshot(
   const routerCustomAvailable =
     routerCustomStatus === "current" ||
     routerCustomStatus === "last-known-good";
-  const launchSource = [
+  const routerOnlyFallback =
+    catalog?.launchSource === "canonical-launch-stamp-router";
+  if (routerOnlyFallback) {
+    const routerStamp = catalog?.routerStamp;
+    if (!(
+      source === "envio-classic-v3" &&
+      catalog?.status === "last-known-good" &&
+      ISO_TIMESTAMP.test(String(generatedAt ?? "")) &&
+      new Date(Date.parse(generatedAt)).toISOString() === generatedAt &&
+      Number.isSafeInteger(catalog.identityCount) &&
+      catalog.identityCount > 0 &&
+      catalog.identityCount === response.body?.total &&
+      catalog.completeness?.classic === "unavailable" &&
+      catalog.completeness?.stock === "excluded" &&
+      customStatus === "unavailable" &&
+      registryCustomStatus === "unavailable" &&
+      routerCustomAvailable &&
+      JSON.stringify(catalog.scope?.included) === JSON.stringify([
+        "canonical-launch-stamp-router",
+      ]) &&
+      JSON.stringify(catalog.scope?.excluded) === JSON.stringify([
+        "classic-v1",
+        "classic-v2",
+        "stock-paired-v1",
+        "stock-paired-v2",
+        "stock-paired-v3",
+      ]) &&
+      JSON.stringify(catalog.scope?.publicCategories) ===
+        JSON.stringify(["classic", "custom"]) &&
+      /^sha256:[0-9a-f]{64}$/u.test(
+        String(catalog.identityCommitment ?? ""),
+      ) &&
+      catalog.evidence === undefined &&
+      POSITIVE_INTEGER.test(String(catalog.asOfBlock ?? "")) &&
+      /^0x[0-9a-f]{64}$/u.test(String(catalog.asOfBlockHash ?? "")) &&
+      routerStamp?.source === "canonical-launch-stamp-router" &&
+      routerStamp.status === routerCustomStatus &&
+      routerStamp.finalityConfirmations === 64 &&
+      Number.isSafeInteger(routerStamp.verifiedIdentityCount) &&
+      routerStamp.verifiedIdentityCount >= catalog.identityCount &&
+      routerStamp.projectedIdentityCount === catalog.identityCount &&
+      routerStamp.generatedAt === generatedAt &&
+      routerStamp.asOfBlock === catalog.asOfBlock &&
+      routerStamp.asOfBlockHash === catalog.asOfBlockHash &&
+      /^sha256:[0-9a-f]{64}$/u.test(
+        String(routerStamp.identityCommitment ?? ""),
+      ) &&
+      response.headers.get("x-programmable-launch-source") ===
+        "canonical-launch-stamp-router" &&
+      response.headers.get("x-programmable-read-source") ===
+        "canonical-launch-stamp-router+dexscreener" &&
+      response.headers.get("x-programmable-canonical-read-status") ===
+        "unavailable" &&
+      response.headers.get("x-programmable-router-read-status") ===
+        routerCustomStatus &&
+      response.headers.get("x-programmable-identity-last-indexed-at") ===
+        generatedAt &&
+      (
+        options.requireLaunchIdentity === false ||
+        (
+          launchIdentity?.custom === "unavailable" &&
+          launchIdentity?.canonical === "unavailable" &&
+          launchIdentity?.status === "partial" &&
+          Number.isSafeInteger(launchIdentity.ageMs) &&
+          launchIdentity.ageMs >= 0
+        )
+      )
+    )) return null;
+    return JSON.stringify({
+      source,
+      identityCount: catalog.identityCount,
+      identityCommitment: catalog.identityCommitment,
+      completeness: catalog.completeness,
+      scope: catalog.scope,
+      evidenceDeployment: null,
+      evidenceSourceCommit: null,
+      routerEvidence: {
+        asOfBlock: routerStamp.asOfBlock,
+        identityCommitment: routerStamp.identityCommitment,
+      },
+      launchSource: catalog.launchSource,
+    });
+  }
+  const expectedLaunchSource = [
     source,
     ...(registryCustomStatus === "current"
       ? ["registry.custom-launched"]
@@ -435,7 +518,7 @@ function exactCatalogSnapshot(
     ISO_TIMESTAMP.test(String(generatedAt ?? "")) &&
     new Date(Date.parse(generatedAt)).toISOString() === generatedAt &&
     catalog.identityCount === response.body?.total &&
-    catalog.launchSource === launchSource &&
+    catalog.launchSource === expectedLaunchSource &&
     ["current", "last-known-good"].includes(catalog.completeness?.classic) &&
     catalog.completeness?.stock === "excluded" &&
     customStatus === expectedCustomStatus &&
@@ -469,9 +552,10 @@ function exactCatalogSnapshot(
     ) &&
     POSITIVE_INTEGER.test(String(catalog.asOfBlock ?? "")) &&
     /^0x[0-9a-f]{64}$/u.test(String(catalog.asOfBlockHash ?? "")) &&
-    response.headers.get("x-programmable-launch-source") === launchSource &&
+    response.headers.get("x-programmable-launch-source") ===
+      expectedLaunchSource &&
     response.headers.get("x-programmable-read-source") ===
-      `${launchSource}+dexscreener` &&
+      `${expectedLaunchSource}+dexscreener` &&
     response.headers.get("x-programmable-identity-last-indexed-at") ===
       generatedAt &&
     (
@@ -495,7 +579,7 @@ function exactCatalogSnapshot(
     scope: catalog.scope,
     evidenceDeployment: catalog.evidence.deployment,
     evidenceSourceCommit: catalog.evidence.sourceCommit,
-    launchSource,
+    launchSource: expectedLaunchSource,
   });
 }
 

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -144,11 +144,19 @@ test("Custom V2 evidence is immutable while the workflow remains stage-only", ()
     stablePreview,
     /STABLE_PREVIEW_HOST: launcher-v4-aficialais-projects\.vercel\.app/u,
   );
+  assert.match(stablePreview, /VERCEL_SCOPE: aficialais-projects/u);
   assert.match(
     stablePreview,
-    /vercel alias set "\$EXPECTED_DEPLOYMENT_ID" "\$STABLE_PREVIEW_HOST"/u,
+    /test "\$VERCEL_SCOPE" = aficialais-projects/u,
   );
-  assert.match(stablePreview, /vercel inspect "\$STABLE_PREVIEW_HOST" --format=json/u);
+  assert.match(
+    stablePreview,
+    /vercel alias set "\$EXPECTED_DEPLOYMENT_ID" "\$STABLE_PREVIEW_HOST" \\\n+            --scope="\$VERCEL_SCOPE"/u,
+  );
+  assert.match(
+    stablePreview,
+    /vercel inspect "\$STABLE_PREVIEW_HOST" --format=json \\\n+            --scope="\$VERCEL_SCOPE"/u,
+  );
   assert.match(stablePreview, /inspected\.id !== process\.env\.EXPECTED_DEPLOYMENT_ID/u);
   assert.match(stablePreview, /inspected\.url !== expectedTarget\.hostname/u);
   assert.doesNotMatch(stablePreview, /inspected\.aliases/u);

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -126,7 +126,7 @@ test("Custom V2 evidence is immutable while the workflow remains stage-only", ()
   assert.match(deploy, /name: custom-v2-stage-evidence-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/u);
   assert.match(deploy, /retention-days: 90/u);
   assert.match(deploy, /vercel deploy --prebuilt --prod --skip-domain/u);
-  assert.doesNotMatch(deploy, /vercel (?:promote|rollback|alias)|--scope-production-alias/u);
+  assert.doesNotMatch(deploy, /vercel (?:promote|rollback)|--scope-production-alias/u);
   assert.match(deploy, /Stage-only: no production promotion was attempted\./u);
   assert.ok(
     deploy.indexOf("Resolve exact staged deployment")
@@ -135,6 +135,33 @@ test("Custom V2 evidence is immutable while the workflow remains stage-only", ()
   assert.ok(
     deploy.indexOf("Gate exact unaliased Custom V2 staged candidate")
       < deploy.indexOf("Reverify staged candidate binding"),
+  );
+  const stablePreview = stepBlock(
+    deploy,
+    "Bind exact candidate to stable protected preview",
+  );
+  assert.match(
+    stablePreview,
+    /STABLE_PREVIEW_HOST: launcher-v4-aficialais-projects\.vercel\.app/u,
+  );
+  assert.match(
+    stablePreview,
+    /vercel alias set "\$EXPECTED_DEPLOYMENT_ID" "\$STABLE_PREVIEW_HOST"/u,
+  );
+  assert.match(stablePreview, /vercel inspect "\$STABLE_PREVIEW_HOST" --format=json/u);
+  assert.match(stablePreview, /inspected\.id !== process\.env\.EXPECTED_DEPLOYMENT_ID/u);
+  assert.match(stablePreview, /inspected\.url !== expectedTarget\.hostname/u);
+  assert.doesNotMatch(stablePreview, /inspected\.aliases/u);
+  assert.match(
+    stablePreview,
+    /test "\$STABLE_PREVIEW_HOST" != programmable\.market/u,
+  );
+  assert.doesNotMatch(stablePreview, /\*\.vercel\.app/u);
+  assert.equal(deploy.match(/vercel alias set/gu)?.length, 1);
+  assert.doesNotMatch(deploy.replace(stablePreview, ""), /vercel alias/u);
+  assert.ok(
+    deploy.indexOf("Reverify staged candidate binding")
+      < deploy.indexOf("Bind exact candidate to stable protected preview"),
   );
 });
 
@@ -244,7 +271,7 @@ test("Generic signer OIDC proof is one-shot, two-Machine and cleanup-attested", 
     standaloneReconcile,
     /PROGRAMMABLE_GENERIC_LAUNCH_SIGNER_PROBE_TOKEN/u,
   );
-  assert.doesNotMatch(deploy, /vercel (?:promote|alias)/u);
+  assert.doesNotMatch(deploy, /vercel promote/u);
 });
 
 test("new stage and cleanup HTTP consumers share the bounded streaming reader", () => {

--- a/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
+++ b/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
@@ -884,6 +884,106 @@ test("staged smoke restarts the full Explore snapshot after ranking-boundary dri
   assert.deepEqual(waits, [16_000]);
 });
 
+test("staged smoke retries a valid Router-only fallback after Envio drops", async () => {
+  let exploreReads = 0;
+  const waits = [];
+  const routerOnlyCatalog = {
+    source: "envio-classic-v3",
+    launchSource: "canonical-launch-stamp-router",
+    status: "last-known-good",
+    lastIndexedAt: NOW,
+    asOfBlock: "25740001",
+    asOfBlockHash: `0x${"ab".repeat(32)}`,
+    identityCount: 1,
+    identityCommitment: `sha256:${"de".repeat(32)}`,
+    completeness: {
+      classic: "unavailable",
+      stock: "excluded",
+      custom: "unavailable",
+      registryCustom: "unavailable",
+      routerCustom: "last-known-good",
+    },
+    scope: {
+      included: ["canonical-launch-stamp-router"],
+      excluded: [
+        "classic-v1",
+        "classic-v2",
+        "stock-paired-v1",
+        "stock-paired-v2",
+        "stock-paired-v3",
+      ],
+      publicCategories: ["classic", "custom"],
+    },
+    routerStamp: {
+      source: "canonical-launch-stamp-router",
+      status: "last-known-good",
+      finalityConfirmations: 64,
+      verifiedIdentityCount: 1,
+      projectedIdentityCount: 1,
+      generatedAt: NOW,
+      asOfBlock: "25740001",
+      asOfBlockHash: `0x${"ab".repeat(32)}`,
+      identityCommitment: `sha256:${"ac".repeat(32)}`,
+    },
+  };
+  const result = await runStagedStaticDexscreenerSmokeV1({
+    environment: {
+      STAGED_TARGET_URL: "https://candidate.vercel.app/",
+      VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+      GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+    },
+    fetchImpl: stagedFetch(
+      ({ body, url }) => {
+        if (url.pathname !== "/api/explore") return body;
+        exploreReads += 1;
+        if (exploreReads !== 2) return body;
+        return {
+          ...body,
+          tokens: [routerCustomEntry()],
+          page: 1,
+          pageSize: 20,
+          total: 1,
+          totalPages: 1,
+          dataQuality: {
+            ...body.dataQuality,
+            launchIdentity: {
+              status: "partial",
+              canonical: "unavailable",
+              custom: "unavailable",
+              ageMs: 1_000,
+            },
+          },
+          catalog: routerOnlyCatalog,
+          marketRead: marketRead(1),
+          ranking: undefined,
+        };
+      },
+      ({ extraHeaders, omittedHeaders, url }) => ({
+        extraHeaders: url.pathname === "/api/explore" && exploreReads === 2
+          ? {
+              ...extraHeaders,
+              "x-programmable-launch-source":
+                "canonical-launch-stamp-router",
+              "x-programmable-read-source":
+                "canonical-launch-stamp-router+dexscreener",
+              "x-programmable-canonical-read-status": "unavailable",
+              "x-programmable-router-read-status": "last-known-good",
+            }
+          : extraHeaders,
+        omittedHeaders,
+      }),
+    ),
+    appendOutput: () => undefined,
+    waitForCatalogConvergence: async (milliseconds) => {
+      waits.push(milliseconds);
+    },
+  });
+
+  assert.equal(result.detailStatus, "verified-identity-market-unavailable");
+  assert.equal(exploreReads, 4);
+  assert.deepEqual(waits, [16_000]);
+});
+
 test("staged smoke restarts list and detail after detail-boundary drift", async () => {
   let advanced = false;
   let exploreReads = 0;


### PR DESCRIPTION
## Outcome

- binds only fully gated staged candidates to the team-controlled protected preview origin
- verifies the stable alias resolves to the exact READY deployment before handoff
- accepts and strictly validates the Router-only last-known-good identity fallback before the existing bounded retry
- leaves programmable.market untouched and never enables a wildcard origin

## Checks

- focused workflow and smoke tests: 49/49
- actionlint
- YAML parse
- node syntax checks
- git diff --check

No production promotion is performed by this PR.