### PR TITLE
Fix production gitleaks squash fingerprint

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -3,3 +3,4 @@
 476f12e8eb16363d95d9b95952ece2856e7d1a60:scripts/data-pipeline/candidate-restore.mjs:generic-api-key:129
 # False positive: Solidity position-liquidity assignment, not an API credential.
 28fcea6ee143e5a259e50a3d22b50c744c2e9e54:contracts/src/MemeLaunchV4.sol:generic-api-key:316
+1ea44bd6b6552a51194a4f82c01d41abb9f87d89:contracts/src/MemeLaunchV4.sol:generic-api-key:316


### PR DESCRIPTION
Adds the GitHub squash-merge fingerprint for the already-reviewed Solidity position-liquidity false positive. The exact production merge range now scans with zero findings.