### PR TITLE
Polish primary navigation and launch actions

### DIFF
--- a/components/profile-projects.module.css
+++ b/components/profile-projects.module.css
@@ -391,69 +391,21 @@
   to { opacity: 0.9; }
 }
 
-.initialBuy {
-  align-items: center;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 2px 8px;
-  margin-block-start: 2px;
-  min-width: 0;
-}
-
-.initialBuy small {
-  overflow: visible;
-  text-overflow: clip;
-  white-space: normal;
-}
-
-.initialBuyStatus {
-  align-items: center;
-  display: inline-flex;
-  gap: 5px;
-}
-
-.initialBuyStatus::before {
-  background: currentcolor;
-  border-radius: 999px;
-  content: "";
-  flex: none;
-  height: 4px;
-  opacity: 0.8;
-  width: 4px;
-}
-
-.initialBuyStatus[data-state="locked"] {
-  color: #e6b46f;
-}
-
-.initialBuyStatus[data-state="vesting"] {
-  color: #9ec7ef;
-}
-
-.initialBuyStatus[data-state="unlocked"],
-.initialBuyStatus[data-state="complete"] {
-  color: #9bd2ae;
-}
-
 .actions {
   display: grid;
   gap: 6px;
-  grid-template-columns: 104px 84px;
-  grid-template-areas: "article token";
+  grid-template-columns: 164px 104px 84px;
+  grid-template-areas: "receiver article token";
   justify-content: flex-end;
-  min-width: 194px;
-}
-
-.actions[data-reward-action="available"] {
-  grid-template-columns: 104px 164px 84px;
-  grid-template-areas: "article receiver token";
   min-width: 364px;
 }
 
 .actions button,
 .actions a {
   align-items: center;
+  background: transparent;
   border-color: var(--webde-line, rgb(255 255 255 / 14%));
+  color: var(--text-soft, rgb(255 255 255 / 72%));
   display: inline-flex;
   justify-content: center;
   padding-inline: 12px;
@@ -491,18 +443,6 @@
 .articleActionState[data-state="loading"] {
   background: color-mix(in srgb, var(--text, #fff) 4%, transparent);
   border-radius: 10px;
-}
-
-.actions button {
-  background: var(--brand-ivory, #f0eee8);
-  border-color: var(--brand-ivory, #f0eee8);
-  color: #0a0a0c;
-}
-
-.actions .rewardReceiverAction {
-  background: transparent;
-  border-color: var(--webde-line, rgb(255 255 255 / 14%));
-  color: var(--text-soft, rgb(255 255 255 / 72%));
 }
 
 .articleAction[data-opening="true"]:disabled {
@@ -734,11 +674,7 @@
     color: var(--text, #fff);
   }
 
-  .actions button:not(:disabled):hover {
-    filter: brightness(0.94);
-  }
-
-  .actions .rewardReceiverAction:not(:disabled):hover,
+  .actions button:not(:disabled):hover,
   .receiverHeader button:hover,
   .receiverActions button:not(.receiverSubmit):hover {
     background: var(--profile-subtle, rgb(255 255 255 / 6%));
@@ -800,8 +736,8 @@
   .actions[data-reward-action="available"] {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     grid-template-areas:
-      "article token"
-      "receiver receiver";
+      "receiver receiver"
+      "article token";
     min-width: 0;
   }
 

--- a/components/profile-projects.tsx
+++ b/components/profile-projects.tsx
@@ -13,7 +13,7 @@ import {
   type FormEvent,
 } from "react";
 import { createPortal } from "react-dom";
-import { formatUnits, getAddress, isAddress } from "viem";
+import { getAddress, isAddress } from "viem";
 
 import {
   acquireCreatorArticleAuthHeadersV1,
@@ -63,19 +63,6 @@ export type CreatorProjectMarketCapV1 = Readonly<{
   usdWad: string | null;
   ethWei: string | null;
   label: string | null;
-}>;
-
-export type CreatorProjectInitialBuyV1 = Readonly<{
-  tokenAddress: `0x${string}`;
-  ethAmountWei: string;
-  tokenAmountRaw: string;
-  tokenDecimals: number;
-  custodyAddress: `0x${string}` | null;
-  custodyMode: "unlocked" | "fixed-lock" | "linear" | "cliff-linear";
-  durationDays: number;
-  cliffDays: number;
-  cliffAt: string;
-  releaseAt: string;
 }>;
 
 export type CreatorProjectOwnerStateV1 = Readonly<{
@@ -222,7 +209,6 @@ export async function loadCreatorProjectListV1(input: Readonly<{
 
 export function ProfileProjects({
   classicRewards = emptyClassicRewardsV1,
-  initialBuys = [],
   marketCaps = [],
   onChangeRewardReceiver,
   onRefresh,
@@ -231,7 +217,6 @@ export function ProfileProjects({
   walletProjects = [],
 }: Readonly<{
   classicRewards?: readonly ClassicV3Reward[];
-  initialBuys?: readonly CreatorProjectInitialBuyV1[];
   marketCaps?: readonly CreatorProjectMarketCapV1[];
   onChangeRewardReceiver?: (
     reward: ClassicV3Reward,
@@ -392,12 +377,6 @@ export function ProfileProjects({
   const marketCapByToken = useMemo(() => new Map(
     marketCaps.map((marketCap) => [marketCap.tokenAddress.toLowerCase(), marketCap]),
   ), [marketCaps]);
-  const initialBuyByToken = useMemo(() => new Map(
-    initialBuys.map((initialBuy) => [
-      initialBuy.tokenAddress.toLowerCase(),
-      initialBuy,
-    ]),
-  ), [initialBuys]);
   const manageableClassicRewardsByToken = useMemo(
     () => manageableClassicRewardsByTokenV1(classicRewards, walletAccount),
     [classicRewards, walletAccount],
@@ -569,12 +548,6 @@ export function ProfileProjects({
       ) : (
         <div className={styles.list}>
           {pageData.items.map((project) => {
-            const initialBuy = initialBuyByToken.get(
-              project.tokenAddress.toLowerCase(),
-            );
-            const initialBuyLabel = initialBuy
-              ? formatCreatorProjectInitialBuyV1(initialBuy, project.symbol)
-              : null;
             const launchType =
               project.source === "registry.custom-launched" ||
               project.source === "canonical-launch-stamp-router"
@@ -623,17 +596,6 @@ export function ProfileProjects({
                     compact
                   />
                 ) : null}
-                {initialBuyLabel ? (
-                  <div className={styles.initialBuy}>
-                    <small>{initialBuyLabel.amount}</small>
-                    <small
-                      className={styles.initialBuyStatus}
-                      data-state={initialBuyLabel.state}
-                    >
-                      {initialBuyLabel.status}
-                    </small>
-                  </div>
-                ) : null}
               </div>
               <div
                 className={styles.actions}
@@ -641,6 +603,26 @@ export function ProfileProjects({
                   canChangeRewardReceiver ? "available" : "unavailable"
                 }
               >
+                {canChangeRewardReceiver && manageableReward ? (
+                  <button
+                    className={styles.rewardReceiverAction}
+                    type="button"
+                    aria-busy={
+                      rewardReceiverActionBusyV1(scopedReceiverState) ||
+                      undefined
+                    }
+                    onClick={(event) => {
+                      rewardReceiverTriggerRef.current = event.currentTarget;
+                      setRewardReceiverEditor({
+                        ownerAccount: walletAccount,
+                        project,
+                        reward: manageableReward,
+                      });
+                    }}
+                  >
+                    {rewardReceiverTriggerLabelV1(scopedReceiverState)}
+                  </button>
+                ) : null}
                 <span className={styles.articleActionSlot}>
                   {canEditArticle ? (
                     <button
@@ -669,26 +651,6 @@ export function ProfileProjects({
                     </span>
                   )}
                 </span>
-                {canChangeRewardReceiver && manageableReward ? (
-                  <button
-                    className={styles.rewardReceiverAction}
-                    type="button"
-                    aria-busy={
-                      rewardReceiverActionBusyV1(scopedReceiverState) ||
-                      undefined
-                    }
-                    onClick={(event) => {
-                      rewardReceiverTriggerRef.current = event.currentTarget;
-                      setRewardReceiverEditor({
-                        ownerAccount: walletAccount,
-                        project,
-                        reward: manageableReward,
-                      });
-                    }}
-                  >
-                    {rewardReceiverTriggerLabelV1(scopedReceiverState)}
-                  </button>
-                ) : null}
                 <Link
                   className={styles.viewTokenAction}
                   href={`/token/${project.tokenAddress}`}
@@ -1117,70 +1079,6 @@ export function mergeCreatorWalletProjectsV1(
     byToken.set(project.tokenAddress.toLowerCase(), project);
   }
   return Object.freeze([...byToken.values()]);
-}
-
-export function formatCreatorProjectInitialBuyV1(
-  initialBuy: CreatorProjectInitialBuyV1,
-  symbol: string | null,
-  now = Date.now(),
-) {
-  const ethAmount = Number(formatUnits(BigInt(initialBuy.ethAmountWei), 18));
-  const tokenAmount = Number(formatUnits(
-    BigInt(initialBuy.tokenAmountRaw),
-    initialBuy.tokenDecimals,
-  ));
-  const ethLabel = Number.isFinite(ethAmount)
-    ? new Intl.NumberFormat("en-US", { maximumSignificantDigits: 6 }).format(ethAmount)
-    : formatUnits(BigInt(initialBuy.ethAmountWei), 18);
-  const tokenLabel = Number.isFinite(tokenAmount)
-    ? new Intl.NumberFormat("en-US", {
-        compactDisplay: "short",
-        maximumFractionDigits: 2,
-        notation: "compact",
-      }).format(tokenAmount)
-    : formatUnits(BigInt(initialBuy.tokenAmountRaw), initialBuy.tokenDecimals);
-  const ticker = symbol ? `$${symbol}` : "tokens";
-  const date = (value: string) => new Intl.DateTimeFormat("en", {
-    day: "numeric",
-    month: "short",
-    timeZone: "UTC",
-    year: "numeric",
-  }).format(new Date(value));
-  const releaseTime = Date.parse(initialBuy.releaseAt);
-  const cliffTime = Date.parse(initialBuy.cliffAt);
-  if (initialBuy.custodyMode === "unlocked") {
-    return Object.freeze({
-      amount: `Initial buy ${ethLabel} ETH → ${tokenLabel} ${ticker}`,
-      status: "Unlocked at launch",
-      state: "unlocked" as const,
-    });
-  }
-  if (initialBuy.custodyMode === "fixed-lock") {
-    return Object.freeze({
-      amount: `Initial buy ${ethLabel} ETH → ${tokenLabel} ${ticker}`,
-      status: now < releaseTime
-        ? `Locked until ${date(initialBuy.releaseAt)}`
-        : `Lock ended ${date(initialBuy.releaseAt)}`,
-      state: now < releaseTime ? "locked" as const : "complete" as const,
-    });
-  }
-  if (
-    initialBuy.custodyMode === "cliff-linear" &&
-    now < cliffTime
-  ) {
-    return Object.freeze({
-      amount: `Initial buy ${ethLabel} ETH → ${tokenLabel} ${ticker}`,
-      status: `Cliff until ${date(initialBuy.cliffAt)} · vests by ${date(initialBuy.releaseAt)}`,
-      state: "locked" as const,
-    });
-  }
-  return Object.freeze({
-    amount: `Initial buy ${ethLabel} ETH → ${tokenLabel} ${ticker}`,
-    status: now < releaseTime
-      ? `Vesting until ${date(initialBuy.releaseAt)}`
-      : `Vesting ended ${date(initialBuy.releaseAt)}`,
-    state: now < releaseTime ? "vesting" as const : "complete" as const,
-  });
 }
 
 function parseProjectList(value: unknown): readonly CreatorProjectSummaryV1[] {

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -22,7 +22,6 @@ import {
   creatorProjectPageSize,
   ProfileProjects,
   rewardReceiverActionKeyV1,
-  type CreatorProjectInitialBuyV1,
   type CreatorProjectMarketCapV1,
   type CreatorProjectSummaryV1,
 } from "@/components/profile-projects";
@@ -2182,12 +2181,6 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     })),
     [scopedOnchainData.tokens],
   );
-  const creatorProjectInitialBuys = useMemo<readonly CreatorProjectInitialBuyV1[]>(
-    () => scopedOnchainData.tokens.flatMap((token) => token.initialBuy
-      ? [{ tokenAddress: token.address, ...token.initialBuy }]
-      : []),
-    [scopedOnchainData.tokens],
-  );
   const creatorWalletProjects = useMemo<readonly CreatorProjectSummaryV1[]>(
     () => scopedOnchainData.tokens.map((token) => ({
       chainId: 1 as const,
@@ -3769,7 +3762,6 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
             ? scopedClassicV3Rewards.rewards
             : []
         }
-        initialBuys={creatorProjectInitialBuys}
         marketCaps={creatorProjectMarketCaps}
         walletProjects={creatorWalletProjects}
         rewardReceiverActionStates={classicV3ActionStates}

--- a/components/site-navigation.module.css
+++ b/components/site-navigation.module.css
@@ -3,12 +3,12 @@
 }
 
 .headerInner.headerInner {
-  grid-template-columns: minmax(44px, 1fr) auto;
+  grid-template-columns: minmax(44px, 1fr) auto minmax(44px, 1fr);
 }
 
 .headerActions.headerActions {
   gap: 0;
-  grid-column: 2;
+  grid-column: 3;
 }
 
 .headerSocials.headerSocials {
@@ -16,7 +16,7 @@
 }
 
 .siteHeader.siteHeader :global(.desktop-nav) {
-  display: none;
+  display: flex;
 }
 
 .menuButton {
@@ -122,7 +122,7 @@
   border-radius: 0;
   bottom: auto;
   box-shadow: none;
-  display: grid;
+  display: none;
   gap: 2px;
   grid-template-columns: 1fr;
   height: auto;
@@ -360,6 +360,22 @@
 
   .mobileSheet {
     top: calc(64px + env(safe-area-inset-top));
+  }
+
+  .headerInner.headerInner {
+    grid-template-columns: minmax(44px, 1fr) auto;
+  }
+
+  .headerActions.headerActions {
+    grid-column: 2;
+  }
+
+  .siteHeader.siteHeader :global(.desktop-nav) {
+    display: none;
+  }
+
+  .mobileSheet.mobileSheet :global(.mobile-nav) {
+    display: grid;
   }
 }
 

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -5,6 +5,7 @@ import {
   useId,
   useRef,
   useState,
+  type FocusEvent,
   type MouseEvent,
 } from "react";
 import Image from "next/image";
@@ -24,10 +25,10 @@ import { useWallet } from "@/components/wallet-provider";
 import styles from "@/components/site-navigation.module.css";
 
 const desktopNavItems = [
-  { href: "/explore", label: "Explore Projects" },
+  { href: "/explore", label: "Explore" },
   { href: "/launch", label: "Create" },
-  { href: "/developers/api-keys", label: "API keys" },
   { href: "/docs", label: "Docs" },
+  { href: "/developers/api-keys", label: "API Keys" },
   { href: "/profile", label: "Profile" },
 ];
 
@@ -131,10 +132,10 @@ function ProgrammableAccountMark() {
 
 function HeaderAccountAction({
   menuOpen,
-  onNavigate,
+  onConnect,
 }: Readonly<{
   menuOpen: boolean;
-  onNavigate: () => void;
+  onConnect: () => void;
 }>) {
   const {
     wallet,
@@ -149,6 +150,7 @@ function HeaderAccountAction({
     preloadWallet,
   } = useWallet();
   const [disconnectError, setDisconnectError] = useState("");
+  const focusConnectAfterDisconnectRef = useRef(false);
 
   if (wallet) {
     return (
@@ -178,13 +180,14 @@ function HeaderAccountAction({
           tabIndex={menuOpen ? undefined : -1}
           onClick={async () => {
             setDisconnectError("");
+            focusConnectAfterDisconnectRef.current = true;
             const disconnected = await disconnect({
               showDialogOnFailure: false,
             });
             if (disconnected) {
-              onNavigate();
               return;
             }
+            focusConnectAfterDisconnectRef.current = false;
             setDisconnectError("Wallet could not be disconnected. Try again.");
           }}
         >
@@ -209,6 +212,11 @@ function HeaderAccountAction({
 
   return (
     <button
+      ref={(node) => {
+        if (!node || !focusConnectAfterDisconnectRef.current) return;
+        focusConnectAfterDisconnectRef.current = false;
+        if (menuOpen) node.focus({ preventScroll: true });
+      }}
       className={styles.connectWallet}
       type="button"
       disabled={!authReady || connecting}
@@ -216,7 +224,10 @@ function HeaderAccountAction({
       aria-busy={connecting || undefined}
       onFocus={preloadWallet}
       onPointerEnter={preloadWallet}
-      onClick={openWallet}
+      onClick={() => {
+        onConnect();
+        openWallet();
+      }}
     >
       <ProgrammableAccountMark />
       <span>{label}</span>
@@ -239,12 +250,37 @@ function isCurrent(pathname: string, item: (typeof desktopNavItems)[number]) {
   return pathname === activePath || pathname.startsWith(`${activePath}/`);
 }
 
+function DesktopNavigation() {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  return (
+    <nav className="desktop-nav" aria-label="Primary navigation">
+      {desktopNavItems.map((item) => {
+        const current = isCurrent(pathname, item);
+        return (
+          <Link
+            key={item.href}
+            className={current ? "active" : undefined}
+            href={item.href}
+            prefetch={false}
+            aria-current={current ? "page" : undefined}
+            onFocus={() => warmNavigationRoute(router, item.href)}
+            onPointerEnter={() => warmNavigationRoute(router, item.href)}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
 export function SiteHeader() {
   const pathname = usePathname();
   const menuId = useId();
   const headerRef = useRef<HTMLElement>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
-  const menuSurfaceRef = useRef<HTMLDivElement>(null);
   const [menuPath, setMenuPath] = useState<string | null>(null);
   const menuOpen = menuPath === pathname;
 
@@ -265,12 +301,6 @@ export function SiteHeader() {
 
   useEffect(() => {
     if (!menuOpen) return;
-
-    window.requestAnimationFrame(() => {
-      menuSurfaceRef.current
-        ?.querySelector<HTMLElement>("a, button:not(:disabled)")
-        ?.focus({ preventScroll: true });
-    });
 
     const closeOnOutsidePress = (event: PointerEvent) => {
       if (
@@ -296,8 +326,27 @@ export function SiteHeader() {
     };
   }, [menuOpen]);
 
+  function closeOnFocusLeave(event: FocusEvent<HTMLElement>) {
+    if (!menuOpen) return;
+    if (
+      event.relatedTarget instanceof Node &&
+      event.currentTarget.contains(event.relatedTarget)
+    ) {
+      return;
+    }
+
+    const header = event.currentTarget;
+    window.requestAnimationFrame(() => {
+      if (!header.contains(document.activeElement)) setMenuPath(null);
+    });
+  }
+
   return (
-    <header ref={headerRef} className={`site-header ${styles.siteHeader}`}>
+    <header
+      ref={headerRef}
+      className={`site-header ${styles.siteHeader}`}
+      onBlur={closeOnFocusLeave}
+    >
       <div className={`header-inner ${styles.headerInner}`}>
         <div className="header-brand">
           <Link
@@ -319,6 +368,8 @@ export function SiteHeader() {
           </Link>
         </div>
 
+        <DesktopNavigation />
+
         <div className={`header-actions ${styles.headerActions}`}>
           <button
             ref={menuButtonRef}
@@ -326,7 +377,7 @@ export function SiteHeader() {
             type="button"
             aria-controls={menuId}
             aria-expanded={menuOpen}
-            aria-label={menuOpen ? "Close navigation" : "Open navigation"}
+            aria-label={menuOpen ? "Close menu" : "Open menu"}
             onClick={() => setMenuPath(menuOpen ? null : pathname)}
           >
             <span className={styles.menuIcon} aria-hidden="true">
@@ -349,13 +400,12 @@ export function SiteHeader() {
         inert={menuOpen ? undefined : true}
       >
         <div
-          ref={menuSurfaceRef}
           className={styles.mobileSheetSurface}
           id={menuId}
         >
           <HeaderAccountAction
             menuOpen={menuOpen}
-            onNavigate={() => setMenuPath(null)}
+            onConnect={() => setMenuPath(null)}
           />
           <MobileNavigation
             id={menuId}

--- a/tests/interaction-accessibility.test.ts
+++ b/tests/interaction-accessibility.test.ts
@@ -184,6 +184,23 @@ describe("interaction accessibility", () => {
     expect(source).toContain("menuButtonRef.current?.focus()");
   });
 
+  it("keeps the shared header disclosure focused without trapping the page", () => {
+    const source = readFileSync(
+      join(root, "components/site-navigation.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain("onBlur={closeOnFocusLeave}");
+    expect(source).toContain("event.currentTarget.contains(event.relatedTarget)");
+    expect(source).toContain("header.contains(document.activeElement)");
+    expect(source).not.toContain(
+      '.querySelector<HTMLElement>("a, button:not(:disabled)")',
+    );
+    expect(source).toContain("focusConnectAfterDisconnectRef.current = true");
+    expect(source).toContain("node.focus({ preventScroll: true })");
+    expect(source).toContain("onConnect();\n        openWallet();");
+  });
+
   it("keeps the sticky header and its wallet disclosure above page content", () => {
     const css = readFileSync(join(root, "app/interface.css"), "utf8");
 

--- a/tests/landing-page-contract.test.ts
+++ b/tests/landing-page-contract.test.ts
@@ -16,7 +16,7 @@ describe("landing page contract", () => {
     expect(explorePage).toContain("import { ExploreView }");
     expect(explorePage).toContain('canonical: "/explore"');
     expect(navigation).toContain(
-      '{ href: "/explore", label: "Explore Projects" }',
+      '{ href: "/explore", label: "Explore" }',
     );
     expect(navigation).toContain('href="/"');
     expect(homePage).toContain(
@@ -202,7 +202,7 @@ describe("landing page contract", () => {
     const navigation = read("components/site-navigation.tsx");
 
     expect(navigation).toContain(
-      '{ href: "/explore", label: "Explore Projects" }',
+      '{ href: "/explore", label: "Explore" }',
     );
     expect(navigation).not.toContain("prepareLandingExploreNavigation(");
     expect(navigation).not.toContain('window.history.pushState(null, "", "/#explore")');

--- a/tests/profile-projects-editor-open.test.ts
+++ b/tests/profile-projects-editor-open.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from "vitest";
 
 import * as profileProjects from "../components/profile-projects";
 import type {
-  CreatorProjectInitialBuyV1,
   CreatorProjectMarketCapV1,
   CreatorProjectSummaryV1,
 } from "../components/profile-projects";
@@ -117,9 +116,27 @@ describe("My projects editor opening", () => {
     expect(source).toContain("Future creator fees for this allocation");
     expect(viewSource).toContain("onChangeRewardReceiver={(reward, newReceiver, allocationIndex)");
     expect(viewSource).toContain("rewardReceiverActionKeyV1(reward.vaultAddress)");
-    expect(styles).toContain('grid-template-areas: "article receiver token"');
+    const receiverAction = source.indexOf(
+      "{canChangeRewardReceiver && manageableReward ? (",
+    );
+    const articleAction = source.indexOf(
+      "<span className={styles.articleActionSlot}>",
+    );
+    const tokenAction = source.indexOf(
+      "className={styles.viewTokenAction}",
+    );
+    expect(receiverAction).toBeGreaterThan(-1);
+    expect(articleAction).toBeGreaterThan(receiverAction);
+    expect(tokenAction).toBeGreaterThan(articleAction);
+    expect(styles).toContain('grid-template-areas: "receiver article token"');
     expect(styles).toMatch(
-      /grid-template-areas:\s*"article token"\s*"receiver receiver"/u,
+      /grid-template-areas:\s*"receiver receiver"\s*"article token"/u,
+    );
+    expect(styles).toMatch(
+      /\.actions button,\s*\.actions a\s*\{[^}]*background:\s*transparent;[^}]*border-color:/su,
+    );
+    expect(styles).not.toMatch(
+      /\.actions button\s*\{[^}]*background:\s*var\(--brand-ivory/u,
     );
   });
 
@@ -439,38 +456,29 @@ describe("My projects editor opening", () => {
     ]);
   });
 
-  it("shows the initial buy amount and immutable custody schedule", () => {
-    const format = (profileProjects as unknown as {
-      formatCreatorProjectInitialBuyV1(
-        initialBuy: CreatorProjectInitialBuyV1,
-        symbol: string | null,
-        now: number,
-      ): Readonly<{ amount: string; status: string; state: string }>;
-    }).formatCreatorProjectInitialBuyV1;
-    const lock = {
-      tokenAddress: project.tokenAddress,
-      ethAmountWei: "50000000000000000",
-      tokenAmountRaw: "34883942100954326694409764",
-      tokenDecimals: 18,
-      custodyAddress: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as const,
-      custodyMode: "fixed-lock" as const,
-      durationDays: 360,
-      cliffDays: 0,
-      cliffAt: "2027-08-18T08:32:59.000Z",
-      releaseAt: "2027-08-18T08:32:59.000Z",
-    };
+  it("keeps launch cards focused on identity, market cap, and actions", () => {
+    const source = readFileSync(
+      join(process.cwd(), "components/profile-projects.tsx"),
+      "utf8",
+    );
+    const viewSource = readFileSync(
+      join(process.cwd(), "components/profile-view.tsx"),
+      "utf8",
+    );
+    const styles = readFileSync(
+      join(process.cwd(), "components/profile-projects.module.css"),
+      "utf8",
+    );
 
-    expect(format(lock, "DIGITALCAT", Date.parse("2026-08-23T12:00:00Z")))
-      .toEqual({
-        amount: "Initial buy 0.05 ETH → 34.88M $DIGITALCAT",
-        status: "Locked until Aug 18, 2027",
-        state: "locked",
-      });
-    expect(format(
-      { ...lock, custodyAddress: null, custodyMode: "unlocked", durationDays: 0 },
-      "DIGITALCAT",
-      Date.parse("2026-08-23T12:00:00Z"),
-    )).toMatchObject({ status: "Unlocked at launch", state: "unlocked" });
+    expect(source).not.toContain("CreatorProjectInitialBuyV1");
+    expect(source).not.toContain("formatCreatorProjectInitialBuyV1");
+    expect(source).not.toContain("Initial buy ");
+    expect(source).toContain("Market cap ");
+    expect(source).toContain("project.partnerAttribution");
+    expect(source).toContain("project.article");
+    expect(viewSource).not.toContain("creatorProjectInitialBuys");
+    expect(viewSource).not.toContain("initialBuys={");
+    expect(styles).not.toContain(".initialBuy");
   });
 
   it("refreshes the Privy identity before reading the bound access token", async () => {

--- a/tests/topbar-hero-polish.test.ts
+++ b/tests/topbar-hero-polish.test.ts
@@ -71,6 +71,7 @@ describe("topbar and Explore hero polish", () => {
     expect(navigation).not.toContain("ThemeToggle");
     expect(navigation).not.toContain('if (pathname === "/") return null;');
     expect(navigation).toContain("<HeaderAccountAction");
+    expect(navigation).toContain("<DesktopNavigation />");
     expect(navigation).toContain("const mobileNavItems = desktopNavItems;");
     expect(navigation).not.toContain("liquid-glass-surface");
     expect(navigation).not.toContain("lucide-react");
@@ -79,10 +80,10 @@ describe("topbar and Explore hero polish", () => {
     expect(navigation).toContain("warmedNavigationRoutes.has(href)");
     expect(navigation).toContain("router.prefetch(href)");
     for (const label of [
-      "Explore Projects",
+      "Explore",
       "Create",
-      "API keys",
       "Docs",
+      "API Keys",
       "Profile",
     ]) {
       expect(navigation).toContain(`label: "${label}"`);
@@ -93,7 +94,16 @@ describe("topbar and Explore hero polish", () => {
     );
     expect(navigation).toContain("<HeaderSocialLinks mobile />");
     expect(navigationCss).toMatch(
-      /\.siteHeader\.siteHeader :global\(\.desktop-nav\)\s*\{[^}]*display:\s*none;[\s\S]*?\.menuButton\s*\{[^}]*display:\s*inline-flex;/s,
+      /\.siteHeader\.siteHeader :global\(\.desktop-nav\)\s*\{[^}]*display:\s*flex;[\s\S]*?\.menuButton\s*\{[^}]*display:\s*inline-flex;/s,
+    );
+    expect(navigationCss).toMatch(
+      /\.mobileSheet\.mobileSheet :global\(\.mobile-nav\)\s*\{[^}]*display:\s*none;/s,
+    );
+    expect(navigationCss).toMatch(
+      /@media \(max-width: 60rem\)[\s\S]*?\.siteHeader\.siteHeader :global\(\.desktop-nav\)\s*\{[^}]*display:\s*none;[\s\S]*?\.mobileSheet\.mobileSheet :global\(\.mobile-nav\)\s*\{[^}]*display:\s*grid;/s,
+    );
+    expect(navigation).toContain(
+      'aria-label={menuOpen ? "Close menu" : "Open menu"}',
     );
     expect(navigationCss).toMatch(
       /\.menuButton\s*\{[^}]*display:\s*inline-flex;[\s\S]*?\.mobileSocials\s*\{[^}]*display:\s*flex;/s,


### PR DESCRIPTION
## Summary
- expose the primary product routes in the desktop header while keeping wallet and socials in the account disclosure
- keep the disclosure open after disconnect and focus the reconnect action
- stabilize Profile launch actions and remove noisy initial-buy custody details

## Verification
- `vitest`: 52 focused tests passed
- targeted ESLint passed
- TypeScript passed
- production build passed before conflict-free rebase; exact rebased tree is covered by required CI
- local browser QA: 1440x900 and 390x844, keyboard focus, Escape, focus-leave, console, and overflow checks
