### PR TITLE
Harden finalized trading and partner attribution

### DIFF
--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -23,8 +23,8 @@ import { readProductionCustomExploreDirectoryV1 } from
   "../../../../lib/server/custom-launch/explore-directory-v1";
 import { readProductionSourceVerificationDisplayV1 } from
   "../../../../lib/server/custom-launch/source-verification-display-v1";
-import { routerTradeProjectForEntryV1 } from
-  "../../../../lib/custom-launch/router-trade-adapters-v1";
+import { routerTradeProjectForServerBoundEntryV1 } from
+  "../../../../lib/server/custom-launch/router-trade-descriptor-v1";
 import {
   publicExploreCatalogEntriesV1,
   publicExplorePresentationEntryV1,
@@ -402,7 +402,10 @@ export async function GET(request: NextRequest) {
   }
 
   const routerTradeProject = entry.exploreKind === "token"
-    ? routerTradeProjectForEntryV1(entry)
+    ? routerTradeProjectForServerBoundEntryV1(
+        entry,
+        acceptedRouterSnapshot,
+      )
     : null;
   const sourceVerificationPromise = entry.exploreKind === "token"
       && entry.launchCategoryProvenance.category === "custom"

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -28,6 +28,8 @@ import {
 } from "@/components/token-price-chart";
 import { TokenDetailShell } from "@/components/token-detail-shell";
 import { CustomMarketTrade } from "@/components/custom-market-trade";
+import { PartnerLaunchAttribution } from
+  "@/components/partner-launch-attribution";
 import { CreatorArticle } from "@/components/creator-article";
 import { CreatorArticleEditAction } from
   "@/components/creator-article-edit-action";
@@ -74,6 +76,8 @@ import {
 import { PROGRAMMABLE_MAIN_TOKEN_ADDRESS } from
   "@/lib/creator-article/programmable-example-v1";
 import type { PostLaunchAuthorityInventoryV1 } from "@/lib/custom-launch/contract-v2";
+import { parseLaunchPartnerAttributionV1 } from
+  "@/lib/launch-partner-attribution";
 import styles from "./token-experience.module.css";
 
 type DetailToken = LauncherToken & Readonly<{
@@ -497,6 +501,12 @@ function parseLauncherToken(value: unknown): DetailToken | null {
         .map(parseTokenLink)
         .filter((link): link is TokenLink => link !== null)
     : [];
+  const partnerAttribution = value.partnerAttribution === undefined
+    ? undefined
+    : parseLaunchPartnerAttributionV1(value.partnerAttribution);
+  if (value.partnerAttribution !== undefined && partnerAttribution === null) {
+    return null;
+  }
   const uniswapV4Pool =
     value.uniswapV4Pool === undefined
       ? undefined
@@ -513,6 +523,7 @@ function parseLauncherToken(value: unknown): DetailToken | null {
     imageUrl: safePublicImageUrl(value.imageUrl),
     uniswapV4Pool: uniswapV4Pool ?? undefined,
     ...(platformFeePolicy ? { platformFeePolicy } : {}),
+    ...(partnerAttribution ? { partnerAttribution } : {}),
   };
   const valuation = value.valuation === undefined
     ? exploreValuation(token)
@@ -803,6 +814,25 @@ function parseRouterTradeProject(
       ...(candidate.poolId === undefined ? {} : { poolId: candidate.poolId }),
     });
     if (capability === null) return null;
+    const baseCurrency = capability.poolKey.currency0AssetId
+        === baseAsset.assetId
+      ? capability.poolKey.currency0
+      : capability.poolKey.currency1;
+    const quoteCurrency = capability.poolKey.currency0AssetId
+        === quoteAsset.assetId
+      ? capability.poolKey.currency0
+      : capability.poolKey.currency1;
+    const namespace = `eip155:${token.launchStampProvenance.chainId}`;
+    if (
+      baseAsset.identity.namespace !== namespace
+      || quoteAsset.identity.namespace !== namespace
+      || !isAddress(baseAsset.identity.value)
+      || !isAddress(quoteAsset.identity.value)
+      || baseCurrency.value.toLowerCase()
+        !== baseAsset.identity.value.toLowerCase()
+      || quoteCurrency.value.toLowerCase()
+        !== quoteAsset.identity.value.toLowerCase()
+    ) return null;
     markets.push({
       marketId: candidate.marketId,
       kind: candidate.kind,
@@ -819,9 +849,7 @@ function parseRouterTradeProject(
       market.status === "active" &&
       market.poolId?.toLowerCase() === token.poolId.toLowerCase() &&
       market.baseAsset.identity.value.toLowerCase() ===
-        token.tokenAddress.toLowerCase() &&
-      market.quoteAsset.identity.value.toLowerCase() ===
-        "0x0000000000000000000000000000000000000000",
+        token.tokenAddress.toLowerCase(),
   );
   if (!exactMarket) return null;
 
@@ -1895,6 +1923,12 @@ function TokenDetailContent({
               >
                 {token.name}
               </h1>
+              {token.partnerAttribution ? (
+                <PartnerLaunchAttribution
+                  attribution={token.partnerAttribution}
+                  compact
+                />
+              ) : null}
               <div className={styles.addressActions}>
                 <button
                   className={styles.address}
@@ -2005,8 +2039,8 @@ function TokenDetailContent({
             <div className={styles.routerNotice} role="status">
               <strong>Router launch</strong>
               <p>
-                This page shows launch data only. Trading is not enabled here
-                for this PoolKey.
+                Onsite trading is not enabled for this launch. Launch details
+                remain available.
               </p>
             </div>
           ) : !canUseClassicTrade || classicSwapFeeBps === null ? (

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -2743,6 +2743,8 @@ export function WalletButton({ compact = false }: { compact?: boolean }) {
     disconnect,
     openWallet,
     preloadWallet,
+    getAccessToken,
+    getIdentityToken,
   } = useWallet();
   const menuRef = useRef<HTMLDivElement>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
@@ -2750,6 +2752,8 @@ export function WalletButton({ compact = false }: { compact?: boolean }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuCopied, setMenuCopied] = useState(false);
   const [menuError, setMenuError] = useState("");
+  const [partnerAdminAccount, setPartnerAdminAccount] =
+    useState<string | null>(null);
   const hydrationPending = !authReady;
   const openingWallet = connecting && authReady;
 
@@ -2779,6 +2783,46 @@ export function WalletButton({ compact = false }: { compact?: boolean }) {
       window.removeEventListener("keydown", closeOnEscape);
     };
   }, [menuOpen]);
+
+  useEffect(() => {
+    const account = wallet?.account ?? null;
+    if (!menuOpen || !account) return;
+    const controller = new AbortController();
+    void (async () => {
+      try {
+        const [accessToken, identityToken] = await Promise.all([
+          getAccessToken(),
+          getIdentityToken().catch(() => null),
+        ]);
+        if (!accessToken || controller.signal.aborted) return;
+        const headers = new Headers({
+          Accept: "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        });
+        if (identityToken) {
+          headers.set("X-Privy-Identity-Token", identityToken);
+        }
+        const query = new URLSearchParams({
+          walletAddress: account,
+          page: "1",
+          pageSize: "1",
+        });
+        const response = await fetch(`/api/admin/partners?${query}`, {
+          cache: "no-store",
+          headers,
+          signal: controller.signal,
+        });
+        if (response.ok && !controller.signal.aborted) {
+          setPartnerAdminAccount(account);
+        }
+      } catch (error) {
+        if (!(error instanceof DOMException && error.name === "AbortError")) {
+          setPartnerAdminAccount(null);
+        }
+      }
+    })();
+    return () => controller.abort();
+  }, [getAccessToken, getIdentityToken, menuOpen, wallet?.account]);
 
   const label = disconnecting
     ? "Disconnecting"
@@ -2823,6 +2867,7 @@ export function WalletButton({ compact = false }: { compact?: boolean }) {
       onClick={() => {
         if (wallet) {
           setMenuError("");
+          setPartnerAdminAccount(null);
           setMenuOpen((current) => !current);
         } else {
           openWallet();
@@ -2904,6 +2949,17 @@ export function WalletButton({ compact = false }: { compact?: boolean }) {
         >
           API keys
         </Link>
+        {partnerAdminAccount?.toLowerCase()
+            === wallet.account.toLowerCase() ? (
+          <Link
+            href="/admin/partners"
+            prefetch={false}
+            tabIndex={menuOpen ? undefined : -1}
+            onClick={() => setMenuOpen(false)}
+          >
+            Partner admin
+          </Link>
+        ) : null}
         <button
           type="button"
           tabIndex={menuOpen ? undefined : -1}

--- a/lib/server/custom-launch/finalized-custom-launch-metadata-feed-v1.ts
+++ b/lib/server/custom-launch/finalized-custom-launch-metadata-feed-v1.ts
@@ -19,6 +19,10 @@ import {
   parseLaunchPartnerAttributionV1,
   type LaunchPartnerAttributionV1,
 } from "../../launch-partner-attribution";
+import {
+  parseFinalizedTradeAdapterDescriptorV1,
+  type FinalizedTradeAdapterDescriptorV1,
+} from "./finalized-trade-adapter-descriptor-v1";
 
 export const FINALIZED_CUSTOM_LAUNCH_METADATA_FEED_URL =
   "https://api.programmable.market/v3/finalized-custom-launches" as const;
@@ -170,6 +174,7 @@ export type FinalizedCustomLaunchMetadataV1 = Readonly<{
   projectMetadata: ProjectMetadataV1;
   projectMetadataHash: Sha256Digest;
   partnerAttribution?: LaunchPartnerAttributionV1;
+  tradeAdapterDescriptor?: FinalizedTradeAdapterDescriptorV1;
   bindings: Readonly<{
     requestHash: Sha256Digest;
     launchIntentHash: Sha256Digest;
@@ -229,6 +234,7 @@ export type RouterCustomMetadataOverlayBindingV1 = Readonly<{
   unboundGraphBundleHash: Sha256Digest;
   artifactHash: Sha256Digest;
   partnerAttribution?: LaunchPartnerAttributionV1;
+  tradeAdapterDescriptor?: FinalizedTradeAdapterDescriptorV1;
   tokenMetadataReadback: Readonly<{
     status: "matching" | "unavailable";
     observedAtBlockNumber: string | null;
@@ -497,6 +503,9 @@ export async function enrichRouterCustomSnapshotWithFinalizedMetadataV1<
       ...(metadata.partnerAttribution
         ? { partnerAttribution: metadata.partnerAttribution }
         : {}),
+      ...(metadata.tradeAdapterDescriptor
+        ? { tradeAdapterDescriptor: metadata.tradeAdapterDescriptor }
+        : {}),
       tokenMetadataReadback: Object.freeze({
         status: metadata.tokenMetadataReadback.status,
         observedAtBlockNumber:
@@ -669,12 +678,17 @@ function parseLaunchV1(value: JsonValue): FinalizedCustomLaunchMetadataV1 {
     && typeof value === "object"
     && !Array.isArray(value)
     && Object.hasOwn(value, "partnerAttribution");
+  const hasTradeAdapterDescriptor = value !== null
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && Object.hasOwn(value, "tradeAdapterDescriptor");
   const record = exactRecord(value, [
     "schemaVersion", "resourceId", "routerLaunchId", "chainId", "router",
     "token", "hook", "poolManager", "poolId", "projectMetadata",
     "projectMetadataHash", "bindings", "tokenMetadataReadback", "finality",
     "createdAt", "finalizedAt",
     ...(hasPartnerAttribution ? ["partnerAttribution"] : []),
+    ...(hasTradeAdapterDescriptor ? ["tradeAdapterDescriptor"] : []),
   ], "Finalized Custom metadata item");
   if (
     record.schemaVersion !== FINALIZED_CUSTOM_LAUNCH_METADATA_SCHEMA_V1
@@ -733,6 +747,39 @@ function parseLaunchV1(value: JsonValue): FinalizedCustomLaunchMetadataV1 {
     throw new Error("Finalized Custom metadata timestamps are invalid");
   }
   const finality = parseFinalityV1(record.finality);
+  const routerLaunchId = lowerBytes32(
+    record.routerLaunchId,
+    "Router launch id",
+  );
+  const router = canonicalAddress(record.router, "Router address");
+  const token = canonicalAddress(record.token, "token address");
+  const hook = canonicalAddress(record.hook, "hook address");
+  const poolManager = canonicalAddress(
+    record.poolManager,
+    "PoolManager address",
+  );
+  const poolId = lowerBytes32(record.poolId, "pool id");
+  const tradeAdapterDescriptor = hasTradeAdapterDescriptor
+    ? parseFinalizedTradeAdapterDescriptorV1(
+        record.tradeAdapterDescriptor,
+        {
+          routerLaunchId,
+          router,
+          token,
+          hook,
+          poolManager,
+          poolId,
+          artifactHash: bindings.artifactHash,
+          graphBundleHash: bindings.graphBundleHash,
+          finality: {
+            transactionHash: finality.transactionHash,
+            blockNumber: finality.blockNumber,
+            blockHash: finality.blockHash,
+            logIndex: finality.logIndex,
+          },
+        },
+      )
+    : null;
   const readback = parseTokenMetadataReadbackV1(
     record.tokenMetadataReadback,
     projectMetadata,
@@ -745,16 +792,17 @@ function parseLaunchV1(value: JsonValue): FinalizedCustomLaunchMetadataV1 {
   return deepFreeze({
     schemaVersion: FINALIZED_CUSTOM_LAUNCH_METADATA_SCHEMA_V1,
     resourceId: record.resourceId,
-    routerLaunchId: lowerBytes32(record.routerLaunchId, "Router launch id"),
+    routerLaunchId,
     chainId: "1",
-    router: canonicalAddress(record.router, "Router address"),
-    token: canonicalAddress(record.token, "token address"),
-    hook: canonicalAddress(record.hook, "hook address"),
-    poolManager: canonicalAddress(record.poolManager, "PoolManager address"),
-    poolId: lowerBytes32(record.poolId, "pool id"),
+    router,
+    token,
+    hook,
+    poolManager,
+    poolId,
     projectMetadata,
     projectMetadataHash,
     ...(partnerAttribution ? { partnerAttribution } : {}),
+    ...(tradeAdapterDescriptor ? { tradeAdapterDescriptor } : {}),
     bindings,
     tokenMetadataReadback: readback,
     finality,

--- a/lib/server/custom-launch/finalized-trade-adapter-descriptor-v1.ts
+++ b/lib/server/custom-launch/finalized-trade-adapter-descriptor-v1.ts
@@ -1,0 +1,533 @@
+import "server-only";
+
+import { getAddress } from "viem";
+
+import type {
+  DiscoverableLaunchMarketV2,
+  DiscoverableMarketTradeCapabilityV1,
+} from "../../custom-launch/contract-v2";
+import { parseDiscoverableMarketTradeCapabilityV1 } from
+  "../../custom-launch/trade-capability-v1";
+import { computeOfficialV4PoolId } from
+  "../../uniswap/liquidity-launcher-sdk";
+import type { JsonValue } from "../projection-target/canonical-json";
+import { canonicalSha256 } from "../projection-target/hashing";
+
+export const FINALIZED_TRADE_ADAPTER_DESCRIPTOR_SCHEMA_V1 =
+  "programmable.finalized-trade-adapter-descriptor.v1" as const;
+export const FINALIZED_TRADE_ADAPTER_PROJECT_SCHEMA_V1 =
+  "programmable.finalized-trade-adapter-project.v1" as const;
+export const FINALIZED_TRADE_ADAPTER_VERIFIER_V1 =
+  "programmable-server-trade-route-review:v1" as const;
+
+const ADDRESS = /^0x[0-9a-f]{40}$/u;
+const HASH32 = /^0x[0-9a-f]{64}$/u;
+const DIGEST = /^sha256:[0-9a-f]{64}$/u;
+const IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._:@/+~-]{0,255}$/u;
+const DECIMAL = /^(?:0|[1-9][0-9]*)$/u;
+const SIGNED_DECIMAL = /^-?(?:0|[1-9][0-9]*)$/u;
+const SAFE_TEXT = /^[^\u0000-\u001f\u007f\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]+$/u;
+const ROUTER_MARKET_ID = /^router-v1-[0-9a-f]{64}$/u;
+
+type Sha256Digest = `sha256:${string}`;
+type Hash32 = `0x${string}`;
+type Address = `0x${string}`;
+type JsonRecord = { readonly [key: string]: JsonValue };
+
+export type FinalizedTradeAdapterAssetV1 = Readonly<{
+  assetId: string;
+  identity: Readonly<{ namespace: "eip155:1"; value: Address }>;
+  name: string;
+  symbol: string;
+  decimals: number;
+}>;
+
+export type FinalizedTradeAdapterRuntimeTargetV1 = Readonly<{
+  targetId: string;
+  kind: "token" | "hook" | "other";
+  identity: Readonly<{ namespace: "eip155:1"; value: Address }>;
+  runtimeCodeKeccak256: Hash32;
+  runtimeCodeSha256: Sha256Digest;
+}>;
+
+export type FinalizedTradeAdapterBindingContextV1 = Readonly<{
+  routerLaunchId: Hash32;
+  router: Address;
+  token: Address;
+  hook: Address;
+  poolManager: Address;
+  poolId: Hash32;
+  artifactHash: Sha256Digest;
+  graphBundleHash: Sha256Digest;
+  finality: Readonly<{
+    transactionHash: Hash32;
+    blockNumber: string;
+    blockHash: Hash32;
+    logIndex: number;
+  }>;
+}>;
+
+export type FinalizedTradeAdapterDescriptorV1 = Readonly<{
+  schemaVersion: typeof FINALIZED_TRADE_ADAPTER_DESCRIPTOR_SCHEMA_V1;
+  status: "verified";
+  adapterId: "uniswap-v4-universal-router-exact-input:v1";
+  projectId: Sha256Digest;
+  chainProfileId: string;
+  chainProfileHash: Sha256Digest;
+  market: Readonly<DiscoverableLaunchMarketV2> & Readonly<{
+    tradeCapability: Readonly<DiscoverableMarketTradeCapabilityV1>;
+  }>;
+  baseAsset: FinalizedTradeAdapterAssetV1;
+  quoteAsset: FinalizedTradeAdapterAssetV1;
+  runtimeTargets: readonly FinalizedTradeAdapterRuntimeTargetV1[];
+  serverVerification: Readonly<{
+    verifierAdapterId: typeof FINALIZED_TRADE_ADAPTER_VERIFIER_V1;
+    verifiedAt: string;
+    evidenceHash: Sha256Digest;
+  }>;
+  descriptorDigest: Sha256Digest;
+}>;
+
+type DescriptorCoreV1 = Omit<
+  FinalizedTradeAdapterDescriptorV1,
+  "descriptorDigest"
+>;
+
+export function finalizedTradeAdapterMarketIdV1(routerLaunchId: string) {
+  return `router-v1-${routerLaunchId.slice(2).toLowerCase()}`;
+}
+
+export function isFinalizedTradeAdapterMarketIdV1(value: string) {
+  return ROUTER_MARKET_ID.test(value);
+}
+
+export function finalizedTradeAdapterProjectIdV1(
+  context: FinalizedTradeAdapterBindingContextV1,
+) {
+  return canonicalSha256(FINALIZED_TRADE_ADAPTER_PROJECT_SCHEMA_V1, context);
+}
+
+function record(value: JsonValue | undefined): JsonRecord | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as JsonRecord
+    : null;
+}
+
+function exactRecord(
+  value: JsonValue | undefined,
+  keys: readonly string[],
+): JsonRecord | null {
+  const candidate = record(value);
+  if (candidate === null) return null;
+  const actual = Object.keys(candidate).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length
+      && actual.every((key, index) => key === expected[index])
+    ? candidate
+    : null;
+}
+
+function digest(value: JsonValue | undefined): Sha256Digest | null {
+  return typeof value === "string" && DIGEST.test(value)
+    ? value as Sha256Digest
+    : null;
+}
+
+function hash32(value: JsonValue | undefined): Hash32 | null {
+  return typeof value === "string" && HASH32.test(value)
+    ? value as Hash32
+    : null;
+}
+
+function address(value: JsonValue | undefined): Address | null {
+  return typeof value === "string" && ADDRESS.test(value)
+    ? value as Address
+    : null;
+}
+
+function sameHex(left: string, right: string) {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function identity(
+  value: JsonValue | undefined,
+): Readonly<{ namespace: "eip155:1"; value: Address }> | null {
+  const candidate = exactRecord(value, ["namespace", "value"]);
+  const valueAddress = candidate ? address(candidate.value) : null;
+  return candidate?.namespace === "eip155:1" && valueAddress
+    ? Object.freeze({ namespace: "eip155:1" as const, value: valueAddress })
+    : null;
+}
+
+function text(
+  value: JsonValue | undefined,
+  minimum: number,
+  maximum: number,
+) {
+  return typeof value === "string"
+      && value === value.trim()
+      && value.length >= minimum
+      && value.length <= maximum
+      && SAFE_TEXT.test(value)
+    ? value
+    : null;
+}
+
+function deepFreeze<T>(value: T): Readonly<T> {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) {
+    return value;
+  }
+  for (const nested of Object.values(value as Record<string, unknown>)) {
+    deepFreeze(nested);
+  }
+  return Object.freeze(value);
+}
+
+function parseAssetV1(
+  value: JsonValue | undefined,
+): FinalizedTradeAdapterAssetV1 | null {
+  const candidate = exactRecord(value, [
+    "assetId", "decimals", "identity", "name", "symbol",
+  ]);
+  const assetIdentity = candidate ? identity(candidate.identity) : null;
+  const name = candidate ? text(candidate.name, 1, 64) : null;
+  const symbol = candidate ? text(candidate.symbol, 1, 32) : null;
+  if (
+    candidate === null
+    || typeof candidate.assetId !== "string"
+    || !IDENTIFIER.test(candidate.assetId)
+    || assetIdentity === null
+    || name === null
+    || symbol === null
+    || !Number.isSafeInteger(candidate.decimals)
+    || Number(candidate.decimals) < 0
+    || Number(candidate.decimals) > 255
+  ) return null;
+  return deepFreeze({
+    assetId: candidate.assetId,
+    identity: assetIdentity,
+    name,
+    symbol,
+    decimals: Number(candidate.decimals),
+  });
+}
+
+function parseRuntimeTargetsV1(
+  value: JsonValue | undefined,
+  context: FinalizedTradeAdapterBindingContextV1,
+): readonly FinalizedTradeAdapterRuntimeTargetV1[] | null {
+  if (!Array.isArray(value) || value.length < 2 || value.length > 64) {
+    return null;
+  }
+  const targets: FinalizedTradeAdapterRuntimeTargetV1[] = [];
+  const targetIds = new Set<string>();
+  const addresses = new Set<string>();
+  let previousTargetId = "";
+  for (const item of value) {
+    const candidate = exactRecord(item, [
+      "identity", "kind", "runtimeCodeKeccak256", "runtimeCodeSha256",
+      "targetId",
+    ]);
+    const targetIdentity = candidate ? identity(candidate.identity) : null;
+    const runtimeCodeKeccak256 = candidate
+      ? hash32(candidate.runtimeCodeKeccak256)
+      : null;
+    const runtimeCodeSha256 = candidate
+      ? digest(candidate.runtimeCodeSha256)
+      : null;
+    if (
+      candidate === null
+      || typeof candidate.targetId !== "string"
+      || !IDENTIFIER.test(candidate.targetId)
+      || candidate.targetId <= previousTargetId
+      || (candidate.kind !== "token"
+        && candidate.kind !== "hook"
+        && candidate.kind !== "other")
+      || targetIdentity === null
+      || runtimeCodeKeccak256 === null
+      || runtimeCodeSha256 === null
+      || targetIds.has(candidate.targetId)
+      || addresses.has(targetIdentity.value)
+    ) return null;
+    previousTargetId = candidate.targetId;
+    targetIds.add(candidate.targetId);
+    addresses.add(targetIdentity.value);
+    targets.push(deepFreeze({
+      targetId: candidate.targetId,
+      kind: candidate.kind,
+      identity: targetIdentity,
+      runtimeCodeKeccak256,
+      runtimeCodeSha256,
+    }));
+  }
+  const tokens = targets.filter(({ kind }) => kind === "token");
+  const hooks = targets.filter(({ kind }) => kind === "hook");
+  if (
+    tokens.length !== 1
+    || hooks.length !== 1
+    || !sameHex(tokens[0]!.identity.value, context.token)
+    || !sameHex(hooks[0]!.identity.value, context.hook)
+  ) return null;
+  return Object.freeze(targets);
+}
+
+function parseMarketV1(
+  value: JsonValue | undefined,
+  input: Readonly<{
+    context: FinalizedTradeAdapterBindingContextV1;
+    chainProfileId: string;
+    chainProfileHash: Sha256Digest;
+    baseAsset: FinalizedTradeAdapterAssetV1;
+    quoteAsset: FinalizedTradeAdapterAssetV1;
+  }>,
+): FinalizedTradeAdapterDescriptorV1["market"] | null {
+  const market = exactRecord(value, [
+    "baseAssetId", "kind", "marketAssetId", "marketEvidenceHash", "marketId",
+    "quoteAssetId", "status", "tradeCapability", "uniswapV4", "verification",
+  ]);
+  if (
+    market === null
+    || typeof market.marketId !== "string"
+    || market.marketId !== finalizedTradeAdapterMarketIdV1(
+      input.context.routerLaunchId,
+    )
+    || typeof market.kind !== "string"
+    || !IDENTIFIER.test(market.kind)
+    || typeof market.marketAssetId !== "string"
+    || !IDENTIFIER.test(market.marketAssetId)
+    || market.baseAssetId !== input.baseAsset.assetId
+    || market.quoteAssetId !== input.quoteAsset.assetId
+    || market.status !== "active"
+    || digest(market.marketEvidenceHash) === null
+  ) return null;
+
+  const verification = exactRecord(market.verification, [
+    "status", "verifierAdapterId", "verifierBindingHash",
+  ]);
+  if (
+    verification === null
+    || verification.status !== "verified"
+    || typeof verification.verifierAdapterId !== "string"
+    || !IDENTIFIER.test(verification.verifierAdapterId)
+    || digest(verification.verifierBindingHash) === null
+  ) return null;
+
+  const pool = exactRecord(market.uniswapV4, [
+    "currency0AssetId", "currency1AssetId", "dynamicFee", "feeRaw",
+    "hooksAssetId", "poolId", "poolKeyEvidenceHash", "poolManager",
+    "poolManagerInterfaceEvidenceBindingHash",
+    "poolManagerReviewEvidenceBindingHash", "poolManagerRuntimeCodeKeccak256",
+    "poolManagerRuntimeCodeSha256", "tickSpacing",
+  ]);
+  const poolManager = pool ? identity(pool.poolManager) : null;
+  const poolId = pool ? hash32(pool.poolId) : null;
+  const poolManagerRuntimeCodeKeccak256 = pool
+    ? hash32(pool.poolManagerRuntimeCodeKeccak256)
+    : null;
+  const poolManagerRuntimeCodeSha256 = pool
+    ? digest(pool.poolManagerRuntimeCodeSha256)
+    : null;
+  if (
+    pool === null
+    || poolManager === null
+    || poolId === null
+    || !sameHex(poolManager.value, input.context.poolManager)
+    || !sameHex(poolId, input.context.poolId)
+    || typeof pool.currency0AssetId !== "string"
+    || typeof pool.currency1AssetId !== "string"
+    || !IDENTIFIER.test(pool.currency0AssetId)
+    || !IDENTIFIER.test(pool.currency1AssetId)
+    || typeof pool.feeRaw !== "string"
+    || !DECIMAL.test(pool.feeRaw)
+    || BigInt(pool.feeRaw) > 0xff_ffffn
+    || typeof pool.tickSpacing !== "string"
+    || !SIGNED_DECIMAL.test(pool.tickSpacing)
+    || BigInt(pool.tickSpacing) < -0x80_0000n
+    || BigInt(pool.tickSpacing) > 0x7f_ffffn
+    || typeof pool.dynamicFee !== "boolean"
+    || pool.dynamicFee !== (BigInt(pool.feeRaw) === 0x80_0000n)
+    || (pool.hooksAssetId !== null
+      && (typeof pool.hooksAssetId !== "string"
+        || !IDENTIFIER.test(pool.hooksAssetId)))
+    || digest(pool.poolKeyEvidenceHash) === null
+    || digest(pool.poolManagerInterfaceEvidenceBindingHash) === null
+    || digest(pool.poolManagerReviewEvidenceBindingHash) === null
+    || poolManagerRuntimeCodeKeccak256 === null
+    || poolManagerRuntimeCodeSha256 === null
+  ) return null;
+
+  const capability = parseDiscoverableMarketTradeCapabilityV1({
+    value: market.tradeCapability,
+    chainId: "1",
+    marketId: market.marketId,
+    baseAssetId: input.baseAsset.assetId,
+    quoteAssetId: input.quoteAsset.assetId,
+    poolId,
+  });
+  const baseCurrency = capability?.poolKey.currency0AssetId
+      === input.baseAsset.assetId
+    ? capability.poolKey.currency0
+    : capability?.poolKey.currency1;
+  const quoteCurrency = capability?.poolKey.currency0AssetId
+      === input.quoteAsset.assetId
+    ? capability.poolKey.currency0
+    : capability?.poolKey.currency1;
+  if (
+    capability === null
+    || capability.chainProfileId !== input.chainProfileId
+    || capability.chainProfileHash !== input.chainProfileHash
+    || capability.adapterId !==
+      "uniswap-v4-universal-router-exact-input:v1"
+    || capability.poolKey.currency0AssetId !== pool.currency0AssetId
+    || capability.poolKey.currency1AssetId !== pool.currency1AssetId
+    || capability.poolKey.feeRaw !== pool.feeRaw
+    || capability.poolKey.tickSpacing !== pool.tickSpacing
+    || capability.poolKey.hooksAssetId !== pool.hooksAssetId
+    || capability.poolKeyEvidenceHash !== pool.poolKeyEvidenceHash
+    || !sameHex(capability.poolKey.hooks.value, input.context.hook)
+    || baseCurrency === undefined
+    || quoteCurrency === undefined
+    || !sameHex(baseCurrency.value, input.baseAsset.identity.value)
+    || !sameHex(quoteCurrency.value, input.quoteAsset.identity.value)
+  ) return null;
+
+  const recomputedPoolId = computeOfficialV4PoolId({
+    currency0: getAddress(capability.poolKey.currency0.value),
+    currency1: getAddress(capability.poolKey.currency1.value),
+    fee: Number(capability.poolKey.feeRaw),
+    tickSpacing: Number(capability.poolKey.tickSpacing),
+    hooks: getAddress(capability.poolKey.hooks.value),
+  });
+  if (!sameHex(recomputedPoolId, input.context.poolId)) return null;
+
+  return deepFreeze({
+    marketId: market.marketId,
+    kind: market.kind,
+    status: "active" as const,
+    marketAssetId: market.marketAssetId,
+    baseAssetId: input.baseAsset.assetId,
+    quoteAssetId: input.quoteAsset.assetId,
+    marketEvidenceHash: market.marketEvidenceHash as Sha256Digest,
+    verification: {
+      status: "verified" as const,
+      verifierAdapterId: verification.verifierAdapterId,
+      verifierBindingHash: verification.verifierBindingHash as Sha256Digest,
+    },
+    uniswapV4: {
+      poolId,
+      poolManager,
+      poolManagerReviewEvidenceBindingHash:
+        pool.poolManagerReviewEvidenceBindingHash as Sha256Digest,
+      poolManagerInterfaceEvidenceBindingHash:
+        pool.poolManagerInterfaceEvidenceBindingHash as Sha256Digest,
+      poolManagerRuntimeCodeKeccak256,
+      poolManagerRuntimeCodeSha256,
+      currency0AssetId: pool.currency0AssetId,
+      currency1AssetId: pool.currency1AssetId,
+      feeRaw: pool.feeRaw,
+      dynamicFee: pool.dynamicFee,
+      tickSpacing: pool.tickSpacing,
+      hooksAssetId: pool.hooksAssetId as string | null,
+      poolKeyEvidenceHash: pool.poolKeyEvidenceHash as Sha256Digest,
+    },
+    tradeCapability: capability,
+  });
+}
+
+export function finalizedTradeAdapterDescriptorDigestV1(
+  context: FinalizedTradeAdapterBindingContextV1,
+  descriptor: DescriptorCoreV1,
+) {
+  return canonicalSha256(FINALIZED_TRADE_ADAPTER_DESCRIPTOR_SCHEMA_V1, {
+    outerBinding: context,
+    descriptor,
+  });
+}
+
+export function parseFinalizedTradeAdapterDescriptorV1(
+  value: JsonValue | undefined,
+  context: FinalizedTradeAdapterBindingContextV1,
+): FinalizedTradeAdapterDescriptorV1 | null {
+  const candidate = exactRecord(value, [
+    "adapterId", "baseAsset", "chainProfileHash", "chainProfileId",
+    "descriptorDigest", "market", "projectId", "quoteAsset", "runtimeTargets",
+    "schemaVersion", "serverVerification", "status",
+  ]);
+  const projectId = candidate ? digest(candidate.projectId) : null;
+  const chainProfileHash = candidate ? digest(candidate.chainProfileHash) : null;
+  const descriptorDigest = candidate ? digest(candidate.descriptorDigest) : null;
+  const baseAsset = candidate ? parseAssetV1(candidate.baseAsset) : null;
+  const quoteAsset = candidate ? parseAssetV1(candidate.quoteAsset) : null;
+  if (
+    candidate === null
+    || candidate.schemaVersion !== FINALIZED_TRADE_ADAPTER_DESCRIPTOR_SCHEMA_V1
+    || candidate.status !== "verified"
+    || candidate.adapterId !==
+      "uniswap-v4-universal-router-exact-input:v1"
+    || projectId === null
+    || projectId !== finalizedTradeAdapterProjectIdV1(context)
+    || typeof candidate.chainProfileId !== "string"
+    || !IDENTIFIER.test(candidate.chainProfileId)
+    || chainProfileHash === null
+    || descriptorDigest === null
+    || baseAsset === null
+    || quoteAsset === null
+    || !sameHex(baseAsset.identity.value, context.token)
+    || baseAsset.assetId === quoteAsset.assetId
+    || sameHex(baseAsset.identity.value, quoteAsset.identity.value)
+  ) return null;
+
+  const runtimeTargets = parseRuntimeTargetsV1(
+    candidate.runtimeTargets,
+    context,
+  );
+  const serverVerification = exactRecord(candidate.serverVerification, [
+    "evidenceHash", "verifiedAt", "verifierAdapterId",
+  ]);
+  const evidenceHash = serverVerification
+    ? digest(serverVerification.evidenceHash)
+    : null;
+  if (
+    runtimeTargets === null
+    || serverVerification === null
+    || serverVerification.verifierAdapterId !==
+      FINALIZED_TRADE_ADAPTER_VERIFIER_V1
+    || typeof serverVerification.verifiedAt !== "string"
+    || !Number.isFinite(Date.parse(serverVerification.verifiedAt))
+    || new Date(serverVerification.verifiedAt).toISOString()
+      !== serverVerification.verifiedAt
+    || evidenceHash === null
+  ) return null;
+
+  const market = parseMarketV1(candidate.market, {
+    context,
+    chainProfileId: candidate.chainProfileId,
+    chainProfileHash,
+    baseAsset,
+    quoteAsset,
+  });
+  if (market === null) return null;
+
+  const core = deepFreeze({
+    schemaVersion: FINALIZED_TRADE_ADAPTER_DESCRIPTOR_SCHEMA_V1,
+    status: "verified" as const,
+    adapterId: "uniswap-v4-universal-router-exact-input:v1" as const,
+    projectId,
+    chainProfileId: candidate.chainProfileId,
+    chainProfileHash,
+    market,
+    baseAsset,
+    quoteAsset,
+    runtimeTargets,
+    serverVerification: {
+      verifierAdapterId: FINALIZED_TRADE_ADAPTER_VERIFIER_V1,
+      verifiedAt: serverVerification.verifiedAt,
+      evidenceHash,
+    },
+  });
+  if (
+    finalizedTradeAdapterDescriptorDigestV1(context, core)
+      !== descriptorDigest
+  ) return null;
+  return deepFreeze({ ...core, descriptorDigest });
+}

--- a/lib/server/custom-launch/router-trade-descriptor-v1.ts
+++ b/lib/server/custom-launch/router-trade-descriptor-v1.ts
@@ -1,0 +1,211 @@
+import "server-only";
+
+import {
+  resolveRouterTradeAdapterV1 as resolveReviewedRouterTradeAdapterV1,
+  type RouterTradeAdapterV1,
+} from "../../custom-launch/router-trade-adapters-v1";
+import type {
+  CanonicalTokenExploreEntry,
+  LaunchStampProvenanceV1,
+} from "../../tokens";
+import type { RouterCustomIdentitySnapshotV1 } from
+  "../../alchemy/router-custom-public.server";
+import type {
+  FinalizedTradeAdapterDescriptorV1,
+  FinalizedTradeAdapterRuntimeTargetV1,
+} from "./finalized-trade-adapter-descriptor-v1";
+import {
+  ROUTER_CUSTOM_METADATA_OVERLAY_SCHEMA_V1,
+  ROUTER_CUSTOM_METADATA_OVERLAY_SOURCE_V1,
+  type RouterCustomMetadataOverlayBindingV1,
+  type RouterCustomMetadataOverlayV1,
+} from "./finalized-custom-launch-metadata-feed-v1";
+import { canonicalSha256 } from "../projection-target/hashing";
+
+type SnapshotWithOptionalTradeMetadataV1 = RouterCustomIdentitySnapshotV1 &
+  Readonly<{ metadataOverlay?: RouterCustomMetadataOverlayV1 }>;
+
+function sameHex(left: unknown, right: unknown) {
+  return typeof left === "string" && typeof right === "string"
+    && left.toLowerCase() === right.toLowerCase();
+}
+
+function exactRuntimeTargetsV1(
+  stamp: LaunchStampProvenanceV1,
+  targets: readonly FinalizedTradeAdapterRuntimeTargetV1[],
+) {
+  const components = stamp.components.filter(
+    ({ scope }) => scope === "exclusive",
+  );
+  if (components.length !== targets.length) return false;
+  return targets.every((target) => {
+    const matches = components.filter((component) =>
+      component.kind === target.kind
+      && sameHex(component.address, target.identity.value)
+      && sameHex(component.runtimeCodeHash, target.runtimeCodeKeccak256)
+      && component.exclusiveProof !== null
+      && sameHex(component.exclusiveProof.launchId, stamp.launchId)
+      && sameHex(component.exclusiveProof.stampHash, stamp.stampHash));
+    return matches.length === 1;
+  });
+}
+
+function bindingMatchesEntryV1(
+  binding: RouterCustomMetadataOverlayBindingV1,
+  entry: CanonicalTokenExploreEntry,
+) {
+  const stamp = entry.launchStampProvenance;
+  return stamp?.kind === "custom-graph"
+    && sameHex(binding.routerLaunchId, stamp.launchId)
+    && sameHex(binding.router, stamp.routerAddress)
+    && sameHex(binding.token, entry.tokenAddress)
+    && sameHex(binding.hook, entry.hookAddress)
+    && sameHex(binding.poolManager, stamp.poolManagerAddress)
+    && sameHex(binding.poolId, entry.poolId);
+}
+
+function descriptorMatchesEntryV1(
+  descriptor: FinalizedTradeAdapterDescriptorV1,
+  entry: CanonicalTokenExploreEntry,
+) {
+  const stamp = entry.launchStampProvenance;
+  const capability = descriptor.market.tradeCapability;
+  if (
+    stamp?.kind !== "custom-graph"
+    || descriptor.status !== "verified"
+    || descriptor.market.status !== "active"
+    || descriptor.market.verification.status !== "verified"
+    || descriptor.market.uniswapV4 === null
+    || !sameHex(descriptor.baseAsset.identity.value, entry.tokenAddress)
+    || descriptor.baseAsset.name !== entry.name
+    || descriptor.baseAsset.symbol !== entry.symbol
+    || descriptor.baseAsset.decimals !== entry.tokenDecimals
+    || !sameHex(descriptor.market.uniswapV4.poolId, stamp.poolId)
+    || !sameHex(
+      descriptor.market.uniswapV4.poolManager.value,
+      stamp.poolManagerAddress,
+    )
+    || !sameHex(capability.poolKey.poolId, stamp.poolId)
+    || !sameHex(capability.poolKey.currency0.value, stamp.poolKey.currency0)
+    || !sameHex(capability.poolKey.currency1.value, stamp.poolKey.currency1)
+    || capability.poolKey.feeRaw !== String(stamp.poolKey.fee)
+    || capability.poolKey.tickSpacing !== String(stamp.poolKey.tickSpacing)
+    || !sameHex(capability.poolKey.hooks.value, stamp.poolKey.hooks)
+    || !sameHex(stamp.poolKey.hooks, entry.hookAddress)
+    || !exactRuntimeTargetsV1(stamp, descriptor.runtimeTargets)
+  ) return false;
+  return true;
+}
+
+function descriptorBindingForEntryV1(
+  entry: CanonicalTokenExploreEntry,
+  snapshot: SnapshotWithOptionalTradeMetadataV1 | null,
+) {
+  const overlay = snapshot?.metadataOverlay;
+  if (
+    !overlay
+    || overlay.schemaVersion !== ROUTER_CUSTOM_METADATA_OVERLAY_SCHEMA_V1
+    || overlay.source !== ROUTER_CUSTOM_METADATA_OVERLAY_SOURCE_V1
+    || overlay.routerIdentityCommitment !== snapshot.identityCommitment
+    || overlay.metadataCommitment !== canonicalSha256(
+      ROUTER_CUSTOM_METADATA_OVERLAY_SCHEMA_V1,
+      {
+        source: overlay.source,
+        generatedAt: overlay.generatedAt,
+        routerIdentityCommitment: overlay.routerIdentityCommitment,
+        appliedBindings: overlay.appliedBindings,
+      },
+    )
+  ) return null;
+  const matches = overlay.appliedBindings.filter((binding) =>
+    binding.tradeAdapterDescriptor !== undefined
+    && bindingMatchesEntryV1(binding, entry)
+    && descriptorMatchesEntryV1(binding.tradeAdapterDescriptor, entry));
+  return matches.length === 1 ? matches[0]! : null;
+}
+
+function descriptorAdapterV1(
+  entry: CanonicalTokenExploreEntry,
+  snapshot: SnapshotWithOptionalTradeMetadataV1 | null,
+): RouterTradeAdapterV1 | null {
+  const binding = descriptorBindingForEntryV1(entry, snapshot);
+  const descriptor = binding?.tradeAdapterDescriptor;
+  const stamp = entry.launchStampProvenance;
+  if (!descriptor || stamp?.kind !== "custom-graph") return null;
+  const tokenTarget = descriptor.runtimeTargets.find(
+    ({ kind }) => kind === "token",
+  );
+  const hookTarget = descriptor.runtimeTargets.find(
+    ({ kind }) => kind === "hook",
+  );
+  if (!tokenTarget || !hookTarget) return null;
+
+  const project = Object.freeze({
+    customProjectId: descriptor.projectId,
+    markets: Object.freeze([Object.freeze({
+      marketId: descriptor.market.marketId,
+      kind: descriptor.market.kind,
+      status: "active" as const,
+      poolId: entry.poolId,
+      baseAsset: descriptor.baseAsset,
+      quoteAsset: descriptor.quoteAsset,
+      tradeCapability: descriptor.market.tradeCapability,
+    })]),
+  });
+  return Object.freeze({
+    adapterId: descriptor.adapterId,
+    projectId: descriptor.projectId,
+    chainId: "1" as const,
+    chainProfileId: descriptor.chainProfileId,
+    chainProfileHash: descriptor.chainProfileHash,
+    launchId: stamp.launchId,
+    stampHash: stamp.stampHash,
+    tokenAddress: entry.tokenAddress,
+    tokenRuntimeCodeKeccak256: tokenTarget.runtimeCodeKeccak256,
+    tokenRuntimeCodeSha256: tokenTarget.runtimeCodeSha256,
+    hookAddress: entry.hookAddress,
+    hookRuntimeCodeKeccak256: hookTarget.runtimeCodeKeccak256,
+    hookRuntimeCodeSha256: hookTarget.runtimeCodeSha256,
+    runtimeTargets: Object.freeze(descriptor.runtimeTargets.map((target) =>
+      Object.freeze({
+        label: target.targetId,
+        address: target.identity.value,
+        runtimeCodeKeccak256: target.runtimeCodeKeccak256,
+        runtimeCodeSha256: target.runtimeCodeSha256,
+      }))),
+    sourceEvidence: null,
+    executionEvidence: null,
+    market: descriptor.market,
+    project,
+  });
+}
+
+export function resolveServerBoundRouterTradeAdapterV1(
+  entry: CanonicalTokenExploreEntry,
+  snapshot: SnapshotWithOptionalTradeMetadataV1 | null,
+): RouterTradeAdapterV1 | null {
+  return resolveReviewedRouterTradeAdapterV1(entry)
+    ?? descriptorAdapterV1(entry, snapshot);
+}
+
+export function routerTradeProjectForServerBoundEntryV1(
+  entry: CanonicalTokenExploreEntry,
+  snapshot: SnapshotWithOptionalTradeMetadataV1 | null,
+) {
+  return resolveServerBoundRouterTradeAdapterV1(entry, snapshot)?.project
+    ?? null;
+}
+
+export function findServerBoundRouterTradeAdapterV1(
+  snapshot: SnapshotWithOptionalTradeMetadataV1,
+  input: Readonly<{ projectId: string }>,
+) {
+  const matches = snapshot.entries.flatMap((entry) => {
+    const adapter = resolveServerBoundRouterTradeAdapterV1(entry, snapshot);
+    return adapter !== null
+        && adapter.projectId === input.projectId
+      ? [adapter]
+      : [];
+  });
+  return matches.length === 1 ? matches[0]! : null;
+}

--- a/lib/server/custom-launch/trade-v1.ts
+++ b/lib/server/custom-launch/trade-v1.ts
@@ -15,7 +15,6 @@ import type {
   DiscoverableMarketTradeCapabilityV1,
 } from "../../custom-launch/contract-v2";
 import {
-  resolveRouterTradeAdapterV1,
   routerTradeAdapterForProjectIdV1,
   type RouterTradeAdapterV1,
 } from "../../custom-launch/router-trade-adapters-v1";
@@ -40,13 +39,17 @@ import {
   type CustomMarketTradeRequestV1,
 } from "../../custom-launch/trade-v1";
 import type { PreparedTradeTransaction } from "../../prepared-transaction";
-import { readFinalizedRouterCustomExploreEntriesV1 } from
+import { readFinalizedRouterCustomIdentitySnapshotV1 } from
   "../../alchemy/router-custom-public.server";
 import { getProductionWebsiteProjectionTargetV1 } from "../projection-target/website-target";
 import {
   isCustomLaunchPublicEnabled,
   isCustomLaunchRegistryPublicReadEnabled,
 } from "./public-readiness";
+import { findServerBoundRouterTradeAdapterV1 } from
+  "./router-trade-descriptor-v1";
+import { isFinalizedTradeAdapterMarketIdV1 } from
+  "./finalized-trade-adapter-descriptor-v1";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const GAS_PRICE_BUFFER_BPS = 12_500n;
@@ -288,23 +291,29 @@ export async function prepareCustomMarketTradeV1(input: Readonly<{
   let projectChainProfileHash: `sha256:${string}`;
   let market: DiscoverableLaunchMarketV2 | undefined;
   let routerAdapter: RouterTradeAdapterV1 | null = null;
-  const requestedRouterAdapter = routerTradeAdapterForProjectIdV1(
+  const isReviewedRouterProject = routerTradeAdapterForProjectIdV1(
     input.request.projectId,
+  ) !== null;
+  const isDescriptorRouterMarket = isFinalizedTradeAdapterMarketIdV1(
+    input.request.marketId,
   );
-  if (requestedRouterAdapter !== null) {
-    const entries = await readFinalizedRouterCustomExploreEntriesV1({
+  if (isReviewedRouterProject || isDescriptorRouterMarket) {
+    const snapshot = await readFinalizedRouterCustomIdentitySnapshotV1({
       signal: AbortSignal.timeout(10_000),
     });
-    const matches = entries.flatMap((entry) => {
-      const adapter = resolveRouterTradeAdapterV1(entry);
-      return adapter?.projectId === input.request.projectId ? [adapter] : [];
+    routerAdapter = findServerBoundRouterTradeAdapterV1(snapshot, {
+      projectId: input.request.projectId,
     });
-    if (matches.length !== 1) {
-      throw new CustomMarketTradeUnavailableErrorV1(
-        "The Router Custom project is not an exact finalized adapter",
-      );
-    }
-    routerAdapter = matches[0]!;
+  }
+  if (
+    (isReviewedRouterProject || isDescriptorRouterMarket)
+    && routerAdapter === null
+  ) {
+    throw new CustomMarketTradeUnavailableErrorV1(
+      "The Router Custom project is not an exact finalized adapter",
+    );
+  }
+  if (routerAdapter !== null) {
     projectId = routerAdapter.projectId;
     projectChainId = routerAdapter.chainId;
     projectChainProfileId = routerAdapter.chainProfileId;

--- a/tests/finalized-custom-launch-metadata-feed-v1.test.ts
+++ b/tests/finalized-custom-launch-metadata-feed-v1.test.ts
@@ -357,6 +357,29 @@ describe("finalized Custom launch metadata feed v1", () => {
     );
   });
 
+  it("quarantines an invalid trade descriptor without hiding launch metadata", async () => {
+    const feed = await parsedFeed({
+      ...launchFixture(),
+      tradeAdapterDescriptor: {
+        schemaVersion: "caller-authored",
+      },
+    } as unknown as ReturnType<typeof launchFixture>);
+    expect(feed.launches[0]?.tradeAdapterDescriptor).toBeUndefined();
+
+    const result = await enrichRouterCustomSnapshotWithFinalizedMetadataV1(
+      routerSnapshot(),
+      { readFeed: async () => feed },
+    );
+    expect(result.entries[0]?.description).toBe(
+      "A finalized Custom Graph project.",
+    );
+    if ("metadataOverlay" in result) {
+      expect(
+        result.metadataOverlay.appliedBindings[0]?.tradeAdapterDescriptor,
+      ).toBeUndefined();
+    }
+  });
+
   it("strictly parses and hash-binds every page of the finalized inventory", async () => {
     const first = launchFixture();
     const second = launchFixture({

--- a/tests/finalized-trade-adapter-descriptor-v1.test.ts
+++ b/tests/finalized-trade-adapter-descriptor-v1.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { SHARD_ROUTER_TRADE_ADAPTER_V1 } from
+  "../lib/custom-launch/router-trade-adapters-v1";
+import {
+  FINALIZED_TRADE_ADAPTER_DESCRIPTOR_SCHEMA_V1,
+  FINALIZED_TRADE_ADAPTER_VERIFIER_V1,
+  finalizedTradeAdapterDescriptorDigestV1,
+  finalizedTradeAdapterMarketIdV1,
+  finalizedTradeAdapterProjectIdV1,
+  parseFinalizedTradeAdapterDescriptorV1,
+  type FinalizedTradeAdapterBindingContextV1,
+  type FinalizedTradeAdapterDescriptorV1,
+} from
+  "../lib/server/custom-launch/finalized-trade-adapter-descriptor-v1";
+import {
+  ROUTER_CUSTOM_METADATA_OVERLAY_SCHEMA_V1,
+  ROUTER_CUSTOM_METADATA_OVERLAY_SOURCE_V1,
+  type RouterCustomMetadataOverlayBindingV1,
+} from
+  "../lib/server/custom-launch/finalized-custom-launch-metadata-feed-v1";
+import {
+  resolveServerBoundRouterTradeAdapterV1,
+  routerTradeProjectForServerBoundEntryV1,
+} from "../lib/server/custom-launch/router-trade-descriptor-v1";
+import { canonicalSha256 } from
+  "../lib/server/projection-target/hashing";
+import type { JsonValue } from
+  "../lib/server/projection-target/canonical-json";
+import type { CanonicalTokenExploreEntry } from "../lib/tokens";
+import {
+  shardRouterTradeEntry,
+  shardRouterTradeStamp,
+} from "./shard-router-trade-fixture";
+
+function digest(byte: string) {
+  return `sha256:${byte.repeat(64)}` as `sha256:${string}`;
+}
+
+const CONTEXT = Object.freeze({
+  routerLaunchId: shardRouterTradeStamp.launchId.toLowerCase(),
+  router: shardRouterTradeStamp.routerAddress.toLowerCase(),
+  token: shardRouterTradeEntry.tokenAddress.toLowerCase(),
+  hook: shardRouterTradeEntry.hookAddress.toLowerCase(),
+  poolManager: shardRouterTradeStamp.poolManagerAddress.toLowerCase(),
+  poolId: shardRouterTradeEntry.poolId.toLowerCase(),
+  artifactHash: digest("a"),
+  graphBundleHash: digest("b"),
+  finality: Object.freeze({
+    transactionHash: shardRouterTradeStamp.transactionHash.toLowerCase(),
+    blockNumber: shardRouterTradeStamp.blockNumber,
+    blockHash: shardRouterTradeStamp.blockHash.toLowerCase(),
+    logIndex: shardRouterTradeStamp.launchLogIndex,
+  }),
+}) as FinalizedTradeAdapterBindingContextV1;
+
+function descriptorCore(decimals = 18) {
+  const reviewedMarket = SHARD_ROUTER_TRADE_ADAPTER_V1.market;
+  const reviewedProjectMarket = SHARD_ROUTER_TRADE_ADAPTER_V1.project.markets[0]!;
+  const marketId = finalizedTradeAdapterMarketIdV1(CONTEXT.routerLaunchId);
+  const tradeCapability = Object.freeze({
+    ...reviewedMarket.tradeCapability!,
+    marketId,
+  });
+  const runtimeTargets = Object.freeze(
+    shardRouterTradeStamp.components.map((component, index) => {
+      const reviewed = SHARD_ROUTER_TRADE_ADAPTER_V1.runtimeTargets.find(
+        ({ address }) => address.toLowerCase() === component.address.toLowerCase(),
+      )!;
+      return Object.freeze({
+        targetId: `component-${String(index).padStart(3, "0")}`,
+        kind: component.kind,
+        identity: Object.freeze({
+          namespace: "eip155:1" as const,
+          value: component.address.toLowerCase() as `0x${string}`,
+        }),
+        runtimeCodeKeccak256:
+          component.runtimeCodeHash.toLowerCase() as `0x${string}`,
+        runtimeCodeSha256: reviewed.runtimeCodeSha256,
+      });
+    }),
+  );
+  return Object.freeze({
+    schemaVersion: FINALIZED_TRADE_ADAPTER_DESCRIPTOR_SCHEMA_V1,
+    status: "verified" as const,
+    adapterId: "uniswap-v4-universal-router-exact-input:v1" as const,
+    projectId: finalizedTradeAdapterProjectIdV1(CONTEXT),
+    chainProfileId: SHARD_ROUTER_TRADE_ADAPTER_V1.chainProfileId,
+    chainProfileHash: SHARD_ROUTER_TRADE_ADAPTER_V1.chainProfileHash,
+    market: Object.freeze({
+      ...reviewedMarket,
+      marketId,
+      tradeCapability,
+      uniswapV4: Object.freeze({
+        ...reviewedMarket.uniswapV4!,
+        poolManager: Object.freeze({
+          namespace: "eip155:1" as const,
+          value: reviewedMarket.uniswapV4!.poolManager.value.toLowerCase() as `0x${string}`,
+        }),
+      }),
+    }),
+    baseAsset: Object.freeze({
+      ...reviewedProjectMarket.baseAsset,
+      identity: Object.freeze({
+        namespace: "eip155:1" as const,
+        value: reviewedProjectMarket.baseAsset.identity.value.toLowerCase() as `0x${string}`,
+      }),
+      decimals,
+    }),
+    quoteAsset: Object.freeze({
+      ...reviewedProjectMarket.quoteAsset,
+      identity: Object.freeze({
+        namespace: "eip155:1" as const,
+        value: reviewedProjectMarket.quoteAsset.identity.value.toLowerCase() as `0x${string}`,
+      }),
+    }),
+    runtimeTargets,
+    serverVerification: Object.freeze({
+      verifierAdapterId: FINALIZED_TRADE_ADAPTER_VERIFIER_V1,
+      verifiedAt: "2026-08-28T12:00:00.000Z",
+      evidenceHash: digest("d"),
+    }),
+  });
+}
+
+function descriptor(decimals = 18): FinalizedTradeAdapterDescriptorV1 {
+  const core = descriptorCore(decimals);
+  return Object.freeze({
+    ...core,
+    descriptorDigest: finalizedTradeAdapterDescriptorDigestV1(CONTEXT, core),
+  });
+}
+
+function descriptorSnapshot(
+  entry: CanonicalTokenExploreEntry,
+  tradeAdapterDescriptor: FinalizedTradeAdapterDescriptorV1 | undefined,
+) {
+  const appliedBinding = Object.freeze({
+    routerLaunchId: CONTEXT.routerLaunchId,
+    router: CONTEXT.router,
+    token: CONTEXT.token,
+    hook: CONTEXT.hook,
+    poolManager: CONTEXT.poolManager,
+    poolId: CONTEXT.poolId,
+    projectMetadataHash: digest("e"),
+    requestHash: digest("f"),
+    launchIntentHash: digest("1"),
+    graphBundleHash: CONTEXT.graphBundleHash,
+    unboundGraphBundleHash: digest("2"),
+    artifactHash: CONTEXT.artifactHash,
+    ...(tradeAdapterDescriptor ? { tradeAdapterDescriptor } : {}),
+    tokenMetadataReadback: Object.freeze({
+      status: "matching" as const,
+      observedAtBlockNumber: shardRouterTradeStamp.finalizedAtBlockNumber,
+      observedAt: "2026-08-28T12:00:00.000Z",
+    }),
+  }) satisfies RouterCustomMetadataOverlayBindingV1;
+  const appliedBindings = Object.freeze([appliedBinding]);
+  const identityCommitment = digest("3");
+  const generatedAt = "2026-08-28T12:00:00.000Z";
+  const metadataCommitment = canonicalSha256(
+    ROUTER_CUSTOM_METADATA_OVERLAY_SCHEMA_V1,
+    {
+      source: ROUTER_CUSTOM_METADATA_OVERLAY_SOURCE_V1,
+      generatedAt,
+      routerIdentityCommitment: identityCommitment,
+      appliedBindings,
+    },
+  );
+  return Object.freeze({
+    schemaVersion: "programmable.router-custom-identity-snapshot.v1" as const,
+    source: "canonical-launch-stamp-router" as const,
+    status: "current" as const,
+    generatedAt,
+    asOfBlock: shardRouterTradeStamp.finalizedAtBlockNumber,
+    asOfBlockHash: shardRouterTradeStamp.finalizedAtBlockHash,
+    finalityConfirmations: 64,
+    identityCommitment,
+    entries: Object.freeze([entry]),
+    metadataOverlay: Object.freeze({
+      schemaVersion: ROUTER_CUSTOM_METADATA_OVERLAY_SCHEMA_V1,
+      source: ROUTER_CUSTOM_METADATA_OVERLAY_SOURCE_V1,
+      status: "current" as const,
+      generatedAt,
+      routerIdentityCommitment: identityCommitment,
+      appliedBindings,
+      metadataCommitment,
+    }),
+  });
+}
+
+describe("finalized server-bound trade adapter descriptor v1", () => {
+  it("accepts an exact digest-bound descriptor and rejects any digest drift", () => {
+    const valid = descriptor();
+    expect(parseFinalizedTradeAdapterDescriptorV1(
+      valid as unknown as JsonValue,
+      CONTEXT,
+    )).toEqual(valid);
+    expect(parseFinalizedTradeAdapterDescriptorV1(
+      {
+        ...valid,
+        supportedByClient: true,
+      } as unknown as JsonValue,
+      CONTEXT,
+    )).toBeNull();
+    expect(parseFinalizedTradeAdapterDescriptorV1(
+      {
+        ...valid,
+        serverVerification: {
+          ...valid.serverVerification,
+          evidenceHash: digest("9"),
+        },
+      } as unknown as JsonValue,
+      CONTEXT,
+    )).toBeNull();
+    const core = descriptorCore();
+    const mismatchedQuoteCore = {
+      ...core,
+      quoteAsset: {
+        ...valid.quoteAsset,
+        identity: {
+          ...valid.quoteAsset.identity,
+          value: "0x1111111111111111111111111111111111111111" as const,
+        },
+      },
+    };
+    expect(parseFinalizedTradeAdapterDescriptorV1(
+      {
+        ...mismatchedQuoteCore,
+        descriptorDigest: finalizedTradeAdapterDescriptorDigestV1(
+          CONTEXT,
+          mismatchedQuoteCore,
+        ),
+      } as unknown as JsonValue,
+      CONTEXT,
+    )).toBeNull();
+  });
+
+  it("activates a generalized route only from the committed metadata overlay", () => {
+    const genericEntry = Object.freeze({
+      ...shardRouterTradeEntry,
+      tokenDecimals: 17,
+    }) as CanonicalTokenExploreEntry;
+    const validDescriptor = descriptor(17);
+    const snapshot = descriptorSnapshot(genericEntry, validDescriptor);
+    expect(resolveServerBoundRouterTradeAdapterV1(
+      genericEntry,
+      snapshot,
+    )).toMatchObject({
+      projectId: validDescriptor.projectId,
+      market: { marketId: validDescriptor.market.marketId },
+    });
+    expect(routerTradeProjectForServerBoundEntryV1(
+      genericEntry,
+      snapshot,
+    )).toMatchObject({
+      customProjectId: validDescriptor.projectId,
+      markets: [{ baseAsset: { decimals: 17 } }],
+    });
+  });
+
+  it("ignores client-shaped descriptors and fails closed without the overlay", () => {
+    const genericEntry = Object.freeze({
+      ...shardRouterTradeEntry,
+      tokenDecimals: 17,
+      tradeAdapterDescriptor: descriptor(17),
+    }) as unknown as CanonicalTokenExploreEntry;
+    expect(resolveServerBoundRouterTradeAdapterV1(
+      genericEntry,
+      descriptorSnapshot(genericEntry, undefined),
+    )).toBeNull();
+    expect(resolveServerBoundRouterTradeAdapterV1(
+      genericEntry,
+      null,
+    )).toBeNull();
+  });
+});

--- a/tests/partner-attribution-ui.test.tsx
+++ b/tests/partner-attribution-ui.test.tsx
@@ -200,7 +200,7 @@ describe("partner attribution UI", () => {
     }
   });
 
-  it("keeps attribution in public Explore and Profile render paths", () => {
+  it("keeps attribution in public Explore, Profile and direct token paths", () => {
     const explore = readFileSync(
       new URL("../components/explore-view.tsx", import.meta.url),
       "utf8",
@@ -209,8 +209,29 @@ describe("partner attribution UI", () => {
       new URL("../components/profile-view.tsx", import.meta.url),
       "utf8",
     );
+    const tokenDetail = readFileSync(
+      new URL("../components/token-detail-view.tsx", import.meta.url),
+      "utf8",
+    );
     expect(explore).toContain("<PartnerLaunchAttribution");
     expect(profile).toContain("<PartnerLaunchAttribution");
+    expect(tokenDetail).toContain("<PartnerLaunchAttribution");
+    expect(tokenDetail).toContain(
+      "parseLaunchPartnerAttributionV1(value.partnerAttribution)",
+    );
+  });
+
+  it("discovers partner administration only after the server allows the wallet", () => {
+    const wallet = readFileSync(
+      new URL("../components/wallet-provider.tsx", import.meta.url),
+      "utf8",
+    );
+    expect(wallet).toContain(
+      "const response = await fetch(`/api/admin/partners?${query}`",
+    );
+    expect(wallet).toContain("if (response.ok && !controller.signal.aborted)");
+    expect(wallet).toContain("=== wallet.account.toLowerCase() ? (");
+    expect(wallet).toContain('href="/admin/partners"');
   });
 
   it("keeps permanent partner revocation and bounded pages explicit", () => {

--- a/tests/router-trade-server-v1.test.ts
+++ b/tests/router-trade-server-v1.test.ts
@@ -11,7 +11,17 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../lib/alchemy/router-custom-public.server", () => ({
-  readFinalizedRouterCustomExploreEntriesV1: mocks.readRouter,
+  readFinalizedRouterCustomIdentitySnapshotV1: async () => ({
+    schemaVersion: "programmable.router-custom-identity-snapshot.v1",
+    source: "canonical-launch-stamp-router",
+    status: "current",
+    generatedAt: "2026-08-27T00:00:00.000Z",
+    asOfBlock: "25850000",
+    asOfBlockHash: `0x${"a".repeat(64)}`,
+    finalityConfirmations: 64,
+    identityCommitment: `sha256:${"b".repeat(64)}`,
+    entries: await mocks.readRouter(),
+  }),
 }));
 vi.mock("../lib/server/custom-launch/public-readiness", () => ({
   isCustomLaunchPublicEnabled: mocks.publicEnabled,

--- a/tests/token-detail-layout.test.ts
+++ b/tests/token-detail-layout.test.ts
@@ -106,7 +106,10 @@ describe("token detail layout", () => {
     );
     expect(detailSource).toContain('className={styles.routerNotice} role="status"');
     expect(detailSource).toContain("market availability");
-    expect(detailSource).toContain("This page shows launch data only.");
+    expect(detailSource).toContain(
+      "Onsite trading is not enabled for this launch.",
+    );
+    expect(detailSource).toContain("Launch details");
     expect(detailSource).toContain("routerTradeAvailable && routerTradeProject");
     expect(detailSource).toContain("project={routerTradeProject}");
     expect(detailStyles).toMatch(


### PR DESCRIPTION
## Outcome

- show immutable partner attribution on direct token pages
- expose Partner API administration navigation only after the authenticated server allowlist check
- accept an optional server-authored finalized trade adapter descriptor with full digest, launch, pool, runtime, finality and trade-capability bindings
- preserve finalized launch identity while keeping trading disabled when the optional descriptor is missing or invalid
- replace the technical launch-data-only error with clear product copy
- retain the separately reviewed SHARD and FADE adapters

## Security boundary

Submitted metadata, the browser, CLI output and model output cannot activate trading. Invalid descriptors are quarantined per launch and do not hide the finalized identity.

## Verification

- TypeScript passed
- targeted ESLint passed
- 9 focused test files / 135 tests passed
- git diff --check passed

Production branch only.
