### PR TITLE
Fix public GitHub organization links

### DIFF
--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -16,7 +16,7 @@ const resourceLinks = [
     label: "Analytics",
   },
   {
-    href: "https://github.com/0xprogrammable",
+    href: "https://github.com/programmablehq",
     label: "GitHub",
     external: true,
   },

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -64,7 +64,7 @@ function HeaderSocialLinks({ mobile = false }: { mobile?: boolean }) {
       </a>
       <a
         className="header-social-link"
-        href="https://github.com/0xprogrammable"
+        href="https://github.com/programmablehq"
         target="_blank"
         rel="noreferrer"
         aria-label="Programmable on GitHub"

--- a/lib/site-structured-data.ts
+++ b/lib/site-structured-data.ts
@@ -17,7 +17,7 @@ export const programmableSiteStructuredData = {
       },
       sameAs: [
         "https://x.com/0xProgrammable",
-        "https://github.com/0xprogrammable",
+        "https://github.com/programmablehq",
         "https://discord.com/invite/programmable",
       ],
     },

--- a/tests/shell-polish.test.ts
+++ b/tests/shell-polish.test.ts
@@ -21,11 +21,23 @@ describe("public shell polish", () => {
     expect(source).toContain("<span>Programmable</span>");
     expect(source).toContain("© 2026 Programmable");
     expect(source).toContain('label: "GitHub"');
+    expect(source).toContain('href: "https://github.com/programmablehq"');
+    expect(source).not.toContain('href: "https://github.com/0xprogrammable"');
     expect(source).toContain('label: "Discord"');
     expect(source).toContain('label: "X"');
     expect(source).toContain('label: "Token"');
     expect(source).not.toContain("XBrandIcon");
     expect(source).not.toContain("GitHubBrandIcon");
+  });
+
+  it("links the public shell and structured identity to the canonical GitHub organization", () => {
+    const navigation = read("components/site-navigation.tsx");
+    const structuredData = read("lib/site-structured-data.ts");
+
+    expect(navigation).toContain('href="https://github.com/programmablehq"');
+    expect(navigation).not.toContain('href="https://github.com/0xprogrammable"');
+    expect(structuredData).toContain('"https://github.com/programmablehq"');
+    expect(structuredData).not.toContain('"https://github.com/0xprogrammable"');
   });
 
   it("keeps route motion measured, interruptible and compositor-friendly", () => {


### PR DESCRIPTION
Updates the shared header, footer, and structured organization identity to the canonical programmablehq namespace. Immutable historical release URLs remain unchanged.\n\nFocused evidence:\n- shell polish: 7/7\n- git diff --check