### PR TITLE
Fix Classic wallet session and linkage

### DIFF
--- a/components/launch-builder.tsx
+++ b/components/launch-builder.tsx
@@ -245,6 +245,30 @@ export function launchDraftIsLocked(
   );
 }
 
+export async function createClassicLaunchPreflightHeaders(
+  input: Readonly<{
+    getAccessToken: () => Promise<string | null>;
+    getIdentityToken: () => Promise<string | null>;
+  }>,
+) {
+  // Identity-token lookup can refresh Privy's current session. Acquire the
+  // authoritative access token afterwards so the two credentials cannot race
+  // and represent different session revisions.
+  const identityToken = await input.getIdentityToken().catch(() => null);
+  const accessToken = await input.getAccessToken();
+  if (!accessToken) {
+    throw new Error("Reconnect the launch wallet and try again");
+  }
+
+  return new Headers({
+    Authorization: `Bearer ${accessToken}`,
+    "Content-Type": "application/json",
+    ...(identityToken
+      ? { "X-Privy-Identity-Token": identityToken }
+      : {}),
+  });
+}
+
 export function launchDraftForSuccessDisplay(
   draft: LaunchDraft,
   submittedFromCurrentDraft: boolean,
@@ -1709,23 +1733,18 @@ function LaunchBuilderFormView({
     const timeout = window.setTimeout(() => controller.abort(), 65_000);
 
     try {
-      const headers = new Headers({ "Content-Type": "application/json" });
+      let headers = new Headers({ "Content-Type": "application/json" });
       if (
         classicV4UiReleaseEnabled
         && checkedDraft.launchModel === "classic-v3"
         && checkedDraft.classicContractRelease === "classic-v4"
       ) {
-        const [accessToken, identityToken] = await Promise.all([
-          getAccessToken(),
-          getIdentityToken().catch(() => null),
-        ]);
-        if (!accessToken) {
-          throw new Error("Reconnect the launch wallet and try again");
-        }
-        headers.set("Authorization", `Bearer ${accessToken}`);
-        if (identityToken) {
-          headers.set("X-Privy-Identity-Token", identityToken);
-        }
+        // Privy's identity lookup can refresh the session. Fetch it before the
+        // access token instead of racing both credentials in parallel.
+        headers = await createClassicLaunchPreflightHeaders({
+          getAccessToken,
+          getIdentityToken,
+        });
       }
       const response = await fetch("/api/launch/preflight", {
         method: "POST",

--- a/components/launch-builder.tsx
+++ b/components/launch-builder.tsx
@@ -269,6 +269,26 @@ export async function createClassicLaunchPreflightHeaders(
   });
 }
 
+export const CLASSIC_V4_LINKED_WALLET_REQUIRED_MESSAGE =
+  "This address is not linked to your Programmable wallet session. Select Add wallet to link it before creating a Classic token.";
+
+export function blockUnlinkedClassicV4Launch(input: Readonly<{
+  hasWallet: boolean;
+  launchModel: LaunchModel;
+  onBlocked: (message: string) => void;
+  releaseEnabled: boolean;
+  walletLinked: boolean;
+}>) {
+  const blocked = input.launchModel === "classic-v3"
+    && input.releaseEnabled
+    && input.hasWallet
+    && !input.walletLinked;
+  if (!blocked) return false;
+
+  input.onBlocked(CLASSIC_V4_LINKED_WALLET_REQUIRED_MESSAGE);
+  return true;
+}
+
 export function launchDraftForSuccessDisplay(
   draft: LaunchDraft,
   submittedFromCurrentDraft: boolean,
@@ -1302,7 +1322,9 @@ function LaunchBuilderFormView({
 }) {
   const {
     wallet,
+    walletLinked,
     openWallet,
+    openWalletWithError,
     readNativeBalance,
     sendTransaction,
     getAccessToken,
@@ -1935,6 +1957,19 @@ function LaunchBuilderFormView({
 
     if (!wallet) {
       openWallet();
+      return;
+    }
+
+    if (blockUnlinkedClassicV4Launch({
+      hasWallet: true,
+      launchModel: model,
+      onBlocked: (message) => {
+        setFormError(message);
+        openWalletWithError(message);
+      },
+      releaseEnabled: classicV4UiReleaseEnabled,
+      walletLinked,
+    })) {
       return;
     }
 

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -124,6 +124,7 @@ export type WalletApplicantSessionV1 = Readonly<{
 
 type WalletContextValue = {
   wallet: WalletState | null;
+  walletLinked: boolean;
   username: string;
   avatarDataUrl: string;
   authReady: boolean;
@@ -134,6 +135,7 @@ type WalletContextValue = {
   switchingNetwork: boolean;
   preloadWallet: () => void;
   openWallet: () => void;
+  openWalletWithError: (message: string) => void;
   switchNetwork: (expectedChainId?: string) => Promise<boolean>;
   disconnect: (options?: {
     showDialogOnFailure?: boolean;
@@ -894,6 +896,7 @@ function DeferredWalletProvider({
   const value = useMemo<WalletContextValue>(
     () => ({
       wallet: null,
+      walletLinked: false,
       username: "",
       avatarDataUrl: "",
       authReady: false,
@@ -904,6 +907,7 @@ function DeferredWalletProvider({
       switchingNetwork: false,
       preloadWallet: onPreload,
       openWallet: () => onActivate("wallet"),
+      openWalletWithError: () => onActivate("wallet"),
       switchNetwork: async () => false,
       disconnect: async () => false,
       getAccessToken: async () => null,
@@ -1188,6 +1192,7 @@ function PrivyWalletBridge({
       chainId: normalizeChainId(connectedWalletChainId),
     };
   }, [connectedWalletAddress, connectedWalletChainId]);
+  const walletLinked = connectedWallet?.linked === true;
   const walletRequestSessionRef = useRef({
     authenticated: activeAuthenticated,
     privyUserId: user?.id ?? null,
@@ -1489,6 +1494,11 @@ function PrivyWalletBridge({
 
     startLogin();
   }, [providerTimedOut, sessionAction, startLogin]);
+
+  const openWalletWithError = useCallback((message: string) => {
+    setError(message);
+    setDialogOpen(true);
+  }, []);
 
   useEffect(() => {
     if (autoAction === null || sessionAction === "wait") return;
@@ -2280,6 +2290,7 @@ function PrivyWalletBridge({
   const value = useMemo<WalletContextValue>(
     () => ({
       wallet,
+      walletLinked,
       username,
       avatarDataUrl,
       authReady: ready,
@@ -2291,6 +2302,7 @@ function PrivyWalletBridge({
       switchingNetwork,
       preloadWallet: () => undefined,
       openWallet,
+      openWalletWithError,
       switchNetwork: switchWalletNetwork,
       disconnect,
       getAccessToken,
@@ -2329,6 +2341,7 @@ function PrivyWalletBridge({
       hasSession,
       loginPending,
       openWallet,
+      openWalletWithError,
       providerTimedOut,
       readNativeBalance,
       readTradeBalances,
@@ -2349,6 +2362,7 @@ function PrivyWalletBridge({
       setUsername,
       username,
       wallet,
+      walletLinked,
     ],
   );
 
@@ -2397,6 +2411,7 @@ function UnconfiguredWalletProvider({ children }: { children: ReactNode }) {
   const value = useMemo<WalletContextValue>(
     () => ({
       wallet: null,
+      walletLinked: false,
       username: "",
       avatarDataUrl: "",
       authReady: false,
@@ -2407,6 +2422,7 @@ function UnconfiguredWalletProvider({ children }: { children: ReactNode }) {
       switchingNetwork: false,
       preloadWallet: () => undefined,
       openWallet: () => setDialogOpen(true),
+      openWalletWithError: () => setDialogOpen(true),
       switchNetwork: async () => false,
       disconnect: async () => false,
       getAccessToken: async () => null,

--- a/tests/classic-v4-ui.test.tsx
+++ b/tests/classic-v4-ui.test.tsx
@@ -1,10 +1,11 @@
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   classicMaximumCheckDraft,
   classicV4TransactionBlockReason,
+  createClassicLaunchPreflightHeaders,
   EnhancedClassicFeeStep,
   normalizeClassicV3Draft,
 } from "../components/launch-builder";
@@ -24,6 +25,51 @@ function renderFeeStep(draft: LaunchDraft, enableV4 = true) {
 }
 
 describe("Classic V4 launch controls", () => {
+  it("gets identity before access so Privy cannot return two racing session revisions", async () => {
+    const events: string[] = [];
+    const getIdentityToken = vi.fn(async () => {
+      events.push("identity-start");
+      await Promise.resolve();
+      events.push("identity-settled");
+      return "fresh-identity-token";
+    });
+    const getAccessToken = vi.fn(async () => {
+      events.push("access");
+      return "fresh-access-token";
+    });
+
+    const headers = await createClassicLaunchPreflightHeaders({
+      getAccessToken,
+      getIdentityToken,
+    });
+
+    expect(events).toEqual(["identity-start", "identity-settled", "access"]);
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
+    expect(getIdentityToken).toHaveBeenCalledTimes(1);
+    expect(headers.get("authorization")).toBe("Bearer fresh-access-token");
+    expect(headers.get("content-type")).toBe("application/json");
+    expect(headers.get("x-privy-identity-token")).toBe(
+      "fresh-identity-token",
+    );
+  });
+
+  it("keeps the verified access session usable when Privy omits its optional identity token", async () => {
+    const headers = await createClassicLaunchPreflightHeaders({
+      getIdentityToken: async () => null,
+      getAccessToken: async () => "fresh-access-token",
+    });
+
+    expect(headers.get("authorization")).toBe("Bearer fresh-access-token");
+    expect(headers.has("x-privy-identity-token")).toBe(false);
+  });
+
+  it("fails closed before preflight when no verified access session is available", async () => {
+    await expect(createClassicLaunchPreflightHeaders({
+      getIdentityToken: async () => "identity-token",
+      getAccessToken: async () => null,
+    })).rejects.toThrow("Reconnect the launch wallet and try again");
+  });
+
   it("lets Max repair an invalid or over-capacity Activation Buy", () => {
     const overCapacity = {
       ...createClassicV3Draft(),

--- a/tests/classic-v4-ui.test.tsx
+++ b/tests/classic-v4-ui.test.tsx
@@ -3,6 +3,8 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  CLASSIC_V4_LINKED_WALLET_REQUIRED_MESSAGE,
+  blockUnlinkedClassicV4Launch,
   classicMaximumCheckDraft,
   classicV4TransactionBlockReason,
   createClassicLaunchPreflightHeaders,
@@ -25,6 +27,64 @@ function renderFeeStep(draft: LaunchDraft, enableV4 = true) {
 }
 
 describe("Classic V4 launch controls", () => {
+  it("blocks only the selected unlinked Classic V4 wallet before preflight", () => {
+    const openWalletWithError = vi.fn();
+    const preflight = vi.fn();
+    if (!blockUnlinkedClassicV4Launch({
+      hasWallet: true,
+      launchModel: "classic-v3",
+      onBlocked: openWalletWithError,
+      releaseEnabled: true,
+      walletLinked: false,
+    })) preflight();
+
+    expect(preflight).not.toHaveBeenCalled();
+    expect(openWalletWithError).toHaveBeenCalledOnce();
+    expect(openWalletWithError).toHaveBeenCalledWith(
+      CLASSIC_V4_LINKED_WALLET_REQUIRED_MESSAGE,
+    );
+
+    for (const allowed of [
+      {
+        hasWallet: false,
+        launchModel: "classic-v3" as const,
+        releaseEnabled: true,
+        walletLinked: false,
+      },
+      {
+        hasWallet: true,
+        launchModel: "classic-v3" as const,
+        releaseEnabled: true,
+        walletLinked: true,
+      },
+      {
+        hasWallet: true,
+        launchModel: "classic-v3" as const,
+        releaseEnabled: false,
+        walletLinked: false,
+      },
+      {
+        hasWallet: true,
+        launchModel: "stock-paired" as const,
+        releaseEnabled: true,
+        walletLinked: false,
+      },
+    ]) {
+      const onBlocked = vi.fn();
+      expect(blockUnlinkedClassicV4Launch({
+        ...allowed,
+        onBlocked,
+      })).toBe(false);
+      expect(onBlocked).not.toHaveBeenCalled();
+    }
+  });
+
+  it("points an unlinked Classic wallet to the existing Add wallet action", () => {
+    expect(CLASSIC_V4_LINKED_WALLET_REQUIRED_MESSAGE).toBe(
+      "This address is not linked to your Programmable wallet session. Select Add wallet to link it before creating a Classic token.",
+    );
+  });
+
   it("gets identity before access so Privy cannot return two racing session revisions", async () => {
     const events: string[] = [];
     const getIdentityToken = vi.fn(async () => {


### PR DESCRIPTION
## Summary
- serialize Privy identity refresh before Classic V4 access-token acquisition
- keep identity optional and access token mandatory
- stop an unlinked selected wallet before preflight and open the existing Add wallet recovery
- keep global wallet selection unchanged; do not auto-switch accounts
- preserve server-side linked-wallet and session binding
- add regression coverage for both 401 and 403 client paths

## Verification
- 60 focused wallet and Classic V4 UI tests
- `npm run typecheck`
- focused ESLint
- `git diff --check`