### PR TITLE
Fail closed on retired Prediction API routes

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -8,6 +8,31 @@ const MARKDOWN_DESTINATIONS = new Map([
   ["/docs/developers", "/docs/developers.md"],
 ]);
 
+function isRetiredPredictionApi(pathname: string): boolean {
+  return pathname === "/api/prediction" ||
+    pathname.startsWith("/api/prediction/");
+}
+
+function retiredPredictionApiResponse(): NextResponse {
+  return NextResponse.json(
+    {
+      schemaVersion: "programmable.api-error.v1",
+      status: "error",
+      error: {
+        code: "api_route_not_found",
+        message: "No public Programmable API route matches this path.",
+      },
+    },
+    {
+      status: 404,
+      headers: {
+        "Cache-Control": "no-store",
+        "X-Robots-Tag": "noindex, nofollow",
+      },
+    },
+  );
+}
+
 function withAcceptVariation(response: NextResponse): NextResponse {
   const values = new Set(
     (response.headers.get("Vary") ?? "")
@@ -32,6 +57,10 @@ function homeMarkdownResponse(): NextResponse {
 }
 
 export function proxy(request: NextRequest) {
+  if (isRetiredPredictionApi(request.nextUrl.pathname)) {
+    return retiredPredictionApiResponse();
+  }
+
   if (request.method !== "GET" && request.method !== "HEAD") {
     return withAcceptVariation(NextResponse.next());
   }
@@ -67,5 +96,5 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/", "/docs/developers"],
+  matcher: ["/", "/docs/developers", "/api/prediction/:path*"],
 };

--- a/tests/agent-readiness.test.ts
+++ b/tests/agent-readiness.test.ts
@@ -22,7 +22,7 @@ import {
   programmableSiteStructuredData,
   serializeStructuredData,
 } from "../lib/site-structured-data";
-import { proxy } from "../proxy";
+import { config as proxyConfig, proxy } from "../proxy";
 
 const ORIGIN = "https://programmable.market";
 const CUSTOM_LAUNCH_API_ORIGIN = "https://api.programmable.market";
@@ -338,6 +338,7 @@ describe("agent-readable public surface", () => {
       source: "/api/prediction/:match*",
       destination: "/api/retired-prediction",
     });
+    expect(proxyConfig.matcher).toContain("/api/prediction/:path*");
 
     for (const response of [
       getRetiredPredictionApi(),
@@ -353,6 +354,36 @@ describe("agent-readable public surface", () => {
         status: "error",
         error: { code: "api_route_not_found" },
       });
+    }
+
+    const retiredBody = JSON.stringify({
+      schemaVersion: "programmable.api-error.v1",
+      status: "error",
+      error: {
+        code: "api_route_not_found",
+        message: "No public Programmable API route matches this path.",
+      },
+    });
+    for (const path of ["/api/prediction", "/api/prediction/v2/directory"]) {
+      for (const method of [
+        "GET",
+        "HEAD",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE",
+        "OPTIONS",
+      ]) {
+        const response = proxy(
+          new NextRequest(`${ORIGIN}${path}`, { method }),
+        );
+        expect(response.status).toBe(404);
+        expect(response.headers.get("cache-control")).toBe("no-store");
+        expect(response.headers.get("x-robots-tag")).toBe(
+          "noindex, nofollow",
+        );
+        expect(await response.text()).toBe(retiredBody);
+      }
     }
 
     expect(programmableHomeMarkdown).not.toMatch(/prediction markets?/iu);


### PR DESCRIPTION
## Outcome

Retires every `/api/prediction` request in the Next proxy before App Router route dispatch, so dormant route modules cannot answer public requests.

The previous `vercel.json` rewrite does not preempt a matching Next filesystem route in the live deployment. That left GET on the old Prediction error schema and framework-generated 405/204 responses for other verbs.

## Behavior

- `/api/prediction` and every nested path return the generic `programmable.api-error.v1` 404.
- GET, HEAD, POST, PUT, PATCH, DELETE, and OPTIONS share the same fail-closed handler.
- Responses are `no-store` and `noindex, nofollow`.
- Dormant internal implementation remains in source but is unreachable through the public path.

## Checks

- `vitest run tests/agent-readiness.test.ts` (11 passed)
- `npm run typecheck`
- `eslint proxy.ts tests/agent-readiness.test.ts`
- Local Next runtime readback for all seven verbs
- `git diff --check`