### PR TITLE
Refresh official project links

### DIFF
--- a/components/creator-article.tsx
+++ b/components/creator-article.tsx
@@ -12,6 +12,10 @@ import {
   creatorArticleLinkLabelV1,
   creatorArticleLinkProviderV1,
 } from "@/components/creator-article-link-icon";
+import { PROGRAMMABLE_MAIN_TOKEN_ADDRESS } from
+  "@/lib/creator-article/programmable-example-v1";
+import { PROGRAMMABLE_MAIN_TOKEN_PRESENTATION } from
+  "@/lib/programmable-main-token-presentation";
 
 import styles from "./creator-article.module.css";
 
@@ -21,6 +25,34 @@ type CreatorArticleHeaderLinkV1 = Readonly<{
   href: string;
   label: string;
 }>;
+
+const PROGRAMMABLE_CURRENT_X =
+  PROGRAMMABLE_MAIN_TOKEN_PRESENTATION.links.find(({ kind }) => kind === "x")!
+    .url;
+const PROGRAMMABLE_CURRENT_GITHUB =
+  PROGRAMMABLE_MAIN_TOKEN_PRESENTATION.supplementalLinks.find(
+    ({ kind }) => kind === "github",
+  )!.url;
+
+function currentCreatorArticleHeaderLinkV1(
+  article: CreatorArticleV1,
+  link: CreatorArticleHeaderLinkV1,
+): CreatorArticleHeaderLinkV1 {
+  if (
+    article.chainId !== 1 ||
+    article.tokenAddress.toLowerCase() !==
+      PROGRAMMABLE_MAIN_TOKEN_ADDRESS.toLowerCase()
+  ) return link;
+  const normalized = link.href.toLowerCase().replace(/\/+$/u, "");
+  const href = normalized === "https://x.com/0xprogrammable"
+    ? PROGRAMMABLE_CURRENT_X
+    : normalized === "https://github.com/0xprogrammable"
+      ? PROGRAMMABLE_CURRENT_GITHUB
+      : link.href;
+  return href === link.href
+    ? link
+    : Object.freeze({ href, label: creatorArticleLinkLabelV1(href) });
+}
 
 export function CreatorArticle({
   article,
@@ -41,6 +73,9 @@ export function CreatorArticle({
     ) : null;
   }
   const headerContent = creatorArticleHeaderContentV1(article.document.content);
+  const headerLinks = headerContent.links.map((link) =>
+    currentCreatorArticleHeaderLinkV1(article, link)
+  );
   const updated = new Intl.DateTimeFormat("en", {
     year: "numeric",
     month: "short",
@@ -75,9 +110,9 @@ export function CreatorArticle({
         <time className={styles.updated} dateTime={article.updatedAt}>
           Updated {updated}
         </time>
-        {headerContent.links.length > 0 ? (
+        {headerLinks.length > 0 ? (
           <nav className={styles.socials} aria-label="Project links">
-            {headerContent.links.map((link) => (
+            {headerLinks.map((link) => (
               <a
                 href={link.href}
                 target="_blank"

--- a/tests/creator-article-renderer.test.ts
+++ b/tests/creator-article-renderer.test.ts
@@ -145,4 +145,43 @@ describe("creator article public renderer", () => {
     expect(html).not.toContain(">Analytics<");
     expect(html).toContain("The article story remains visible.");
   });
+
+  it("replaces stale organization links on the official Programmable article", () => {
+    const staleArticle = parseCreatorArticleV1({
+      ...article,
+      document: {
+        type: "doc",
+        content: [{
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "X",
+              marks: [{
+                type: "link",
+                attrs: { href: "https://x.com/0xProgrammable" },
+              }],
+            },
+            { type: "text", text: "   " },
+            {
+              type: "text",
+              text: "GitHub",
+              marks: [{
+                type: "link",
+                attrs: { href: "https://github.com/0xprogrammable" },
+              }],
+            },
+          ],
+        }],
+      },
+    });
+
+    const html = renderToStaticMarkup(createElement(CreatorArticle, {
+      article: staleArticle,
+    }));
+    expect(html).toContain('href="https://x.com/ProgrammableHQ"');
+    expect(html).toContain('href="https://github.com/programmablehq"');
+    expect(html).not.toContain('href="https://x.com/0xProgrammable"');
+    expect(html).not.toContain('href="https://github.com/0xprogrammable"');
+  });
 });


### PR DESCRIPTION
## Summary
- replace the stale official Programmable article links with ProgrammableHQ and programmablehq at render time
- keep user-authored article content and non-official project links unchanged

## Checks
- npm run typecheck -- --pretty false
- npm exec eslint -- components/creator-article.tsx tests/creator-article-renderer.test.ts
- npm test -- --run tests/creator-article-renderer.test.ts (7 passed)
- git diff --check