### PR TITLE
fix: update current public repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ intake is closed.
 
 | Repository                                                                                 | Responsibility                                                              |
 | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
-| [`Launch-Policy`](https://github.com/0xprogrammable/Launch-Policy)                         | Versioned Custom launch requirements, policies and schemas                  |
-| [`Developers`](https://github.com/0xprogrammable/Developers)                               | Read-only discovery manifests, API contracts and verification rules         |
+| [`Launch-Policy`](https://github.com/programmablehq/Launch-Policy)                         | Versioned Custom launch requirements, policies and schemas                  |
+| [`Developers`](https://github.com/programmablehq/Developers)                               | Read-only discovery manifests, API contracts and verification rules         |
 
 ## Release and security boundaries
 
@@ -183,7 +183,7 @@ The smart contracts in this repository have not undergone an external audit or p
   &nbsp;·&nbsp;
   <a href="https://programmable.market/docs">Docs</a>
   &nbsp;·&nbsp;
-  <a href="https://github.com/0xprogrammable">GitHub</a>
+  <a href="https://github.com/programmablehq">GitHub</a>
   &nbsp;·&nbsp;
   <a href="https://x.com/0xprogrammable">X</a>
 </p>

--- a/components/developer-docs-contract.ts
+++ b/components/developer-docs-contract.ts
@@ -1,7 +1,7 @@
 export const PROGRAMMABLE_DEVELOPER_ORIGIN =
   "https://developers.programmable.family";
 export const PROGRAMMABLE_DEVELOPER_REPOSITORY =
-  "https://github.com/0xprogrammable/developers";
+  "https://github.com/programmablehq/Developers";
 
 export const PROGRAMMABLE_PLATFORM_ID = "programmable";
 export const PROGRAMMABLE_ACTIVE_API_VERSION = "2";

--- a/components/docs-public-policy.ts
+++ b/components/docs-public-policy.ts
@@ -14,10 +14,10 @@ export type DocsProductState = Readonly<{
 }>;
 
 export const PROGRAMMABLE_PUBLIC_REPOSITORIES = {
-  developers: "https://github.com/0xprogrammable/Developers",
-  product: "https://github.com/0xprogrammable/PROGRAMMABLE",
-  productIssues: "https://github.com/0xprogrammable/PROGRAMMABLE/issues",
-  launchPolicy: "https://github.com/0xprogrammable/Launch-Policy",
+  developers: "https://github.com/programmablehq/Developers",
+  product: "https://github.com/programmablehq/PROGRAMMABLE-EVM",
+  productIssues: "https://github.com/programmablehq/PROGRAMMABLE-EVM/issues",
+  launchPolicy: "https://github.com/programmablehq/Launch-Policy",
 } as const;
 
 export const PROGRAMMABLE_PRODUCT_STATES = {

--- a/components/launch-stamp-docs-contract.ts
+++ b/components/launch-stamp-docs-contract.ts
@@ -13,17 +13,17 @@ export const PROGRAMMABLE_LAUNCH_STAMP_RESOURCES = {
   abiUrl:
     "https://developers.programmable.family/abis/ethereum/programmable-launch-stamp-router-v1.json",
   abiGithubUrl:
-    "https://raw.githubusercontent.com/0xprogrammable/developers/main/abis/ethereum/programmable-launch-stamp-router-v1.json",
+    "https://raw.githubusercontent.com/programmablehq/Developers/main/abis/ethereum/programmable-launch-stamp-router-v1.json",
   abiSha256:
     "sha256:bb4e728e9f9c850eb01f928e8a798ac206a82e241a8d93b3b3c686635c88ed86",
   referenceUrl:
-    "https://github.com/0xprogrammable/developers/blob/main/docs/reference/launch-stamp.md",
+    "https://github.com/programmablehq/Developers/blob/main/docs/reference/launch-stamp.md",
   terminalGuideUrl:
-    "https://github.com/0xprogrammable/developers/blob/main/docs/guides/terminals-and-scanners.md",
+    "https://github.com/programmablehq/Developers/blob/main/docs/guides/terminals-and-scanners.md",
   jsonRpcVerifierUrl:
-    "https://github.com/0xprogrammable/developers/blob/main/examples/verify-launch-stamp.mjs",
+    "https://github.com/programmablehq/Developers/blob/main/examples/verify-launch-stamp.mjs",
   viemVerifierUrl:
-    "https://github.com/0xprogrammable/developers/blob/main/examples/verify-launch-stamp-viem.ts",
+    "https://github.com/programmablehq/Developers/blob/main/examples/verify-launch-stamp-viem.ts",
 } as const;
 
 export const PROGRAMMABLE_LAUNCH_STAMP_ROUTER_V1_ABI = {
@@ -212,7 +212,7 @@ export const PROGRAMMABLE_LAUNCH_STAMP_MANIFEST = {
         classicOnchainCanary: false,
       },
       source: {
-        sourceRepository: "https://github.com/0xprogrammable/programmable",
+        sourceRepository: "https://github.com/programmablehq/PROGRAMMABLE-EVM",
         sourceCommit: "b3cfed41bb841ae8d6188dbb815eddb5e1440218",
         commitSubject: "Add graph launch stamp canary",
       },

--- a/lib/server/custom-launch/well-known-v1.ts
+++ b/lib/server/custom-launch/well-known-v1.ts
@@ -33,7 +33,7 @@ export function programmableWellKnownDocumentV1(
       "https://developers.programmable.family/openapi/programmable-v2.yaml",
     schemasBaseUrl: "https://developers.programmable.family/schemas/v2/",
     documentationUrl: "https://developers.programmable.family/",
-    sourceUrl: "https://github.com/0xprogrammable/developers",
+    sourceUrl: "https://github.com/programmablehq/Developers",
     customLaunchApi: Object.freeze({
       status: "live" as const,
       readStatus: "live" as const,
@@ -510,7 +510,7 @@ export function programmableWellKnownDocumentV1(
         status: "supported" as const,
         apiBaseUrl: "https://developers.programmable.family/api/v1",
         migrationGuideUrl:
-          "https://github.com/0xprogrammable/developers/blob/main/docs/migrations/v1-to-v2.md",
+          "https://github.com/programmablehq/Developers/blob/main/docs/migrations/v1-to-v2.md",
       }),
     }),
   });

--- a/tests/custom-launch-agent-remediation-contract.test.ts
+++ b/tests/custom-launch-agent-remediation-contract.test.ts
@@ -49,6 +49,13 @@ describe("Custom Launch cold-agent remediation contract", () => {
       PRELAUNCH_CUSTOM_REGISTRY_PUBLIC_MANIFEST_V1,
     );
 
+    expect(document.sourceUrl).toBe(
+      "https://github.com/programmablehq/Developers",
+    );
+    expect(document.extensions["programmable.legacy-v1"].migrationGuideUrl)
+      .toBe(
+        "https://github.com/programmablehq/Developers/blob/main/docs/migrations/v1-to-v2.md",
+      );
     expect(document.customLaunchApi.agentIntegration).toEqual({
       status: "live",
       schemaVersion:

--- a/tests/developer-docs-contract-parity.test.ts
+++ b/tests/developer-docs-contract-parity.test.ts
@@ -3,6 +3,8 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { PROGRAMMABLE_DEVELOPER_REPOSITORY } from
+  "../components/developer-docs-contract";
 import {
   LAUNCH_KIND_V1,
   PROGRAMMABLE_LAUNCH_STAMP_MANIFEST,
@@ -38,6 +40,12 @@ const routerReferenceSource = readFileSync(
 const router = PROGRAMMABLE_LAUNCH_STAMP_MANIFEST.launchStampRouter;
 
 describe("Router-first public developer-contract facts", () => {
+  it("publishes the transferred developer repository", () => {
+    expect(PROGRAMMABLE_DEVELOPER_REPOSITORY).toBe(
+      "https://github.com/programmablehq/Developers",
+    );
+  });
+
   it("locks the live Ethereum trust root", () => {
     expect(PROGRAMMABLE_LAUNCH_STAMP_MANIFEST.chainId).toBe(1);
     expect(router).toMatchObject({
@@ -70,17 +78,17 @@ describe("Router-first public developer-contract facts", () => {
       abiUrl:
         "https://developers.programmable.family/abis/ethereum/programmable-launch-stamp-router-v1.json",
       abiGithubUrl:
-        "https://raw.githubusercontent.com/0xprogrammable/developers/main/abis/ethereum/programmable-launch-stamp-router-v1.json",
+        "https://raw.githubusercontent.com/programmablehq/Developers/main/abis/ethereum/programmable-launch-stamp-router-v1.json",
       abiSha256:
         "sha256:bb4e728e9f9c850eb01f928e8a798ac206a82e241a8d93b3b3c686635c88ed86",
       referenceUrl:
-        "https://github.com/0xprogrammable/developers/blob/main/docs/reference/launch-stamp.md",
+        "https://github.com/programmablehq/Developers/blob/main/docs/reference/launch-stamp.md",
       terminalGuideUrl:
-        "https://github.com/0xprogrammable/developers/blob/main/docs/guides/terminals-and-scanners.md",
+        "https://github.com/programmablehq/Developers/blob/main/docs/guides/terminals-and-scanners.md",
       jsonRpcVerifierUrl:
-        "https://github.com/0xprogrammable/developers/blob/main/examples/verify-launch-stamp.mjs",
+        "https://github.com/programmablehq/Developers/blob/main/examples/verify-launch-stamp.mjs",
       viemVerifierUrl:
-        "https://github.com/0xprogrammable/developers/blob/main/examples/verify-launch-stamp-viem.ts",
+        "https://github.com/programmablehq/Developers/blob/main/examples/verify-launch-stamp-viem.ts",
     });
     for (const value of [
       PROGRAMMABLE_LAUNCH_STAMP_RESOURCES.discoveryUrl,

--- a/tests/docs-public-policy.test.ts
+++ b/tests/docs-public-policy.test.ts
@@ -4,6 +4,7 @@ import {
   formatBps,
   isProgrammableStatusCurrent,
   PROGRAMMABLE_FEE_TABLE,
+  PROGRAMMABLE_PUBLIC_REPOSITORIES,
   PROGRAMMABLE_PRODUCT_STATES,
   PROGRAMMABLE_REVENUE_CURRENT,
   PROGRAMMABLE_REVENUE_TARGET,
@@ -11,6 +12,16 @@ import {
 } from "../components/docs-public-policy";
 
 describe("Public documentation policy", () => {
+  it("publishes the transferred public repositories", () => {
+    expect(PROGRAMMABLE_PUBLIC_REPOSITORIES).toEqual({
+      developers: "https://github.com/programmablehq/Developers",
+      product: "https://github.com/programmablehq/PROGRAMMABLE-EVM",
+      productIssues:
+        "https://github.com/programmablehq/PROGRAMMABLE-EVM/issues",
+      launchPolicy: "https://github.com/programmablehq/Launch-Policy",
+    });
+  });
+
   it("keeps active and planned fee paths distinct", () => {
     expect(PROGRAMMABLE_FEE_TABLE.classic).toMatchObject({
       programmableBps: 10,

--- a/tests/launch-stamp-docs.test.ts
+++ b/tests/launch-stamp-docs.test.ts
@@ -127,7 +127,8 @@ describe("Launch Stamp developer documentation", () => {
             classicOnchainCanary: false,
           },
           source: {
-            sourceRepository: "https://github.com/0xprogrammable/programmable",
+            sourceRepository:
+              "https://github.com/programmablehq/PROGRAMMABLE-EVM",
             sourceCommit: "b3cfed41bb841ae8d6188dbb815eddb5e1440218",
             commitSubject: "Add graph launch stamp canary",
           },
@@ -230,17 +231,17 @@ describe("Launch Stamp developer documentation", () => {
       abiUrl:
         "https://developers.programmable.family/abis/ethereum/programmable-launch-stamp-router-v1.json",
       abiGithubUrl:
-        "https://raw.githubusercontent.com/0xprogrammable/developers/main/abis/ethereum/programmable-launch-stamp-router-v1.json",
+        "https://raw.githubusercontent.com/programmablehq/Developers/main/abis/ethereum/programmable-launch-stamp-router-v1.json",
       abiSha256:
         "sha256:bb4e728e9f9c850eb01f928e8a798ac206a82e241a8d93b3b3c686635c88ed86",
       referenceUrl:
-        "https://github.com/0xprogrammable/developers/blob/main/docs/reference/launch-stamp.md",
+        "https://github.com/programmablehq/Developers/blob/main/docs/reference/launch-stamp.md",
       terminalGuideUrl:
-        "https://github.com/0xprogrammable/developers/blob/main/docs/guides/terminals-and-scanners.md",
+        "https://github.com/programmablehq/Developers/blob/main/docs/guides/terminals-and-scanners.md",
       jsonRpcVerifierUrl:
-        "https://github.com/0xprogrammable/developers/blob/main/examples/verify-launch-stamp.mjs",
+        "https://github.com/programmablehq/Developers/blob/main/examples/verify-launch-stamp.mjs",
       viemVerifierUrl:
-        "https://github.com/0xprogrammable/developers/blob/main/examples/verify-launch-stamp-viem.ts",
+        "https://github.com/programmablehq/Developers/blob/main/examples/verify-launch-stamp-viem.ts",
     });
     expect(page).toContain("eth_getLogs filter");
     expect(page).toContain("eth_chainId == 0x1");
@@ -494,7 +495,7 @@ describe("Launch Stamp developer documentation", () => {
     expect(page).toContain('alternates: { canonical: "/docs/launch-stamps" }');
     expect(sitemap).toContain('"/docs/launch-stamps"');
     expect(developerDocsMarkdown).toContain(
-      "[GitHub Router reference](https://github.com/0xprogrammable/developers/blob/main/docs/reference/launch-stamp.md)",
+      "[GitHub Router reference](https://github.com/programmablehq/Developers/blob/main/docs/reference/launch-stamp.md)",
     );
     expect(developerDocsMarkdown).toContain(
       "Only launches executed and stamped through this Router inside its published block range",


### PR DESCRIPTION
## Summary

- point current public Developers, product, issues, Launch-Policy, and organization links at programmablehq
- preserve immutable published CLI release URLs and historical evidence locators
- lock the transferred repository targets in focused tests

## Checks

- Vitest: 4 files, 29 tests passed
- focused ESLint passed
- git diff --check passed
- eight new public targets returned HTTP 200