### PR TITLE
Bind Robinhood Phase-A provenance across repositories

### DIFF
--- a/.github/workflows/finalize-robinhood-custom-launch-promotion.yml
+++ b/.github/workflows/finalize-robinhood-custom-launch-promotion.yml
@@ -72,6 +72,23 @@ jobs:
         with:
           node-version: 24.14.0
 
+      - name: Install exact Cosign verifier
+        run: |
+          set -euo pipefail
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          cosign_dir="$(mktemp -d "$RUNNER_TEMP/cosign-v3.1.3.XXXXXX")"
+          chmod 0700 "$cosign_dir"
+          cosign="$cosign_dir/cosign-linux-amd64"
+          curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+            "https://github.com/sigstore/cosign/releases/download/v3.1.3/cosign-linux-amd64" \
+            --output "$cosign"
+          printf '%s  %s\n' \
+            '4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71' \
+            "$cosign" | sha256sum --check --strict
+          chmod 0700 "$cosign"
+          echo "PROGRAMMABLE_COSIGN_BIN=$cosign" >> "$GITHUB_ENV"
+
       - name: Install exact toolchain and dependency closure
         run: |
           set -euo pipefail
@@ -152,7 +169,7 @@ jobs:
           test -s "$trusted_root"
           echo "path=$trusted_root" >> "$GITHUB_OUTPUT"
 
-      - name: Verify all imported portable attestations offline
+      - name: Verify PROGRAMMABLE bundles and backend Sigstore evidence
         env:
           BACKEND_DIR: ${{ steps.imported.outputs.backend }}
           BACKEND_REVISION: ${{ steps.imported.outputs.backend_revision }}
@@ -194,12 +211,26 @@ jobs:
             "$PHASE_A_DIR/programmable-stage-bundle.attestation.json" \
             "$GITHUB_REPOSITORY" ".github/workflows/capture-robinhood-custom-launch-postdeployment.yml" \
             "refs/heads/production" "$CAPTURE_REVISION"
-          verify_portable \
-            "$BACKEND_DIR/backend-promotion-input.public.json" \
-            "$BACKEND_DIR/backend-promotion-input.attestation.json" \
-            "programmablehq/programmable-open-hook-v2-internal" \
-            ".github/workflows/capture-programmable-robinhood-promotion.yml" \
-            "refs/heads/main" "$BACKEND_REVISION"
+          trust_overrides="$(
+            compgen -A variable | grep -E '^(COSIGN|FULCIO|REKOR|SIGSTORE|TUF)_' || true
+          )"
+          if [[ -n "$trust_overrides" ]]; then
+            echo "Sigstore trust override environment is forbidden" >&2
+            exit 1
+          fi
+          "$PROGRAMMABLE_COSIGN_BIN" verify-blob \
+            --bundle "$BACKEND_DIR/backend-promotion-input.attestation.json" \
+            --certificate-identity \
+              "https://github.com/programmablehq/programmable-open-hook-v2-internal/.github/workflows/capture-programmable-robinhood-promotion.yml@refs/heads/main" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            --certificate-github-workflow-name \
+              "Capture Programmable Robinhood backend promotion" \
+            --certificate-github-workflow-repository \
+              "programmablehq/programmable-open-hook-v2-internal" \
+            --certificate-github-workflow-ref "refs/heads/main" \
+            --certificate-github-workflow-sha "$BACKEND_REVISION" \
+            --certificate-github-workflow-trigger "workflow_dispatch" \
+            "$BACKEND_DIR/backend-promotion-input.public.json"
 
       - name: Read exact historical Verify coordinates
         id: coordinates

--- a/.github/workflows/release-programmable-launch.yml
+++ b/.github/workflows/release-programmable-launch.yml
@@ -83,6 +83,23 @@ jobs:
         with:
           node-version: 24.14.0
 
+      - name: Install exact Cosign verifier
+        run: |
+          set -euo pipefail
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          cosign_dir="$(mktemp -d "$RUNNER_TEMP/cosign-v3.1.3.XXXXXX")"
+          chmod 0700 "$cosign_dir"
+          cosign="$cosign_dir/cosign-linux-amd64"
+          curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+            "https://github.com/sigstore/cosign/releases/download/v3.1.3/cosign-linux-amd64" \
+            --output "$cosign"
+          printf '%s  %s\n' \
+            '4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71' \
+            "$cosign" | sha256sum --check --strict
+          chmod 0700 "$cosign"
+          echo "PROGRAMMABLE_COSIGN_BIN=$cosign" >> "$GITHUB_ENV"
+
       - name: Set up exact npm
         run: |
           set -euo pipefail

--- a/contracts/scripts/finalize-robinhood-custom-launch-deployment.mjs
+++ b/contracts/scripts/finalize-robinhood-custom-launch-deployment.mjs
@@ -35,6 +35,10 @@ import {
   ROBINHOOD_BACKEND_CHAIN_DEPLOYMENT_PATH,
   ROBINHOOD_BACKEND_SOURCE_MANIFEST_PATH,
   ROBINHOOD_BACKEND_STANDARD_JSON_PATHS,
+  ROBINHOOD_BACKEND_PHASE_A_STAGE_BUNDLE_PATH,
+  ROBINHOOD_BACKEND_PHASE_A_STAGE_ATTESTATION_PATH,
+  ROBINHOOD_BACKEND_PHASE_A_PRODUCTION_CAPTURE_PATH,
+  ROBINHOOD_BACKEND_PHASE_A_PRODUCTION_CAPTURE_ATTESTATION_PATH,
   ROBINHOOD_STAGE_BUNDLE_PATH,
   ROBINHOOD_PROMOTION_BUNDLE_PATH,
   materializeRobinhoodStageBundle,
@@ -62,16 +66,27 @@ import {
 import {
   ROBINHOOD_BACKEND_CAPTURE_AUTHORIZATION_SCHEMA,
   ROBINHOOD_BACKEND_ATTESTATION_BUNDLE_PATH,
+  ROBINHOOD_BACKEND_CAPTURE_CERTIFICATE_IDENTITY,
+  ROBINHOOD_BACKEND_CAPTURE_CERTIFICATE_OIDC_ISSUER,
+  ROBINHOOD_BACKEND_CAPTURE_SOURCE_REF,
+  ROBINHOOD_BACKEND_CAPTURE_TRIGGER,
+  ROBINHOOD_BACKEND_CAPTURE_TRUST_CLASS,
   ROBINHOOD_BACKEND_CAPTURE_WORKFLOW,
+  ROBINHOOD_BACKEND_CAPTURE_WORKFLOW_NAME,
+  ROBINHOOD_BACKEND_COSIGN_LINUX_AMD64_SHA256,
+  ROBINHOOD_BACKEND_COSIGN_VERSION,
   ROBINHOOD_BACKEND_AUTHORIZATION_PATH,
   ROBINHOOD_BACKEND_AUTHORIZATION_ATTESTATION_PATH,
   ROBINHOOD_BACKEND_PROMOTION_PUBLIC_INPUT_PATH,
   buildRobinhoodBackendAuthorization,
+  buildRobinhoodBackendCosignVerifyBlobArgs,
   buildRobinhoodBackendCaptureAuthorization,
   freshVerifyRobinhoodBackendPromotionInput,
   validateRobinhoodBackendAuthorization,
   validateRobinhoodBackendCaptureAuthorization,
   validateRobinhoodBackendPromotionPublicInput,
+  validateSigstoreMessageBundleV03,
+  SIGSTORE_BUNDLE_V03_MEDIA_TYPE,
 } from "./robinhood-backend-promotion-v1.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -83,7 +98,7 @@ function usage() {
     "Usage:",
     "  finalize-robinhood-custom-launch-deployment.mjs assemble-stage --input <path> [--output <path>] [--repository-root <path>]",
     "  finalize-robinhood-custom-launch-deployment.mjs verify-stage --stage <path> --capture <path> [--repository-root <path>]",
-    "  finalize-robinhood-custom-launch-deployment.mjs stage-backend-assets --stage <path> --capture <path> --backend-service-root <path> [--repository-root <path>]",
+    "  finalize-robinhood-custom-launch-deployment.mjs stage-backend-assets --stage <path> --capture <path> --capture-attestation-bundle <path> --stage-attestation-bundle <path> --backend-service-root <path> [--repository-root <path>]",
     "  finalize-robinhood-custom-launch-deployment.mjs authorize-backend --stage <path> --capture <path> --backend-input <path> --backend-attestation-bundle <path> [--output <path>] [--repository-root <path>]",
     "  finalize-robinhood-custom-launch-deployment.mjs promote --stage <path> --capture <path> --backend-input <path> --backend-attestation-bundle <path> --backend-authorization <path> --backend-authorization-attestation-bundle <path> [--output <path>] [--repository-root <path>]",
     "  finalize-robinhood-custom-launch-deployment.mjs verify-promotion --bundle <path> --stage <path> --capture <path> --backend-input <path> --backend-attestation-bundle <path> --backend-authorization <path> --backend-authorization-attestation-bundle <path> [--repository-root <path>]",
@@ -130,7 +145,10 @@ function parseCli(argv) {
   const expected = {
     "assemble-stage": ["--input"],
     "verify-stage": ["--stage", "--capture"],
-    "stage-backend-assets": ["--stage", "--capture", "--backend-service-root"],
+    "stage-backend-assets": [
+      "--stage", "--capture", "--capture-attestation-bundle",
+      "--stage-attestation-bundle", "--backend-service-root",
+    ],
     "authorize-backend": ["--stage", "--capture", "--backend-input",
       "--backend-attestation-bundle"],
     promote: ["--stage", "--capture", "--backend-input", "--backend-attestation-bundle",
@@ -287,30 +305,47 @@ async function freshGithubTrustedRoot() {
 }
 
 async function verifyPortableGithubAttestation({
-  subjectPath,
-  bundlePath,
+  subjectBytes,
+  bundleBytes,
   trustedRootPath,
   repository,
   workflow,
   sourceRef,
   sourceRevision,
 }) {
-  const result = await execFileAsync("gh", [
-    "attestation", "verify", subjectPath,
-    "--bundle", bundlePath,
-    "--custom-trusted-root", trustedRootPath,
-    "--repo", repository,
-    "--signer-workflow", `${repository}/${workflow}`,
-    "--source-ref", sourceRef,
-    "--source-digest", sourceRevision,
-    "--signer-digest", sourceRevision,
-    "--deny-self-hosted-runners",
-    "--format", "json",
-  ], { encoding: "utf8", maxBuffer: 16 * 1024 * 1024, timeout: 30_000 });
-  if (result.stderr.length !== 0) {
-    throw new TypeError("GitHub offline attestation verification returned diagnostics");
+  if (!Buffer.isBuffer(subjectBytes) || subjectBytes.byteLength < 1
+    || subjectBytes.byteLength > 128 * 1024 * 1024
+    || !Buffer.isBuffer(bundleBytes) || bundleBytes.byteLength < 1
+    || bundleBytes.byteLength > 16 * 1024 * 1024) {
+    throw new TypeError("GitHub attestation subject or bundle bytes are invalid");
   }
-  return sha256Digest(Buffer.from(result.stdout, "utf8"));
+  const temporary = await mkdtemp(path.join(os.tmpdir(), "programmable-gh-attestation-"));
+  const subjectPath = path.join(temporary, "subject");
+  const bundlePath = path.join(temporary, "bundle.json");
+  try {
+    await Promise.all([
+      writeFile(subjectPath, subjectBytes, { flag: "wx", mode: 0o600 }),
+      writeFile(bundlePath, bundleBytes, { flag: "wx", mode: 0o600 }),
+    ]);
+    const result = await execFileAsync("gh", [
+      "attestation", "verify", subjectPath,
+      "--bundle", bundlePath,
+      "--custom-trusted-root", trustedRootPath,
+      "--repo", repository,
+      "--signer-workflow", `${repository}/${workflow}`,
+      "--source-ref", sourceRef,
+      "--source-digest", sourceRevision,
+      "--signer-digest", sourceRevision,
+      "--deny-self-hosted-runners",
+      "--format", "json",
+    ], { encoding: "utf8", maxBuffer: 16 * 1024 * 1024, timeout: 30_000 });
+    if (result.stderr.length !== 0) {
+      throw new TypeError("GitHub offline attestation verification returned diagnostics");
+    }
+    return sha256Digest(Buffer.from(result.stdout, "utf8"));
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
 }
 
 async function withFreshGithubTrustedRoot(callback) {
@@ -320,6 +355,54 @@ async function withFreshGithubTrustedRoot(callback) {
   try {
     await writeFile(trustedRootPath, trustedRootBytes, { flag: "wx", mode: 0o600 });
     return await callback({ trustedRootBytes, trustedRootPath });
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+}
+
+async function withPinnedBackendCosign({ subjectBytes, bundleBytes }, callback) {
+  const trustOverride = Object.keys(process.env).sort().find((name) =>
+    /^(?:COSIGN|FULCIO|REKOR|SIGSTORE|TUF)_/u.test(name));
+  if (trustOverride !== undefined) {
+    throw new TypeError("backend Sigstore verification rejects trust override environment");
+  }
+  const configured = process.env.PROGRAMMABLE_COSIGN_BIN;
+  if (typeof configured !== "string" || !path.isAbsolute(configured)) {
+    throw new TypeError("backend Sigstore verification requires absolute PROGRAMMABLE_COSIGN_BIN");
+  }
+  let handle;
+  let bytes;
+  try {
+    handle = await open(configured, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+    const metadata = await handle.stat();
+    if (!metadata.isFile() || metadata.size < 1 || metadata.size > 256 * 1024 * 1024) {
+      throw new TypeError("configured Cosign verifier must be a bounded physical file");
+    }
+    bytes = await handle.readFile();
+    if (bytes.byteLength !== metadata.size) {
+      throw new TypeError("configured Cosign verifier changed while being read");
+    }
+  } catch (error) {
+    throw new TypeError("configured Cosign verifier must be a bounded physical file", {
+      cause: error,
+    });
+  } finally {
+    await handle?.close();
+  }
+  if (sha256Digest(bytes) !== ROBINHOOD_BACKEND_COSIGN_LINUX_AMD64_SHA256) {
+    throw new TypeError("configured Cosign verifier differs from pinned v3.1.3 bytes");
+  }
+  const temporary = await mkdtemp(path.join(os.tmpdir(), "programmable-cosign-v3-"));
+  const executable = path.join(temporary, "cosign");
+  const subjectPath = path.join(temporary, "backend-promotion-input.public.json");
+  const bundlePath = path.join(temporary, "backend-promotion-input.attestation.json");
+  try {
+    await Promise.all([
+      writeFile(executable, bytes, { flag: "wx", mode: 0o700 }),
+      writeFile(subjectPath, subjectBytes, { flag: "wx", mode: 0o600 }),
+      writeFile(bundlePath, bundleBytes, { flag: "wx", mode: 0o600 }),
+    ]);
+    return await callback({ executable, subjectPath, bundlePath });
   } finally {
     await rm(temporary, { recursive: true, force: true });
   }
@@ -493,8 +576,8 @@ async function verifyPortableSourceProof({
     verificationMode: "change",
   });
   await verifyPortableGithubAttestation({
-    subjectPath: portable.sourceProof.path,
-    bundlePath: portable.sourceProofBundle.path,
+    subjectBytes: portable.sourceProof.bytes,
+    bundleBytes: portable.sourceProofBundle.bytes,
     trustedRootPath,
     repository: ROBINHOOD_PRODUCTION_REPOSITORY,
     workflow: ".github/workflows/verify.yml",
@@ -504,7 +587,6 @@ async function verifyPortableSourceProof({
 }
 
 async function verifyGithubCaptureAttestation({
-  capturePath,
   captureBytes,
   capture,
   repositoryRoot,
@@ -514,8 +596,8 @@ async function verifyGithubCaptureAttestation({
   await requireGithubContext(capture, repositoryRoot);
   return withFreshGithubTrustedRoot(async ({ trustedRootBytes, trustedRootPath }) => {
     await verifyPortableGithubAttestation({
-      subjectPath: capturePath,
-      bundlePath: portable.captureBundle.path,
+      subjectBytes: captureBytes,
+      bundleBytes: portable.captureBundle.bytes,
       trustedRootPath,
       repository: ROBINHOOD_PRODUCTION_REPOSITORY,
       workflow: ROBINHOOD_CAPTURE_WORKFLOW,
@@ -574,7 +656,6 @@ async function authorizationFor(inputFile, dependencies, options = null) {
   const portable = dependencies.authorizeCapture === undefined
     ? await loadPortableCaptureSidecars(options) : null;
   const result = await authorize({
-    capturePath: inputFile.path,
     captureBytes: inputFile.bytes,
     capture: inputFile.value.capture,
     repositoryRoot: options?.repositoryRoot,
@@ -589,7 +670,10 @@ async function authorizationFor(inputFile, dependencies, options = null) {
 
 async function embeddedStageAuthorization({ options, stageFile, inputFile, dependencies }) {
   if (dependencies.authorizeCapture !== undefined) {
-    return authorizationFor(inputFile, dependencies, options);
+    return {
+      authorization: await authorizationFor(inputFile, dependencies, options),
+      portable: null,
+    };
   }
   const capture = inputFile.value.capture;
   const portable = await loadPortableCaptureSidecars(options, { requireStage: true });
@@ -600,8 +684,8 @@ async function embeddedStageAuthorization({ options, stageFile, inputFile, depen
   );
   await withFreshGithubTrustedRoot(async ({ trustedRootPath }) => {
     await verifyPortableGithubAttestation({
-      subjectPath: inputFile.path,
-      bundlePath: portable.captureBundle.path,
+      subjectBytes: inputFile.bytes,
+      bundleBytes: portable.captureBundle.bytes,
       trustedRootPath,
       repository: ROBINHOOD_PRODUCTION_REPOSITORY,
       workflow: ROBINHOOD_CAPTURE_WORKFLOW,
@@ -615,8 +699,8 @@ async function embeddedStageAuthorization({ options, stageFile, inputFile, depen
       trustedRootPath,
     });
     await verifyPortableGithubAttestation({
-      subjectPath: stageFile.path,
-      bundlePath: portable.stageBundle.path,
+      subjectBytes: stageFile.bytes,
+      bundleBytes: portable.stageBundle.bytes,
       trustedRootPath,
       repository: ROBINHOOD_PRODUCTION_REPOSITORY,
       workflow: ROBINHOOD_CAPTURE_WORKFLOW,
@@ -649,25 +733,32 @@ async function embeddedStageAuthorization({ options, stageFile, inputFile, depen
       throw new TypeError(`embedded capture authorization ${key} differs from portable proof`);
     }
   }
-  return authorization;
+  return { authorization, portable };
 }
 
-async function verifyGithubBackendCaptureAttestation({
+async function verifySigstoreBackendCaptureAttestation({
   inputFile,
   attestationBundleFile,
   now = () => new Date(),
 }) {
   const capture = inputFile.value;
-  return withFreshGithubTrustedRoot(async ({ trustedRootBytes, trustedRootPath }) => {
-    await verifyPortableGithubAttestation({
-      subjectPath: inputFile.path,
-      bundlePath: attestationBundleFile.path,
-      trustedRootPath,
-      repository: capture.backendSource.repository,
-      workflow: ROBINHOOD_BACKEND_CAPTURE_WORKFLOW,
-      sourceRef: "refs/heads/main",
-      sourceRevision: capture.backendSource.sourceCommit,
-    });
+  validateSigstoreMessageBundleV03({
+    bundleBytes: attestationBundleFile.bytes,
+    subjectBytes: inputFile.bytes,
+  });
+  return withPinnedBackendCosign({
+    subjectBytes: inputFile.bytes,
+    bundleBytes: attestationBundleFile.bytes,
+  }, async ({ executable, subjectPath, bundlePath }) => {
+    const result = await execFileAsync(executable, buildRobinhoodBackendCosignVerifyBlobArgs({
+      subjectPath,
+      bundlePath,
+      sourceCommit: capture.backendSource.sourceCommit,
+    }), { encoding: "utf8", maxBuffer: 16 * 1024 * 1024, timeout: 30_000 });
+    if (Buffer.byteLength(result.stdout) > 16 * 1024 * 1024
+      || Buffer.byteLength(result.stderr) > 16 * 1024 * 1024) {
+      throw new TypeError("Cosign backend verification diagnostics exceeded their bound");
+    }
     const verifiedDate = now();
     const verifiedAt = verifiedDate instanceof Date && Number.isFinite(verifiedDate.getTime())
       ? new Date(Math.floor(verifiedDate.getTime() / 1000) * 1000)
@@ -675,20 +766,30 @@ async function verifyGithubBackendCaptureAttestation({
       : null;
     if (verifiedAt === null) throw new TypeError("backend verifier clock is invalid");
     return {
-      trustedRootBytes,
       authorization: buildRobinhoodBackendCaptureAuthorization({
         schemaVersion: ROBINHOOD_BACKEND_CAPTURE_AUTHORIZATION_SCHEMA,
-        trustClass: "github-artifact-attestation",
+        trustClass: ROBINHOOD_BACKEND_CAPTURE_TRUST_CLASS,
         subjectPath: ROBINHOOD_BACKEND_PROMOTION_PUBLIC_INPUT_PATH,
         subjectSha256: sha256Digest(inputFile.bytes),
         attestationBundlePath: ROBINHOOD_BACKEND_ATTESTATION_BUNDLE_PATH,
         attestationBundleSha256: sha256Digest(attestationBundleFile.bytes),
-        trustedRootSource: "github-cli-embedded-tuf",
-        trustedRootSha256: sha256Digest(trustedRootBytes),
+        bundleMediaType: SIGSTORE_BUNDLE_V03_MEDIA_TYPE,
+        verifier: {
+          name: "cosign",
+          version: ROBINHOOD_BACKEND_COSIGN_VERSION,
+          sha256: ROBINHOOD_BACKEND_COSIGN_LINUX_AMD64_SHA256,
+        },
+        certificateIdentity: ROBINHOOD_BACKEND_CAPTURE_CERTIFICATE_IDENTITY,
+        certificateOidcIssuer: ROBINHOOD_BACKEND_CAPTURE_CERTIFICATE_OIDC_ISSUER,
+        certificateGithubWorkflowName: ROBINHOOD_BACKEND_CAPTURE_WORKFLOW_NAME,
+        certificateGithubWorkflowRepository: capture.backendSource.repository,
+        certificateGithubWorkflowRef: ROBINHOOD_BACKEND_CAPTURE_SOURCE_REF,
+        certificateGithubWorkflowSha: capture.backendSource.sourceCommit,
+        certificateGithubWorkflowTrigger: ROBINHOOD_BACKEND_CAPTURE_TRIGGER,
         repository: capture.backendSource.repository,
         repositoryId: "1318883798",
         workflow: ROBINHOOD_BACKEND_CAPTURE_WORKFLOW,
-        sourceRef: "refs/heads/main",
+        sourceRef: ROBINHOOD_BACKEND_CAPTURE_SOURCE_REF,
         sourceRevision: capture.backendSource.sourceCommit,
         sourceTree: capture.backendSource.sourceTree,
         verifiedAt,
@@ -718,7 +819,7 @@ async function backendAuthoritiesFor({
     now: backendValidationNow,
   });
   const authorizeCapture = dependencies.authorizeBackendCapture
-    ?? verifyGithubBackendCaptureAttestation;
+    ?? verifySigstoreBackendCaptureAttestation;
   const captureResult = await authorizeCapture({
     inputFile: backendInputFile,
     attestationBundleFile: backendAttestationBundleFile,
@@ -731,14 +832,10 @@ async function backendAuthoritiesFor({
   const freshlyVerifiedCaptureAuthorization = captureResult?.authorization ?? captureResult;
   const backendCaptureAuthorization = embeddedBackendCaptureAuthorization
     ?? freshlyVerifiedCaptureAuthorization;
-  const backendTrustedRootBytes = embeddedBackendCaptureAuthorization === null
-    ? captureResult?.trustedRootBytes ?? dependencies.backendTrustedRootBytes
-    : null;
   validateRobinhoodBackendCaptureAuthorization({
     authorization: backendCaptureAuthorization,
     inputBytes: backendInputFile.bytes,
     attestationBundleBytes: backendAttestationBundleFile.bytes,
-    trustedRootBytes: backendTrustedRootBytes,
     input: backendInputFile.value,
     allowTestOnly: dependencies.backendDependencies?.allowTestOnly === true,
   });
@@ -771,7 +868,6 @@ async function backendAuthoritiesFor({
     backendCaptureAuthorization,
     backendAuthorization,
     backendAttestationBundleBytes: backendAttestationBundleFile.bytes,
-    backendTrustedRootBytes,
   };
 }
 
@@ -834,8 +930,8 @@ async function verifyPortableBackendAuthorization({
   }
   await withFreshGithubTrustedRoot(({ trustedRootPath }) =>
     verifyPortableGithubAttestation({
-      subjectPath: authorizationFile.path,
-      bundlePath: attestationBundleFile.path,
+      subjectBytes: authorizationFile.bytes,
+      bundleBytes: attestationBundleFile.bytes,
       trustedRootPath,
       repository: ROBINHOOD_PRODUCTION_REPOSITORY,
       workflow: ".github/workflows/finalize-robinhood-custom-launch-promotion.yml",
@@ -919,7 +1015,7 @@ async function verifyStage(options, dependencies) {
   const inputFile = await readJsonPath(capturePath, {
     label: "postdeployment capture", maximumBytes: 128 * 1024 * 1024,
   });
-  const captureAuthorization = await embeddedStageAuthorization({
+  const { authorization: captureAuthorization } = await embeddedStageAuthorization({
     options,
     stageFile: bundleFile,
     inputFile,
@@ -946,7 +1042,10 @@ async function stageBackendAssets(options, dependencies) {
   const inputFile = await readJsonPath(capturePath, {
     label: "postdeployment capture", maximumBytes: 128 * 1024 * 1024,
   });
-  const captureAuthorization = await embeddedStageAuthorization({
+  const {
+    authorization: captureAuthorization,
+    portable,
+  } = await embeddedStageAuthorization({
     options,
     stageFile: bundleFile,
     inputFile,
@@ -962,6 +1061,22 @@ async function stageBackendAssets(options, dependencies) {
   });
   if (verified.phase !== "backend-assets" || verified.releaseReady !== false) {
     throw new TypeError("backend assets require the closed phase-A promotion bundle");
+  }
+  const captureAttestationBytes = portable?.captureBundle.bytes
+    ?? (await readOpaquePath(
+      options.captureAttestationBundlePath,
+      "phase-A production capture attestation bundle",
+    )).bytes;
+  const stageAttestationBytes = portable?.stageBundle.bytes
+    ?? (await readOpaquePath(
+      options.stageAttestationBundlePath,
+      "phase-A stage attestation bundle",
+    )).bytes;
+  if (sha256Digest(captureAttestationBytes)
+    !== captureAuthorization.attestationBundleSha256) {
+    throw new TypeError(
+      "phase-A production capture attestation differs from the authenticated closure",
+    );
   }
   const bundle = bundleFile.value;
   const artifacts = bundle.artifacts.backendRelease;
@@ -995,6 +1110,26 @@ async function stageBackendAssets(options, dependencies) {
       }
       return { path: entry.path, bytes, sha256: entry.sha256 };
     }),
+    {
+      path: ROBINHOOD_BACKEND_PHASE_A_PRODUCTION_CAPTURE_PATH,
+      bytes: inputFile.bytes,
+      sha256: captureAuthorization.subjectSha256,
+    },
+    {
+      path: ROBINHOOD_BACKEND_PHASE_A_PRODUCTION_CAPTURE_ATTESTATION_PATH,
+      bytes: captureAttestationBytes,
+      sha256: captureAuthorization.attestationBundleSha256,
+    },
+    {
+      path: ROBINHOOD_BACKEND_PHASE_A_STAGE_BUNDLE_PATH,
+      bytes: bundleFile.bytes,
+      sha256: sha256Digest(bundleFile.bytes),
+    },
+    {
+      path: ROBINHOOD_BACKEND_PHASE_A_STAGE_ATTESTATION_PATH,
+      bytes: stageAttestationBytes,
+      sha256: sha256Digest(stageAttestationBytes),
+    },
   ];
   const repositoryPhysicalRoot = await realpath(repositoryRoot);
   const repositoryLexicalRoot = path.resolve(repositoryRoot);
@@ -1068,7 +1203,7 @@ async function authorizeBackend(options, dependencies) {
       () => readOpaquePath(options.backendAttestationBundlePath,
         "backend portable attestation bundle"),
     ]);
-  const captureAuthorization = await embeddedStageAuthorization({
+  const { authorization: captureAuthorization } = await embeddedStageAuthorization({
     options,
     stageFile,
     inputFile,
@@ -1094,7 +1229,7 @@ async function authorizeBackend(options, dependencies) {
     now: dependencies.backendDependencies?.now,
   });
   const authorizeCapture = dependencies.authorizeBackendCapture
-    ?? verifyGithubBackendCaptureAttestation;
+    ?? verifySigstoreBackendCaptureAttestation;
   const captureResult = await authorizeCapture({
     inputFile: backendInputFile,
     attestationBundleFile: backendAttestationBundleFile,
@@ -1103,13 +1238,10 @@ async function authorizeBackend(options, dependencies) {
     now: dependencies.backendVerificationNow,
   });
   const backendCaptureAuthorization = captureResult?.authorization ?? captureResult;
-  const trustedRootBytes = captureResult?.trustedRootBytes
-    ?? dependencies.backendTrustedRootBytes;
   validateRobinhoodBackendCaptureAuthorization({
     authorization: backendCaptureAuthorization,
     inputBytes: backendInputFile.bytes,
     attestationBundleBytes: backendAttestationBundleFile.bytes,
-    trustedRootBytes,
     input: backendInputFile.value,
     allowTestOnly: dependencies.backendDependencies?.allowTestOnly === true,
   });
@@ -1205,7 +1337,7 @@ async function promotionSidecars(
       "backend authorization portable attestation bundle",
     ),
   ]);
-  const captureAuthorization = await embeddedStageAuthorization({
+  const { authorization: captureAuthorization } = await embeddedStageAuthorization({
     options,
     stageFile,
     inputFile,
@@ -1245,7 +1377,6 @@ async function promote(options, dependencies) {
     backendPromotionInput: sidecars.backendInputFile.value,
     backendPromotionInputBytes: sidecars.backendInputFile.bytes,
     backendAttestationBundleBytes: sidecars.backendAttestationBundleBytes,
-    backendTrustedRootBytes: sidecars.backendTrustedRootBytes,
     backendCaptureAuthorization: sidecars.backendCaptureAuthorization,
     backendAuthorization: sidecars.backendAuthorization,
     backendDependencies: dependencies.backendDependencies,
@@ -1262,7 +1393,6 @@ async function promote(options, dependencies) {
     backendPromotionInput: sidecars.backendInputFile.value,
     backendPromotionInputBytes: sidecars.backendInputFile.bytes,
     backendAttestationBundleBytes: sidecars.backendAttestationBundleBytes,
-    backendTrustedRootBytes: sidecars.backendTrustedRootBytes,
     backendCaptureAuthorization: sidecars.backendCaptureAuthorization,
     backendAuthorization: sidecars.backendAuthorization,
     backendDependencies: dependencies.backendDependencies,
@@ -1310,7 +1440,6 @@ async function verifyPromotion(options, dependencies) {
       backendPromotionInput: sidecars.backendInputFile.value,
       backendPromotionInputBytes: sidecars.backendInputFile.bytes,
       backendAttestationBundleBytes: sidecars.backendAttestationBundleBytes,
-      backendTrustedRootBytes: sidecars.backendTrustedRootBytes,
       backendCaptureAuthorization: sidecars.backendCaptureAuthorization,
       backendAuthorization: sidecars.backendAuthorization,
       backendDependencies: dependencies.backendDependencies,
@@ -1337,7 +1466,6 @@ async function materializeReleaseAssets(options, dependencies) {
     backendPromotionInput: sidecars.backendInputFile.value,
     backendPromotionInputBytes: sidecars.backendInputFile.bytes,
     backendAttestationBundleBytes: sidecars.backendAttestationBundleBytes,
-    backendTrustedRootBytes: sidecars.backendTrustedRootBytes,
     backendCaptureAuthorization: sidecars.backendCaptureAuthorization,
     backendAuthorization: sidecars.backendAuthorization,
     backendDependencies: dependencies.backendDependencies,
@@ -1414,7 +1542,6 @@ async function apply(options, dependencies) {
     backendPromotionInput: sidecars.backendInputFile.value,
     backendPromotionInputBytes: sidecars.backendInputFile.bytes,
     backendAttestationBundleBytes: sidecars.backendAttestationBundleBytes,
-    backendTrustedRootBytes: sidecars.backendTrustedRootBytes,
     backendCaptureAuthorization: sidecars.backendCaptureAuthorization,
     backendAuthorization: sidecars.backendAuthorization,
     backendDependencies: backendReplayDependencies,

--- a/contracts/scripts/robinhood-backend-promotion-v1.mjs
+++ b/contracts/scripts/robinhood-backend-promotion-v1.mjs
@@ -33,9 +33,25 @@ export const ROBINHOOD_BACKEND_AUTHORIZATION_SCHEMA =
 export const ROBINHOOD_BACKEND_AUTHORIZATION_WORKFLOW =
   ".github/workflows/finalize-robinhood-custom-launch-promotion.yml";
 export const ROBINHOOD_BACKEND_CAPTURE_AUTHORIZATION_SCHEMA =
-  "programmable.robinhood-custom-launch.backend-capture-authorization.v2";
+  "programmable.robinhood-custom-launch.backend-capture-authorization.v3";
 export const ROBINHOOD_BACKEND_CAPTURE_WORKFLOW =
   ".github/workflows/capture-programmable-robinhood-promotion.yml";
+export const ROBINHOOD_BACKEND_CAPTURE_WORKFLOW_NAME =
+  "Capture Programmable Robinhood backend promotion";
+export const ROBINHOOD_BACKEND_CAPTURE_TRUST_CLASS =
+  "sigstore-keyless-github-actions-protected-main-v1";
+export const ROBINHOOD_BACKEND_CAPTURE_CERTIFICATE_IDENTITY =
+  "https://github.com/programmablehq/programmable-open-hook-v2-internal/"
+    + ".github/workflows/capture-programmable-robinhood-promotion.yml@refs/heads/main";
+export const ROBINHOOD_BACKEND_CAPTURE_CERTIFICATE_OIDC_ISSUER =
+  "https://token.actions.githubusercontent.com";
+export const ROBINHOOD_BACKEND_CAPTURE_SOURCE_REF = "refs/heads/main";
+export const ROBINHOOD_BACKEND_CAPTURE_TRIGGER = "workflow_dispatch";
+export const ROBINHOOD_BACKEND_COSIGN_VERSION = "v3.1.3";
+export const ROBINHOOD_BACKEND_COSIGN_LINUX_AMD64_SHA256 =
+  "sha256:4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71";
+export const SIGSTORE_BUNDLE_V03_MEDIA_TYPE =
+  "application/vnd.dev.sigstore.bundle.v0.3+json";
 export const ROBINHOOD_BACKEND_READINESS_SCHEMA =
   "programmable.custom-launch-api-release-identity.v4";
 export const ROBINHOOD_BACKEND_EVIDENCE_SCHEMA =
@@ -134,6 +150,90 @@ const BACKEND_MIGRATION_SHA256 =
 const BACKEND_API_CONTRACT_PATH = "release/custom-launch-api-contract.v4.json";
 const BACKEND_API_CONTRACT_SHA256 =
   "sha256:ddf45b96ff5bc402951e009849924fda8796b8db8498521c6903f7b1a2c29e62";
+
+export function validateSigstoreMessageBundleV03({ bundleBytes, subjectBytes }) {
+  if (!Buffer.isBuffer(bundleBytes) || bundleBytes.byteLength < 1
+    || bundleBytes.byteLength > 16 * 1024 * 1024
+    || !Buffer.isBuffer(subjectBytes) || subjectBytes.byteLength < 1
+    || subjectBytes.byteLength > BACKEND_PUBLIC_INPUT_BYTES) {
+    throw new TypeError("Sigstore bundle or subject bytes are empty or oversized");
+  }
+  const bundle = parseStrictJson(
+    decodeExactUtf8(bundleBytes, "Sigstore v0.3 bundle"),
+    { maximumBytes: 16 * 1024 * 1024, maximumDepth: 256 },
+  );
+  assertExactKeys(bundle, [
+    "mediaType", "verificationMaterial", "messageSignature",
+  ], "Sigstore v0.3 message-signature bundle");
+  if (bundle.mediaType !== SIGSTORE_BUNDLE_V03_MEDIA_TYPE) {
+    throw new TypeError("Sigstore bundle is not the required standardized v0.3 format");
+  }
+  const materialKeys = Object.keys(bundle.verificationMaterial ?? {});
+  const allowedMaterialKeys = new Set([
+    "certificate", "tlogEntries", "timestampVerificationData",
+  ]);
+  if (bundle.verificationMaterial?.certificate !== undefined) {
+    assertExactKeys(
+      bundle.verificationMaterial.certificate,
+      ["rawBytes"],
+      "Sigstore leaf certificate",
+    );
+  }
+  const certificateBytes = typeof bundle.verificationMaterial?.certificate?.rawBytes === "string"
+    ? Buffer.from(bundle.verificationMaterial.certificate.rawBytes, "base64")
+    : Buffer.alloc(0);
+  if (materialKeys.some((key) => !allowedMaterialKeys.has(key))
+    || certificateBytes.byteLength === 0
+    || certificateBytes.toString("base64")
+      !== bundle.verificationMaterial?.certificate?.rawBytes
+    || !Array.isArray(bundle.verificationMaterial?.tlogEntries)
+    || bundle.verificationMaterial.tlogEntries.length < 1
+    || bundle.verificationMaterial.tlogEntries.some((entry) =>
+      entry === null || typeof entry !== "object" || Array.isArray(entry))) {
+    throw new TypeError("Sigstore bundle lacks keyless certificate or transparency-log proof");
+  }
+  assertExactKeys(bundle.messageSignature, [
+    "messageDigest", "signature",
+  ], "Sigstore message signature");
+  assertExactKeys(bundle.messageSignature.messageDigest, [
+    "algorithm", "digest",
+  ], "Sigstore message digest");
+  const expectedDigest = createHash("sha256").update(subjectBytes).digest("base64");
+  const signatureBytes = typeof bundle.messageSignature.signature === "string"
+    ? Buffer.from(bundle.messageSignature.signature, "base64")
+    : Buffer.alloc(0);
+  if (bundle.messageSignature.messageDigest.algorithm !== "SHA2_256"
+    || bundle.messageSignature.messageDigest.digest !== expectedDigest
+    || signatureBytes.byteLength === 0
+    || signatureBytes.toString("base64") !== bundle.messageSignature.signature) {
+    throw new TypeError("Sigstore message signature does not bind the exact subject bytes");
+  }
+  return Object.freeze(structuredClone(bundle));
+}
+
+export function buildRobinhoodBackendCosignVerifyBlobArgs({
+  subjectPath,
+  bundlePath,
+  sourceCommit,
+}) {
+  if (typeof subjectPath !== "string" || subjectPath.length === 0
+    || typeof bundlePath !== "string" || bundlePath.length === 0
+    || !HEX40.test(sourceCommit)) {
+    throw new TypeError("backend Cosign verification coordinates are invalid");
+  }
+  return Object.freeze([
+    "verify-blob",
+    "--bundle", bundlePath,
+    "--certificate-identity", ROBINHOOD_BACKEND_CAPTURE_CERTIFICATE_IDENTITY,
+    "--certificate-oidc-issuer", ROBINHOOD_BACKEND_CAPTURE_CERTIFICATE_OIDC_ISSUER,
+    "--certificate-github-workflow-name", ROBINHOOD_BACKEND_CAPTURE_WORKFLOW_NAME,
+    "--certificate-github-workflow-repository", BACKEND_REPOSITORY,
+    "--certificate-github-workflow-ref", ROBINHOOD_BACKEND_CAPTURE_SOURCE_REF,
+    "--certificate-github-workflow-sha", sourceCommit,
+    "--certificate-github-workflow-trigger", ROBINHOOD_BACKEND_CAPTURE_TRIGGER,
+    subjectPath,
+  ]);
+}
 
 function framedSha256(domain, value) {
   return sha256Digest(Buffer.concat([
@@ -1177,7 +1277,6 @@ export function validateRobinhoodBackendCaptureAuthorization({
   authorization,
   inputBytes,
   attestationBundleBytes,
-  trustedRootBytes = null,
   input,
   allowTestOnly = false,
 }) {
@@ -1190,34 +1289,58 @@ export function validateRobinhoodBackendCaptureAuthorization({
   assertExactKeys(authorization, [
     "schemaVersion", "trustClass", "subjectPath", "subjectSha256",
     "attestationBundlePath", "attestationBundleSha256",
-    "trustedRootSource", "trustedRootSha256",
+    "bundleMediaType", "verifier",
+    "certificateIdentity", "certificateOidcIssuer",
+    "certificateGithubWorkflowName", "certificateGithubWorkflowRepository",
+    "certificateGithubWorkflowRef", "certificateGithubWorkflowSha",
+    "certificateGithubWorkflowTrigger",
     "repository", "repositoryId",
     "workflow", "sourceRef", "sourceRevision", "sourceTree", "verifiedAt",
     "verificationDigest",
   ], "backend capture authorization");
+  assertExactKeys(authorization.verifier, [
+    "name", "version", "sha256",
+  ], "backend capture Cosign verifier");
   if (!Buffer.isBuffer(attestationBundleBytes) || attestationBundleBytes.byteLength < 1
-    || attestationBundleBytes.byteLength > 16 * 1024 * 1024
-    || (trustedRootBytes !== null && (!Buffer.isBuffer(trustedRootBytes)
-      || trustedRootBytes.byteLength < 1 || trustedRootBytes.byteLength > 16 * 1024 * 1024))) {
-    throw new TypeError("backend capture trust sidecars are empty or oversized");
+    || attestationBundleBytes.byteLength > 16 * 1024 * 1024) {
+    throw new TypeError("backend capture trust sidecar is empty or oversized");
   }
-  const trustAllowed = authorization.trustClass === "github-artifact-attestation"
+  const productionTrust = authorization.trustClass
+    === ROBINHOOD_BACKEND_CAPTURE_TRUST_CLASS;
+  const trustAllowed = productionTrust
     || (allowTestOnly && authorization.trustClass === "test-only");
-  const trustedRootBindingValid = trustedRootBytes === null
-    ? SHA256.test(authorization.trustedRootSha256)
-    : authorization.trustedRootSha256 === sha256Digest(trustedRootBytes);
+  if (productionTrust) {
+    validateSigstoreMessageBundleV03({
+      bundleBytes: attestationBundleBytes,
+      subjectBytes: inputBytes,
+    });
+  }
   if (authorization.schemaVersion !== ROBINHOOD_BACKEND_CAPTURE_AUTHORIZATION_SCHEMA
     || !trustAllowed
     || authorization.subjectPath !== ROBINHOOD_BACKEND_PROMOTION_PUBLIC_INPUT_PATH
     || authorization.subjectSha256 !== sha256Digest(inputBytes)
     || authorization.attestationBundlePath !== ROBINHOOD_BACKEND_ATTESTATION_BUNDLE_PATH
     || authorization.attestationBundleSha256 !== sha256Digest(attestationBundleBytes)
-    || authorization.trustedRootSource !== "github-cli-embedded-tuf"
-    || !trustedRootBindingValid
+    || authorization.bundleMediaType !== SIGSTORE_BUNDLE_V03_MEDIA_TYPE
+    || authorization.verifier.name !== "cosign"
+    || authorization.verifier.version !== ROBINHOOD_BACKEND_COSIGN_VERSION
+    || authorization.verifier.sha256 !== ROBINHOOD_BACKEND_COSIGN_LINUX_AMD64_SHA256
+    || authorization.certificateIdentity
+      !== ROBINHOOD_BACKEND_CAPTURE_CERTIFICATE_IDENTITY
+    || authorization.certificateOidcIssuer
+      !== ROBINHOOD_BACKEND_CAPTURE_CERTIFICATE_OIDC_ISSUER
+    || authorization.certificateGithubWorkflowName
+      !== ROBINHOOD_BACKEND_CAPTURE_WORKFLOW_NAME
+    || authorization.certificateGithubWorkflowRepository !== BACKEND_REPOSITORY
+    || authorization.certificateGithubWorkflowRef
+      !== ROBINHOOD_BACKEND_CAPTURE_SOURCE_REF
+    || authorization.certificateGithubWorkflowSha !== input.backendSource.sourceCommit
+    || authorization.certificateGithubWorkflowTrigger
+      !== ROBINHOOD_BACKEND_CAPTURE_TRIGGER
     || authorization.repository !== BACKEND_REPOSITORY
     || authorization.repositoryId !== BACKEND_REPOSITORY_ID
     || authorization.workflow !== ROBINHOOD_BACKEND_CAPTURE_WORKFLOW
-    || authorization.sourceRef !== "refs/heads/main"
+    || authorization.sourceRef !== ROBINHOOD_BACKEND_CAPTURE_SOURCE_REF
     || authorization.sourceRevision !== input.backendSource.sourceCommit
     || authorization.sourceTree !== input.backendSource.sourceTree) {
     throw new TypeError("backend capture authorization does not bind protected backend source");

--- a/contracts/scripts/robinhood-custom-launch-postdeploy-core.mjs
+++ b/contracts/scripts/robinhood-custom-launch-postdeploy-core.mjs
@@ -39,6 +39,7 @@ import {
   validateRobinhoodBackendAuthorization,
   validateRobinhoodBackendCaptureAuthorization,
   validateRobinhoodBackendPromotionPublicInput,
+  ROBINHOOD_BACKEND_CAPTURE_TRUST_CLASS,
 } from "./robinhood-backend-promotion-v1.mjs";
 
 export const ROBINHOOD_POSTDEPLOYMENT_INPUT_SCHEMA =
@@ -65,6 +66,14 @@ export const ROBINHOOD_BACKEND_STANDARD_JSON_PATHS = Object.freeze({
   graphFactory:
     "release/assets/robinhood-v4/ProgrammableCreate2GraphDeployerV1.standard-input.json",
 });
+export const ROBINHOOD_BACKEND_PHASE_A_STAGE_BUNDLE_PATH =
+  "release/robinhood-v4-phase-a-stage-bundle.v1.json";
+export const ROBINHOOD_BACKEND_PHASE_A_STAGE_ATTESTATION_PATH =
+  "release/robinhood-v4-phase-a-stage-bundle.v1.attestation.json";
+export const ROBINHOOD_BACKEND_PHASE_A_PRODUCTION_CAPTURE_PATH =
+  "release/robinhood-v4-phase-a-production-capture.v3.json";
+export const ROBINHOOD_BACKEND_PHASE_A_PRODUCTION_CAPTURE_ATTESTATION_PATH =
+  "release/robinhood-v4-phase-a-production-capture.v3.attestation.json";
 
 const PREDEPLOYMENT_SHA256 =
   "sha256:2d58b964232d345f82aa7c7d58e678df03bf83828b9d95da42f3cd54ab03319e";
@@ -2042,8 +2051,20 @@ function buildPublicBackendPromotionBinding({
       subjectSha256: backendCaptureAuthorization.subjectSha256,
       attestationBundlePath: backendCaptureAuthorization.attestationBundlePath,
       attestationBundleSha256: backendCaptureAuthorization.attestationBundleSha256,
-      trustedRootSource: backendCaptureAuthorization.trustedRootSource,
-      trustedRootSha256: backendCaptureAuthorization.trustedRootSha256,
+      bundleMediaType: backendCaptureAuthorization.bundleMediaType,
+      verifier: structuredClone(backendCaptureAuthorization.verifier),
+      certificateIdentity: backendCaptureAuthorization.certificateIdentity,
+      certificateOidcIssuer: backendCaptureAuthorization.certificateOidcIssuer,
+      certificateGithubWorkflowName:
+        backendCaptureAuthorization.certificateGithubWorkflowName,
+      certificateGithubWorkflowRepository:
+        backendCaptureAuthorization.certificateGithubWorkflowRepository,
+      certificateGithubWorkflowRef:
+        backendCaptureAuthorization.certificateGithubWorkflowRef,
+      certificateGithubWorkflowSha:
+        backendCaptureAuthorization.certificateGithubWorkflowSha,
+      certificateGithubWorkflowTrigger:
+        backendCaptureAuthorization.certificateGithubWorkflowTrigger,
       repository: backendCaptureAuthorization.repository,
       repositoryId: backendCaptureAuthorization.repositoryId,
       workflow: backendCaptureAuthorization.workflow,
@@ -2096,7 +2117,6 @@ async function buildRobinhoodPromotionBundle({
   backendPromotionInput,
   backendPromotionInputBytes = canonicalJsonBytes(backendPromotionInput),
   backendAttestationBundleBytes,
-  backendTrustedRootBytes,
   backendCaptureAuthorization,
   backendAuthorization,
   backendDependencies = {},
@@ -2120,7 +2140,6 @@ async function buildRobinhoodPromotionBundle({
     authorization: backendCaptureAuthorization,
     inputBytes: backendPromotionInputBytes,
     attestationBundleBytes: backendAttestationBundleBytes,
-    trustedRootBytes: backendTrustedRootBytes,
     input: backendPromotionInput,
     allowTestOnly: backendDependencies.allowTestOnly === true,
   });
@@ -2146,7 +2165,7 @@ async function buildRobinhoodPromotionBundle({
   });
   const productionAuthorized = stageBundle.captureAuthorization.trustClass
       === "github-artifact-attestation"
-    && backendCapture.trustClass === "github-artifact-attestation"
+    && backendCapture.trustClass === ROBINHOOD_BACKEND_CAPTURE_TRUST_CLASS
     && authorization.trustClass === "github-artifact-attestation";
   const explicitlyTestOnly = backendDependencies.allowTestOnlyPromotion === true
     && stageBundle.captureAuthorization.trustClass === "test-only"

--- a/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
@@ -55,6 +55,10 @@ import {
 import {
   ROBINHOOD_LIVE_DEPLOYMENT_PATH,
   ROBINHOOD_PREDEPLOYMENT_PATH,
+  ROBINHOOD_BACKEND_PHASE_A_STAGE_BUNDLE_PATH,
+  ROBINHOOD_BACKEND_PHASE_A_STAGE_ATTESTATION_PATH,
+  ROBINHOOD_BACKEND_PHASE_A_PRODUCTION_CAPTURE_PATH,
+  ROBINHOOD_BACKEND_PHASE_A_PRODUCTION_CAPTURE_ATTESTATION_PATH,
   materializeRobinhoodStageBundle,
   materializeRobinhoodPromotionBundle,
   verifyRobinhoodStageBundle,
@@ -66,19 +70,31 @@ import {
   ROBINHOOD_BACKEND_AUTHORIZATION_ATTESTATION_PATH,
   ROBINHOOD_BACKEND_AUTHORIZATION_WORKFLOW,
   ROBINHOOD_BACKEND_ATTESTATION_BUNDLE_PATH,
+  ROBINHOOD_BACKEND_CAPTURE_CERTIFICATE_IDENTITY,
+  ROBINHOOD_BACKEND_CAPTURE_CERTIFICATE_OIDC_ISSUER,
+  ROBINHOOD_BACKEND_CAPTURE_SOURCE_REF,
+  ROBINHOOD_BACKEND_CAPTURE_TRIGGER,
+  ROBINHOOD_BACKEND_CAPTURE_TRUST_CLASS,
   ROBINHOOD_BACKEND_CAPTURE_AUTHORIZATION_SCHEMA,
   ROBINHOOD_BACKEND_CAPTURE_WORKFLOW,
+  ROBINHOOD_BACKEND_CAPTURE_WORKFLOW_NAME,
+  ROBINHOOD_BACKEND_COSIGN_LINUX_AMD64_SHA256,
+  ROBINHOOD_BACKEND_COSIGN_VERSION,
   ROBINHOOD_BACKEND_PROMOTION_INPUT_PATH,
   ROBINHOOD_BACKEND_PROMOTION_PUBLIC_INPUT_PATH,
   buildRobinhoodBackendAuthorization,
+  buildRobinhoodBackendCosignVerifyBlobArgs,
   buildRobinhoodBackendCaptureAuthorization,
   buildRobinhoodBackendPromotionFixture,
   buildRobinhoodBackendPromotionInput,
   buildRobinhoodBackendPromotionPublicInput,
   buildRobinhoodBackendPromotionPublicInputFromPrivate,
   freshVerifyRobinhoodBackendPromotionInput,
+  validateRobinhoodBackendCaptureAuthorization,
   validateRobinhoodBackendPromotionInput,
   validateRobinhoodBackendPromotionPublicInput,
+  validateSigstoreMessageBundleV03,
+  SIGSTORE_BUNDLE_V03_MEDIA_TYPE,
 } from "../robinhood-backend-promotion-v1.mjs";
 import { runRobinhoodPostdeploymentCli } from "../finalize-robinhood-custom-launch-deployment.mjs";
 import { validateRobinhoodCaptureEndpoint } from
@@ -569,7 +585,6 @@ test("test-only Phase B remains closed and canonical apply rejects it", async ()
       ...cliDependencies(built),
       authorizeBackendCapture: async () => backend.captureAuthorization,
       authorizeBackendPromotion: async () => ({ authorization: backend.authorization }),
-      backendTrustedRootBytes: backend.trustedRootBytes,
       backendDependencies: backend.dependencies,
     };
     const promotion = await runRobinhoodPostdeploymentCli([
@@ -689,7 +704,7 @@ test("apply replays old authenticated backend evidence but still requires fresh 
     const backend = testBackendEvidence(stage);
     const backendCaptureAuthorization = buildRobinhoodBackendCaptureAuthorization({
       ...structuredClone(backend.captureAuthorization),
-      trustClass: "github-artifact-attestation",
+      trustClass: ROBINHOOD_BACKEND_CAPTURE_TRUST_CLASS,
       verificationDigest: null,
     });
     const distinctRevision =
@@ -721,7 +736,6 @@ test("apply replays old authenticated backend evidence but still requires fresh 
       ...captureDependencies,
       authorizeBackendCapture: async () => backendCaptureAuthorization,
       authorizeBackendPromotion: async () => ({ authorization: backendAuthorization }),
-      backendTrustedRootBytes: backend.trustedRootBytes,
       backendDependencies: { now: backend.dependencies.now },
     };
     const evidenceArgs = [
@@ -916,7 +930,6 @@ test("backend raw promotion input rejects fake summaries, ref swaps, and incompl
       backendPromotionInput: baseline.input,
       backendPromotionInputBytes: baseline.inputBytes,
       backendAttestationBundleBytes: baseline.attestationBundleBytes,
-      backendTrustedRootBytes: baseline.trustedRootBytes,
       backendCaptureAuthorization: wrongCaptureRef,
       backendAuthorization: baseline.authorization,
       backendDependencies: baseline.dependencies,
@@ -938,7 +951,6 @@ test("backend raw promotion input rejects fake summaries, ref swaps, and incompl
         backendPromotionInput: baseline.input,
         backendPromotionInputBytes: baseline.inputBytes,
         backendAttestationBundleBytes: baseline.attestationBundleBytes,
-        backendTrustedRootBytes: baseline.trustedRootBytes,
         backendCaptureAuthorization: invalidClock,
         backendAuthorization: baseline.authorization,
         backendDependencies: baseline.dependencies,
@@ -970,7 +982,6 @@ test("backend raw promotion input rejects fake summaries, ref swaps, and incompl
       backendPromotionInput: baseline.input,
       backendPromotionInputBytes: baseline.inputBytes,
       backendAttestationBundleBytes: baseline.attestationBundleBytes,
-      backendTrustedRootBytes: baseline.trustedRootBytes,
       backendCaptureAuthorization: baseline.captureAuthorization,
       backendAuthorization: wrongFinalRef,
       backendDependencies: baseline.dependencies,
@@ -1202,26 +1213,150 @@ test("phase-A staging copies exact backend assets and rejects missing, tampered,
   try {
     const built = await buildInput(fixture);
     const dependencies = cliDependencies(built);
+    const captureAttestationPath = path.join(
+      fixture.root,
+      "programmable-postdeployment-capture.attestation.json",
+    );
+    const stageAttestationPath = path.join(
+      fixture.root,
+      "programmable-stage-bundle.attestation.json",
+    );
+    await writeFile(captureAttestationPath, built.attestationBundleBytes);
+    await writeFile(stageAttestationPath, dependencies.stageAttestationBundleBytes);
+    const portableStageArguments = [
+      "--capture-attestation-bundle", captureAttestationPath,
+      "--stage-attestation-bundle", stageAttestationPath,
+    ];
     const assembled = await runRobinhoodPostdeploymentCli([
       "assemble-stage", "--input", built.path, "--repository-root", fixture.root,
     ], dependencies);
-    const staged = await runRobinhoodPostdeploymentCli([
-      "stage-backend-assets",
-      "--stage", assembled.outputPath,
-      "--capture", built.path,
-      "--backend-service-root", backendRoot,
-      "--repository-root", fixture.root,
-    ], dependencies);
-    assert.equal(staged.releaseReady, false);
-    assert.equal(staged.assets.length, 4);
-    for (const asset of staged.assets) {
-      assert.equal(sha256Digest(await readFile(asset.output)), asset.sha256);
-    }
     await assert.rejects(
       runRobinhoodPostdeploymentCli([
         "stage-backend-assets",
         "--stage", assembled.outputPath,
         "--capture", built.path,
+        "--stage-attestation-bundle", stageAttestationPath,
+        "--backend-service-root", backendRoot,
+        "--repository-root", fixture.root,
+      ], dependencies),
+      /Usage:/u,
+    );
+    const staged = await runRobinhoodPostdeploymentCli([
+      "stage-backend-assets",
+      "--stage", assembled.outputPath,
+      "--capture", built.path,
+      ...portableStageArguments,
+      "--backend-service-root", backendRoot,
+      "--repository-root", fixture.root,
+    ], dependencies);
+    assert.equal(staged.releaseReady, false);
+    assert.deepEqual(staged.assets.map((asset) => asset.path), [
+      "release/robinhood-v4-chain-deployment.v1.json",
+      "release/robinhood-v4-prepared-root-source-manifest.v1.json",
+      "release/assets/robinhood-v4/ProgrammableLaunchStampRouterV1.standard-input.json",
+      "release/assets/robinhood-v4/ProgrammableCreate2GraphDeployerV1.standard-input.json",
+      ROBINHOOD_BACKEND_PHASE_A_PRODUCTION_CAPTURE_PATH,
+      ROBINHOOD_BACKEND_PHASE_A_PRODUCTION_CAPTURE_ATTESTATION_PATH,
+      ROBINHOOD_BACKEND_PHASE_A_STAGE_BUNDLE_PATH,
+      ROBINHOOD_BACKEND_PHASE_A_STAGE_ATTESTATION_PATH,
+    ]);
+    for (const asset of staged.assets) {
+      assert.equal(sha256Digest(await readFile(asset.output)), asset.sha256);
+    }
+    const stagedPhaseA = staged.assets.find(
+      (asset) => asset.path === ROBINHOOD_BACKEND_PHASE_A_STAGE_BUNDLE_PATH,
+    );
+    const stagedPhaseAAttestation = staged.assets.find(
+      (asset) => asset.path === ROBINHOOD_BACKEND_PHASE_A_STAGE_ATTESTATION_PATH,
+    );
+    assert.ok(stagedPhaseA);
+    assert.ok(stagedPhaseAAttestation);
+    const stagedCapture = staged.assets.find(
+      (asset) => asset.path === ROBINHOOD_BACKEND_PHASE_A_PRODUCTION_CAPTURE_PATH,
+    );
+    const stagedCaptureAttestation = staged.assets.find(
+      (asset) => asset.path
+        === ROBINHOOD_BACKEND_PHASE_A_PRODUCTION_CAPTURE_ATTESTATION_PATH,
+    );
+    assert.ok(stagedCapture);
+    assert.ok(stagedCaptureAttestation);
+    assert.deepEqual(await readFile(stagedCapture.output), built.bytes);
+    assert.deepEqual(
+      await readFile(stagedCaptureAttestation.output),
+      built.attestationBundleBytes,
+    );
+    assert.deepEqual(await readFile(stagedPhaseA.output), await readFile(assembled.outputPath));
+    assert.deepEqual(
+      await readFile(stagedPhaseAAttestation.output),
+      dependencies.stageAttestationBundleBytes,
+    );
+    const signedStage = JSON.parse(await readFile(assembled.outputPath, "utf8"));
+    const bridgedCapture = JSON.parse(await readFile(stagedCapture.output, "utf8"));
+    assert.equal(
+      bridgedCapture.schemaVersion,
+      "programmable.robinhood-custom-launch.postdeployment-input.v3",
+    );
+    assert.equal(
+      bridgedCapture.capture.schemaVersion,
+      "programmable.robinhood-custom-launch.production-capture.v3",
+    );
+    assert.equal(
+      sha256CaptureBytes(await readFile(stagedCapture.output)),
+      signedStage.captureAuthorization.subjectSha256,
+    );
+    assert.equal(
+      sha256Digest(await readFile(stagedCaptureAttestation.output)),
+      signedStage.captureAuthorization.attestationBundleSha256,
+    );
+    assert.equal(
+      computeRobinhoodCaptureClosureDigest(bridgedCapture.capture),
+      bridgedCapture.capture.captureClosureDigest,
+    );
+    const stagedDescriptor = staged.assets.find(
+      (asset) => asset.path === "release/robinhood-v4-chain-deployment.v1.json",
+    );
+    assert.ok(stagedDescriptor);
+    assert.deepEqual(
+      await readFile(stagedDescriptor.output),
+      Buffer.from(`${JSON.stringify(
+        signedStage.artifacts.backendRelease.chainDeployment.value,
+        null,
+        2,
+      )}\n`, "utf8"),
+    );
+    const descriptor = JSON.parse(await readFile(stagedDescriptor.output, "utf8"));
+    const ethereumFinality = descriptor.deploymentEvidence.ethereumFinalityEvidence;
+    for (const field of [
+      "captureClosureDigest", "postingEventDigest", "l1EvidenceDigest",
+    ]) {
+      assert.match(ethereumFinality[field], /^sha256:[0-9a-f]{64}$/u, field);
+    }
+    const substitutedCaptureAttestationPath = path.join(
+      fixture.root,
+      "substituted-capture.attestation.json",
+    );
+    await writeFile(
+      substitutedCaptureAttestationPath,
+      Buffer.from("substituted-capture-attestation\n", "utf8"),
+    );
+    await assert.rejects(
+      runRobinhoodPostdeploymentCli([
+        "stage-backend-assets",
+        "--stage", assembled.outputPath,
+        "--capture", built.path,
+        "--capture-attestation-bundle", substitutedCaptureAttestationPath,
+        "--stage-attestation-bundle", stageAttestationPath,
+        "--backend-service-root", backendRoot,
+        "--repository-root", fixture.root,
+      ], dependencies),
+      /capture attestation differs from the authenticated closure/u,
+    );
+    await assert.rejects(
+      runRobinhoodPostdeploymentCli([
+        "stage-backend-assets",
+        "--stage", assembled.outputPath,
+        "--capture", built.path,
+        ...portableStageArguments,
         "--backend-service-root", fixture.root,
         "--repository-root", fixture.root,
       ], dependencies),
@@ -1234,6 +1369,7 @@ test("phase-A staging copies exact backend assets and rejects missing, tampered,
         "stage-backend-assets",
         "--stage", assembled.outputPath,
         "--capture", built.path,
+        ...portableStageArguments,
         "--backend-service-root", rootAlias,
         "--repository-root", fixture.root,
       ], dependencies),
@@ -1245,6 +1381,7 @@ test("phase-A staging copies exact backend assets and rejects missing, tampered,
         "stage-backend-assets",
         "--stage", assembled.outputPath,
         "--capture", built.path,
+        ...portableStageArguments,
         "--backend-service-root", backendRoot,
         "--repository-root", fixture.root,
       ], dependencies),
@@ -1259,6 +1396,7 @@ test("phase-A staging copies exact backend assets and rejects missing, tampered,
         "stage-backend-assets",
         "--stage", missingPath,
         "--capture", built.path,
+        ...portableStageArguments,
         "--backend-service-root", escapedRoot,
         "--repository-root", fixture.root,
       ], dependencies),
@@ -1270,6 +1408,7 @@ test("phase-A staging copies exact backend assets and rejects missing, tampered,
         "stage-backend-assets",
         "--stage", assembled.outputPath,
         "--capture", built.path,
+        ...portableStageArguments,
         "--backend-service-root", escapedRoot,
         "--repository-root", fixture.root,
       ], dependencies),
@@ -1280,6 +1419,116 @@ test("phase-A staging copies exact backend assets and rejects missing, tampered,
     await rm(backendRoot, { recursive: true, force: true });
     await rm(escapedRoot, { recursive: true, force: true });
     await rm(outside, { recursive: true, force: true });
+  }
+});
+
+test("backend capture authorization requires exact standardized keyless Sigstore bytes", async () => {
+  const fixture = await fixtureRepository();
+  try {
+    const built = await buildInput(fixture);
+    const stage = await materialize(fixture, built);
+    const backend = testBackendEvidence(stage);
+    const productionAuthorization = buildRobinhoodBackendCaptureAuthorization({
+      ...structuredClone(backend.captureAuthorization),
+      trustClass: ROBINHOOD_BACKEND_CAPTURE_TRUST_CLASS,
+      verificationDigest: null,
+    });
+    assert.doesNotThrow(() => validateRobinhoodBackendCaptureAuthorization({
+      authorization: productionAuthorization,
+      inputBytes: backend.inputBytes,
+      attestationBundleBytes: backend.attestationBundleBytes,
+      input: backend.input,
+    }));
+    assert.deepEqual(buildRobinhoodBackendCosignVerifyBlobArgs({
+      subjectPath: "/tmp/backend-promotion-input.public.json",
+      bundlePath: "/tmp/backend-promotion-input.attestation.json",
+      sourceCommit: backend.input.backendSource.sourceCommit,
+    }), [
+      "verify-blob",
+      "--bundle", "/tmp/backend-promotion-input.attestation.json",
+      "--certificate-identity", ROBINHOOD_BACKEND_CAPTURE_CERTIFICATE_IDENTITY,
+      "--certificate-oidc-issuer", ROBINHOOD_BACKEND_CAPTURE_CERTIFICATE_OIDC_ISSUER,
+      "--certificate-github-workflow-name", ROBINHOOD_BACKEND_CAPTURE_WORKFLOW_NAME,
+      "--certificate-github-workflow-repository", backend.input.backendSource.repository,
+      "--certificate-github-workflow-ref", ROBINHOOD_BACKEND_CAPTURE_SOURCE_REF,
+      "--certificate-github-workflow-sha", backend.input.backendSource.sourceCommit,
+      "--certificate-github-workflow-trigger", ROBINHOOD_BACKEND_CAPTURE_TRIGGER,
+      "/tmp/backend-promotion-input.public.json",
+    ]);
+    assert.equal(buildRobinhoodBackendCosignVerifyBlobArgs({
+      subjectPath: "/tmp/backend-promotion-input.public.json",
+      bundlePath: "/tmp/backend-promotion-input.attestation.json",
+      sourceCommit: backend.input.backendSource.sourceCommit,
+    }).some((argument) => argument.startsWith("--insecure")), false);
+
+    const authorizationMutations = [
+      ["legacy trust", { trustClass: "github-artifact-attestation" }],
+      ["legacy schema", {
+        schemaVersion: "programmable.robinhood-custom-launch.backend-capture-authorization.v2",
+      }],
+      ["legacy bundle", {
+        bundleMediaType: "application/vnd.dev.sigstore.bundle+json;version=0.2",
+      }],
+      ["old verifier", {
+        verifier: { ...productionAuthorization.verifier, version: "v3.1.2" },
+      }],
+      ["verifier digest", {
+        verifier: { ...productionAuthorization.verifier, sha256: digest("wrong-cosign") },
+      }],
+      ["certificate identity", { certificateIdentity: "https://github.com/attacker" }],
+      ["certificate issuer", { certificateOidcIssuer: "https://issuer.invalid" }],
+      ["workflow name", { certificateGithubWorkflowName: "Attacker workflow" }],
+      ["workflow repository", { certificateGithubWorkflowRepository: "attacker/repo" }],
+      ["workflow ref", { certificateGithubWorkflowRef: "refs/heads/unprotected" }],
+      ["workflow SHA", { certificateGithubWorkflowSha: "1".repeat(40) }],
+      ["workflow trigger", { certificateGithubWorkflowTrigger: "push" }],
+    ];
+    for (const [label, override] of authorizationMutations) {
+      assert.throws(() => {
+        const candidate = buildRobinhoodBackendCaptureAuthorization({
+          ...structuredClone(productionAuthorization),
+          ...override,
+          verificationDigest: null,
+        });
+        validateRobinhoodBackendCaptureAuthorization({
+          authorization: candidate,
+          inputBytes: backend.inputBytes,
+          attestationBundleBytes: backend.attestationBundleBytes,
+          input: backend.input,
+        });
+      }, /protected backend source|authorization/u, label);
+    }
+
+    const legacyBundle = Buffer.from(JSON.stringify({
+      mediaType: "application/vnd.dev.sigstore.bundle+json;version=0.2",
+      verificationMaterial: { certificate: { rawBytes: "dGVzdA==" }, tlogEntries: [{}] },
+      messageSignature: {
+        messageDigest: {
+          algorithm: "SHA2_256",
+          digest: createHash("sha256").update(backend.inputBytes).digest("base64"),
+        },
+        signature: "dGVzdA==",
+      },
+    }), "utf8");
+    assert.throws(() => validateSigstoreMessageBundleV03({
+      bundleBytes: legacyBundle,
+      subjectBytes: backend.inputBytes,
+    }), /standardized v0\.3/u);
+
+    const publicKeyBundle = JSON.parse(backend.attestationBundleBytes.toString("utf8"));
+    delete publicKeyBundle.verificationMaterial.certificate;
+    publicKeyBundle.verificationMaterial.publicKey = { hint: "dGVzdA==" };
+    assert.throws(() => validateSigstoreMessageBundleV03({
+      bundleBytes: Buffer.from(JSON.stringify(publicKeyBundle), "utf8"),
+      subjectBytes: backend.inputBytes,
+    }), /keyless certificate/u);
+
+    assert.throws(() => validateSigstoreMessageBundleV03({
+      bundleBytes: backend.attestationBundleBytes,
+      subjectBytes: Buffer.from("substituted backend public input\n", "utf8"),
+    }), /exact subject bytes/u);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
   }
 });
 
@@ -2326,6 +2575,10 @@ function cliDependencies(built) {
     allowTestOnly: true,
     authorizeCapture: async () => built.authorization,
     captureDependencies: testCaptureDependencies,
+    stageAttestationBundleBytes: Buffer.from(
+      "test-only-portable-phase-a-stage-attestation\n",
+      "utf8",
+    ),
   };
 }
 
@@ -2349,8 +2602,7 @@ function testBackendEvidence(stageBundle, { privateCanaries = false } = {}) {
     now: () => new Date("2026-08-29T12:01:00Z"),
   });
   const inputBytes = Buffer.from(`${JSON.stringify(input, null, 2)}\n`, "utf8");
-  const attestationBundleBytes = Buffer.from("test-only-attestation-bundle\n", "utf8");
-  const trustedRootBytes = Buffer.from("test-only-trusted-root\n", "utf8");
+  const attestationBundleBytes = fakeSigstoreMessageBundle(inputBytes);
   const dependencies = {
     allowTestOnly: true,
     allowTestOnlyPromotion: true,
@@ -2368,12 +2620,23 @@ function testBackendEvidence(stageBundle, { privateCanaries = false } = {}) {
     subjectSha256: sha256Digest(inputBytes),
     attestationBundlePath: ROBINHOOD_BACKEND_ATTESTATION_BUNDLE_PATH,
     attestationBundleSha256: sha256Digest(attestationBundleBytes),
-    trustedRootSource: "github-cli-embedded-tuf",
-    trustedRootSha256: sha256Digest(trustedRootBytes),
+    bundleMediaType: SIGSTORE_BUNDLE_V03_MEDIA_TYPE,
+    verifier: {
+      name: "cosign",
+      version: ROBINHOOD_BACKEND_COSIGN_VERSION,
+      sha256: ROBINHOOD_BACKEND_COSIGN_LINUX_AMD64_SHA256,
+    },
+    certificateIdentity: ROBINHOOD_BACKEND_CAPTURE_CERTIFICATE_IDENTITY,
+    certificateOidcIssuer: ROBINHOOD_BACKEND_CAPTURE_CERTIFICATE_OIDC_ISSUER,
+    certificateGithubWorkflowName: ROBINHOOD_BACKEND_CAPTURE_WORKFLOW_NAME,
+    certificateGithubWorkflowRepository: input.backendSource.repository,
+    certificateGithubWorkflowRef: ROBINHOOD_BACKEND_CAPTURE_SOURCE_REF,
+    certificateGithubWorkflowSha: input.backendSource.sourceCommit,
+    certificateGithubWorkflowTrigger: ROBINHOOD_BACKEND_CAPTURE_TRIGGER,
     repository: input.backendSource.repository,
     repositoryId: "1318883798",
     workflow: ROBINHOOD_BACKEND_CAPTURE_WORKFLOW,
-    sourceRef: "refs/heads/main",
+    sourceRef: ROBINHOOD_BACKEND_CAPTURE_SOURCE_REF,
     sourceRevision: input.backendSource.sourceCommit,
     sourceTree: input.backendSource.sourceTree,
     verifiedAt: input.observedAt,
@@ -2415,7 +2678,6 @@ function testBackendEvidence(stageBundle, { privateCanaries = false } = {}) {
     privateInput,
     privateInputBytes,
     attestationBundleBytes,
-    trustedRootBytes,
     stageBundleBytes,
     evidence: validated.backendReleaseEvidence,
     captureAuthorization,
@@ -2538,6 +2800,25 @@ function externalBlockHash(blockNumber) {
 
 function digest(label) {
   return `sha256:${createHash("sha256").update(label).digest("hex")}`;
+}
+
+function fakeSigstoreMessageBundle(subjectBytes) {
+  return Buffer.from(`${JSON.stringify({
+    mediaType: SIGSTORE_BUNDLE_V03_MEDIA_TYPE,
+    verificationMaterial: {
+      certificate: {
+        rawBytes: Buffer.from("test-only-certificate", "utf8").toString("base64"),
+      },
+      tlogEntries: [{}],
+    },
+    messageSignature: {
+      messageDigest: {
+        algorithm: "SHA2_256",
+        digest: createHash("sha256").update(subjectBytes).digest("base64"),
+      },
+      signature: Buffer.from("test-only-signature", "utf8").toString("base64"),
+    },
+  }, null, 2)}\n`, "utf8");
 }
 
 function abiWord(value) {

--- a/docs/operations/releases/custom-launch-v4/POSTDEPLOYMENT.md
+++ b/docs/operations/releases/custom-launch-v4/POSTDEPLOYMENT.md
@@ -39,11 +39,15 @@ Phase B runs in
 `.github/workflows/finalize-robinhood-custom-launch-promotion.yml`. It consumes only the nine
 tracked portable Phase A/public-safe backend files at the protected producer commit. It rejects the
 private raw backend capture, creates the GitHub CLI embedded-TUF trusted root itself in
-`RUNNER_TEMP`, and verifies all portable attestations offline. It then emits and attests the
-canonical backend authorization and promotion bundle, materializes the exact live descriptor and
-CLI binding into an outside-repository artifact tree, preserves attestation bytes, and uploads the
-eight exact public-safe handoff files. It accepts no operator-supplied trusted root and serializes
-no credentials.
+`RUNNER_TEMP`, and verifies the three public PROGRAMMABLE attestations offline. The private
+backend's public-safe input is instead verified with the SHA-256-pinned Cosign v3.1.3 binary, a
+standardized Sigstore v0.3 bundle, exact GitHub Actions certificate identity, repository, protected
+`main` ref, source SHA, workflow name and `workflow_dispatch` trigger. Transparency-log and SCT
+verification remain enabled. Phase B then emits and attests the canonical backend authorization and
+promotion bundle, materializes the exact live descriptor and CLI binding into an
+outside-repository artifact tree, preserves attestation bytes, and uploads the eight exact
+public-safe handoff files. It accepts no operator-supplied trusted root and serializes no
+credentials.
 
 An authenticated Phase A bundle is always non-public:
 
@@ -72,9 +76,10 @@ The backend producer owns two different artifacts. They are intentionally not in
   bindings, and a semantic capture ID/digest derived only from those public facts. It contains no
   private raw artifact path or digest, raw request or response bytes, raw request ID, machine
   configuration, environment or private address.
-- `release/robinhood-chain-4663/backend-promotion-input.attestation.json` is the portable GitHub
-  attestation bundle for the public-safe input. It does not authorize or disclose the private raw
-  file.
+- `release/robinhood-chain-4663/backend-promotion-input.attestation.json` is the standardized
+  Sigstore v0.3 Cosign bundle for the public-safe input. Keyless signing publishes the subject
+  digest and GitHub Actions identity metadata to the public transparency service; it does not
+  publish, authorize or disclose the private raw file.
 
 The public-safe input is validated against the exact staged deployment, active OpenAPI digest,
 policy/profile/finality identity, backend source commit/tree, readiness response and Fly release.
@@ -86,7 +91,7 @@ private fields cannot alter either digest or any other public byte.
 
 | Artifact | Canonical path | Schema or role |
 | --- | --- | --- |
-| Raw Phase A capture | `release/robinhood-chain-4663/programmable-postdeployment-capture.json` | Top-level `programmable.robinhood-custom-launch.postdeployment-input.v2`; nested `capture` is `programmable.robinhood-custom-launch.production-capture.v2` |
+| Raw Phase A capture | `release/robinhood-chain-4663/programmable-postdeployment-capture.json` | Top-level `programmable.robinhood-custom-launch.postdeployment-input.v3`; nested `capture` is `programmable.robinhood-custom-launch.production-capture.v3` |
 | Capture attestation | `release/robinhood-chain-4663/programmable-postdeployment-capture.attestation.json` | Portable GitHub bundle |
 | Historical Verify proof | `release/robinhood-chain-4663/production-verify-proof.json` | Protected `verify.yml` artifact |
 | Verify proof attestation | `release/robinhood-chain-4663/production-verify-proof.attestation.json` | Portable GitHub bundle |
@@ -94,7 +99,11 @@ private fields cannot alter either digest or any other public byte.
 | Stage attestation | `release/robinhood-chain-4663/programmable-stage-bundle.attestation.json` | Portable GitHub bundle |
 | Private backend raw input | `release/robinhood-chain-4663/backend-promotion-input.json` | `programmable.robinhood-custom-launch.backend-promotion-input.v1`; restricted |
 | Public backend input | `release/robinhood-chain-4663/backend-promotion-input.public.json` | `programmable.robinhood-custom-launch.backend-promotion-public-input.v2` |
-| Public backend attestation | `release/robinhood-chain-4663/backend-promotion-input.attestation.json` | Portable GitHub bundle |
+| Public backend attestation | `release/robinhood-chain-4663/backend-promotion-input.attestation.json` | Standardized Sigstore v0.3 Cosign bundle |
+| Backend Phase A capture bridge | `release/robinhood-v4-phase-a-production-capture.v3.json` | Exact authenticated Phase A production-capture subject bytes copied into the backend repository |
+| Backend Phase A capture attestation bridge | `release/robinhood-v4-phase-a-production-capture.v3.attestation.json` | Exact existing portable PROGRAMMABLE capture-attestation bytes copied into the backend repository |
+| Backend Phase A stage bridge | `release/robinhood-v4-phase-a-stage-bundle.v1.json` | Exact authenticated Phase A stage bytes copied into the backend repository |
+| Backend Phase A stage attestation bridge | `release/robinhood-v4-phase-a-stage-bundle.v1.attestation.json` | Exact existing portable PROGRAMMABLE stage-attestation bytes copied into the backend repository |
 | Backend authorization | `release/robinhood-chain-4663/programmable-backend-authorization.json` | `programmable.launch-cli-v4-backend-release-authorization.v1` |
 | Backend authorization attestation | `release/robinhood-chain-4663/programmable-backend-authorization.attestation.json` | Portable GitHub bundle |
 | Phase B promotion | `release/robinhood-chain-4663/programmable-promotion-bundle.json` | `programmable.robinhood-custom-launch.promotion-bundle.v2` |
@@ -185,9 +194,40 @@ npm run contracts:robinhood:postdeploy:verify-stage -- \
 ```
 
 `stage-backend-assets` accepts the same stage/capture portable evidence and adds
-`--backend-service-root`. It writes only the four fixed Phase A backend-image assets, verifies all
-bytes before creation, rejects symbolic-link parents and replays only when every existing byte is
-identical.
+`--backend-service-root`. Both `--capture-attestation-bundle` and
+`--stage-attestation-bundle` are mandatory CLI inputs. It writes exactly eight fixed files: the
+four Phase A backend-image assets, the byte-exact credential-free production capture at
+`release/robinhood-v4-phase-a-production-capture.v3.json`, its already verified portable
+attestation bytes at
+`release/robinhood-v4-phase-a-production-capture.v3.attestation.json`, the exact authenticated
+Stage A subject bytes at
+`release/robinhood-v4-phase-a-stage-bundle.v1.json`, and its existing portable attestation bytes
+at `release/robinhood-v4-phase-a-stage-bundle.v1.attestation.json`. It verifies all bytes before
+creation, rejects symbolic-link parents and replays only when every existing byte is identical.
+The raw capture is never normalized: its digest is the subject digest in the embedded capture
+authorization and its own `captureClosureDigest` is computed with that field set to `null`. The
+signed stage, not a reconstructed manifest, binds the complete deployment descriptor, including
+`captureClosureDigest`, `postingEventDigest` and `l1EvidenceDigest`, to the four raw backend assets.
+A renderer must separately verify the capture and stage subjects before trusting that inventory.
+
+```sh
+npm run contracts:robinhood:postdeploy:stage-backend-assets -- \
+  --stage /absolute/path/programmable-stage-bundle.json \
+  --capture /absolute/path/programmable-postdeployment-capture.json \
+  --capture-attestation-bundle /absolute/path/programmable-postdeployment-capture.attestation.json \
+  --stage-attestation-bundle /absolute/path/programmable-stage-bundle.attestation.json \
+  --source-verify-proof /absolute/path/production-verify-proof.json \
+  --source-verify-attestation-bundle /absolute/path/production-verify-proof.attestation.json \
+  --source-verify-run-id "$VERIFY_RUN_ID" \
+  --source-verify-run-attempt "$VERIFY_RUN_ATTEMPT" \
+  --source-verify-artifact-id "$VERIFY_ARTIFACT_ID" \
+  --source-verify-artifact-digest "$VERIFY_ARTIFACT_DIGEST" \
+  --backend-service-root \
+    /absolute/path/to/programmable-open-hook-v2-internal/services/custom-launch-api-v1
+```
+
+The backend service root is the private repository's `services/custom-launch-api-v1` directory,
+not the private repository root; all eight paths above are relative to that service root.
 
 The backend fixture command exists for deterministic tests only:
 
@@ -289,7 +329,7 @@ and exclusive file creation.
 ## Exact Phase A capture
 
 The top-level capture input has exactly these keys in schema
-`programmable.robinhood-custom-launch.postdeployment-input.v2`:
+`programmable.robinhood-custom-launch.postdeployment-input.v3`:
 
 ```text
 schemaVersion
@@ -383,14 +423,18 @@ Its protected backend capture authorization has exactly:
 schemaVersion
 trustClass
 subjectPath
-subjectByteLength
 subjectSha256
 attestationBundlePath
-attestationBundleByteLength
 attestationBundleSha256
-trustedRootSource
-trustedRootByteLength
-trustedRootSha256
+bundleMediaType
+verifier
+certificateIdentity
+certificateOidcIssuer
+certificateGithubWorkflowName
+certificateGithubWorkflowRepository
+certificateGithubWorkflowRef
+certificateGithubWorkflowSha
+certificateGithubWorkflowTrigger
 repository
 repositoryId
 workflow
@@ -400,6 +444,12 @@ sourceTree
 verifiedAt
 verificationDigest
 ```
+
+The authorization schema is
+`programmable.robinhood-custom-launch.backend-capture-authorization.v3`; its production
+`trustClass` is `sigstore-keyless-github-actions-protected-main-v1`. `verifier` fixes `cosign`,
+version `v3.1.3`, and the exact Linux amd64 binary digest. Legacy bundles, public-key fallback,
+wrong subject bytes, certificate-claim drift and insecure transparency/SCT bypasses fail closed.
 
 The canonical PROGRAMMABLE backend authorization has exactly:
 
@@ -483,12 +533,12 @@ sha256(UTF8(domain) || 0x00 || UTF8(canonicalJson(value)))
 The relevant domains are:
 
 ```text
-programmable.robinhood-custom-launch.capture-authorization.v1
-programmable.robinhood-custom-launch.capture-closure.v2
+programmable.robinhood-custom-launch.capture-authorization.v2
+programmable.robinhood-custom-launch.capture-closure.v3
 programmable.robinhood-custom-launch.backend-promotion-input.v1
 programmable.robinhood-custom-launch.backend-promotion-public-input.v2
 programmable.robinhood-custom-launch.backend-promotion-semantic-input.v1
-programmable.robinhood-custom-launch.backend-capture-authorization.v2
+programmable.robinhood-custom-launch.backend-capture-authorization.v3
 programmable.launch-cli-v4-backend-release-authorization.v1
 programmable.launch-cli-v4-backend-release-evidence.v1
 programmable.robinhood-custom-launch.stage-bundle.v1

--- a/docs/operations/releases/custom-launch-v4/backend-capture-authorization.schema.json
+++ b/docs/operations/releases/custom-launch-v4/backend-capture-authorization.schema.json
@@ -11,8 +11,15 @@
     "subjectSha256",
     "attestationBundlePath",
     "attestationBundleSha256",
-    "trustedRootSource",
-    "trustedRootSha256",
+    "bundleMediaType",
+    "verifier",
+    "certificateIdentity",
+    "certificateOidcIssuer",
+    "certificateGithubWorkflowName",
+    "certificateGithubWorkflowRepository",
+    "certificateGithubWorkflowRef",
+    "certificateGithubWorkflowSha",
+    "certificateGithubWorkflowTrigger",
     "repository",
     "repositoryId",
     "workflow",
@@ -24,10 +31,10 @@
   ],
   "properties": {
     "schemaVersion": {
-      "const": "programmable.robinhood-custom-launch.backend-capture-authorization.v2"
+      "const": "programmable.robinhood-custom-launch.backend-capture-authorization.v3"
     },
     "trustClass": {
-      "enum": ["github-artifact-attestation", "test-only"]
+      "enum": ["sigstore-keyless-github-actions-protected-main-v1", "test-only"]
     },
     "subjectPath": {
       "const": "release/robinhood-chain-4663/backend-promotion-input.public.json"
@@ -37,8 +44,36 @@
       "const": "release/robinhood-chain-4663/backend-promotion-input.attestation.json"
     },
     "attestationBundleSha256": { "$ref": "#/$defs/sha256" },
-    "trustedRootSource": { "const": "github-cli-embedded-tuf" },
-    "trustedRootSha256": { "$ref": "#/$defs/sha256" },
+    "bundleMediaType": {
+      "const": "application/vnd.dev.sigstore.bundle.v0.3+json"
+    },
+    "verifier": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "sha256"],
+      "properties": {
+        "name": { "const": "cosign" },
+        "version": { "const": "v3.1.3" },
+        "sha256": {
+          "const": "sha256:4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71"
+        }
+      }
+    },
+    "certificateIdentity": {
+      "const": "https://github.com/programmablehq/programmable-open-hook-v2-internal/.github/workflows/capture-programmable-robinhood-promotion.yml@refs/heads/main"
+    },
+    "certificateOidcIssuer": {
+      "const": "https://token.actions.githubusercontent.com"
+    },
+    "certificateGithubWorkflowName": {
+      "const": "Capture Programmable Robinhood backend promotion"
+    },
+    "certificateGithubWorkflowRepository": {
+      "const": "programmablehq/programmable-open-hook-v2-internal"
+    },
+    "certificateGithubWorkflowRef": { "const": "refs/heads/main" },
+    "certificateGithubWorkflowSha": { "$ref": "#/$defs/gitHash" },
+    "certificateGithubWorkflowTrigger": { "const": "workflow_dispatch" },
     "repository": {
       "const": "programmablehq/programmable-open-hook-v2-internal"
     },

--- a/docs/operations/releases/custom-launch-v4/promotion-bundle.schema.json
+++ b/docs/operations/releases/custom-launch-v4/promotion-bundle.schema.json
@@ -87,7 +87,9 @@
         "backendCaptureAuthorization": {
           "type": "object",
           "properties": {
-            "trustClass": { "const": "github-artifact-attestation" }
+            "trustClass": {
+              "const": "sigstore-keyless-github-actions-protected-main-v1"
+            }
           }
         },
         "backendAuthorization": {
@@ -296,8 +298,15 @@
         "subjectSha256",
         "attestationBundlePath",
         "attestationBundleSha256",
-        "trustedRootSource",
-        "trustedRootSha256",
+        "bundleMediaType",
+        "verifier",
+        "certificateIdentity",
+        "certificateOidcIssuer",
+        "certificateGithubWorkflowName",
+        "certificateGithubWorkflowRepository",
+        "certificateGithubWorkflowRef",
+        "certificateGithubWorkflowSha",
+        "certificateGithubWorkflowTrigger",
         "repository",
         "repositoryId",
         "workflow",
@@ -308,7 +317,7 @@
       ],
       "properties": {
         "trustClass": {
-          "enum": ["github-artifact-attestation", "test-only"]
+          "enum": ["sigstore-keyless-github-actions-protected-main-v1", "test-only"]
         },
         "subjectPath": {
           "const": "release/robinhood-chain-4663/backend-promotion-input.public.json"
@@ -318,8 +327,36 @@
           "const": "release/robinhood-chain-4663/backend-promotion-input.attestation.json"
         },
         "attestationBundleSha256": { "$ref": "#/$defs/sha256" },
-        "trustedRootSource": { "const": "github-cli-embedded-tuf" },
-        "trustedRootSha256": { "$ref": "#/$defs/sha256" },
+        "bundleMediaType": {
+          "const": "application/vnd.dev.sigstore.bundle.v0.3+json"
+        },
+        "verifier": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "version", "sha256"],
+          "properties": {
+            "name": { "const": "cosign" },
+            "version": { "const": "v3.1.3" },
+            "sha256": {
+              "const": "sha256:4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71"
+            }
+          }
+        },
+        "certificateIdentity": {
+          "const": "https://github.com/programmablehq/programmable-open-hook-v2-internal/.github/workflows/capture-programmable-robinhood-promotion.yml@refs/heads/main"
+        },
+        "certificateOidcIssuer": {
+          "const": "https://token.actions.githubusercontent.com"
+        },
+        "certificateGithubWorkflowName": {
+          "const": "Capture Programmable Robinhood backend promotion"
+        },
+        "certificateGithubWorkflowRepository": {
+          "const": "programmablehq/programmable-open-hook-v2-internal"
+        },
+        "certificateGithubWorkflowRef": { "const": "refs/heads/main" },
+        "certificateGithubWorkflowSha": { "$ref": "#/$defs/gitHash" },
+        "certificateGithubWorkflowTrigger": { "const": "workflow_dispatch" },
         "repository": {
           "const": "programmablehq/programmable-open-hook-v2-internal"
         },

--- a/scripts/test/programmable-launch-release-workflow.test.mjs
+++ b/scripts/test/programmable-launch-release-workflow.test.mjs
@@ -76,6 +76,12 @@ function failures(value) {
     "test \"$(git remote get-url origin)\" = \"https://github.com/$GITHUB_REPOSITORY\"",
     "test -z \"$(git status --porcelain=v1 --untracked-files=all)\"",
     "node-version: 24.14.0",
+    "mktemp -d \"$RUNNER_TEMP/cosign-v3.1.3.XXXXXX\"",
+    "curl --proto '=https' --tlsv1.2",
+    "https://github.com/sigstore/cosign/releases/download/v3.1.3/cosign-linux-amd64",
+    "4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71",
+    "sha256sum --check --strict",
+    "PROGRAMMABLE_COSIGN_BIN=$cosign",
     "npm@11.16.0",
     "npm install --global npm@11.16.0 --ignore-scripts --no-audit --no-fund",
     "pkg.packageManager !== \"npm@11.16.0\"",
@@ -521,6 +527,12 @@ function robinhoodPromotionFailures(value) {
     cleanCheckoutAssertion,
     "actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444",
     "node-version: 24.14.0",
+    "mktemp -d \"$RUNNER_TEMP/cosign-v3.1.3.XXXXXX\"",
+    "curl --proto '=https' --tlsv1.2",
+    "https://github.com/sigstore/cosign/releases/download/v3.1.3/cosign-linux-amd64",
+    "4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71",
+    "sha256sum --check --strict",
+    "PROGRAMMABLE_COSIGN_BIN=$cosign",
     "npm@11.16.0",
     "npm install --global npm@11.16.0 --ignore-scripts --no-audit --no-fund",
     "npm ci --ignore-scripts --no-audit --no-fund",
@@ -540,6 +552,18 @@ function robinhoodPromotionFailures(value) {
     "test \"$capture_revision\" != \"$GITHUB_SHA\"",
     "backend-promotion-input.public.json",
     "backend-promotion-input.attestation.json",
+    "compgen -A variable | grep -E '^(COSIGN|FULCIO|REKOR|SIGSTORE|TUF)_' || true",
+    "Sigstore trust override environment is forbidden",
+    "\"$PROGRAMMABLE_COSIGN_BIN\" verify-blob",
+    "--certificate-identity",
+    "https://github.com/programmablehq/programmable-open-hook-v2-internal/.github/workflows/capture-programmable-robinhood-promotion.yml@refs/heads/main",
+    "--certificate-oidc-issuer \"https://token.actions.githubusercontent.com\"",
+    "--certificate-github-workflow-name",
+    "Capture Programmable Robinhood backend promotion",
+    "--certificate-github-workflow-repository",
+    "--certificate-github-workflow-ref \"refs/heads/main\"",
+    "--certificate-github-workflow-sha \"$BACKEND_REVISION\"",
+    "--certificate-github-workflow-trigger \"workflow_dispatch\"",
     "gh attestation trusted-root > \"$trusted_root\"",
     "--bundle \"$bundle\"",
     "--custom-trusted-root \"$TRUSTED_ROOT\"",
@@ -579,6 +603,20 @@ function robinhoodPromotionFailures(value) {
     "Reconfirm finalization producer remains protected production tip",
   ];
   const missing = required.filter((item) => !value.includes(item));
+  const forbiddenCosignOptions = [
+    "--insecure-ignore-tlog",
+    "--insecure-ignore-sct",
+    "--certificate-identity-regexp",
+    "--certificate-oidc-issuer-regexp",
+    "--key",
+    "--trusted-root",
+    "--rekor-url",
+    "--fulcio-url",
+  ];
+  for (const option of forbiddenCosignOptions) {
+    const pattern = new RegExp(`(^|\\s)${option}(?:\\s|=|$)`, "u");
+    if (pattern.test(value)) missing.push(`forbidden Cosign option ${option}`);
+  }
   if (value.split(cleanCheckoutAssertion).length - 1 !== 2) {
     missing.push("exactly two initial/final clean-checkout assertions");
   }
@@ -631,6 +669,22 @@ test("Robinhood Phase B workflow contract mutations fail closed", () => {
     robinhoodPromotionSource.replace("--source-digest \"$source_revision\"", ""),
     robinhoodPromotionSource.replace("--signer-digest \"$source_revision\"", ""),
     robinhoodPromotionSource.replace("--deny-self-hosted-runners", ""),
+    robinhoodPromotionSource.replace("--certificate-github-workflow-sha \"$BACKEND_REVISION\"", ""),
+    robinhoodPromotionSource.replace("--certificate-github-workflow-trigger \"workflow_dispatch\"", ""),
+    robinhoodPromotionSource.replace(
+      "compgen -A variable | grep -E '^(COSIGN|FULCIO|REKOR|SIGSTORE|TUF)_' || true",
+      "true",
+    ),
+    ...[
+      "--insecure-ignore-tlog",
+      "--insecure-ignore-sct",
+      "--certificate-identity-regexp",
+      "--certificate-oidc-issuer-regexp",
+      "--key",
+      "--trusted-root",
+      "--rekor-url",
+      "--fulcio-url",
+    ].map((option) => `${robinhoodPromotionSource}\n${option} attacker-controlled\n`),
     robinhoodPromotionSource.replaceAll("backend-promotion-input.public.json", "backend-promotion-input.json"),
     robinhoodPromotionSource.replace(
       "finalize-robinhood-custom-launch-deployment.mjs authorize-backend",


### PR DESCRIPTION
## Summary

- stage the fixed eight-file Phase-A backend bridge without changing public launch state
- bind the outer postdeployment capture, nested closure digests, Stage bundle, exact source assets, and portable GitHub attestations
- verify backend promotion evidence with pinned Cosign v3.1.3 and exact protected-main workflow claims
- preserve owner-controlled wallet broadcast, deployment, Rekor publication, and promotion boundaries

## Verification

- V4 release suite: 45/45
- postdeployment suite: 17/17
- release workflow suite: 7/7
- focused bridge and Sigstore tests: passed
- actionlint, JSON/syntax checks, and git diff --check: passed
- SSH-signed Noreply commit; worktree clean

No deploy, signature, Rekor write, or public promotion was performed by this PR.