### PR TITLE
Add reward receiver handoff to Launches

### DIFF
--- a/components/profile-projects.module.css
+++ b/components/profile-projects.module.css
@@ -439,8 +439,15 @@
   display: grid;
   gap: 6px;
   grid-template-columns: 104px 84px;
+  grid-template-areas: "article token";
   justify-content: flex-end;
   min-width: 194px;
+}
+
+.actions[data-reward-action="available"] {
+  grid-template-columns: 104px 164px 84px;
+  grid-template-areas: "article receiver token";
+  min-width: 364px;
 }
 
 .actions button,
@@ -456,7 +463,16 @@
 
 .articleActionSlot {
   display: flex;
+  grid-area: article;
   min-width: 0;
+}
+
+.rewardReceiverAction {
+  grid-area: receiver;
+}
+
+.viewTokenAction {
+  grid-area: token;
 }
 
 .articleActionState {
@@ -483,6 +499,12 @@
   color: #0a0a0c;
 }
 
+.actions .rewardReceiverAction {
+  background: transparent;
+  border-color: var(--webde-line, rgb(255 255 255 / 14%));
+  color: var(--text-soft, rgb(255 255 255 / 72%));
+}
+
 .articleAction[data-opening="true"]:disabled {
   cursor: wait;
   opacity: 0.74;
@@ -500,10 +522,205 @@
   color: #ff9d9d;
 }
 
+.receiverBackdrop {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  box-sizing: border-box;
+  color: inherit;
+  display: flex;
+  height: 100dvh;
+  inset: 0;
+  justify-content: center;
+  margin: 0;
+  max-height: none;
+  max-width: none;
+  overflow: hidden;
+  padding: 1rem;
+  position: fixed;
+  width: 100%;
+  z-index: 1001;
+}
+
+.receiverBackdrop::backdrop {
+  background: rgb(0 0 0 / 78%);
+}
+
+.receiverDialog {
+  background: #0b0b0f;
+  border: 1px solid rgb(255 255 255 / 14%);
+  border-radius: 1rem;
+  box-shadow: 0 30px 90px rgb(0 0 0 / 55%);
+  max-height: calc(100dvh - 2rem);
+  max-width: 32rem;
+  overflow: auto;
+  overscroll-behavior: contain;
+  padding: 0;
+  width: 100%;
+}
+
+.receiverHeader {
+  align-items: center;
+  border-block-end: 1px solid rgb(255 255 255 / 10%);
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 1rem 1rem 0.9rem 1.1rem;
+}
+
+.receiverHeader p,
+.receiverHeader h2 {
+  margin: 0;
+}
+
+.receiverHeader p {
+  color: rgb(255 255 255 / 48%);
+  font-size: 0.7rem;
+  font-weight: 620;
+  letter-spacing: 0.02em;
+}
+
+.receiverHeader h2 {
+  font-size: 1.05rem;
+  letter-spacing: -0.018em;
+  margin-block-start: 0.15rem;
+}
+
+.receiverHeader button {
+  align-items: center;
+  background: transparent;
+  border: 1px solid rgb(255 255 255 / 14%);
+  border-radius: 0.6rem;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  flex: none;
+  height: 2.75rem;
+  justify-content: center;
+  width: 2.75rem;
+}
+
+.receiverForm {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.1rem;
+}
+
+.receiverField {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.receiverField > span,
+.currentReceiver > span {
+  color: rgb(255 255 255 / 66%);
+  font-size: 0.72rem;
+  font-weight: 620;
+}
+
+.receiverForm input,
+.receiverForm select {
+  background: rgb(255 255 255 / 5%);
+  border: 1px solid rgb(255 255 255 / 15%);
+  border-radius: 0.7rem;
+  color: inherit;
+  font: inherit;
+  font-size: 1rem;
+  min-height: 3rem;
+  padding-inline: 0.8rem;
+  width: 100%;
+}
+
+.receiverForm input::placeholder {
+  color: rgb(255 255 255 / 34%);
+}
+
+.receiverForm input[aria-invalid="true"] {
+  border-color: #ff9d9d;
+}
+
+.currentReceiver {
+  background: rgb(255 255 255 / 4%);
+  border: 1px solid rgb(255 255 255 / 10%);
+  border-radius: 0.75rem;
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.75rem 0.8rem;
+}
+
+.currentReceiver code {
+  color: rgb(255 255 255 / 86%);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 0.72rem;
+  overflow-wrap: anywhere;
+}
+
+.currentReceiver small,
+.receiverHint,
+.receiverStatus,
+.receiverError {
+  font-size: 0.72rem;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.currentReceiver small,
+.receiverHint,
+.receiverStatus {
+  color: rgb(255 255 255 / 52%);
+}
+
+.receiverError,
+.receiverStatus[role="alert"] {
+  color: #ff9d9d;
+}
+
+.receiverStatus:empty {
+  display: none;
+}
+
+.receiverActions {
+  display: grid;
+  gap: 0.55rem;
+  grid-template-columns: 1fr 1.3fr;
+  margin-block-start: 0.2rem;
+}
+
+.receiverActions button {
+  align-items: center;
+  background: transparent;
+  border: 1px solid rgb(255 255 255 / 14%);
+  border-radius: 0.7rem;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 650;
+  justify-content: center;
+  min-height: 3rem;
+  padding-inline: 0.9rem;
+}
+
+.receiverActions .receiverSubmit {
+  background: var(--brand-ivory, #f0eee8);
+  border-color: var(--brand-ivory, #f0eee8);
+  color: #0a0a0c;
+}
+
+.receiverActions button:disabled {
+  cursor: wait;
+  opacity: 0.72;
+}
+
 .refresh:focus-visible,
 .pagination button:focus-visible,
 .actions button:focus-visible,
-.actions a:focus-visible {
+.actions a:focus-visible,
+.receiverHeader button:focus-visible,
+.receiverForm input:focus-visible,
+.receiverForm select:focus-visible,
+.receiverActions button:focus-visible {
   outline: 2px solid #8fc5ff;
   outline-offset: 2px;
 }
@@ -518,6 +735,19 @@
   }
 
   .actions button:not(:disabled):hover {
+    filter: brightness(0.94);
+  }
+
+  .actions .rewardReceiverAction:not(:disabled):hover,
+  .receiverHeader button:hover,
+  .receiverActions button:not(.receiverSubmit):hover {
+    background: var(--profile-subtle, rgb(255 255 255 / 6%));
+    border-color: var(--webde-line, rgb(255 255 255 / 18%));
+    color: var(--text, #fff);
+    filter: none;
+  }
+
+  .receiverActions .receiverSubmit:not(:disabled):hover {
     filter: brightness(0.94);
   }
 
@@ -563,6 +793,15 @@
   .actions {
     grid-column: 1 / -1;
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas: "article token";
+    min-width: 0;
+  }
+
+  .actions[data-reward-action="available"] {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+      "article token"
+      "receiver receiver";
     min-width: 0;
   }
 
@@ -579,6 +818,18 @@
   .openingDialog {
     border-radius: 1rem 1rem 0 0;
     border-width: 1px 0 0;
+    max-width: none;
+  }
+
+  .receiverBackdrop {
+    align-items: flex-end;
+    padding: 0;
+  }
+
+  .receiverDialog {
+    border-radius: 1rem 1rem 0 0;
+    border-width: 1px 0 0;
+    max-height: min(92dvh, 44rem);
     max-width: none;
   }
 }
@@ -604,6 +855,13 @@
 
   .openingProgress {
     animation: none;
+  }
+
+  .receiverDialog,
+  .receiverActions button,
+  .receiverForm input,
+  .receiverForm select {
+    scroll-behavior: auto;
   }
 
   .skeletonArt,

--- a/components/profile-projects.tsx
+++ b/components/profile-projects.tsx
@@ -4,7 +4,14 @@ import dynamic from "next/dynamic";
 import Image from "next/image";
 import Link from "next/link";
 import { ChevronLeft, ChevronRight, RefreshCw, X } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
 import { createPortal } from "react-dom";
 import { formatUnits, getAddress, isAddress } from "viem";
 
@@ -19,6 +26,7 @@ import { PartnerLaunchAttribution } from
   "@/components/partner-launch-attribution";
 import { parseLaunchPartnerAttributionV1 } from
   "@/lib/launch-partner-attribution";
+import type { ClassicV3Reward } from "@/lib/profile/classic-v3-rewards";
 
 import styles from "./profile-projects.module.css";
 
@@ -44,6 +52,11 @@ const creatorProjectRefreshTimeoutMs = 12_000;
 const creatorProjectRefreshTimeoutReason = "creator-project-refresh-timeout";
 const emptyCreatorProjectsV1: readonly CreatorProjectSummaryV1[] =
   Object.freeze([]);
+const emptyClassicRewardsV1: readonly ClassicV3Reward[] = Object.freeze([]);
+const emptyRewardReceiverActionStatesV1: Readonly<
+  Record<string, CreatorProjectRewardReceiverActionStateV1>
+> = Object.freeze({});
+const zeroAddress = "0x0000000000000000000000000000000000000000";
 
 export type CreatorProjectMarketCapV1 = Readonly<{
   tokenAddress: `0x${string}`;
@@ -70,6 +83,64 @@ export type CreatorProjectOwnerStateV1 = Readonly<{
   phase: "loading" | "ready" | "error";
   projects: readonly CreatorProjectSummaryV1[];
 }>;
+
+export type CreatorProjectRewardReceiverActionStateV1 = Readonly<{
+  account: string;
+  status:
+    | "preparing"
+    | "wallet"
+    | "confirming"
+    | "pending"
+    | "not-found"
+    | "confirmed"
+    | "error";
+  message: string;
+}>;
+
+export function rewardReceiverActionKeyV1(vaultAddress: string) {
+  return `${vaultAddress.toLowerCase()}:update-payout`;
+}
+
+export function rewardReceiverAddressErrorV1(
+  value: string,
+  currentReceiver: string,
+) {
+  const candidate = value.trim();
+  if (!isAddress(candidate) || candidate.toLowerCase() === zeroAddress) {
+    return "Enter a valid Ethereum address.";
+  }
+  if (candidate.toLowerCase() === currentReceiver.toLowerCase()) {
+    return "Enter a different reward receiver.";
+  }
+  return "";
+}
+
+export function manageableClassicRewardsByTokenV1(
+  rewards: readonly ClassicV3Reward[],
+  walletAccount: string | null,
+) {
+  const candidates = new Map<string, ClassicV3Reward | null>();
+  if (walletAccount === null) return new Map<string, ClassicV3Reward>();
+
+  for (const reward of rewards) {
+    if (
+      !reward.ownedAllocations.some(
+        (allocation) =>
+          allocation.payoutAddress.toLowerCase() === walletAccount,
+      )
+    ) {
+      continue;
+    }
+    const token = reward.tokenAddress.toLowerCase();
+    candidates.set(token, candidates.has(token) ? null : reward);
+  }
+
+  return new Map(
+    [...candidates].filter(
+      (entry): entry is [string, ClassicV3Reward] => entry[1] !== null,
+    ),
+  );
+}
 
 export function scopeCreatorProjectOwnerStateV1(
   state: CreatorProjectOwnerStateV1 | null,
@@ -150,15 +221,27 @@ export async function loadCreatorProjectListV1(input: Readonly<{
 }
 
 export function ProfileProjects({
+  classicRewards = emptyClassicRewardsV1,
   initialBuys = [],
   marketCaps = [],
+  onChangeRewardReceiver,
   onRefresh,
+  rewardReceiverActionStates = emptyRewardReceiverActionStatesV1,
   refreshing = false,
   walletProjects = [],
 }: Readonly<{
+  classicRewards?: readonly ClassicV3Reward[];
   initialBuys?: readonly CreatorProjectInitialBuyV1[];
   marketCaps?: readonly CreatorProjectMarketCapV1[];
+  onChangeRewardReceiver?: (
+    reward: ClassicV3Reward,
+    newReceiver: string,
+    allocationIndex: number,
+  ) => void;
   onRefresh?: () => void;
+  rewardReceiverActionStates?: Readonly<
+    Record<string, CreatorProjectRewardReceiverActionStateV1>
+  >;
   refreshing?: boolean;
   walletProjects?: readonly CreatorProjectSummaryV1[];
 }>) {
@@ -174,6 +257,12 @@ export function ProfileProjects({
     ownerAccount: string;
     project: CreatorProjectSummaryV1;
   }> | null>(null);
+  const [rewardReceiverEditor, setRewardReceiverEditor] =
+    useState<Readonly<{
+      ownerAccount: string;
+      project: CreatorProjectSummaryV1;
+      reward: ClassicV3Reward;
+    }> | null>(null);
   const [projectPage, setProjectPage] = useState(1);
   const [projectError, setProjectError] = useState<Readonly<{
     ownerAccount: string;
@@ -181,6 +270,7 @@ export function ProfileProjects({
   }> | null>(null);
   const editorRequestsRef = useRef(new Map<string, Promise<EditorState>>());
   const editorTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const rewardReceiverTriggerRef = useRef<HTMLButtonElement | null>(null);
   const openRequestRef = useRef(0);
   const projectRequestRef = useRef(0);
   const projectRefreshControllerRef = useRef<AbortController | null>(null);
@@ -198,6 +288,10 @@ export function ProfileProjects({
   const scopedOpeningProject = openingProject?.ownerAccount === walletAccount
     ? openingProject.project
     : null;
+  const scopedRewardReceiverEditor =
+    rewardReceiverEditor?.ownerAccount === walletAccount
+      ? rewardReceiverEditor
+      : null;
   const scopedProjectError = projectError?.ownerAccount === walletAccount
     ? projectError.message
     : "";
@@ -304,6 +398,10 @@ export function ProfileProjects({
       initialBuy,
     ]),
   ), [initialBuys]);
+  const manageableClassicRewardsByToken = useMemo(
+    () => manageableClassicRewardsByTokenV1(classicRewards, walletAccount),
+    [classicRewards, walletAccount],
+  );
 
   const getEditorState = useCallback((project: CreatorProjectSummaryV1) => {
     if (walletAccount === null) {
@@ -374,7 +472,25 @@ export function ProfileProjects({
     focusEditorTrigger();
   }, [focusEditorTrigger, setEditor]);
 
-  if (!wallet) return null;
+  const closeRewardReceiverEditor = useCallback(() => {
+    setRewardReceiverEditor(null);
+    window.requestAnimationFrame(() =>
+      rewardReceiverTriggerRef.current?.focus());
+  }, [setRewardReceiverEditor]);
+
+  const receiverEditorActionState = scopedRewardReceiverEditor
+    ? rewardReceiverActionStates[
+        rewardReceiverActionKeyV1(
+          scopedRewardReceiverEditor.reward.vaultAddress,
+        )
+      ]
+    : undefined;
+  const scopedReceiverEditorActionState =
+    receiverEditorActionState?.account.toLowerCase() === walletAccount
+      ? receiverEditorActionState
+      : undefined;
+
+  if (!wallet || walletAccount === null) return null;
   return (
     <section className={styles.section} aria-labelledby="profile-launches-title">
       <header className={styles.heading}>
@@ -467,6 +583,21 @@ export function ProfileProjects({
             const canEditArticle = editableTokens.has(
               project.tokenAddress.toLowerCase(),
             );
+            const manageableReward = manageableClassicRewardsByToken.get(
+              project.tokenAddress.toLowerCase(),
+            );
+            const receiverState = manageableReward
+              ? rewardReceiverActionStates[
+                  rewardReceiverActionKeyV1(manageableReward.vaultAddress)
+                ]
+              : undefined;
+            const scopedReceiverState =
+              receiverState?.account.toLowerCase() === walletAccount
+                ? receiverState
+                : undefined;
+            const canChangeRewardReceiver = Boolean(
+              manageableReward && onChangeRewardReceiver,
+            );
             return (
             <article className={styles.project} key={project.tokenAddress}>
               <div className={styles.art}>
@@ -504,7 +635,12 @@ export function ProfileProjects({
                   </div>
                 ) : null}
               </div>
-              <div className={styles.actions}>
+              <div
+                className={styles.actions}
+                data-reward-action={
+                  canChangeRewardReceiver ? "available" : "unavailable"
+                }
+              >
                 <span className={styles.articleActionSlot}>
                   {canEditArticle ? (
                     <button
@@ -533,7 +669,32 @@ export function ProfileProjects({
                     </span>
                   )}
                 </span>
-                <Link href={`/token/${project.tokenAddress}`}>View token</Link>
+                {canChangeRewardReceiver && manageableReward ? (
+                  <button
+                    className={styles.rewardReceiverAction}
+                    type="button"
+                    aria-busy={
+                      rewardReceiverActionBusyV1(scopedReceiverState) ||
+                      undefined
+                    }
+                    onClick={(event) => {
+                      rewardReceiverTriggerRef.current = event.currentTarget;
+                      setRewardReceiverEditor({
+                        ownerAccount: walletAccount,
+                        project,
+                        reward: manageableReward,
+                      });
+                    }}
+                  >
+                    {rewardReceiverTriggerLabelV1(scopedReceiverState)}
+                  </button>
+                ) : null}
+                <Link
+                  className={styles.viewTokenAction}
+                  href={`/token/${project.tokenAddress}`}
+                >
+                  View token
+                </Link>
               </div>
             </article>
             );
@@ -578,8 +739,247 @@ export function ProfileProjects({
           onClose={closeOpeningEditor}
         />
       ) : null}
+      {scopedRewardReceiverEditor && onChangeRewardReceiver ? (
+        <RewardReceiverDialog
+          project={scopedRewardReceiverEditor.project}
+          reward={scopedRewardReceiverEditor.reward}
+          actionState={scopedReceiverEditorActionState}
+          onClose={closeRewardReceiverEditor}
+          onSubmit={(newReceiver, allocationIndex) =>
+            onChangeRewardReceiver(
+              scopedRewardReceiverEditor.reward,
+              newReceiver,
+              allocationIndex,
+            )}
+        />
+      ) : null}
     </section>
   );
+}
+
+function rewardReceiverActionBusyV1(
+  state?: CreatorProjectRewardReceiverActionStateV1,
+) {
+  return (
+    state?.status === "preparing" ||
+    state?.status === "wallet" ||
+    state?.status === "confirming"
+  );
+}
+
+function rewardReceiverTriggerLabelV1(
+  state?: CreatorProjectRewardReceiverActionStateV1,
+) {
+  if (rewardReceiverActionBusyV1(state)) return "Updating receiver…";
+  if (state?.status === "pending" || state?.status === "not-found") {
+    return "Check receiver status";
+  }
+  if (state?.status === "confirmed") return "Receiver updated";
+  if (state?.status === "error") return "Retry receiver update";
+  return "Change reward receiver";
+}
+
+function formatRewardShareV1(shareBps: number) {
+  return `${new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  }).format(shareBps / 100)}%`;
+}
+
+function RewardReceiverDialog({
+  actionState,
+  onClose,
+  onSubmit,
+  project,
+  reward,
+}: Readonly<{
+  actionState?: CreatorProjectRewardReceiverActionStateV1;
+  onClose(): void;
+  onSubmit(newReceiver: string, allocationIndex: number): void;
+  project: CreatorProjectSummaryV1;
+  reward: ClassicV3Reward;
+}>) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const [allocationIndex, setAllocationIndex] = useState(
+    reward.ownedAllocations[0]?.allocationIndex ?? 0,
+  );
+  const [newReceiver, setNewReceiver] = useState("");
+  const [fieldError, setFieldError] = useState("");
+  const [complete, setComplete] = useState(false);
+  const currentAllocation = reward.ownedAllocations.find(
+    (allocation) => allocation.allocationIndex === allocationIndex,
+  ) ?? reward.ownedAllocations[0];
+  const currentReceiver = currentAllocation?.payoutAddress ?? reward.payoutAddress;
+  const busy = rewardReceiverActionBusyV1(actionState);
+  const checkingStatus =
+    actionState?.status === "pending" || actionState?.status === "not-found";
+  const titleId = `reward-receiver-${project.tokenAddress.slice(2)}-title`;
+  const fieldId = `reward-receiver-${project.tokenAddress.slice(2)}-address`;
+  const hintId = `${fieldId}-hint`;
+  const errorId = `${fieldId}-error`;
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const previousOverflow = window.document.body.style.overflow;
+    window.document.body.style.overflow = "hidden";
+    if (!dialog.open) dialog.showModal();
+    inputRef.current?.focus({ preventScroll: true });
+    return () => {
+      window.document.body.style.overflow = previousOverflow;
+      if (dialog.open) dialog.close();
+    };
+  }, []);
+
+  if (!complete && actionState?.status === "confirmed") {
+    setComplete(true);
+  }
+
+  function submitReceiver(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (checkingStatus) {
+      onSubmit(currentReceiver, allocationIndex);
+      return;
+    }
+    const error = rewardReceiverAddressErrorV1(
+      newReceiver,
+      currentReceiver,
+    );
+    setFieldError(error);
+    if (error) {
+      inputRef.current?.focus();
+      return;
+    }
+    onSubmit(getAddress(newReceiver.trim()), allocationIndex);
+  }
+
+  if (typeof document === "undefined") return null;
+  return createPortal((
+    <dialog
+      ref={dialogRef}
+      className={styles.receiverBackdrop}
+      aria-labelledby={titleId}
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <section className={styles.receiverDialog}>
+        <header className={styles.receiverHeader}>
+          <div>
+            <p>{project.symbol ? `$${project.symbol}` : "Classic launch"}</p>
+            <h2 id={titleId}>Change reward receiver</h2>
+          </div>
+          <button
+            ref={closeRef}
+            type="button"
+            aria-label="Close reward receiver"
+            onClick={onClose}
+          >
+            <X aria-hidden="true" size={18} strokeWidth={1.8} />
+          </button>
+        </header>
+
+        <form className={styles.receiverForm} noValidate onSubmit={submitReceiver}>
+          {reward.ownedAllocations.length > 1 ? (
+            <label className={styles.receiverField}>
+              <span>Reward allocation</span>
+              <select
+                value={allocationIndex}
+                disabled={busy || complete}
+                onChange={(event) => {
+                  setAllocationIndex(Number(event.target.value));
+                  setNewReceiver("");
+                  setFieldError("");
+                }}
+              >
+                {reward.ownedAllocations.map((allocation) => (
+                  <option
+                    key={allocation.allocationIndex}
+                    value={allocation.allocationIndex}
+                  >
+                    {`Allocation ${allocation.allocationIndex + 1} · ${formatRewardShareV1(allocation.shareBps)}`}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : null}
+
+          <div className={styles.currentReceiver}>
+            <span>Current receiver</span>
+            <code>{currentReceiver}</code>
+            <small>{formatRewardShareV1(currentAllocation?.shareBps ?? reward.shareBps)} of creator rewards</small>
+          </div>
+
+          <label className={styles.receiverField} htmlFor={fieldId}>
+            <span>New reward receiver</span>
+          </label>
+          <input
+            ref={inputRef}
+            id={fieldId}
+            name="reward-receiver"
+            type="text"
+            inputMode="text"
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="0x…"
+            value={newReceiver}
+            disabled={busy || checkingStatus || complete}
+            aria-invalid={fieldError ? true : undefined}
+            aria-describedby={`${hintId}${fieldError ? ` ${errorId}` : ""}`}
+            onChange={(event) => {
+              setNewReceiver(event.target.value);
+              if (fieldError) setFieldError("");
+            }}
+          />
+          <p id={hintId} className={styles.receiverHint}>
+            Future creator fees for this allocation will go to the new address.
+            Fees earned before confirmation stay with the current receiver.
+          </p>
+          {fieldError ? (
+            <p id={errorId} className={styles.receiverError}>
+              {fieldError}
+            </p>
+          ) : null}
+          <p
+            className={styles.receiverStatus}
+            role={actionState?.status === "error" ? "alert" : "status"}
+            aria-live="polite"
+          >
+            {complete
+              ? "Reward receiver changed. Future creator fees now use the new address."
+              : actionState?.message ?? ""}
+          </p>
+
+          <div className={styles.receiverActions}>
+            <button type="button" onClick={onClose}>
+              {complete ? "Done" : "Cancel"}
+            </button>
+            {!complete ? (
+              <button
+                className={styles.receiverSubmit}
+                type="submit"
+                aria-busy={busy || undefined}
+                disabled={busy}
+              >
+                {busy
+                  ? rewardReceiverTriggerLabelV1(actionState)
+                  : checkingStatus
+                    ? "Check status"
+                    : actionState?.status === "error"
+                      ? "Try again"
+                      : "Change receiver"}
+              </button>
+            ) : null}
+          </div>
+        </form>
+      </section>
+    </dialog>
+  ), document.body);
 }
 
 function ProfileProjectsSkeleton() {

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -21,6 +21,7 @@ import { useWallet } from "@/components/wallet-provider";
 import {
   creatorProjectPageSize,
   ProfileProjects,
+  rewardReceiverActionKeyV1,
   type CreatorProjectInitialBuyV1,
   type CreatorProjectMarketCapV1,
   type CreatorProjectSummaryV1,
@@ -481,7 +482,10 @@ export function profileCreatorClaimErrorMessage(error: unknown) {
   return creatorClaimNotSubmitted;
 }
 
-export function profileRewardActionErrorMessage(error: unknown) {
+export function profileRewardActionErrorMessage(
+  error: unknown,
+  action: "claim" | "update-payout" = "claim",
+) {
   if (walletActionWasCancelled(error)) {
     return "Transaction cancelled. Rewards remain available.";
   }
@@ -497,7 +501,9 @@ export function profileRewardActionErrorMessage(error: unknown) {
       return message;
     }
   }
-  return "Unable to claim. Try again.";
+  return action === "update-payout"
+    ? "Unable to change the reward receiver. Try again."
+    : "Unable to claim. Try again.";
 }
 
 const pendingProfileTransactionStoragePrefix =
@@ -2606,7 +2612,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
       const stateKey =
         action === "claim"
           ? `${reward.vaultAddress.toLowerCase()}:claim`
-          : `${reward.vaultAddress.toLowerCase()}:update-payout:${allocationIndex}`;
+          : rewardReceiverActionKeyV1(reward.vaultAddress);
       const setActionState = (
         state: Omit<ClassicV3ActionState, "account">,
       ) => {
@@ -2715,7 +2721,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
         }
         setActionState({
           status: "error",
-          message: profileRewardActionErrorMessage(caught),
+          message: profileRewardActionErrorMessage(caught, action),
         });
       }
     },
@@ -3758,9 +3764,22 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
 
       <ProfileProjects
         key={account?.toLowerCase() ?? "disconnected"}
+        classicRewards={
+          scopedClassicV3Rewards.status === "ready"
+            ? scopedClassicV3Rewards.rewards
+            : []
+        }
         initialBuys={creatorProjectInitialBuys}
         marketCaps={creatorProjectMarketCaps}
         walletProjects={creatorWalletProjects}
+        rewardReceiverActionStates={classicV3ActionStates}
+        onChangeRewardReceiver={(reward, newReceiver, allocationIndex) =>
+          void submitClassicV3Action(
+            reward,
+            "update-payout",
+            newReceiver,
+            allocationIndex,
+          )}
         onRefresh={retryProfileData}
         refreshing={profileRefreshing}
       />

--- a/tests/profile-projects-editor-open.test.ts
+++ b/tests/profile-projects-editor-open.test.ts
@@ -8,6 +8,7 @@ import type {
   CreatorProjectMarketCapV1,
   CreatorProjectSummaryV1,
 } from "../components/profile-projects";
+import type { ClassicV3Reward } from "../lib/profile/classic-v3-rewards";
 
 const project = {
   chainId: 1 as const,
@@ -19,7 +20,109 @@ const project = {
   article: null,
 };
 
+const rewardOwner = "0x1111111111111111111111111111111111111111" as const;
+const rewardVault = "0x2222222222222222222222222222222222222222" as const;
+const reward = {
+  releaseVersion: "classic-v4",
+  tokenAddress: project.tokenAddress,
+  tokenName: project.name,
+  tokenSymbol: project.symbol,
+  poolId: `0x${"4".repeat(64)}`,
+  vaultAddress: rewardVault,
+  beneficiary: rewardOwner,
+  payoutAddress: rewardOwner,
+  shareBps: 10_000,
+  ownedAllocations: [{
+    allocationIndex: 0,
+    beneficiary: rewardOwner,
+    payoutAddress: rewardOwner,
+    shareBps: 10_000,
+  }],
+  claimableWei: "0",
+  claimableEth: "0",
+  claimedWei: "0",
+  claimedEth: "0",
+  buySwapFeeBps: 10,
+  sellSwapFeeBps: 10,
+  platformFeeBps: 10,
+  beneficiaries: [{
+    allocationIndex: 0,
+    beneficiary: rewardOwner,
+    payoutAddress: rewardOwner,
+    shareBps: 10_000,
+  }],
+  launchTransactionHash: `0x${"5".repeat(64)}`,
+} satisfies ClassicV3Reward;
+
 describe("My projects editor opening", () => {
+  it("offers reward receiver changes only to the verified current owner", () => {
+    const manageable = profileProjects.manageableClassicRewardsByTokenV1(
+      [reward],
+      rewardOwner,
+    );
+
+    expect(manageable.get(project.tokenAddress.toLowerCase())).toBe(reward);
+    expect(profileProjects.manageableClassicRewardsByTokenV1(
+      [reward],
+      "0x9999999999999999999999999999999999999999",
+    ).size).toBe(0);
+    expect(profileProjects.manageableClassicRewardsByTokenV1(
+      [{ ...reward, ownedAllocations: [] }],
+      rewardOwner,
+    ).size).toBe(0);
+  });
+
+  it("fails closed when two reward identities claim the same token", () => {
+    expect(profileProjects.manageableClassicRewardsByTokenV1(
+      [reward, { ...reward, vaultAddress: project.tokenAddress }],
+      rewardOwner,
+    ).size).toBe(0);
+  });
+
+  it("validates a new, non-zero reward receiver", () => {
+    expect(profileProjects.rewardReceiverAddressErrorV1("nope", rewardOwner))
+      .toBe("Enter a valid Ethereum address.");
+    expect(profileProjects.rewardReceiverAddressErrorV1(
+      "0x0000000000000000000000000000000000000000",
+      rewardOwner,
+    )).toBe("Enter a valid Ethereum address.");
+    expect(profileProjects.rewardReceiverAddressErrorV1(
+      rewardOwner.toUpperCase().replace("0X", "0x"),
+      rewardOwner,
+    )).toBe("Enter a different reward receiver.");
+    expect(profileProjects.rewardReceiverAddressErrorV1(
+      "0x9999999999999999999999999999999999999999",
+      rewardOwner,
+    )).toBe("");
+  });
+
+  it("wires an accessible reward receiver dialog into each eligible launch", () => {
+    const source = readFileSync(
+      join(process.cwd(), "components/profile-projects.tsx"),
+      "utf8",
+    );
+    const viewSource = readFileSync(
+      join(process.cwd(), "components/profile-view.tsx"),
+      "utf8",
+    );
+    const styles = readFileSync(
+      join(process.cwd(), "components/profile-projects.module.css"),
+      "utf8",
+    );
+
+    expect(source).toContain("Change reward receiver");
+    expect(source).toContain("if (!dialog.open) dialog.showModal()");
+    expect(source).toContain("htmlFor={fieldId}");
+    expect(source).toContain("aria-invalid={fieldError ? true : undefined}");
+    expect(source).toContain("Future creator fees for this allocation");
+    expect(viewSource).toContain("onChangeRewardReceiver={(reward, newReceiver, allocationIndex)");
+    expect(viewSource).toContain("rewardReceiverActionKeyV1(reward.vaultAddress)");
+    expect(styles).toContain('grid-template-areas: "article receiver token"');
+    expect(styles).toMatch(
+      /grid-template-areas:\s*"article token"\s*"receiver receiver"/u,
+    );
+  });
+
   it("preloads the editor only after explicit user intent", () => {
     const source = readFileSync(
       join(process.cwd(), "components/profile-projects.tsx"),

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -1607,6 +1607,7 @@ describe("profile transaction status", () => {
 
   it("restores only validated pending transactions for the connected account", () => {
     const stateKey = `${secondAddress.toLowerCase()}:claim`;
+    const updateStateKey = `${secondAddress.toLowerCase()}:update-payout`;
     const record = {
       version: 1,
       account: firstAddress.toLowerCase(),
@@ -1617,10 +1618,17 @@ describe("profile transaction status", () => {
       transactionHash,
       submittedAt: 1_800_000_000_000,
     } satisfies PendingProfileTransactionRecord;
+    const updateRecord = {
+      ...record,
+      stateKey: updateStateKey,
+      action: "update-payout",
+      transactionHash: secondTransactionHash,
+    } satisfies PendingProfileTransactionRecord;
     const serialized = JSON.stringify({
       version: 1,
       transactions: [
         record,
+        updateRecord,
         { ...record, account: secondAddress.toLowerCase() },
         { ...record, transactionHash: "0x1234" },
         { ...record, stateKey: `${secondAddress.toLowerCase()}:update-payout` },
@@ -1630,17 +1638,23 @@ describe("profile transaction status", () => {
 
     expect(parsePendingProfileTransactions(serialized, firstAddress)).toEqual([
       record,
+      updateRecord,
     ]);
     expect(parsePendingProfileTransactions(serialized, secondAddress)).toEqual([
       { ...record, account: secondAddress.toLowerCase() },
     ]);
     expect(parsePendingProfileTransactions("{", firstAddress)).toEqual([]);
 
-    const restored = groupPendingProfileTransactionStates([record]);
+    const restored = groupPendingProfileTransactionStates([record, updateRecord]);
     expect(restored["classic-v3"][stateKey]).toMatchObject({
       account: firstAddress.toLowerCase(),
       status: "pending",
       transactionHash,
+    });
+    expect(restored["classic-v3"][updateStateKey]).toMatchObject({
+      account: firstAddress.toLowerCase(),
+      status: "pending",
+      transactionHash: secondTransactionHash,
     });
     expect(restored.classic).toEqual({});
     expect(restored.deep).toEqual({});


### PR DESCRIPTION
Adds a Change reward receiver action beside the article and token actions for eligible Classic launches. The current onchain allocation owner can transfer future creator-fee routing to a new address through the existing verified transaction preparation flow. Includes pending transaction recovery, validation, responsive UI, accessibility, and regression coverage.\n\nVerified locally on the exact commit with lint, 4,627 interface tests, wallet-lock browser tests, production build, and desktop/mobile browser QA.