### PR TITLE
fix: publish ProgrammableHQ social identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Canonical repository
 
-- The public product repository is `https://github.com/0xprogrammable/programmable`.
+- The public product repository is `https://github.com/programmablehq/PROGRAMMABLE`.
 - `production` is the canonical full-product branch and the only branch used for website production releases.
 - `main` remains the public contracts and release-evidence branch. Never deploy the website from `main`.
 - Confirm the destination remote before every push. Do not assume that a remote named `origin` is canonical.

--- a/README.md
+++ b/README.md
@@ -185,5 +185,5 @@ The smart contracts in this repository have not undergone an external audit or p
   &nbsp;·&nbsp;
   <a href="https://github.com/programmablehq">GitHub</a>
   &nbsp;·&nbsp;
-  <a href="https://x.com/0xprogrammable">X</a>
+  <a href="https://x.com/ProgrammableHQ">X</a>
 </p>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -88,7 +88,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Programmable",
     description: siteDescription,
-    creator: "@0xprogrammable",
+    creator: "@ProgrammableHQ",
     images: [
       {
         url: socialImageUrl,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Programmable",
     description: pageDescription,
-    creator: "@0xprogrammable",
+    creator: "@ProgrammableHQ",
     images: [
       {
         url: pageSocialImage,

--- a/components/docs-public-policy.ts
+++ b/components/docs-public-policy.ts
@@ -15,8 +15,8 @@ export type DocsProductState = Readonly<{
 
 export const PROGRAMMABLE_PUBLIC_REPOSITORIES = {
   developers: "https://github.com/programmablehq/Developers",
-  product: "https://github.com/programmablehq/PROGRAMMABLE-EVM",
-  productIssues: "https://github.com/programmablehq/PROGRAMMABLE-EVM/issues",
+  product: "https://github.com/programmablehq/PROGRAMMABLE",
+  productIssues: "https://github.com/programmablehq/PROGRAMMABLE/issues",
   launchPolicy: "https://github.com/programmablehq/Launch-Policy",
 } as const;
 

--- a/components/explore-preview-data.ts
+++ b/components/explore-preview-data.ts
@@ -22,7 +22,7 @@ export type ExplorePreviewProject = {
 
 const PROJECT_LINKS = [
   { kind: "website" as const, url: "https://programmable.market" },
-  { kind: "x" as const, url: "https://x.com/0xProgrammable" },
+  { kind: "x" as const, url: "https://x.com/ProgrammableHQ" },
   { kind: "telegram" as const, url: "https://t.me/programmable" },
 ];
 

--- a/components/launch-stamp-docs-contract.ts
+++ b/components/launch-stamp-docs-contract.ts
@@ -212,7 +212,7 @@ export const PROGRAMMABLE_LAUNCH_STAMP_MANIFEST = {
         classicOnchainCanary: false,
       },
       source: {
-        sourceRepository: "https://github.com/programmablehq/PROGRAMMABLE-EVM",
+        sourceRepository: "https://github.com/programmablehq/PROGRAMMABLE",
         sourceCommit: "b3cfed41bb841ae8d6188dbb815eddb5e1440218",
         commitSubject: "Add graph launch stamp canary",
       },

--- a/components/prediction-market-v2-local-preview.tsx
+++ b/components/prediction-market-v2-local-preview.tsx
@@ -151,7 +151,7 @@ function rawCandidate(fixture: FixtureDefinition) {
     },
     links: {
       websites: [{ label: "Website", url: "https://programmable.market" }],
-      socials: [{ type: "twitter", url: "https://x.com/0xprogrammable" }],
+      socials: [{ type: "twitter", url: "https://x.com/ProgrammableHQ" }],
     },
   };
 }

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -36,7 +36,7 @@ const resourceLinks = [
     external: true,
   },
   {
-    href: "https://x.com/0xProgrammable",
+    href: "https://x.com/ProgrammableHQ",
     label: "X",
     external: true,
   },

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -55,7 +55,7 @@ function HeaderSocialLinks({ mobile = false }: { mobile?: boolean }) {
     >
       <a
         className="header-social-link"
-        href="https://x.com/0xProgrammable"
+        href="https://x.com/ProgrammableHQ"
         target="_blank"
         rel="noreferrer"
         aria-label="Programmable on X"

--- a/config/creator-article-programmable-example.v1.json
+++ b/config/creator-article-programmable-example.v1.json
@@ -32,7 +32,7 @@
           {
             "type": "text",
             "text": "X",
-            "marks": [{ "type": "link", "attrs": { "href": "https://x.com/0xProgrammable" } }]
+            "marks": [{ "type": "link", "attrs": { "href": "https://x.com/ProgrammableHQ" } }]
           },
           { "type": "text", "text": "   " },
           {

--- a/docs/public/reference/official-links.md
+++ b/docs/public/reference/official-links.md
@@ -21,7 +21,7 @@ description: Official Programmable product, source, community and analytics link
 | Custom Launch CLI 1.0.1 | [V1 compatibility asset](https://github.com/0xprogrammable/PROGRAMMABLE/releases/download/programmable-launch-v1.0.1/programmable-launch-1.0.1.tgz) |
 | Launch policy           | [github.com/programmablehq/Launch-Policy](https://github.com/programmablehq/Launch-Policy)                         |
 | Read-only developer API | [developers.programmable.family](https://developers.programmable.family)                                           |
-| X                       | [x.com/0xProgrammable](https://x.com/0xProgrammable)                                                               |
+| X                       | [x.com/ProgrammableHQ](https://x.com/ProgrammableHQ)                                                               |
 | Discord                 | [discord.com/invite/programmable](https://discord.com/invite/programmable)                                         |
 | Dune                    | [Programmable analytics](https://dune.com/0xprogrammable6098/programmable-analytics)                               |
 | V4 token                | [Dexscreener](https://dexscreener.com/ethereum/0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0) |

--- a/lib/site-structured-data.ts
+++ b/lib/site-structured-data.ts
@@ -16,7 +16,7 @@ export const programmableSiteStructuredData = {
         url: `${SITE_ORIGIN}/apple-touch-icon.png`,
       },
       sameAs: [
-        "https://x.com/0xProgrammable",
+        "https://x.com/ProgrammableHQ",
         "https://github.com/programmablehq",
         "https://discord.com/invite/programmable",
       ],

--- a/lib/token-detail-metadata.ts
+++ b/lib/token-detail-metadata.ts
@@ -201,7 +201,7 @@ export function genericTokenDetailMetadata(
       card: "summary_large_image",
       title: "Programmable",
       description: SITE_DESCRIPTION,
-      creator: "@0xprogrammable",
+      creator: "@ProgrammableHQ",
       images: [{ url: FALLBACK_SOCIAL_IMAGE, alt: FALLBACK_SOCIAL_ALT }],
     },
   };
@@ -249,7 +249,7 @@ export function tokenDetailMetadataFromProjection(
       card: "summary_large_image",
       title,
       description: projected.description,
-      creator: "@0xprogrammable",
+      creator: "@ProgrammableHQ",
       images: [{ url: projected.imageUrl, alt: imageAlt }],
     },
   };

--- a/scripts/production-verify-proof.mjs
+++ b/scripts/production-verify-proof.mjs
@@ -11,7 +11,7 @@ import { pathToFileURL } from "node:url";
 export const PRODUCTION_VERIFY_PROOF_SCHEMA_VERSION =
   "programmable.production-verify-proof.v4";
 export const PRODUCTION_VERIFY_PROOF_MAX_AGE_MS = 6 * 60 * 60 * 1_000;
-export const PRODUCTION_REPOSITORY = "programmablehq/programmable-evm";
+export const PRODUCTION_REPOSITORY = "programmablehq/programmable";
 export const PRODUCTION_REPOSITORY_ID = 1_314_365_508;
 export const PRODUCTION_REF = "refs/heads/production";
 export const VERIFY_WORKFLOW_PATH = ".github/workflows/verify.yml";

--- a/scripts/programmable-launch-release-assets.mjs
+++ b/scripts/programmable-launch-release-assets.mjs
@@ -11,7 +11,7 @@ import { pathToFileURL } from "node:url";
 
 export const RELEASE_ASSET_SCHEMA =
   "programmable.launch-cli-release-assets.v1";
-export const RELEASE_REPOSITORY = "programmablehq/programmable-evm";
+export const RELEASE_REPOSITORY = "programmablehq/programmable";
 export const RELEASE_NODE_VERSION = "24.14.0";
 export const RELEASE_NPM_VERSION = "11.16.0";
 

--- a/scripts/test/custom-launch-v2-release-gate.test.mjs
+++ b/scripts/test/custom-launch-v2-release-gate.test.mjs
@@ -499,7 +499,7 @@ test("backend binding preserves historical revision 2 profile evidence", async (
     BACKEND_REPOSITORY,
     "programmablehq/programmable-open-hook-v2-internal",
   );
-  assert.equal(WEBSITE_REPOSITORY, "programmablehq/programmable-evm");
+  assert.equal(WEBSITE_REPOSITORY, "programmablehq/programmable");
 });
 
 test("Fly readback accepts the real tag-only release ref and exact machine digest", () => {

--- a/scripts/test/production-verify-proof.test.mjs
+++ b/scripts/test/production-verify-proof.test.mjs
@@ -31,7 +31,7 @@ const ARTIFACT_DIGEST =
 const RUN_ID = 31_519_898_545;
 const RUN_ATTEMPT = 1;
 const WORKFLOW_ID = 321_772_273;
-const REPOSITORY_URL = "https://github.com/programmablehq/programmable-evm";
+const REPOSITORY_URL = "https://github.com/programmablehq/programmable";
 const NOW_MS = Date.parse("2026-08-11T18:10:00Z");
 
 test("pins the immutable production repository identity", () => {
@@ -261,24 +261,24 @@ test("full production Verify proof is deterministic and exact", () => {
 
 test("GitHub display-case drift preserves the canonical production identity", () => {
   assert.equal(
-    canonicalProductionRepository("programmablehq/PROGRAMMABLE-EVM"),
+    canonicalProductionRepository("programmablehq/PROGRAMMABLE"),
     PRODUCTION_REPOSITORY,
   );
   assert.equal(
     canonicalProductionWorkflowRef(
-      "programmablehq/PROGRAMMABLE-EVM/.github/workflows/verify.yml@refs/heads/production",
+      "programmablehq/PROGRAMMABLE/.github/workflows/verify.yml@refs/heads/production",
     ),
     `${PRODUCTION_REPOSITORY}/${VERIFY_WORKFLOW_PATH}@${PRODUCTION_REF}`,
   );
   assert.throws(() =>
-    canonicalProductionRepository("attacker/PROGRAMMABLE-EVM"));
+    canonicalProductionRepository("attacker/PROGRAMMABLE"));
   assert.throws(() =>
-    canonicalProductionRepository("programmable-infra/PROGRAMMABLE-EVM"));
+    canonicalProductionRepository("programmable-infra/PROGRAMMABLE"));
   assert.throws(() =>
-    canonicalProductionRepository("programmablehq/PROGRAMMABLE-EVM "));
+    canonicalProductionRepository("programmablehq/PROGRAMMABLE "));
   assert.throws(() =>
     canonicalProductionWorkflowRef(
-      "programmablehq/PROGRAMMABLE-EVM/.github/workflows/verify.yml@refs/heads/main",
+      "programmablehq/PROGRAMMABLE/.github/workflows/verify.yml@refs/heads/main",
     ));
 });
 
@@ -420,9 +420,9 @@ test("resolver accepts only a fresh exact successful run and immutable artifact"
 test("resolver accepts GitHub repository display-case drift with the exact ID", async () => {
   const fixtures = validApiFixtures();
   const run = fixtures.runs.workflow_runs[0];
-  run.repository.full_name = "programmablehq/PROGRAMMABLE-EVM";
-  run.repository.html_url = "https://github.com/programmablehq/PROGRAMMABLE-EVM";
-  run.head_repository.full_name = "programmablehq/PROGRAMMABLE-EVM";
+  run.repository.full_name = "programmablehq/PROGRAMMABLE";
+  run.repository.html_url = "https://github.com/programmablehq/PROGRAMMABLE";
+  run.head_repository.full_name = "programmablehq/PROGRAMMABLE";
   run.html_url = `${run.repository.html_url}/actions/runs/${RUN_ID}`;
   assert.equal((await resolveFixtures(fixtures)).runId, RUN_ID);
 });

--- a/scripts/test/programmable-launch-release-assets.test.mjs
+++ b/scripts/test/programmable-launch-release-assets.test.mjs
@@ -58,7 +58,7 @@ test("release manifest binds source, exact toolchain, and all payload bytes", ()
   });
   assert.equal(manifest.schemaVersion, RELEASE_ASSET_SCHEMA);
   assert.equal(manifest.repository, RELEASE_REPOSITORY);
-  assert.equal(manifest.repository, "programmablehq/programmable-evm");
+  assert.equal(manifest.repository, "programmablehq/programmable");
   assert.equal(manifest.source.commitSha, COMMIT);
   assert.equal(manifest.source.treeSha, TREE);
   assert.equal(manifest.toolchain.node, "24.14.0");

--- a/scripts/verify-custom-launch-api-release-binding-v1.mjs
+++ b/scripts/verify-custom-launch-api-release-binding-v1.mjs
@@ -6,7 +6,7 @@ import Ajv2020 from "ajv/dist/2020.js";
 export const BACKEND_REPOSITORY =
   "programmablehq/programmable-open-hook-v2-internal";
 export const BACKEND_REPOSITORY_ID = 1_318_883_798;
-export const WEBSITE_REPOSITORY = "programmablehq/programmable-evm";
+export const WEBSITE_REPOSITORY = "programmablehq/programmable";
 export const WEBSITE_REPOSITORY_ID = 1_314_365_508;
 export const BINDING_PATH =
   "services/custom-launch-api-v1/release/public-v3-release-binding-v1.json";

--- a/tests/agent-readiness.test.ts
+++ b/tests/agent-readiness.test.ts
@@ -432,6 +432,7 @@ describe("agent-readable public surface", () => {
     ]);
     const serialized = serializeStructuredData(programmableSiteStructuredData);
     expect(serialized).toContain('"@context":"https://schema.org"');
+    expect(serialized).toContain("https://x.com/ProgrammableHQ");
     expect(serialized).not.toContain('"address"');
     expect(serialized).not.toContain('"contactPoint"');
     expect(serialized).not.toContain('"offers"');

--- a/tests/docs-public-policy.test.ts
+++ b/tests/docs-public-policy.test.ts
@@ -15,9 +15,9 @@ describe("Public documentation policy", () => {
   it("publishes the transferred public repositories", () => {
     expect(PROGRAMMABLE_PUBLIC_REPOSITORIES).toEqual({
       developers: "https://github.com/programmablehq/Developers",
-      product: "https://github.com/programmablehq/PROGRAMMABLE-EVM",
+      product: "https://github.com/programmablehq/PROGRAMMABLE",
       productIssues:
-        "https://github.com/programmablehq/PROGRAMMABLE-EVM/issues",
+        "https://github.com/programmablehq/PROGRAMMABLE/issues",
       launchPolicy: "https://github.com/programmablehq/Launch-Policy",
     });
   });

--- a/tests/explore-interface-preview.test.ts
+++ b/tests/explore-interface-preview.test.ts
@@ -33,6 +33,10 @@ describe("Explore interface preview", () => {
     for (const token of EXPLORE_PREVIEW_TOKENS) {
       expect(token.imageUrl).toMatch(/^\/brand\/.+\.(?:avif|webp)$/);
       expect(token.links).toHaveLength(3);
+      expect(token.links).toContainEqual({
+        kind: "x",
+        url: "https://x.com/ProgrammableHQ",
+      });
       expect(getExplorePreviewProject(token.tokenAddress)).toMatchObject({
         contributors: expect.any(Number),
         communityMembers: expect.any(Number),

--- a/tests/launch-stamp-docs.test.ts
+++ b/tests/launch-stamp-docs.test.ts
@@ -128,7 +128,7 @@ describe("Launch Stamp developer documentation", () => {
           },
           source: {
             sourceRepository:
-              "https://github.com/programmablehq/PROGRAMMABLE-EVM",
+              "https://github.com/programmablehq/PROGRAMMABLE",
             sourceCommit: "b3cfed41bb841ae8d6188dbb815eddb5e1440218",
             commitSubject: "Add graph launch stamp canary",
           },

--- a/tests/programmable-creator-article-example.test.ts
+++ b/tests/programmable-creator-article-example.test.ts
@@ -12,6 +12,7 @@ describe("Programmable Main-token creator article example", () => {
     expect(draft.bannerImage).toMatchObject({ width: 1500, height: 500, size: "wide" });
     expect(draft.document.content.some((block) => block.type === "articleImage")).toBe(false);
     expect(JSON.stringify(draft)).toContain("https://programmable.market/docs");
+    expect(JSON.stringify(draft)).toContain("https://x.com/ProgrammableHQ");
     expect(JSON.stringify(draft)).toContain("https://dune.com/0xprogrammable6098/programmable-analytics");
     expect(JSON.stringify(draft)).not.toMatch(/unruggable|guaranteed|partnered/iu);
   });

--- a/tests/shell-polish.test.ts
+++ b/tests/shell-polish.test.ts
@@ -25,19 +25,55 @@ describe("public shell polish", () => {
     expect(source).not.toContain('href: "https://github.com/0xprogrammable"');
     expect(source).toContain('label: "Discord"');
     expect(source).toContain('label: "X"');
+    expect(source).toContain('href: "https://x.com/ProgrammableHQ"');
     expect(source).toContain('label: "Token"');
     expect(source).not.toContain("XBrandIcon");
     expect(source).not.toContain("GitHubBrandIcon");
   });
 
-  it("links the public shell and structured identity to the canonical GitHub organization", () => {
+  it("links the public shell and structured identity to the canonical public accounts", () => {
     const navigation = read("components/site-navigation.tsx");
     const structuredData = read("lib/site-structured-data.ts");
+    const rootLayout = read("app/layout.tsx");
+    const homePage = read("app/page.tsx");
+    const officialLinks = read("docs/public/reference/official-links.md");
+    const readme = read("README.md");
 
     expect(navigation).toContain('href="https://github.com/programmablehq"');
+    expect(navigation).toContain('href="https://x.com/ProgrammableHQ"');
     expect(navigation).not.toContain('href="https://github.com/0xprogrammable"');
     expect(structuredData).toContain('"https://github.com/programmablehq"');
+    expect(structuredData).toContain('"https://x.com/ProgrammableHQ"');
     expect(structuredData).not.toContain('"https://github.com/0xprogrammable"');
+    expect(rootLayout).toContain('creator: "@ProgrammableHQ"');
+    expect(homePage).toContain('creator: "@ProgrammableHQ"');
+    expect(officialLinks).toContain(
+      "[x.com/ProgrammableHQ](https://x.com/ProgrammableHQ)",
+    );
+    expect(readme).toContain('href="https://x.com/ProgrammableHQ"');
+  });
+
+  it("keeps the retired X identity out of current public sources", () => {
+    const retiredXProfile = ["https://x.com/", "0x", "programmable"].join("");
+    const retiredCreator = ["@", "0x", "programmable"].join("");
+    const currentPublicSources = [
+      "README.md",
+      "app/layout.tsx",
+      "app/page.tsx",
+      "components/explore-preview-data.ts",
+      "components/prediction-market-v2-local-preview.tsx",
+      "components/site-footer.tsx",
+      "components/site-navigation.tsx",
+      "config/creator-article-programmable-example.v1.json",
+      "docs/public/reference/official-links.md",
+      "lib/site-structured-data.ts",
+      "lib/token-detail-metadata.ts",
+    ].map((path) => read(path).toLowerCase());
+
+    for (const source of currentPublicSources) {
+      expect(source).not.toContain(retiredXProfile);
+      expect(source).not.toContain(retiredCreator);
+    }
   });
 
   it("keeps route motion measured, interruptible and compositor-friendly", () => {

--- a/tests/site-footer.test.ts
+++ b/tests/site-footer.test.ts
@@ -29,6 +29,13 @@ describe("Site footer", () => {
     expect(footerSource).toContain('label: "Discord"');
   });
 
+  it("links the official X account from Resources", () => {
+    expect(footerSource).toContain(
+      'href: "https://x.com/ProgrammableHQ"',
+    );
+    expect(footerSource).toContain('label: "X"');
+  });
+
   it("places the Dune dashboard between Dexscreener and Discord", () => {
     const dexscreener = footerSource.indexOf("https://dexscreener.com/");
     const dune = footerSource.indexOf(

--- a/tests/token-detail-metadata.test.ts
+++ b/tests/token-detail-metadata.test.ts
@@ -52,6 +52,7 @@ describe("token detail metadata", () => {
     });
     expect(metadata.twitter).toMatchObject({
       card: "summary_large_image",
+      creator: "@ProgrammableHQ",
       title: "Shard ($SHARD) | Programmable",
       images: [{
         url: "https://programmable.market/brand/projects/shard-token-v1.png",

--- a/tests/topbar-hero-polish.test.ts
+++ b/tests/topbar-hero-polish.test.ts
@@ -52,6 +52,7 @@ describe("topbar and Explore hero polish", () => {
       'src="/brand/platforms/dexscreener-mark-warm-ivory-v1.png"',
     );
     expect(navigation).toContain('aria-label="Programmable on X"');
+    expect(navigation).toContain('href="https://x.com/ProgrammableHQ"');
     expect(navigation).toContain('aria-label="Programmable on GitHub"');
     expect(navigation).toContain('aria-label="Programmable on Discord"');
     expect(navigation).toContain('aria-label="Programmable on Dexscreener"');


### PR DESCRIPTION
## Summary

- update the official X identity to `ProgrammableHQ` across the live shell, metadata, structured data, examples and public docs
- bind current production tooling and documentation to the renamed `programmablehq/PROGRAMMABLE` repository
- preserve historical release and evidence locators

## Focused checks

- Vitest: 9 files, 57 tests passed
- Node test: 30 tests passed
- ESLint on every changed executable and test file passed
- `git diff --check` passed