### PR TITLE
Improve critical UI copy readability

### DIFF
--- a/components/custom-market-trade.tsx
+++ b/components/custom-market-trade.tsx
@@ -361,9 +361,12 @@ export function CustomMarketTrade({
           <div><dt>Recipient</dt><dd>{review.preparation.recipient.slice(0, 6)}…{review.preparation.recipient.slice(-4)}</dd></div>
         </dl>
         <p className={styles.customTradeBinding}>
-          Route binding: {review.request.tradeCapabilityBindingHash}
-          <br />
-          Programmable validates this market, route, and recipient before opening your wallet.
+          <span className={styles.customTradeBindingHash}>
+            Route binding: {review.request.tradeCapabilityBindingHash}
+          </span>
+          <span className={styles.customTradeBindingNote}>
+            Programmable validates this market, route, and recipient before opening your wallet.
+          </span>
         </p>
         {error ? <p className={styles.error} role="alert">{error}</p> : null}
         <div className={styles.customTradeReviewActions}>

--- a/components/partner-admin-console.tsx
+++ b/components/partner-admin-console.tsx
@@ -379,7 +379,7 @@ export function PartnerAdminConsole() {
     if (invalidBudget) {
       setFieldError(
         invalidBudget.field,
-        "Use a whole-number budget within the limit shown for this field.",
+        `Use a whole number from 1 to ${invalidBudget.maximum}.`,
       );
       return;
     }

--- a/components/profile-projects.module.css
+++ b/components/profile-projects.module.css
@@ -313,14 +313,20 @@
   text-transform: uppercase;
 }
 
-.copy small,
-.loading,
-.empty,
-.error {
+.copy small {
   color: var(--text-soft, rgb(255 255 255 / 62%));
   font-size: 11px;
   font-variant-numeric: tabular-nums;
   line-height: 1.3;
+}
+
+.loading,
+.empty,
+.error {
+  color: var(--text-soft, rgb(255 255 255 / 62%));
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.45;
 }
 
 .skeletonList {

--- a/components/token-experience.module.css
+++ b/components/token-experience.module.css
@@ -647,10 +647,21 @@
 
 .customTradeBinding {
   color: var(--muted);
+  display: grid;
+  gap: 6px;
+  margin: 0;
+}
+
+.customTradeBindingHash {
   font-family: var(--font-plex-mono), monospace;
   font-size: 10px;
-  margin: 0;
   overflow-wrap: anywhere;
+}
+
+.customTradeBindingNote {
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.45;
 }
 
 .customTradeReviewActions {

--- a/tests/custom-market-selector-ui.test.ts
+++ b/tests/custom-market-selector-ui.test.ts
@@ -65,6 +65,12 @@ describe("Custom market selector UI", () => {
     expect(tradeSource).not.toContain(
       "tradeCapabilityBindingHash.slice(",
     );
+    expect(tradeStyles).toMatch(
+      /\.customTradeBindingHash\s*\{[^}]*font-size:\s*10px;/s,
+    );
+    expect(tradeStyles).toMatch(
+      /\.customTradeBindingNote\s*\{[^}]*font-size:\s*13px;/s,
+    );
   });
 
   it("keeps the branded options touch-sized with visible keyboard focus", () => {

--- a/tests/partner-attribution-ui.test.tsx
+++ b/tests/partner-attribution-ui.test.tsx
@@ -243,6 +243,9 @@ describe("partner attribution UI", () => {
     expect(source).toContain("This cannot be undone");
     expect(source).toContain('aria-label="Partner pages"');
     expect(source).toContain("ROOT_KEYS_PER_PAGE");
+    expect(source).toContain(
+      "`Use a whole number from 1 to ${invalidBudget.maximum}.`",
+    );
   });
 
   it("recovers an unlinked partner-admin wallet without retrying the request", () => {

--- a/tests/profile-projects-editor-open.test.ts
+++ b/tests/profile-projects-editor-open.test.ts
@@ -257,6 +257,9 @@ describe("My projects editor opening", () => {
     expect(styles).toMatch(
       /@media \(prefers-reduced-motion: no-preference\) \{[\s\S]*\.refresh\[data-loading="true"\] \.refreshIcon/u,
     );
+    expect(styles).toMatch(
+      /\.loading,\s*\.empty,\s*\.error\s*\{[^}]*font-size:\s*13px;/s,
+    );
   });
 
   it("returns a stalled launch refresh to an actionable error state", () => {


### PR DESCRIPTION
## Summary
- keep the route binding hash compact while rendering the wallet safety explanation at normal UI size
- make profile loading, empty, and error states readable
- show exact partner budget limits in validation errors

## Checks
- `npx vitest run tests/custom-market-selector-ui.test.ts tests/profile-projects-editor-open.test.ts tests/partner-attribution-ui.test.tsx` (36 passed)
- targeted ESLint
- `git diff --check`