### PR TITLE
Keep Explore identities during cold reads

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -12,11 +12,16 @@ import {
   envioClassicV3IdentityCommitmentV1,
   mergeEnvioClassicV3CatalogEntriesV1,
   readEnvioClassicV3CatalogV1,
+  type EnvioClassicV3CatalogV1,
 } from
   "../../../lib/market-data/envio-classic-v3-catalog.server";
 import {
+  lastGoodLaunchIdentityCommitmentV1,
+  readLastGoodLaunchCatalogV1,
+  type LastGoodLaunchCatalogV1,
+} from "../../../lib/market-data/last-good-launch-catalog.server";
+import {
   mergeRouterCustomExploreEntriesV1,
-  publicLaunchSourceV1,
   readFinalizedRouterCustomIdentitySnapshotV1,
   ROUTER_CUSTOM_FINALITY_CONFIRMATIONS,
   ROUTER_CUSTOM_LAUNCH_SOURCE,
@@ -48,6 +53,37 @@ const CLASSIC_EXCLUSIONS = Object.freeze([
   "stock-paired-v2",
   "stock-paired-v3",
 ] as const);
+
+type BoundDurableLaunchCatalogV1 = LastGoodLaunchCatalogV1 & Readonly<{
+  asOfBlock: string;
+  asOfBlockHash: `0x${string}`;
+}>;
+
+type ExploreCanonicalCatalogV1 =
+  | EnvioClassicV3CatalogV1
+  | BoundDurableLaunchCatalogV1;
+
+function boundDurableLaunchCatalogV1(
+  catalog: LastGoodLaunchCatalogV1,
+): BoundDurableLaunchCatalogV1 | null {
+  return catalog.asOfBlock !== null && catalog.asOfBlockHash !== null
+    ? catalog as BoundDurableLaunchCatalogV1
+    : null;
+}
+
+function exploreLaunchSourceV1(input: Readonly<{
+  catalog: ExploreCanonicalCatalogV1 | null;
+  registryCustomCurrent: boolean;
+  routerCustomAvailable: boolean;
+}>) {
+  return [
+    ...(input.catalog === null ? [] : [input.catalog.source]),
+    ...(input.registryCustomCurrent ? ["registry.custom-launched"] : []),
+    ...(input.routerCustomAvailable
+      ? [ROUTER_CUSTOM_LAUNCH_SOURCE]
+      : []),
+  ].join("+");
+}
 
 const EXPLORE_QUERY_PARAMETERS = new Set([
   "limit",
@@ -319,18 +355,26 @@ export async function GET(request: NextRequest) {
       socials,
       model,
     } as const;
-    const catalogRead = readEnvioClassicV3CatalogV1({
+    const durableCatalogRead = readLastGoodLaunchCatalogV1({
       signal: readSignal,
       deadlineMs,
     }).then(
-      (catalog) => catalog,
-      () => {
-        console.error("Explore Envio identity read unavailable", {
-          name: "EnvioClassicV3ReadError",
-        });
-        return null;
-      },
+      boundDurableLaunchCatalogV1,
+      () => null,
     );
+    const catalogRead: Promise<ExploreCanonicalCatalogV1 | null> =
+      readEnvioClassicV3CatalogV1({
+        signal: readSignal,
+        deadlineMs,
+      }).then(
+        (catalog) => catalog,
+        async () => {
+          console.error("Explore Envio identity read unavailable", {
+            name: "EnvioClassicV3ReadError",
+          });
+          return await durableCatalogRead;
+        },
+      );
     const registryRead = isCustomLaunchRegistryPublicReadEnabled()
       ? readProductionCustomExploreDirectoryV1(readSignal).then(
           (entries) => ({ entries, status: "current" as const }),
@@ -447,7 +491,15 @@ export async function GET(request: NextRequest) {
           asOfBlock: identityAsOfBlock,
           entries: publicIdentityEntries,
         })
-      : envioClassicV3IdentityCommitmentV1(catalog, publicIdentityEntries);
+      : catalog.source === "envio-classic-v3"
+        ? envioClassicV3IdentityCommitmentV1(
+            catalog,
+            publicIdentityEntries,
+          )
+        : lastGoodLaunchIdentityCommitmentV1(
+            catalog,
+            publicIdentityEntries,
+          );
     const customStatus =
       registryCustomStatus === "current" && routerCustomStatus === "current"
         ? "current" as const
@@ -455,10 +507,10 @@ export async function GET(request: NextRequest) {
             routerCustomStatus === "last-known-good"
           ? "last-known-good" as const
         : "unavailable" as const;
-    const launchSource = publicLaunchSourceV1({
-      envioAvailable: catalog !== null,
+    const launchSource = exploreLaunchSourceV1({
+      catalog,
       registryCustomCurrent: registryCustomStatus === "current",
-      routerCustomCurrent: routerAvailable,
+      routerCustomAvailable: routerAvailable,
     });
     const projectedRouterIdentityCount = publicIdentityEntries.filter(
       (entry) => entry.exploreKind === "token" &&
@@ -466,11 +518,13 @@ export async function GET(request: NextRequest) {
     ).length;
     const catalogStatus = catalog?.status ?? "last-known-good" as const;
     const canonicalStatus = catalog?.status ?? "unavailable" as const;
-    const catalogScope = catalog?.scope ?? {
-      included: [] as readonly string[],
-      excluded: CLASSIC_EXCLUSIONS,
-      publicCategories: ["classic", "custom"] as const,
-    };
+    const catalogScope = catalog?.source === "envio-classic-v3"
+      ? catalog.scope
+      : {
+          included: [] as readonly string[],
+          excluded: CLASSIC_EXCLUSIONS,
+          publicCategories: ["classic", "custom"] as const,
+        };
     const includedSources = new Set<string>(catalogScope.included);
     if (registryCustomStatus === "current") {
       includedSources.add("registry.custom-launched");
@@ -549,7 +603,7 @@ export async function GET(request: NextRequest) {
         snapshot: null,
         marketRead,
         catalog: {
-          source: "envio-classic-v3" as const,
+          source: catalog?.source ?? ("envio-classic-v3" as const),
           launchSource,
           status: catalogStatus,
           lastIndexedAt: identityGeneratedAt,
@@ -567,11 +621,15 @@ export async function GET(request: NextRequest) {
             registryCustom: registryCustomStatus,
             routerCustom: routerCustomStatus,
           },
-          scope: {
-            ...catalogScope,
-            included: [...includedSources],
-          },
-          ...(catalog ? { evidence: catalog.evidence } : {}),
+          ...(catalog?.source === "durable-blob"
+            ? { evidence: catalog.evidence }
+            : {
+                scope: {
+                  ...catalogScope,
+                  included: [...includedSources],
+                },
+                ...(catalog ? { evidence: catalog.evidence } : {}),
+              }),
           routerStamp: {
             source: ROUTER_CUSTOM_LAUNCH_SOURCE,
             status: routerCustomStatus,

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -167,8 +167,12 @@ type ExploreRanking = Readonly<{
 }>;
 
 type ExploreCatalogBoundary = Readonly<{
-  source: "envio-classic-v3";
+  source: "envio-classic-v3" | "durable-blob";
   launchSource:
+    | "durable-blob"
+    | "durable-blob+registry.custom-launched"
+    | "durable-blob+canonical-launch-stamp-router"
+    | "durable-blob+registry.custom-launched+canonical-launch-stamp-router"
     | "registry.custom-launched"
     | "canonical-launch-stamp-router"
     | "registry.custom-launched+canonical-launch-stamp-router"
@@ -184,12 +188,12 @@ type ExploreCatalogBoundary = Readonly<{
   identityCommitment: `sha256:${string}`;
   completeness: Readonly<{
     classic: "current" | "last-known-good" | "unavailable";
-    stock: "excluded";
+    stock: "current" | "last-known-good" | "unavailable" | "excluded";
     custom: "current" | "last-known-good" | "unavailable";
     registryCustom?: "current" | "unavailable";
     routerCustom?: "current" | "last-known-good" | "unavailable";
   }>;
-  scope: Readonly<{
+  scope?: Readonly<{
     included: readonly (
       | "classic-v3"
       | "classic-v4"
@@ -213,6 +217,9 @@ type ExploreCatalogBoundary = Readonly<{
     progressBlock: string;
     progressOccurrenceId: string;
     commitment: `sha256:${string}`;
+  }> | Readonly<{
+    kind: "durable-envelope";
+    commitment: `0x${string}`;
   }>;
   routerStamp?: Readonly<{
     source: "canonical-launch-stamp-router";
@@ -1180,14 +1187,33 @@ function exactStringArray(value: unknown, expected: readonly string[]) {
 }
 
 function parseExploreCatalog(value: unknown): ExploreCatalogBoundary | null {
-  if (!isRecord(value) || !isRecord(value.completeness) ||
-    !isRecord(value.scope)) return null;
-  const envioEvidence = value.evidence === undefined
+  if (!isRecord(value) || !isRecord(value.completeness)) return null;
+  const evidence = value.evidence === undefined
     ? null
     : isRecord(value.evidence)
       ? value.evidence
       : null;
-  if (value.evidence !== undefined && envioEvidence === null) return null;
+  const scope = value.scope === undefined
+    ? null
+    : isRecord(value.scope)
+      ? value.scope
+      : null;
+  if (
+    (value.evidence !== undefined && evidence === null) ||
+    (value.scope !== undefined && scope === null)
+  ) return null;
+  const envioEvidence = evidence?.kind === "envio-indexer-state"
+    ? evidence
+    : null;
+  const durableEvidence = evidence?.kind === "durable-envelope"
+    ? evidence
+    : null;
+  if (evidence !== null && envioEvidence === null && durableEvidence === null) {
+    return null;
+  }
+  const durableSource = value.source === "durable-blob";
+  const envioSource = value.source === "envio-classic-v3";
+  if (!durableSource && !envioSource) return null;
   const hasSplitCustomStatus =
     value.completeness.registryCustom !== undefined ||
     value.completeness.routerCustom !== undefined;
@@ -1214,7 +1240,11 @@ function parseExploreCatalog(value: unknown): ExploreCatalogBoundary | null {
     CLASSIC_V4_PUBLIC_RELEASE_BINDING,
   );
   const expectedLaunchSource = [
-    ...(envioEvidence ? ["envio-classic-v3"] : []),
+    ...(durableSource
+      ? ["durable-blob"]
+      : envioEvidence
+        ? ["envio-classic-v3"]
+        : []),
     ...(registryCustomStatus === "current"
       ? ["registry.custom-launched"]
       : []),
@@ -1263,7 +1293,6 @@ function parseExploreCatalog(value: unknown): ExploreCatalogBoundary | null {
   ) return null;
   if (!hasSplitCustomStatus && routerStamp !== undefined) return null;
   if (
-    value.source !== "envio-classic-v3" ||
     value.launchSource !== expectedLaunchSource ||
     !["current", "last-known-good"].includes(String(value.status)) ||
     !exactIsoTimestamp(value.lastIndexedAt) ||
@@ -1278,7 +1307,11 @@ function parseExploreCatalog(value: unknown): ExploreCatalogBoundary | null {
     !["current", "last-known-good", "unavailable"].includes(
       String(value.completeness.classic),
     ) ||
-    value.completeness.stock !== "excluded" ||
+    (durableSource
+      ? !["current", "last-known-good", "unavailable"].includes(
+          String(value.completeness.stock),
+        )
+      : value.completeness.stock !== "excluded") ||
     !["current", "last-known-good", "unavailable"].includes(
       String(value.completeness.custom),
     ) ||
@@ -1290,20 +1323,30 @@ function parseExploreCatalog(value: unknown): ExploreCatalogBoundary | null {
               routerCustomStatus === "last-known-good"
             ? "last-known-good"
           : "unavailable")) ||
-    !exactStringArray(value.scope.included, expectedIncluded) ||
-    !exactStringArray(value.scope.excluded, [
-      "classic-v1",
-      "classic-v2",
-      "stock-paired-v1",
-      "stock-paired-v2",
-      "stock-paired-v3",
-    ]) ||
-    !exactStringArray(value.scope.publicCategories, ["classic", "custom"]) ||
-    (envioEvidence === null && (
+    (durableSource
+      ? scope !== null
+      : scope === null ||
+        !exactStringArray(scope.included, expectedIncluded) ||
+        !exactStringArray(scope.excluded, [
+          "classic-v1",
+          "classic-v2",
+          "stock-paired-v1",
+          "stock-paired-v2",
+          "stock-paired-v3",
+        ]) ||
+        !exactStringArray(scope.publicCategories, ["classic", "custom"])) ||
+    (durableSource && (
+      envioEvidence !== null ||
+      durableEvidence === null ||
+      typeof durableEvidence.commitment !== "string" ||
+      !/^0x[0-9a-f]{64}$/u.test(durableEvidence.commitment)
+    )) ||
+    (envioSource && durableEvidence !== null) ||
+    (envioSource && envioEvidence === null && (
       value.status !== "last-known-good" ||
       value.completeness.classic !== "unavailable"
     )) ||
-    (envioEvidence !== null && (
+    (envioSource && envioEvidence !== null && (
       envioEvidence.kind !== "envio-indexer-state" ||
       typeof envioEvidence.deployment !== "string" ||
       !/^[a-z0-9][a-z0-9-]{0,127}$/u.test(envioEvidence.deployment) ||
@@ -1334,6 +1377,12 @@ function exploreCatalogBoundaryKey(value: ExploreCatalogBoundary) {
         status: value.routerStamp.status,
         finalityConfirmations: value.routerStamp.finalityConfirmations,
       };
+  const envioEvidence = value.evidence?.kind === "envio-indexer-state"
+    ? value.evidence
+    : null;
+  const durableEvidence = value.evidence?.kind === "durable-envelope"
+    ? value.evidence
+    : null;
   return JSON.stringify({
     source: value.source,
     launchSource: value.launchSource,
@@ -1343,8 +1392,9 @@ function exploreCatalogBoundaryKey(value: ExploreCatalogBoundary) {
     completeness: value.completeness,
     scope: value.scope,
     routerStamp: routerStampBoundary,
-    deployment: value.evidence?.deployment ?? null,
-    sourceCommit: value.evidence?.sourceCommit ?? null,
+    deployment: envioEvidence?.deployment ?? null,
+    sourceCommit: envioEvidence?.sourceCommit ?? null,
+    durableCommitment: durableEvidence?.commitment ?? null,
   });
 }
 

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -12,8 +12,10 @@ import type { ExploreEntry, LauncherToken } from "../lib/tokens";
 
 const mocks = vi.hoisted(() => ({
   readCatalog: vi.fn(),
+  readLastGoodCatalog: vi.fn(),
   readDex: vi.fn(),
   identityCommitment: vi.fn(() => `sha256:${"ef".repeat(32)}`),
+  lastGoodIdentityCommitment: vi.fn(() => `sha256:${"de".repeat(32)}`),
   mergeEntries: vi.fn((canonical: readonly unknown[], custom: readonly unknown[]) => [
     ...canonical,
     ...custom,
@@ -28,6 +30,10 @@ vi.mock("../lib/market-data/envio-classic-v3-catalog.server", () => ({
   readEnvioClassicV3CatalogV1: mocks.readCatalog,
   envioClassicV3IdentityCommitmentV1: mocks.identityCommitment,
   mergeEnvioClassicV3CatalogEntriesV1: mocks.mergeEntries,
+}));
+vi.mock("../lib/market-data/last-good-launch-catalog.server", () => ({
+  readLastGoodLaunchCatalogV1: mocks.readLastGoodCatalog,
+  lastGoodLaunchIdentityCommitmentV1: mocks.lastGoodIdentityCommitment,
 }));
 vi.mock("../lib/market-data/dexscreener-explore.server", () => ({
   readDexscreenerExploreEntriesV1: mocks.readDex,
@@ -174,6 +180,27 @@ function catalog(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function durableCatalog(overrides: Record<string, unknown> = {}) {
+  return {
+    source: "durable-blob",
+    status: "last-known-good",
+    generatedAt: NOW,
+    asOfBlock: "25740000",
+    asOfBlockHash: `0x${"ab".repeat(32)}`,
+    entries,
+    completeness: {
+      classic: "last-known-good",
+      stock: "last-known-good",
+      custom: "unavailable",
+    },
+    evidence: {
+      kind: "durable-envelope",
+      commitment: `0x${"cd".repeat(32)}`,
+    },
+    ...overrides,
+  };
+}
+
 function marketRead(input: Readonly<{
   requested: number;
   qualified: number;
@@ -240,6 +267,9 @@ describe("Explore static identity and Dexscreener market contract", () => {
     vi.clearAllMocks();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     mocks.readCatalog.mockResolvedValue(catalog());
+    mocks.readLastGoodCatalog.mockRejectedValue(
+      new Error("durable fallback unavailable"),
+    );
     mocks.customEnabled.mockReturnValue(false);
     mocks.readCustom.mockResolvedValue([]);
     mocks.readRouter.mockResolvedValue([]);
@@ -465,6 +495,39 @@ describe("Explore static identity and Dexscreener market contract", () => {
     expect(body.dataQuality.launchIdentity.canonical).toBe("unavailable");
     expect(response.headers.get("x-programmable-canonical-read-status")).toBe(
       "unavailable",
+    );
+  });
+
+  it("uses the durable catalog when a cold Envio read is unavailable", async () => {
+    mocks.readCatalog.mockRejectedValue(new Error("Envio unavailable"));
+    mocks.readLastGoodCatalog.mockResolvedValue(durableCatalog());
+    mocks.readRouter.mockResolvedValue([customGraphExploreEntry]);
+
+    const response = await GET(request("sort=newest&page=1&limit=100"));
+    const body = await json(response);
+
+    expect(response.status).toBe(200);
+    expect(body.total).toBe(TOKEN_COUNT + 1);
+    expect(body.catalog).toMatchObject({
+      source: "durable-blob",
+      launchSource: "durable-blob+canonical-launch-stamp-router",
+      status: "last-known-good",
+      completeness: {
+        classic: "last-known-good",
+        routerCustom: "current",
+      },
+      evidence: {
+        kind: "durable-envelope",
+        commitment: `0x${"cd".repeat(32)}`,
+      },
+    });
+    expect(body.catalog).not.toHaveProperty("scope");
+    expect(body.dataQuality.launchIdentity.canonical).toBe("last-known-good");
+    expect(response.headers.get("x-programmable-launch-source")).toBe(
+      "durable-blob+canonical-launch-stamp-router",
+    );
+    expect(response.headers.get("x-programmable-canonical-read-status")).toBe(
+      "last-known-good",
     );
   });
 
@@ -755,6 +818,7 @@ describe("Explore static identity and Dexscreener market contract", () => {
       const response = await GET(request(query));
       expect(response.status).toBe(400);
       expect(mocks.readCatalog).not.toHaveBeenCalled();
+      expect(mocks.readLastGoodCatalog).not.toHaveBeenCalled();
       expect(mocks.readDex).not.toHaveBeenCalled();
     },
   );

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -507,6 +507,77 @@ describe("Explore refresh state", () => {
     });
   });
 
+  it("hydrates a bounded durable catalog during a cold Envio read", () => {
+    const durableFallback = {
+      ...payload,
+      catalog: {
+        source: "durable-blob" as const,
+        launchSource:
+          "durable-blob+canonical-launch-stamp-router" as const,
+        status: "last-known-good" as const,
+        lastIndexedAt: "2026-08-25T06:00:00.000Z",
+        asOfBlock: "25740001",
+        asOfBlockHash: `0x${"bc".repeat(32)}`,
+        identityCount: 351,
+        identityCommitment: `sha256:${"ac".repeat(32)}`,
+        completeness: {
+          classic: "last-known-good" as const,
+          stock: "last-known-good" as const,
+          custom: "unavailable" as const,
+          registryCustom: "unavailable" as const,
+          routerCustom: "current" as const,
+        },
+        evidence: {
+          kind: "durable-envelope" as const,
+          commitment: `0x${"cd".repeat(32)}`,
+        },
+        routerStamp: {
+          source: "canonical-launch-stamp-router" as const,
+          status: "current" as const,
+          finalityConfirmations: 64 as const,
+          verifiedIdentityCount: 1,
+          projectedIdentityCount: 1,
+          generatedAt: "2026-08-25T06:00:00.000Z",
+          asOfBlock: "25740001",
+          asOfBlockHash: `0x${"bc".repeat(32)}`,
+          identityCommitment: `sha256:${"ac".repeat(32)}`,
+        },
+      },
+    };
+
+    expect(createExploreInitialState(
+      { ok: true, body: durableFallback },
+      {
+        contentKey: "durable-fallback-content",
+        requestKey: "durable-fallback-request",
+        pageSize: EXPLORE_TOKENS_PER_PAGE,
+      },
+    )).toMatchObject({
+      phase: "ready",
+      payload: {
+        catalog: {
+          source: "durable-blob",
+          status: "last-known-good",
+        },
+      },
+    });
+
+    expect(createExploreInitialState({
+      ok: true,
+      body: {
+        ...durableFallback,
+        catalog: { ...durableFallback.catalog, evidence: undefined },
+      },
+    }, {
+      contentKey: "durable-fallback-invalid-content",
+      requestKey: "durable-fallback-invalid-request",
+      pageSize: EXPLORE_TOKENS_PER_PAGE,
+    })).toMatchObject({
+      phase: "error",
+      message: "The token registry returned invalid catalog data",
+    });
+  });
+
   it("surfaces a server-side Explore failure with explicit recovery", () => {
     const initialState = createExploreInitialState(
         {


### PR DESCRIPTION
## Summary
- keep the verified durable launch catalog available when a cold Envio read times out
- preserve Router Custom identities and report the fallback as last-known-good
- validate the durable catalog contract in the Explore client

## Checks
- npm run typecheck -- --pretty false
- npm exec eslint -- app/api/explore/route.ts components/explore-view.tsx tests/explore-api.test.ts tests/explore-view-state.test.ts
- npm test -- --run tests/explore-api.test.ts tests/explore-view-state.test.ts tests/last-good-launch-catalog.test.ts (94 passed)
- npm run build
- git diff --check