### PR TITLE
Fix image upload response handling

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -556,11 +556,6 @@ jobs:
             echo "No promotion is authorized by this staging gate."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Build production deployment
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: vercel build --prod --token="$VERCEL_TOKEN"
-
       - name: Reconcile all residual Generic signer probes before new authority
         id: generic-signer-probe-preflight
         if: >-
@@ -700,7 +695,7 @@ jobs:
           set -euo pipefail
           probe_secret="$(<"${{ steps.generic-signer-probe-authority.outputs.secret_path }}")"
           probe_contract="$(<"${{ steps.generic-signer-probe-authority.outputs.contract_path }}")"
-          deployment_url="$(vercel deploy --prebuilt --prod --skip-domain --archive=tgz \
+          deployment_url="$(vercel deploy --prod --skip-domain --archive=tgz \
             --meta githubCommitSha="$GITHUB_SHA" \
             --meta programmableGenericSignerProbe=one-shot-v1 \
             --meta programmableRepositoryId=1314365508 \
@@ -787,12 +782,12 @@ jobs:
           unlinkSync(target);
           NODE
 
-      - name: Stage production build without assigning domains
+      - name: Stage production source build without assigning domains
         id: deploy
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          deployment_url="$(vercel deploy --prebuilt --prod --skip-domain --archive=tgz --meta githubCommitSha="$GITHUB_SHA" --env VERCEL_GIT_COMMIT_SHA="$GITHUB_SHA" --env PROGRAMMABLE_RELEASE_COMMIT_SHA="$GITHUB_SHA" --token="$VERCEL_TOKEN")"
+          deployment_url="$(vercel deploy --prod --skip-domain --archive=tgz --meta githubCommitSha="$GITHUB_SHA" --env VERCEL_GIT_COMMIT_SHA="$GITHUB_SHA" --env PROGRAMMABLE_RELEASE_COMMIT_SHA="$GITHUB_SHA" --token="$VERCEL_TOKEN")"
           case "$deployment_url" in
             https://*) ;;
             *)
@@ -811,6 +806,49 @@ jobs:
           npm run perf:read-model:staged-deployment --
           --target-url "$DEPLOYMENT_URL"
           --github-output "$GITHUB_OUTPUT"
+
+      - name: Probe staged token image runtime without writes
+        env:
+          STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import { readBoundedResponseText } from "./scripts/read-bounded-response.mjs";
+
+          const response = await fetch(new URL(
+            "/api/token-image",
+            process.env.STAGED_TARGET_URL,
+          ), {
+            method: "POST",
+            redirect: "error",
+            headers: {
+              accept: "application/json",
+              "x-vercel-protection-bypass":
+                process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+              "x-vercel-set-bypass-cookie": "false",
+            },
+            signal: AbortSignal.timeout(30_000),
+          });
+          const contentType = response.headers.get("content-type")
+            ?.split(";", 1)[0]?.trim().toLowerCase();
+          if (contentType !== "application/json") {
+            await response.body?.cancel("unexpected content type").catch(() => {});
+            throw new Error("staged token image runtime did not return JSON");
+          }
+          const body = JSON.parse(await readBoundedResponseText(response, {
+            maximumBytes: 65_536,
+            label: "staged token image runtime response",
+          }));
+          if (
+            response.status !== 401
+            || body === null
+            || Array.isArray(body)
+            || typeof body !== "object"
+            || Object.keys(body).length !== 1
+            || body.error !== "Connect your wallet and try again"
+          ) throw new Error("staged token image runtime contract is invalid");
+          NODE
 
       - name: Probe exact staged Custom Launch V3 release
         id: custom-launch-v3-stage

--- a/components/custom-launch-experience.tsx
+++ b/components/custom-launch-experience.tsx
@@ -109,6 +109,7 @@ import {
   getTokenCardImageSource,
   isProgrammableTokenImageUrl,
   prepareTokenImage,
+  readTokenImageUploadResponse,
   TOKEN_IMAGE_OUTPUT_SIZE,
 } from "@/lib/token-image";
 
@@ -2105,16 +2106,8 @@ function CustomLaunchRuntime({
         redirect: "error",
         signal: imageController.signal,
       });
-      const contentType = response.headers.get("content-type")
-        ?.split(";", 1)[0]?.trim().toLowerCase();
-      if (contentType !== "application/json" || response.redirected) {
-        throw new Error("Unable to verify the uploaded image");
-      }
-      const body = await response.json() as {
-        url?: unknown;
-        receipt?: unknown;
-        error?: unknown;
-      };
+      const body = await readTokenImageUploadResponse(response);
+      if (body === null) throw new Error("Unable to upload image. Try again.");
       if (!isCurrent()) return;
       if (!response.ok) {
         throw new Error(typeof body.error === "string"

--- a/components/launch-builder.tsx
+++ b/components/launch-builder.tsx
@@ -95,7 +95,11 @@ import {
   type LaunchDraft,
   type LaunchModel,
 } from "@/lib/launch";
-import { prepareTokenImage } from "@/lib/token-image";
+import {
+  isProgrammableTokenImageUrl,
+  prepareTokenImage,
+  readTokenImageUploadResponse,
+} from "@/lib/token-image";
 import {
   browserWalletRequestIsPending,
   subscribeToBrowserWalletRequest,
@@ -3087,11 +3091,19 @@ function TokenStep({
           },
           body: form,
         });
-        const body = (await response.json()) as
-          { url: string } | { error: string };
-        if (!response.ok || !("url" in body)) {
+        const body = await readTokenImageUploadResponse(response);
+        if (body === null) {
+          throw new Error("Image uploads are temporarily unavailable. Try again.");
+        }
+        if (
+          !response.ok
+          || typeof body.url !== "string"
+          || !isProgrammableTokenImageUrl(body.url)
+        ) {
           throw new Error(
-            "error" in body ? body.error : "The image could not be uploaded",
+            typeof body.error === "string"
+              ? body.error
+              : "The image could not be uploaded",
           );
         }
 

--- a/lib/token-image.ts
+++ b/lib/token-image.ts
@@ -5,6 +5,8 @@ export const PROGRAMMABLE_TOKEN_IMAGE_HOST =
   "k2uoipt9wchjtz3h.public.blob.vercel-storage.com";
 export const PROGRAMMABLE_TOKEN_IMAGE_STORE_ID = "store_k2uoiPT9WCHJtz3H";
 
+export type TokenImageUploadResponse = Readonly<Record<string, unknown>>;
+
 const acceptedTokenImageTypes = new Set([
   "image/jpeg",
   "image/png",
@@ -75,6 +77,23 @@ export function getTokenImageFileError(file: Pick<File, "size" | "type">) {
     return "Choose an image smaller than 8 MB";
   }
   return "";
+}
+
+export async function readTokenImageUploadResponse(
+  response: Response,
+): Promise<TokenImageUploadResponse | null> {
+  const contentType = response.headers.get("content-type")
+    ?.split(";", 1)[0]?.trim().toLowerCase();
+  if (response.redirected || contentType !== "application/json") return null;
+
+  try {
+    const body: unknown = await response.json();
+    return typeof body === "object" && body !== null && !Array.isArray(body)
+      ? body as TokenImageUploadResponse
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 function loadImage(source: string) {

--- a/next.config.ts
+++ b/next.config.ts
@@ -74,8 +74,18 @@ const securityHeaders = [
   },
 ];
 
+export const sharpRuntimeFiles = [
+  "./node_modules/sharp/**/*",
+  "./node_modules/@img/**/*",
+];
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  outputFileTracingIncludes: {
+    "/api/token-image": sharpRuntimeFiles,
+    "/api/prediction/asset-logo/*": sharpRuntimeFiles,
+    "/api/profile/projects/*/article/media": sharpRuntimeFiles,
+  },
   async headers() {
     return [
       {

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2075,6 +2075,16 @@ export function evaluateReadModelOperationsSourceContracts(
     stagedCatalogProbe >= 0 && stagedCatalogProbeEnd > stagedCatalogProbe
       ? deployWorkflow.slice(stagedCatalogProbe, stagedCatalogProbeEnd)
       : "";
+  const stagedTokenImageProbe = deployWorkflow.indexOf(
+    "      - name: Probe staged token image runtime without writes",
+  );
+  const stagedTokenImageProbeEnd = deployWorkflow.indexOf(
+    "      - name: Probe exact staged Custom Launch V3 release",
+  );
+  const stagedTokenImageProbeBlock =
+    stagedTokenImageProbe >= 0 && stagedTokenImageProbeEnd > stagedTokenImageProbe
+      ? deployWorkflow.slice(stagedTokenImageProbe, stagedTokenImageProbeEnd)
+      : "";
   const stagedBitquerySmokeEnd = deployWorkflow.indexOf(
     "Reverify staged candidate binding",
     stagedBitquerySmoke,
@@ -2620,7 +2630,31 @@ export function evaluateReadModelOperationsSourceContracts(
       ) &&
       deployWorkflow.indexOf(
         "Verify Sigstore provenance and exact proof contents",
-      ) < deployWorkflow.indexOf("vercel build --prod") &&
+      ) < deployWorkflow.indexOf(
+        "Stage production source build without assigning domains",
+      ) &&
+      deployWorkflow.includes(
+        "vercel deploy --prod --skip-domain --archive=tgz",
+      ) &&
+      !deployWorkflow.includes("vercel build --prod") &&
+      !deployWorkflow.includes("--prebuilt") &&
+      stagedTokenImageProbe >
+        deployWorkflow.indexOf("Resolve exact staged deployment") &&
+      includesEverySourceFragment(stagedTokenImageProbeBlock, [
+        "STAGED_TARGET_URL: $\{{ steps.staged-deployment.outputs.target_url }}",
+        '"/api/token-image"',
+        'method: "POST"',
+        'contentType !== "application/json"',
+        "readBoundedResponseText(response",
+        "response.status !== 401",
+        'body.error !== "Connect your wallet and try again"',
+      ]) &&
+      !/(?:^|[{,\n])\s*["']?(?:authorization|cookie|x-privy-identity-token)["']?\s*:/iu.test(
+        stagedTokenImageProbeBlock,
+      ) &&
+      !/\n\s+"?body"?\s*:|new\s+(?:FormData|File)\b/iu.test(
+        stagedTokenImageProbeBlock,
+      ) &&
       deployWorkflow.indexOf(
         "Confirm consumed Verify proof identity after production approval",
       ) < deployWorkflow.indexOf("Pull production configuration"),

--- a/scripts/test/custom-launch-release-workflow-contract.test.mjs
+++ b/scripts/test/custom-launch-release-workflow-contract.test.mjs
@@ -283,24 +283,31 @@ function workflowFailures(source) {
     "candidate-runtime-commit-binding",
     '--env PROGRAMMABLE_RELEASE_COMMIT_SHA="$GITHUB_SHA"',
   );
-  requireText(
-    "stage-skips-domain-assignment",
-    "vercel deploy --prebuilt --prod --skip-domain",
+  const sourceBuildStart = source.indexOf(
+    "      - name: Stage production source build without assigning domains",
   );
+  const sourceBuildEnd = source.indexOf(
+    "      - name: Resolve exact staged deployment",
+  );
+  const sourceBuildBlock =
+    sourceBuildStart >= 0 && sourceBuildEnd > sourceBuildStart
+      ? source.slice(sourceBuildStart, sourceBuildEnd)
+      : "";
+  if (!sourceBuildBlock.includes(
+    "vercel deploy --prod --skip-domain --archive=tgz",
+  )) failures.push("stage-skips-domain-assignment");
+  if (source.includes("vercel build --prod") || source.includes("--prebuilt")) {
+    failures.push("stage-must-build-source-on-vercel");
+  }
   requireOrder(
     "record-after-rollback-capture",
     "Capture current production rollback target",
     "Verify detached Custom Launch release record",
   );
   requireOrder(
-    "record-before-build",
-    "Verify detached Custom Launch release record",
-    "Build production deployment",
-  );
-  requireOrder(
     "record-before-stage",
     "Verify detached Custom Launch release record",
-    "Stage production build without assigning domains",
+    "Stage production source build without assigning domains",
   );
   requireOrder(
     "proof-before-production-configuration",
@@ -360,6 +367,40 @@ function workflowFailures(source) {
     "candidate-canary-after-stage-resolution",
     "Resolve exact staged deployment",
     "Gate exact staged Custom Launch candidate",
+  );
+  const tokenImageProbeStart = source.indexOf(
+    "      - name: Probe staged token image runtime without writes",
+  );
+  const tokenImageProbeEnd = source.indexOf(
+    "      - name: Probe exact staged Custom Launch V3 release",
+  );
+  const tokenImageProbeBlock =
+    tokenImageProbeStart >= 0 && tokenImageProbeEnd > tokenImageProbeStart
+      ? source.slice(tokenImageProbeStart, tokenImageProbeEnd)
+      : "";
+  for (const [id, binding] of [
+    ["token-image-probe-target", "STAGED_TARGET_URL: ${{ steps.staged-deployment.outputs.target_url }}"],
+    ["token-image-probe-route", '"/api/token-image"'],
+    ["token-image-probe-method", 'method: "POST"'],
+    ["token-image-probe-json", 'contentType !== "application/json"'],
+    ["token-image-probe-status", "response.status !== 401"],
+    ["token-image-probe-error", 'body.error !== "Connect your wallet and try again"'],
+    ["token-image-probe-bounded", "readBoundedResponseText(response"],
+  ]) {
+    if (!tokenImageProbeBlock.includes(binding)) failures.push(id);
+  }
+  if (
+    /(?:^|[{,\n])\s*["']?(?:authorization|cookie|x-privy-identity-token)["']?\s*:/iu
+      .test(tokenImageProbeBlock)
+    || /\n\s+"?body"?\s*:|new\s+(?:FormData|File)\b/iu
+      .test(tokenImageProbeBlock)
+  ) {
+    failures.push("token-image-probe-must-not-send-upload-authority-or-content");
+  }
+  requireOrder(
+    "token-image-probe-after-stage-resolution",
+    "Resolve exact staged deployment",
+    "Probe staged token image runtime without writes",
   );
   const darkGateStart = source.indexOf(
     "      - name: Gate exact staged dark Custom Launch candidate",
@@ -610,6 +651,15 @@ test("workflow contract detects weakened record and stage-only gates", async () 
       "missing-dark-release-artifact",
     ),
     source.replaceAll("--skip-domain", ""),
+    source.replace(
+      "vercel deploy --prod --skip-domain --archive=tgz",
+      "vercel deploy --prebuilt --prod --skip-domain --archive=tgz",
+    ),
+    source.replace("response.status !== 401", "response.status !== 500"),
+    source.replace(
+      'accept: "application/json",',
+      'accept: "application/json",\n              "Authorization": "Bearer unsafe",',
+    ),
     source.replace('--source-digest "$GITHUB_SHA"', ""),
     source.replace('--signer-digest "$GITHUB_SHA"', ""),
     source.replace("--deny-self-hosted-runners", ""),

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -125,7 +125,12 @@ test("Custom V2 stage expectations are explicit, observational, and default disa
 test("Custom V2 evidence is immutable while the workflow remains stage-only", () => {
   assert.match(deploy, /name: custom-v2-stage-evidence-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/u);
   assert.match(deploy, /retention-days: 90/u);
-  assert.match(deploy, /vercel deploy --prebuilt --prod --skip-domain/u);
+  const sourceBuild = stepBlock(
+    deploy,
+    "Stage production source build without assigning domains",
+  );
+  assert.match(sourceBuild, /vercel deploy --prod --skip-domain --archive=tgz/u);
+  assert.doesNotMatch(deploy, /vercel build --prod|--prebuilt/u);
   assert.doesNotMatch(deploy, /vercel (?:promote|rollback)|--scope-production-alias/u);
   assert.match(deploy, /Stage-only: no production promotion was attempted\./u);
   assert.ok(
@@ -173,6 +178,38 @@ test("Custom V2 evidence is immutable while the workflow remains stage-only", ()
   );
 });
 
+test("every staged source build proves the token image runtime without a write", () => {
+  const probe = stepBlock(
+    deploy,
+    "Probe staged token image runtime without writes",
+  );
+  assert.match(
+    probe,
+    /STAGED_TARGET_URL: \$\{\{ steps\.staged-deployment\.outputs\.target_url \}\}/u,
+  );
+  assert.match(probe, /"\/api\/token-image"/u);
+  assert.match(probe, /method: "POST"/u);
+  assert.match(probe, /contentType !== "application\/json"/u);
+  assert.match(probe, /readBoundedResponseText\(response/u);
+  assert.match(probe, /response\.status !== 401/u);
+  assert.match(
+    probe,
+    /body\.error !== "Connect your wallet and try again"/u,
+  );
+  assert.doesNotMatch(
+    probe,
+    /(?:^|[{,\n])\s*["']?(?:authorization|cookie|x-privy-identity-token)["']?\s*:/iu,
+  );
+  assert.doesNotMatch(
+    probe,
+    /\n\s+"?body"?\s*:|new\s+(?:FormData|File)\b/iu,
+  );
+  assert.ok(
+    deploy.indexOf("Resolve exact staged deployment")
+      < deploy.indexOf("Probe staged token image runtime without writes"),
+  );
+});
+
 test("Generic signer OIDC proof is one-shot, two-Machine and cleanup-attested", () => {
   for (const input of [
     "custom_v2_generic_signer_probe_expected_json",
@@ -199,7 +236,7 @@ test("Generic signer OIDC proof is one-shot, two-Machine and cleanup-attested", 
     deploy,
     "Deploy one-shot unaliased Generic signer probe candidate",
   );
-  assert.match(probeDeploy, /vercel deploy --prebuilt --prod --skip-domain/u);
+  assert.match(probeDeploy, /vercel deploy --prod --skip-domain --archive=tgz/u);
   assert.match(probeDeploy, /PROGRAMMABLE_GENERIC_LAUNCH_SIGNER_PROBE_TOKEN/u);
   assert.match(probeDeploy, /PROGRAMMABLE_GENERIC_LAUNCH_SIGNER_PROBE_EXPECTED_V1_JSON/u);
   assert.match(probeDeploy, /programmableGenericSignerProbeRecoveryId/u);
@@ -249,7 +286,7 @@ test("Generic signer OIDC proof is one-shot, two-Machine and cleanup-attested", 
   assert.match(deploy, /id-token: write/u);
   assert.ok(
     deploy.indexOf("Reconcile every secret-bearing Generic signer probe deployment")
-      < deploy.indexOf("Stage production build without assigning domains"),
+      < deploy.indexOf("Stage production source build without assigning domains"),
   );
   assert.ok(
     deploy.indexOf("Reconcile all residual Generic signer probes before new authority")

--- a/tests/data-pipeline/performance-contract.test.ts
+++ b/tests/data-pipeline/performance-contract.test.ts
@@ -1491,6 +1491,17 @@ describe("read-model performance contract", () => {
       "utf8",
     );
     expect(deployWorkflow).toContain("--prod --skip-domain");
+    expect(
+      deployWorkflow.match(
+        /vercel deploy --prod --skip-domain --archive=tgz/gu,
+      ),
+    ).toHaveLength(2);
+    expect(deployWorkflow).not.toContain("vercel build --prod");
+    expect(deployWorkflow).not.toContain("--prebuilt");
+    expect(deployWorkflow).toContain(
+      "Probe staged token image runtime without writes",
+    );
+    expect(deployWorkflow).toContain("response.status !== 401");
     expect(deployWorkflow).toContain(
       '--env VERCEL_GIT_COMMIT_SHA="$GITHUB_SHA"',
     );

--- a/tests/token-image-upload-route.test.ts
+++ b/tests/token-image-upload-route.test.ts
@@ -58,6 +58,23 @@ beforeAll(async () => {
 });
 
 describe("token image upload route", () => {
+  it("returns a JSON session error before reading or writing image data", async () => {
+    const putBlob = vi.fn<Dependencies["putBlob"]>();
+    const handler = createTokenImageUploadHandlerV1(dependencies({
+      authenticateSession: async () => null,
+      putBlob,
+    }));
+    const response = await handler(request(webp));
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    await expect(response.json()).resolves.toEqual({
+      error: "Connect your wallet and try again",
+    });
+    expect(putBlob).not.toHaveBeenCalled();
+  });
+
   it("rejects JPEG bytes relabelled as WebP before Blob write", async () => {
     const putBlob = vi.fn<Dependencies["putBlob"]>();
     const handler = createTokenImageUploadHandlerV1(dependencies({ putBlob }));

--- a/tests/token-image.test.ts
+++ b/tests/token-image.test.ts
@@ -12,6 +12,7 @@ import {
   isProgrammableTokenImageUrl,
   MAX_TOKEN_IMAGE_UPLOAD_BYTES,
   PROGRAMMABLE_TOKEN_IMAGE_HOST,
+  readTokenImageUploadResponse,
 } from "../lib/token-image";
 import {
   inspectWebpStructure,
@@ -180,5 +181,41 @@ describe("token image policy", () => {
     expect(image.src).toBe(
       "/brand/programmable-token-fallback-01-dawn.webp",
     );
+  });
+
+  it.each([
+    [500, "text/html; charset=utf-8", "<!DOCTYPE html>"],
+    [404, "text/html", "<html>Not found</html>"],
+    [200, "text/plain", JSON.stringify({ url: "https://example.com/image.webp" })],
+    [500, "application/json", "{broken"],
+  ])("rejects non-JSON upload responses without leaking parser errors", async (
+    status,
+    contentType,
+    body,
+  ) => {
+    const response = new Response(body, {
+      status,
+      headers: { "content-type": contentType },
+    });
+    await expect(readTokenImageUploadResponse(response)).resolves.toBeNull();
+  });
+
+  it("preserves valid upload errors and success responses", async () => {
+    const rejected = new Response(JSON.stringify({
+      error: "Connect your wallet and try again",
+    }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+    await expect(readTokenImageUploadResponse(rejected)).resolves.toEqual({
+      error: "Connect your wallet and try again",
+    });
+
+    const url = `https://${PROGRAMMABLE_TOKEN_IMAGE_HOST}/token-images/example.webp`;
+    const accepted = new Response(JSON.stringify({ url }), {
+      status: 201,
+      headers: { "content-type": "application/json; charset=utf-8" },
+    });
+    await expect(readTokenImageUploadResponse(accepted)).resolves.toEqual({ url });
   });
 });

--- a/tests/token-image.test.ts
+++ b/tests/token-image.test.ts
@@ -18,8 +18,21 @@ import {
   inspectWebpStructure,
   verifyTokenImageWebpV1,
 } from "../lib/server/token-image-webp-v1";
+import nextConfig, { sharpRuntimeFiles } from "../next.config";
 
 describe("token image policy", () => {
+  it("traces the native Sharp runtime into every image-processing route", () => {
+    expect(sharpRuntimeFiles).toEqual([
+      "./node_modules/sharp/**/*",
+      "./node_modules/@img/**/*",
+    ]);
+    expect(nextConfig.outputFileTracingIncludes).toEqual({
+      "/api/token-image": sharpRuntimeFiles,
+      "/api/prediction/asset-logo/*": sharpRuntimeFiles,
+      "/api/profile/projects/*/article/media": sharpRuntimeFiles,
+    });
+  });
+
   it("keeps prepared uploads within the card-performance budget", () => {
     expect(MAX_TOKEN_IMAGE_UPLOAD_BYTES).toBe(1_000_000);
   });


### PR DESCRIPTION
## What changed
- guard Classic and Custom token-image uploads against HTML or malformed responses
- validate Classic upload URLs against the canonical image store
- add JSON response and unauthenticated route regressions

## Root cause
The current production deployment used macOS prebuilt artifacts, so its Sharp native module cannot load on Vercel Linux. This PR prevents the raw JSON parser error; the release will use a Vercel source build and must pass a 401 JSON route probe before promotion.

## Verification
- 77 focused tests passed
- 4,622 interface tests passed; 33 skipped
- wallet lock browser tests passed
- typecheck passed
- ESLint passed
- production build passed
- diff check passed