### PR TITLE
feat(indexer): prepare Classic V4 source candidate

### DIFF
--- a/indexer/README.md
+++ b/indexer/README.md
@@ -4,14 +4,25 @@ This isolated Envio HyperIndex project builds a reorg-aware read model for the
 active Programmable releases on Ethereum Mainnet:
 
 - Classic V2 and Classic V3
+- Classic V4 source candidate
 - Stock-Paired V1, V2 and V3
 
-Classic V4 ABI and handlers are source-ready but deliberately have no chain
-binding before the provider-backed, sealed-source Mainnet release manifest
-exists. All other releases are intentionally out of scope. Source addresses and
-inclusive start blocks are pinned to the checked-in deployment manifests.
+Classic V4 ABI, handlers, and finalized Mainnet source addresses are present in
+the source-only candidate. They do not activate the product release binding or
+public website before the provider-backed Envio deployment, backfill, parity
+audit, and manifest gates pass. All other releases are intentionally out of
+scope. Source addresses and inclusive start blocks are pinned to finalized
+deployment evidence.
 Shared Stock V2/V3 hook and vault-factory events are attributed only after an
 indexed `poolId` relation identifies the release.
+
+The live Custom Registry V1 event sources remain as a compatibility-only
+read-model prefix so an Envio replacement cannot silently lose the provider's
+current event history. This does not restore V1 as launch, discovery, claim, or
+website authority. Custom Registry V2 remains a separate inactive prelaunch
+source until its own deployment and release gates pass. The immutable
+`live-production-92f6373.config.yaml` snapshot makes every replacement prove a
+semantic source-and-event superset of the currently deployed Envio surface.
 
 ## Safety boundary
 
@@ -120,11 +131,26 @@ local test must not update that binding.
 
 ## Classic V4 source activation
 
-The pre-deploy `chains[].contracts` list contains no Classic V4 entry. After
-`contracts/deployments/mainnet-classic-v4.json` has been generated from
-finalized deployment, provider-backed source matching with exact sealed source
-closure, and lifecycle evidence, first
-inspect the deterministic activation plan:
+The source-only candidate binds the finalized V4 hook and launcher in
+`chains[].contracts`; this alone does not change the canonical product release
+binding. Once the complete `contracts/deployments/mainnet-classic-v4.json` and
+an independently promoted Envio candidate identity exist, generate the exact
+append-only release binding without mutating the frozen base binding:
+
+```bash
+pnpm release:classic-v4-binding -- \
+  --manifest </absolute/mainnet-classic-v4.json> \
+  --identity </absolute/envio-candidate-identity.json> \
+  --endpoint https://indexer.hyperindex.xyz/<endpoint-id>/v1/graphql \
+  --output </absolute/classic-v4-release-binding.json>
+```
+
+The generator requires the complete finalized source and lifecycle manifest,
+verifies that the checked-out V4 source markers match it exactly, preserves the
+entire existing source and release prefixes, and appends only the V4 hook,
+launcher, and `classic-v4` release fragment. The output is then an input to the
+immutable Envio candidate audit. After that audit exists, inspect the
+deterministic activation plan:
 
 ```bash
 pnpm classic-v4:activate -- \

--- a/indexer/config.yaml
+++ b/indexer/config.yaml
@@ -185,5 +185,5 @@ chains:
       - name: ClassicV4Hook
         address: "0xadf955a44fd7f009380240d56d71dfafb46020cc"
       - name: ClassicV4Launcher
-        address: "0x1af508f9af9f8f5cf7bf712b7d2974d4ee7a6681"
+        address: "0xbbdf30a2fe1394e4aa864ac269c6cf09b518e699"
       # CLASSIC_V4_ACTIVATION_END

--- a/indexer/live-production-92f6373.config.yaml
+++ b/indexer/live-production-92f6373.config.yaml
@@ -36,19 +36,6 @@ contracts:
       - event: "NativeSwapFeesAccrued(bytes32 indexed poolId, address indexed swapSender, bool indexed isBuy, uint16 appliedTotalSwapFeeBps, uint256 grossNativeAmount, uint256 creatorFee, uint256 launcherFee)"
       - event: "CreatorFeesClaimed(bytes32 indexed poolId, address indexed rewardVault, address indexed caller, uint256 amount)"
       - event: "LauncherFeesClaimed(address indexed treasury, address indexed recipient, address indexed caller, uint256 amount)"
-  - name: ClassicV4Launcher
-    events:
-      - event: "MemeTokenLaunchedV2(address indexed deployer, address indexed token, bytes32 indexed poolId, address feeHook, address rewardVault, address positionRecipient, uint256 positionTokenId, uint16 buySwapFeeBps, uint16 sellSwapFeeBps, bytes32 rewardConfigurationHash, bytes32 launchHash)"
-      - event: "MemeLiquidityConfiguredV2(address indexed token, uint256 totalSupply, uint256 tokenLiquidityAmount, uint256 lockedTokenDust, int24 initialTick, int24 tickLower, int24 tickUpper, uint24 lpFeePips, bytes32 launchHash)"
-      - event: "MemeCreatorInitialBuyV2(address indexed deployer, address indexed token, bytes32 indexed poolId, uint256 nativeAmount, uint256 tokenAmount, bytes32 launchHash)"
-      - event: "MemeCreatorInitialBuyCustodyV2(address indexed deployer, address indexed token, address indexed custody, uint8 mode, uint16 durationDays, uint16 cliffDays, bytes32 configurationHash, bytes32 launchHash)"
-  - name: ClassicV4Hook
-    events:
-      - event: "PoolRegistered(bytes32 indexed poolId, address indexed token, address indexed rewardVault, address registrar, uint16 buySwapFeeBps, uint16 sellSwapFeeBps, bytes32 rewardConfigurationHash)"
-      - event: "PoolFeeDisclosure(bytes32 indexed poolId, address indexed token, address indexed rewardVault, uint16 buySwapFeeBps, uint16 sellSwapFeeBps, uint16 buyCreatorFeeBps, uint16 sellCreatorFeeBps, uint16 launcherFeeBps, uint16 transferTaxBps, uint24 lpFeePips)"
-      - event: "NativeSwapFeesAccrued(bytes32 indexed poolId, address indexed swapSender, bool indexed isBuy, uint16 appliedTotalSwapFeeBps, uint256 grossNativeAmount, uint256 creatorFee, uint256 launcherFee)"
-      - event: "CreatorFeesClaimed(bytes32 indexed poolId, address indexed rewardVault, address indexed caller, uint256 amount)"
-      - event: "LauncherFeesClaimed(address indexed treasury, address indexed recipient, address indexed caller, uint256 amount)"
   - name: ClassicV3RewardVaultFactory
     events:
       - event: "ClassicRewardVaultDeployed(address indexed vault, bytes32 indexed poolId, address indexed feeHook, bytes32 salt, bytes32 configurationHash)"
@@ -181,9 +168,3 @@ chains:
         address: "0xf8aef69201621ad20fa256da595426b7e6192dba"
       - name: CustomAtomicRegistrarV1
         address: "0xcc916e5200d2626edfd918dc219bc4296629e997"
-      # CLASSIC_V4_ACTIVATION_START
-      - name: ClassicV4Hook
-        address: "0xadf955a44fd7f009380240d56d71dfafb46020cc"
-      - name: ClassicV4Launcher
-        address: "0x1af508f9af9f8f5cf7bf712b7d2974d4ee7a6681"
-      # CLASSIC_V4_ACTIVATION_END

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -16,6 +16,7 @@
     "test:watch": "vitest",
     "classic-v4:activate": "tsx scripts/activate-classic-v4.mjs",
     "classic-v4:public:promote": "tsx scripts/promote-classic-v4-public-availability.mjs",
+    "release:classic-v4-binding": "tsx scripts/generate-classic-v4-release-binding.mjs",
     "release:identity": "node scripts/release-candidate.mjs identity",
     "release:snapshot": "node scripts/release-candidate.mjs snapshot",
     "release:audit": "node scripts/release-candidate.mjs audit"

--- a/indexer/scripts/activate-classic-v4.d.mts
+++ b/indexer/scripts/activate-classic-v4.d.mts
@@ -42,6 +42,17 @@ export function buildClassicV4CatalogReleaseArtifact(
   reviewedBinding: unknown,
 ): Record<string, unknown>;
 
+export function renderClassicV4IndexerSources(
+  plan: unknown,
+  current: Readonly<{
+    releaseMap: string;
+    envioConfig: string;
+  }>,
+): Readonly<{
+  releaseMap: string;
+  envioConfig: string;
+}>;
+
 export function renderClassicV4Activation(
   plan: unknown,
   current: Readonly<{

--- a/indexer/scripts/activate-classic-v4.mjs
+++ b/indexer/scripts/activate-classic-v4.mjs
@@ -642,7 +642,10 @@ function assertCatalogEnvioIdentity(candidate, base) {
       "reviewed Envio event-set digest",
     ) === exactBytes32(base.eventSetSha256, "base Envio event-set digest") ||
     !Number.isSafeInteger(candidate.eventCount) ||
-    candidate.eventCount <= base.eventCount
+    candidate.eventCount <
+      base.eventCount +
+        REQUIRED_LAUNCHER_EVENTS.length +
+        REQUIRED_HOOK_EVENTS.length
   ) {
     fail("Reviewed Envio release identity was not independently promoted");
   }
@@ -865,7 +868,7 @@ export function renderClassicV4PublicReleaseBindingSource(binding, source) {
   );
 }
 
-export function renderClassicV4Activation(plan, current) {
+export function renderClassicV4IndexerSources(plan, current) {
   return Object.freeze({
     releaseMap: replaceActivationBlock(
       current.releaseMap,
@@ -881,6 +884,13 @@ export function renderClassicV4Activation(plan, current) {
       renderEnvioConfigBlock(plan),
       "Envio config",
     ),
+  });
+}
+
+export function renderClassicV4Activation(plan, current) {
+  const indexerSources = renderClassicV4IndexerSources(plan, current);
+  return Object.freeze({
+    ...indexerSources,
     publicReleaseBinding: renderClassicV4PublicReleaseBindingSource(
       plan.publicReleaseBinding,
       current.publicReleaseBinding,

--- a/indexer/scripts/activate-classic-v4.mjs
+++ b/indexer/scripts/activate-classic-v4.mjs
@@ -16,7 +16,7 @@ import { fileURLToPath } from "node:url";
 import {
   CLASSIC_V4_DIGEST_DOMAINS,
   digestJson,
-} from "../../scripts/classic-v4-digest.mjs";
+} from "./classic-v4-digest.mjs";
 import * as classicV4ReleaseModule from "../../lib/classic-v4-release.ts";
 import * as classicV4PublicReleaseModule from "../../lib/classic-v4-public-release.ts";
 import { parseReleaseAuditArtifact } from "./release-candidate.mjs";

--- a/indexer/scripts/classic-v4-digest.d.mts
+++ b/indexer/scripts/classic-v4-digest.d.mts
@@ -1,0 +1,22 @@
+import type { Hex } from "viem";
+
+export const CLASSIC_V4_DIGEST_DOMAINS: Readonly<{
+  generic: string;
+  preparationPlan: string;
+  deploymentEvidence: string;
+  sourceEvidence: string;
+  releaseBinding: string;
+  lifecycleAuthorization: string;
+  lifecycleCanaryPlan: string;
+  lifecycleEvidence: string;
+  releaseManifest: string;
+  canaryCreatorSalt: string;
+  deploymentRpcSnapshot: string;
+  lifecycleRpcSnapshot: string;
+  sourcePins: string;
+  dependencyClosure: string;
+  buildArtifacts: string;
+}>;
+
+export function stableStringify(value: unknown): string;
+export function digestJson(value: unknown, domain?: string): Hex;

--- a/indexer/scripts/classic-v4-digest.mjs
+++ b/indexer/scripts/classic-v4-digest.mjs
@@ -1,0 +1,86 @@
+import {
+  encodeAbiParameters,
+  keccak256,
+  stringToHex,
+} from "viem";
+
+export const CLASSIC_V4_DIGEST_DOMAINS = Object.freeze({
+  generic: "programmable.classic-v4.generic-json.v1",
+  preparationPlan: "programmable.classic-v4.preparation-plan.v1",
+  deploymentEvidence: "programmable.classic-v4.deployment-evidence.v1",
+  sourceEvidence: "programmable.classic-v4.source-evidence.v1",
+  releaseBinding: "programmable.classic-v4.release-binding.v1",
+  lifecycleAuthorization:
+    "programmable.classic-v4.lifecycle-authorization.v1",
+  lifecycleCanaryPlan: "programmable.classic-v4.lifecycle-canary-plan.v1",
+  lifecycleEvidence: "programmable.classic-v4.lifecycle-evidence.v1",
+  releaseManifest: "programmable.classic-v4.release-manifest.v1",
+  canaryCreatorSalt: "programmable.classic-v4.canary-creator-salt.v1",
+  deploymentRpcSnapshot: "programmable.classic-v4.deployment-rpc-snapshot.v1",
+  lifecycleRpcSnapshot: "programmable.classic-v4.lifecycle-rpc-snapshot.v1",
+  sourcePins: "programmable.classic-v4.source-pins.v1",
+  dependencyClosure: "programmable.classic-v4.dependency-closure.v1",
+  buildArtifacts: "programmable.classic-v4.build-artifacts.v1",
+});
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function canonicalDigestString(value) {
+  if (/^0x[0-9a-f]+$/i.test(value) || /^[0-9a-f]{40}$/i.test(value)) {
+    return value.toLowerCase();
+  }
+  return value.replace(/0x[0-9a-f]{40}/gi, (address) =>
+    address.toLowerCase(),
+  );
+}
+
+function stableValue(value) {
+  if (value === null) return ["null"];
+  if (Array.isArray(value)) return ["array", value.map(stableValue)];
+  if (typeof value === "string") {
+    return ["string", canonicalDigestString(value)];
+  }
+  if (typeof value === "boolean") return ["boolean", value];
+  if (typeof value === "number") {
+    assert(Number.isFinite(value), "Digest input contains a non-finite number");
+    return ["number", Object.is(value, -0) ? 0 : value];
+  }
+  if (typeof value === "bigint") return ["bigint", value.toString()];
+  if (typeof value === "object") {
+    const prototype = Object.getPrototypeOf(value);
+    assert(
+      prototype === Object.prototype || prototype === null,
+      "Digest input contains a non-plain object",
+    );
+    return [
+      "object",
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, stableValue(value[key])]),
+    ];
+  }
+  throw new Error(`Digest input contains unsupported ${typeof value}`);
+}
+
+export function stableStringify(value) {
+  return JSON.stringify(stableValue(value));
+}
+
+export function digestJson(
+  value,
+  domain = CLASSIC_V4_DIGEST_DOMAINS.generic,
+) {
+  assert(
+    typeof domain === "string" &&
+      /^[a-z0-9][a-z0-9.-]+\.v[1-9][0-9]*$/.test(domain),
+    "Invalid digest domain",
+  );
+  return keccak256(
+    encodeAbiParameters(
+      [{ type: "string" }, { type: "bytes" }],
+      [domain, stringToHex(stableStringify(value))],
+    ),
+  );
+}

--- a/indexer/scripts/generate-classic-v4-release-binding.d.mts
+++ b/indexer/scripts/generate-classic-v4-release-binding.d.mts
@@ -1,0 +1,23 @@
+export type ClassicV4ReleaseBinding = Readonly<Record<string, unknown>>;
+
+export function buildClassicV4ExpandedReleaseBinding(
+  plan: unknown,
+  baseBinding: unknown,
+  candidateIdentity: unknown,
+  graphqlEndpoint: string,
+): ClassicV4ReleaseBinding;
+
+export function assertClassicV4IndexerSourceBindings(
+  plan: unknown,
+  current: Readonly<{
+    releaseMap: string;
+    envioConfig: string;
+  }>,
+): void;
+
+export function writeClassicV4ReleaseBinding(
+  filename: string,
+  releaseBinding: unknown,
+): Promise<void>;
+
+export function main(argv?: readonly string[]): Promise<void>;

--- a/indexer/scripts/generate-classic-v4-release-binding.mjs
+++ b/indexer/scripts/generate-classic-v4-release-binding.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import * as classicV4ReleaseModule from "../../lib/classic-v4-release.ts";
+import {
+  buildClassicV4ActivationPlan,
+  buildClassicV4CatalogReleaseArtifact,
+  renderClassicV4IndexerSources,
+} from "./activate-classic-v4.mjs";
+import {
+  LIVE_ENVIO_SURFACE_REFERENCE,
+  endpointIdFromUrl,
+  parseCandidateIdentity,
+  releaseBindingDigest,
+} from "./release-candidate.mjs";
+
+const { parseClassicV4PendingRelease } =
+  classicV4ReleaseModule.default ?? classicV4ReleaseModule;
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repositoryRoot = path.resolve(path.dirname(scriptPath), "..", "..");
+const canonicalManifestPath = path.join(
+  repositoryRoot,
+  "contracts/deployments/mainnet-classic-v4.json",
+);
+const baseReleaseBindingPath = path.join(
+  repositoryRoot,
+  "config/data-pipeline-release.v1.json",
+);
+const releaseMapPath = path.join(
+  repositoryRoot,
+  "indexer/src/lib/release-map.ts",
+);
+const envioConfigPath = path.join(repositoryRoot, "indexer/config.yaml");
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArguments(argv) {
+  const options = {
+    manifest: canonicalManifestPath,
+    identity: null,
+    endpoint: null,
+    output: null,
+  };
+  const seen = new Set();
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--") continue;
+    const [key, inlineValue] = argument.split("=", 2);
+    if (!["--manifest", "--identity", "--endpoint", "--output"].includes(key)) {
+      fail(`Unknown argument: ${argument}`);
+    }
+    if (seen.has(key)) fail(`Duplicate argument: ${key}`);
+    seen.add(key);
+    const value = inlineValue ?? argv[++index];
+    if (!value || value.startsWith("--")) fail(`Missing value for ${key}`);
+    if (key === "--manifest") options.manifest = path.resolve(value);
+    if (key === "--identity") options.identity = path.resolve(value);
+    if (key === "--endpoint") options.endpoint = value;
+    if (key === "--output") options.output = path.resolve(value);
+  }
+  if (!options.identity) fail("--identity is required");
+  if (!options.endpoint) fail("--endpoint is required");
+  return options;
+}
+
+async function readJson(filename, label) {
+  let source;
+  try {
+    source = await readFile(filename, "utf8");
+  } catch (error) {
+    fail(`${label} is unavailable: ${error.message}`);
+  }
+  try {
+    return JSON.parse(source);
+  } catch {
+    fail(`${label} is not valid JSON`);
+  }
+}
+
+export function buildClassicV4ExpandedReleaseBinding(
+  plan,
+  baseBinding,
+  candidateIdentityInput,
+  graphqlEndpoint,
+) {
+  const expectedSourceContracts = [
+    "ClassicV3RewardVaultFactory",
+    "ClassicV3VestingWalletFactory",
+    "ClassicV4Hook",
+    "ClassicV4Launcher",
+  ];
+  if (
+    plan?.schemaVersion !== 1 ||
+    plan?.chainId !== 1 ||
+    plan?.model !== "classic" ||
+    plan?.releaseVersion !== "classic-v4" ||
+    !Array.isArray(plan.sources) ||
+    plan.sources.length !== 2 ||
+    plan.sources[0]?.contractName !== "ClassicV4Hook" ||
+    plan.sources[1]?.contractName !== "ClassicV4Launcher" ||
+    plan.dataPipelineReleaseFragment?.model !== "classic" ||
+    plan.dataPipelineReleaseFragment?.releaseVersion !== "classic-v4" ||
+    plan.dataPipelineReleaseFragment?.activationBlock !==
+      plan.activationBlock ||
+    JSON.stringify(plan.dataPipelineReleaseFragment?.sourceContracts) !==
+      JSON.stringify(expectedSourceContracts) ||
+    JSON.stringify(plan.dataPipelineReleaseFragment?.dynamicContracts) !==
+      JSON.stringify(["ClassicV3RewardVault"])
+  ) {
+    fail("Classic V4 release-binding plan is invalid");
+  }
+  if (
+    !Array.isArray(baseBinding?.sources) ||
+    !Array.isArray(baseBinding?.releases) ||
+    baseBinding.sources.some(({ contractName }) =>
+      ["ClassicV4Hook", "ClassicV4Launcher"].includes(contractName),
+    ) ||
+    baseBinding.releases.some(
+      ({ model, releaseVersion }) =>
+        model === "classic" && releaseVersion === "classic-v4",
+    )
+  ) {
+    fail("Base data pipeline binding already contains Classic V4");
+  }
+  if (
+    baseBinding.envio?.deploymentLabel !==
+      LIVE_ENVIO_SURFACE_REFERENCE.deployment ||
+    baseBinding.envio?.sourceCommit !== LIVE_ENVIO_SURFACE_REFERENCE.sourceCommit ||
+    baseBinding.envio?.configSha256 !==
+      LIVE_ENVIO_SURFACE_REFERENCE.configSha256 ||
+    baseBinding.envio?.eventSetSha256 !==
+      LIVE_ENVIO_SURFACE_REFERENCE.eventSetSha256 ||
+    baseBinding.envio?.eventCount !== LIVE_ENVIO_SURFACE_REFERENCE.eventCount
+  ) {
+    fail("Base data pipeline binding is not the frozen live Envio surface");
+  }
+  const candidateIdentity = parseCandidateIdentity(candidateIdentityInput);
+  endpointIdFromUrl(graphqlEndpoint);
+  const releaseBinding = {
+    schemaVersion: baseBinding.schemaVersion,
+    chainId: baseBinding.chainId,
+    startBlock: baseBinding.startBlock,
+    confirmations: baseBinding.confirmations,
+    envio: {
+      deploymentLabel: candidateIdentity.deployment,
+      graphqlEndpoint,
+      schemaVersion: "1",
+      sourceCommit: candidateIdentity.sourceCommit,
+      configSha256: candidateIdentity.configSha256,
+      schemaSha256: candidateIdentity.schemaSha256,
+      handlerSha256: candidateIdentity.handlerSha256,
+      sourceRegistrySha256: candidateIdentity.sourceRegistrySha256,
+      eventSetSha256: candidateIdentity.eventSetSha256,
+      eventCount: candidateIdentity.eventCount,
+    },
+    uniswapV4Subgraph: structuredClone(baseBinding.uniswapV4Subgraph),
+    sources: [
+      ...structuredClone(baseBinding.sources),
+      ...structuredClone(plan.sources),
+    ],
+    releases: [
+      ...structuredClone(baseBinding.releases),
+      structuredClone(plan.dataPipelineReleaseFragment),
+    ],
+  };
+  const digest = releaseBindingDigest(releaseBinding);
+  buildClassicV4CatalogReleaseArtifact(
+    { ...plan, indexerBindingDigest: digest },
+    baseBinding,
+    releaseBinding,
+  );
+  return Object.freeze(releaseBinding);
+}
+
+export function assertClassicV4IndexerSourceBindings(plan, current) {
+  const expected = renderClassicV4IndexerSources(plan, current);
+  if (
+    expected.releaseMap !== current.releaseMap ||
+    expected.envioConfig !== current.envioConfig
+  ) {
+    fail(
+      "Checked-out Classic V4 Envio sources do not match the finalized release manifest",
+    );
+  }
+}
+
+export async function writeClassicV4ReleaseBinding(filename, releaseBinding) {
+  await writeFile(filename, `${JSON.stringify(releaseBinding, null, 2)}\n`, {
+    flag: "wx",
+    mode: 0o600,
+    flush: true,
+  });
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArguments(argv);
+  const [manifestInput, candidateIdentity, baseBinding, releaseMap, envioConfig] =
+    await Promise.all([
+      readJson(options.manifest, "Classic V4 release manifest"),
+      readJson(options.identity, "Envio candidate identity"),
+      readJson(baseReleaseBindingPath, "base data pipeline release binding"),
+      readFile(releaseMapPath, "utf8"),
+      readFile(envioConfigPath, "utf8"),
+    ]);
+  const manifest = parseClassicV4PendingRelease(manifestInput);
+  if (!manifest) {
+    fail(
+      "Classic V4 manifest failed the complete finalized source and lifecycle parser",
+    );
+  }
+  const provisionalPlan = buildClassicV4ActivationPlan(
+    manifest,
+    baseBinding,
+    releaseBindingDigest(baseBinding),
+  );
+  assertClassicV4IndexerSourceBindings(provisionalPlan, {
+    releaseMap,
+    envioConfig,
+  });
+  const releaseBinding = buildClassicV4ExpandedReleaseBinding(
+    provisionalPlan,
+    baseBinding,
+    candidateIdentity,
+    options.endpoint,
+  );
+  const digest = releaseBindingDigest(releaseBinding);
+  const finalPlan = buildClassicV4ActivationPlan(manifest, baseBinding, digest);
+  assertClassicV4IndexerSourceBindings(finalPlan, {
+    releaseMap,
+    envioConfig,
+  });
+  buildClassicV4CatalogReleaseArtifact(
+    finalPlan,
+    baseBinding,
+    releaseBinding,
+  );
+
+  const output = `${JSON.stringify(releaseBinding, null, 2)}\n`;
+  if (options.output) {
+    await writeClassicV4ReleaseBinding(options.output, releaseBinding);
+    process.stdout.write(
+      `${JSON.stringify({ output: options.output, releaseBindingDigest: digest }, null, 2)}\n`,
+    );
+    return;
+  }
+  process.stdout.write(output);
+}
+
+if (path.resolve(process.argv[1] ?? "") === scriptPath) {
+  main().catch((error) => {
+    process.stderr.write(
+      `Classic V4 release binding: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/indexer/scripts/release-candidate.mjs
+++ b/indexer/scripts/release-candidate.mjs
@@ -43,6 +43,16 @@ const STOCK_COORDINATOR_SOURCES = Object.freeze({
   "stock-paired-v2": "0xfb9e1034df6161088e8f358502b19e7515c30fd2",
   "stock-paired-v3": "0xddc3abbab0df7f1189310a4f70e7e365796b74e2",
 });
+const LIVE_ENVIO_SURFACE_REFERENCE = Object.freeze({
+  relativePath: "live-production-92f6373.config.yaml",
+  deployment: "production-92f6373",
+  sourceCommit: "92f63731ff0a61601a649cf40ceba3e492f63c62",
+  configSha256:
+    "0x133099a107e8d9c91aea1f0e811dbcc179fae8cf35919e612df7139deab3ee6a",
+  eventSetSha256:
+    "0xe5a88608068d4c84582cc63de55cbf386fa7f36b201722a39164eb4af61de95f",
+  eventCount: 66,
+});
 const BASE_CHAIN_CONTRACTS = Object.freeze([
   "ClassicV2Hook",
   "ClassicV2Launcher",
@@ -51,6 +61,9 @@ const BASE_CHAIN_CONTRACTS = Object.freeze([
   "ClassicV3RewardVault",
   "ClassicV3RewardVaultFactory",
   "ClassicV3VestingWalletFactory",
+  "CustomAtomicRegistrarV1",
+  "CustomPartnerFactoryRegistryV1",
+  "CustomRegistryV1",
   "StockV1EthCoordinator",
   "StockV1Hook",
   "StockV1Launcher",
@@ -323,6 +336,98 @@ function exactNames(label, names, expectedNames) {
   }
 }
 
+function configEventSurface(config, label) {
+  if (!Array.isArray(config?.contracts)) {
+    throw new Error(`${label} has no contract event surface`);
+  }
+  const events = [];
+  const contractEvents = [];
+  for (const contract of config.contracts) {
+    if (
+      typeof contract?.name !== "string" ||
+      !Array.isArray(contract.events) ||
+      contract.events.length === 0
+    ) {
+      throw new Error(`${label} has an invalid contract event surface`);
+    }
+    const local = new Set();
+    for (const declaration of contract.events) {
+      const event = declaration?.event;
+      if (typeof event !== "string" || event.length === 0 || event.trim() !== event) {
+        throw new Error(`${label} has an invalid event signature`);
+      }
+      if (local.has(event)) {
+        throw new Error(`${label} repeats an event signature for ${contract.name}`);
+      }
+      local.add(event);
+      events.push(event);
+      contractEvents.push(`${contract.name}\u0000${event}`);
+    }
+  }
+  return Object.freeze({ events, contractEvents });
+}
+
+function parseLiveEnvioSurfaceReference(referenceBytes) {
+  if (sha256(referenceBytes) !== LIVE_ENVIO_SURFACE_REFERENCE.configSha256) {
+    throw new Error("live Envio surface reference digest is invalid");
+  }
+  const reference = parse(referenceBytes.toString("utf8"));
+  if (
+    !Array.isArray(reference?.chains) ||
+    reference.chains.length !== 1 ||
+    reference.chains[0]?.id !== 1 ||
+    !Array.isArray(reference.chains[0]?.contracts)
+  ) {
+    throw new Error("live Envio surface reference is invalid");
+  }
+  const surface = configEventSurface(reference, "live Envio surface reference");
+  const eventSet = Buffer.from(
+    `${[...surface.events].sort(compareUtf8).join("\n")}\n`,
+    "utf8",
+  );
+  if (
+    surface.events.length !== LIVE_ENVIO_SURFACE_REFERENCE.eventCount ||
+    sha256(eventSet) !== LIVE_ENVIO_SURFACE_REFERENCE.eventSetSha256
+  ) {
+    throw new Error("live Envio event-set reference is invalid");
+  }
+  return Object.freeze({ config: reference, surface });
+}
+
+function assertLiveEnvioSurfaceSuperset(candidate, referenceInput) {
+  const reference = referenceInput.config ?? referenceInput;
+  const referenceSurface = referenceInput.surface ??
+    configEventSurface(reference, "live Envio surface reference");
+  const candidateSurface = configEventSurface(candidate, "candidate Envio config");
+  const candidateContractEvents = new Set(candidateSurface.contractEvents);
+  for (const required of referenceSurface.contractEvents) {
+    if (!candidateContractEvents.has(required)) {
+      const separator = required.indexOf("\u0000");
+      throw new Error(
+        `candidate must preserve live ${required.slice(0, separator)} event ${required.slice(separator + 1)}`,
+      );
+    }
+  }
+
+  const candidateSources = candidate.chains?.[0]?.contracts;
+  if (!Array.isArray(candidateSources)) {
+    throw new Error("candidate must preserve the live Envio source surface");
+  }
+  for (const required of reference.chains[0].contracts) {
+    const matches = candidateSources.filter(({ name }) => name === required.name);
+    if (
+      matches.length !== 1 ||
+      (required.address !== undefined && matches[0]?.address !== required.address)
+    ) {
+      throw new Error(`candidate must preserve live ${required.name} source`);
+    }
+  }
+  return Object.freeze({
+    requiredEventCount: referenceSurface.events.length,
+    candidateEventCount: candidateSurface.events.length,
+  });
+}
+
 function exactChainContractScope(contracts) {
   if (!Array.isArray(contracts)) {
     throw new Error("chain registry must be the exact reviewed contract scope");
@@ -335,10 +440,12 @@ function exactChainContractScope(contracts) {
     sorted.length === expected.length &&
     new Set(sorted).size === sorted.length &&
     sorted.every((name, index) => name === expected[index]);
-  if (matches(baseline)) return false;
-  if (!matches(activated)) {
+  const isBaseline = matches(baseline);
+  const isActivated = matches(activated);
+  if (!isBaseline && !isActivated) {
     throw new Error("chain registry must be the exact reviewed contract scope");
   }
+  if (isBaseline) return false;
   for (const contractName of ["ClassicV4Hook", "ClassicV4Launcher"]) {
     const source = contracts.find((entry) => entry?.name === contractName);
     exactAddress(source?.address, `${contractName} chain address`);
@@ -346,7 +453,7 @@ function exactChainContractScope(contracts) {
   return true;
 }
 
-function validatedConfig(configBytes) {
+function validatedConfig(configBytes, liveSurfaceReferenceBytes) {
   const config = parse(configBytes.toString("utf8"));
   if (!Array.isArray(config?.contracts) || !Array.isArray(config?.chains)) {
     throw new Error("config.yaml is missing the reviewed contract registry");
@@ -364,6 +471,10 @@ function validatedConfig(configBytes) {
     config.contracts.map((entry) => entry?.name),
     EXPECTED_ABI_CONTRACTS,
   );
+  assertLiveEnvioSurfaceSuperset(
+    config,
+    parseLiveEnvioSurfaceReference(liveSurfaceReferenceBytes),
+  );
   const classicV4Activated = exactChainContractScope(
     config.chains[0].contracts,
   );
@@ -373,6 +484,7 @@ function validatedConfig(configBytes) {
 function validatedLocalConfig(sourceCommit) {
   return validatedConfig(
     localArtifactBytes(sourceCommit, ARTIFACTS.configSha256),
+    localArtifactBytes(sourceCommit, LIVE_ENVIO_SURFACE_REFERENCE.relativePath),
   );
 }
 
@@ -383,6 +495,7 @@ function workingTreeArtifactBytes(relativePath) {
 function workingTreeClassicV4Activated() {
   return validatedConfig(
     workingTreeArtifactBytes(ARTIFACTS.configSha256),
+    workingTreeArtifactBytes(LIVE_ENVIO_SURFACE_REFERENCE.relativePath),
   ).classicV4Activated;
 }
 
@@ -410,7 +523,10 @@ function localArtifactBytes(sourceCommit, relativePath) {
 function identityFromArtifactReader(sourceCommitInput, readArtifact) {
   const sourceCommit = exactCommit(sourceCommitInput);
   const configBytes = readArtifact(ARTIFACTS.configSha256);
-  const { config } = validatedConfig(configBytes);
+  const { config } = validatedConfig(
+    configBytes,
+    readArtifact(LIVE_ENVIO_SURFACE_REFERENCE.relativePath),
+  );
 
   const events = [];
   for (const contract of config.contracts) {
@@ -1600,14 +1716,17 @@ export {
   IDENTITY_KEYS,
   INVENTORY_QUERY,
   LAUNCH_FIELDS,
+  LIVE_ENVIO_SURFACE_REFERENCE,
   STABLE_LAUNCH_FIELDS,
   assertFrozenBaseline,
+  assertLiveEnvioSurfaceSuperset,
   auditCandidate,
   auditWorkingTreeCandidate,
   endpointIdFromUrl,
   localIdentity,
   parseBaseline,
   parseCandidateIdentity,
+  parseLiveEnvioSurfaceReference,
   parseReleaseAuditArtifact,
   releaseBindingDigest,
   snapshotBaseline,

--- a/indexer/scripts/release-candidate.mjs
+++ b/indexer/scripts/release-candidate.mjs
@@ -11,7 +11,7 @@ import { parse } from "yaml";
 import {
   CLASSIC_V4_DIGEST_DOMAINS,
   digestJson,
-} from "../../scripts/classic-v4-digest.mjs";
+} from "./classic-v4-digest.mjs";
 
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const INDEXER_ROOT = path.resolve(path.dirname(SCRIPT_PATH), "..");
@@ -676,7 +676,8 @@ function parseAuditReleaseBinding(value, endpoint, expectedIdentity) {
 }
 
 function parseArgs(argv) {
-  const [command, ...rest] = argv;
+  const [command, ...rawRest] = argv;
+  const rest = rawRest[0] === "--" ? rawRest.slice(1) : rawRest;
   if (rest.length % 2 !== 0) throw new Error("every option requires one value");
   const values = {};
   for (let index = 0; index < rest.length; index += 2) {

--- a/indexer/src/EventHandlers.ts
+++ b/indexer/src/EventHandlers.ts
@@ -2217,3 +2217,124 @@ indexer.onEvent(
   { contract: "StockV2V3RewardVault", event: "BeneficiaryFeesClaimed" },
   handleEvent,
 );
+
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchApprovalAuthorizedV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchRegisteredV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchProvenanceBoundV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchReviewBoundV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchAttributionBoundV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchFeePolicyBoundV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchFeeScopeBoundV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchFeeEvidenceBoundV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchFinalizedV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchRecordCorrectedV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomRegistryV1",
+    event: "CustomLaunchRevokedV1",
+    where: eventBlockFilter("CustomRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomPartnerFactoryRegistryV1",
+    event: "CustomPartnerFactoryAuthorizedV1",
+    where: eventBlockFilter("CustomPartnerFactoryRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomPartnerFactoryRegistryV1",
+    event: "CustomPartnerFactorySourceBoundV1",
+    where: eventBlockFilter("CustomPartnerFactoryRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomPartnerFactoryRegistryV1",
+    event: "CustomPartnerFactoryRevokedV1",
+    where: eventBlockFilter("CustomPartnerFactoryRegistryV1"),
+  },
+  handleEvent,
+);
+indexer.onEvent(
+  {
+    contract: "CustomAtomicRegistrarV1",
+    event: "AtomicCustomLaunchExecutedV1",
+    where: eventBlockFilter("CustomAtomicRegistrarV1"),
+  },
+  handleEvent,
+);

--- a/indexer/src/lib/release-map.ts
+++ b/indexer/src/lib/release-map.ts
@@ -116,8 +116,8 @@ const ACTIVATED_CLASSIC_V4_SOURCES = [
   },
   {
     contractName: "ClassicV4Launcher",
-    address: "0x1af508f9af9f8f5cf7bf712b7d2974d4ee7a6681",
-    startBlock: 25_851_150,
+    address: "0xbbdf30a2fe1394e4aa864ac269c6cf09b518e699",
+    startBlock: 25_853_086,
   },
 ] as const satisfies readonly SourceRegistryEntry[];
 // CLASSIC_V4_ACTIVATION_END

--- a/indexer/src/lib/release-map.ts
+++ b/indexer/src/lib/release-map.ts
@@ -90,10 +90,36 @@ const BASE_SOURCE_REGISTRY = [
     address: "0xddc3abbab0df7f1189310a4f70e7e365796b74e2",
     startBlock: 25_642_745,
   },
+  {
+    contractName: "CustomRegistryV1",
+    address: "0x17e18c88bda9bfb73924cdc989c07b0707e72671",
+    startBlock: 25_701_139,
+  },
+  {
+    contractName: "CustomPartnerFactoryRegistryV1",
+    address: "0xf8aef69201621ad20fa256da595426b7e6192dba",
+    startBlock: 25_701_136,
+  },
+  {
+    contractName: "CustomAtomicRegistrarV1",
+    address: "0xcc916e5200d2626edfd918dc219bc4296629e997",
+    startBlock: 25_701_142,
+  },
 ] as const satisfies readonly SourceRegistryEntry[];
 
 // CLASSIC_V4_ACTIVATION_START
-const ACTIVATED_CLASSIC_V4_SOURCES = [] as const satisfies readonly SourceRegistryEntry[];
+const ACTIVATED_CLASSIC_V4_SOURCES = [
+  {
+    contractName: "ClassicV4Hook",
+    address: "0xadf955a44fd7f009380240d56d71dfafb46020cc",
+    startBlock: 25_851_137,
+  },
+  {
+    contractName: "ClassicV4Launcher",
+    address: "0x1af508f9af9f8f5cf7bf712b7d2974d4ee7a6681",
+    startBlock: 25_851_150,
+  },
+] as const satisfies readonly SourceRegistryEntry[];
 // CLASSIC_V4_ACTIVATION_END
 
 export const SOURCE_REGISTRY = [
@@ -138,6 +164,9 @@ export function staticReleaseForContract(
   }
   if (STOCK_V3_CONTRACTS.has(contractName)) {
     return { model: "stock-paired", releaseVersion: "stock-paired-v3" };
+  }
+  if (CUSTOM_REGISTRY_V1_CONTRACTS.has(contractName)) {
+    return { model: "custom", releaseVersion: "custom-registry-v1" };
   }
   return undefined;
 }
@@ -192,4 +221,9 @@ const STOCK_V2_CONTRACTS = new Set([
 const STOCK_V3_CONTRACTS = new Set([
   "StockV3Launcher",
   "StockV3EthCoordinator",
+]);
+const CUSTOM_REGISTRY_V1_CONTRACTS = new Set([
+  "CustomRegistryV1",
+  "CustomPartnerFactoryRegistryV1",
+  "CustomAtomicRegistrarV1",
 ]);

--- a/indexer/test/classic-v4-predeploy-config.test.ts
+++ b/indexer/test/classic-v4-predeploy-config.test.ts
@@ -7,7 +7,7 @@ import { buildClassicV4ActivationPlan } from "../scripts/activate-classic-v4.mjs
 import {
   CLASSIC_V4_DIGEST_DOMAINS,
   digestJson,
-} from "../../scripts/classic-v4-digest.mjs";
+} from "../scripts/classic-v4-digest.mjs";
 
 const configPath = fileURLToPath(new URL("../config.yaml", import.meta.url));
 const releaseMapPath = fileURLToPath(

--- a/indexer/test/classic-v4-predeploy-config.test.ts
+++ b/indexer/test/classic-v4-predeploy-config.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
@@ -18,9 +18,6 @@ const currentBindingPath = fileURLToPath(
 );
 const classicV3ManifestPath = fileURLToPath(
   new URL("../../contracts/deployments/mainnet-classic-v3.json", import.meta.url),
-);
-const classicV4ManifestPath = fileURLToPath(
-  new URL("../../contracts/deployments/mainnet-classic-v4.json", import.meta.url),
 );
 const INDEXER_BINDING_DIGEST = `0x${"ab".repeat(32)}`;
 
@@ -204,8 +201,8 @@ function validActivationFixture(binding: { sources: FixtureBindingSource[] }) {
   return { ...manifest, manifestDigest: digest(manifest) };
 }
 
-describe("Classic V4 pre-deploy Envio configuration", () => {
-  it("keeps ABI definitions available without binding a wildcard chain source", () => {
+describe("Classic V4 source-only Envio configuration", () => {
+  it("binds only the exact finalized hook and launcher sources", () => {
     const config = readFileSync(configPath, "utf8");
     const [definitions, chainBindings] = config.split(/^chains:\s*$/mu);
 
@@ -214,31 +211,35 @@ describe("Classic V4 pre-deploy Envio configuration", () => {
     expect(chainBindings).toBeDefined();
     if (chainBindings === undefined) throw new Error("Envio chain bindings are missing");
     const releaseMap = readFileSync(releaseMapPath, "utf8");
-    const inactive = releaseMap.includes(
+    expect(releaseMap).not.toContain(
       "const ACTIVATED_CLASSIC_V4_SOURCES = [] as const",
     );
-    if (!existsSync(classicV4ManifestPath)) expect(inactive).toBe(true);
-
-    if (inactive) {
-      expect(chainBindings).not.toContain("name: ClassicV4Hook");
-      expect(chainBindings).not.toContain("name: ClassicV4Launcher");
-      expect(releaseMap).not.toMatch(
-        /contractName: "ClassicV4(?:Hook|Launcher)",\s+address:/u,
-      );
-      return;
-    }
-
-    for (const contractName of ["ClassicV4Hook", "ClassicV4Launcher"]) {
+    const expected = {
+      ClassicV4Hook: {
+        address: "0xadf955a44fd7f009380240d56d71dfafb46020cc",
+        startBlock: "25_851_137",
+      },
+      ClassicV4Launcher: {
+        address: "0x1af508f9af9f8f5cf7bf712b7d2974d4ee7a6681",
+        startBlock: "25_851_150",
+      },
+    } as const;
+    for (const contractName of ["ClassicV4Hook", "ClassicV4Launcher"] as const) {
       const releaseAddress = new RegExp(
         `contractName: "${contractName}",[\\s\\S]*?address: "(0x[0-9a-f]{40})"`,
+        "u",
+      ).exec(releaseMap)?.[1];
+      const releaseStartBlock = new RegExp(
+        `contractName: "${contractName}",[\\s\\S]*?startBlock: ([0-9_]+)`,
         "u",
       ).exec(releaseMap)?.[1];
       const chainAddress = new RegExp(
         `name: ${contractName}\\s+address: "(0x[0-9a-f]{40})"`,
         "u",
       ).exec(chainBindings)?.[1];
-      expect(releaseAddress).toMatch(/^0x(?!0{40}$)[0-9a-f]{40}$/u);
-      expect(chainAddress).toBe(releaseAddress);
+      expect(releaseAddress).toBe(expected[contractName].address);
+      expect(releaseStartBlock).toBe(expected[contractName].startBlock);
+      expect(chainAddress).toBe(expected[contractName].address);
     }
   });
 

--- a/indexer/test/classic-v4-predeploy-config.test.ts
+++ b/indexer/test/classic-v4-predeploy-config.test.ts
@@ -220,8 +220,8 @@ describe("Classic V4 source-only Envio configuration", () => {
         startBlock: "25_851_137",
       },
       ClassicV4Launcher: {
-        address: "0x1af508f9af9f8f5cf7bf712b7d2974d4ee7a6681",
-        startBlock: "25_851_150",
+        address: "0xbbdf30a2fe1394e4aa864ac269c6cf09b518e699",
+        startBlock: "25_853_086",
       },
     } as const;
     for (const contractName of ["ClassicV4Hook", "ClassicV4Launcher"] as const) {

--- a/indexer/test/classic-v4-public-release-binding.test.ts
+++ b/indexer/test/classic-v4-public-release-binding.test.ts
@@ -8,7 +8,7 @@ import baseReleaseBinding from "../../config/data-pipeline-release.v1.json";
 import {
   CLASSIC_V4_DIGEST_DOMAINS,
   digestJson,
-} from "../../scripts/classic-v4-digest.mjs";
+} from "../scripts/classic-v4-digest.mjs";
 
 import {
   buildClassicV4CatalogReleaseArtifact,

--- a/indexer/test/classic-v4-release-binding-generator.test.ts
+++ b/indexer/test/classic-v4-release-binding-generator.test.ts
@@ -1,0 +1,239 @@
+import { readFileSync } from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import baseReleaseBinding from "../../config/data-pipeline-release.v1.json";
+import {
+  CLASSIC_V4_DIGEST_DOMAINS,
+  digestJson,
+} from "../../scripts/classic-v4-digest.mjs";
+import {
+  assertClassicV4IndexerSourceBindings,
+  buildClassicV4ExpandedReleaseBinding,
+  writeClassicV4ReleaseBinding,
+} from "../scripts/generate-classic-v4-release-binding.mjs";
+
+const CANDIDATE_ENDPOINT =
+  "https://indexer.hyperindex.xyz/cand001/v1/graphql";
+const HOOK = "0xadf955a44fd7f009380240d56d71dfafb46020cc";
+const LAUNCHER = "0x1af508f9af9f8f5cf7bf712b7d2974d4ee7a6681";
+
+function identity() {
+  return {
+    deployment: "production-cand001",
+    sourceCommit: "b".repeat(40),
+    configSha256: `0x${"b1".repeat(32)}`,
+    schemaSha256: baseReleaseBinding.envio.schemaSha256,
+    handlerSha256: baseReleaseBinding.envio.handlerSha256,
+    sourceRegistrySha256: `0x${"b2".repeat(32)}`,
+    eventSetSha256: `0x${"b3".repeat(32)}`,
+    eventCount: 75,
+  };
+}
+
+function plan() {
+  const sources = [
+    {
+      contractName: "ClassicV4Hook",
+      address: HOOK,
+      startBlock: 25_851_137,
+      runtimeCodeHash:
+        "0xf3a1a628ce898c527f24569b426aa795ec65ff9d97afa2b89e8ea5a2b99ad280",
+    },
+    {
+      contractName: "ClassicV4Launcher",
+      address: LAUNCHER,
+      startBlock: 25_851_150,
+      runtimeCodeHash:
+        "0xafd7bdd723da2f8ab076cd067dd7c8486a89a0dc348fc3a8cbca677f7999798c",
+    },
+  ];
+  const activationBlock = 25_851_150;
+  return {
+    schemaVersion: 1,
+    chainId: 1,
+    model: "classic",
+    releaseVersion: "classic-v4",
+    activationBlock,
+    manifestDigest: `0x${"44".repeat(32)}`,
+    indexerBindingDigest: `0x${"45".repeat(32)}`,
+    publicReleaseBinding: { launcher: LAUNCHER },
+    sources,
+    dataPipelineReleaseFragment: {
+      model: "classic",
+      releaseVersion: "classic-v4",
+      activationBlock,
+      sourceContracts: [
+        "ClassicV3RewardVaultFactory",
+        "ClassicV3VestingWalletFactory",
+        "ClassicV4Hook",
+        "ClassicV4Launcher",
+      ],
+      dynamicContracts: ["ClassicV3RewardVault"],
+    },
+  };
+}
+
+describe("Classic V4 expanded Envio release binding", () => {
+  it("preserves the frozen base and appends only the exact V4 scope", () => {
+    const before = structuredClone(baseReleaseBinding);
+    const binding = buildClassicV4ExpandedReleaseBinding(
+      plan(),
+      baseReleaseBinding,
+      identity(),
+      CANDIDATE_ENDPOINT,
+    ) as typeof baseReleaseBinding & {
+      sources: Array<(typeof baseReleaseBinding.sources)[number]>;
+      releases: Array<(typeof baseReleaseBinding.releases)[number]>;
+    };
+
+    expect(baseReleaseBinding).toEqual(before);
+    expect(Object.keys(binding)).toEqual([
+      "schemaVersion",
+      "chainId",
+      "startBlock",
+      "confirmations",
+      "envio",
+      "uniswapV4Subgraph",
+      "sources",
+      "releases",
+    ]);
+    expect(binding.sources.slice(0, before.sources.length)).toEqual(
+      before.sources,
+    );
+    expect(binding.sources.slice(before.sources.length)).toEqual(
+      plan().sources,
+    );
+    expect(binding.releases.slice(0, before.releases.length)).toEqual(
+      before.releases,
+    );
+    expect(binding.releases.at(-1)).toEqual(
+      plan().dataPipelineReleaseFragment,
+    );
+    expect(binding.envio).toEqual({
+      deploymentLabel: identity().deployment,
+      graphqlEndpoint: CANDIDATE_ENDPOINT,
+      schemaVersion: "1",
+      sourceCommit: identity().sourceCommit,
+      configSha256: identity().configSha256,
+      schemaSha256: identity().schemaSha256,
+      handlerSha256: identity().handlerSha256,
+      sourceRegistrySha256: identity().sourceRegistrySha256,
+      eventSetSha256: identity().eventSetSha256,
+      eventCount: identity().eventCount,
+    });
+    expect(binding.envio.eventCount).toBe(
+      baseReleaseBinding.envio.eventCount + 9,
+    );
+    expect(
+      digestJson(binding, CLASSIC_V4_DIGEST_DOMAINS.releaseBinding),
+    ).toMatch(/^0x[0-9a-f]{64}$/u);
+  });
+
+  it("rejects endpoints and identities that are not independently promoted", () => {
+    expect(() =>
+      buildClassicV4ExpandedReleaseBinding(
+        plan(),
+        baseReleaseBinding,
+        identity(),
+        "https://example.com/cand001/v1/graphql",
+      ),
+    ).toThrow("reviewed Envio GraphQL endpoint");
+
+    expect(() =>
+      buildClassicV4ExpandedReleaseBinding(
+        plan(),
+        baseReleaseBinding,
+        {
+          ...identity(),
+          configSha256: baseReleaseBinding.envio.configSha256,
+        },
+        CANDIDATE_ENDPOINT,
+      ),
+    ).toThrow("independently promoted");
+
+    expect(() =>
+      buildClassicV4ExpandedReleaseBinding(
+        plan(),
+        baseReleaseBinding,
+        { ...identity(), eventCount: baseReleaseBinding.envio.eventCount + 8 },
+        CANDIDATE_ENDPOINT,
+      ),
+    ).toThrow("independently promoted");
+  });
+
+  it("rejects an already-expanded base or a reordered V4 plan", () => {
+    const expandedBase = structuredClone(baseReleaseBinding);
+    expandedBase.sources.push(plan().sources[0]!);
+    expect(() =>
+      buildClassicV4ExpandedReleaseBinding(
+        plan(),
+        expandedBase,
+        identity(),
+        CANDIDATE_ENDPOINT,
+      ),
+    ).toThrow("already contains Classic V4");
+
+    const driftedLiveBase = structuredClone(baseReleaseBinding);
+    driftedLiveBase.envio.eventCount -= 1;
+    expect(() =>
+      buildClassicV4ExpandedReleaseBinding(
+        plan(),
+        driftedLiveBase,
+        identity(),
+        CANDIDATE_ENDPOINT,
+      ),
+    ).toThrow("not the frozen live Envio surface");
+
+    const reordered = plan();
+    reordered.sources.reverse();
+    expect(() =>
+      buildClassicV4ExpandedReleaseBinding(
+        reordered,
+        baseReleaseBinding,
+        identity(),
+        CANDIDATE_ENDPOINT,
+      ),
+    ).toThrow("plan is invalid");
+  });
+
+  it("pins the checked-out Envio markers to the exact live source plan", () => {
+    const current = {
+      releaseMap: readFileSync(
+        fileURLToPath(new URL("../src/lib/release-map.ts", import.meta.url)),
+        "utf8",
+      ),
+      envioConfig: readFileSync(
+        fileURLToPath(new URL("../config.yaml", import.meta.url)),
+        "utf8",
+      ),
+    };
+    expect(() =>
+      assertClassicV4IndexerSourceBindings(plan(), current),
+    ).not.toThrow();
+
+    const drifted = plan();
+    drifted.sources[1]!.startBlock += 1;
+    expect(() =>
+      assertClassicV4IndexerSourceBindings(drifted, current),
+    ).toThrow("do not match the finalized release manifest");
+  });
+
+  it("never overwrites an existing release-binding output", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "classic-v4-binding-"));
+    const output = path.join(directory, "release-binding.json");
+    try {
+      await writeFile(output, "owner evidence\n", "utf8");
+      await expect(
+        writeClassicV4ReleaseBinding(output, { schemaVersion: 1 }),
+      ).rejects.toMatchObject({ code: "EEXIST" });
+      await expect(readFile(output, "utf8")).resolves.toBe("owner evidence\n");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/indexer/test/classic-v4-release-binding-generator.test.ts
+++ b/indexer/test/classic-v4-release-binding-generator.test.ts
@@ -10,7 +10,7 @@ import baseReleaseBinding from "../../config/data-pipeline-release.v1.json";
 import {
   CLASSIC_V4_DIGEST_DOMAINS,
   digestJson,
-} from "../../scripts/classic-v4-digest.mjs";
+} from "../scripts/classic-v4-digest.mjs";
 import {
   assertClassicV4IndexerSourceBindings,
   buildClassicV4ExpandedReleaseBinding,

--- a/indexer/test/classic-v4-release-binding-generator.test.ts
+++ b/indexer/test/classic-v4-release-binding-generator.test.ts
@@ -20,7 +20,7 @@ import {
 const CANDIDATE_ENDPOINT =
   "https://indexer.hyperindex.xyz/cand001/v1/graphql";
 const HOOK = "0xadf955a44fd7f009380240d56d71dfafb46020cc";
-const LAUNCHER = "0x1af508f9af9f8f5cf7bf712b7d2974d4ee7a6681";
+const LAUNCHER = "0xbbdf30a2fe1394e4aa864ac269c6cf09b518e699";
 
 function identity() {
   return {
@@ -47,12 +47,12 @@ function plan() {
     {
       contractName: "ClassicV4Launcher",
       address: LAUNCHER,
-      startBlock: 25_851_150,
+      startBlock: 25_853_086,
       runtimeCodeHash:
         "0xafd7bdd723da2f8ab076cd067dd7c8486a89a0dc348fc3a8cbca677f7999798c",
     },
   ];
-  const activationBlock = 25_851_150;
+  const activationBlock = 25_853_086;
   return {
     schemaVersion: 1,
     chainId: 1,

--- a/indexer/test/custom-registry-v2-release-map.test.ts
+++ b/indexer/test/custom-registry-v2-release-map.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -6,6 +8,18 @@ import {
 } from "../src/lib/custom-registry-v2-release-map.js";
 
 describe("Custom Registry V2 prelaunch source binding", () => {
+  it("stays separate from the live V1 compatibility stream", () => {
+    const mainConfig = readFileSync(
+      new URL("../config.yaml", import.meta.url),
+      "utf8",
+    );
+    expect(mainConfig).toContain("- name: CustomRegistryV1");
+    expect(mainConfig).toContain("- name: CustomPartnerFactoryRegistryV1");
+    expect(mainConfig).toContain("- name: CustomAtomicRegistrarV1");
+    expect(mainConfig).not.toContain("- name: CustomRegistryV2");
+    expect(CUSTOM_REGISTRY_V2_PRELAUNCH_SOURCE.active).toBe(false);
+  });
+
   it("does not invent a deployment source or legacy release identity", () => {
     expect(CUSTOM_REGISTRY_V2_PRELAUNCH_SOURCE).toEqual({
       contractName: "CustomRegistryV2",

--- a/indexer/test/release-candidate.test.ts
+++ b/indexer/test/release-candidate.test.ts
@@ -277,13 +277,13 @@ describe("Envio release candidate identity", () => {
       deployment: `production-${SOURCE_COMMIT.slice(0, 7)}`,
       sourceCommit: SOURCE_COMMIT,
       configSha256:
-        "0xb589a1f73e92393d4b415a266c60109248ce874f5d48fa71de0565c5617dfe12",
+        "0xb2d34d55b7d733452b011c5030ad773e9cafd0fd3d18364f2de5699e02fd7a43",
       schemaSha256:
         "0xdf3d65e033e96d7ebbe62b6f114b6a30f10c8944e5c6fca6b020c3130bb738c0",
       handlerSha256:
         "0x4b6299cddeffaa900bcd7da8428bb715b65c6289d662e908c20f27ef483329fc",
       sourceRegistrySha256:
-        "0x46d8c08e7d3d0e60e5cc1921fd0feee8d89163769db8c0de6d14ac54bddb3a07",
+        "0xfcb55c4aab63ae77d483b59f068f4ef152aa479bf5e8a9f1ec630b8392c28bd9",
       eventSetSha256:
         "0x932d5f9f56fd1baaa9d78188dc071f8937c653785a673f2019c11c3bc8a5b7c7",
       eventCount: 75,

--- a/indexer/test/release-candidate.test.ts
+++ b/indexer/test/release-candidate.test.ts
@@ -1,13 +1,15 @@
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
 
 import baseReleaseBinding from "../../config/data-pipeline-release.v1.json";
 
 // The release gate is deliberately a standalone Node script rather than indexer runtime code.
 // @ts-expect-error The checked-in mjs script has no declaration file by design.
-import { IDENTITY_KEYS, INVENTORY_QUERY, LAUNCH_FIELDS, STABLE_LAUNCH_FIELDS, assertFrozenBaseline, auditWorkingTreeCandidate, endpointIdFromUrl, parseBaseline, parseCandidateIdentity, parseReleaseAuditArtifact, releaseBindingDigest, snapshotBaseline, workingTreeIdentity } from "../scripts/release-candidate.mjs";
+import { IDENTITY_KEYS, INVENTORY_QUERY, LAUNCH_FIELDS, LIVE_ENVIO_SURFACE_REFERENCE, STABLE_LAUNCH_FIELDS, assertFrozenBaseline, assertLiveEnvioSurfaceSuperset, auditWorkingTreeCandidate, endpointIdFromUrl, parseBaseline, parseCandidateIdentity, parseLiveEnvioSurfaceReference, parseReleaseAuditArtifact, releaseBindingDigest, snapshotBaseline, workingTreeIdentity } from "../scripts/release-candidate.mjs";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
 const REPOSITORY_ROOT = path.resolve(ROOT, "..");
@@ -169,6 +171,18 @@ function fixtureFetcher(options: FixtureOptions = {}) {
   return { fetcher, anchors, inventoryReads: () => inventoryReads };
 }
 
+function candidateFixture(options: FixtureOptions = {}) {
+  const sourceRows = options.rows ?? rows();
+  const candidateRows = sourceRows.some(
+    ({ releaseVersion }) => releaseVersion === "classic-v4",
+  )
+    ? sourceRows
+    : [...sourceRows, launchRow("classic-v4", 9)].sort((left, right) =>
+        String(left.id).localeCompare(String(right.id)),
+      );
+  return fixtureFetcher({ ...options, rows: candidateRows });
+}
+
 async function baseline(fixtureRows = rows()) {
   const fixture = fixtureFetcher({ rows: fixtureRows });
   return snapshotBaseline(BASELINE_ENDPOINT, fixture.fetcher, () => new Date(CAPTURED_AT));
@@ -229,7 +243,7 @@ function releaseBinding(identity: JsonRecord, includeClassicV4 = false): JsonRec
 
 async function auditCandidate(input: Record<string, unknown>) {
   return auditWorkingTreeCandidate({
-    releaseBinding: releaseBinding(input.expectedIdentity as JsonRecord),
+    releaseBinding: releaseBinding(input.expectedIdentity as JsonRecord, true),
     ...input,
   });
 }
@@ -263,16 +277,16 @@ describe("Envio release candidate identity", () => {
       deployment: `production-${SOURCE_COMMIT.slice(0, 7)}`,
       sourceCommit: SOURCE_COMMIT,
       configSha256:
-        "0x0286e176b7e8f9baf49a6751390abb6ca97c246e717d00fda34dbe023830d2a6",
+        "0xb589a1f73e92393d4b415a266c60109248ce874f5d48fa71de0565c5617dfe12",
       schemaSha256:
         "0xdf3d65e033e96d7ebbe62b6f114b6a30f10c8944e5c6fca6b020c3130bb738c0",
       handlerSha256:
-        "0x3249c4d6e733e271ce1cd9a9407a1e3881fa79491500143b08e77c1d7e5e1fdf",
+        "0x4b6299cddeffaa900bcd7da8428bb715b65c6289d662e908c20f27ef483329fc",
       sourceRegistrySha256:
-        "0x98d6a49f606f198340f1938127744ee5d12b786e0d1b7cd1e31a1b1b4a713ef0",
+        "0x46d8c08e7d3d0e60e5cc1921fd0feee8d89163769db8c0de6d14ac54bddb3a07",
       eventSetSha256:
-        "0x79bd6a7e9c4e4c76141ff72dd1a295b32c8115d85cd6826c7c9a403a4ed3c63f",
-      eventCount: 60,
+        "0x932d5f9f56fd1baaa9d78188dc071f8937c653785a673f2019c11c3bc8a5b7c7",
+      eventCount: 75,
     });
   });
 
@@ -300,6 +314,35 @@ describe("Envio release candidate identity", () => {
     expect(() =>
       parseCandidateIdentity({ ...identity, handlerSha256: String(identity.handlerSha256).toUpperCase() }),
     ).toThrow(/invalid/u);
+  });
+
+  it("requires a semantic superset of the frozen live Envio surface", () => {
+    const reference = parseLiveEnvioSurfaceReference(
+      readFileSync(path.join(ROOT, LIVE_ENVIO_SURFACE_REFERENCE.relativePath)),
+    );
+    const candidate = parse(readFileSync(path.join(ROOT, "config.yaml"), "utf8"));
+    expect(assertLiveEnvioSurfaceSuperset(candidate, reference)).toEqual({
+      requiredEventCount: 66,
+      candidateEventCount: 75,
+    });
+
+    const missingEvent = structuredClone(candidate);
+    const customRegistry = missingEvent.contracts.find(
+      ({ name }: JsonRecord) => name === "CustomRegistryV1",
+    );
+    customRegistry.events.pop();
+    expect(() => assertLiveEnvioSurfaceSuperset(missingEvent, reference)).toThrow(
+      /must preserve live CustomRegistryV1 event/u,
+    );
+
+    const driftedSource = structuredClone(candidate);
+    const partnerFactory = driftedSource.chains[0].contracts.find(
+      ({ name }: JsonRecord) => name === "CustomPartnerFactoryRegistryV1",
+    );
+    partnerFactory.address = hex(20, 9_999);
+    expect(() => assertLiveEnvioSurfaceSuperset(driftedSource, reference)).toThrow(
+      /must preserve live CustomPartnerFactoryRegistryV1 source/u,
+    );
   });
 });
 
@@ -451,7 +494,7 @@ describe("Envio candidate audit", () => {
   it("corroborates control-plane, endpoint, reviewed runtime and baseline evidence", async () => {
     const identity = workingTreeIdentity(SOURCE_COMMIT) as JsonRecord;
     const frozenBaseline = await baseline();
-    const firstFixture = fixtureFetcher({ identity, progressBlock: 1_100 });
+    const firstFixture = candidateFixture({ identity, progressBlock: 1_100 });
     const first = await auditCandidate({
       endpoint: CANDIDATE_ENDPOINT,
       expectedIdentity: identity,
@@ -461,7 +504,7 @@ describe("Envio candidate audit", () => {
       fetcher: firstFixture.fetcher,
       now: () => new Date(CAPTURED_AT),
     });
-    const secondFixture = fixtureFetcher({ identity, progressBlock: 1_100 });
+    const secondFixture = candidateFixture({ identity, progressBlock: 1_100 });
     const second = await auditCandidate({
       endpoint: CANDIDATE_ENDPOINT,
       expectedIdentity: identity,
@@ -482,11 +525,11 @@ describe("Envio candidate audit", () => {
       endpointId: "cand001",
     });
     expect(first.identity).toEqual(identity);
-    expect(first.releaseBinding).toEqual(releaseBinding(identity));
+    expect(first.releaseBinding).toEqual(releaseBinding(identity, true));
     expect(first.releaseBindingDigest).toBe(
-      releaseBindingDigest(releaseBinding(identity)),
+      releaseBindingDigest(releaseBinding(identity, true)),
     );
-    expect(first.classicV4Activated).toBe(false);
+    expect(first.classicV4Activated).toBe(true);
     expect(first.baseline.digest).toBe(frozenBaseline.digest);
     expect(first.anchor.progressBlock).toBe("1100");
     expect(first.inventory.sha256).toMatch(/^0x[0-9a-f]{64}$/u);
@@ -570,7 +613,7 @@ describe("Envio candidate audit", () => {
       baseline: await baseline(frozenRows),
       sourceCommit: SOURCE_COMMIT,
       deployment: deployment(identity),
-      fetcher: fixtureFetcher({
+      fetcher: candidateFixture({
         identity,
         rows: candidateRows,
         progressBlock: 1_100,
@@ -596,7 +639,7 @@ describe("Envio candidate audit", () => {
         baseline: await baseline(),
         sourceCommit: SOURCE_COMMIT,
         deployment: deployment(identity),
-        fetcher: fixtureFetcher({ identity, progressBlock: 1_100 }).fetcher,
+        fetcher: candidateFixture({ identity, progressBlock: 1_100 }).fetcher,
       }),
     ).rejects.toThrow(/reviewed checkout identity mismatch/u);
   });
@@ -614,7 +657,7 @@ describe("Envio candidate audit", () => {
         ...common,
         endpoint: CANDIDATE_ENDPOINT,
         deployment: { ...deployment(identity), "deployment-endpoint-id": "other01" },
-        fetcher: fixtureFetcher({ identity, progressBlock: 1_100 }).fetcher,
+        fetcher: candidateFixture({ identity, progressBlock: 1_100 }).fetcher,
       }),
     ).rejects.toThrow(/reviewed Envio/u);
     await expect(
@@ -622,7 +665,7 @@ describe("Envio candidate audit", () => {
         ...common,
         endpoint: CANDIDATE_ENDPOINT,
         deployment: { ...deployment(identity), "deployment-label": "production-substitute" },
-        fetcher: fixtureFetcher({ identity, progressBlock: 1_100 }).fetcher,
+        fetcher: candidateFixture({ identity, progressBlock: 1_100 }).fetcher,
       }),
     ).rejects.toThrow(/does not match candidate identity/u);
     await expect(
@@ -630,7 +673,7 @@ describe("Envio candidate audit", () => {
         ...common,
         endpoint: CANDIDATE_ENDPOINT,
         deployment: { ...deployment(identity), "mirror-commit": "HEAD" },
-        fetcher: fixtureFetcher({ identity, progressBlock: 1_100 }).fetcher,
+        fetcher: candidateFixture({ identity, progressBlock: 1_100 }).fetcher,
       }),
     ).rejects.toThrow(/mirror commit is invalid/u);
     await expect(
@@ -638,7 +681,7 @@ describe("Envio candidate audit", () => {
         ...common,
         endpoint: CANDIDATE_ENDPOINT,
         deployment: deployment(identity),
-        fetcher: fixtureFetcher({
+        fetcher: candidateFixture({
           identity: { ...identity, eventSetSha256: hex(32, 123) },
           progressBlock: 1_100,
         }).fetcher,
@@ -655,7 +698,7 @@ describe("Envio candidate audit", () => {
         baseline: await baseline(),
         sourceCommit: SOURCE_COMMIT,
         deployment: deployment(identity),
-        fetcher: fixtureFetcher({ identity, progressBlock: 999 }).fetcher,
+        fetcher: candidateFixture({ identity, progressBlock: 999 }).fetcher,
       }),
     ).rejects.toThrow(/has not reached/u);
   });
@@ -672,7 +715,7 @@ describe("Envio candidate audit", () => {
         baseline: frozenBaseline,
         sourceCommit: SOURCE_COMMIT,
         deployment: deployment(identity),
-        fetcher: fixtureFetcher({ identity, rows: changed, progressBlock: 1_100 }).fetcher,
+        fetcher: candidateFixture({ identity, rows: changed, progressBlock: 1_100 }).fetcher,
       }),
     ).rejects.toThrow(/changed frozen launch .* at totalSupply/u);
   });

--- a/indexer/test/replay.test.ts
+++ b/indexer/test/replay.test.ts
@@ -10,7 +10,10 @@ import {
   canonicalPayloadJson,
   encodeEventPayload,
 } from "../src/lib/payload-hash.js";
-import { SOURCE_REGISTRY } from "../src/lib/release-map.js";
+import {
+  SOURCE_REGISTRY,
+  staticReleaseForContract,
+} from "../src/lib/release-map.js";
 
 const POOL_ID =
   "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -431,6 +434,11 @@ describe("checked-in manifest fixtures", () => {
       ["StockV2V3RewardVaultFactory", stockV2.addresses.feeSplitVaultFactory, stockV2.startBlock],
       ["StockV3Launcher", stockV3.addresses.launcher, stockV3.startBlock],
       ["StockV3EthCoordinator", stockV3.addresses.ethLaunchCoordinator, stockV3.startBlock],
+      ["CustomRegistryV1", "0x17e18c88bda9bfb73924cdc989c07b0707e72671", 25_701_139],
+      ["CustomPartnerFactoryRegistryV1", "0xf8aef69201621ad20fa256da595426b7e6192dba", 25_701_136],
+      ["CustomAtomicRegistrarV1", "0xcc916e5200d2626edfd918dc219bc4296629e997", 25_701_142],
+      ["ClassicV4Hook", "0xadf955a44fd7f009380240d56d71dfafb46020cc", 25_851_137],
+      ["ClassicV4Launcher", "0x1af508f9af9f8f5cf7bf712b7d2974d4ee7a6681", 25_851_150],
     ].map(([contractName, address, startBlock]) => ({
       contractName: String(contractName),
       address: String(address).toLowerCase(),
@@ -438,6 +446,16 @@ describe("checked-in manifest fixtures", () => {
     }));
 
     expect([...SOURCE_REGISTRY]).toEqual(expected);
+    for (const contractName of [
+      "CustomRegistryV1",
+      "CustomPartnerFactoryRegistryV1",
+      "CustomAtomicRegistrarV1",
+    ]) {
+      expect(staticReleaseForContract(contractName)).toEqual({
+        model: "custom",
+        releaseVersion: "custom-registry-v1",
+      });
+    }
 
     const config = parse(
       readFileSync(path.join(process.cwd(), "config.yaml"), "utf8"),
@@ -465,7 +483,10 @@ describe("checked-in manifest fixtures", () => {
             })),
       );
     expect(configuredAddresses).toEqual(
-      expected.map(({ contractName, address }) => ({ contractName, address })),
+      expected.map(({ contractName, address }) => ({
+        contractName,
+        address,
+      })),
     );
     expect(config).toMatchObject({
       address_format: "lowercase",

--- a/indexer/test/replay.test.ts
+++ b/indexer/test/replay.test.ts
@@ -438,7 +438,7 @@ describe("checked-in manifest fixtures", () => {
       ["CustomPartnerFactoryRegistryV1", "0xf8aef69201621ad20fa256da595426b7e6192dba", 25_701_136],
       ["CustomAtomicRegistrarV1", "0xcc916e5200d2626edfd918dc219bc4296629e997", 25_701_142],
       ["ClassicV4Hook", "0xadf955a44fd7f009380240d56d71dfafb46020cc", 25_851_137],
-      ["ClassicV4Launcher", "0x1af508f9af9f8f5cf7bf712b7d2974d4ee7a6681", 25_851_150],
+      ["ClassicV4Launcher", "0xbbdf30a2fe1394e4aa864ac269c6cf09b518e699", 25_853_086],
     ].map(([contractName, address, startBlock]) => ({
       contractName: String(contractName),
       address: String(address).toLowerCase(),


### PR DESCRIPTION
Adds the source-only Envio candidate for the final Classic V4 hook and launcher while preserving the existing 66 events and Custom Registry V1. Includes exact release-binding generation, append-only handler coverage, and regression tests. This PR does not activate a provider deployment or public catalog binding.