### PR TITLE
fix(discovery): accept finalized feed quality

### DIFF
--- a/lib/server/custom-launch/finalized-custom-launch-metadata-feed-v1.ts
+++ b/lib/server/custom-launch/finalized-custom-launch-metadata-feed-v1.ts
@@ -648,8 +648,13 @@ function metadataMatchesRouterEntryV1(
 }
 
 function parseFeedPageV1(value: JsonValue, now: number): FeedPageV1 {
+  const hasQuality = value !== null
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && Object.hasOwn(value, "quality");
   const record = exactRecord(value, [
     "schemaVersion", "generatedAt", "launches", "nextCursor",
+    ...(hasQuality ? ["quality"] : []),
   ], "Finalized Custom metadata list");
   if (
     record.schemaVersion !== FINALIZED_CUSTOM_LAUNCH_METADATA_LIST_SCHEMA_V1
@@ -665,12 +670,67 @@ function parseFeedPageV1(value: JsonValue, now: number): FeedPageV1 {
     generatedAtMs > now + MAXIMUM_FUTURE_SKEW_MS
     || now - generatedAtMs > MAXIMUM_GENERATED_AGE_MS
   ) throw new Error("Finalized Custom metadata list is stale");
+  if (hasQuality) parseFeedQualityV1(record.quality, record.launches.length);
   return deepFreeze({
     schemaVersion: FINALIZED_CUSTOM_LAUNCH_METADATA_LIST_SCHEMA_V1,
     generatedAt,
     launches: record.launches.map(parseLaunchV1),
     nextCursor: record.nextCursor as string | null,
   });
+}
+
+function parseFeedQualityV1(
+  value: JsonValue | undefined,
+  publishedLaunchCount: number,
+) {
+  const record = exactRecord(value, [
+    "status", "sourceRowCount", "publishedRowCount",
+    "quarantinedRowCount", "diagnostics",
+  ], "Finalized Custom metadata quality");
+  if (
+    (record.status !== "complete" && record.status !== "partial")
+    || !boundedInteger(
+      record.sourceRowCount,
+      0,
+      FINALIZED_CUSTOM_LAUNCH_METADATA_PAGE_LIMIT,
+    )
+    || !boundedInteger(
+      record.publishedRowCount,
+      0,
+      FINALIZED_CUSTOM_LAUNCH_METADATA_PAGE_LIMIT,
+    )
+    || !boundedInteger(
+      record.quarantinedRowCount,
+      0,
+      FINALIZED_CUSTOM_LAUNCH_METADATA_PAGE_LIMIT,
+    )
+    || !Array.isArray(record.diagnostics)
+    || record.diagnostics.length > FINALIZED_CUSTOM_LAUNCH_METADATA_PAGE_LIMIT
+    || record.publishedRowCount !== publishedLaunchCount
+    || record.publishedRowCount + record.quarantinedRowCount
+      !== record.sourceRowCount
+    || record.diagnostics.length !== record.quarantinedRowCount
+    || (record.status === "complete" && record.quarantinedRowCount !== 0)
+    || (record.status === "partial" && record.quarantinedRowCount === 0)
+  ) throw new Error("Finalized Custom metadata quality is invalid");
+
+  const rowIndexes = new Set<number>();
+  for (const value of record.diagnostics) {
+    const diagnostic = exactRecord(value, [
+      "rowIndex", "code",
+    ], "Finalized Custom metadata quality diagnostic");
+    if (
+      !boundedInteger(
+        diagnostic.rowIndex,
+        0,
+        FINALIZED_CUSTOM_LAUNCH_METADATA_PAGE_LIMIT - 1,
+      )
+      || diagnostic.rowIndex >= record.sourceRowCount
+      || diagnostic.code !== "FINALIZED_ROW_QUARANTINED"
+      || rowIndexes.has(diagnostic.rowIndex)
+    ) throw new Error("Finalized Custom metadata quality diagnostic is invalid");
+    rowIndexes.add(diagnostic.rowIndex);
+  }
 }
 
 function parseLaunchV1(value: JsonValue): FinalizedCustomLaunchMetadataV1 {

--- a/tests/finalized-custom-launch-metadata-feed-v1.test.ts
+++ b/tests/finalized-custom-launch-metadata-feed-v1.test.ts
@@ -259,12 +259,37 @@ function launchFixture(input: LaunchFixtureOptions = {}) {
 function feedPage(
   launches: readonly ReturnType<typeof launchFixture>[],
   nextCursor: string | null = null,
+  quality?: Readonly<Record<string, unknown>>,
 ) {
   return {
     schemaVersion: "programmable.finalized-custom-launch-metadata-list.v1",
     generatedAt: GENERATED_AT,
     launches,
     nextCursor,
+    ...(quality ? { quality } : {}),
+  } as const;
+}
+
+function completeFeedQuality(publishedRowCount: number) {
+  return {
+    status: "complete",
+    sourceRowCount: publishedRowCount,
+    publishedRowCount,
+    quarantinedRowCount: 0,
+    diagnostics: [],
+  } as const;
+}
+
+function partialFeedQuality(publishedRowCount: number) {
+  return {
+    status: "partial",
+    sourceRowCount: publishedRowCount + 1,
+    publishedRowCount,
+    quarantinedRowCount: 1,
+    diagnostics: [{
+      rowIndex: publishedRowCount,
+      code: "FINALIZED_ROW_QUARANTINED",
+    }],
   } as const;
 }
 
@@ -314,6 +339,95 @@ afterEach(() => {
 });
 
 describe("finalized Custom launch metadata feed v1", () => {
+  it.each([
+    ["complete", completeFeedQuality(1)],
+    ["partial", partialFeedQuality(1)],
+  ])("accepts and validates the documented %s page-quality envelope", async (
+    _status,
+    quality,
+  ) => {
+    const launch = launchFixture();
+    const feed = await readFinalizedCustomLaunchMetadataPagesV1({
+      fetchFeed: (async () => jsonResponse(feedPage(
+        [launch],
+        null,
+        quality,
+      ))) as typeof fetch,
+      now: () => NOW,
+      timeoutMs: 50,
+    });
+
+    expect(feed.launches).toHaveLength(1);
+    expect(feed.launches[0]?.routerLaunchId).toBe(launch.routerLaunchId);
+  });
+
+  it("keeps the legacy list page without quality compatible", async () => {
+    const launch = launchFixture();
+    const feed = await readFinalizedCustomLaunchMetadataPagesV1({
+      fetchFeed: (async () => jsonResponse(feedPage([launch]))) as typeof fetch,
+      now: () => NOW,
+      timeoutMs: 50,
+    });
+
+    expect(feed.launches[0]?.routerLaunchId).toBe(launch.routerLaunchId);
+  });
+
+  it.each([
+    {
+      name: "unknown quality key",
+      quality: { ...completeFeedQuality(1), extra: true },
+    },
+    {
+      name: "unsupported status",
+      quality: { ...completeFeedQuality(1), status: "unknown" },
+    },
+    {
+      name: "published count mismatch",
+      quality: { ...completeFeedQuality(1), publishedRowCount: 0 },
+    },
+    {
+      name: "broken source accounting",
+      quality: { ...completeFeedQuality(1), sourceRowCount: 2 },
+    },
+    {
+      name: "partial status without quarantine",
+      quality: { ...completeFeedQuality(1), status: "partial" },
+    },
+    {
+      name: "wrong diagnostic code",
+      quality: {
+        status: "partial",
+        sourceRowCount: 2,
+        publishedRowCount: 1,
+        quarantinedRowCount: 1,
+        diagnostics: [{ rowIndex: 1, code: "UNKNOWN" }],
+      },
+    },
+    {
+      name: "duplicate diagnostic row",
+      quality: {
+        status: "partial",
+        sourceRowCount: 3,
+        publishedRowCount: 1,
+        quarantinedRowCount: 2,
+        diagnostics: [
+          { rowIndex: 1, code: "FINALIZED_ROW_QUARANTINED" },
+          { rowIndex: 1, code: "FINALIZED_ROW_QUARANTINED" },
+        ],
+      },
+    },
+  ])("rejects malformed page quality: $name", async ({ quality }) => {
+    await expect(readFinalizedCustomLaunchMetadataPagesV1({
+      fetchFeed: (async () => jsonResponse(feedPage(
+        [launchFixture()],
+        null,
+        quality,
+      ))) as typeof fetch,
+      now: () => NOW,
+      timeoutMs: 50,
+    })).rejects.toThrow(/metadata quality/u);
+  });
+
   it("binds immutable partner attribution into the public Router overlay", async () => {
     const feed = await parsedFeed(launchFixture({
       partnerAttribution: PARTNER_ATTRIBUTION,


### PR DESCRIPTION
## Summary
- accept the documented optional `quality` envelope returned by `/v3/finalized-custom-launches` while retaining legacy list-page compatibility
- validate exact quality and diagnostic keys, bounded counts, source accounting, status consistency, published-row parity, and unique row indexes
- keep unknown top-level fields fail-closed and leave pagination, metadata overlays, and bounded LKG behavior unchanged

## Checks
- `npx vitest run tests/finalized-custom-launch-metadata-feed-v1.test.ts tests/router-custom-public.test.ts tests/finalized-trade-adapter-descriptor-v1.test.ts` (63 passed)
- `npm run typecheck`
- `npx eslint lib/server/custom-launch/finalized-custom-launch-metadata-feed-v1.ts tests/finalized-custom-launch-metadata-feed-v1.test.ts`
- `git diff --check`

No merge or deployment performed.