### PR TITLE
Fix Shard artwork rendering in Explore

### DIFF
--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -1223,6 +1223,16 @@
   width: 100% !important;
 }
 
+.runnerArtPreserved {
+  background: #321a2b;
+}
+
+.runnerImagePreserved {
+  background: transparent;
+  object-fit: contain;
+  object-position: center;
+}
+
 .runnerBody {
   min-height: 118px;
   padding: 18px 18px 14px;

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -90,6 +90,11 @@ type TokenCard = {
   partnerAttribution?: LaunchPartnerAttributionV1;
 };
 
+const EXPLORE_CARD_IMAGE_SIZES =
+  "(max-width: 520px) calc((100vw - 38px) / 2), (max-width: 900px) calc((100vw - 48px) / 2), (max-width: 1280px) calc((100vw - 88px) / 3), 416px";
+const SHARD_ORIGINAL_ARTWORK_SOURCE =
+  "/brand/projects/shard-token-v1.png";
+
 export function exploreMarketStatusLabel(
   entry: ExploreEntry | ValuedExploreEntry,
 ): ExploreMarketStatus | undefined {
@@ -2955,22 +2960,35 @@ export function ExploreView({
             ? `/token/${token.tokenAddress}`
             : null;
           const imageSource = getTokenCardImageSource(token.imageUrl);
+          const preserveArtworkAspectRatio =
+            imageSource === SHARD_ORIGINAL_ARTWORK_SOURCE;
           const valuationLabel = token.valuation
             ? formatMarketCapMetric(token.valuation)
             : null;
           const eagerImage = !embedded && index < Math.min(pageSize, 4);
           const cardContent = (
             <>
-              <div className={styles.runnerArt}>
+              <div
+                className={`${styles.runnerArt} ${
+                  preserveArtworkAspectRatio ? styles.runnerArtPreserved : ""
+                }`}
+              >
                 <Image
-                  className={styles.runnerImage}
+                  className={`${styles.runnerImage} ${
+                    preserveArtworkAspectRatio
+                      ? styles.runnerImagePreserved
+                      : ""
+                  }`}
                   src={imageSource}
                   alt={token.usesFallbackImage ? "" : `${token.name} artwork`}
                   fill
                   loading={eagerImage ? "eager" : "lazy"}
                   priority={eagerImage}
-                  sizes="(max-width: 700px) calc((100vw - 42px) / 2), (max-width: 900px) 330px, 299px"
-                  unoptimized={!canOptimizeTokenImage(imageSource)}
+                  sizes={EXPLORE_CARD_IMAGE_SIZES}
+                  unoptimized={
+                    preserveArtworkAspectRatio ||
+                    !canOptimizeTokenImage(imageSource)
+                  }
                   referrerPolicy="no-referrer"
                   draggable={false}
                   onError={(event) => {

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -321,7 +321,12 @@ describe("Explore UI contract", () => {
       /\.runnerHeading h3\s*\{[^}]*line-height:\s*1\.15;/s,
     );
     expect(source).toContain(
-      'sizes="(max-width: 700px) calc((100vw - 42px) / 2), (max-width: 900px) 330px, 299px"',
+      '"(max-width: 520px) calc((100vw - 38px) / 2), (max-width: 900px) calc((100vw - 48px) / 2), (max-width: 1280px) calc((100vw - 88px) / 3), 416px"',
+    );
+    expect(source).toContain("preserveArtworkAspectRatio");
+    expect(source).toContain("styles.runnerImagePreserved");
+    expect(styles).toMatch(
+      /\.runnerImagePreserved\s*\{[^}]*object-fit:\s*contain;[^}]*object-position:\s*center;/s,
     );
     expect(source).not.toContain("<small>CA</small>");
     expect(source).toContain("<small>Market cap</small>");


### PR DESCRIPTION
## Outcome
- preserve the supplied SHARD artwork aspect ratio instead of stretching/cropping its 196px source across a 416px desktop card
- serve the original local artwork directly and center it on a matching matte
- correct the responsive Next Image `sizes` contract for the current 3-column/2-column Explore layout

## Verification
- `vitest run tests/explore-ui-contract.test.ts` (8/8)
- `git diff --check`
- local rendered QA at 1440x900 and 390x844: no horizontal overflow, no browser console/page errors

No deployment or merge was performed.