### PR TITLE
Fix SHARD artwork on creator profile

### DIFF
--- a/app/api/explore/profile/route.ts
+++ b/app/api/explore/profile/route.ts
@@ -47,6 +47,8 @@ import {
 import {
   resolveRouterCustomCreatorClaimCapabilityV1,
 } from "@/lib/profile/router-custom-creator-claim";
+import { publicExplorePresentationEntryV1 } from
+  "@/lib/public-explore-catalog-v1";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -762,7 +764,7 @@ export async function GET(request: NextRequest) {
       deadlineMs,
     }).then(
       (snapshot) => ({
-        entries: snapshot.entries,
+        entries: snapshot.entries.map(publicExplorePresentationEntryV1),
         snapshot,
         status: snapshot.status,
       }),

--- a/lib/profile/onchain-profile.ts
+++ b/lib/profile/onchain-profile.ts
@@ -18,6 +18,7 @@ import {
   parseLaunchPartnerAttributionV1,
   type LaunchPartnerAttributionV1,
 } from "../launch-partner-attribution";
+import { safePublicImageUrl } from "../safe-public-image-url";
 import {
   FADE_ROUTER_CUSTOM_CREATOR_CLAIM_ADAPTER_ID,
   resolveRouterCustomCreatorClaimCapabilityV1,
@@ -402,7 +403,7 @@ function containsRecognizableProfileSecret(value: string) {
   return PROFILE_SECRET_PATTERNS.some((pattern) => pattern.test(value));
 }
 
-function safePublicHttpsUrl(value: unknown) {
+function safeProfileUrlValue(value: unknown) {
   const decoded = typeof value === "string"
     ? fullyDecodeProfileText(value)
     : "";
@@ -417,9 +418,15 @@ function safePublicHttpsUrl(value: unknown) {
   ) {
     return undefined;
   }
+  return value;
+}
+
+function safePublicHttpsUrl(value: unknown) {
+  const safeValue = safeProfileUrlValue(value);
+  if (safeValue === undefined) return undefined;
 
   try {
-    const url = new URL(value);
+    const url = new URL(safeValue);
     const hostname = url.hostname.toLowerCase();
     if (
       url.protocol !== "https:" ||
@@ -436,7 +443,7 @@ function safePublicHttpsUrl(value: unknown) {
       /^\d{1,3}(?:\.\d{1,3}){3}$/u.test(hostname) ||
       !/^[a-z0-9.-]+$/u.test(hostname) ||
       url.hash !== "" ||
-      url.href !== value ||
+      url.href !== safeValue ||
       [...url.searchParams].some(([key, queryValue]) =>
         PROFILE_SENSITIVE_QUERY_KEY.test(fullyDecodeProfileText(key)) ||
         containsRecognizableProfileSecret(
@@ -446,19 +453,23 @@ function safePublicHttpsUrl(value: unknown) {
     ) {
       return undefined;
     }
-    return value;
+    return safeValue;
   } catch {
     return undefined;
   }
 }
 
-function readOptionalHttpsUrl(
+function readOptionalImageUrl(
   record: Record<string, unknown>,
   key: string,
 ) {
   const value = record[key];
   if (value === undefined || value === null || value === "") return undefined;
-  return safePublicHttpsUrl(value);
+  const safeValue = safeProfileUrlValue(value);
+  if (safeValue === undefined) return undefined;
+  return safeValue.startsWith("/") && !safeValue.startsWith("//")
+    ? safePublicImageUrl(safeValue)
+    : safePublicHttpsUrl(safeValue);
 }
 
 function readOptionalProjectDescription(record: Record<string, unknown>) {
@@ -863,7 +874,7 @@ function parseToken(
   const poolId = readHex(token, "poolId", "pool id", 32);
   const hookAddress = readAddress(token, "hookAddress", "token hook address");
   const description = readOptionalProjectDescription(token);
-  const imageUrl = readOptionalHttpsUrl(token, "imageUrl");
+  const imageUrl = readOptionalImageUrl(token, "imageUrl");
   const projectMetadataLinks = readOptionalProjectMetadataLinks(token);
   const projectMetadataStatus = readOptionalProjectMetadataStatus(token);
   const partnerAttribution = token.partnerAttribution === undefined

--- a/tests/profile-client.test.ts
+++ b/tests/profile-client.test.ts
@@ -377,6 +377,29 @@ describe("profile API client", () => {
     },
   );
 
+  it("preserves the canonical rooted SHARD artwork path", () => {
+    const response = profileResponse();
+    response.tokens[0]!.imageUrl = "/brand/projects/shard-token-v1.png";
+
+    const profile = mapCreatorProfileResponse(response, account);
+
+    expect(profile.tokens[0]?.imageUrl).toBe(
+      "/brand/projects/shard-token-v1.png",
+    );
+  });
+
+  it.each([
+    "//images.example/project.png",
+    "/\\images.example/project.png",
+  ])("drops unsafe relative artwork %s", (imageUrl) => {
+    const response = profileResponse();
+    response.tokens[0]!.imageUrl = imageUrl;
+
+    const profile = mapCreatorProfileResponse(response, account);
+
+    expect(profile.tokens[0]?.imageUrl).toBeUndefined();
+  });
+
   it("keeps canonical identity while dropping untrusted presentation URLs", () => {
     const response = profileResponse();
     Object.assign(response.tokens[0], {

--- a/tests/public-route-handler-wiring.test.ts
+++ b/tests/public-route-handler-wiring.test.ts
@@ -45,6 +45,7 @@ const mocks = vi.hoisted(() => ({
   readAlchemyCreatorProfile: vi.fn(),
   readAlchemyExploreModel: vi.fn(),
   readRouter: vi.fn(),
+  routerAsOfBlock: vi.fn(() => "25740001"),
   safeAlchemyError: vi.fn((error) => error),
 }));
 
@@ -129,7 +130,7 @@ vi.mock("../lib/alchemy/router-custom-public.server", () => ({
       source: "canonical-launch-stamp-router",
       status: "current",
       generatedAt: "2026-08-22T08:00:01.000Z",
-      asOfBlock: "25740001",
+      asOfBlock: mocks.routerAsOfBlock(),
       asOfBlockHash: `0x${"bc".repeat(32)}`,
       finalityConfirmations: 64,
       identityCommitment: `sha256:${"ac".repeat(32)}`,
@@ -211,7 +212,10 @@ vi.mock("../lib/market-data/envio-classic-v3-catalog.server", () => ({
 
 import { GET as creatorProfile } from "../app/api/explore/profile/route";
 import { GET as stockLaunchLookup } from "../app/api/explore/launch/stock-paired/route";
+import { SHARD_PUBLIC_PRESENTATION_V1 } from
+  "../lib/custom-launch/router-trade-adapters-v1";
 import { customGraphExploreEntry } from "./launch-stamp-surface-fixture";
+import { shardRouterTradeEntry } from "./shard-router-trade-fixture";
 
 const ACCOUNT = "0x1111111111111111111111111111111111111111";
 const TRANSACTION = `0x${"22".repeat(32)}`;
@@ -377,6 +381,57 @@ describe("public route coordinator wiring", () => {
       generatedWei: "0",
       claimedWei: "0",
     });
+  });
+
+  it("reuses the exact SHARD presentation without trusting mutable lookalikes", async () => {
+    mocks.readEnvioClassicV3CatalogV1.mockResolvedValue({
+      ...profileCatalog(),
+      asOfBlock: "25845472",
+      asOfBlockHash: `0x${"97".repeat(32)}`,
+      entries: [],
+    });
+    mocks.routerAsOfBlock.mockReturnValue("25845472");
+    mocks.readRouter.mockResolvedValue([shardRouterTradeEntry]);
+
+    const shardResponse = await creatorProfile(new NextRequest(
+      `http://localhost/api/explore/profile?account=${shardRouterTradeEntry.creatorAddress}`,
+    ));
+    const shardBody = await shardResponse.json();
+
+    expect(shardResponse.status).toBe(200);
+    expect(shardBody.tokens).toEqual([
+      expect.objectContaining({
+        tokenAddress: SHARD_PUBLIC_PRESENTATION_V1.tokenAddress,
+        description: SHARD_PUBLIC_PRESENTATION_V1.description,
+        imageUrl: SHARD_PUBLIC_PRESENTATION_V1.imageUrl,
+        links: SHARD_PUBLIC_PRESENTATION_V1.links,
+      }),
+    ]);
+
+    mocks.readEnvioClassicV3CatalogV1.mockResolvedValue({
+      ...profileCatalog(),
+      asOfBlock: "25740001",
+      entries: [],
+    });
+    mocks.routerAsOfBlock.mockReturnValue("25740001");
+    mocks.readRouter.mockResolvedValue([{
+      ...customGraphExploreEntry,
+      name: "Shard",
+      symbol: "SHARD",
+    }]);
+
+    const lookalikeResponse = await creatorProfile(new NextRequest(
+      `http://localhost/api/explore/profile?account=${customGraphExploreEntry.creatorAddress}`,
+    ));
+    const lookalikeBody = await lookalikeResponse.json();
+
+    expect(lookalikeResponse.status).toBe(200);
+    expect(lookalikeBody.tokens).toEqual([
+      expect.objectContaining({ name: "Shard", symbol: "SHARD" }),
+    ]);
+    expect(lookalikeBody.tokens[0]).not.toHaveProperty("description");
+    expect(lookalikeBody.tokens[0]).not.toHaveProperty("imageUrl");
+    expect(lookalikeBody.tokens[0]).not.toHaveProperty("links");
   });
 
   it("keeps the Envio profile visible when Router discovery fails", async () => {


### PR DESCRIPTION
## Outcome

- reuse the existing SHARD public presentation only after its exact chain ID, token address, launch ID, and stamp hash match
- preserve the canonical `/brand/projects/shard-token-v1.png` path through the Profile client
- keep external artwork on the existing strict HTTPS, private-host, query, fragment, and secret checks
- prove a mutable Shard/SHARD lookalike does not inherit the reviewed presentation

## Verification

- `npx vitest run tests/public-route-handler-wiring.test.ts tests/profile-client.test.ts tests/public-explore-catalog-v1.test.ts tests/explore-api.test.ts tests/token-detail-api.test.ts tests/safe-public-image-url.test.ts` (87 passed)
- `npm run typecheck`
- `npx eslint app/api/explore/profile/route.ts lib/profile/onchain-profile.ts tests/public-route-handler-wiring.test.ts tests/profile-client.test.ts`
- `git diff --check`

## Release boundary

- exact production base: `9f0283e5d2e8e2ba6cc1927ff4d94de97c2353ba`
- candidate head: `8077177e8206b1b2095eeff14355a4f3f0f495c2`
- candidate tree: `5b570184dac3eac9c38e5db10d9bee832351e846`
- no merge or deployment performed