### PR TITLE
fix(launch): disclose wallet fee boundary

### DIFF
--- a/components/developer-launch-history.tsx
+++ b/components/developer-launch-history.tsx
@@ -950,6 +950,18 @@ function routerTransactionReview(launch: LaunchResource) {
   }
 }
 
+export function walletPlatformFeeDisclosureV3(
+  launchProfileVersion: LaunchResource["launchProfileVersion"],
+) {
+  if (launchProfileVersion === "3.3.0") {
+    return "No automatic Programmable fee claim";
+  }
+  if (launchProfileVersion === "3.4.0") {
+    return "10 bps · exact fee-path verification required";
+  }
+  return "Defined by the bound launch profile";
+}
+
 function sameFundingAuthorization(
   left: CustomLaunchFundingAuthorizationV3,
   right: CustomLaunchFundingAuthorizationV3,
@@ -3261,6 +3273,14 @@ export function DeveloperLaunchHistory({
                       <div>
                         <dt>Native value</dt>
                         <dd>{routerReview.walletAction.valueWei} wei</dd>
+                      </div>
+                      <div>
+                        <dt>Programmable fee</dt>
+                        <dd>
+                          {walletPlatformFeeDisclosureV3(
+                            reviewLaunch.launchProfileVersion,
+                          )}
+                        </dd>
                       </div>
                       <div>
                         <dt>Router</dt>

--- a/tests/developer-api-keys-ui.test.ts
+++ b/tests/developer-api-keys-ui.test.ts
@@ -549,6 +549,13 @@ describe("developer launch history interface", () => {
     expect(historySource).toContain('aria-live="polite"');
     expect(historySource).toContain("state === \"loading\" || loadingMore || refreshing");
     expect(historySource).toContain("Prepared transaction");
+    expect(historySource).toContain("Programmable fee");
+    expect(historySource).toContain(
+      "No automatic Programmable fee claim",
+    );
+    expect(historySource).toContain(
+      "10 bps · exact fee-path verification required",
+    );
     expect(historySource).toContain("Admission checks running");
     expect(historySource).toContain("Changes required");
     expect(historySource).toContain("Fix source or configuration");


### PR DESCRIPTION
## Outcome

The final wallet review now shows the server-bound Programmable fee boundary before the controller sends the Router transaction.

- live open-hook profile 3.3.0 explicitly says there is no automatic Programmable fee claim
- preparatory 3.4.0 explicitly says exact 10 bps fee-path verification is required
- older immutable resources defer to their bound launch profile instead of inventing a fee

This is presentation only. It does not weaken wallet checks, activate profile 3.4, or claim universal 10 bps.

## Focused verification

- developer API keys UI test: 24 of 24
- TypeScript no-emit check: pass
- git diff check: pass