### PR TITLE
Fix token detail social metadata

### DIFF
--- a/app/token/[address]/page.tsx
+++ b/app/token/[address]/page.tsx
@@ -1,5 +1,6 @@
+import type { Metadata } from "next";
 import { NextRequest } from "next/server";
-import { Suspense } from "react";
+import { cache, Suspense } from "react";
 
 import { GET as readTokenDetailResponse } from
   "@/app/api/explore/token/route";
@@ -8,6 +9,8 @@ import {
   type TokenDetailInitialResponse,
 } from "@/components/token-detail-view";
 import { TokenDetailShell } from "@/components/token-detail-shell";
+import { tokenDetailMetadataFromProjection } from
+  "@/lib/token-detail-metadata";
 
 export const dynamic = "force-dynamic";
 
@@ -47,6 +50,33 @@ export async function readInitialTokenDetailWithinDeadline(
   }
 }
 
+const readInitialTokenDetail = cache(async (address: string) => {
+  const search = new URLSearchParams({ address });
+  return await readInitialTokenDetailWithinDeadline(async (signal) => {
+    const response = await readTokenDetailResponse(new NextRequest(
+      `http://programmable.local/api/explore/token?${search.toString()}`,
+      {
+        headers: { Accept: "application/json" },
+        signal,
+      },
+    ));
+    const body: unknown = await response.json().catch(() => null);
+    return { status: response.status, body };
+  });
+});
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ address: string }>;
+}): Promise<Metadata> {
+  const { address } = await params;
+  return tokenDetailMetadataFromProjection(
+    address,
+    await readInitialTokenDetail(address),
+  );
+}
+
 export default async function TokenPage({
   params,
 }: {
@@ -61,20 +91,7 @@ export default async function TokenPage({
 }
 
 async function InitialTokenDetail({ address }: { address: string }) {
-  const search = new URLSearchParams({ address });
-  const initialResponse = await readInitialTokenDetailWithinDeadline(
-    async (signal) => {
-      const response = await readTokenDetailResponse(new NextRequest(
-        `http://programmable.local/api/explore/token?${search.toString()}`,
-        {
-          headers: { Accept: "application/json" },
-          signal,
-        },
-      ));
-      const body: unknown = await response.json().catch(() => null);
-      return { status: response.status, body };
-    },
-  );
+  const initialResponse = await readInitialTokenDetail(address);
 
   return (
     <TokenDetailView

--- a/lib/token-detail-metadata.ts
+++ b/lib/token-detail-metadata.ts
@@ -1,0 +1,256 @@
+import type { Metadata } from "next";
+import { getAddress, isAddress } from "viem";
+
+import {
+  characterLength,
+  hasUnsafeDisplayCharacters,
+  isValidTokenSymbol,
+  MAX_TOKEN_DESCRIPTION_BYTES,
+  MAX_TOKEN_NAME_BYTES,
+  MAX_TOKEN_NAME_CHARACTERS,
+  MAX_TOKEN_SYMBOL_BYTES,
+  MAX_TOKEN_SYMBOL_CHARACTERS,
+  utf8ByteLength,
+} from "./metadata-policy";
+import { safePublicImageUrl } from "./safe-public-image-url";
+
+const SITE_ORIGIN = "https://programmable.market";
+const SITE_DESCRIPTION = "Shape what assets can do";
+const FALLBACK_SOCIAL_IMAGE =
+  `${SITE_ORIGIN}/og/programmable-landing-preview-v2-1200x630.jpg`;
+const FALLBACK_SOCIAL_ALT =
+  "Programmable and Shape what assets can do over a vivid floral night garden";
+const BIDI_OVERRIDE_CHARACTERS = /[\u202a-\u202e\u2066-\u2069]/u;
+
+type TokenDetailProjectionResponse = Readonly<{
+  status: number;
+  body: unknown;
+}>;
+
+type ProjectedTokenMetadata = Readonly<{
+  address: `0x${string}`;
+  name: string;
+  symbol: string | null;
+  description: string;
+  imageUrl: string;
+}>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function safeDisplayText(
+  value: unknown,
+  maximumBytes: number,
+  maximumCharacters?: number,
+) {
+  if (typeof value !== "string" || value.length === 0) return null;
+  if (
+    value.trim() !== value ||
+    value.normalize("NFC") !== value ||
+    hasUnsafeDisplayCharacters(value) ||
+    BIDI_OVERRIDE_CHARACTERS.test(value) ||
+    utf8ByteLength(value) > maximumBytes ||
+    (maximumCharacters !== undefined &&
+      characterLength(value) > maximumCharacters)
+  ) {
+    return null;
+  }
+  return value;
+}
+
+function absolutePublicImageUrl(value: unknown) {
+  const safeValue = safePublicImageUrl(value);
+  if (!safeValue) return null;
+  try {
+    const url = new URL(safeValue, SITE_ORIGIN);
+    if (safeValue.startsWith("/")) {
+      return url.origin === SITE_ORIGIN ? url.toString() : null;
+    }
+    if (url.origin === SITE_ORIGIN) return url.toString();
+
+    const hostname = url.hostname.toLowerCase();
+    if (
+      url.protocol !== "https:" ||
+      url.username !== "" ||
+      url.password !== "" ||
+      hostname === "" ||
+      hostname === "localhost" ||
+      hostname === "localhost." ||
+      hostname.endsWith(".localhost") ||
+      hostname.endsWith(".localhost.") ||
+      hostname.endsWith(".local") ||
+      hostname.endsWith(".local.") ||
+      hostname.endsWith(".") ||
+      hostname.includes(":") ||
+      /^(?:\d{1,3}\.){3}\d{1,3}$/u.test(hostname) ||
+      !/^[a-z0-9.-]+$/u.test(hostname) ||
+      !hostname.includes(".") ||
+      url.hash !== ""
+    ) {
+      return null;
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function fallbackTokenCanonical(requestedAddress?: string) {
+  if (!requestedAddress || !isAddress(requestedAddress)) return SITE_ORIGIN;
+  return `${SITE_ORIGIN}/token/${getAddress(requestedAddress)}`;
+}
+
+function shouldNoIndexFallback(
+  requestedAddress: string,
+  response: TokenDetailProjectionResponse,
+) {
+  return !isAddress(requestedAddress) ||
+    response.status === 400 ||
+    response.status === 404 ||
+    response.status === 410;
+}
+
+function projectedTokenMetadata(
+  requestedAddress: string,
+  response: TokenDetailProjectionResponse,
+): ProjectedTokenMetadata | null {
+  if (
+    response.status < 200 ||
+    response.status >= 300 ||
+    !isAddress(requestedAddress) ||
+    !isRecord(response.body) ||
+    response.body.status !== "ready"
+  ) {
+    return null;
+  }
+
+  const token = isRecord(response.body.token) ? response.body.token : null;
+  const customProject = isRecord(response.body.customProject)
+    ? response.body.customProject
+    : null;
+  if ((token === null) === (customProject === null)) return null;
+  const entity = token ?? customProject;
+  if (entity === null) return null;
+
+  if (
+    typeof entity.tokenAddress !== "string" ||
+    !isAddress(entity.tokenAddress) ||
+    getAddress(entity.tokenAddress).toLowerCase() !==
+      getAddress(requestedAddress).toLowerCase()
+  ) {
+    return null;
+  }
+
+  const name = safeDisplayText(
+    entity.name,
+    MAX_TOKEN_NAME_BYTES,
+    MAX_TOKEN_NAME_CHARACTERS,
+  );
+  if (!name) return null;
+
+  const symbol = entity.symbol === undefined || entity.symbol === null
+    ? null
+    : safeDisplayText(
+        entity.symbol,
+        MAX_TOKEN_SYMBOL_BYTES,
+        MAX_TOKEN_SYMBOL_CHARACTERS,
+      );
+  if (entity.symbol !== undefined && entity.symbol !== null && !symbol) {
+    return null;
+  }
+  if (symbol && !isValidTokenSymbol(symbol)) return null;
+
+  const description = safeDisplayText(
+    entity.description,
+    MAX_TOKEN_DESCRIPTION_BYTES,
+  );
+  const symbolLabel = symbol
+    ? symbol.startsWith("$") ? symbol : `$${symbol}`
+    : null;
+
+  return {
+    address: getAddress(entity.tokenAddress),
+    name,
+    symbol,
+    description:
+      description ?? `Explore ${name}${symbolLabel ? ` (${symbolLabel})` : ""} on Programmable.`,
+    imageUrl:
+      absolutePublicImageUrl(entity.imageUrl) ?? FALLBACK_SOCIAL_IMAGE,
+  };
+}
+
+export function genericTokenDetailMetadata(
+  requestedAddress?: string,
+  noIndex = false,
+): Metadata {
+  const canonical = fallbackTokenCanonical(requestedAddress);
+  const metadata: Metadata = {
+    title: "Programmable",
+    description: SITE_DESCRIPTION,
+    alternates: { canonical },
+    openGraph: {
+      type: "website",
+      url: canonical,
+      siteName: "Programmable",
+      title: "Programmable",
+      description: SITE_DESCRIPTION,
+      images: [{ url: FALLBACK_SOCIAL_IMAGE, alt: FALLBACK_SOCIAL_ALT }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: "Programmable",
+      description: SITE_DESCRIPTION,
+      creator: "@0xprogrammable",
+      images: [{ url: FALLBACK_SOCIAL_IMAGE, alt: FALLBACK_SOCIAL_ALT }],
+    },
+  };
+  if (noIndex) metadata.robots = { index: false, follow: false };
+  return metadata;
+}
+
+export function tokenDetailMetadataFromProjection(
+  requestedAddress: string,
+  response: TokenDetailProjectionResponse,
+): Metadata {
+  const projected = projectedTokenMetadata(requestedAddress, response);
+  if (!projected) {
+    return genericTokenDetailMetadata(
+      requestedAddress,
+      shouldNoIndexFallback(requestedAddress, response),
+    );
+  }
+
+  const symbolLabel = projected.symbol
+    ? projected.symbol.startsWith("$")
+      ? projected.symbol
+      : `$${projected.symbol}`
+    : null;
+  const identityLabel = symbolLabel
+    ? `${projected.name} (${symbolLabel})`
+    : projected.name;
+  const title = `${identityLabel} | Programmable`;
+  const canonical = `${SITE_ORIGIN}/token/${projected.address}`;
+  const imageAlt = `${projected.name} artwork`;
+
+  return {
+    title,
+    description: projected.description,
+    alternates: { canonical },
+    openGraph: {
+      type: "website",
+      url: canonical,
+      siteName: "Programmable",
+      title,
+      description: projected.description,
+      images: [{ url: projected.imageUrl, alt: imageAlt }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: projected.description,
+      creator: "@0xprogrammable",
+      images: [{ url: projected.imageUrl, alt: imageAlt }],
+    },
+  };
+}

--- a/tests/token-detail-metadata.test.ts
+++ b/tests/token-detail-metadata.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  genericTokenDetailMetadata,
+  tokenDetailMetadataFromProjection,
+} from "../lib/token-detail-metadata";
+
+const SHARD = "0xFAce73B63787960282f2d4682d3752Beb25271Ad";
+
+function readyProjection(
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    status: 200,
+    body: {
+      status: "ready",
+      token: {
+        tokenAddress: SHARD,
+        name: "Shard",
+        symbol: "SHARD",
+        description: "The NFT bonding curve built directly on UNI v4",
+        imageUrl: "/brand/projects/shard-token-v1.png",
+        ...overrides,
+      },
+      customProject: null,
+    },
+  };
+}
+
+describe("token detail metadata", () => {
+  it("projects exact token metadata from the server-bound detail response", () => {
+    const metadata = tokenDetailMetadataFromProjection(
+      SHARD,
+      readyProjection(),
+    );
+
+    expect(metadata.title).toBe("Shard ($SHARD) | Programmable");
+    expect(metadata.description).toBe(
+      "The NFT bonding curve built directly on UNI v4",
+    );
+    expect(metadata.alternates?.canonical).toBe(
+      `https://programmable.market/token/${SHARD}`,
+    );
+    expect(metadata.openGraph).toMatchObject({
+      url: `https://programmable.market/token/${SHARD}`,
+      title: "Shard ($SHARD) | Programmable",
+      description: "The NFT bonding curve built directly on UNI v4",
+      images: [{
+        url: "https://programmable.market/brand/projects/shard-token-v1.png",
+        alt: "Shard artwork",
+      }],
+    });
+    expect(metadata.twitter).toMatchObject({
+      card: "summary_large_image",
+      title: "Shard ($SHARD) | Programmable",
+      images: [{
+        url: "https://programmable.market/brand/projects/shard-token-v1.png",
+        alt: "Shard artwork",
+      }],
+    });
+  });
+
+  it("uses the same exact-address projection for custom projects", () => {
+    const response = readyProjection();
+    const token = (response.body as Record<string, unknown>).token;
+    const metadata = tokenDetailMetadataFromProjection(SHARD, {
+      status: 200,
+      body: {
+        status: "ready",
+        token: null,
+        customProject: token,
+      },
+    });
+
+    expect(metadata.title).toBe("Shard ($SHARD) | Programmable");
+    expect(metadata.alternates?.canonical).toBe(
+      `https://programmable.market/token/${SHARD}`,
+    );
+  });
+
+  it("does not trust lookalike or caller-supplied metadata", () => {
+    const response = readyProjection({
+      tokenAddress: "0x1111111111111111111111111111111111111111",
+    });
+    (response.body as Record<string, unknown>).name = "Caller supplied name";
+    (response.body as Record<string, unknown>).imageUrl =
+      "https://attacker.invalid/image.png";
+
+    expect(tokenDetailMetadataFromProjection(SHARD, response)).toEqual(
+      genericTokenDetailMetadata(SHARD),
+    );
+  });
+
+  it("fails soft for unavailable, malformed and conflicting projections", () => {
+    const fallback = genericTokenDetailMetadata(SHARD);
+    expect(tokenDetailMetadataFromProjection(SHARD, {
+      status: 503,
+      body: { error: "temporarily unavailable" },
+    })).toEqual(fallback);
+    expect(tokenDetailMetadataFromProjection("not-an-address", readyProjection()))
+      .toEqual(genericTokenDetailMetadata("not-an-address", true));
+    expect(tokenDetailMetadataFromProjection(SHARD, {
+      status: 200,
+      body: {
+        status: "ready",
+        token: (readyProjection().body as Record<string, unknown>).token,
+        customProject: (readyProjection().body as Record<string, unknown>).token,
+      },
+    })).toEqual(fallback);
+  });
+
+  it("rejects unsafe identity text and falls back per-field for missing media", () => {
+    expect(tokenDetailMetadataFromProjection(
+      SHARD,
+      readyProjection({ name: "Shard\u202e" }),
+    )).toEqual(genericTokenDetailMetadata(SHARD));
+
+    const metadata = tokenDetailMetadataFromProjection(
+      SHARD,
+      readyProjection({ description: undefined, imageUrl: "javascript:bad" }),
+    );
+    expect(metadata.description).toBe("Explore Shard ($SHARD) on Programmable.");
+    expect(metadata.openGraph).toMatchObject({
+      images: [{
+        url: "https://programmable.market/og/programmable-landing-preview-v2-1200x630.jpg",
+      }],
+    });
+  });
+
+  it("keeps a valid token canonical during temporary projection failure", () => {
+    const metadata = tokenDetailMetadataFromProjection(SHARD, {
+      status: 503,
+      body: { error: "temporarily unavailable" },
+    });
+
+    expect(metadata.alternates?.canonical).toBe(
+      `https://programmable.market/token/${SHARD}`,
+    );
+    expect(metadata.openGraph).toMatchObject({
+      url: `https://programmable.market/token/${SHARD}`,
+    });
+    expect(metadata.robots).toBeUndefined();
+  });
+
+  it("marks invalid and not-found token routes as noindex", () => {
+    expect(tokenDetailMetadataFromProjection("not-an-address", readyProjection()))
+      .toMatchObject({ robots: { index: false, follow: false } });
+    expect(tokenDetailMetadataFromProjection(SHARD, {
+      status: 404,
+      body: { error: "not found" },
+    })).toMatchObject({
+      alternates: { canonical: `https://programmable.market/token/${SHARD}` },
+      robots: { index: false, follow: false },
+    });
+  });
+
+  it("does not publish private or local crawler image targets", () => {
+    for (const imageUrl of [
+      "https://localhost/token.png",
+      "https://127.0.0.1/token.png",
+      "https://[::1]/token.png",
+      "https://metadata.local/token.png",
+      "https://169.254.169.254/latest/meta-data",
+      "/\\attacker.example/token.png",
+    ]) {
+      expect(tokenDetailMetadataFromProjection(
+        SHARD,
+        readyProjection({ imageUrl }),
+      ).openGraph).toMatchObject({
+        images: [{
+          url: "https://programmable.market/og/programmable-landing-preview-v2-1200x630.jpg",
+        }],
+      });
+    }
+  });
+});

--- a/tests/token-page-ssr.test.ts
+++ b/tests/token-page-ssr.test.ts
@@ -30,6 +30,9 @@ describe("token detail initial server read", () => {
     );
     expect(source).toContain("<Suspense fallback={<TokenDetailShell />}> ".trim());
     expect(source).toContain("<InitialTokenDetail address={address} />");
+    expect(source).toContain("const readInitialTokenDetail = cache");
+    expect(source).toContain("export async function generateMetadata");
+    expect(source.match(/readTokenDetailResponse\(/gu)).toHaveLength(1);
   });
 
   it("keeps the token layout stable while the initial detail read is pending", () => {


### PR DESCRIPTION
## Outcome

Token detail routes now publish server-generated canonical, Open Graph, and Twitter metadata from the existing server-owned token-detail projection. Identity metadata is accepted only when the projected token address exactly matches the requested address.

## Safety and fallback

- temporary projection failures keep the valid token canonical and generic Programmable metadata
- invalid and definitive not-found routes are noindex
- unsafe identity text and private/local/IP image targets are rejected
- no client-supplied metadata is trusted
- no raw Router feed was mixed into presentation

## Compatibility

`mode=custom` is not publicly documented or linked in this tree, so no query alias was added. Existing `model=custom` behavior is unchanged.

## Verification

- `npx vitest run tests/token-detail-metadata.test.ts tests/token-page-ssr.test.ts tests/token-detail-api.test.ts tests/token-detail-view.test.ts tests/safe-public-image-url.test.ts` (61 passed)
- `npm run typecheck`
- focused ESLint on changed files
- `git diff --check`