### PR TITLE
Prevent duplicate wallet login prompts

### DIFF
--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -75,6 +75,13 @@ import {
   parsePreparedTransactionForAccount,
   type PreparedTransaction,
 } from "../lib/prepared-transaction";
+import {
+  acquireBrowserWalletLoginLease,
+  createWalletLoginAttemptGate,
+  WALLET_LOGIN_OTHER_TAB_MESSAGE,
+  WalletLoginPendingError,
+  type BrowserWalletLoginLease,
+} from "../lib/wallet-login-lock";
 import { runWithBrowserWalletRequestLock } from "../lib/wallet-request-lock";
 
 type WalletState = {
@@ -1032,23 +1039,37 @@ function PrivyWalletBridge({
   const [dialogOpen, setDialogOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
+  const [loginPending, setLoginPending] = useState(false);
+  const [walletLoginStatus, setWalletLoginStatus] = useState("");
   const [sessionSuppressed, setSessionSuppressed] = useState(false);
   const [switchingNetwork, setSwitchingNetwork] = useState(false);
   const [error, setError] = useState("");
   const [providerTimedOut, setProviderTimedOut] = useState(false);
   const [selectedWalletAddress, setSelectedWalletAddress] = useState<string | null>(null);
+  const walletLoginAttemptGateRef = useRef(createWalletLoginAttemptGate());
+  const walletLoginLeaseRef = useRef<BrowserWalletLoginLease | null>(null);
+  const settleWalletLoginAttempt = useCallback(() => {
+    walletLoginAttemptGateRef.current.settle();
+    walletLoginLeaseRef.current?.release();
+    walletLoginLeaseRef.current = null;
+    setLoginPending(false);
+  }, []);
   const { login } = useLogin({
     onComplete: () => {
+      settleWalletLoginAttempt();
       applicantRefreshUserGate.invalidate();
       setSessionSuppressed(false);
       setError("");
+      setWalletLoginStatus("");
       setDialogOpen(false);
     },
     onError: (errorCode) => {
+      settleWalletLoginAttempt();
       const message = getWalletLoginErrorMessage(errorCode);
       if (!message) return;
 
       setError(message);
+      setWalletLoginStatus("");
       setDialogOpen(true);
     },
   });
@@ -1290,11 +1311,16 @@ function PrivyWalletBridge({
   );
 
   const startLogin = useCallback(() => {
+    if (!walletLoginAttemptGateRef.current.tryStart()) return;
+
+    setLoginPending(true);
     setSessionSuppressed(false);
     setError("");
+    setWalletLoginStatus("");
     setDialogOpen(false);
 
     if (!ready) {
+      settleWalletLoginAttempt();
       setError(
         "Wallet access is taking longer than expected. Reload the page and try again.",
       );
@@ -1302,11 +1328,44 @@ function PrivyWalletBridge({
       return;
     }
 
-    login({
-      loginMethods: ["wallet", "email"],
-      walletChainType: "ethereum-only",
-    });
-  }, [login, ready]);
+    void acquireBrowserWalletLoginLease()
+      .then((lease) => {
+        if (!walletLoginAttemptGateRef.current.isPending()) {
+          lease.release();
+          return;
+        }
+        walletLoginLeaseRef.current = lease;
+
+        try {
+          login({
+            loginMethods: ["wallet", "email"],
+            walletChainType: "ethereum-only",
+          });
+        } catch {
+          settleWalletLoginAttempt();
+          setError("Unable to connect wallet. Try again.");
+          setWalletLoginStatus("");
+          setDialogOpen(true);
+        }
+      })
+      .catch((loginError: unknown) => {
+        settleWalletLoginAttempt();
+        if (loginError instanceof WalletLoginPendingError) {
+          setError("");
+          setWalletLoginStatus(WALLET_LOGIN_OTHER_TAB_MESSAGE);
+        } else {
+          setError("Unable to connect wallet. Try again.");
+          setWalletLoginStatus("");
+        }
+        setDialogOpen(true);
+      });
+  }, [login, ready, settleWalletLoginAttempt]);
+
+  useEffect(() => () => {
+    walletLoginAttemptGateRef.current.settle();
+    walletLoginLeaseRef.current?.release();
+    walletLoginLeaseRef.current = null;
+  }, []);
 
   const connectGithub = useCallback(() => {
     setSessionSuppressed(false);
@@ -2145,7 +2204,8 @@ function PrivyWalletBridge({
       authReady: ready,
       authenticated: activeAuthenticated,
       hasSession,
-      connecting: !providerSettled && !providerTimedOut,
+      connecting:
+        loginPending || (!providerSettled && !providerTimedOut),
       disconnecting,
       switchingNetwork,
       preloadWallet: () => undefined,
@@ -2186,6 +2246,7 @@ function PrivyWalletBridge({
       githubUserId,
       githubUsername,
       hasSession,
+      loginPending,
       openWallet,
       providerTimedOut,
       readNativeBalance,
@@ -2213,6 +2274,14 @@ function PrivyWalletBridge({
   return (
     <WalletContext.Provider value={value}>
       {children}
+      <span
+        className="sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {walletLoginStatus}
+      </span>
       {dialogOpen ? (
         <WalletDialog
           wallet={wallet}
@@ -2221,6 +2290,7 @@ function PrivyWalletBridge({
           copied={copied}
           disconnecting={disconnecting}
           error={error}
+          status={walletLoginStatus}
           switchingNetwork={switchingNetwork}
           walletOptions={walletOptions}
           onAddWallet={addWallet}
@@ -2338,6 +2408,7 @@ function WalletDialog({
   copied,
   disconnecting,
   error,
+  status,
   switchingNetwork,
   walletOptions,
   onAddWallet,
@@ -2354,6 +2425,7 @@ function WalletDialog({
   copied: boolean;
   disconnecting: boolean;
   error: string;
+  status: string;
   switchingNetwork: boolean;
   walletOptions: readonly WalletState[];
   onAddWallet: () => void;
@@ -2370,7 +2442,9 @@ function WalletDialog({
       ? "Complete wallet setup"
       : error
         ? "Wallet connection failed"
-        : "Finish wallet connection";
+        : status
+          ? "Wallet connection in progress"
+          : "Finish wallet connection";
 
   return (
     <DialogFrame eyebrow="Wallet" title={title} onClose={onClose}>
@@ -2478,6 +2552,8 @@ function WalletDialog({
                 ? "The wallet connected, but sign-in was not completed"
                 : "Connect an Ethereum wallet to continue"}
           </p>
+
+          {status ? <p className="dialog-copy">{status}</p> : null}
 
           {error ? (
             <p className="form-error" role="alert">
@@ -2639,7 +2715,8 @@ export function WalletButton({ compact = false }: { compact?: boolean }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuCopied, setMenuCopied] = useState(false);
   const [menuError, setMenuError] = useState("");
-  const hydrationPending = connecting || !authReady;
+  const hydrationPending = !authReady;
+  const openingWallet = connecting && authReady;
 
   useEffect(() => {
     if (!menuOpen) return;
@@ -2670,17 +2747,19 @@ export function WalletButton({ compact = false }: { compact?: boolean }) {
 
   const label = disconnecting
     ? "Disconnecting"
-    : hydrationPending
-      ? "Loading wallet"
-      : wallet
-        ? username || shortenAddress(wallet.account)
-        : authenticated
-          ? "Set up wallet"
-          : hasSession
-            ? "Reconnect"
-            : compact
-              ? "Connect"
-              : "Connect wallet";
+    : openingWallet
+      ? "Opening wallet"
+      : hydrationPending
+        ? "Loading wallet"
+        : wallet
+          ? username || shortenAddress(wallet.account)
+          : authenticated
+            ? "Set up wallet"
+            : hasSession
+              ? "Reconnect"
+              : compact
+                ? "Connect"
+                : "Connect wallet";
 
   const button = (
     <button

--- a/lib/wallet-login-lock.ts
+++ b/lib/wallet-login-lock.ts
@@ -1,0 +1,118 @@
+const WALLET_LOGIN_LOCK_NAME = "programmable:wallet-login:v1";
+
+export const WALLET_LOGIN_OTHER_TAB_MESSAGE =
+  "Wallet connection is already open in another Programmable tab.";
+
+type LockManagerLike = Readonly<{
+  request: <Result>(
+    name: string,
+    options: Readonly<{ mode: "exclusive"; ifAvailable: true }>,
+    callback: (lock: Readonly<{ name: string }> | null) => Promise<Result>,
+  ) => Promise<Result>;
+}>;
+
+type WalletLoginLockRuntime = Readonly<{
+  locks?: LockManagerLike;
+}>;
+
+export type BrowserWalletLoginLease = Readonly<{
+  release: () => void;
+}>;
+
+export type WalletLoginAttemptGate = Readonly<{
+  isPending: () => boolean;
+  tryStart: () => boolean;
+  settle: () => void;
+}>;
+
+export class WalletLoginPendingError extends Error {
+  constructor() {
+    super(WALLET_LOGIN_OTHER_TAB_MESSAGE);
+    this.name = "WalletLoginPendingError";
+  }
+}
+
+export function createWalletLoginAttemptGate(): WalletLoginAttemptGate {
+  let pending = false;
+  return Object.freeze({
+    isPending: () => pending,
+    tryStart: () => {
+      if (pending) return false;
+      pending = true;
+      return true;
+    },
+    settle: () => {
+      pending = false;
+    },
+  });
+}
+
+function browserRuntime(): WalletLoginLockRuntime {
+  if (typeof navigator === "undefined") return Object.freeze({});
+  return Object.freeze({
+    locks: navigator.locks as LockManagerLike | undefined,
+  });
+}
+
+const unsupportedBrowserLease: BrowserWalletLoginLease = Object.freeze({
+  release: () => undefined,
+});
+
+export function acquireBrowserWalletLoginLease(
+  runtime: WalletLoginLockRuntime = browserRuntime(),
+): Promise<BrowserWalletLoginLease> {
+  const locks = runtime.locks;
+  if (locks === undefined) {
+    // The synchronous component gate still prevents duplicate login calls in
+    // this tab. Without Web Locks, do not claim or emulate cross-tab safety.
+    return Promise.resolve(unsupportedBrowserLease);
+  }
+
+  return new Promise<BrowserWalletLoginLease>((resolve, reject) => {
+    let acquisitionSettled = false;
+    const resolveAcquisition = (lease: BrowserWalletLoginLease) => {
+      if (acquisitionSettled) return;
+      acquisitionSettled = true;
+      resolve(lease);
+    };
+    const rejectAcquisition = (error: unknown) => {
+      if (acquisitionSettled) return;
+      acquisitionSettled = true;
+      reject(error);
+    };
+
+    try {
+      const lockRequest = locks.request(
+        WALLET_LOGIN_LOCK_NAME,
+        { mode: "exclusive", ifAvailable: true },
+        async (lock) => {
+          if (lock === null) {
+            rejectAcquisition(new WalletLoginPendingError());
+            return;
+          }
+
+          let released = false;
+          let resolveRelease!: () => void;
+          const releaseSignal = new Promise<void>((release) => {
+            resolveRelease = release;
+          });
+          resolveAcquisition(Object.freeze({
+            release: () => {
+              if (released) return;
+              released = true;
+              resolveRelease();
+            },
+          }));
+
+          // The Web Lock remains held for the complete Privy attempt. It is
+          // released only by onComplete, onError, synchronous failure or
+          // component unmount calling lease.release().
+          await releaseSignal;
+        },
+      );
+      void lockRequest.catch(rejectAcquisition);
+    } catch (error) {
+      rejectAcquisition(error);
+    }
+  });
+}

--- a/tests/wallet-login-lock.test.ts
+++ b/tests/wallet-login-lock.test.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  acquireBrowserWalletLoginLease,
+  createWalletLoginAttemptGate,
+  WALLET_LOGIN_OTHER_TAB_MESSAGE,
+} from "../lib/wallet-login-lock";
+
+class ExclusiveTestLocks {
+  readonly active = new Set<string>();
+
+  async request<Result>(
+    name: string,
+    _options: Readonly<{ mode: "exclusive"; ifAvailable: true }>,
+    callback: (lock: Readonly<{ name: string }> | null) => Promise<Result>,
+  ): Promise<Result> {
+    if (this.active.has(name)) return callback(null);
+    this.active.add(name);
+    try {
+      return await callback(Object.freeze({ name }));
+    } finally {
+      this.active.delete(name);
+    }
+  }
+}
+
+describe("wallet login lock", () => {
+  it("turns a same-tab double click into exactly one Privy login invocation", () => {
+    const gate = createWalletLoginAttemptGate();
+    const login = vi.fn();
+    const startLogin = () => {
+      if (!gate.tryStart()) return;
+      login();
+    };
+
+    startLogin();
+    startLogin();
+
+    expect(login).toHaveBeenCalledOnce();
+    expect(gate.isPending()).toBe(true);
+  });
+
+  it("unlocks the same tab after every settled login attempt", () => {
+    const gate = createWalletLoginAttemptGate();
+
+    expect(gate.tryStart()).toBe(true);
+    expect(gate.tryStart()).toBe(false);
+    gate.settle();
+    expect(gate.isPending()).toBe(false);
+    expect(gate.tryStart()).toBe(true);
+  });
+
+  it("holds the Web Lock until the active Privy attempt releases it", async () => {
+    const locks = new ExclusiveTestLocks();
+    const firstRuntime = { locks };
+    const secondRuntime = { locks };
+    const first = await acquireBrowserWalletLoginLease(firstRuntime);
+    expect(locks.active.size).toBe(1);
+
+    await expect(
+      acquireBrowserWalletLoginLease(secondRuntime),
+    ).rejects.toMatchObject({
+      name: "WalletLoginPendingError",
+      message: WALLET_LOGIN_OTHER_TAB_MESSAGE,
+    });
+    expect(locks.active.size).toBe(1);
+
+    first.release();
+    first.release();
+    await vi.waitFor(() => expect(locks.active.size).toBe(0));
+
+    const second = await acquireBrowserWalletLoginLease(secondRuntime);
+    expect(locks.active.size).toBe(1);
+    second.release();
+    await vi.waitFor(() => expect(locks.active.size).toBe(0));
+  });
+
+  it("degrades to a safe no-op lease when Web Locks are unavailable", async () => {
+    const first = await acquireBrowserWalletLoginLease({});
+    const second = await acquireBrowserWalletLoginLease({});
+
+    expect(first.release).toBeTypeOf("function");
+    expect(second.release).toBeTypeOf("function");
+    expect(() => {
+      first.release();
+      first.release();
+      second.release();
+    }).not.toThrow();
+  });
+
+  it("wires settlement, busy UI and the accessible cross-tab status", () => {
+    const provider = readFileSync(
+      join(process.cwd(), "components/wallet-provider.tsx"),
+      "utf8",
+    );
+    const apiKeys = readFileSync(
+      join(process.cwd(), "components/developer-api-keys.tsx"),
+      "utf8",
+    );
+
+    expect(provider).toContain(
+      "if (!walletLoginAttemptGateRef.current.tryStart()) return;",
+    );
+    expect(provider).toMatch(
+      /onComplete: \(\) => \{\s+settleWalletLoginAttempt\(\);/u,
+    );
+    expect(provider).toMatch(
+      /onError: \(errorCode\) => \{\s+settleWalletLoginAttempt\(\);/u,
+    );
+    expect(provider).toContain(
+      "loginPending || (!providerSettled && !providerTimedOut)",
+    );
+    expect(provider).not.toContain("walletLoginExpiryTimerRef");
+    expect(provider).toContain('? "Opening wallet"');
+    expect(provider).toContain('role="status"');
+    expect(provider).toContain("{walletLoginStatus}");
+    expect(apiKeys).toContain("disabled={connecting}");
+    expect(apiKeys).toContain(
+      '{connecting ? "Opening wallet" : "Connect wallet"}',
+    );
+  });
+});

--- a/tests/wallet-state.test.ts
+++ b/tests/wallet-state.test.ts
@@ -170,9 +170,11 @@ describe("wallet recovery state", () => {
     expect(provider).toContain("onPointerEnter={preloadWallet}");
     expect(provider).toContain("onFocus={preloadWallet}");
     expect(provider).toContain("globalThis.setTimeout(preload, 0)");
+    expect(provider).toContain("const hydrationPending = !authReady");
     expect(provider).toContain(
-      "const hydrationPending = connecting || !authReady",
+      "const openingWallet = connecting && authReady",
     );
+    expect(provider).toMatch(/openingWallet\s*\?\s*"Opening wallet"/u);
     expect(provider).toMatch(/hydrationPending\s*\?\s*"Loading wallet"/u);
     expect(provider).toContain("wallet-button-hydrating");
     expect(provider).not.toContain("requestIdleCallback");


### PR DESCRIPTION
## Outcome
- coalesces rapid same-tab wallet login attempts
- holds an origin-wide Web Lock for the complete Privy attempt when supported
- disables Connect controls immediately with clear Opening wallet feedback
- announces a calm, accessible status when another Programmable tab already owns the login
- leaves transaction and signing locks unchanged

## Verification
- 78 focused tests passed
- scoped ESLint passed
- TypeScript noEmit passed
- git diff --check passed
- independent concurrency, React, accessibility and signing review approved the final revision