### PR TITLE
fix(release): bind renamed production repository

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -80,7 +80,7 @@ jobs:
   release-gate:
     name: Consume exact full production Verify proof
     if: >-
-      github.repository == '0xprogrammable/programmable' &&
+      github.repository_id == 1314365508 &&
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/production'
     permissions:
@@ -205,7 +205,7 @@ jobs:
     name: Stage programmable.market candidate
     needs: release-gate
     if: >-
-      github.repository == '0xprogrammable/programmable' &&
+      github.repository_id == 1314365508 &&
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/production' &&
       needs.release-gate.outputs.verified_sha == github.sha
@@ -379,7 +379,7 @@ jobs:
             --header "Authorization: Bearer $COMMAND_CENTER_GITHUB_TOKEN" \
             --header "X-GitHub-Api-Version: 2022-11-28" \
             --output "$record_commit_json" \
-            "https://api.github.com/repos/0xprogrammable/programmable/commits/$RECORD_COMMIT_SHA"
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/commits/$RECORD_COMMIT_SHA"
           RECORD_COMMIT_JSON="$record_commit_json" node --input-type=module <<'NODE'
           import { readFileSync } from "node:fs";
           const commit = JSON.parse(readFileSync(process.env.RECORD_COMMIT_JSON, "utf8"));
@@ -463,7 +463,7 @@ jobs:
             --header "Authorization: Bearer $COMMAND_CENTER_GITHUB_TOKEN" \
             --header "X-GitHub-Api-Version: 2022-11-28" \
             --output "$record_commit_json" \
-            "https://api.github.com/repos/0xprogrammable/programmable/commits/$RECORD_COMMIT_SHA"
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/commits/$RECORD_COMMIT_SHA"
           RECORD_COMMIT_JSON="$record_commit_json" node --input-type=module <<'NODE'
           import { readFileSync } from "node:fs";
           const commit = JSON.parse(readFileSync(process.env.RECORD_COMMIT_JSON, "utf8"));
@@ -1515,7 +1515,7 @@ jobs:
     needs: [release-gate, deploy]
     if: >-
       always() &&
-      github.repository == '0xprogrammable/programmable' &&
+      github.repository_id == 1314365508 &&
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/production' &&
       needs.release-gate.result == 'success' &&

--- a/scripts/production-verify-proof.mjs
+++ b/scripts/production-verify-proof.mjs
@@ -11,7 +11,7 @@ import { pathToFileURL } from "node:url";
 export const PRODUCTION_VERIFY_PROOF_SCHEMA_VERSION =
   "programmable.production-verify-proof.v4";
 export const PRODUCTION_VERIFY_PROOF_MAX_AGE_MS = 6 * 60 * 60 * 1_000;
-export const PRODUCTION_REPOSITORY = "0xprogrammable/programmable";
+export const PRODUCTION_REPOSITORY = "0xprogrammable/programmable-evm";
 export const PRODUCTION_REPOSITORY_ID = 1_314_365_508;
 export const PRODUCTION_REF = "refs/heads/production";
 export const VERIFY_WORKFLOW_PATH = ".github/workflows/verify.yml";

--- a/scripts/test/production-verify-proof.test.mjs
+++ b/scripts/test/production-verify-proof.test.mjs
@@ -31,7 +31,7 @@ const ARTIFACT_DIGEST =
 const RUN_ID = 31_519_898_545;
 const RUN_ATTEMPT = 1;
 const WORKFLOW_ID = 321_772_273;
-const REPOSITORY_URL = "https://github.com/0xprogrammable/programmable";
+const REPOSITORY_URL = "https://github.com/0xprogrammable/programmable-evm";
 const NOW_MS = Date.parse("2026-08-11T18:10:00Z");
 
 function validProofInput() {
@@ -257,22 +257,22 @@ test("full production Verify proof is deterministic and exact", () => {
 
 test("GitHub display-case drift preserves the canonical production identity", () => {
   assert.equal(
-    canonicalProductionRepository("0xprogrammable/PROGRAMMABLE"),
+    canonicalProductionRepository("0xprogrammable/PROGRAMMABLE-EVM"),
     PRODUCTION_REPOSITORY,
   );
   assert.equal(
     canonicalProductionWorkflowRef(
-      "0xprogrammable/PROGRAMMABLE/.github/workflows/verify.yml@refs/heads/production",
+      "0xprogrammable/PROGRAMMABLE-EVM/.github/workflows/verify.yml@refs/heads/production",
     ),
     `${PRODUCTION_REPOSITORY}/${VERIFY_WORKFLOW_PATH}@${PRODUCTION_REF}`,
   );
   assert.throws(() =>
-    canonicalProductionRepository("attacker/PROGRAMMABLE"));
+    canonicalProductionRepository("attacker/PROGRAMMABLE-EVM"));
   assert.throws(() =>
-    canonicalProductionRepository("0xprogrammable/PROGRAMMABLE "));
+    canonicalProductionRepository("0xprogrammable/PROGRAMMABLE-EVM "));
   assert.throws(() =>
     canonicalProductionWorkflowRef(
-      "0xprogrammable/PROGRAMMABLE/.github/workflows/verify.yml@refs/heads/main",
+      "0xprogrammable/PROGRAMMABLE-EVM/.github/workflows/verify.yml@refs/heads/main",
     ));
 });
 
@@ -414,9 +414,9 @@ test("resolver accepts only a fresh exact successful run and immutable artifact"
 test("resolver accepts GitHub repository display-case drift with the exact ID", async () => {
   const fixtures = validApiFixtures();
   const run = fixtures.runs.workflow_runs[0];
-  run.repository.full_name = "0xprogrammable/PROGRAMMABLE";
-  run.repository.html_url = "https://github.com/0xprogrammable/PROGRAMMABLE";
-  run.head_repository.full_name = "0xprogrammable/PROGRAMMABLE";
+  run.repository.full_name = "0xprogrammable/PROGRAMMABLE-EVM";
+  run.repository.html_url = "https://github.com/0xprogrammable/PROGRAMMABLE-EVM";
+  run.head_repository.full_name = "0xprogrammable/PROGRAMMABLE-EVM";
   run.html_url = `${run.repository.html_url}/actions/runs/${RUN_ID}`;
   assert.equal((await resolveFixtures(fixtures)).runId, RUN_ID);
 });


### PR DESCRIPTION
## Summary
- bind production verification to the renamed PROGRAMMABLE-EVM repository while preserving the immutable repository ID
- make production workflow guards rename-stable via repository_id
- resolve detached-record commit reads through the current GitHub repository context

## Verification
- 31 focused production-proof and release-workflow tests passed
- git diff --check passed

This restores exact production proof generation and staging after the repository rename.