### PR TITLE
Fix partner admin linked wallet recovery

### DIFF
--- a/components/partner-admin-console.tsx
+++ b/components/partner-admin-console.tsx
@@ -148,6 +148,7 @@ function PartnerListSkeleton() {
 export function PartnerAdminConsole() {
   const {
     authReady,
+    authenticated,
     connecting,
     getAccessToken,
     getIdentityToken,
@@ -162,6 +163,8 @@ export function PartnerAdminConsole() {
     useState<Record<string, number>>({});
   const [loadState, setLoadState] = useState<LoadState>("idle");
   const [accessDenied, setAccessDenied] =
+    useState<PartnerAdminBrowserErrorV1 | null>(null);
+  const [walletNotLinked, setWalletNotLinked] =
     useState<PartnerAdminBrowserErrorV1 | null>(null);
   const [pageError, setPageError] = useState("");
   const [statusMessage, setStatusMessage] = useState("");
@@ -179,6 +182,25 @@ export function PartnerAdminConsole() {
   const [keyExpiryDays, setKeyExpiryDays] = useState<Record<string, string>>({});
   const secretRef = useRef<HTMLDivElement>(null);
   const nameRef = useRef<HTMLInputElement>(null);
+
+  const applyAuthorityError = useCallback((error: unknown) => {
+    if (
+      !(error instanceof PartnerAdminBrowserErrorV1)
+      || (!error.accessDenied && !error.walletNotLinked)
+    ) return false;
+    setPartners([]);
+    setPartnerPagination(EMPTY_PARTNER_PAGINATION);
+    setConfirmation(null);
+    setLoadState("error");
+    if (error.walletNotLinked) {
+      setWalletNotLinked(error);
+      setAccessDenied(null);
+    } else {
+      setAccessDenied(error);
+      setWalletNotLinked(null);
+    }
+    return true;
+  }, []);
 
   const getAuthHeaders = useCallback(async (json = false) => {
     const identityToken = await getIdentityToken().catch(() => null);
@@ -202,6 +224,8 @@ export function PartnerAdminConsole() {
     if (!account) return;
     setLoadState("loading");
     setPageError("");
+    setAccessDenied(null);
+    setWalletNotLinked(null);
     try {
       const query = new URLSearchParams({
         walletAddress: account,
@@ -229,21 +253,18 @@ export function PartnerAdminConsole() {
       setPartners([...parsed.partners]);
       setPartnerPagination(parsed.pagination);
       setAccessDenied(null);
+      setWalletNotLinked(null);
       setLoadState("ready");
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") return;
-      if (error instanceof PartnerAdminBrowserErrorV1 && error.accessDenied) {
-        setPartners([]);
-        setPartnerPagination(EMPTY_PARTNER_PAGINATION);
-        setAccessDenied(error);
+      if (applyAuthorityError(error)) {
         setPageError("");
-        setLoadState("error");
         return;
       }
       setPageError(error instanceof Error ? error.message : "Unable to load partners.");
       setLoadState("error");
     }
-  }, [account, getAuthHeaders]);
+  }, [account, applyAuthorityError, getAuthHeaders]);
 
   useEffect(() => {
     if (!authReady || !account) return;
@@ -356,8 +377,7 @@ export function PartnerAdminConsole() {
       }
       void loadPartners(undefined, 1);
     } catch (error) {
-      if (error instanceof PartnerAdminBrowserErrorV1 && error.accessDenied) {
-        setAccessDenied(error);
+      if (applyAuthorityError(error)) {
         setFormError("");
         return;
       }
@@ -397,8 +417,7 @@ export function PartnerAdminConsole() {
       setConfirmation(null);
       setStatusMessage(success(partner));
     } catch (error) {
-      if (error instanceof PartnerAdminBrowserErrorV1 && error.accessDenied) {
-        setAccessDenied(error);
+      if (applyAuthorityError(error)) {
         setPageError("");
         return;
       }
@@ -495,8 +514,7 @@ export function PartnerAdminConsole() {
       setRootKeyPages((current) => ({ ...current, [partner.id]: 1 }));
       void loadPartners(undefined, partnerPagination.page);
     } catch (error) {
-      if (error instanceof PartnerAdminBrowserErrorV1 && error.accessDenied) {
-        setAccessDenied(error);
+      if (applyAuthorityError(error)) {
         setPageError("");
         return;
       }
@@ -538,8 +556,7 @@ export function PartnerAdminConsole() {
       setStatusMessage(`${partner.displayName} root key was revoked.`);
       await loadPartners(undefined, partnerPagination.page);
     } catch (error) {
-      if (error instanceof PartnerAdminBrowserErrorV1 && error.accessDenied) {
-        setAccessDenied(error);
+      if (applyAuthorityError(error)) {
         setPageError("");
         return;
       }
@@ -619,11 +636,35 @@ export function PartnerAdminConsole() {
         </section>
       ) : !account ? (
         <section className={styles.statePanel}>
-          <h2>Connect the admin wallet</h2>
-          <p>The backend verifies admin access after the wallet session is connected.</p>
+          <h2>{authenticated ? "Link an admin wallet" : "Connect the admin wallet"}</h2>
+          <p>
+            {authenticated
+              ? "Link or select an Ethereum wallet before checking partner access."
+              : "The backend verifies admin access after the wallet session is connected."}
+          </p>
           <button type="button" disabled={connecting} onClick={openWallet}>
-            {connecting ? "Connecting wallet" : "Connect wallet"}
+            {connecting
+              ? "Connecting wallet"
+              : authenticated
+                ? "Manage wallets"
+                : "Connect wallet"}
           </button>
+        </section>
+      ) : walletNotLinked ? (
+        <section className={styles.statePanel} data-state="wallet-not-linked">
+          <p className={styles.kicker}>Wallet setup</p>
+          <h2>Link this wallet to continue</h2>
+          <p>
+            This wallet is connected but not linked to your Programmable
+            sign-in. Link it or select another linked wallet.
+          </p>
+          {walletNotLinked.requestId ? (
+            <p className={styles.requestId}>
+              <span>Request ID</span>
+              <code>{walletNotLinked.requestId}</code>
+            </p>
+          ) : null}
+          <button type="button" onClick={openWallet}>Manage wallets</button>
         </section>
       ) : accessDenied ? (
         <section className={styles.statePanel} data-state="access-denied">

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -202,7 +202,14 @@ function loadWalletProviderRuntime() {
 }
 
 export function shouldEagerLoadWalletRuntime(pathname: string) {
-  return ["/launch", "/markets", "/profile", "/token", "/developers/api-keys"].some(
+  return [
+    "/launch",
+    "/markets",
+    "/profile",
+    "/token",
+    "/developers/api-keys",
+    "/admin/partners",
+  ].some(
     (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
   );
 }
@@ -759,9 +766,30 @@ export function selectAuthenticatedWallet<T extends WalletCandidate>(
   return selectConnectedWallet(wallets, primaryAddress);
 }
 
+export function selectPartnerAdminWallet<T extends WalletCandidate>(
+  wallets: readonly T[],
+  primaryAddress?: string,
+) {
+  const linkedWallets = [...wallets]
+    .filter((candidate) => candidate.linked && isEthereumAddress(candidate.address))
+    .sort((left, right) => right.connectedAt - left.connectedAt);
+  const normalizedPrimaryAddress = primaryAddress?.toLowerCase();
+
+  return linkedWallets.find((candidate) =>
+    normalizedPrimaryAddress !== undefined
+    && candidate.address.toLowerCase() === normalizedPrimaryAddress)
+    ?? linkedWallets[0];
+}
+
+export function requiresPartnerAdminLinkedWallet(pathname: string) {
+  return pathname === "/admin/partners"
+    || pathname.startsWith("/admin/partners/");
+}
+
 export function WalletProvider({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const eager = shouldEagerLoadWalletRuntime(pathname);
+  const partnerAdminLinkedWalletOnly = requiresPartnerAdminLinkedWallet(pathname);
   const [activationRequested, setActivationRequested] = useState(false);
   const [pendingAction, setPendingAction] = useState<"wallet" | "github" | null>(
     null,
@@ -842,6 +870,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       appId={privyAppId}
       autoAction={pendingAction}
       onAutoActionConsumed={() => setPendingAction(null)}
+      partnerAdminLinkedWalletOnly={partnerAdminLinkedWalletOnly}
       runtime={runtime}
     >
       {children}
@@ -946,12 +975,14 @@ function ConfiguredWalletProvider({
   autoAction,
   children,
   onAutoActionConsumed,
+  partnerAdminLinkedWalletOnly,
   runtime,
 }: {
   appId: string;
   autoAction: "wallet" | "github" | null;
   children: ReactNode;
   onAutoActionConsumed: () => void;
+  partnerAdminLinkedWalletOnly: boolean;
   runtime: WalletProviderRuntime;
 }) {
   const { PrivyProvider } = runtime;
@@ -980,6 +1011,7 @@ function ConfiguredWalletProvider({
       <PrivyWalletBridge
         autoAction={autoAction}
         onAutoActionConsumed={onAutoActionConsumed}
+        partnerAdminLinkedWalletOnly={partnerAdminLinkedWalletOnly}
         runtime={runtime}
       >
         {children}
@@ -992,11 +1024,13 @@ function PrivyWalletBridge({
   autoAction,
   children,
   onAutoActionConsumed,
+  partnerAdminLinkedWalletOnly,
   runtime,
 }: Readonly<{
   autoAction: "wallet" | "github" | null;
   children: ReactNode;
   onAutoActionConsumed: () => void;
+  partnerAdminLinkedWalletOnly: boolean;
   runtime: WalletProviderRuntime;
 }>) {
   const {
@@ -1105,17 +1139,29 @@ function PrivyWalletBridge({
       ? undefined
       : wallets.find((candidate) =>
         isEthereumAddress(candidate.address)
+        && (!partnerAdminLinkedWalletOnly || candidate.linked)
         && candidate.address.toLowerCase() === selectedWalletAddress.toLowerCase());
-    return selected ?? selectAuthenticatedWallet(
-      activeAuthenticated,
-      wallets,
-      user?.wallet?.address,
-    );
-  }, [activeAuthenticated, selectedWalletAddress, user?.wallet?.address, wallets]);
+    return selected ?? (partnerAdminLinkedWalletOnly
+      ? selectPartnerAdminWallet(wallets, user?.wallet?.address)
+      : selectAuthenticatedWallet(
+          activeAuthenticated,
+          wallets,
+          user?.wallet?.address,
+        ));
+  }, [
+    activeAuthenticated,
+    partnerAdminLinkedWalletOnly,
+    selectedWalletAddress,
+    user?.wallet?.address,
+    wallets,
+  ]);
   const walletOptions = useMemo(() => {
     const seen = new Set<string>();
     return wallets.flatMap((candidate) => {
-      if (!isEthereumAddress(candidate.address)) return [];
+      if (
+        !isEthereumAddress(candidate.address)
+        || (partnerAdminLinkedWalletOnly && !candidate.linked)
+      ) return [];
       const normalized = candidate.address.toLowerCase();
       if (seen.has(normalized)) return [];
       seen.add(normalized);
@@ -1124,7 +1170,7 @@ function PrivyWalletBridge({
         chainId: normalizeChainId(candidate.chainId),
       })];
     });
-  }, [wallets]);
+  }, [partnerAdminLinkedWalletOnly, wallets]);
 
   const connectedWalletAddress = connectedWallet?.address;
   const connectedWalletChainId = connectedWallet?.chainId;

--- a/lib/partner-admin-browser-error.ts
+++ b/lib/partner-admin-browser-error.ts
@@ -4,6 +4,7 @@ const RETRY_AFTER_SECONDS = /^[1-9][0-9]{0,4}$/u;
 
 export class PartnerAdminBrowserErrorV1 extends Error {
   readonly accessDenied: boolean;
+  readonly walletNotLinked: boolean;
 
   constructor(
     readonly status: number,
@@ -15,6 +16,7 @@ export class PartnerAdminBrowserErrorV1 extends Error {
     super(message);
     this.name = "PartnerAdminBrowserErrorV1";
     this.accessDenied = status === 403 && code === "PARTNER_ADMIN_FORBIDDEN";
+    this.walletNotLinked = status === 403 && code === "wallet_not_linked";
   }
 }
 
@@ -44,6 +46,16 @@ export function partnerAdminBrowserErrorV1(
       requestId,
       null,
       "This wallet is signed in but does not have partner administration access.",
+    );
+  }
+
+  if (response.status === 403 && code === "wallet_not_linked") {
+    return new PartnerAdminBrowserErrorV1(
+      response.status,
+      code,
+      requestId,
+      null,
+      "This wallet is connected but not linked to your Programmable sign-in.",
     );
   }
 

--- a/tests/partner-admin-browser-error.test.ts
+++ b/tests/partner-admin-browser-error.test.ts
@@ -40,6 +40,34 @@ describe("partner admin browser errors", () => {
     expect(JSON.stringify(error)).not.toContain("pm_partner_root_");
   });
 
+  it("keeps an unlinked wallet separate from backend access denial", () => {
+    const error = partnerAdminBrowserErrorV1(
+      new Response(null, {
+        status: 403,
+        headers: { "x-request-id": REQUEST_ID },
+      }),
+      {
+        schemaVersion: "programmable.partner-admin.v1",
+        error: {
+          code: "wallet_not_linked",
+          message: "The request could not be completed.",
+          requestId: REQUEST_ID,
+        },
+      },
+      "Unable to load partners.",
+    );
+
+    expect(error).toMatchObject({
+      status: 403,
+      code: "wallet_not_linked",
+      requestId: REQUEST_ID,
+      retryAfter: null,
+      accessDenied: false,
+      walletNotLinked: true,
+      message: "This wallet is connected but not linked to your Programmable sign-in.",
+    });
+  });
+
   it("keeps bounded retry and request correlation for ordinary errors", () => {
     const error = partnerAdminBrowserErrorV1(
       new Response(null, {

--- a/tests/partner-attribution-ui.test.tsx
+++ b/tests/partner-attribution-ui.test.tsx
@@ -244,4 +244,22 @@ describe("partner attribution UI", () => {
     expect(source).toContain('aria-label="Partner pages"');
     expect(source).toContain("ROOT_KEYS_PER_PAGE");
   });
+
+  it("recovers an unlinked partner-admin wallet without retrying the request", () => {
+    const source = readFileSync(
+      new URL("../components/partner-admin-console.tsx", import.meta.url),
+      "utf8",
+    );
+    const start = source.indexOf('data-state="wallet-not-linked"');
+    const end = source.indexOf(") : accessDenied ? (", start);
+    const walletRecoveryState = source.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(walletRecoveryState).toContain("Link this wallet to continue");
+    expect(walletRecoveryState).toContain("select another linked wallet");
+    expect(walletRecoveryState).toContain("onClick={openWallet}");
+    expect(walletRecoveryState).toContain("Manage wallets");
+    expect(walletRecoveryState).not.toContain("Try again");
+  });
 });

--- a/tests/wallet-state.test.ts
+++ b/tests/wallet-state.test.ts
@@ -39,6 +39,16 @@ type WalletProviderContract = {
     wallets: readonly T[],
     primaryAddress?: string,
   ) => T | undefined;
+  selectPartnerAdminWallet: <T extends {
+    address: string;
+    connectedAt: number;
+    linked: boolean;
+    walletClientType: string;
+  }>(
+    wallets: readonly T[],
+    primaryAddress?: string,
+  ) => T | undefined;
+  requiresPartnerAdminLinkedWallet: (pathname: string) => boolean;
   getWalletProfileStorageKey: (account: string) => string;
   readUsernameFromProfileValue: (value: string | null) => string;
   getWalletLoginErrorMessage: (errorCode: string) => string;
@@ -143,6 +153,7 @@ describe("wallet recovery state", () => {
       "/profile",
       "/profile/settings",
       "/token/0x7987f03462200b3d8a072e02c89a8a41dcb124ee",
+      "/admin/partners",
     ]) {
       expect(subject.shouldEagerLoadWalletRuntime(pathname)).toBe(true);
       expect(subject.shouldBackgroundLoadWalletRuntime(pathname)).toBe(false);
@@ -829,5 +840,43 @@ describe("wallet recovery state", () => {
     };
 
     expect(subject.selectConnectedWallet([older, newer])).toBe(newer);
+  });
+
+  it("uses only a linked wallet for partner admin and prefers the exact primary", () => {
+    const unlinkedExternal = {
+      address: "0x1111111111111111111111111111111111111111",
+      connectedAt: 30,
+      linked: false,
+      walletClientType: "metamask",
+    };
+    const linkedExternal = {
+      address: "0x2222222222222222222222222222222222222222",
+      connectedAt: 20,
+      linked: true,
+      walletClientType: "phantom",
+    };
+    const linkedPrimary = {
+      address: "0x3333333333333333333333333333333333333333",
+      connectedAt: 10,
+      linked: true,
+      walletClientType: "privy",
+    };
+
+    expect(subject.selectPartnerAdminWallet(
+      [unlinkedExternal, linkedExternal, linkedPrimary],
+      linkedPrimary.address,
+    )).toBe(linkedPrimary);
+    expect(subject.selectPartnerAdminWallet(
+      [unlinkedExternal, linkedExternal],
+      unlinkedExternal.address,
+    )).toBe(linkedExternal);
+    expect(subject.selectPartnerAdminWallet([unlinkedExternal])).toBeUndefined();
+  });
+
+  it("limits linked-wallet selection to the partner admin route tree", () => {
+    expect(subject.requiresPartnerAdminLinkedWallet("/admin/partners")).toBe(true);
+    expect(subject.requiresPartnerAdminLinkedWallet("/admin/partners/example")).toBe(true);
+    expect(subject.requiresPartnerAdminLinkedWallet("/developers/api-keys")).toBe(false);
+    expect(subject.requiresPartnerAdminLinkedWallet("/admin/partnerships")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- restrict `/admin/partners` to Privy-linked Ethereum wallets while preserving wallet selection elsewhere
- prefer the exact linked Privy primary wallet and hide unlinked wallet options on the admin route
- classify `wallet_not_linked` as an explicit link/select recovery state without retrying the failed request

## Verification
- `npm exec vitest run -- tests/wallet-state.test.ts tests/partner-admin-browser-error.test.ts tests/partner-attribution-ui.test.tsx` (48 passed)
- focused ESLint on all changed files
- `npm run typecheck`
- `git diff --check`

No deployment or wallet interaction is included.