### PR TITLE
fix(explore): use Newest server fast path

### DIFF
--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -268,6 +268,13 @@ export function resolveExploreServerSort(
   return "newest";
 }
 
+export function requiresCompleteExploreDataset(
+  valuationSort: ExploreValuationSort,
+  ageSort: ExploreAgeSort,
+) {
+  return valuationSort !== "none" && ageSort === "oldest";
+}
+
 type ExploreState =
   | { phase: "loading" }
   | {
@@ -2422,8 +2429,10 @@ export function ExploreView({
   } | null>(null);
   const filterRef = useRef<HTMLDetailsElement>(null);
   const sort = resolveExploreServerSort(valuationSort, ageSort);
-  const requiresCompleteDataset =
-    valuationSort !== "none" && ageSort !== "none";
+  const requiresCompleteDataset = requiresCompleteExploreDataset(
+    valuationSort,
+    ageSort,
+  );
   const contentKey = `${debouncedQuery}\u0000${valuationSort}\u0000${ageSort}\u0000${socialFilter}\u0000${modelFilter}\u0000${currentPage}\u0000${pageSize}`;
   const requestKey = `${contentKey}\u0000${retryKey}`;
   const modelDatasetKey = `${debouncedQuery}\u0000${valuationSort}\u0000${ageSort}\u0000${socialFilter}\u0000${modelFilter}\u0000${retryKey}`;

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -26,6 +26,7 @@ import {
   paginateTokensByExploreSelections,
   paginateTokensBySocialPresence,
   preserveExplorePayloadOnRefreshFailure,
+  requiresCompleteExploreDataset,
   resolveExploreServerSort,
   sortExploreEntriesBySelections,
   tokenHasSocialLinks,
@@ -840,6 +841,10 @@ describe("Explore refresh state", () => {
 
     expect(resolveExploreServerSort("highest", "newest")).toBe("market-cap");
     expect(resolveExploreServerSort("none", "oldest")).toBe("oldest");
+    expect(requiresCompleteExploreDataset("highest", "newest")).toBe(false);
+    expect(requiresCompleteExploreDataset("lowest", "newest")).toBe(false);
+    expect(requiresCompleteExploreDataset("highest", "oldest")).toBe(true);
+    expect(requiresCompleteExploreDataset("none", "oldest")).toBe(false);
     expect(
       sortExploreEntriesBySelections(
         [lowNewest, highOld, unavailable, highNew],


### PR DESCRIPTION
Remove the unnecessary full-catalog fetch for valuation + Newest. The Explore API already applies newest launch order as the valuation tie-breaker, so this selection can use the normal single-page path without transient cross-page cache drift.

Valuation + Oldest keeps the complete-dataset path.

Checks:
- 61 focused Explore tests
- TypeScript
- ESLint
- diff check