### PR TITLE
Allow bounded Router fallback during staging

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -862,7 +862,6 @@ jobs:
           let response;
           let body;
           let expectedLaunchSource;
-          let catalogMode;
           let exactCatalog = false;
           for (let attempt = 0; attempt < 5; attempt += 1) {
             response = undefined;
@@ -914,60 +913,11 @@ jobs:
                 : registryCustomCurrent && routerCustomStatus === "last-known-good"
                   ? "last-known-good"
                   : "unavailable";
-            const classicCurrent =
-              body?.catalog?.completeness?.classic === "current" &&
-              body.catalog.evidence?.kind === "envio-indexer-state" &&
-              body.catalog.evidence?.progressBlock === body.catalog.asOfBlock &&
-              /^sha256:[0-9a-f]{64}$/u.test(
-                body.catalog.evidence?.commitment ?? "",
-              );
-            const routerStamp = body?.catalog?.routerStamp;
-            const routerOnlyFallback =
-              body?.catalog?.launchSource === "canonical-launch-stamp-router" &&
-              body.catalog.status === "last-known-good" &&
-              body.catalog.completeness?.classic === "unavailable" &&
-              body.catalog.completeness?.custom === "unavailable" &&
-              body.catalog.completeness?.registryCustom === "unavailable" &&
-              routerCustomAvailable &&
-              Number.isSafeInteger(body.catalog.identityCount) &&
-              body.catalog.identityCount > 0 &&
-              body.catalog.identityCount === body.total &&
-              JSON.stringify(body.catalog.scope?.included) ===
-                JSON.stringify(["canonical-launch-stamp-router"]) &&
-              JSON.stringify(body.catalog.scope?.excluded) ===
-                JSON.stringify([
-                  "classic-v1",
-                  "classic-v2",
-                  "stock-paired-v1",
-                  "stock-paired-v2",
-                  "stock-paired-v3",
-                ]) &&
-              /^sha256:[0-9a-f]{64}$/u.test(
-                body.catalog.identityCommitment ?? "",
-              ) &&
-              body.catalog.evidence === undefined &&
-              /^[1-9][0-9]*$/u.test(String(body.catalog.asOfBlock ?? "")) &&
-              /^0x[0-9a-f]{64}$/u.test(body.catalog.asOfBlockHash ?? "") &&
-              routerStamp?.source === "canonical-launch-stamp-router" &&
-              routerStamp.status === routerCustomStatus &&
-              routerStamp.finalityConfirmations === 64 &&
-              Number.isSafeInteger(routerStamp.verifiedIdentityCount) &&
-              routerStamp.verifiedIdentityCount >= body.catalog.identityCount &&
-              routerStamp.projectedIdentityCount === body.catalog.identityCount &&
-              routerStamp.generatedAt === body.catalog.lastIndexedAt &&
-              routerStamp.asOfBlock === body.catalog.asOfBlock &&
-              routerStamp.asOfBlockHash === body.catalog.asOfBlockHash &&
-              /^sha256:[0-9a-f]{64}$/u.test(
-                routerStamp.identityCommitment ?? "",
-              ) &&
-              response.headers.get("x-programmable-canonical-read-status") ===
-                "unavailable" &&
-              response.headers.get("x-programmable-router-read-status") ===
-                routerCustomStatus;
             exactCatalog =
               body?.status === "ready" &&
               body?.catalog?.source === "envio-classic-v3" &&
               body.catalog.launchSource === expectedLaunchSource &&
+              body.catalog.completeness?.classic === "current" &&
               body.catalog.completeness?.custom === expectedCustomStatus &&
               ["current", "unavailable"].includes(
                 body.catalog.completeness?.registryCustom,
@@ -976,19 +926,18 @@ jobs:
                 routerCustomStatus,
               ) &&
               body.catalog.completeness?.stock === "excluded" &&
-              (classicCurrent || routerOnlyFallback) &&
+              body.catalog.evidence?.kind === "envio-indexer-state" &&
+              body.catalog.evidence?.progressBlock === body.catalog.asOfBlock &&
+              /^sha256:[0-9a-f]{64}$/u.test(
+                body.catalog.evidence?.commitment ?? "",
+              ) &&
               JSON.stringify(body.catalog.scope?.publicCategories) ===
                 JSON.stringify(["classic", "custom"]) &&
               Number.isSafeInteger(body.total) && body.total >= 1 &&
               Array.isArray(body.tokens) && body.tokens.length === 1 &&
               response.headers.get("x-programmable-launch-source") ===
                 expectedLaunchSource;
-            if (exactCatalog) {
-              catalogMode = classicCurrent
-                ? "envio-classic-current"
-                : "bounded-router-only-fallback";
-              break;
-            }
+            if (exactCatalog) break;
             if (attempt < 4) {
               await new Promise((resolve) => setTimeout(resolve, 5_000));
             }
@@ -998,7 +947,7 @@ jobs:
           }
           appendFileSync(
             process.env.GITHUB_OUTPUT,
-            `block_number=${body.catalog.asOfBlock}\ntoken_count=${body.total}\ncatalog_mode=${catalogMode}\n`,
+            `block_number=${body.catalog.asOfBlock}\ntoken_count=${body.total}\n`,
           );
           NODE
 
@@ -1475,7 +1424,6 @@ jobs:
           CHART_SMOKE_STATUS: ${{ steps.public-provider-smoke.outputs.chart_status }}
           CATALOG_BLOCK_NUMBER: ${{ steps.envio-catalog-probe.outputs.block_number }}
           CATALOG_TOKEN_COUNT: ${{ steps.envio-catalog-probe.outputs.token_count }}
-          CATALOG_MODE: ${{ steps.envio-catalog-probe.outputs.catalog_mode }}
         run: |
           {
             echo "## Staged production candidate"
@@ -1486,10 +1434,9 @@ jobs:
             echo "- Stable protected preview: $STABLE_PREVIEW_URL"
             echo "- Previous production deployment: \`$PREVIOUS_DEPLOYMENT_ID\`"
             echo "- Previous production commit: \`$PREVIOUS_GIT_HEAD\`"
-            echo "- Launch identities: validated current Classic or bounded Router fallback"
-            echo "- Catalog mode: \`$CATALOG_MODE\`"
-            echo "- Catalog progress block: \`$CATALOG_BLOCK_NUMBER\`"
-            echo "- Catalog identity count: \`$CATALOG_TOKEN_COUNT\`"
+            echo "- Launch identities: validated Envio Classic V3 catalog"
+            echo "- Envio catalog progress block: \`$CATALOG_BLOCK_NUMBER\`"
+            echo "- Envio catalog identity count: \`$CATALOG_TOKEN_COUNT\`"
             echo "- Market data provider: Dexscreener (optional enrichment)"
             echo "- Explore market read status: \`${MARKET_READ_STATUS:-not-run}\`"
             echo "- Token detail smoke: \`${DETAIL_SMOKE_STATUS:-not-run}\`"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -862,6 +862,7 @@ jobs:
           let response;
           let body;
           let expectedLaunchSource;
+          let catalogMode;
           let exactCatalog = false;
           for (let attempt = 0; attempt < 5; attempt += 1) {
             response = undefined;
@@ -913,11 +914,60 @@ jobs:
                 : registryCustomCurrent && routerCustomStatus === "last-known-good"
                   ? "last-known-good"
                   : "unavailable";
+            const classicCurrent =
+              body?.catalog?.completeness?.classic === "current" &&
+              body.catalog.evidence?.kind === "envio-indexer-state" &&
+              body.catalog.evidence?.progressBlock === body.catalog.asOfBlock &&
+              /^sha256:[0-9a-f]{64}$/u.test(
+                body.catalog.evidence?.commitment ?? "",
+              );
+            const routerStamp = body?.catalog?.routerStamp;
+            const routerOnlyFallback =
+              body?.catalog?.launchSource === "canonical-launch-stamp-router" &&
+              body.catalog.status === "last-known-good" &&
+              body.catalog.completeness?.classic === "unavailable" &&
+              body.catalog.completeness?.custom === "unavailable" &&
+              body.catalog.completeness?.registryCustom === "unavailable" &&
+              routerCustomAvailable &&
+              Number.isSafeInteger(body.catalog.identityCount) &&
+              body.catalog.identityCount > 0 &&
+              body.catalog.identityCount === body.total &&
+              JSON.stringify(body.catalog.scope?.included) ===
+                JSON.stringify(["canonical-launch-stamp-router"]) &&
+              JSON.stringify(body.catalog.scope?.excluded) ===
+                JSON.stringify([
+                  "classic-v1",
+                  "classic-v2",
+                  "stock-paired-v1",
+                  "stock-paired-v2",
+                  "stock-paired-v3",
+                ]) &&
+              /^sha256:[0-9a-f]{64}$/u.test(
+                body.catalog.identityCommitment ?? "",
+              ) &&
+              body.catalog.evidence === undefined &&
+              /^[1-9][0-9]*$/u.test(String(body.catalog.asOfBlock ?? "")) &&
+              /^0x[0-9a-f]{64}$/u.test(body.catalog.asOfBlockHash ?? "") &&
+              routerStamp?.source === "canonical-launch-stamp-router" &&
+              routerStamp.status === routerCustomStatus &&
+              routerStamp.finalityConfirmations === 64 &&
+              Number.isSafeInteger(routerStamp.verifiedIdentityCount) &&
+              routerStamp.verifiedIdentityCount >= body.catalog.identityCount &&
+              routerStamp.projectedIdentityCount === body.catalog.identityCount &&
+              routerStamp.generatedAt === body.catalog.lastIndexedAt &&
+              routerStamp.asOfBlock === body.catalog.asOfBlock &&
+              routerStamp.asOfBlockHash === body.catalog.asOfBlockHash &&
+              /^sha256:[0-9a-f]{64}$/u.test(
+                routerStamp.identityCommitment ?? "",
+              ) &&
+              response.headers.get("x-programmable-canonical-read-status") ===
+                "unavailable" &&
+              response.headers.get("x-programmable-router-read-status") ===
+                routerCustomStatus;
             exactCatalog =
               body?.status === "ready" &&
               body?.catalog?.source === "envio-classic-v3" &&
               body.catalog.launchSource === expectedLaunchSource &&
-              body.catalog.completeness?.classic === "current" &&
               body.catalog.completeness?.custom === expectedCustomStatus &&
               ["current", "unavailable"].includes(
                 body.catalog.completeness?.registryCustom,
@@ -926,18 +976,19 @@ jobs:
                 routerCustomStatus,
               ) &&
               body.catalog.completeness?.stock === "excluded" &&
-              body.catalog.evidence?.kind === "envio-indexer-state" &&
-              body.catalog.evidence?.progressBlock === body.catalog.asOfBlock &&
-              /^sha256:[0-9a-f]{64}$/u.test(
-                body.catalog.evidence?.commitment ?? "",
-              ) &&
+              (classicCurrent || routerOnlyFallback) &&
               JSON.stringify(body.catalog.scope?.publicCategories) ===
                 JSON.stringify(["classic", "custom"]) &&
               Number.isSafeInteger(body.total) && body.total >= 1 &&
               Array.isArray(body.tokens) && body.tokens.length === 1 &&
               response.headers.get("x-programmable-launch-source") ===
                 expectedLaunchSource;
-            if (exactCatalog) break;
+            if (exactCatalog) {
+              catalogMode = classicCurrent
+                ? "envio-classic-current"
+                : "bounded-router-only-fallback";
+              break;
+            }
             if (attempt < 4) {
               await new Promise((resolve) => setTimeout(resolve, 5_000));
             }
@@ -947,7 +998,7 @@ jobs:
           }
           appendFileSync(
             process.env.GITHUB_OUTPUT,
-            `block_number=${body.catalog.asOfBlock}\ntoken_count=${body.total}\n`,
+            `block_number=${body.catalog.asOfBlock}\ntoken_count=${body.total}\ncatalog_mode=${catalogMode}\n`,
           );
           NODE
 
@@ -1424,6 +1475,7 @@ jobs:
           CHART_SMOKE_STATUS: ${{ steps.public-provider-smoke.outputs.chart_status }}
           CATALOG_BLOCK_NUMBER: ${{ steps.envio-catalog-probe.outputs.block_number }}
           CATALOG_TOKEN_COUNT: ${{ steps.envio-catalog-probe.outputs.token_count }}
+          CATALOG_MODE: ${{ steps.envio-catalog-probe.outputs.catalog_mode }}
         run: |
           {
             echo "## Staged production candidate"
@@ -1434,9 +1486,10 @@ jobs:
             echo "- Stable protected preview: $STABLE_PREVIEW_URL"
             echo "- Previous production deployment: \`$PREVIOUS_DEPLOYMENT_ID\`"
             echo "- Previous production commit: \`$PREVIOUS_GIT_HEAD\`"
-            echo "- Launch identities: validated Envio Classic V3 catalog"
-            echo "- Envio catalog progress block: \`$CATALOG_BLOCK_NUMBER\`"
-            echo "- Envio catalog identity count: \`$CATALOG_TOKEN_COUNT\`"
+            echo "- Launch identities: validated current Classic or bounded Router fallback"
+            echo "- Catalog mode: \`$CATALOG_MODE\`"
+            echo "- Catalog progress block: \`$CATALOG_BLOCK_NUMBER\`"
+            echo "- Catalog identity count: \`$CATALOG_TOKEN_COUNT\`"
             echo "- Market data provider: Dexscreener (optional enrichment)"
             echo "- Explore market read status: \`${MARKET_READ_STATUS:-not-run}\`"
             echo "- Token detail smoke: \`${DETAIL_SMOKE_STATUS:-not-run}\`"

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2401,7 +2401,13 @@ export function evaluateReadModelOperationsSourceContracts(
         '"/api/explore?limit=1&page=1&sort=newest"',
         "response.status === 200",
         'body?.catalog?.source === "envio-classic-v3"',
-        'body.catalog.completeness?.classic === "current"',
+        "const classicCurrent =",
+        'body?.catalog?.completeness?.classic === "current"',
+        "const routerOnlyFallback =",
+        'body?.catalog?.launchSource === "canonical-launch-stamp-router"',
+        'body.catalog.completeness?.classic === "unavailable"',
+        "routerStamp.projectedIdentityCount === body.catalog.identityCount",
+        "classicCurrent || routerOnlyFallback",
         'body.catalog.completeness?.stock === "excluded"',
         'body.catalog.evidence?.kind === "envio-indexer-state"',
         "body.total >= 1",
@@ -2411,13 +2417,13 @@ export function evaluateReadModelOperationsSourceContracts(
         "response = undefined",
         "if (attempt === 4) throw error",
         "continue;",
-        "if (exactCatalog) break",
+        "if (exactCatalog) {",
       ]) &&
       !stagedCatalogProbeBlock.includes("body.tokens[0]?.launchModel") &&
       !stagedCatalogProbeBlock.includes("CRON_SECRET") &&
       !stagedCatalogProbeBlock.includes("/api/ops/index-v2") &&
       !stagedCatalogProbeBlock.includes("        if:"),
-    "every exact staged candidate proves a non-empty verified Envio Classic V3 catalog before public Fast-Lane smoke",
+    "every exact staged candidate proves either a non-empty current Envio Classic V3 catalog or an exact bounded Router-only fallback before public Fast-Lane smoke",
   );
   check(
     "ops-protected-public-provider-stage-smoke",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1939,8 +1939,7 @@ export function evaluateReadModelOperationsSourceContracts(
   const envioClassicV3Catalog =
     source("lib/market-data/envio-classic-v3-catalog.server.ts") ?? "";
   const envioClassicV4CatalogBinding =
-    source("lib/data-pipeline/envio-classic-v4-catalog-binding.server.ts") ??
-    "";
+    source("lib/data-pipeline/envio-classic-v4-catalog-binding.server.ts") ?? "";
   const dexscreenerExplore =
     source("lib/market-data/dexscreener-explore.server.ts") ?? "";
   const dexscreenerShadow =
@@ -1970,27 +1969,20 @@ export function evaluateReadModelOperationsSourceContracts(
     "\nexport function ",
     primaryResolverStart + 1,
   );
-  const primaryResolver =
-    primaryResolverStart >= 0
-      ? websiteRpcProviders.slice(
-          primaryResolverStart,
-          primaryResolverEnd >= 0 ? primaryResolverEnd : undefined,
-        )
-      : "";
-  const classicProfileGetEnd = publicClassicProfile.indexOf(
-    "export async function POST",
-  );
-  const publicClassicProfileGet =
-    classicProfileGetEnd >= 0
-      ? publicClassicProfile.slice(0, classicProfileGetEnd)
-      : "";
-  const stockProfileGetEnd = publicStockProfile.indexOf(
-    "export async function POST",
-  );
-  const publicStockProfileGet =
-    stockProfileGetEnd >= 0
-      ? publicStockProfile.slice(0, stockProfileGetEnd)
-      : "";
+  const primaryResolver = primaryResolverStart >= 0
+    ? websiteRpcProviders.slice(
+        primaryResolverStart,
+        primaryResolverEnd >= 0 ? primaryResolverEnd : undefined,
+      )
+    : "";
+  const classicProfileGetEnd = publicClassicProfile.indexOf("export async function POST");
+  const publicClassicProfileGet = classicProfileGetEnd >= 0
+    ? publicClassicProfile.slice(0, classicProfileGetEnd)
+    : "";
+  const stockProfileGetEnd = publicStockProfile.indexOf("export async function POST");
+  const publicStockProfileGet = stockProfileGetEnd >= 0
+    ? publicStockProfile.slice(0, stockProfileGetEnd)
+    : "";
   const retiredCandidateCutover = Object.freeze({
     productionRunbook: productionCutoverRunbook,
     envioRunbook: envioCandidateRunbook,
@@ -2100,9 +2092,10 @@ export function evaluateReadModelOperationsSourceContracts(
     'echo "- Market chart smoke: \\`${CHART_SMOKE_STATUS:-not-run}\\`"',
   ]);
   const publicActionRoutes = [creatorClaimPrepare, tradePrepare];
-  const primaryRpcLaunchCatalogCacheStart = primaryRpcLaunchCatalog.indexOf(
-    "export function createPrimaryRpcLaunchCatalogCacheV1",
-  );
+  const primaryRpcLaunchCatalogCacheStart =
+    primaryRpcLaunchCatalog.indexOf(
+      "export function createPrimaryRpcLaunchCatalogCacheV1",
+    );
   const primaryRpcLaunchCatalogCacheEnd = primaryRpcLaunchCatalog.indexOf(
     "function catalogCacheKey(",
     primaryRpcLaunchCatalogCacheStart,
@@ -2160,8 +2153,8 @@ export function evaluateReadModelOperationsSourceContracts(
       "createEnvioClient({",
       '{ model: { _eq: "classic" } }',
       '{ releaseVersion: { _in: ["classic-v3", "classic-v4"] } }',
-      "{ isComplete: { _eq: true } }",
-      "{ provenanceValid: { _eq: true } }",
+      '{ isComplete: { _eq: true } }',
+      '{ provenanceValid: { _eq: true } }',
       "assertLaunchEventBinding(launch, event, release)",
       'source: "envio-classic-v3" as const',
       'stock: "excluded" as const',
@@ -2264,7 +2257,7 @@ export function evaluateReadModelOperationsSourceContracts(
       "mergeEnvioClassicV3CatalogEntriesV1(",
       "readProductionCustomExploreDirectoryV1(request.signal)",
       'let customStatus: "current" | "unavailable" = "unavailable"',
-      "`${catalog.source}+registry.custom-launched`",
+      '`${catalog.source}+registry.custom-launched`',
       'schemaVersion: "programmable.market-chart-error.v1"',
       'reason: "identity-unavailable"',
       '"X-Programmable-Market-Provider": "bitquery"',
@@ -2291,7 +2284,7 @@ export function evaluateReadModelOperationsSourceContracts(
       "routerCustomEntriesAtOrBeforeBlockV1",
       "mergeRouterCustomCreatorProfileV1",
       "BigInt(stamp.blockNumber) > snapshotBlock",
-      "entry.launchCategoryProvenance.source !== ROUTER_CUSTOM_LAUNCH_SOURCE",
+      'entry.launchCategoryProvenance.source !== ROUTER_CUSTOM_LAUNCH_SOURCE',
     ]);
   check(
     "ops-public-provider-split-source-contract",
@@ -2324,7 +2317,7 @@ export function evaluateReadModelOperationsSourceContracts(
       "const launchSource = result === null",
       'routerStatus !== "unavailable"',
       ': "envio-classic-v3"',
-      ": `${launchSource}+rpc`",
+      ': `${launchSource}+rpc`',
       '"X-Programmable-Router-Read-Status": routerStatus',
       '"X-Programmable-Router-Claim-Read-Status": routerClaimStatus',
       '"X-Programmable-Rpc-Provider": rpcProvider',
@@ -2394,9 +2387,7 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       publicProfileAndActionRoutes.every(
         (route) =>
-          !/Promise\.allSettled|secondaryProvider|fallbackProvider/u.test(
-            route,
-          ),
+          !/Promise\.allSettled|secondaryProvider|fallbackProvider/u.test(route),
       ),
     "Profile identity combines Envio with the bounded durable Router Custom snapshot and remains fail-closed without either identity source, while reviewed reward reads, Classic rewards, Claim, and Trade use the commitment-bound Website pair with at most one complete-operation QuickNode retry after an eligible dRPC transport or capacity failure; Stock retains its singular committed action provider and all action routes retain no write authority or hidden provider rotation",
   );
@@ -2410,13 +2401,7 @@ export function evaluateReadModelOperationsSourceContracts(
         '"/api/explore?limit=1&page=1&sort=newest"',
         "response.status === 200",
         'body?.catalog?.source === "envio-classic-v3"',
-        "const classicCurrent =",
-        'body?.catalog?.completeness?.classic === "current"',
-        "const routerOnlyFallback =",
-        'body?.catalog?.launchSource === "canonical-launch-stamp-router"',
-        'body.catalog.completeness?.classic === "unavailable"',
-        "routerStamp.projectedIdentityCount === body.catalog.identityCount",
-        "classicCurrent || routerOnlyFallback",
+        'body.catalog.completeness?.classic === "current"',
         'body.catalog.completeness?.stock === "excluded"',
         'body.catalog.evidence?.kind === "envio-indexer-state"',
         "body.total >= 1",
@@ -2426,13 +2411,13 @@ export function evaluateReadModelOperationsSourceContracts(
         "response = undefined",
         "if (attempt === 4) throw error",
         "continue;",
-        "if (exactCatalog) {",
+        "if (exactCatalog) break",
       ]) &&
       !stagedCatalogProbeBlock.includes("body.tokens[0]?.launchModel") &&
       !stagedCatalogProbeBlock.includes("CRON_SECRET") &&
       !stagedCatalogProbeBlock.includes("/api/ops/index-v2") &&
       !stagedCatalogProbeBlock.includes("        if:"),
-    "every exact staged candidate proves either a non-empty current Envio Classic V3 catalog or an exact bounded Router-only fallback before public Fast-Lane smoke",
+    "every exact staged candidate proves a non-empty verified Envio Classic V3 catalog before public Fast-Lane smoke",
   );
   check(
     "ops-protected-public-provider-stage-smoke",
@@ -2494,15 +2479,15 @@ export function evaluateReadModelOperationsSourceContracts(
         "!exactSamePageOrder(highest, newest)",
         'token.exploreKind === "token"',
         'token.exploreKind !== "custom-project" ||\n    !/^sha256:[0-9a-f]{64}$/u.test(String(token.customProjectId ?? ""))',
-        "token.customProjectId",
-        "token.customLaunchId",
-        "Array.isArray(token.markets)",
+        'token.customProjectId',
+        'token.customLaunchId',
+        'Array.isArray(token.markets)',
         "const deterministicMarkets = markets",
         "exactIdentity(detailToken) !== exactIdentity(selectedToken)",
         "detail.body?.token ?? detail.body?.customProject",
         "catalogBoundary.launchSource",
         "const profileFailClosed =",
-        "profile.status === 503",
+        'profile.status === 503',
         'exactObjectKeys(profile.body, ["error", "status"])',
         'exactObjectKeys(profile.body?.error, ["code", "kind", "message"])',
         'profile.body?.error?.code === "creator_profile_temporarily_unavailable"',
@@ -2532,7 +2517,7 @@ export function evaluateReadModelOperationsSourceContracts(
         'profile.headers.get("x-programmable-read-source") ===\n        "envio-classic-v3+rpc"',
         'schemaVersion !== "programmable.market-chart.v1"',
         'chart.body?.source !== "bitquery"',
-        "chart.body?.identity?.tokenAddress?.toLowerCase() !== tokenAddress.toLowerCase()",
+        'chart.body?.identity?.tokenAddress?.toLowerCase() !== tokenAddress.toLowerCase()',
         'chart.headers.get("cache-control") !==\n      "public, max-age=0, s-maxage=2, stale-while-revalidate=2"',
         'chart.headers.get("x-programmable-market-provider") !== "bitquery"',
         'chart.headers.get("x-programmable-valuation-block") !== null',
@@ -2685,7 +2670,7 @@ export function evaluateReadModelOperationsSourceContracts(
       postPromotion.includes("verifyProductionDeploymentBinding") &&
       productionBinding.includes("resolveProductionBinding") &&
       includesEverySourceFragment(postPromotionVerifierBlock, [
-        "target.toString() !== `${PRODUCTION_ORIGIN}/`",
+        'target.toString() !== `${PRODUCTION_ORIGIN}/`',
         'throw new Error("exact production deployment binding is required")',
         "verifyProductionDeploymentBinding({",
         "runProductionStaticDexscreenerSmokeV1({ fetchImpl })",

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1939,7 +1939,8 @@ export function evaluateReadModelOperationsSourceContracts(
   const envioClassicV3Catalog =
     source("lib/market-data/envio-classic-v3-catalog.server.ts") ?? "";
   const envioClassicV4CatalogBinding =
-    source("lib/data-pipeline/envio-classic-v4-catalog-binding.server.ts") ?? "";
+    source("lib/data-pipeline/envio-classic-v4-catalog-binding.server.ts") ??
+    "";
   const dexscreenerExplore =
     source("lib/market-data/dexscreener-explore.server.ts") ?? "";
   const dexscreenerShadow =
@@ -1969,20 +1970,27 @@ export function evaluateReadModelOperationsSourceContracts(
     "\nexport function ",
     primaryResolverStart + 1,
   );
-  const primaryResolver = primaryResolverStart >= 0
-    ? websiteRpcProviders.slice(
-        primaryResolverStart,
-        primaryResolverEnd >= 0 ? primaryResolverEnd : undefined,
-      )
-    : "";
-  const classicProfileGetEnd = publicClassicProfile.indexOf("export async function POST");
-  const publicClassicProfileGet = classicProfileGetEnd >= 0
-    ? publicClassicProfile.slice(0, classicProfileGetEnd)
-    : "";
-  const stockProfileGetEnd = publicStockProfile.indexOf("export async function POST");
-  const publicStockProfileGet = stockProfileGetEnd >= 0
-    ? publicStockProfile.slice(0, stockProfileGetEnd)
-    : "";
+  const primaryResolver =
+    primaryResolverStart >= 0
+      ? websiteRpcProviders.slice(
+          primaryResolverStart,
+          primaryResolverEnd >= 0 ? primaryResolverEnd : undefined,
+        )
+      : "";
+  const classicProfileGetEnd = publicClassicProfile.indexOf(
+    "export async function POST",
+  );
+  const publicClassicProfileGet =
+    classicProfileGetEnd >= 0
+      ? publicClassicProfile.slice(0, classicProfileGetEnd)
+      : "";
+  const stockProfileGetEnd = publicStockProfile.indexOf(
+    "export async function POST",
+  );
+  const publicStockProfileGet =
+    stockProfileGetEnd >= 0
+      ? publicStockProfile.slice(0, stockProfileGetEnd)
+      : "";
   const retiredCandidateCutover = Object.freeze({
     productionRunbook: productionCutoverRunbook,
     envioRunbook: envioCandidateRunbook,
@@ -2092,10 +2100,9 @@ export function evaluateReadModelOperationsSourceContracts(
     'echo "- Market chart smoke: \\`${CHART_SMOKE_STATUS:-not-run}\\`"',
   ]);
   const publicActionRoutes = [creatorClaimPrepare, tradePrepare];
-  const primaryRpcLaunchCatalogCacheStart =
-    primaryRpcLaunchCatalog.indexOf(
-      "export function createPrimaryRpcLaunchCatalogCacheV1",
-    );
+  const primaryRpcLaunchCatalogCacheStart = primaryRpcLaunchCatalog.indexOf(
+    "export function createPrimaryRpcLaunchCatalogCacheV1",
+  );
   const primaryRpcLaunchCatalogCacheEnd = primaryRpcLaunchCatalog.indexOf(
     "function catalogCacheKey(",
     primaryRpcLaunchCatalogCacheStart,
@@ -2153,8 +2160,8 @@ export function evaluateReadModelOperationsSourceContracts(
       "createEnvioClient({",
       '{ model: { _eq: "classic" } }',
       '{ releaseVersion: { _in: ["classic-v3", "classic-v4"] } }',
-      '{ isComplete: { _eq: true } }',
-      '{ provenanceValid: { _eq: true } }',
+      "{ isComplete: { _eq: true } }",
+      "{ provenanceValid: { _eq: true } }",
       "assertLaunchEventBinding(launch, event, release)",
       'source: "envio-classic-v3" as const',
       'stock: "excluded" as const',
@@ -2257,7 +2264,7 @@ export function evaluateReadModelOperationsSourceContracts(
       "mergeEnvioClassicV3CatalogEntriesV1(",
       "readProductionCustomExploreDirectoryV1(request.signal)",
       'let customStatus: "current" | "unavailable" = "unavailable"',
-      '`${catalog.source}+registry.custom-launched`',
+      "`${catalog.source}+registry.custom-launched`",
       'schemaVersion: "programmable.market-chart-error.v1"',
       'reason: "identity-unavailable"',
       '"X-Programmable-Market-Provider": "bitquery"',
@@ -2284,7 +2291,7 @@ export function evaluateReadModelOperationsSourceContracts(
       "routerCustomEntriesAtOrBeforeBlockV1",
       "mergeRouterCustomCreatorProfileV1",
       "BigInt(stamp.blockNumber) > snapshotBlock",
-      'entry.launchCategoryProvenance.source !== ROUTER_CUSTOM_LAUNCH_SOURCE',
+      "entry.launchCategoryProvenance.source !== ROUTER_CUSTOM_LAUNCH_SOURCE",
     ]);
   check(
     "ops-public-provider-split-source-contract",
@@ -2317,7 +2324,7 @@ export function evaluateReadModelOperationsSourceContracts(
       "const launchSource = result === null",
       'routerStatus !== "unavailable"',
       ': "envio-classic-v3"',
-      ': `${launchSource}+rpc`',
+      ": `${launchSource}+rpc`",
       '"X-Programmable-Router-Read-Status": routerStatus',
       '"X-Programmable-Router-Claim-Read-Status": routerClaimStatus',
       '"X-Programmable-Rpc-Provider": rpcProvider',
@@ -2387,7 +2394,9 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       publicProfileAndActionRoutes.every(
         (route) =>
-          !/Promise\.allSettled|secondaryProvider|fallbackProvider/u.test(route),
+          !/Promise\.allSettled|secondaryProvider|fallbackProvider/u.test(
+            route,
+          ),
       ),
     "Profile identity combines Envio with the bounded durable Router Custom snapshot and remains fail-closed without either identity source, while reviewed reward reads, Classic rewards, Claim, and Trade use the commitment-bound Website pair with at most one complete-operation QuickNode retry after an eligible dRPC transport or capacity failure; Stock retains its singular committed action provider and all action routes retain no write authority or hidden provider rotation",
   );
@@ -2401,7 +2410,13 @@ export function evaluateReadModelOperationsSourceContracts(
         '"/api/explore?limit=1&page=1&sort=newest"',
         "response.status === 200",
         'body?.catalog?.source === "envio-classic-v3"',
-        'body.catalog.completeness?.classic === "current"',
+        "const classicCurrent =",
+        'body?.catalog?.completeness?.classic === "current"',
+        "const routerOnlyFallback =",
+        'body?.catalog?.launchSource === "canonical-launch-stamp-router"',
+        'body.catalog.completeness?.classic === "unavailable"',
+        "routerStamp.projectedIdentityCount === body.catalog.identityCount",
+        "classicCurrent || routerOnlyFallback",
         'body.catalog.completeness?.stock === "excluded"',
         'body.catalog.evidence?.kind === "envio-indexer-state"',
         "body.total >= 1",
@@ -2411,13 +2426,13 @@ export function evaluateReadModelOperationsSourceContracts(
         "response = undefined",
         "if (attempt === 4) throw error",
         "continue;",
-        "if (exactCatalog) break",
+        "if (exactCatalog) {",
       ]) &&
       !stagedCatalogProbeBlock.includes("body.tokens[0]?.launchModel") &&
       !stagedCatalogProbeBlock.includes("CRON_SECRET") &&
       !stagedCatalogProbeBlock.includes("/api/ops/index-v2") &&
       !stagedCatalogProbeBlock.includes("        if:"),
-    "every exact staged candidate proves a non-empty verified Envio Classic V3 catalog before public Fast-Lane smoke",
+    "every exact staged candidate proves either a non-empty current Envio Classic V3 catalog or an exact bounded Router-only fallback before public Fast-Lane smoke",
   );
   check(
     "ops-protected-public-provider-stage-smoke",
@@ -2479,15 +2494,15 @@ export function evaluateReadModelOperationsSourceContracts(
         "!exactSamePageOrder(highest, newest)",
         'token.exploreKind === "token"',
         'token.exploreKind !== "custom-project" ||\n    !/^sha256:[0-9a-f]{64}$/u.test(String(token.customProjectId ?? ""))',
-        'token.customProjectId',
-        'token.customLaunchId',
-        'Array.isArray(token.markets)',
+        "token.customProjectId",
+        "token.customLaunchId",
+        "Array.isArray(token.markets)",
         "const deterministicMarkets = markets",
         "exactIdentity(detailToken) !== exactIdentity(selectedToken)",
         "detail.body?.token ?? detail.body?.customProject",
         "catalogBoundary.launchSource",
         "const profileFailClosed =",
-        'profile.status === 503',
+        "profile.status === 503",
         'exactObjectKeys(profile.body, ["error", "status"])',
         'exactObjectKeys(profile.body?.error, ["code", "kind", "message"])',
         'profile.body?.error?.code === "creator_profile_temporarily_unavailable"',
@@ -2517,7 +2532,7 @@ export function evaluateReadModelOperationsSourceContracts(
         'profile.headers.get("x-programmable-read-source") ===\n        "envio-classic-v3+rpc"',
         'schemaVersion !== "programmable.market-chart.v1"',
         'chart.body?.source !== "bitquery"',
-        'chart.body?.identity?.tokenAddress?.toLowerCase() !== tokenAddress.toLowerCase()',
+        "chart.body?.identity?.tokenAddress?.toLowerCase() !== tokenAddress.toLowerCase()",
         'chart.headers.get("cache-control") !==\n      "public, max-age=0, s-maxage=2, stale-while-revalidate=2"',
         'chart.headers.get("x-programmable-market-provider") !== "bitquery"',
         'chart.headers.get("x-programmable-valuation-block") !== null',
@@ -2670,7 +2685,7 @@ export function evaluateReadModelOperationsSourceContracts(
       postPromotion.includes("verifyProductionDeploymentBinding") &&
       productionBinding.includes("resolveProductionBinding") &&
       includesEverySourceFragment(postPromotionVerifierBlock, [
-        'target.toString() !== `${PRODUCTION_ORIGIN}/`',
+        "target.toString() !== `${PRODUCTION_ORIGIN}/`",
         'throw new Error("exact production deployment binding is required")',
         "verifyProductionDeploymentBinding({",
         "runProductionStaticDexscreenerSmokeV1({ fetchImpl })",

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -29,9 +29,15 @@ function stepBlock(source, name) {
 test("Custom V2 production proof is a dedicated versioned protected lane", () => {
   assert.match(proof, /programmable\.production-verify-proof\.v4/u);
   assert.match(proof, /"custom_v2"/u);
-  assert.match(proof, /id: "custom-v2", name: "Custom V2", scopeKey: "custom_v2"/u);
+  assert.match(
+    proof,
+    /id: "custom-v2", name: "Custom V2", scopeKey: "custom_v2"/u,
+  );
   assert.match(verify, /^  custom-v2:$/mu);
-  assert.match(verify, /name: Verify exact Custom V2 surface[\s\S]*npm run verify:custom-v2:ci/u);
+  assert.match(
+    verify,
+    /name: Verify exact Custom V2 surface[\s\S]*npm run verify:custom-v2:ci/u,
+  );
   const projectionDatabaseOperator = stepBlock(
     verify,
     "Verify exact Website projection database operator",
@@ -63,10 +69,7 @@ test("manual Generic release verification runs the complete current Custom V2 tr
   assert.match(scope, /VERIFICATION_MODE:/u);
   assert.match(scope, /test "\$GITHUB_EVENT_NAME" = workflow_dispatch/u);
   assert.match(scope, /test "\$GITHUB_REF" = refs\/heads\/production/u);
-  assert.match(
-    scope,
-    /classify-verify-paths\.mjs --custom-v2-release/u,
-  );
+  assert.match(scope, /classify-verify-paths\.mjs --custom-v2-release/u);
   assert.match(
     verify,
     /name: Bind production Verify proof[\s\S]*github\.event_name == 'workflow_dispatch'[\s\S]*inputs\.verification_mode == 'custom-v2-release'/u,
@@ -78,10 +81,7 @@ test("manual Generic release verification runs the complete current Custom V2 tr
     deploy,
     /PRODUCTION_VERIFY_MODE:[\s\S]*custom-v2-release[\s\S]*--verification-mode "\$PRODUCTION_VERIFY_MODE"/u,
   );
-  assert.match(
-    deploy,
-    /--verification-mode "\$VERIFY_MODE"/u,
-  );
+  assert.match(deploy, /--verification-mode "\$VERIFY_MODE"/u);
   assert.match(
     deploy,
     /--verification-mode "\$\{\{ needs\.release-gate\.outputs\.verification_mode \}\}"/u,
@@ -90,7 +90,10 @@ test("manual Generic release verification runs the complete current Custom V2 tr
 
 test("trusted-base classification bootstraps Custom V2 without narrowing legacy lanes", () => {
   const block = stepBlock(verify, "Classify changed paths");
-  assert.match(block, /git show "\$BASE_SHA:scripts\/ci\/classify-verify-paths\.mjs"/u);
+  assert.match(
+    block,
+    /git show "\$BASE_SHA:scripts\/ci\/classify-verify-paths\.mjs"/u,
+  );
   assert.match(block, /if ! grep -Eq '\^custom_v2=\(true\|false\)\$'/u);
   assert.match(block, /echo 'custom_v2=true'/u);
   assert.match(block, /changing or narrowing any trusted-base legacy result/u);
@@ -103,16 +106,34 @@ test("Custom V2 stage expectations are explicit, observational, and default disa
   ]) {
     assert.match(
       deploy,
-      new RegExp(`${input}:[\\s\\S]{0,240}default: false[\\s\\S]{0,80}type: boolean`, "u"),
+      new RegExp(
+        `${input}:[\\s\\S]{0,240}default: false[\\s\\S]{0,80}type: boolean`,
+        "u",
+      ),
     );
   }
   assert.match(deploy, /this does not change configuration/u);
   assert.match(deploy, /this does not activate them/u);
-  assert.match(deploy, /verified_custom_v2: \$\{\{ steps\.verify-proof\.outputs\.verified_custom_v2 \}\}/u);
-  const gate = stepBlock(deploy, "Gate exact unaliased Custom V2 staged candidate");
-  assert.match(gate, /if: needs\.release-gate\.outputs\.verified_custom_v2 == 'true'/u);
-  assert.match(gate, /STAGED_DEPLOYMENT_ID: \$\{\{ steps\.staged-deployment\.outputs\.deployment_id \}\}/u);
-  assert.match(gate, /STAGED_TARGET_URL: \$\{\{ steps\.staged-deployment\.outputs\.target_url \}\}/u);
+  assert.match(
+    deploy,
+    /verified_custom_v2: \$\{\{ steps\.verify-proof\.outputs\.verified_custom_v2 \}\}/u,
+  );
+  const gate = stepBlock(
+    deploy,
+    "Gate exact unaliased Custom V2 staged candidate",
+  );
+  assert.match(
+    gate,
+    /if: needs\.release-gate\.outputs\.verified_custom_v2 == 'true'/u,
+  );
+  assert.match(
+    gate,
+    /STAGED_DEPLOYMENT_ID: \$\{\{ steps\.staged-deployment\.outputs\.deployment_id \}\}/u,
+  );
+  assert.match(
+    gate,
+    /STAGED_TARGET_URL: \$\{\{ steps\.staged-deployment\.outputs\.target_url \}\}/u,
+  );
   assert.match(gate, /EXPECTED_GIT_HEAD: \$\{\{ github\.sha \}\}/u);
   assert.match(gate, /vercel env run --environment=production/u);
   assert.match(gate, /npm run probe:custom-v2:stage/u);
@@ -123,18 +144,24 @@ test("Custom V2 stage expectations are explicit, observational, and default disa
 });
 
 test("Custom V2 evidence is immutable while the workflow remains stage-only", () => {
-  assert.match(deploy, /name: custom-v2-stage-evidence-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/u);
+  assert.match(
+    deploy,
+    /name: custom-v2-stage-evidence-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/u,
+  );
   assert.match(deploy, /retention-days: 90/u);
   assert.match(deploy, /vercel deploy --prebuilt --prod --skip-domain/u);
-  assert.doesNotMatch(deploy, /vercel (?:promote|rollback)|--scope-production-alias/u);
+  assert.doesNotMatch(
+    deploy,
+    /vercel (?:promote|rollback)|--scope-production-alias/u,
+  );
   assert.match(deploy, /Stage-only: no production promotion was attempted\./u);
   assert.ok(
-    deploy.indexOf("Resolve exact staged deployment")
-      < deploy.indexOf("Gate exact unaliased Custom V2 staged candidate"),
+    deploy.indexOf("Resolve exact staged deployment") <
+      deploy.indexOf("Gate exact unaliased Custom V2 staged candidate"),
   );
   assert.ok(
-    deploy.indexOf("Gate exact unaliased Custom V2 staged candidate")
-      < deploy.indexOf("Reverify staged candidate binding"),
+    deploy.indexOf("Gate exact unaliased Custom V2 staged candidate") <
+      deploy.indexOf("Reverify staged candidate binding"),
   );
   const stablePreview = stepBlock(
     deploy,
@@ -145,10 +172,7 @@ test("Custom V2 evidence is immutable while the workflow remains stage-only", ()
     /STABLE_PREVIEW_HOST: launcher-v4-aficialais-projects\.vercel\.app/u,
   );
   assert.match(stablePreview, /VERCEL_SCOPE: aficialais-projects/u);
-  assert.match(
-    stablePreview,
-    /test "\$VERCEL_SCOPE" = aficialais-projects/u,
-  );
+  assert.match(stablePreview, /test "\$VERCEL_SCOPE" = aficialais-projects/u);
   assert.match(
     stablePreview,
     /vercel alias set "\$EXPECTED_DEPLOYMENT_ID" "\$STABLE_PREVIEW_HOST" \\\n+            --scope="\$VERCEL_SCOPE"/u,
@@ -157,7 +181,10 @@ test("Custom V2 evidence is immutable while the workflow remains stage-only", ()
     stablePreview,
     /vercel inspect "\$STABLE_PREVIEW_HOST" --format=json \\\n+            --scope="\$VERCEL_SCOPE"/u,
   );
-  assert.match(stablePreview, /inspected\.id !== process\.env\.EXPECTED_DEPLOYMENT_ID/u);
+  assert.match(
+    stablePreview,
+    /inspected\.id !== process\.env\.EXPECTED_DEPLOYMENT_ID/u,
+  );
   assert.match(stablePreview, /inspected\.url !== expectedTarget\.hostname/u);
   assert.doesNotMatch(stablePreview, /inspected\.aliases/u);
   assert.match(
@@ -168,8 +195,8 @@ test("Custom V2 evidence is immutable while the workflow remains stage-only", ()
   assert.equal(deploy.match(/vercel alias set/gu)?.length, 1);
   assert.doesNotMatch(deploy.replace(stablePreview, ""), /vercel alias/u);
   assert.ok(
-    deploy.indexOf("Reverify staged candidate binding")
-      < deploy.indexOf("Bind exact candidate to stable protected preview"),
+    deploy.indexOf("Reverify staged candidate binding") <
+      deploy.indexOf("Bind exact candidate to stable protected preview"),
   );
 });
 
@@ -177,8 +204,12 @@ test("Generic signer OIDC proof is one-shot, two-Machine and cleanup-attested", 
   for (const input of [
     "custom_v2_generic_signer_probe_expected_json",
     "custom_v2_generic_signer_probe_expected_sha256",
-  ]) assert.match(deploy, new RegExp(`${input}:`, "u"));
-  const prepare = stepBlock(deploy, "Prepare one-shot Generic signer probe authority");
+  ])
+    assert.match(deploy, new RegExp(`${input}:`, "u"));
+  const prepare = stepBlock(
+    deploy,
+    "Prepare one-shot Generic signer probe authority",
+  );
   assert.match(prepare, /randomBytes\(32\)\.toString\("hex"\)/u);
   assert.match(prepare, /::add-mask::/u);
   assert.match(prepare, /generic-launch-read-stage-probe-operation\.v1/u);
@@ -201,7 +232,10 @@ test("Generic signer OIDC proof is one-shot, two-Machine and cleanup-attested", 
   );
   assert.match(probeDeploy, /vercel deploy --prebuilt --prod --skip-domain/u);
   assert.match(probeDeploy, /PROGRAMMABLE_GENERIC_LAUNCH_SIGNER_PROBE_TOKEN/u);
-  assert.match(probeDeploy, /PROGRAMMABLE_GENERIC_LAUNCH_SIGNER_PROBE_EXPECTED_V1_JSON/u);
+  assert.match(
+    probeDeploy,
+    /PROGRAMMABLE_GENERIC_LAUNCH_SIGNER_PROBE_EXPECTED_V1_JSON/u,
+  );
   assert.match(probeDeploy, /programmableGenericSignerProbeRecoveryId/u);
   assert.match(probeDeploy, /programmableGenericSignerProbe=one-shot-v1/u);
   assert.match(probeDeploy, /programmableRepositoryId=1314365508/u);
@@ -215,8 +249,14 @@ test("Generic signer OIDC proof is one-shot, two-Machine and cleanup-attested", 
     "Reconcile every secret-bearing Generic signer probe deployment",
   );
   assert.match(reconciliation, /always\(\)/u);
-  assert.match(reconciliation, /generic-signer-probe-authority\.outcome == 'success'/u);
-  assert.doesNotMatch(reconciliation, /generic-signer-probe-deploy\.outcome == 'success'/u);
+  assert.match(
+    reconciliation,
+    /generic-signer-probe-authority\.outcome == 'success'/u,
+  );
+  assert.doesNotMatch(
+    reconciliation,
+    /generic-signer-probe-deploy\.outcome == 'success'/u,
+  );
   assert.match(
     reconciliation,
     /reconcile-generic-signer-probe-deployments\.mjs/u,
@@ -239,7 +279,10 @@ test("Generic signer OIDC proof is one-shot, two-Machine and cleanup-attested", 
     deploy,
     "Attest canonical Generic signer probe cleanup bundle",
   );
-  assert.match(attest, /actions\/attest@59d89421af93a897026c735860bf21b6eb4f7b26/u);
+  assert.match(
+    attest,
+    /actions\/attest@59d89421af93a897026c735860bf21b6eb4f7b26/u,
+  );
   assert.match(attest, /create-storage-record: false/u);
   assert.match(
     deploy,
@@ -248,23 +291,32 @@ test("Generic signer OIDC proof is one-shot, two-Machine and cleanup-attested", 
   assert.match(deploy, /attestations: write/u);
   assert.match(deploy, /id-token: write/u);
   assert.ok(
-    deploy.indexOf("Reconcile every secret-bearing Generic signer probe deployment")
-      < deploy.indexOf("Stage production build without assigning domains"),
+    deploy.indexOf(
+      "Reconcile every secret-bearing Generic signer probe deployment",
+    ) < deploy.indexOf("Stage production build without assigning domains"),
   );
   assert.ok(
-    deploy.indexOf("Reconcile all residual Generic signer probes before new authority")
-      < deploy.indexOf("Prepare one-shot Generic signer probe authority"),
+    deploy.indexOf(
+      "Reconcile all residual Generic signer probes before new authority",
+    ) < deploy.indexOf("Prepare one-shot Generic signer probe authority"),
   );
   assert.ok(
-    deploy.indexOf("Preserve pre-mutation Generic signer probe operation record")
-      < deploy.indexOf("Deploy one-shot unaliased Generic signer probe candidate"),
+    deploy.indexOf(
+      "Preserve pre-mutation Generic signer probe operation record",
+    ) <
+      deploy.indexOf(
+        "Deploy one-shot unaliased Generic signer probe candidate",
+      ),
   );
   assert.match(deploy, /^  generic-signer-probe-reconcile:$/mu);
   assert.match(
     deploy,
     /generic-signer-probe-reconcile:[\s\S]*needs: \[release-gate, deploy\][\s\S]*always\(\)[\s\S]*Delete every residual exact probe deployment and prove absence[\s\S]*reconcile-generic-signer-probe-deployments\.mjs/u,
   );
-  assert.match(standaloneReconcile, /^name: Reconcile Generic Signer Probes$/mu);
+  assert.match(
+    standaloneReconcile,
+    /^name: Reconcile Generic Signer Probes$/mu,
+  );
   assert.match(standaloneReconcile, /^  workflow_dispatch:$/mu);
   assert.match(standaloneReconcile, /group: programmable-production/u);
   assert.match(standaloneReconcile, /cancel-in-progress: false/u);
@@ -313,16 +365,19 @@ test("every staged candidate proves the Envio catalog before public data smoke",
   assert.match(probe, /VERCEL_AUTOMATION_BYPASS_SECRET:/u);
   assert.match(probe, /\/api\/explore\?limit=1&page=1&sort=newest/u);
   assert.match(probe, /catalog\?\.source === "envio-classic-v3"/u);
+  assert.match(probe, /const classicCurrent =/u);
   assert.match(probe, /completeness\?\.classic === "current"/u);
+  assert.match(probe, /const routerOnlyFallback =/u);
+  assert.match(probe, /launchSource === "canonical-launch-stamp-router"/u);
+  assert.match(probe, /completeness\?\.classic === "unavailable"/u);
+  assert.match(
+    probe,
+    /routerStamp\.projectedIdentityCount === body\.catalog\.identityCount/u,
+  );
+  assert.match(probe, /classicCurrent \|\| routerOnlyFallback/u);
   assert.match(probe, /completeness\?\.stock === "excluded"/u);
-  assert.match(
-    probe,
-    /completeness\?\.registryCustom === "current"/u,
-  );
-  assert.match(
-    probe,
-    /routerCustomStatus === "last-known-good"/u,
-  );
+  assert.match(probe, /completeness\?\.registryCustom === "current"/u);
+  assert.match(probe, /routerCustomStatus === "last-known-good"/u);
   assert.match(
     probe,
     /envio-classic-v3\+registry\.custom-launched\+canonical-launch-stamp-router/u,
@@ -336,7 +391,7 @@ test("every staged candidate proves the Envio catalog before public data smoke",
   assert.match(probe, /response = undefined/u);
   assert.match(probe, /if \(attempt === 4\) throw error/u);
   assert.match(probe, /continue/u);
-  assert.match(probe, /if \(exactCatalog\) break/u);
+  assert.match(probe, /if \(exactCatalog\) \{/u);
   assert.doesNotMatch(probe, /CRON_SECRET|\/api\/ops\/index-v2/u);
   assert.doesNotMatch(probe, /\n        if:/u);
 
@@ -361,9 +416,13 @@ test("every staged candidate proves the Envio catalog before public data smoke",
   );
 
   const handoff = stepBlock(deploy, "Record staged candidate handoff");
-  assert.match(handoff, /Launch identities: validated Envio Classic V3 catalog/u);
-  assert.match(handoff, /Envio catalog progress block:/u);
-  assert.match(handoff, /Envio catalog identity count:/u);
+  assert.match(
+    handoff,
+    /Launch identities: validated current Classic or bounded Router fallback/u,
+  );
+  assert.match(handoff, /Catalog mode:/u);
+  assert.match(handoff, /Catalog progress block:/u);
+  assert.match(handoff, /Catalog identity count:/u);
   assert.match(
     handoff,
     /Market data provider: Dexscreener \(optional enrichment\)/u,
@@ -400,5 +459,8 @@ test("the staged public smoke is a separate bounded script", () => {
     /PROGRAMMABLE_WEBSITE_MAINNET_RPC|BITQUERY_API_KEY|runtimeProductionProviderEndpoints|readPrimaryRpc|readBitquery|fetchBitquery/iu,
   );
   assert.doesNotMatch(source, /https?:\/\/[^"'`]*(?:drpc|bitquery)/iu);
-  assert.doesNotMatch(source, /\/api\/explore\/profile\/claim|\/api\/trade\/prepare/u);
+  assert.doesNotMatch(
+    source,
+    /\/api\/explore\/profile\/claim|\/api\/trade\/prepare/u,
+  );
 });

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -29,15 +29,9 @@ function stepBlock(source, name) {
 test("Custom V2 production proof is a dedicated versioned protected lane", () => {
   assert.match(proof, /programmable\.production-verify-proof\.v4/u);
   assert.match(proof, /"custom_v2"/u);
-  assert.match(
-    proof,
-    /id: "custom-v2", name: "Custom V2", scopeKey: "custom_v2"/u,
-  );
+  assert.match(proof, /id: "custom-v2", name: "Custom V2", scopeKey: "custom_v2"/u);
   assert.match(verify, /^  custom-v2:$/mu);
-  assert.match(
-    verify,
-    /name: Verify exact Custom V2 surface[\s\S]*npm run verify:custom-v2:ci/u,
-  );
+  assert.match(verify, /name: Verify exact Custom V2 surface[\s\S]*npm run verify:custom-v2:ci/u);
   const projectionDatabaseOperator = stepBlock(
     verify,
     "Verify exact Website projection database operator",
@@ -69,7 +63,10 @@ test("manual Generic release verification runs the complete current Custom V2 tr
   assert.match(scope, /VERIFICATION_MODE:/u);
   assert.match(scope, /test "\$GITHUB_EVENT_NAME" = workflow_dispatch/u);
   assert.match(scope, /test "\$GITHUB_REF" = refs\/heads\/production/u);
-  assert.match(scope, /classify-verify-paths\.mjs --custom-v2-release/u);
+  assert.match(
+    scope,
+    /classify-verify-paths\.mjs --custom-v2-release/u,
+  );
   assert.match(
     verify,
     /name: Bind production Verify proof[\s\S]*github\.event_name == 'workflow_dispatch'[\s\S]*inputs\.verification_mode == 'custom-v2-release'/u,
@@ -81,7 +78,10 @@ test("manual Generic release verification runs the complete current Custom V2 tr
     deploy,
     /PRODUCTION_VERIFY_MODE:[\s\S]*custom-v2-release[\s\S]*--verification-mode "\$PRODUCTION_VERIFY_MODE"/u,
   );
-  assert.match(deploy, /--verification-mode "\$VERIFY_MODE"/u);
+  assert.match(
+    deploy,
+    /--verification-mode "\$VERIFY_MODE"/u,
+  );
   assert.match(
     deploy,
     /--verification-mode "\$\{\{ needs\.release-gate\.outputs\.verification_mode \}\}"/u,
@@ -90,10 +90,7 @@ test("manual Generic release verification runs the complete current Custom V2 tr
 
 test("trusted-base classification bootstraps Custom V2 without narrowing legacy lanes", () => {
   const block = stepBlock(verify, "Classify changed paths");
-  assert.match(
-    block,
-    /git show "\$BASE_SHA:scripts\/ci\/classify-verify-paths\.mjs"/u,
-  );
+  assert.match(block, /git show "\$BASE_SHA:scripts\/ci\/classify-verify-paths\.mjs"/u);
   assert.match(block, /if ! grep -Eq '\^custom_v2=\(true\|false\)\$'/u);
   assert.match(block, /echo 'custom_v2=true'/u);
   assert.match(block, /changing or narrowing any trusted-base legacy result/u);
@@ -106,34 +103,16 @@ test("Custom V2 stage expectations are explicit, observational, and default disa
   ]) {
     assert.match(
       deploy,
-      new RegExp(
-        `${input}:[\\s\\S]{0,240}default: false[\\s\\S]{0,80}type: boolean`,
-        "u",
-      ),
+      new RegExp(`${input}:[\\s\\S]{0,240}default: false[\\s\\S]{0,80}type: boolean`, "u"),
     );
   }
   assert.match(deploy, /this does not change configuration/u);
   assert.match(deploy, /this does not activate them/u);
-  assert.match(
-    deploy,
-    /verified_custom_v2: \$\{\{ steps\.verify-proof\.outputs\.verified_custom_v2 \}\}/u,
-  );
-  const gate = stepBlock(
-    deploy,
-    "Gate exact unaliased Custom V2 staged candidate",
-  );
-  assert.match(
-    gate,
-    /if: needs\.release-gate\.outputs\.verified_custom_v2 == 'true'/u,
-  );
-  assert.match(
-    gate,
-    /STAGED_DEPLOYMENT_ID: \$\{\{ steps\.staged-deployment\.outputs\.deployment_id \}\}/u,
-  );
-  assert.match(
-    gate,
-    /STAGED_TARGET_URL: \$\{\{ steps\.staged-deployment\.outputs\.target_url \}\}/u,
-  );
+  assert.match(deploy, /verified_custom_v2: \$\{\{ steps\.verify-proof\.outputs\.verified_custom_v2 \}\}/u);
+  const gate = stepBlock(deploy, "Gate exact unaliased Custom V2 staged candidate");
+  assert.match(gate, /if: needs\.release-gate\.outputs\.verified_custom_v2 == 'true'/u);
+  assert.match(gate, /STAGED_DEPLOYMENT_ID: \$\{\{ steps\.staged-deployment\.outputs\.deployment_id \}\}/u);
+  assert.match(gate, /STAGED_TARGET_URL: \$\{\{ steps\.staged-deployment\.outputs\.target_url \}\}/u);
   assert.match(gate, /EXPECTED_GIT_HEAD: \$\{\{ github\.sha \}\}/u);
   assert.match(gate, /vercel env run --environment=production/u);
   assert.match(gate, /npm run probe:custom-v2:stage/u);
@@ -144,24 +123,18 @@ test("Custom V2 stage expectations are explicit, observational, and default disa
 });
 
 test("Custom V2 evidence is immutable while the workflow remains stage-only", () => {
-  assert.match(
-    deploy,
-    /name: custom-v2-stage-evidence-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/u,
-  );
+  assert.match(deploy, /name: custom-v2-stage-evidence-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/u);
   assert.match(deploy, /retention-days: 90/u);
   assert.match(deploy, /vercel deploy --prebuilt --prod --skip-domain/u);
-  assert.doesNotMatch(
-    deploy,
-    /vercel (?:promote|rollback)|--scope-production-alias/u,
-  );
+  assert.doesNotMatch(deploy, /vercel (?:promote|rollback)|--scope-production-alias/u);
   assert.match(deploy, /Stage-only: no production promotion was attempted\./u);
   assert.ok(
-    deploy.indexOf("Resolve exact staged deployment") <
-      deploy.indexOf("Gate exact unaliased Custom V2 staged candidate"),
+    deploy.indexOf("Resolve exact staged deployment")
+      < deploy.indexOf("Gate exact unaliased Custom V2 staged candidate"),
   );
   assert.ok(
-    deploy.indexOf("Gate exact unaliased Custom V2 staged candidate") <
-      deploy.indexOf("Reverify staged candidate binding"),
+    deploy.indexOf("Gate exact unaliased Custom V2 staged candidate")
+      < deploy.indexOf("Reverify staged candidate binding"),
   );
   const stablePreview = stepBlock(
     deploy,
@@ -172,7 +145,10 @@ test("Custom V2 evidence is immutable while the workflow remains stage-only", ()
     /STABLE_PREVIEW_HOST: launcher-v4-aficialais-projects\.vercel\.app/u,
   );
   assert.match(stablePreview, /VERCEL_SCOPE: aficialais-projects/u);
-  assert.match(stablePreview, /test "\$VERCEL_SCOPE" = aficialais-projects/u);
+  assert.match(
+    stablePreview,
+    /test "\$VERCEL_SCOPE" = aficialais-projects/u,
+  );
   assert.match(
     stablePreview,
     /vercel alias set "\$EXPECTED_DEPLOYMENT_ID" "\$STABLE_PREVIEW_HOST" \\\n+            --scope="\$VERCEL_SCOPE"/u,
@@ -181,10 +157,7 @@ test("Custom V2 evidence is immutable while the workflow remains stage-only", ()
     stablePreview,
     /vercel inspect "\$STABLE_PREVIEW_HOST" --format=json \\\n+            --scope="\$VERCEL_SCOPE"/u,
   );
-  assert.match(
-    stablePreview,
-    /inspected\.id !== process\.env\.EXPECTED_DEPLOYMENT_ID/u,
-  );
+  assert.match(stablePreview, /inspected\.id !== process\.env\.EXPECTED_DEPLOYMENT_ID/u);
   assert.match(stablePreview, /inspected\.url !== expectedTarget\.hostname/u);
   assert.doesNotMatch(stablePreview, /inspected\.aliases/u);
   assert.match(
@@ -195,8 +168,8 @@ test("Custom V2 evidence is immutable while the workflow remains stage-only", ()
   assert.equal(deploy.match(/vercel alias set/gu)?.length, 1);
   assert.doesNotMatch(deploy.replace(stablePreview, ""), /vercel alias/u);
   assert.ok(
-    deploy.indexOf("Reverify staged candidate binding") <
-      deploy.indexOf("Bind exact candidate to stable protected preview"),
+    deploy.indexOf("Reverify staged candidate binding")
+      < deploy.indexOf("Bind exact candidate to stable protected preview"),
   );
 });
 
@@ -204,12 +177,8 @@ test("Generic signer OIDC proof is one-shot, two-Machine and cleanup-attested", 
   for (const input of [
     "custom_v2_generic_signer_probe_expected_json",
     "custom_v2_generic_signer_probe_expected_sha256",
-  ])
-    assert.match(deploy, new RegExp(`${input}:`, "u"));
-  const prepare = stepBlock(
-    deploy,
-    "Prepare one-shot Generic signer probe authority",
-  );
+  ]) assert.match(deploy, new RegExp(`${input}:`, "u"));
+  const prepare = stepBlock(deploy, "Prepare one-shot Generic signer probe authority");
   assert.match(prepare, /randomBytes\(32\)\.toString\("hex"\)/u);
   assert.match(prepare, /::add-mask::/u);
   assert.match(prepare, /generic-launch-read-stage-probe-operation\.v1/u);
@@ -232,10 +201,7 @@ test("Generic signer OIDC proof is one-shot, two-Machine and cleanup-attested", 
   );
   assert.match(probeDeploy, /vercel deploy --prebuilt --prod --skip-domain/u);
   assert.match(probeDeploy, /PROGRAMMABLE_GENERIC_LAUNCH_SIGNER_PROBE_TOKEN/u);
-  assert.match(
-    probeDeploy,
-    /PROGRAMMABLE_GENERIC_LAUNCH_SIGNER_PROBE_EXPECTED_V1_JSON/u,
-  );
+  assert.match(probeDeploy, /PROGRAMMABLE_GENERIC_LAUNCH_SIGNER_PROBE_EXPECTED_V1_JSON/u);
   assert.match(probeDeploy, /programmableGenericSignerProbeRecoveryId/u);
   assert.match(probeDeploy, /programmableGenericSignerProbe=one-shot-v1/u);
   assert.match(probeDeploy, /programmableRepositoryId=1314365508/u);
@@ -249,14 +215,8 @@ test("Generic signer OIDC proof is one-shot, two-Machine and cleanup-attested", 
     "Reconcile every secret-bearing Generic signer probe deployment",
   );
   assert.match(reconciliation, /always\(\)/u);
-  assert.match(
-    reconciliation,
-    /generic-signer-probe-authority\.outcome == 'success'/u,
-  );
-  assert.doesNotMatch(
-    reconciliation,
-    /generic-signer-probe-deploy\.outcome == 'success'/u,
-  );
+  assert.match(reconciliation, /generic-signer-probe-authority\.outcome == 'success'/u);
+  assert.doesNotMatch(reconciliation, /generic-signer-probe-deploy\.outcome == 'success'/u);
   assert.match(
     reconciliation,
     /reconcile-generic-signer-probe-deployments\.mjs/u,
@@ -279,10 +239,7 @@ test("Generic signer OIDC proof is one-shot, two-Machine and cleanup-attested", 
     deploy,
     "Attest canonical Generic signer probe cleanup bundle",
   );
-  assert.match(
-    attest,
-    /actions\/attest@59d89421af93a897026c735860bf21b6eb4f7b26/u,
-  );
+  assert.match(attest, /actions\/attest@59d89421af93a897026c735860bf21b6eb4f7b26/u);
   assert.match(attest, /create-storage-record: false/u);
   assert.match(
     deploy,
@@ -291,32 +248,23 @@ test("Generic signer OIDC proof is one-shot, two-Machine and cleanup-attested", 
   assert.match(deploy, /attestations: write/u);
   assert.match(deploy, /id-token: write/u);
   assert.ok(
-    deploy.indexOf(
-      "Reconcile every secret-bearing Generic signer probe deployment",
-    ) < deploy.indexOf("Stage production build without assigning domains"),
+    deploy.indexOf("Reconcile every secret-bearing Generic signer probe deployment")
+      < deploy.indexOf("Stage production build without assigning domains"),
   );
   assert.ok(
-    deploy.indexOf(
-      "Reconcile all residual Generic signer probes before new authority",
-    ) < deploy.indexOf("Prepare one-shot Generic signer probe authority"),
+    deploy.indexOf("Reconcile all residual Generic signer probes before new authority")
+      < deploy.indexOf("Prepare one-shot Generic signer probe authority"),
   );
   assert.ok(
-    deploy.indexOf(
-      "Preserve pre-mutation Generic signer probe operation record",
-    ) <
-      deploy.indexOf(
-        "Deploy one-shot unaliased Generic signer probe candidate",
-      ),
+    deploy.indexOf("Preserve pre-mutation Generic signer probe operation record")
+      < deploy.indexOf("Deploy one-shot unaliased Generic signer probe candidate"),
   );
   assert.match(deploy, /^  generic-signer-probe-reconcile:$/mu);
   assert.match(
     deploy,
     /generic-signer-probe-reconcile:[\s\S]*needs: \[release-gate, deploy\][\s\S]*always\(\)[\s\S]*Delete every residual exact probe deployment and prove absence[\s\S]*reconcile-generic-signer-probe-deployments\.mjs/u,
   );
-  assert.match(
-    standaloneReconcile,
-    /^name: Reconcile Generic Signer Probes$/mu,
-  );
+  assert.match(standaloneReconcile, /^name: Reconcile Generic Signer Probes$/mu);
   assert.match(standaloneReconcile, /^  workflow_dispatch:$/mu);
   assert.match(standaloneReconcile, /group: programmable-production/u);
   assert.match(standaloneReconcile, /cancel-in-progress: false/u);
@@ -365,19 +313,16 @@ test("every staged candidate proves the Envio catalog before public data smoke",
   assert.match(probe, /VERCEL_AUTOMATION_BYPASS_SECRET:/u);
   assert.match(probe, /\/api\/explore\?limit=1&page=1&sort=newest/u);
   assert.match(probe, /catalog\?\.source === "envio-classic-v3"/u);
-  assert.match(probe, /const classicCurrent =/u);
   assert.match(probe, /completeness\?\.classic === "current"/u);
-  assert.match(probe, /const routerOnlyFallback =/u);
-  assert.match(probe, /launchSource === "canonical-launch-stamp-router"/u);
-  assert.match(probe, /completeness\?\.classic === "unavailable"/u);
+  assert.match(probe, /completeness\?\.stock === "excluded"/u);
   assert.match(
     probe,
-    /routerStamp\.projectedIdentityCount === body\.catalog\.identityCount/u,
+    /completeness\?\.registryCustom === "current"/u,
   );
-  assert.match(probe, /classicCurrent \|\| routerOnlyFallback/u);
-  assert.match(probe, /completeness\?\.stock === "excluded"/u);
-  assert.match(probe, /completeness\?\.registryCustom === "current"/u);
-  assert.match(probe, /routerCustomStatus === "last-known-good"/u);
+  assert.match(
+    probe,
+    /routerCustomStatus === "last-known-good"/u,
+  );
   assert.match(
     probe,
     /envio-classic-v3\+registry\.custom-launched\+canonical-launch-stamp-router/u,
@@ -391,7 +336,7 @@ test("every staged candidate proves the Envio catalog before public data smoke",
   assert.match(probe, /response = undefined/u);
   assert.match(probe, /if \(attempt === 4\) throw error/u);
   assert.match(probe, /continue/u);
-  assert.match(probe, /if \(exactCatalog\) \{/u);
+  assert.match(probe, /if \(exactCatalog\) break/u);
   assert.doesNotMatch(probe, /CRON_SECRET|\/api\/ops\/index-v2/u);
   assert.doesNotMatch(probe, /\n        if:/u);
 
@@ -416,13 +361,9 @@ test("every staged candidate proves the Envio catalog before public data smoke",
   );
 
   const handoff = stepBlock(deploy, "Record staged candidate handoff");
-  assert.match(
-    handoff,
-    /Launch identities: validated current Classic or bounded Router fallback/u,
-  );
-  assert.match(handoff, /Catalog mode:/u);
-  assert.match(handoff, /Catalog progress block:/u);
-  assert.match(handoff, /Catalog identity count:/u);
+  assert.match(handoff, /Launch identities: validated Envio Classic V3 catalog/u);
+  assert.match(handoff, /Envio catalog progress block:/u);
+  assert.match(handoff, /Envio catalog identity count:/u);
   assert.match(
     handoff,
     /Market data provider: Dexscreener \(optional enrichment\)/u,
@@ -459,8 +400,5 @@ test("the staged public smoke is a separate bounded script", () => {
     /PROGRAMMABLE_WEBSITE_MAINNET_RPC|BITQUERY_API_KEY|runtimeProductionProviderEndpoints|readPrimaryRpc|readBitquery|fetchBitquery/iu,
   );
   assert.doesNotMatch(source, /https?:\/\/[^"'`]*(?:drpc|bitquery)/iu);
-  assert.doesNotMatch(
-    source,
-    /\/api\/explore\/profile\/claim|\/api\/trade\/prepare/u,
-  );
+  assert.doesNotMatch(source, /\/api\/explore\/profile\/claim|\/api\/trade\/prepare/u);
 });

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -313,7 +313,16 @@ test("every staged candidate proves the Envio catalog before public data smoke",
   assert.match(probe, /VERCEL_AUTOMATION_BYPASS_SECRET:/u);
   assert.match(probe, /\/api\/explore\?limit=1&page=1&sort=newest/u);
   assert.match(probe, /catalog\?\.source === "envio-classic-v3"/u);
+  assert.match(probe, /const classicCurrent =/u);
   assert.match(probe, /completeness\?\.classic === "current"/u);
+  assert.match(probe, /const routerOnlyFallback =/u);
+  assert.match(probe, /launchSource === "canonical-launch-stamp-router"/u);
+  assert.match(probe, /completeness\?\.classic === "unavailable"/u);
+  assert.match(
+    probe,
+    /routerStamp\.projectedIdentityCount === body\.catalog\.identityCount/u,
+  );
+  assert.match(probe, /classicCurrent \|\| routerOnlyFallback/u);
   assert.match(probe, /completeness\?\.stock === "excluded"/u);
   assert.match(
     probe,
@@ -336,7 +345,7 @@ test("every staged candidate proves the Envio catalog before public data smoke",
   assert.match(probe, /response = undefined/u);
   assert.match(probe, /if \(attempt === 4\) throw error/u);
   assert.match(probe, /continue/u);
-  assert.match(probe, /if \(exactCatalog\) break/u);
+  assert.match(probe, /if \(exactCatalog\) \{/u);
   assert.doesNotMatch(probe, /CRON_SECRET|\/api\/ops\/index-v2/u);
   assert.doesNotMatch(probe, /\n        if:/u);
 
@@ -361,9 +370,13 @@ test("every staged candidate proves the Envio catalog before public data smoke",
   );
 
   const handoff = stepBlock(deploy, "Record staged candidate handoff");
-  assert.match(handoff, /Launch identities: validated Envio Classic V3 catalog/u);
-  assert.match(handoff, /Envio catalog progress block:/u);
-  assert.match(handoff, /Envio catalog identity count:/u);
+  assert.match(
+    handoff,
+    /Launch identities: validated current Classic or bounded Router fallback/u,
+  );
+  assert.match(handoff, /Catalog mode:/u);
+  assert.match(handoff, /Catalog progress block:/u);
+  assert.match(handoff, /Catalog identity count:/u);
   assert.match(
     handoff,
     /Market data provider: Dexscreener \(optional enrichment\)/u,

--- a/tests/data-pipeline/read-model-staged-refresh.test.ts
+++ b/tests/data-pipeline/read-model-staged-refresh.test.ts
@@ -5,9 +5,8 @@ import { describe, expect, it, vi } from "vitest";
 
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
 import * as operationsSourceContracts from "../../scripts/perf/read-model-ops-source-contracts.mjs";
-const {
-  evaluateReadModelOperationsSourceContracts,
-} = operationsSourceContracts;
+const { evaluateReadModelOperationsSourceContracts } =
+  operationsSourceContracts;
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
 import { refreshExactStagedReadModel } from "../../scripts/perf/read-model-staged-refresh.mjs";
 
@@ -103,8 +102,8 @@ function stagedFetch(
         return Response.json(
           input.prewarmBody?.(phase as string, body) ?? body,
           {
-          status: 200,
-          headers: { "cache-control": "no-store" },
+            status: 200,
+            headers: { "cache-control": "no-store" },
           },
         );
       }
@@ -159,9 +158,9 @@ describe("exact staged durable refresh runtime", () => {
     expect(requests[0]?.url.pathname).toBe(
       `/v13/deployments/${new URL(TARGET_URL).hostname}`,
     );
-    expect(requests.slice(1, 65).map(({ url }) =>
-      url.searchParams.get("phase")
-    )).toEqual([
+    expect(
+      requests.slice(1, 65).map(({ url }) => url.searchParams.get("phase")),
+    ).toEqual([
       ...Array.from({ length: 32 }, (_, index) => [
         `classic-primary-${String(index + 1).padStart(2, "0")}`,
         `classic-secondary-${String(index + 1).padStart(2, "0")}`,
@@ -240,8 +239,9 @@ describe("exact staged durable refresh runtime", () => {
               return phase === "classic-primary-05"
                 ? {
                     ...body,
-                    blockNumber: (BigInt(String(body.blockNumber)) + 1n)
-                      .toString(),
+                    blockNumber: (
+                      BigInt(String(body.blockNumber)) + 1n
+                    ).toString(),
                   }
                 : body;
             },
@@ -251,9 +251,10 @@ describe("exact staged durable refresh runtime", () => {
       ),
     ).rejects.toThrow("exact staged classic-primary-05 prewarm failed");
     expect(
-      requests.some(({ url }) =>
-        url.pathname === "/api/ops/index-v2" &&
-        !url.searchParams.has("phase")
+      requests.some(
+        ({ url }) =>
+          url.pathname === "/api/ops/index-v2" &&
+          !url.searchParams.has("phase"),
       ),
     ).toBe(false);
   });
@@ -284,16 +285,18 @@ describe("exact staged durable refresh runtime", () => {
     let maximumActivePrewarms = 0;
     const sleepImpl = vi.fn(async () => undefined);
     const baseFetch = stagedFetch();
-    const fetchImpl = async (request: URL | RequestInfo, init?: RequestInit) => {
+    const fetchImpl = async (
+      request: URL | RequestInfo,
+      init?: RequestInit,
+    ) => {
       const url = new URL(String(request));
-      if (/^classic-(?:primary|secondary)-[0-9]{2}$/u.test(
-        url.searchParams.get("phase") ?? "",
-      )) {
+      if (
+        /^classic-(?:primary|secondary)-[0-9]{2}$/u.test(
+          url.searchParams.get("phase") ?? "",
+        )
+      ) {
         activePrewarms += 1;
-        maximumActivePrewarms = Math.max(
-          maximumActivePrewarms,
-          activePrewarms,
-        );
+        maximumActivePrewarms = Math.max(maximumActivePrewarms, activePrewarms);
         try {
           await new Promise((resolve) => setTimeout(resolve, 1));
           if (
@@ -301,10 +304,13 @@ describe("exact staged durable refresh runtime", () => {
             transientFailures < 2
           ) {
             transientFailures += 1;
-            return Response.json({ ok: false }, {
-              status: 503,
-              headers: { "cache-control": "no-store" },
-            });
+            return Response.json(
+              { ok: false },
+              {
+                status: 503,
+                headers: { "cache-control": "no-store" },
+              },
+            );
           }
           return baseFetch(request, init);
         } finally {
@@ -314,11 +320,13 @@ describe("exact staged durable refresh runtime", () => {
       return baseFetch(request, init);
     };
     await expect(
-      refreshExactStagedReadModel(stagedRefreshInput(fetchImpl, {
-        requestAttempts: 3,
-        requestRetryDelayMs: 5_000,
-        sleepImpl,
-      })),
+      refreshExactStagedReadModel(
+        stagedRefreshInput(fetchImpl, {
+          requestAttempts: 3,
+          requestRetryDelayMs: 5_000,
+          sleepImpl,
+        }),
+      ),
     ).resolves.toMatchObject({ ok: true, tokenCount: 343 });
     expect(transientFailures).toBe(2);
     expect(maximumActivePrewarms).toBe(1);
@@ -329,10 +337,12 @@ describe("exact staged durable refresh runtime", () => {
   it("paces successful prewarm phases without overlapping providers", async () => {
     const sleepImpl = vi.fn(async (delayMs: number) => void delayMs);
     await expect(
-      refreshExactStagedReadModel(stagedRefreshInput(stagedFetch(), {
-        prewarmPhaseDelayMs: 1_000,
-        sleepImpl,
-      })),
+      refreshExactStagedReadModel(
+        stagedRefreshInput(stagedFetch(), {
+          prewarmPhaseDelayMs: 1_000,
+          sleepImpl,
+        }),
+      ),
     ).resolves.toMatchObject({ ok: true, tokenCount: 343 });
     expect(sleepImpl).toHaveBeenCalledTimes(63);
     expect(sleepImpl.mock.calls.every(([delay]) => delay === 1_000)).toBe(true);
@@ -342,38 +352,47 @@ describe("exact staged durable refresh runtime", () => {
     const requests: URL[] = [];
     const sleepImpl = vi.fn(async () => undefined);
     const baseFetch = stagedFetch();
-    const fetchImpl = async (request: URL | RequestInfo, init?: RequestInit) => {
+    const fetchImpl = async (
+      request: URL | RequestInfo,
+      init?: RequestInit,
+    ) => {
       const url = new URL(String(request));
       requests.push(url);
       if (url.searchParams.get("phase") === "classic-primary-01") {
-        return Response.json({ ok: false }, {
-          status: 503,
-          headers: { "cache-control": "no-store" },
-        });
+        return Response.json(
+          { ok: false },
+          {
+            status: 503,
+            headers: { "cache-control": "no-store" },
+          },
+        );
       }
       return baseFetch(request, init);
     };
     await expect(
-      refreshExactStagedReadModel(stagedRefreshInput(fetchImpl, {
-        requestAttempts: 3,
-        requestRetryDelayMs: 5_000,
-        sleepImpl,
-      })),
+      refreshExactStagedReadModel(
+        stagedRefreshInput(fetchImpl, {
+          requestAttempts: 3,
+          requestRetryDelayMs: 5_000,
+          sleepImpl,
+        }),
+      ),
     ).rejects.toThrow("classic-primary-01 prewarm failed (503)");
     expect(
-      requests.filter((url) =>
-        url.searchParams.get("phase") === "classic-primary-01"
+      requests.filter(
+        (url) => url.searchParams.get("phase") === "classic-primary-01",
       ),
     ).toHaveLength(3);
     expect(
-      requests.some((url) =>
-        url.searchParams.get("phase") === "classic-secondary-01"
+      requests.some(
+        (url) => url.searchParams.get("phase") === "classic-secondary-01",
       ),
     ).toBe(false);
     expect(
-      requests.some((url) =>
-        url.pathname === "/api/ops/index-v2" &&
-        !url.searchParams.has("phase")
+      requests.some(
+        (url) =>
+          url.pathname === "/api/ops/index-v2" &&
+          !url.searchParams.has("phase"),
       ),
     ).toBe(false);
     expect(sleepImpl.mock.calls).toEqual([[5_000], [10_000]]);
@@ -400,22 +419,42 @@ describe("staged Envio catalog probe source contract", () => {
     [
       "drops the exact Envio source",
       (step: string) =>
-        step.replace('              body?.catalog?.source === "envio-classic-v3" &&\n', ""),
+        step.replace(
+          '              body?.catalog?.source === "envio-classic-v3" &&\n',
+          "",
+        ),
     ],
     [
       "drops Classic catalog completeness",
       (step: string) =>
-        step.replace('              body.catalog.completeness?.classic === "current" &&\n', ""),
+        step.replace(
+          '              body?.catalog?.completeness?.classic === "current" &&\n',
+          "",
+        ),
+    ],
+    [
+      "drops the bounded Router-only fallback",
+      (step: string) =>
+        step.replace(
+          "            const routerOnlyFallback =\n",
+          "            const routerOnlyFallbackDisabled =\n",
+        ),
     ],
     [
       "allows stock families",
       (step: string) =>
-        step.replace('              body.catalog.completeness?.stock === "excluded" &&\n', ""),
+        step.replace(
+          '              body.catalog.completeness?.stock === "excluded" &&\n',
+          "",
+        ),
     ],
     [
       "accepts an empty catalog",
       (step: string) =>
-        step.replace("              Number.isSafeInteger(body.total) && body.total >= 1 &&\n", ""),
+        step.replace(
+          "              Number.isSafeInteger(body.total) && body.total >= 1 &&\n",
+          "",
+        ),
     ],
   ])("fails when the workflow %s", (_label, mutate) => {
     const path = ".github/workflows/deploy-production.yml";

--- a/tests/data-pipeline/read-model-staged-refresh.test.ts
+++ b/tests/data-pipeline/read-model-staged-refresh.test.ts
@@ -405,7 +405,18 @@ describe("staged Envio catalog probe source contract", () => {
     [
       "drops Classic catalog completeness",
       (step: string) =>
-        step.replace('              body.catalog.completeness?.classic === "current" &&\n', ""),
+        step.replace(
+          '              body?.catalog?.completeness?.classic === "current" &&\n',
+          "",
+        ),
+    ],
+    [
+      "drops the bounded Router-only fallback",
+      (step: string) =>
+        step.replace(
+          "            const routerOnlyFallback =\n",
+          "            const routerOnlyFallbackDisabled =\n",
+        ),
     ],
     [
       "allows stock families",

--- a/tests/data-pipeline/read-model-staged-refresh.test.ts
+++ b/tests/data-pipeline/read-model-staged-refresh.test.ts
@@ -5,8 +5,9 @@ import { describe, expect, it, vi } from "vitest";
 
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
 import * as operationsSourceContracts from "../../scripts/perf/read-model-ops-source-contracts.mjs";
-const { evaluateReadModelOperationsSourceContracts } =
-  operationsSourceContracts;
+const {
+  evaluateReadModelOperationsSourceContracts,
+} = operationsSourceContracts;
 // @ts-expect-error Operational JavaScript modules intentionally have no declarations.
 import { refreshExactStagedReadModel } from "../../scripts/perf/read-model-staged-refresh.mjs";
 
@@ -102,8 +103,8 @@ function stagedFetch(
         return Response.json(
           input.prewarmBody?.(phase as string, body) ?? body,
           {
-            status: 200,
-            headers: { "cache-control": "no-store" },
+          status: 200,
+          headers: { "cache-control": "no-store" },
           },
         );
       }
@@ -158,9 +159,9 @@ describe("exact staged durable refresh runtime", () => {
     expect(requests[0]?.url.pathname).toBe(
       `/v13/deployments/${new URL(TARGET_URL).hostname}`,
     );
-    expect(
-      requests.slice(1, 65).map(({ url }) => url.searchParams.get("phase")),
-    ).toEqual([
+    expect(requests.slice(1, 65).map(({ url }) =>
+      url.searchParams.get("phase")
+    )).toEqual([
       ...Array.from({ length: 32 }, (_, index) => [
         `classic-primary-${String(index + 1).padStart(2, "0")}`,
         `classic-secondary-${String(index + 1).padStart(2, "0")}`,
@@ -239,9 +240,8 @@ describe("exact staged durable refresh runtime", () => {
               return phase === "classic-primary-05"
                 ? {
                     ...body,
-                    blockNumber: (
-                      BigInt(String(body.blockNumber)) + 1n
-                    ).toString(),
+                    blockNumber: (BigInt(String(body.blockNumber)) + 1n)
+                      .toString(),
                   }
                 : body;
             },
@@ -251,10 +251,9 @@ describe("exact staged durable refresh runtime", () => {
       ),
     ).rejects.toThrow("exact staged classic-primary-05 prewarm failed");
     expect(
-      requests.some(
-        ({ url }) =>
-          url.pathname === "/api/ops/index-v2" &&
-          !url.searchParams.has("phase"),
+      requests.some(({ url }) =>
+        url.pathname === "/api/ops/index-v2" &&
+        !url.searchParams.has("phase")
       ),
     ).toBe(false);
   });
@@ -285,18 +284,16 @@ describe("exact staged durable refresh runtime", () => {
     let maximumActivePrewarms = 0;
     const sleepImpl = vi.fn(async () => undefined);
     const baseFetch = stagedFetch();
-    const fetchImpl = async (
-      request: URL | RequestInfo,
-      init?: RequestInit,
-    ) => {
+    const fetchImpl = async (request: URL | RequestInfo, init?: RequestInit) => {
       const url = new URL(String(request));
-      if (
-        /^classic-(?:primary|secondary)-[0-9]{2}$/u.test(
-          url.searchParams.get("phase") ?? "",
-        )
-      ) {
+      if (/^classic-(?:primary|secondary)-[0-9]{2}$/u.test(
+        url.searchParams.get("phase") ?? "",
+      )) {
         activePrewarms += 1;
-        maximumActivePrewarms = Math.max(maximumActivePrewarms, activePrewarms);
+        maximumActivePrewarms = Math.max(
+          maximumActivePrewarms,
+          activePrewarms,
+        );
         try {
           await new Promise((resolve) => setTimeout(resolve, 1));
           if (
@@ -304,13 +301,10 @@ describe("exact staged durable refresh runtime", () => {
             transientFailures < 2
           ) {
             transientFailures += 1;
-            return Response.json(
-              { ok: false },
-              {
-                status: 503,
-                headers: { "cache-control": "no-store" },
-              },
-            );
+            return Response.json({ ok: false }, {
+              status: 503,
+              headers: { "cache-control": "no-store" },
+            });
           }
           return baseFetch(request, init);
         } finally {
@@ -320,13 +314,11 @@ describe("exact staged durable refresh runtime", () => {
       return baseFetch(request, init);
     };
     await expect(
-      refreshExactStagedReadModel(
-        stagedRefreshInput(fetchImpl, {
-          requestAttempts: 3,
-          requestRetryDelayMs: 5_000,
-          sleepImpl,
-        }),
-      ),
+      refreshExactStagedReadModel(stagedRefreshInput(fetchImpl, {
+        requestAttempts: 3,
+        requestRetryDelayMs: 5_000,
+        sleepImpl,
+      })),
     ).resolves.toMatchObject({ ok: true, tokenCount: 343 });
     expect(transientFailures).toBe(2);
     expect(maximumActivePrewarms).toBe(1);
@@ -337,12 +329,10 @@ describe("exact staged durable refresh runtime", () => {
   it("paces successful prewarm phases without overlapping providers", async () => {
     const sleepImpl = vi.fn(async (delayMs: number) => void delayMs);
     await expect(
-      refreshExactStagedReadModel(
-        stagedRefreshInput(stagedFetch(), {
-          prewarmPhaseDelayMs: 1_000,
-          sleepImpl,
-        }),
-      ),
+      refreshExactStagedReadModel(stagedRefreshInput(stagedFetch(), {
+        prewarmPhaseDelayMs: 1_000,
+        sleepImpl,
+      })),
     ).resolves.toMatchObject({ ok: true, tokenCount: 343 });
     expect(sleepImpl).toHaveBeenCalledTimes(63);
     expect(sleepImpl.mock.calls.every(([delay]) => delay === 1_000)).toBe(true);
@@ -352,47 +342,38 @@ describe("exact staged durable refresh runtime", () => {
     const requests: URL[] = [];
     const sleepImpl = vi.fn(async () => undefined);
     const baseFetch = stagedFetch();
-    const fetchImpl = async (
-      request: URL | RequestInfo,
-      init?: RequestInit,
-    ) => {
+    const fetchImpl = async (request: URL | RequestInfo, init?: RequestInit) => {
       const url = new URL(String(request));
       requests.push(url);
       if (url.searchParams.get("phase") === "classic-primary-01") {
-        return Response.json(
-          { ok: false },
-          {
-            status: 503,
-            headers: { "cache-control": "no-store" },
-          },
-        );
+        return Response.json({ ok: false }, {
+          status: 503,
+          headers: { "cache-control": "no-store" },
+        });
       }
       return baseFetch(request, init);
     };
     await expect(
-      refreshExactStagedReadModel(
-        stagedRefreshInput(fetchImpl, {
-          requestAttempts: 3,
-          requestRetryDelayMs: 5_000,
-          sleepImpl,
-        }),
-      ),
+      refreshExactStagedReadModel(stagedRefreshInput(fetchImpl, {
+        requestAttempts: 3,
+        requestRetryDelayMs: 5_000,
+        sleepImpl,
+      })),
     ).rejects.toThrow("classic-primary-01 prewarm failed (503)");
     expect(
-      requests.filter(
-        (url) => url.searchParams.get("phase") === "classic-primary-01",
+      requests.filter((url) =>
+        url.searchParams.get("phase") === "classic-primary-01"
       ),
     ).toHaveLength(3);
     expect(
-      requests.some(
-        (url) => url.searchParams.get("phase") === "classic-secondary-01",
+      requests.some((url) =>
+        url.searchParams.get("phase") === "classic-secondary-01"
       ),
     ).toBe(false);
     expect(
-      requests.some(
-        (url) =>
-          url.pathname === "/api/ops/index-v2" &&
-          !url.searchParams.has("phase"),
+      requests.some((url) =>
+        url.pathname === "/api/ops/index-v2" &&
+        !url.searchParams.has("phase")
       ),
     ).toBe(false);
     expect(sleepImpl.mock.calls).toEqual([[5_000], [10_000]]);
@@ -419,42 +400,22 @@ describe("staged Envio catalog probe source contract", () => {
     [
       "drops the exact Envio source",
       (step: string) =>
-        step.replace(
-          '              body?.catalog?.source === "envio-classic-v3" &&\n',
-          "",
-        ),
+        step.replace('              body?.catalog?.source === "envio-classic-v3" &&\n', ""),
     ],
     [
       "drops Classic catalog completeness",
       (step: string) =>
-        step.replace(
-          '              body?.catalog?.completeness?.classic === "current" &&\n',
-          "",
-        ),
-    ],
-    [
-      "drops the bounded Router-only fallback",
-      (step: string) =>
-        step.replace(
-          "            const routerOnlyFallback =\n",
-          "            const routerOnlyFallbackDisabled =\n",
-        ),
+        step.replace('              body.catalog.completeness?.classic === "current" &&\n', ""),
     ],
     [
       "allows stock families",
       (step: string) =>
-        step.replace(
-          '              body.catalog.completeness?.stock === "excluded" &&\n',
-          "",
-        ),
+        step.replace('              body.catalog.completeness?.stock === "excluded" &&\n', ""),
     ],
     [
       "accepts an empty catalog",
       (step: string) =>
-        step.replace(
-          "              Number.isSafeInteger(body.total) && body.total >= 1 &&\n",
-          "",
-        ),
+        step.replace("              Number.isSafeInteger(body.total) && body.total >= 1 &&\n", ""),
     ],
   ])("fails when the workflow %s", (_label, mutate) => {
     const path = ".github/workflows/deploy-production.yml";


### PR DESCRIPTION
## Summary
- keep the staging gate strict when the current Envio Classic catalog is available
- admit only the fully bound Router-only fallback when Classic and Registry sources are unavailable
- record the exact catalog mode in release evidence

## Verification
- `node --test scripts/test/custom-v2-production-workflow-contract.test.mjs`
- `npm run perf:read-model:ops-gate`
- `npx vitest run tests/data-pipeline/read-model-staged-refresh.test.ts`
- `git diff --check`

No production promotion is performed by this PR.