### PR TITLE
Keep profile editor values in sync

### DIFF
--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -1318,6 +1318,20 @@ function getServerHydrationSnapshot() {
   return false;
 }
 
+export function readProfileForEditor(
+  storage: Parameters<typeof readLocalProfile>[0],
+  address: string | undefined,
+  fallback: ReturnType<typeof readLocalProfile>,
+) {
+  if (!address) return fallback;
+
+  try {
+    return readLocalProfile(storage, address);
+  } catch {
+    return fallback;
+  }
+}
+
 export function withoutClosedDeepProfileData(
   data: ProfileOnchainData,
 ): ProfileOnchainData {
@@ -1998,12 +2012,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
 
   function latestProfileForEditor() {
     if (!account || typeof window === "undefined") return savedProfile;
-
-    try {
-      return readLocalProfile(window.localStorage, account);
-    } catch {
-      return savedProfile;
-    }
+    return readProfileForEditor(window.localStorage, account, savedProfile);
   }
 
   function beginEditingProfile() {

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -84,6 +84,7 @@ import {
   normalizeProfileUsername,
   parseLocalProfile,
   PROFILE_UPDATED_EVENT,
+  readLocalProfile,
   writeLocalProfile,
 } from "@/lib/profile/local-profile";
 import {
@@ -1981,18 +1982,32 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     profileRefresh,
   ]);
 
-  function beginEditingProfile() {
-    setUsernameDraft(savedProfile.username);
-    setAvatarDraft(savedProfile.avatarDataUrl);
-    setBannerDraft(savedProfile.bannerDataUrl ?? "");
+  function populateProfileDrafts(profile: typeof savedProfile) {
+    setUsernameDraft(profile.username);
+    setAvatarDraft(profile.avatarDataUrl);
+    setBannerDraft(profile.bannerDataUrl ?? "");
     setBannerPositionDraft({
-      x: savedProfile.bannerPositionX ?? 50,
-      y: savedProfile.bannerPositionY ?? 50,
+      x: profile.bannerPositionX ?? 50,
+      y: profile.bannerPositionY ?? 50,
     });
-    setBioDraft(savedProfile.bio ?? "");
-    setXUrlDraft(savedProfile.xUrl ?? "");
-    setWebsiteUrlDraft(savedProfile.websiteUrl ?? "");
-    setGithubUrlDraft(savedProfile.githubUrl ?? "");
+    setBioDraft(profile.bio ?? "");
+    setXUrlDraft(profile.xUrl ?? "");
+    setWebsiteUrlDraft(profile.websiteUrl ?? "");
+    setGithubUrlDraft(profile.githubUrl ?? "");
+  }
+
+  function latestProfileForEditor() {
+    if (!account || typeof window === "undefined") return savedProfile;
+
+    try {
+      return readLocalProfile(window.localStorage, account);
+    } catch {
+      return savedProfile;
+    }
+  }
+
+  function beginEditingProfile() {
+    populateProfileDrafts(latestProfileForEditor());
     setUsernameError("");
     setAvatarError("");
     setBannerError("");
@@ -2001,17 +2016,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
   }
 
   function cancelEditingProfile() {
-    setUsernameDraft(savedProfile.username);
-    setAvatarDraft(savedProfile.avatarDataUrl);
-    setBannerDraft(savedProfile.bannerDataUrl ?? "");
-    setBannerPositionDraft({
-      x: savedProfile.bannerPositionX ?? 50,
-      y: savedProfile.bannerPositionY ?? 50,
-    });
-    setBioDraft(savedProfile.bio ?? "");
-    setXUrlDraft(savedProfile.xUrl ?? "");
-    setWebsiteUrlDraft(savedProfile.websiteUrl ?? "");
-    setGithubUrlDraft(savedProfile.githubUrl ?? "");
+    populateProfileDrafts(latestProfileForEditor());
     setUsernameError("");
     setAvatarError("");
     setBannerError("");

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -27,6 +27,7 @@ import {
   profileHasRewardSurface,
   profileNativeClaimMeetsVisibilityThreshold,
   publicProfileAccountFromQuery,
+  readProfileForEditor,
   prioritizedProfileActionState,
   profileRouterLaunchEntries,
   profileRewardsForAccount,
@@ -89,9 +90,29 @@ function profileCssDeclarationsFor(selectorFragment: string) {
 
 describe("profile editor composition", () => {
   it("hydrates editor drafts from the latest wallet-local profile", () => {
-    expect(profileViewSource).toMatch(
-      /readLocalProfile\(window\.localStorage, account\)/u,
-    );
+    const storage = {
+      getItem: vi.fn(() => JSON.stringify({
+        version: 2,
+        username: "Programmable",
+        avatarDataUrl: "",
+        xUrl: "ProgrammableHQ",
+        websiteUrl: "programmable.market",
+        githubUrl: "programmablehq",
+      })),
+      removeItem: vi.fn(),
+      setItem: vi.fn(),
+    };
+
+    expect(readProfileForEditor(
+      storage,
+      firstAddress,
+      { username: "", avatarDataUrl: "" },
+    )).toMatchObject({
+      username: "Programmable",
+      xUrl: "ProgrammableHQ",
+      websiteUrl: "programmable.market",
+      githubUrl: "programmablehq",
+    });
     expect(profileViewSource).toMatch(
       /populateProfileDrafts\(latestProfileForEditor\(\)\)/u,
     );

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -114,7 +114,7 @@ describe("profile editor composition", () => {
       githubUrl: "programmablehq",
     });
     expect(profileViewSource).toMatch(
-      /populateProfileDrafts\(latestProfileForEditor\(\)\)/u,
+      /function beginEditingProfile\(\)\s*\{\s*populateProfileDrafts\(latestProfileForEditor\(\)\);/u,
     );
   });
 

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -88,6 +88,15 @@ function profileCssDeclarationsFor(selectorFragment: string) {
 }
 
 describe("profile editor composition", () => {
+  it("hydrates editor drafts from the latest wallet-local profile", () => {
+    expect(profileViewSource).toMatch(
+      /readLocalProfile\(window\.localStorage, account\)/u,
+    );
+    expect(profileViewSource).toMatch(
+      /populateProfileDrafts\(latestProfileForEditor\(\)\)/u,
+    );
+  });
+
   it("keeps banner actions on the trailing edge away from the avatar", () => {
     expect(profileExperienceCss).toMatch(
       /\.bannerActions\s*\{[^}]*flex-direction:\s*row-reverse;[^}]*right:\s*14px;/s,


### PR DESCRIPTION
## Summary
- hydrate profile editor drafts from the latest wallet-local profile at edit time
- preserve current values when cancelling
- add a focused regression check

## Verification
- profile-view tests: 70 passed
- ESLint: passed
- TypeScript: passed
- git diff --check: passed