### PR TITLE
Prepare production for programmablehq transfer

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -370,8 +370,11 @@ jobs:
           git cat-file -e "$RECORD_COMMIT_SHA^{commit}"
           git merge-base --is-ancestor \
             "$RECORD_COMMIT_SHA" "refs/remotes/origin/command-center-release-records"
-          test "$(git show -s --format=%ae "$RECORD_COMMIT_SHA")" = \
-            "309941960+0xprogrammable@users.noreply.github.com"
+          record_author_email="$(git show -s --format=%ae "$RECORD_COMMIT_SHA")"
+          if [[ ! "$record_author_email" =~ ^309941960\+[A-Za-z0-9-]+@users\.noreply\.github\.com$ ]]; then
+            echo "The detached record author is not the Programmable service account" >&2
+            exit 1
+          fi
           record_commit_json="$RUNNER_TEMP/custom-launch-release-record-commit.json"
           test ! -e "$record_commit_json"
           curl --fail --silent --show-error \
@@ -385,8 +388,10 @@ jobs:
           const commit = JSON.parse(readFileSync(process.env.RECORD_COMMIT_JSON, "utf8"));
           if (
             commit.sha !== process.env.RECORD_COMMIT_SHA ||
-            commit.author?.login !== "0xprogrammable" ||
-            commit.committer?.login !== "0xprogrammable" ||
+            commit.author?.id !== 309941960 ||
+            commit.author?.login !== "programmable-infra" ||
+            commit.committer?.id !== 309941960 ||
+            commit.committer?.login !== "programmable-infra" ||
             commit.commit?.verification?.verified !== true
           ) {
             throw new Error("detached record commit lacks verified Programmable provenance");
@@ -454,8 +459,11 @@ jobs:
             "+refs/heads/command-center-release-records:$record_ref"
           git cat-file -e "$RECORD_COMMIT_SHA^{commit}"
           git merge-base --is-ancestor "$RECORD_COMMIT_SHA" "$record_ref"
-          test "$(git show -s --format=%ae "$RECORD_COMMIT_SHA")" = \
-            "309941960+0xprogrammable@users.noreply.github.com"
+          record_author_email="$(git show -s --format=%ae "$RECORD_COMMIT_SHA")"
+          if [[ ! "$record_author_email" =~ ^309941960\+[A-Za-z0-9-]+@users\.noreply\.github\.com$ ]]; then
+            echo "The detached V3 record author is not the Programmable service account" >&2
+            exit 1
+          fi
           record_commit_json="$RUNNER_TEMP/custom-launch-v3-release-record-commit.json"
           test ! -e "$record_commit_json"
           curl --fail --silent --show-error \
@@ -469,8 +477,10 @@ jobs:
           const commit = JSON.parse(readFileSync(process.env.RECORD_COMMIT_JSON, "utf8"));
           if (
             commit.sha !== process.env.RECORD_COMMIT_SHA
-            || commit.author?.login !== "0xprogrammable"
-            || commit.committer?.login !== "0xprogrammable"
+            || commit.author?.id !== 309941960
+            || commit.author?.login !== "programmable-infra"
+            || commit.committer?.id !== 309941960
+            || commit.committer?.login !== "programmable-infra"
             || commit.commit?.verification?.verified !== Boolean(true)
           ) throw new Error("detached V3 record commit lacks verified Programmable provenance");
           NODE

--- a/.github/workflows/reconcile-generic-signer-probes.yml
+++ b/.github/workflows/reconcile-generic-signer-probes.yml
@@ -14,7 +14,7 @@ jobs:
   reconcile:
     name: Remove every residual one-shot signer probe
     if: >-
-      github.repository == '0xprogrammable/programmable' &&
+      github.repository_id == 1314365508 &&
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/production'
     permissions:

--- a/.github/workflows/refresh-production-read-model.yml
+++ b/.github/workflows/refresh-production-read-model.yml
@@ -13,7 +13,7 @@ jobs:
   refresh:
     name: Refresh legacy durable production read model
     if: >-
-      github.repository == '0xprogrammable/programmable' &&
+      github.repository_id == 1314365508 &&
       github.ref == 'refs/heads/production'
     runs-on: ubuntu-latest
     timeout-minutes: 9

--- a/.github/workflows/release-programmable-launch.yml
+++ b/.github/workflows/release-programmable-launch.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     name: Build, attest, and publish exact CLI release
     if: >-
-      github.repository == '0xprogrammable/programmable' &&
+      github.repository_id == 1314365508 &&
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/production'
     runs-on: ubuntu-latest

--- a/config/read-model-operations.v1.json
+++ b/config/read-model-operations.v1.json
@@ -51,7 +51,7 @@
       "provider": "github-actions",
       "workflow": {
         "path": ".github/workflows/refresh-production-read-model.yml",
-        "sha256": "778f68df03c9a66a17c5f58643940e0beb2e4090eacd5f126a5feb9a0ed6b616"
+        "sha256": "6eb33f2cd54447b7ada4adc02341feb0d82f874e79358ceae166584a72ef836f"
       },
       "nodeRuntime": {
         "setupAction": "actions/setup-node",

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -40,11 +40,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/0xprogrammable/PROGRAMMABLE.git",
+    "url": "git+https://github.com/programmablehq/PROGRAMMABLE-EVM.git",
     "directory": "packages/launch"
   },
   "homepage": "https://programmable.market/docs/developers/custom-launch",
   "bugs": {
-    "url": "https://github.com/0xprogrammable/PROGRAMMABLE/issues"
+    "url": "https://github.com/programmablehq/PROGRAMMABLE-EVM/issues"
   }
 }

--- a/packages/launch/package.json
+++ b/packages/launch/package.json
@@ -40,11 +40,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/programmablehq/PROGRAMMABLE-EVM.git",
+    "url": "git+https://github.com/0xprogrammable/PROGRAMMABLE.git",
     "directory": "packages/launch"
   },
   "homepage": "https://programmable.market/docs/developers/custom-launch",
   "bugs": {
-    "url": "https://github.com/programmablehq/PROGRAMMABLE-EVM/issues"
+    "url": "https://github.com/0xprogrammable/PROGRAMMABLE/issues"
   }
 }

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -63,7 +63,7 @@ const APPROVED_OPERATIONS = Object.freeze({
       workflow: Object.freeze({
         path: ".github/workflows/refresh-production-read-model.yml",
         sha256:
-          "778f68df03c9a66a17c5f58643940e0beb2e4090eacd5f126a5feb9a0ed6b616",
+          "6eb33f2cd54447b7ada4adc02341feb0d82f874e79358ceae166584a72ef836f",
       }),
       nodeRuntime: Object.freeze({
         setupAction: "actions/setup-node",
@@ -1645,8 +1645,15 @@ export function evaluateReadModelOperationsSourceContracts(
   const schedulerWatchdog = operations?.legacyIndexer?.schedulerWatchdog;
   check(
     "ops-legacy-scheduler-watchdog",
-    schedulerWatchdog?.workflow?.path ===
-      APPROVED_OPERATIONS.legacyIndexer.schedulerWatchdog.workflow.path,
+    exactJson(
+      schedulerWatchdog?.workflow,
+      APPROVED_OPERATIONS.legacyIndexer.schedulerWatchdog.workflow,
+    ) &&
+      sourceBindingMatches(
+        source,
+        schedulerWatchdog?.workflow,
+        expectedSha256Overrides,
+      ),
     "the recurring durable refresh remains bound to its reviewed production workflow",
   );
   const closedLegacyAlias = APPROVED_OPERATIONS.legacyIndexer.closedAlias;

--- a/scripts/production-verify-proof.mjs
+++ b/scripts/production-verify-proof.mjs
@@ -11,7 +11,7 @@ import { pathToFileURL } from "node:url";
 export const PRODUCTION_VERIFY_PROOF_SCHEMA_VERSION =
   "programmable.production-verify-proof.v4";
 export const PRODUCTION_VERIFY_PROOF_MAX_AGE_MS = 6 * 60 * 60 * 1_000;
-export const PRODUCTION_REPOSITORY = "programmable-infra/programmable-evm";
+export const PRODUCTION_REPOSITORY = "programmablehq/programmable-evm";
 export const PRODUCTION_REPOSITORY_ID = 1_314_365_508;
 export const PRODUCTION_REF = "refs/heads/production";
 export const VERIFY_WORKFLOW_PATH = ".github/workflows/verify.yml";

--- a/scripts/programmable-launch-release-assets.mjs
+++ b/scripts/programmable-launch-release-assets.mjs
@@ -11,7 +11,7 @@ import { pathToFileURL } from "node:url";
 
 export const RELEASE_ASSET_SCHEMA =
   "programmable.launch-cli-release-assets.v1";
-export const RELEASE_REPOSITORY = "0xprogrammable/programmable";
+export const RELEASE_REPOSITORY = "programmablehq/programmable-evm";
 export const RELEASE_NODE_VERSION = "24.14.0";
 export const RELEASE_NPM_VERSION = "11.16.0";
 

--- a/scripts/test/custom-launch-cross-repository-attestation.test.mjs
+++ b/scripts/test/custom-launch-cross-repository-attestation.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 import {
   BACKEND_RELEASE_BINDING_PATH,
   BACKEND_RELEASE_REPOSITORY,
+  BACKEND_RELEASE_REPOSITORY_ID,
   verifyCrossRepositoryReleaseBindingFromGitHubV1,
 } from "../verify-custom-launch-cross-repository-attestation.mjs";
 
@@ -27,7 +28,7 @@ function releaseBinding() {
     disabledReason: null,
     pendingCandidates: null,
     backend: {
-      repositoryUrl: `https://github.com/${BACKEND_RELEASE_REPOSITORY}.git`,
+      repositoryUrl: "https://github.com/0xprogrammable/programmable-open-hook-v2-internal.git",
       candidateCommitSha: commits.backend,
       candidateTreeSha: "7".repeat(40),
       packedAttestationPath: "services/autonomous-approval-v1/release/production-packed-artifact.json",
@@ -60,7 +61,7 @@ function releaseBinding() {
       builderVendorReceiptSha256: digest("0"),
     },
     productionAuthority: {
-      repositoryUrl: `https://github.com/${BACKEND_RELEASE_REPOSITORY}.git`,
+      repositoryUrl: "https://github.com/0xprogrammable/programmable-open-hook-v2-internal.git",
       candidateCommitSha: commits.authority,
       candidateTreeSha: "b".repeat(40),
       subjectAgentPath: "services/production-authorities-v1/deploy/fly/fly-oidc-subject-agent.mjs",
@@ -86,8 +87,8 @@ function fixture(options = {}) {
   const blobSha = gitBlobSha1(bytes);
   const commit = {
     sha: commits.attestation,
-    author: { login: "0xprogrammable" },
-    committer: { login: "0xprogrammable" },
+    author: { id: 309_941_960, login: "programmable-infra" },
+    committer: { id: 309_941_960, login: "programmable-infra" },
     commit: { verification: { verified: true } },
     parents: [{ sha: commits.backend }],
     files: [{
@@ -107,6 +108,7 @@ function fixture(options = {}) {
   };
   options.mutateContents?.(contents);
   const fetchImpl = async (url, request) => {
+    assert.match(url.pathname, new RegExp(`^/repositories/${BACKEND_RELEASE_REPOSITORY_ID}/`, "u"));
     assert.equal(request.method, "GET");
     assert.equal(request.redirect, "error");
     assert.equal(request.headers.authorization, "Bearer test-token");
@@ -136,7 +138,7 @@ test("reads the exact signed Git blob and closes the five-component release set"
   const result = await verify(fixture());
   assert.deepEqual(result, {
     schemaVersion: "programmable.website-observed-cross-repository-release-binding.v1",
-    repository: BACKEND_RELEASE_REPOSITORY,
+    repository: "0xprogrammable/programmable-open-hook-v2-internal",
     attestationCommitSha: commits.attestation,
     parentCommitSha: commits.backend,
     documentPath: BACKEND_RELEASE_BINDING_PATH,
@@ -152,6 +154,10 @@ test("reads the exact signed Git blob and closes the five-component release set"
     commitSignatureVerified: true,
   });
   assert.match(result.documentBlobSha, /^[0-9a-f]{40}$/u);
+  assert.equal(
+    BACKEND_RELEASE_REPOSITORY,
+    "programmablehq/programmable-open-hook-v2-internal",
+  );
 });
 
 test("rejects an attestation commit that changes more than the binding", async () => {

--- a/scripts/test/custom-launch-release-workflow-contract.test.mjs
+++ b/scripts/test/custom-launch-release-workflow-contract.test.mjs
@@ -12,6 +12,13 @@ const WORKFLOW_URL = new URL(
   import.meta.url,
 );
 
+function mutateWorkflowStep(source, startMarker, endMarker, mutate) {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start + startMarker.length);
+  assert.ok(start >= 0 && end > start, `missing workflow step ${startMarker}`);
+  return `${source.slice(0, start)}${mutate(source.slice(start, end))}${source.slice(end)}`;
+}
+
 function workflowFailures(source) {
   const failures = [];
   const requireText = (id, text) => {
@@ -182,18 +189,51 @@ function workflowFailures(source) {
     "record-reachability",
     'git merge-base --is-ancestor "$RECORD_COMMIT_SHA" "$record_ref"',
   );
-  requireText(
-    "record-github-provenance",
-    "commit.commit?.verification?.verified !== true",
+  const v3RecordGateStart = source.indexOf(
+    "      - name: Verify detached Custom Launch V3 release record",
   );
-  requireText(
-    "record-programmable-author",
-    'commit.author?.login !== "0xprogrammable"',
+  const v3RecordGateEnd = source.indexOf(
+    "      - name: Set up Fly CLI for read-only release verification",
+    v3RecordGateStart,
   );
-  requireText(
-    "record-programmable-committer",
-    'commit.committer?.login !== "0xprogrammable"',
-  );
+  const v3RecordGateBlock =
+    v3RecordGateStart >= 0 && v3RecordGateEnd > v3RecordGateStart
+      ? source.slice(v3RecordGateStart, v3RecordGateEnd)
+      : "";
+  const provenanceRequirements = [
+    ["programmable-author-id", "commit.author?.id !== 309941960"],
+    [
+      "programmable-author-login",
+      'commit.author?.login !== "programmable-infra"',
+    ],
+    ["programmable-committer-id", "commit.committer?.id !== 309941960"],
+    [
+      "programmable-committer-login",
+      'commit.committer?.login !== "programmable-infra"',
+    ],
+    [
+      "programmable-email-id",
+      "^309941960\\+[A-Za-z0-9-]+@users\\.noreply\\.github\\.com$",
+    ],
+  ];
+  for (const [lane, block] of [
+    ["v1", recordGateBlock],
+    ["v3", v3RecordGateBlock],
+  ]) {
+    for (const [id, text] of provenanceRequirements) {
+      if (!block.includes(text)) failures.push(`record-${lane}-${id}`);
+    }
+  }
+  if (!recordGateBlock.includes("commit.commit?.verification?.verified !== true")) {
+    failures.push("record-v1-github-provenance");
+  }
+  if (
+    !v3RecordGateBlock.includes(
+      "commit.commit?.verification?.verified !== Boolean(true)",
+    )
+  ) {
+    failures.push("record-v3-github-provenance");
+  }
   requireText(
     "record-fixed-path",
     'record_path="release-records/custom-launch-v1/release-record.json"',
@@ -592,6 +632,18 @@ test("the production workflow enforces the complete conditional detached-record 
 test("workflow contract detects weakened record and stage-only gates", async () => {
   const source = await readFile(WORKFLOW_URL, "utf8");
   const mutations = [
+    mutateWorkflowStep(
+      source,
+      "      - name: Verify detached Custom Launch release record",
+      "      - name: Preserve detached Custom Launch release record",
+      (step) => step.replaceAll("309941960", "0"),
+    ),
+    mutateWorkflowStep(
+      source,
+      "      - name: Verify detached Custom Launch V3 release record",
+      "      - name: Set up Fly CLI for read-only release verification",
+      (step) => step.replaceAll("309941960", "0"),
+    ),
     source.replace(
       "if: steps.custom-launch-policy.outputs.release_record_required == 'true'",
       "if: always()",

--- a/scripts/test/custom-launch-v2-release-gate.test.mjs
+++ b/scripts/test/custom-launch-v2-release-gate.test.mjs
@@ -4,6 +4,10 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import {
+  BACKEND_REPOSITORY,
+  BACKEND_REPOSITORY_ID,
+  WEBSITE_REPOSITORY,
+  WEBSITE_REPOSITORY_ID,
   parseDeterministicCustomLaunchApiReleaseBindingV1,
   verifyCustomLaunchApiReleaseBindingV1,
 } from "../verify-custom-launch-api-release-binding-v1.mjs";
@@ -372,8 +376,8 @@ test("V2 staging fails closed on API drift, secrets and per-state overclaim", as
 function commitResponse(sha, tree) {
   return {
     sha,
-    author: { login: "0xprogrammable" },
-    committer: { login: "0xprogrammable" },
+    author: { id: 309_941_960, login: "programmable-infra" },
+    committer: { id: 309_941_960, login: "programmable-infra" },
     commit: { tree: { sha: tree }, verification: { verified: true } },
   };
 }
@@ -446,6 +450,13 @@ test("backend binding preserves historical revision 2 profile evidence", async (
   };
   const fetchImpl = async (input) => {
     const url = new URL(input);
+    assert.match(
+      url.pathname,
+      new RegExp(
+        `^/repositories/(?:${BACKEND_REPOSITORY_ID}|${WEBSITE_REPOSITORY_ID})/`,
+        "u",
+      ),
+    );
     let body;
     if (url.pathname.endsWith(`/commits/${hashes.d}`)) body = attestation;
     else if (url.pathname.endsWith(`/commits/${hashes.a}`)) body = commitResponse(hashes.a, hashes.b);
@@ -484,6 +495,11 @@ test("backend binding preserves historical revision 2 profile evidence", async (
   });
   assert.equal(result.api.publicProfileSha256, publicProfileSha256);
   assert.equal(result.commitSignatureVerified, true);
+  assert.equal(
+    BACKEND_REPOSITORY,
+    "programmablehq/programmable-open-hook-v2-internal",
+  );
+  assert.equal(WEBSITE_REPOSITORY, "programmablehq/programmable-evm");
 });
 
 test("Fly readback accepts the real tag-only release ref and exact machine digest", () => {

--- a/scripts/test/custom-v2-production-workflow-contract.test.mjs
+++ b/scripts/test/custom-v2-production-workflow-contract.test.mjs
@@ -303,6 +303,7 @@ test("Generic signer OIDC proof is one-shot, two-Machine and cleanup-attested", 
   );
   assert.match(standaloneReconcile, /^name: Reconcile Generic Signer Probes$/mu);
   assert.match(standaloneReconcile, /^  workflow_dispatch:$/mu);
+  assert.match(standaloneReconcile, /github\.repository_id == 1314365508/u);
   assert.match(standaloneReconcile, /group: programmable-production/u);
   assert.match(standaloneReconcile, /cancel-in-progress: false/u);
   assert.match(standaloneReconcile, /environment:[\s\S]*name: production/u);

--- a/scripts/test/production-verify-proof.test.mjs
+++ b/scripts/test/production-verify-proof.test.mjs
@@ -31,8 +31,12 @@ const ARTIFACT_DIGEST =
 const RUN_ID = 31_519_898_545;
 const RUN_ATTEMPT = 1;
 const WORKFLOW_ID = 321_772_273;
-const REPOSITORY_URL = "https://github.com/programmable-infra/programmable-evm";
+const REPOSITORY_URL = "https://github.com/programmablehq/programmable-evm";
 const NOW_MS = Date.parse("2026-08-11T18:10:00Z");
+
+test("pins the immutable production repository identity", () => {
+  assert.equal(PRODUCTION_REPOSITORY_ID, 1_314_365_508);
+});
 
 function validProofInput() {
   return {
@@ -257,22 +261,24 @@ test("full production Verify proof is deterministic and exact", () => {
 
 test("GitHub display-case drift preserves the canonical production identity", () => {
   assert.equal(
-    canonicalProductionRepository("programmable-infra/PROGRAMMABLE-EVM"),
+    canonicalProductionRepository("programmablehq/PROGRAMMABLE-EVM"),
     PRODUCTION_REPOSITORY,
   );
   assert.equal(
     canonicalProductionWorkflowRef(
-      "programmable-infra/PROGRAMMABLE-EVM/.github/workflows/verify.yml@refs/heads/production",
+      "programmablehq/PROGRAMMABLE-EVM/.github/workflows/verify.yml@refs/heads/production",
     ),
     `${PRODUCTION_REPOSITORY}/${VERIFY_WORKFLOW_PATH}@${PRODUCTION_REF}`,
   );
   assert.throws(() =>
     canonicalProductionRepository("attacker/PROGRAMMABLE-EVM"));
   assert.throws(() =>
-    canonicalProductionRepository("programmable-infra/PROGRAMMABLE-EVM "));
+    canonicalProductionRepository("programmable-infra/PROGRAMMABLE-EVM"));
+  assert.throws(() =>
+    canonicalProductionRepository("programmablehq/PROGRAMMABLE-EVM "));
   assert.throws(() =>
     canonicalProductionWorkflowRef(
-      "programmable-infra/PROGRAMMABLE-EVM/.github/workflows/verify.yml@refs/heads/main",
+      "programmablehq/PROGRAMMABLE-EVM/.github/workflows/verify.yml@refs/heads/main",
     ));
 });
 
@@ -414,9 +420,9 @@ test("resolver accepts only a fresh exact successful run and immutable artifact"
 test("resolver accepts GitHub repository display-case drift with the exact ID", async () => {
   const fixtures = validApiFixtures();
   const run = fixtures.runs.workflow_runs[0];
-  run.repository.full_name = "programmable-infra/PROGRAMMABLE-EVM";
-  run.repository.html_url = "https://github.com/programmable-infra/PROGRAMMABLE-EVM";
-  run.head_repository.full_name = "programmable-infra/PROGRAMMABLE-EVM";
+  run.repository.full_name = "programmablehq/PROGRAMMABLE-EVM";
+  run.repository.html_url = "https://github.com/programmablehq/PROGRAMMABLE-EVM";
+  run.head_repository.full_name = "programmablehq/PROGRAMMABLE-EVM";
   run.html_url = `${run.repository.html_url}/actions/runs/${RUN_ID}`;
   assert.equal((await resolveFixtures(fixtures)).runId, RUN_ID);
 });

--- a/scripts/test/programmable-launch-release-assets.test.mjs
+++ b/scripts/test/programmable-launch-release-assets.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   RELEASE_ASSET_SCHEMA,
+  RELEASE_REPOSITORY,
   buildReleaseManifest,
   canonicalJson,
   normalizeCycloneDx,
@@ -56,6 +57,8 @@ test("release manifest binds source, exact toolchain, and all payload bytes", ()
     ],
   });
   assert.equal(manifest.schemaVersion, RELEASE_ASSET_SCHEMA);
+  assert.equal(manifest.repository, RELEASE_REPOSITORY);
+  assert.equal(manifest.repository, "programmablehq/programmable-evm");
   assert.equal(manifest.source.commitSha, COMMIT);
   assert.equal(manifest.source.treeSha, TREE);
   assert.equal(manifest.toolchain.node, "24.14.0");

--- a/scripts/test/programmable-launch-release-workflow.test.mjs
+++ b/scripts/test/programmable-launch-release-workflow.test.mjs
@@ -10,6 +10,7 @@ const source = readFileSync(workflowPath, "utf8");
 
 function failures(value) {
   const required = [
+    "github.repository_id == 1314365508",
     "github.ref == 'refs/heads/production'",
     "environment: production",
     "actions: read",

--- a/scripts/verify-custom-launch-api-release-binding-v1.mjs
+++ b/scripts/verify-custom-launch-api-release-binding-v1.mjs
@@ -4,8 +4,10 @@ import { readFileSync } from "node:fs";
 import Ajv2020 from "ajv/dist/2020.js";
 
 export const BACKEND_REPOSITORY =
-  "0xprogrammable/programmable-open-hook-v2-internal";
-export const WEBSITE_REPOSITORY = "0xprogrammable/programmable";
+  "programmablehq/programmable-open-hook-v2-internal";
+export const BACKEND_REPOSITORY_ID = 1_318_883_798;
+export const WEBSITE_REPOSITORY = "programmablehq/programmable-evm";
+export const WEBSITE_REPOSITORY_ID = 1_314_365_508;
 export const BINDING_PATH =
   "services/custom-launch-api-v1/release/public-v3-release-binding-v1.json";
 export const PUBLIC_OPENAPI_PATH = "public/openapi/custom-launch-v3.json";
@@ -16,6 +18,8 @@ export const OBSERVATION_SCHEMA_VERSION =
 const COMMIT = /^[0-9a-f]{40}$/u;
 const SHA256 = /^sha256:[0-9a-f]{64}$/u;
 const MAXIMUM_GITHUB_BYTES = 2 * 1024 * 1024;
+const PROGRAMMABLE_OPERATOR_ID = 309_941_960;
+const PROGRAMMABLE_OPERATOR_LOGIN = "programmable-infra";
 const schema = JSON.parse(readFileSync(new URL(
   "../docs/operations/releases/custom-launch-v2/backend-release-binding.schema.json",
   import.meta.url,
@@ -94,8 +98,10 @@ function commitIdentity(value, expectedSha, label, { operator = false } = {}) {
     || value?.commit?.verification?.verified !== true
     || !COMMIT.test(value?.commit?.tree?.sha ?? "")
     || (operator && (
-      value?.author?.login !== "0xprogrammable"
-      || value?.committer?.login !== "0xprogrammable"
+      value?.author?.id !== PROGRAMMABLE_OPERATOR_ID
+      || value?.author?.login !== PROGRAMMABLE_OPERATOR_LOGIN
+      || value?.committer?.id !== PROGRAMMABLE_OPERATOR_ID
+      || value?.committer?.login !== PROGRAMMABLE_OPERATOR_LOGIN
     ))
   ) {
     throw new Error(`${label} lacks exact verified Programmable provenance`);
@@ -171,19 +177,19 @@ export async function verifyCustomLaunchApiReleaseBindingV1(input) {
   const fetchImpl = input.fetchImpl ?? fetch;
   const [attestationCommit, contents, websiteCommit] = await Promise.all([
     readGitHubJson(
-      githubUrl(`/repos/${BACKEND_REPOSITORY}/commits/${input.attestationCommitSha}?per_page=100`),
+      githubUrl(`/repositories/${BACKEND_REPOSITORY_ID}/commits/${input.attestationCommitSha}?per_page=100`),
       input.githubToken,
       fetchImpl,
       input.signal,
     ),
     readGitHubJson(
-      githubUrl(`/repos/${BACKEND_REPOSITORY}/contents/${encodedPath(BINDING_PATH)}?ref=${input.attestationCommitSha}`),
+      githubUrl(`/repositories/${BACKEND_REPOSITORY_ID}/contents/${encodedPath(BINDING_PATH)}?ref=${input.attestationCommitSha}`),
       input.githubToken,
       fetchImpl,
       input.signal,
     ),
     readGitHubJson(
-      githubUrl(`/repos/${WEBSITE_REPOSITORY}/commits/${input.expectedWebsiteCommitSha}`),
+      githubUrl(`/repositories/${WEBSITE_REPOSITORY_ID}/commits/${input.expectedWebsiteCommitSha}`),
       input.githubToken,
       fetchImpl,
       input.signal,
@@ -223,25 +229,25 @@ export async function verifyCustomLaunchApiReleaseBindingV1(input) {
     launchPackageManifestContents,
   ] = await Promise.all([
     readGitHubJson(
-      githubUrl(`/repos/${BACKEND_REPOSITORY}/commits/${binding.backend.candidateCommitSha}`),
+      githubUrl(`/repositories/${BACKEND_REPOSITORY_ID}/commits/${binding.backend.candidateCommitSha}`),
       input.githubToken,
       fetchImpl,
       input.signal,
     ),
     readGitHubJson(
-      githubUrl(`/repos/${BACKEND_REPOSITORY}/contents/${encodedPath(binding.api.publicProfilePath)}?ref=${binding.backend.candidateCommitSha}`),
+      githubUrl(`/repositories/${BACKEND_REPOSITORY_ID}/contents/${encodedPath(binding.api.publicProfilePath)}?ref=${binding.backend.candidateCommitSha}`),
       input.githubToken,
       fetchImpl,
       input.signal,
     ),
     readGitHubJson(
-      githubUrl(`/repos/${WEBSITE_REPOSITORY}/contents/${encodedPath(PUBLIC_OPENAPI_PATH)}?ref=${binding.website.candidateCommitSha}`),
+      githubUrl(`/repositories/${WEBSITE_REPOSITORY_ID}/contents/${encodedPath(PUBLIC_OPENAPI_PATH)}?ref=${binding.website.candidateCommitSha}`),
       input.githubToken,
       fetchImpl,
       input.signal,
     ),
     readGitHubJson(
-      githubUrl(`/repos/${WEBSITE_REPOSITORY}/contents/${encodedPath(LAUNCH_PACKAGE_MANIFEST_PATH)}?ref=${binding.website.candidateCommitSha}`),
+      githubUrl(`/repositories/${WEBSITE_REPOSITORY_ID}/contents/${encodedPath(LAUNCH_PACKAGE_MANIFEST_PATH)}?ref=${binding.website.candidateCommitSha}`),
       input.githubToken,
       fetchImpl,
       input.signal,
@@ -305,7 +311,7 @@ export async function verifyCustomLaunchApiReleaseBindingV1(input) {
   }
   return Object.freeze({
     schemaVersion: OBSERVATION_SCHEMA_VERSION,
-    repository: BACKEND_REPOSITORY,
+    repository: binding.backend.repository,
     attestationCommitSha: input.attestationCommitSha,
     bindingDocumentPath: BINDING_PATH,
     bindingDocumentSha256: documentSha256,

--- a/scripts/verify-custom-launch-cross-repository-attestation.mjs
+++ b/scripts/verify-custom-launch-cross-repository-attestation.mjs
@@ -4,7 +4,8 @@ import { readFileSync } from "node:fs";
 import Ajv2020 from "ajv/dist/2020.js";
 
 export const BACKEND_RELEASE_REPOSITORY =
-  "0xprogrammable/programmable-open-hook-v2-internal";
+  "programmablehq/programmable-open-hook-v2-internal";
+export const BACKEND_RELEASE_REPOSITORY_ID = 1_318_883_798;
 export const BACKEND_RELEASE_BINDING_PATH =
   "services/autonomous-approval-v1/release/cross-repository-release-binding-v1.json";
 export const CROSS_REPOSITORY_OBSERVATION_SCHEMA_VERSION =
@@ -14,6 +15,10 @@ const COMMIT = /^[0-9a-f]{40}$/u;
 const SHA256 = /^sha256:[0-9a-f]{64}$/u;
 const MAX_GITHUB_RESPONSE_BYTES = 2 * 1024 * 1024;
 const GITHUB_REQUEST_TIMEOUT_MS = 10_000;
+const PROGRAMMABLE_OPERATOR_ID = 309_941_960;
+const PROGRAMMABLE_OPERATOR_LOGIN = "programmable-infra";
+const HISTORICAL_BACKEND_RELEASE_REPOSITORY =
+  "0xprogrammable/programmable-open-hook-v2-internal";
 const BACKEND_SCHEMA = JSON.parse(readFileSync(
   new URL(
     "../docs/operations/releases/custom-launch-v1/backend-cross-repository-release-binding-v1.schema.json",
@@ -43,10 +48,10 @@ export async function verifyCrossRepositoryReleaseBindingFromGitHubV1(input) {
 
   const fetchImpl = input.fetchImpl ?? fetch;
   const commitUrl = githubApiUrl(
-    `/repos/${BACKEND_RELEASE_REPOSITORY}/commits/${input.attestationCommitSha}?per_page=100`,
+    `/repositories/${BACKEND_RELEASE_REPOSITORY_ID}/commits/${input.attestationCommitSha}?per_page=100`,
   );
   const contentsUrl = githubApiUrl(
-    `/repos/${BACKEND_RELEASE_REPOSITORY}/contents/${encodePath(BACKEND_RELEASE_BINDING_PATH)}`
+    `/repositories/${BACKEND_RELEASE_REPOSITORY_ID}/contents/${encodePath(BACKEND_RELEASE_BINDING_PATH)}`
       + `?ref=${input.attestationCommitSha}`,
   );
   const [commit, contents] = await Promise.all([
@@ -77,7 +82,7 @@ export async function verifyCrossRepositoryReleaseBindingFromGitHubV1(input) {
 
   return Object.freeze({
     schemaVersion: CROSS_REPOSITORY_OBSERVATION_SCHEMA_VERSION,
-    repository: BACKEND_RELEASE_REPOSITORY,
+    repository: HISTORICAL_BACKEND_RELEASE_REPOSITORY,
     attestationCommitSha: input.attestationCommitSha,
     parentCommitSha,
     documentPath: BACKEND_RELEASE_BINDING_PATH,
@@ -139,8 +144,10 @@ function validateAttestationCommit(commit, expectedCommitSha) {
     throw new Error("Backend release attestation commit identity is invalid.");
   }
   if (
-    commit.author?.login !== "0xprogrammable"
-    || commit.committer?.login !== "0xprogrammable"
+    commit.author?.id !== PROGRAMMABLE_OPERATOR_ID
+    || commit.author?.login !== PROGRAMMABLE_OPERATOR_LOGIN
+    || commit.committer?.id !== PROGRAMMABLE_OPERATOR_ID
+    || commit.committer?.login !== PROGRAMMABLE_OPERATOR_LOGIN
     || commit.commit?.verification?.verified !== true
   ) {
     throw new Error("Backend release attestation lacks verified Programmable provenance.");

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -449,12 +449,32 @@ describe("read-model operations source contract", () => {
   });
 
   it("binds the per-minute schedulers, activation gates and release workflow", () => {
+    const watchdogWorkflow = readFileSync(
+      resolve(ROOT, ".github/workflows/refresh-production-read-model.yml"),
+      "utf8",
+    );
+    expect(watchdogWorkflow).toContain("github.repository_id == 1314365508");
     const result = evaluateReadModelOperationsSourceContracts(ROOT, {
       sourceOverrides: integratedOverrides(),
       expectedSha256Overrides: fixtureDigests(),
     });
     expect(result.failures).toEqual([]);
     expect(result.ok).toBe(true);
+  });
+
+  it("rejects scheduler workflow drift even when the repository guard remains", () => {
+    const workflowPath = ".github/workflows/refresh-production-read-model.yml";
+    const watchdogWorkflow = readFileSync(resolve(ROOT, workflowPath), "utf8");
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        ...integratedOverrides(),
+        [workflowPath]: `${watchdogWorkflow}\n# unreviewed scheduler drift\n`,
+      },
+      expectedSha256Overrides: fixtureDigests(),
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-legacy-scheduler-watchdog",
+    );
   });
 
   it("rejects scheduler, authorization and activation drift", () => {


### PR DESCRIPTION
## Summary

- replace stale owner/name workflow guards with immutable repository ID 1314365508
- bind post-transfer production Verify proofs and new CLI release metadata to programmablehq
- move live cross-repository release reads to immutable repository IDs and pin the Programmable service account by ID plus current login
- preserve historical signed release-record identities while enforcing the reviewed scheduler workflow bytes

## Activation order

DO NOT MERGE BEFORE THE REPOSITORY TRANSFER. The production proof intentionally binds programmablehq/programmable-evm, while repository ID 1314365508 still resolves to programmable-infra/PROGRAMMABLE-EVM. Merging before transfer would fail proof creation and release workflows closed.

Required cutover order:
1. transfer PROGRAMMABLE-EVM and programmable-open-hook-v2-internal to programmablehq
2. verify immutable IDs 1314365508 and 1318883798 resolve under programmablehq
3. merge this PR to production
4. create a fresh full Verify proof and run the normal protected release flow

## Verification

- 54 focused Node contract tests passed
- 93 read-model Vitest checks passed
- targeted ESLint passed
- npm run typecheck passed
- npm run build passed, including candidate-neutral source/build and production bundle scans
- Ruby YAML parsing passed for all four changed workflows
- git diff --check passed

Base: 64b80a82c10cef48871240f84105973f4166bc3f
Patch: 1ca65d9c