### PR TITLE
fix(profile): expose public launches and fee truth

### DIFF
--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -36,6 +36,8 @@ import { readPublicCreatorArticleV1 } from
   "../../../../lib/server/creator-article/public-read.server";
 import { canonicalSha256 } from
   "../../../../lib/server/projection-target/hashing";
+import { platformFeeCertificationForTokenV1 } from
+  "../../../../lib/platform-fee-certification";
 import type {
   CanonicalTokenExploreEntry,
   ExploreEntry,
@@ -382,6 +384,7 @@ export async function GET(request: NextRequest) {
         token: null,
         customProject: null,
         routerTradeProject: null,
+        platformFeeCertification: null,
         sourceVerification: null,
         creatorArticle: null,
         snapshot: null,
@@ -433,14 +436,20 @@ export async function GET(request: NextRequest) {
     const publicEntry = publicExploreEntryV1(
       publicExplorePresentationEntryV1(valuedEntry),
     );
+    const publicToken = publicEntry.exploreKind === "token"
+      ? publicEntry
+      : null;
 
     return NextResponse.json(
       {
         status: "ready",
-        token: publicEntry.exploreKind === "token" ? publicEntry : null,
+        token: publicToken,
         customProject:
           publicEntry.exploreKind === "custom-project" ? publicEntry : null,
         routerTradeProject,
+        platformFeeCertification: publicToken
+          ? platformFeeCertificationForTokenV1(publicToken)
+          : null,
         sourceVerification: await sourceVerificationPromise,
         creatorArticle: await creatorArticlePromise,
         snapshot:
@@ -471,14 +480,20 @@ export async function GET(request: NextRequest) {
         valuation: { status: "unavailable", reason: "source-unavailable" },
       }),
     );
+    const publicToken = publicEntry.exploreKind === "token"
+      ? publicEntry
+      : null;
     const creatorArticle = await readPublicCreatorArticleV1(entry.tokenAddress!);
     return NextResponse.json(
       {
         status: "ready",
-        token: publicEntry.exploreKind === "token" ? publicEntry : null,
+        token: publicToken,
         customProject:
           publicEntry.exploreKind === "custom-project" ? publicEntry : null,
         routerTradeProject,
+        platformFeeCertification: publicToken
+          ? platformFeeCertificationForTokenV1(publicToken)
+          : null,
         sourceVerification: await sourceVerificationPromise,
         creatorArticle,
         snapshot: publicEntry.exploreKind === "token" ? { chainId: 1 } : null,

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,5 +1,14 @@
-import { ProfileView } from "@/components/profile-view";
+import { Suspense } from "react";
+
+import {
+  ProfileSessionLoadingState,
+  ProfileView,
+} from "@/components/profile-view";
 
 export default function ProfilePage() {
-  return <ProfileView />;
+  return (
+    <Suspense fallback={<ProfileSessionLoadingState />}>
+      <ProfileView />
+    </Suspense>
+  );
 }

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -82,6 +82,10 @@
   gap: 10px;
 }
 
+.publicProfileNameRow {
+  flex-wrap: wrap;
+}
+
 .nameRow h1 {
   font-size: clamp(28px, 3.2vw, 40px);
   font-weight: 585;
@@ -102,6 +106,15 @@
   font-variant-numeric: tabular-nums;
   margin-block-start: 7px;
   overflow-wrap: anywhere;
+}
+
+.publicProfileNote {
+  color: var(--text-soft);
+  font-size: 13px;
+  line-height: 1.5;
+  margin-block-start: 8px;
+  max-width: 560px;
+  text-wrap: pretty;
 }
 
 .editButton,
@@ -457,6 +470,32 @@
   box-shadow: var(--liquid-glass-shadow);
   margin-block-end: 10px;
   padding: 15px 16px 16px;
+}
+
+.publicProfileState {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-block-start: 18px;
+  min-height: 180px;
+  text-align: center;
+}
+
+.publicProfileState h2 {
+  font-size: 20px;
+  font-weight: 640;
+  letter-spacing: -0.026em;
+  line-height: 1.1;
+}
+
+.publicProfileState p {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+  margin-block-start: 7px;
+  max-width: 420px;
+  text-wrap: pretty;
 }
 
 .launchesHeader {

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { ChevronLeft, ChevronRight, RefreshCw, X } from "lucide-react";
 import { formatUnits, type Hex } from "viem";
 import {
@@ -893,6 +894,18 @@ function normalizeEthereumAddress(value: string) {
   return ethereumAddressPattern.test(normalized) ? normalized : null;
 }
 
+export function publicProfileAccountFromQuery(
+  queryAccounts: readonly string[],
+  connectedAccount?: string,
+) {
+  if (queryAccounts.length !== 1) return null;
+  const requestedAccount = normalizeEthereumAddress(queryAccounts[0] ?? "");
+  if (!requestedAccount) return null;
+  return requestedAccount === connectedAccount?.toLowerCase()
+    ? null
+    : requestedAccount;
+}
+
 function isPendingProfileTransactionRecord(
   value: unknown,
   expectedAccount: string,
@@ -1369,6 +1382,7 @@ export function formatBannerPositionStatus(position: {
 
 export function ProfileView({ onchainData }: ProfileViewProps = {}) {
   const { wallet, openWallet, sendTransaction, connecting } = useWallet();
+  const searchParams = useSearchParams();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const bannerInputRef = useRef<HTMLInputElement>(null);
   const bannerDragRef = useRef<{
@@ -3364,9 +3378,22 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
   }
 
   const sessionView = getProfileSessionView(connecting, account);
+  const publicProfileAccount = publicProfileAccountFromQuery(
+    searchParams.getAll("account"),
+    account,
+  );
 
   if (!clientHydrated || sessionView === "loading") {
     return <ProfileSessionLoadingState />;
+  }
+
+  if (publicProfileAccount) {
+    return (
+      <PublicCreatorProfile
+        account={publicProfileAccount}
+        onConnect={openWallet}
+      />
+    );
   }
 
   if (sessionView === "connect" || !account) {
@@ -4456,7 +4483,7 @@ export function profileRewardsForAccount<
   );
 }
 
-function ProfileSessionLoadingState() {
+export function ProfileSessionLoadingState() {
   return (
     <div className={`${styles.page} page-width`}>
       <ProfileLoadingSkeleton label="Restoring wallet profile" showHero />
@@ -4620,6 +4647,113 @@ export function ProfileRouterLaunches({
         })}
       </div>
     </section>
+  );
+}
+
+function PublicCreatorProfile({
+  account,
+  onConnect,
+}: {
+  account: string;
+  onConnect: () => void;
+}) {
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [data, setData] = useState<ProfileOnchainData>(() =>
+    loadingProfileData(account)
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    queueMicrotask(() => {
+      if (!controller.signal.aborted) setData(loadingProfileData(account));
+    });
+    void fetchCreatorProfile(account, controller.signal).then(
+      (profile) => {
+        if (!controller.signal.aborted) setData(profile);
+      },
+      (caught) => {
+        if (controller.signal.aborted) return;
+        const errorKind = caught instanceof ProfileResponseError
+          ? caught.kind
+          : "temporary";
+        setData(errorProfileData(
+          account,
+          caught instanceof Error
+            ? caught.message
+            : "Public profile data is temporarily unavailable",
+          errorKind,
+        ));
+      },
+    );
+    return () => controller.abort();
+  }, [account, refreshKey]);
+
+  const entries = data.status === "ready"
+    ? profileRouterLaunchEntries(
+        buildProfilePortfolio(data.tokens, [], []),
+      )
+    : [];
+
+  return (
+    <div className={`${styles.page} page-width`}>
+      <section className={styles.hero} aria-labelledby="public-profile-title">
+        <div className={styles.avatar} aria-hidden="true">
+          <span>{account.slice(2, 4).toUpperCase()}</span>
+        </div>
+        <div className={styles.heroCopy}>
+          <div className={`${styles.nameRow} ${styles.publicProfileNameRow}`}>
+            <h1 id="public-profile-title">Creator profile</h1>
+            <button
+              className={styles.editButton}
+              type="button"
+              onClick={onConnect}
+            >
+              Connect wallet
+            </button>
+          </div>
+          <p className={styles.address}>{account}</p>
+          <p className={styles.publicProfileNote}>
+            Finalized launches are public. Connect this wallet to manage the
+            profile and rewards.
+          </p>
+        </div>
+      </section>
+
+      {data.status === "loading" ? (
+        <section
+          className={`${styles.launchesPanel} ${styles.publicProfileState}`}
+          aria-busy="true"
+          aria-live="polite"
+        >
+          <h2>Loading launches</h2>
+          <p>Reading finalized Router launches.</p>
+        </section>
+      ) : data.status === "error" ? (
+        <section
+          className={`${styles.launchesPanel} ${styles.publicProfileState}`}
+          aria-live="polite"
+        >
+          <h2>Launches unavailable</h2>
+          <p>Unable to load this public profile. Check again.</p>
+          <button
+            className={styles.retryButton}
+            type="button"
+            onClick={() => setRefreshKey((current) => current + 1)}
+          >
+            Check again
+          </button>
+        </section>
+      ) : entries.length ? (
+        <ProfileRouterLaunches entries={entries} />
+      ) : (
+        <section
+          className={`${styles.launchesPanel} ${styles.publicProfileState}`}
+        >
+          <h2>No finalized launches yet</h2>
+          <p>Finalized Router launches will appear here.</p>
+        </section>
+      )}
+    </div>
   );
 }
 

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -78,6 +78,11 @@ import { PROGRAMMABLE_MAIN_TOKEN_ADDRESS } from
 import type { PostLaunchAuthorityInventoryV1 } from "@/lib/custom-launch/contract-v2";
 import { parseLaunchPartnerAttributionV1 } from
   "@/lib/launch-partner-attribution";
+import {
+  parsePlatformFeeCertificationV1,
+  platformFeeCertificationForTokenV1,
+  type PlatformFeeCertificationV1,
+} from "@/lib/platform-fee-certification";
 import styles from "./token-experience.module.css";
 
 type DetailToken = LauncherToken & Readonly<{
@@ -107,6 +112,7 @@ type DetailPayload = {
   token: DetailToken | null;
   customProject: DetailCustomProject | null;
   routerTradeProject: RouterTradeProject | null;
+  platformFeeCertification: PlatformFeeCertificationV1 | null;
   sourceVerification: SourceVerificationDisplay | null;
   creatorArticle: CreatorArticleV1 | null;
   snapshot: { chainId: number } | null;
@@ -121,6 +127,7 @@ export type DetailState =
       phase: "ready";
       token: DetailToken;
       routerTradeProject: RouterTradeProject | null;
+      platformFeeCertification: PlatformFeeCertificationV1 | null;
       sourceVerification: SourceVerificationDisplay | null;
       creatorArticle: CreatorArticleV1 | null;
       chainId: number;
@@ -896,6 +903,31 @@ export function parseDetailPayload(value: unknown): DetailPayload {
   ) {
     throw new Error("The token registry returned an invalid Router trade route");
   }
+  const platformFeeCertification =
+    value.platformFeeCertification === null ||
+      value.platformFeeCertification === undefined
+      ? null
+      : parsePlatformFeeCertificationV1(value.platformFeeCertification);
+  if (
+    value.platformFeeCertification !== null &&
+    value.platformFeeCertification !== undefined &&
+    platformFeeCertification === null
+  ) {
+    throw new Error("The token registry returned invalid fee certification");
+  }
+  const expectedPlatformFeeCertification = token
+    ? platformFeeCertificationForTokenV1(token)
+    : null;
+  if (
+    platformFeeCertification !== null &&
+    (expectedPlatformFeeCertification === null ||
+      platformFeeCertification.status !==
+        expectedPlatformFeeCertification.status ||
+      platformFeeCertification.programmableFeeBps !==
+        expectedPlatformFeeCertification.programmableFeeBps)
+  ) {
+    throw new Error("The token registry returned conflicting fee certification");
+  }
   const sourceVerification = parseSourceVerificationDisplay(
     value.sourceVerification,
   );
@@ -939,6 +971,7 @@ export function parseDetailPayload(value: unknown): DetailPayload {
     token,
     customProject,
     routerTradeProject,
+    platformFeeCertification,
     sourceVerification,
     creatorArticle,
     snapshot,
@@ -1008,6 +1041,7 @@ function detailStateFromResponse(
       phase: "ready",
       token: payload.token!,
       routerTradeProject: payload.routerTradeProject,
+      platformFeeCertification: payload.platformFeeCertification,
       sourceVerification: payload.sourceVerification,
       creatorArticle: payload.creatorArticle,
     chainId: payload.snapshot.chainId,
@@ -1326,10 +1360,13 @@ export function buildTokenDetailMetrics(
   );
 }
 
-export function platformFeePolicyDisclosure(token: LauncherToken) {
-  return token.platformFeePolicy?.status === "onchain-confirmed"
-    ? "Platform fee policy recorded: 10 bps are configured for this stamped pool. This does not prove current accrual or a claimable balance."
-    : null;
+export function platformFeePolicyDisclosure(
+  token: LauncherToken,
+  certification?: PlatformFeeCertificationV1 | null,
+) {
+  return (
+    certification ?? platformFeeCertificationForTokenV1(token)
+  )?.label ?? null;
 }
 
 export function canUseClassicTokenTrade(token: LauncherToken) {
@@ -1560,6 +1597,7 @@ function TokenDetailContent({
   preview,
   creatorArticle = null,
   routerTradeProject = null,
+  platformFeeCertification = null,
   sourceVerification = null,
 }: {
   token: LauncherToken;
@@ -1567,6 +1605,7 @@ function TokenDetailContent({
   preview: boolean;
   creatorArticle?: CreatorArticleV1 | null;
   routerTradeProject?: RouterTradeProject | null;
+  platformFeeCertification?: PlatformFeeCertificationV1 | null;
   sourceVerification?: SourceVerificationDisplay | null;
 }) {
   const {
@@ -1677,7 +1716,10 @@ function TokenDetailContent({
       buildChartVolumeMetric(chartVolume),
     );
   }, [chartVolume, token]);
-  const platformFeeDisclosure = platformFeePolicyDisclosure(token);
+  const platformFeeDisclosure = platformFeePolicyDisclosure(
+    token,
+    platformFeeCertification,
+  );
 
   const explorerBase =
     chainId === 1
@@ -1988,7 +2030,15 @@ function TokenDetailContent({
               ) : null}
 
               {platformFeeDisclosure ? (
-                <p className={styles.sourceVerification}>
+                <p
+                  className={styles.sourceVerification}
+                  data-status={
+                    platformFeeCertification?.status === "certified" ||
+                      token.platformFeePolicy?.status === "onchain-confirmed"
+                      ? "verified"
+                      : undefined
+                  }
+                >
                   {platformFeeDisclosure}
                 </p>
               ) : null}
@@ -2691,6 +2741,7 @@ export function TokenDetailView({
         chainId={activeState.chainId}
         preview={false}
         routerTradeProject={activeState.routerTradeProject}
+        platformFeeCertification={activeState.platformFeeCertification}
         sourceVerification={activeState.sourceVerification}
         creatorArticle={activeState.creatorArticle}
       />

--- a/lib/platform-fee-certification.ts
+++ b/lib/platform-fee-certification.ts
@@ -1,0 +1,76 @@
+import {
+  isPlatformFeePolicyReadbackV2,
+  type LauncherToken,
+} from "./tokens";
+
+export type PlatformFeeCertificationV1 = Readonly<{
+  schemaVersion: "programmable.platform-fee-certification.v1";
+  status: "certified" | "not-certified";
+  programmableFeeBps: 10 | null;
+  label:
+    | "Programmable fee: 10 bps certified for this launch"
+    | "Programmable fee: not certified for this launch";
+}>;
+
+const CERTIFIED_PLATFORM_FEE = Object.freeze({
+  schemaVersion: "programmable.platform-fee-certification.v1" as const,
+  status: "certified" as const,
+  programmableFeeBps: 10 as const,
+  label: "Programmable fee: 10 bps certified for this launch" as const,
+});
+
+const UNCERTIFIED_PLATFORM_FEE = Object.freeze({
+  schemaVersion: "programmable.platform-fee-certification.v1" as const,
+  status: "not-certified" as const,
+  programmableFeeBps: null,
+  label: "Programmable fee: not certified for this launch" as const,
+});
+
+export function platformFeeCertificationForTokenV1(
+  token: LauncherToken,
+): PlatformFeeCertificationV1 | null {
+  if (
+    token.launchModel !== "custom-graph" ||
+    token.launchStampProvenance?.kind !== "custom-graph"
+  ) {
+    return null;
+  }
+
+  return isPlatformFeePolicyReadbackV2(token.platformFeePolicy, {
+    tokenAddress: token.tokenAddress,
+    hookAddress: token.hookAddress,
+    poolId: token.poolId,
+  })
+    ? CERTIFIED_PLATFORM_FEE
+    : UNCERTIFIED_PLATFORM_FEE;
+}
+
+export function parsePlatformFeeCertificationV1(
+  value: unknown,
+): PlatformFeeCertificationV1 | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (
+    record.schemaVersion !== "programmable.platform-fee-certification.v1"
+  ) {
+    return null;
+  }
+
+  if (
+    record.status === "certified" &&
+    record.programmableFeeBps === 10 &&
+    record.label === "Programmable fee: 10 bps certified for this launch"
+  ) {
+    return CERTIFIED_PLATFORM_FEE;
+  }
+
+  if (
+    record.status === "not-certified" &&
+    record.programmableFeeBps === null &&
+    record.label === "Programmable fee: not certified for this launch"
+  ) {
+    return UNCERTIFIED_PLATFORM_FEE;
+  }
+
+  return null;
+}

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -26,6 +26,7 @@ import {
   profileEntryHasClaimableReward,
   profileHasRewardSurface,
   profileNativeClaimMeetsVisibilityThreshold,
+  publicProfileAccountFromQuery,
   prioritizedProfileActionState,
   profileRouterLaunchEntries,
   profileRewardsForAccount,
@@ -320,6 +321,32 @@ describe("profile workspace loading state", () => {
     expect(getProfileSessionView(true, firstAddress)).toBe("loading");
     expect(getProfileSessionView(false)).toBe("connect");
     expect(getProfileSessionView(false, firstAddress)).toBe("profile");
+  });
+
+  it("opens a query-address profile as public unless it is the connected wallet", () => {
+    expect(publicProfileAccountFromQuery([firstAddress])).toBe(
+      firstAddress.toLowerCase(),
+    );
+    expect(publicProfileAccountFromQuery([firstAddress], firstAddress)).toBeNull();
+    expect(publicProfileAccountFromQuery([firstAddress], secondAddress)).toBe(
+      firstAddress.toLowerCase(),
+    );
+    expect(publicProfileAccountFromQuery([])).toBeNull();
+    expect(publicProfileAccountFromQuery([firstAddress, secondAddress])).toBeNull();
+    expect(publicProfileAccountFromQuery(["not-an-address"])).toBeNull();
+  });
+
+  it("keeps the public profile surface read-only", () => {
+    expect(profileViewSource).toContain("<PublicCreatorProfile");
+    expect(profileViewSource).toContain(
+      "Finalized launches are public. Connect this wallet to manage the",
+    );
+    expect(profileViewSource).toContain(
+      "<ProfileRouterLaunches entries={entries}",
+    );
+    expect(profileViewSource).not.toContain(
+      "<PublicCreatorProfile account={account}",
+    );
   });
 
   it("keeps a stable loading state until every pending source settles", () => {

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -80,6 +80,8 @@ import {
   "../lib/custom-launch/router-trade-adapters-v1";
 import { customGraphExploreEntry } from "./launch-stamp-surface-fixture";
 import { fadeRouterTradeEntry } from "./fade-router-trade-fixture";
+import { confirmedPlatformFeePolicyV2 } from
+  "./platform-fee-policy-fixture";
 import { shardRouterTradeEntry } from "./shard-router-trade-fixture";
 
 const NOW = "2026-08-16T08:00:00.000Z";
@@ -330,6 +332,12 @@ describe("Token detail static identity and Dexscreener market contract", () => {
       label: "Source not verified",
       updatedAt: null,
     });
+    expect(body.platformFeeCertification).toEqual({
+      schemaVersion: "programmable.platform-fee-certification.v1",
+      status: "not-certified",
+      programmableFeeBps: null,
+      label: "Programmable fee: not certified for this launch",
+    });
     expect(mocks.readSourceVerification).toHaveBeenCalledWith(
       customGraphExploreEntry.tokenAddress,
       expect.any(AbortSignal),
@@ -337,6 +345,33 @@ describe("Token detail static identity and Dexscreener market contract", () => {
     expect(response.headers.get("x-programmable-launch-source")).toBe(
       "envio-classic-v3+canonical-launch-stamp-router",
     );
+  });
+
+  it("certifies 10 bps only from the exact bound platform fee readback", async () => {
+    const certifiedEntry = {
+      ...customGraphExploreEntry,
+      platformFeePolicy: confirmedPlatformFeePolicyV2,
+    };
+    mocks.readRouter.mockResolvedValue([certifiedEntry]);
+    mocks.mergeRouter.mockReturnValue([certifiedEntry]);
+    mocks.readDex.mockResolvedValueOnce({
+      entries: [{
+        ...certifiedEntry,
+        valuation: { status: "unavailable", reason: "source-unavailable" },
+      }],
+      marketRead: marketRead("unavailable"),
+    });
+
+    const response = await GET(request(certifiedEntry.tokenAddress));
+    const body = await json(response);
+
+    expect(response.status).toBe(200);
+    expect(body.platformFeeCertification).toEqual({
+      schemaVersion: "programmable.platform-fee-certification.v1",
+      status: "certified",
+      programmableFeeBps: 10,
+      label: "Programmable fee: 10 bps certified for this launch",
+    });
   });
 
   it("serves the exact Router token when Envio is unavailable", async () => {

--- a/tests/token-detail-view.test.ts
+++ b/tests/token-detail-view.test.ts
@@ -187,9 +187,48 @@ describe("token detail metrics", () => {
     expect(buildTokenDetailMetrics(confirmed).map((metric) => metric.label))
       .not.toContain("Programmable fee");
     expect(platformFeePolicyDisclosure(confirmed)).toBe(
-      "Platform fee policy recorded: 10 bps are configured for this stamped pool. This does not prove current accrual or a claimable balance.",
+      "Programmable fee: 10 bps certified for this launch",
     );
-    expect(platformFeePolicyDisclosure(customGraphToken)).toBeNull();
+    expect(platformFeePolicyDisclosure(customGraphToken)).toBe(
+      "Programmable fee: not certified for this launch",
+    );
+    expect(platformFeePolicyDisclosure(token)).toBeNull();
+  });
+
+  it("rejects an API fee claim that conflicts with the exact token proof", () => {
+    expect(() => parseDetailPayload({
+      status: "ready",
+      token: {
+        ...customGraphToken,
+        exploreKind: "token",
+        launchCategoryProvenance: {
+          schemaVersion: "programmable.explore-launch-category-provenance.v1",
+          category: "custom",
+          source: "canonical-launch-stamp-router",
+          launchId: customGraphToken.launchStampProvenance.launchId,
+          stampHash: customGraphToken.launchStampProvenance.stampHash,
+          routerAddress: customGraphToken.launchStampProvenance.routerAddress,
+          transactionHash:
+            customGraphToken.launchStampProvenance.transactionHash,
+          blockHash: customGraphToken.launchStampProvenance.blockHash,
+          blockNumber: customGraphToken.launchStampProvenance.blockNumber,
+          transactionIndex:
+            customGraphToken.launchStampProvenance.transactionIndex,
+          logIndex: customGraphToken.launchStampProvenance.launchLogIndex,
+        },
+      },
+      customProject: null,
+      routerTradeProject: null,
+      platformFeeCertification: {
+        schemaVersion: "programmable.platform-fee-certification.v1",
+        status: "certified",
+        programmableFeeBps: 10,
+        label: "Programmable fee: 10 bps certified for this launch",
+      },
+      sourceVerification: null,
+      creatorArticle: null,
+      snapshot: { chainId: 1 },
+    })).toThrow("conflicting fee certification");
   });
 
   it("shows unavailable instead of inventing FDV without reliable supply or liquidity", () => {


### PR DESCRIPTION
## Outcome
- renders finalized canonical Router launches on public query-address profiles while keeping claims, edits, predictions, and wallet mutations owner-gated
- adds a machine-readable Custom launch fee-certification boundary to the token API
- shows a neutral per-launch fee disclosure: exact 10 bps only with the bound onchain policy proof, otherwise not certified

## Verification
- npx vitest run tests/profile-view.test.ts tests/token-detail-view.test.ts tests/token-detail-api.test.ts (115 passed)
- npm run typecheck
- focused ESLint on all changed TypeScript files
- npm run build
- git diff --check

No OpenAPI or CLI release binding changed.