### PR TITLE
Fix production repository binding after rename

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -80,7 +80,7 @@ jobs:
   release-gate:
     name: Consume exact full production Verify proof
     if: >-
-      github.repository == '0xprogrammable/programmable' &&
+      github.repository == '0xprogrammable/PROGRAMMABLE-EVM' &&
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/production'
     permissions:
@@ -205,7 +205,7 @@ jobs:
     name: Stage programmable.market candidate
     needs: release-gate
     if: >-
-      github.repository == '0xprogrammable/programmable' &&
+      github.repository == '0xprogrammable/PROGRAMMABLE-EVM' &&
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/production' &&
       needs.release-gate.outputs.verified_sha == github.sha
@@ -379,7 +379,7 @@ jobs:
             --header "Authorization: Bearer $COMMAND_CENTER_GITHUB_TOKEN" \
             --header "X-GitHub-Api-Version: 2022-11-28" \
             --output "$record_commit_json" \
-            "https://api.github.com/repos/0xprogrammable/programmable/commits/$RECORD_COMMIT_SHA"
+            "https://api.github.com/repos/0xprogrammable/PROGRAMMABLE-EVM/commits/$RECORD_COMMIT_SHA"
           RECORD_COMMIT_JSON="$record_commit_json" node --input-type=module <<'NODE'
           import { readFileSync } from "node:fs";
           const commit = JSON.parse(readFileSync(process.env.RECORD_COMMIT_JSON, "utf8"));
@@ -463,7 +463,7 @@ jobs:
             --header "Authorization: Bearer $COMMAND_CENTER_GITHUB_TOKEN" \
             --header "X-GitHub-Api-Version: 2022-11-28" \
             --output "$record_commit_json" \
-            "https://api.github.com/repos/0xprogrammable/programmable/commits/$RECORD_COMMIT_SHA"
+            "https://api.github.com/repos/0xprogrammable/PROGRAMMABLE-EVM/commits/$RECORD_COMMIT_SHA"
           RECORD_COMMIT_JSON="$record_commit_json" node --input-type=module <<'NODE'
           import { readFileSync } from "node:fs";
           const commit = JSON.parse(readFileSync(process.env.RECORD_COMMIT_JSON, "utf8"));
@@ -1515,7 +1515,7 @@ jobs:
     needs: [release-gate, deploy]
     if: >-
       always() &&
-      github.repository == '0xprogrammable/programmable' &&
+      github.repository == '0xprogrammable/PROGRAMMABLE-EVM' &&
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/production' &&
       needs.release-gate.result == 'success' &&

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Canonical repository
 
-- The public product repository is `https://github.com/0xprogrammable/programmable`.
+- The public product repository is `https://github.com/0xprogrammable/PROGRAMMABLE-EVM`.
 - `production` is the canonical full-product branch and the only branch used for website production releases.
 - `main` remains the public contracts and release-evidence branch. Never deploy the website from `main`.
 - Confirm the destination remote before every push. Do not assume that a remote named `origin` is canonical.

--- a/docs/public/.gitbook/STYLEGUIDE.md
+++ b/docs/public/.gitbook/STYLEGUIDE.md
@@ -60,4 +60,4 @@ Use meaningful alt text when an image carries information and empty alt text whe
 
 ## Ownership
 
-The canonical public documentation source lives in the `0xprogrammable/programmable` repository under `docs/public`. Changes are reviewed through the production branch and GitBook publishes the synced result. When product state changes, update the evidence and the explanatory copy together.
+The canonical public documentation source lives in the `0xprogrammable/PROGRAMMABLE-EVM` repository under `docs/public`. Changes are reviewed through the production branch and GitBook publishes the synced result. When product state changes, update the evidence and the explanatory copy together.

--- a/scripts/production-verify-proof.mjs
+++ b/scripts/production-verify-proof.mjs
@@ -11,7 +11,7 @@ import { pathToFileURL } from "node:url";
 export const PRODUCTION_VERIFY_PROOF_SCHEMA_VERSION =
   "programmable.production-verify-proof.v4";
 export const PRODUCTION_VERIFY_PROOF_MAX_AGE_MS = 6 * 60 * 60 * 1_000;
-export const PRODUCTION_REPOSITORY = "0xprogrammable/programmable";
+export const PRODUCTION_REPOSITORY = "0xprogrammable/PROGRAMMABLE-EVM";
 export const PRODUCTION_REPOSITORY_ID = 1_314_365_508;
 export const PRODUCTION_REF = "refs/heads/production";
 export const VERIFY_WORKFLOW_PATH = ".github/workflows/verify.yml";
@@ -50,7 +50,7 @@ const EXPECTED_GITHUB_API_URL = "https://api.github.com";
 
 function isProductionRepository(value) {
   return typeof value === "string"
-    && value.toLowerCase() === PRODUCTION_REPOSITORY;
+    && value.toLowerCase() === PRODUCTION_REPOSITORY.toLowerCase();
 }
 
 export function canonicalProductionRepository(value, name = "repository") {

--- a/scripts/test/custom-launch-release-workflow-contract.test.mjs
+++ b/scripts/test/custom-launch-release-workflow-contract.test.mjs
@@ -31,6 +31,13 @@ function workflowFailures(source) {
     "name: Consume exact full production Verify proof",
   );
   requireText(
+    "canonical-production-repository",
+    "github.repository == '0xprogrammable/PROGRAMMABLE-EVM'",
+  );
+  if (source.includes("github.repository == '0xprogrammable/programmable'")) {
+    failures.push("retired-production-repository");
+  }
+  requireText(
     "proof-exact-artifact-download",
     "artifact-ids: ${{ steps.resolve-proof.outputs.artifact_id }}",
   );
@@ -627,6 +634,10 @@ test("workflow contract detects weakened record and stage-only gates", async () 
     source.replace(
       "node scripts/production-verify-proof.mjs resolve",
       "node scripts/production-verify-proof.mjs verify",
+    ),
+    source.replaceAll(
+      "github.repository == '0xprogrammable/PROGRAMMABLE-EVM'",
+      "github.repository == '0xprogrammable/programmable'",
     ),
     source.replace("workflow_dispatch:\n", "push:\n    branches: [production]\n"),
     source.replace(

--- a/scripts/test/production-verify-proof.test.mjs
+++ b/scripts/test/production-verify-proof.test.mjs
@@ -31,7 +31,7 @@ const ARTIFACT_DIGEST =
 const RUN_ID = 31_519_898_545;
 const RUN_ATTEMPT = 1;
 const WORKFLOW_ID = 321_772_273;
-const REPOSITORY_URL = "https://github.com/0xprogrammable/programmable";
+const REPOSITORY_URL = "https://github.com/0xprogrammable/PROGRAMMABLE-EVM";
 const NOW_MS = Date.parse("2026-08-11T18:10:00Z");
 
 function validProofInput() {
@@ -257,22 +257,22 @@ test("full production Verify proof is deterministic and exact", () => {
 
 test("GitHub display-case drift preserves the canonical production identity", () => {
   assert.equal(
-    canonicalProductionRepository("0xprogrammable/PROGRAMMABLE"),
+    canonicalProductionRepository("0xprogrammable/programmable-evm"),
     PRODUCTION_REPOSITORY,
   );
   assert.equal(
     canonicalProductionWorkflowRef(
-      "0xprogrammable/PROGRAMMABLE/.github/workflows/verify.yml@refs/heads/production",
+      "0xprogrammable/programmable-evm/.github/workflows/verify.yml@refs/heads/production",
     ),
     `${PRODUCTION_REPOSITORY}/${VERIFY_WORKFLOW_PATH}@${PRODUCTION_REF}`,
   );
   assert.throws(() =>
-    canonicalProductionRepository("attacker/PROGRAMMABLE"));
+    canonicalProductionRepository("attacker/PROGRAMMABLE-EVM"));
   assert.throws(() =>
-    canonicalProductionRepository("0xprogrammable/PROGRAMMABLE "));
+    canonicalProductionRepository("0xprogrammable/PROGRAMMABLE-EVM "));
   assert.throws(() =>
     canonicalProductionWorkflowRef(
-      "0xprogrammable/PROGRAMMABLE/.github/workflows/verify.yml@refs/heads/main",
+      "0xprogrammable/PROGRAMMABLE-EVM/.github/workflows/verify.yml@refs/heads/main",
     ));
 });
 
@@ -414,9 +414,9 @@ test("resolver accepts only a fresh exact successful run and immutable artifact"
 test("resolver accepts GitHub repository display-case drift with the exact ID", async () => {
   const fixtures = validApiFixtures();
   const run = fixtures.runs.workflow_runs[0];
-  run.repository.full_name = "0xprogrammable/PROGRAMMABLE";
-  run.repository.html_url = "https://github.com/0xprogrammable/PROGRAMMABLE";
-  run.head_repository.full_name = "0xprogrammable/PROGRAMMABLE";
+  run.repository.full_name = "0xprogrammable/programmable-evm";
+  run.repository.html_url = "https://github.com/0xprogrammable/programmable-evm";
+  run.head_repository.full_name = "0xprogrammable/programmable-evm";
   run.html_url = `${run.repository.html_url}/actions/runs/${RUN_ID}`;
   assert.equal((await resolveFixtures(fixtures)).runId, RUN_ID);
 });


### PR DESCRIPTION
## Summary
- bind production Verify proof to the current repository name while preserving the immutable repository ID
- update stage workflow repository guards and canonical API URLs
- add regression coverage for the renamed production repository

## Verification
- 23/23 focused production proof/workflow tests pass
- exact proof creation succeeds with `GITHUB_REPOSITORY=0xprogrammable/PROGRAMMABLE-EVM`
- `git diff --check` clean

This is the minimal release-control repair required after the GitHub repository rename.