### PR TITLE
Update GitBook links after organization transfer

### DIFF
--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -51,4 +51,4 @@ Programmable keeps agent evidence, exact-source provider status, API preparation
 
 ## Official sources
 
-The website is [programmable.market](https://programmable.market), the authenticated Custom write API is [api.programmable.market](https://api.programmable.market), and the read only Ethereum developer service is [developers.programmable.family](https://developers.programmable.family). The public organization is [0xprogrammable](https://github.com/0xprogrammable). Contract addresses and integration data should come from canonical release evidence rather than copied screenshots or third party token metadata.
+The website is [programmable.market](https://programmable.market), the authenticated Custom write API is [api.programmable.market](https://api.programmable.market), and the read only Ethereum developer service is [developers.programmable.family](https://developers.programmable.family). The public organization is [programmablehq](https://github.com/programmablehq). Contract addresses and integration data should come from canonical release evidence rather than copied screenshots or third party token metadata.

--- a/docs/public/developers/machine-readable.md
+++ b/docs/public/developers/machine-readable.md
@@ -32,4 +32,4 @@ The public-read OpenAPI below describes the Developer API. The standalone V3 Cus
 [programmable-v2.yaml](../.gitbook/assets/programmable-v2.yaml)
 {% endopenapi %}
 
-The canonical OpenAPI source is maintained in the [developers repository](https://github.com/0xprogrammable/developers/blob/main/openapi/programmable-v2.yaml). This copy is included so GitBook can render the interactive reference together with the official product documentation.
+The canonical OpenAPI source is maintained in the [Developers repository](https://github.com/programmablehq/Developers/blob/main/openapi/programmable-v2.yaml). This copy is included so GitBook can render the interactive reference together with the official product documentation.

--- a/docs/public/developers/verify.md
+++ b/docs/public/developers/verify.md
@@ -22,4 +22,4 @@ Only assign a Programmable Classic or Programmable Custom label when the Router 
 
 A valid result proves canonical Router provenance. It does not prove present liquidity, audit status, sellability, quoting support or price quality.
 
-The complete implementation reference and conformance fixtures live in the [0xprogrammable developers repository](https://github.com/0xprogrammable/developers).
+The complete implementation reference and conformance fixtures live in the [Programmable Developers repository](https://github.com/programmablehq/Developers).

--- a/docs/public/reference/official-links.md
+++ b/docs/public/reference/official-links.md
@@ -9,7 +9,7 @@ description: Official Programmable product, source, community and analytics link
 | Website                 | [programmable.market](https://programmable.market)                                                                 |
 | Create                  | [programmable.market/launch](https://programmable.market/launch)                                                   |
 | Explore                 | [programmable.market/explore](https://programmable.market/explore)                                                 |
-| GitHub                  | [github.com/0xprogrammable](https://github.com/0xprogrammable)                                                     |
+| GitHub                  | [github.com/programmablehq](https://github.com/programmablehq)                                                     |
 | Custom Launch API keys  | [programmable.market/developers/api-keys](https://programmable.market/developers/api-keys)                         |
 | Custom Launch API guide | [programmable.market/developers/custom-launch-api-v1.md](https://programmable.market/developers/custom-launch-api-v1.md) |
 | Custom Launch V1 OpenAPI | [live reads and write fence](https://programmable.market/openapi/custom-launch-v1.json)                    |
@@ -19,7 +19,7 @@ description: Official Programmable product, source, community and analytics link
 | Custom API readiness    | [api.programmable.market/readyz](https://api.programmable.market/readyz)                                           |
 | Custom Launch CLI 3.3.9 | [public V3 GitHub Release asset](https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v3.3.9/programmable-launch-3.3.9.tgz) |
 | Custom Launch CLI 1.0.1 | [V1 compatibility asset](https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz) |
-| Launch policy           | [github.com/0xprogrammable/launch-policy](https://github.com/0xprogrammable/launch-policy)                         |
+| Launch policy           | [github.com/programmablehq/Launch-Policy](https://github.com/programmablehq/Launch-Policy)                         |
 | Read-only developer API | [developers.programmable.family](https://developers.programmable.family)                                           |
 | X                       | [x.com/0xProgrammable](https://x.com/0xProgrammable)                                                               |
 | Discord                 | [discord.com/invite/programmable](https://discord.com/invite/programmable)                                         |

--- a/docs/public/trust.md
+++ b/docs/public/trust.md
@@ -26,4 +26,4 @@ The Programmable contracts in the public product repository have not undergone a
 
 Token transactions can be irreversible. Tokens can be volatile, illiquid or lose all value. Verify the connected wallet, network, contract address, transaction destination and value before signing. Programmable does not provide financial advice or guarantee a token's quality, future price or trading activity.
 
-Security sensitive reports belong in the private reporting path of the affected [0xprogrammable repository](https://github.com/0xprogrammable). Do not post private keys, access tokens, signatures or unpublished exploit details in a public issue.
+Security sensitive reports belong in the private reporting path of the affected [Programmable repository](https://github.com/programmablehq). Do not post private keys, access tokens, signatures or unpublished exploit details in a public issue.


### PR DESCRIPTION
## Summary

- update the current public GitBook organization link to `programmablehq`
- update mutable Developers and Launch-Policy repository links after the transfer
- preserve checksum-bound historical CLI release asset URLs

## Verification

- GitBook root and SUMMARY target validation
- no mutable `github.com/0xprogrammable` links remain under `docs/public`
- 34 focused documentation tests passed
- `git diff --check`