### PR TITLE
Stabilize API key list layout

### DIFF
--- a/components/developer-api-keys.module.css
+++ b/components/developer-api-keys.module.css
@@ -285,7 +285,7 @@
   align-items: start;
   display: grid;
   gap: 16px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 0.72fr) minmax(0, 1.28fr);
 }
 
 .panel {
@@ -304,9 +304,34 @@
   min-width: 0;
 }
 
+.listPanel {
+  --api-key-row-min-height: 244px;
+  container-name: api-key-list;
+  container-type: inline-size;
+}
+
 .panelHeading {
   gap: 16px;
   min-height: 48px;
+}
+
+.listPanel .panelHeading {
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.listToolbar {
+  align-items: center;
+  display: flex;
+  flex: none;
+  gap: 6px;
+  justify-content: flex-end;
+  margin-inline-start: auto;
+}
+
+.listToolbar .textButton {
+  flex: none;
+  min-width: 128px;
 }
 
 .createForm {
@@ -597,25 +622,40 @@
   align-content: start;
   display: grid;
   gap: 8px;
+  grid-auto-rows: minmax(var(--api-key-row-min-height), auto);
   margin-top: 16px;
 }
 
+.keyList[data-paginated="true"] {
+  grid-template-rows: repeat(
+    3,
+    minmax(var(--api-key-row-min-height), auto)
+  );
+}
+
 .keyItem {
+  align-content: start;
   background: var(--api-subtle);
   border: 1px solid var(--api-line);
   border-radius: 10px;
+  display: grid;
+  gap: 12px;
+  min-height: var(--api-key-row-min-height);
   min-width: 0;
   padding: 12px;
 }
 
 .keyIdentity {
   display: grid;
-  gap: 8px;
+  gap: 7px;
   min-width: 0;
 }
 
 .keyIdentity > div {
-  gap: 12px;
+  align-items: start;
+  display: grid;
+  gap: 4px;
+  justify-content: start;
 }
 
 .keyIdentity h3,
@@ -625,12 +665,21 @@
   font-weight: 590;
   line-height: 1.3;
   min-width: 0;
-  overflow-wrap: anywhere;
+}
+
+.keyIdentity h3 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .keyIdentity > code {
   color: var(--webde-dim);
+  display: block;
   font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .keyStatus {
@@ -662,8 +711,8 @@
 .keyMetadata {
   display: grid;
   gap: 8px 12px;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  margin: 12px 0 0;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 0;
 }
 
 .keyMetadata div {
@@ -679,6 +728,7 @@
 .keyMetadata dd {
   color: var(--webde-muted);
   font-size: 12px;
+  font-variant-numeric: tabular-nums;
   line-height: 1.45;
   margin: 4px 0 0;
   overflow-wrap: anywhere;
@@ -689,7 +739,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-top: 12px;
+  margin-top: 0;
 }
 
 .keyActions .revokeButton {
@@ -699,7 +749,7 @@
 .mutationConfirmation {
   border: 1px solid color-mix(in srgb, var(--danger) 36%, var(--api-line));
   border-radius: var(--webde-radius-control);
-  margin-top: 12px;
+  margin-top: 0;
   padding: 12px;
 }
 
@@ -743,15 +793,22 @@
   display: grid;
   flex: 1;
   gap: 8px;
+  grid-template-rows: repeat(
+    3,
+    minmax(var(--api-key-row-min-height), auto)
+  );
   margin-top: 16px;
   min-height: 0;
 }
 
 .skeletonRow {
+  align-content: start;
   background: var(--api-subtle);
   border: 1px solid var(--api-line);
   border-radius: 10px;
-  min-height: 124px;
+  display: grid;
+  gap: 12px;
+  min-height: var(--api-key-row-min-height);
   padding: 12px;
 }
 
@@ -774,10 +831,14 @@
 
 .keyPagination {
   align-items: center;
+  background: var(--webde-control);
+  border: 1px solid var(--api-line);
+  border-radius: var(--webde-radius-control);
   display: flex;
-  gap: 6px;
+  flex: none;
+  gap: 2px;
   justify-content: flex-end;
-  margin-top: 12px;
+  padding: 2px;
 }
 
 .keyPagination button {
@@ -807,6 +868,89 @@
   font-variant-numeric: tabular-nums;
   min-width: 42px;
   text-align: center;
+}
+
+@container api-key-list (min-width: 560px) {
+  .keyList,
+  .skeletonList {
+    --api-key-row-min-height: 136px;
+  }
+
+  .keyItem,
+  .skeletonRow {
+    align-content: center;
+    align-items: center;
+    grid-template-columns:
+      minmax(130px, 0.8fr)
+      minmax(238px, 1.55fr)
+      minmax(120px, 0.7fr);
+    gap: 12px;
+  }
+
+  .keyIdentity {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .keyMetadata {
+    grid-column: 2;
+    grid-row: 1;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .keyActions {
+    align-items: stretch;
+    flex-direction: column;
+    grid-column: 3;
+    grid-row: 1;
+  }
+
+  .keyActions > button {
+    width: 100%;
+  }
+
+  .mutationConfirmation {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+
+  .skeletonTitle {
+    width: 74%;
+  }
+
+  .skeletonLine {
+    margin-top: 0;
+    width: 92%;
+  }
+
+  .skeletonLineShort {
+    margin-top: 0;
+    width: 88%;
+  }
+}
+
+@container api-key-list (max-width: 460px) {
+  .listToolbar {
+    justify-content: space-between;
+    margin-inline-start: 0;
+    width: 100%;
+  }
+}
+
+@container api-key-list (max-width: 300px) {
+  .listToolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .keyPagination,
+  .listToolbar .textButton {
+    width: 100%;
+  }
+
+  .keyPagination {
+    justify-content: space-between;
+  }
 }
 
 .visuallyHidden {
@@ -887,7 +1031,7 @@
   outline-offset: 3px;
 }
 
-@media (max-width: 760px) {
+@media (max-width: 1040px) {
   .workspace {
     grid-template-columns: minmax(0, 1fr);
     height: auto;
@@ -964,13 +1108,11 @@
     padding-inline: 0;
   }
 
-  .keyActions,
   .mutationConfirmation > div {
     align-items: stretch;
     flex-direction: column;
   }
 
-  .keyActions > button,
   .mutationConfirmation > div > button {
     width: 100%;
   }

--- a/components/developer-api-keys.tsx
+++ b/components/developer-api-keys.tsx
@@ -1447,27 +1447,78 @@ function DeveloperApiKeysView({
                     <p className={styles.kicker}>Existing</p>
                     <h2 id="api-keys-title">Your keys</h2>
                   </div>
-                  <button
-                    className={styles.textButton}
-                    disabled={listState === "loading" || refreshingKeys}
-                    type="button"
-                    onClick={refreshApiKeys}
-                  >
-                    <RefreshCw
-                      aria-hidden="true"
-                      className={styles.refreshIcon}
-                      data-spinning={
-                        listState === "loading" || refreshingKeys
-                          ? "true"
-                          : "false"
-                      }
-                      size={16}
-                      strokeWidth={1.9}
-                    />
-                    {listState === "loading" || refreshingKeys
-                      ? "Refreshing"
-                      : "Refresh keys"}
-                  </button>
+                  <div className={styles.listToolbar}>
+                    {keyPageCount > 1 ? (
+                      <nav
+                        className={styles.keyPagination}
+                        aria-label="API key pages"
+                      >
+                        <button
+                          type="button"
+                          aria-label="Previous API key page"
+                          disabled={
+                            activeKeyPage === 1
+                            || listState === "loading"
+                            || refreshingKeys
+                          }
+                          onClick={() => {
+                            const nextPage = Math.max(1, activeKeyPage - 1);
+                            setKeyPage(nextPage);
+                            setStatusMessage(
+                              `Showing API key page ${nextPage}.`,
+                            );
+                          }}
+                        >
+                          <ChevronLeft aria-hidden="true" size={17} />
+                        </button>
+                        <span>
+                          {activeKeyPage} / {keyPageCount}
+                        </span>
+                        <button
+                          type="button"
+                          aria-label="Next API key page"
+                          disabled={
+                            activeKeyPage === keyPageCount
+                            || listState === "loading"
+                            || refreshingKeys
+                          }
+                          onClick={() => {
+                            const nextPage = Math.min(
+                              keyPageCount,
+                              activeKeyPage + 1,
+                            );
+                            setKeyPage(nextPage);
+                            setStatusMessage(
+                              `Showing API key page ${nextPage}.`,
+                            );
+                          }}
+                        >
+                          <ChevronRight aria-hidden="true" size={17} />
+                        </button>
+                      </nav>
+                    ) : null}
+                    <button
+                      className={styles.textButton}
+                      disabled={listState === "loading" || refreshingKeys}
+                      type="button"
+                      onClick={refreshApiKeys}
+                    >
+                      <RefreshCw
+                        aria-hidden="true"
+                        className={styles.refreshIcon}
+                        data-spinning={
+                          listState === "loading" || refreshingKeys
+                            ? "true"
+                            : "false"
+                        }
+                        size={16}
+                        strokeWidth={1.9}
+                      />
+                      {listState === "loading" || refreshingKeys
+                        ? "Refreshing"
+                        : "Refresh keys"}
+                    </button>
+                  </div>
                 </div>
 
                 {listState === "loading" ? <KeyListSkeleton /> : null}
@@ -1495,7 +1546,10 @@ function DeveloperApiKeysView({
 
                 {listState === "ready" && apiKeys.length > 0 ? (
                   <>
-                    <ul className={styles.keyList}>
+                    <ul
+                      className={styles.keyList}
+                      data-paginated={keyPageCount > 1 ? "true" : undefined}
+                    >
                     {visibleApiKeys.map((apiKey) => {
                       const status = keyStatus(apiKey);
                       const confirmingRevoke = confirmingRevokeId === apiKey.id;
@@ -1521,7 +1575,7 @@ function DeveloperApiKeysView({
                         >
                           <div className={styles.keyIdentity}>
                             <div>
-                              <h3>{apiKey.label}</h3>
+                              <h3 title={apiKey.label}>{apiKey.label}</h3>
                               <span
                                 className={styles.keyStatus}
                                 data-status={status.toLowerCase()}
@@ -1667,43 +1721,6 @@ function DeveloperApiKeysView({
                       );
                     })}
                     </ul>
-                    {keyPageCount > 1 ? (
-                      <nav
-                        className={styles.keyPagination}
-                        aria-label="API key pages"
-                      >
-                        <button
-                          type="button"
-                          aria-label="Previous API key page"
-                          disabled={activeKeyPage === 1}
-                          onClick={() => {
-                            const nextPage = Math.max(1, activeKeyPage - 1);
-                            setKeyPage(nextPage);
-                            setStatusMessage(`Showing API key page ${nextPage}.`);
-                          }}
-                        >
-                          <ChevronLeft aria-hidden="true" size={17} />
-                        </button>
-                        <span aria-live="polite">
-                          {activeKeyPage} / {keyPageCount}
-                        </span>
-                        <button
-                          type="button"
-                          aria-label="Next API key page"
-                          disabled={activeKeyPage === keyPageCount}
-                          onClick={() => {
-                            const nextPage = Math.min(
-                              keyPageCount,
-                              activeKeyPage + 1,
-                            );
-                            setKeyPage(nextPage);
-                            setStatusMessage(`Showing API key page ${nextPage}.`);
-                          }}
-                        >
-                          <ChevronRight aria-hidden="true" size={17} />
-                        </button>
-                      </nav>
-                    ) : null}
                   </>
                 ) : null}
                 {listState === "ready" && listError ? (

--- a/tests/developer-api-keys-ui.test.ts
+++ b/tests/developer-api-keys-ui.test.ts
@@ -291,7 +291,15 @@ describe("developer API key interface", () => {
       /\.workspace\s*\{[^}]*align-items:\s*start;/su,
     );
     expect(apiKeysStyles).toMatch(
-      /\.workspace\s*\{[^}]*grid-template-columns:\s*repeat\(2,/su,
+      /\.workspace\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*0\.72fr\)\s+minmax\(0,\s*1\.28fr\);/su,
+    );
+    expect(apiKeysStyles).toMatch(
+      /\.listToolbar\s*\{[^}]*display:\s*flex;[^}]*justify-content:\s*flex-end;/su,
+    );
+    expect(apiKeysStyles).toContain("--api-key-row-min-height");
+    expect(apiKeysStyles).toContain("grid-template-rows: repeat(");
+    expect(apiKeysSource.indexOf('aria-label="API key pages"')).toBeLessThan(
+      apiKeysSource.indexOf('className={styles.keyList}'),
     );
     expect(apiKeysStyles).not.toContain("height: clamp(");
     expect(apiKeysStyles).not.toMatch(


### PR DESCRIPTION
## Summary
- move API key pagination into the Your keys toolbar
- align key metadata and actions on stable shared tracks
- reserve three row slots so page changes do not resize the panel
- give the key list more room and preserve mobile reflow

## Validation
- 24 focused API-key UI tests pass
- focused ESLint passes
- git diff --check passes

No API key values or secrets are included.