### PR TITLE
fix(explore): accept bound Classic V4 catalog

### DIFF
--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -46,6 +46,10 @@ import {
 } from "@/lib/explore-financial-data";
 import { DEFAULT_EXPLORE_VIEW_SORT } from "@/lib/explore-defaults";
 import {
+  CLASSIC_V4_PUBLIC_RELEASE_BINDING,
+  isClassicV4AnchoredPublicReleaseBinding,
+} from "@/lib/classic-v4-public-release";
+import {
   isTokenMarketDataV1,
   marketDataStatusLabel,
 } from "@/lib/market-data/market-data-v1";
@@ -189,6 +193,7 @@ type ExploreCatalogBoundary = Readonly<{
   scope: Readonly<{
     included: readonly (
       | "classic-v3"
+      | "classic-v4"
       | "official-main-token"
       | "registry.custom-launched"
       | "canonical-launch-stamp-router"
@@ -1146,6 +1151,9 @@ function parseExploreCatalog(value: unknown): ExploreCatalogBoundary | null {
     ? value.completeness.routerCustom
     : "unavailable";
   const routerAvailable = routerCustomStatus !== "unavailable";
+  const classicV4IsBound = isClassicV4AnchoredPublicReleaseBinding(
+    CLASSIC_V4_PUBLIC_RELEASE_BINDING,
+  );
   const expectedLaunchSource = [
     ...(envioEvidence ? ["envio-classic-v3"] : []),
     ...(registryCustomStatus === "current"
@@ -1156,6 +1164,7 @@ function parseExploreCatalog(value: unknown): ExploreCatalogBoundary | null {
   const expectedIncluded = envioEvidence
     ? [
         "classic-v3",
+        ...(classicV4IsBound ? ["classic-v4"] : []),
         "official-main-token",
         "registry.custom-launched",
         ...(routerAvailable ? ["canonical-launch-stamp-router"] : []),

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -31,6 +31,12 @@ describe("Explore UI contract", () => {
     expect(source).toContain(
       "handledInitialExploreRequestKey(initialState, requestKey)",
     );
+    expect(source).toContain(
+      "isClassicV4AnchoredPublicReleaseBinding(",
+    );
+    expect(source).toContain(
+      '...(classicV4IsBound ? ["classic-v4"] : [])',
+    );
     expect(source).not.toContain("useLiveDataRefresh");
     expect(source).toContain(
       "const [valuationSort, setValuationSort] = useState<ExploreValuationSort>",

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -127,6 +127,7 @@ const catalogBoundary = {
   scope: {
     included: [
       "classic-v3",
+      "classic-v4",
       "official-main-token",
       "registry.custom-launched",
     ] as const,
@@ -378,6 +379,48 @@ describe("Explore refresh state", () => {
     });
   });
 
+  it("accepts only the exact bound Classic V4 catalog scope", () => {
+    const input = {
+      contentKey: "classic-v4-content",
+      requestKey: "classic-v4-request",
+      pageSize: EXPLORE_TOKENS_PER_PAGE,
+    };
+
+    expect(createExploreInitialState({ ok: true, body: payload }, input))
+      .toMatchObject({ phase: "ready" });
+
+    for (const included of [
+      [
+        "classic-v3",
+        "official-main-token",
+        "registry.custom-launched",
+      ],
+      [
+        "classic-v3",
+        "classic-v4",
+        "classic-v4",
+        "official-main-token",
+        "registry.custom-launched",
+      ],
+    ]) {
+      const state = createExploreInitialState({
+        ok: true,
+        body: {
+          ...payload,
+          catalog: {
+            ...catalogBoundary,
+            scope: { ...catalogBoundary.scope, included },
+          },
+        },
+      }, input);
+
+      expect(state).toMatchObject({
+        phase: "error",
+        message: "The token registry returned invalid catalog data",
+      });
+    }
+  });
+
   it("hydrates a Router-only fallback when Envio is unavailable", () => {
     const routerFallback = {
       status: "ready" as const,
@@ -439,6 +482,27 @@ describe("Explore refresh state", () => {
         tokens: [{ tokenAddress: customGraphExploreEntry.tokenAddress }],
         catalog: { launchSource: "canonical-launch-stamp-router" },
       },
+    });
+
+    expect(createExploreInitialState({
+      ok: true,
+      body: {
+        ...routerFallback,
+        catalog: {
+          ...routerFallback.catalog,
+          scope: {
+            ...routerFallback.catalog.scope,
+            included: ["classic-v4", "canonical-launch-stamp-router"],
+          },
+        },
+      },
+    }, {
+      contentKey: "router-fallback-invalid-content",
+      requestKey: "router-fallback-invalid-request",
+      pageSize: EXPLORE_TOKENS_PER_PAGE,
+    })).toMatchObject({
+      phase: "error",
+      message: "The token registry returned invalid catalog data",
     });
   });
 

--- a/tests/launch-stamp-surfaces.test.ts
+++ b/tests/launch-stamp-surfaces.test.ts
@@ -213,6 +213,7 @@ describe("canonical Router stamp surfaces", () => {
           scope: {
             included: [
               "classic-v3",
+              "classic-v4",
               "official-main-token",
               "registry.custom-launched",
               "canonical-launch-stamp-router",


### PR DESCRIPTION
Fixes the Explore client boundary so the active Classic V4 Envio scope is accepted only when the browser-side V4 release anchor is valid. Exact scope validation remains fail-closed, including Router-only fallback.\n\nLocal proof: 101 focused tests, TypeScript, ESLint, and diff checks pass. Independent review: GO.