### PR TITLE
Stabilize Explore and add chain views

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -42,6 +42,7 @@ import type { ExploreSort } from "../../../lib/onchain/types";
 import { canonicalSha256 } from
   "../../../lib/server/projection-target/hashing";
 import type { ExploreEntry } from "../../../lib/tokens";
+import { tryParseViewChainId } from "../../../lib/view-chain";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -86,6 +87,7 @@ function exploreLaunchSourceV1(input: Readonly<{
 }
 
 const EXPLORE_QUERY_PARAMETERS = new Set([
+  "chain",
   "limit",
   "model",
   "page",
@@ -346,8 +348,48 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  const chainValue = search.get("chain");
+  const chain = chainValue === null ? 1 : tryParseViewChainId(chainValue);
+  if (chain === null) {
+    return NextResponse.json(
+      { error: "Unsupported chain" },
+      { status: 400, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  if (chain === 4663) {
+    const pageSize = positiveInteger(
+      integerQuery(search.get("limit"), 9),
+      9,
+      100,
+    );
+    return NextResponse.json(
+      {
+        status: "not-deployed" as const,
+        activationStage: "planned-not-deployed" as const,
+        chainId: chain,
+        tokens: [],
+        page: 1,
+        pageSize,
+        total: 0,
+        totalPages: 0,
+        sort: parseExploreSort(search.get("sort")),
+        query: search.get("q")?.trim() ?? "",
+      },
+      {
+        headers: {
+          "Cache-Control":
+            "public, max-age=0, s-maxage=15, stale-while-revalidate=45",
+          "X-Programmable-Chain-Id": String(chain),
+          "X-Programmable-Read-Source": "planned-not-deployed",
+        },
+      },
+    );
+  }
+
   try {
     const options = {
+      chain,
       query: search.get("q")?.trim() ?? "",
       sort: parseExploreSort(search.get("sort")),
       page: integerQuery(search.get("page"), 1),
@@ -476,17 +518,18 @@ export async function GET(request: NextRequest) {
     const identityAsOfBlockHash = routerOwnsAggregateBoundary
       ? acceptedRouterSnapshot!.asOfBlockHash
       : catalog!.asOfBlockHash;
-    const identityGeneratedAt = catalog?.generatedAt ??
-      acceptedRouterSnapshot!.generatedAt;
+    const identityGeneratedAt = routerOwnsAggregateBoundary
+      ? acceptedRouterSnapshot!.generatedAt
+      : catalog!.generatedAt;
     const publicIdentityEntries = publicExploreCatalogEntriesV1(
       identityEntries,
-    );
+    ).filter((entry) => entryChainId(entry) === String(options.chain));
     const presentedPublicEntries = publicIdentityEntries.map(
       publicExplorePresentationEntryV1,
     );
     const identityCommitment = catalog === null
       ? canonicalSha256("programmable.public-identity-fallback.v1", {
-          chainId: 1,
+          chainId: options.chain,
           launchSource: ROUTER_CUSTOM_LAUNCH_SOURCE,
           asOfBlock: identityAsOfBlock,
           entries: publicIdentityEntries,
@@ -594,6 +637,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       {
         status: "ready" as const,
+        chainId: options.chain,
         ...paginated,
         tokens: pageEntries.map(publicExploreEntryV1),
         sort: options.sort,
@@ -670,6 +714,7 @@ export async function GET(request: NextRequest) {
           "Cache-Control":
             "public, max-age=0, s-maxage=15, stale-while-revalidate=45",
           "X-Programmable-Data-Quality": dataQuality.status,
+          "X-Programmable-Chain-Id": String(options.chain),
           "X-Programmable-Launch-Source": launchSource,
           "X-Programmable-Read-Source": `${launchSource}+dexscreener`,
           "X-Programmable-Market-Read-Status": marketRead.status,

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { headers } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { NextRequest } from "next/server";
 import { Suspense } from "react";
 
@@ -10,6 +10,11 @@ import type {
   ExploreModelFilter,
 } from "@/components/explore-view";
 import { DEFAULT_EXPLORE_VIEW_SORT } from "@/lib/explore-defaults";
+import {
+  parseViewChainId,
+  VIEW_CHAIN_COOKIE_NAME,
+  type ViewChainId,
+} from "@/lib/view-chain";
 
 export const dynamic = "force-dynamic";
 
@@ -18,6 +23,7 @@ export const dynamic = "force-dynamic";
 // browser, while keeping the initial render strictly bounded.
 export const INITIAL_EXPLORE_TIMEOUT_MS = 8_500;
 export const INITIAL_EXPLORE_QUERY = new URLSearchParams({
+  chain: "1",
   q: "",
   sort: DEFAULT_EXPLORE_VIEW_SORT,
   page: "1",
@@ -36,8 +42,12 @@ export function initialExploreModelFilter(
   return "all";
 }
 
-export function initialExploreQuery(modelFilter: ExploreModelFilter) {
+export function initialExploreQuery(
+  modelFilter: ExploreModelFilter,
+  viewChainId: ViewChainId = 1,
+) {
   const query = new URLSearchParams(INITIAL_EXPLORE_QUERY);
+  query.set("chain", String(viewChainId));
   if (modelFilter !== "all") {
     query.set(
       "model",
@@ -97,10 +107,15 @@ function isLocalPreviewHost(host: string | null) {
 async function InitialExploreView({
   searchParams,
 }: Readonly<{ searchParams: ExplorePageSearchParams }>) {
-  const [requestHeaders, resolvedSearchParams] = await Promise.all([
-    headers(),
-    searchParams,
-  ]);
+  const [requestHeaders, requestCookies, resolvedSearchParams] =
+    await Promise.all([
+      headers(),
+      cookies(),
+      searchParams,
+    ]);
+  const viewChainId = parseViewChainId(
+    requestCookies.get(VIEW_CHAIN_COOKIE_NAME)?.value,
+  );
   const modelFilter = initialExploreModelFilter(resolvedSearchParams.model);
   if (isLocalPreviewHost(requestHeaders.get("host"))) {
     return <ExploreView initialModelFilter={modelFilter} />;
@@ -110,7 +125,7 @@ async function InitialExploreView({
     async (signal) => {
       // prettier-ignore
       const response = await readExploreResponse(new NextRequest(
-        `http://programmable.local/api/explore?${initialExploreQuery(modelFilter)}`,
+        `http://programmable.local/api/explore?${initialExploreQuery(modelFilter, viewChainId)}`,
         {
           headers: { Accept: "application/json" },
           signal,
@@ -124,6 +139,7 @@ async function InitialExploreView({
   return (
     <ExploreView
       initialResponse={initialResponse}
+      initialResponseChainId={viewChainId}
       initialModelFilter={modelFilter}
     />
   );

--- a/components/animated-market-cap.tsx
+++ b/components/animated-market-cap.tsx
@@ -7,6 +7,8 @@ export type MarketCapMetric =
   | { kind: "eth"; value: number }
   | { kind: "quote"; symbol: string; value: number };
 
+export const MARKET_CAP_ANIMATION_DURATION_MS = 220;
+
 const useClientLayoutEffect =
   typeof window === "undefined" ? useEffect : useLayoutEffect;
 
@@ -61,14 +63,6 @@ export function formatMarketCapMetric(
   );
 }
 
-export function getMarketCapAnimationKey(
-  metric: MarketCapMetric,
-  replayKey: string,
-) {
-  const symbol = metric.kind === "quote" ? metric.symbol : "";
-  return `${replayKey}\u0000${metric.kind}\u0000${symbol}\u0000${metric.value}`;
-}
-
 function formatMarketCapValue(
   kind: MarketCapMetric["kind"],
   target: number,
@@ -87,6 +81,57 @@ function formatMarketCapValue(
   return `${formatted} ${kind === "eth" ? "ETH" : symbol}`;
 }
 
+function hasSameMetricIdentity(
+  previousMetric: MarketCapMetric,
+  nextMetric: MarketCapMetric,
+) {
+  if (previousMetric.kind !== nextMetric.kind) return false;
+
+  return previousMetric.kind !== "quote" ||
+    (nextMetric.kind === "quote" &&
+      previousMetric.symbol === nextMetric.symbol);
+}
+
+export function shouldAnimateMarketCapChange({
+  nextMetric,
+  nextReplayKey,
+  previousMetric,
+  previousReplayKey,
+  reducedMotion,
+}: Readonly<{
+  nextMetric: MarketCapMetric;
+  nextReplayKey: string;
+  previousMetric: MarketCapMetric | null;
+  previousReplayKey: string | null;
+  reducedMotion: boolean;
+}>) {
+  if (
+    previousMetric === null ||
+    previousReplayKey !== nextReplayKey ||
+    reducedMotion ||
+    !hasSameMetricIdentity(previousMetric, nextMetric) ||
+    !Number.isFinite(previousMetric.value) ||
+    !Number.isFinite(nextMetric.value) ||
+    previousMetric.value <= 0 ||
+    nextMetric.value <= 0 ||
+    Object.is(previousMetric.value, nextMetric.value)
+  ) {
+    return false;
+  }
+
+  return formatMarketCapMetric(previousMetric) !== formatMarketCapMetric(nextMetric);
+}
+
+export function interpolateMarketCapValue(
+  fromValue: number,
+  toValue: number,
+  progress: number,
+) {
+  const clampedProgress = Math.min(1, Math.max(0, progress));
+  const easedProgress = 1 - Math.pow(1 - clampedProgress, 3);
+  return fromValue + (toValue - fromValue) * easedProgress;
+}
+
 export function AnimatedMarketCap({
   delay = 0,
   metric,
@@ -97,91 +142,135 @@ export function AnimatedMarketCap({
   replayKey: string;
 }) {
   const valueRef = useRef<HTMLSpanElement>(null);
-  const completedAnimationKeyRef = useRef<string | null>(null);
+  const currentValueRef = useRef(metric.value);
+  const previousSnapshotRef = useRef<{
+    metric: MarketCapMetric;
+    replayKey: string;
+  } | null>(null);
   const kind = metric.kind;
   const value = metric.value;
   const symbol = metric.kind === "quote" ? metric.symbol : "";
-  const animationKey = getMarketCapAnimationKey(metric, replayKey);
-  const finalLabel = formatMarketCapValue(
-    kind,
-    value,
-    symbol,
-    value,
-  );
+  const finalLabel = formatMarketCapValue(kind, value, symbol, value);
 
   useClientLayoutEffect(() => {
     const element = valueRef.current;
     if (!element) return;
 
-    if (completedAnimationKeyRef.current === animationKey) {
-      element.textContent = finalLabel;
-      return;
-    }
-
+    const nextMetric: MarketCapMetric =
+      kind === "quote"
+        ? { kind, symbol, value }
+        : { kind, value };
+    const previousSnapshot = previousSnapshotRef.current;
     const reducedMotion = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     ).matches;
-    if (reducedMotion || value <= 0) {
+    const shouldAnimate = shouldAnimateMarketCapChange({
+      nextMetric,
+      nextReplayKey: replayKey,
+      previousMetric: previousSnapshot?.metric ?? null,
+      previousReplayKey: previousSnapshot?.replayKey ?? null,
+      reducedMotion,
+    });
+    const fromValue = currentValueRef.current;
+
+    previousSnapshotRef.current = {
+      metric: nextMetric,
+      replayKey,
+    };
+
+    if (
+      !shouldAnimate ||
+      !Number.isFinite(fromValue) ||
+      Object.is(fromValue, value)
+    ) {
       element.textContent = finalLabel;
-      completedAnimationKeyRef.current = animationKey;
+      currentValueRef.current = value;
       return;
     }
 
     let animationFrame = 0;
     let delayTimer = 0;
-    const duration = 520;
+    const normalizedDelay = Number.isFinite(delay) ? Math.max(0, delay) : 0;
 
-    element.textContent = formatMarketCapValue(kind, value, symbol, 0);
+    element.textContent = formatMarketCapValue(
+      kind,
+      value,
+      symbol,
+      fromValue,
+    );
 
     delayTimer = window.setTimeout(() => {
       const start = performance.now();
 
       const tick = (now: number) => {
-        const elapsed = Math.min(1, (now - start) / duration);
-        const eased = 1 - Math.pow(1 - elapsed, 3);
+        const progress = (now - start) / MARKET_CAP_ANIMATION_DURATION_MS;
+        const nextValue = interpolateMarketCapValue(
+          fromValue,
+          value,
+          progress,
+        );
+
+        currentValueRef.current = nextValue;
         element.textContent = formatMarketCapValue(
           kind,
           value,
           symbol,
-          value * eased,
+          nextValue,
         );
 
-        if (elapsed < 1) {
+        if (progress < 1) {
           animationFrame = window.requestAnimationFrame(tick);
-        } else {
-          element.textContent = finalLabel;
-          completedAnimationKeyRef.current = animationKey;
+          return;
         }
+
+        currentValueRef.current = value;
+        element.textContent = finalLabel;
       };
 
       animationFrame = window.requestAnimationFrame(tick);
-    }, delay);
+    }, normalizedDelay);
 
     return () => {
       window.clearTimeout(delayTimer);
       window.cancelAnimationFrame(animationFrame);
     };
-  }, [
-    animationKey,
-    delay,
-    finalLabel,
-    kind,
-    symbol,
-    value,
-  ]);
+  }, [delay, finalLabel, kind, replayKey, symbol, value]);
 
   return (
     <strong
       className="animated-market-cap"
-      style={{ position: "relative" }}
+      style={{
+        display: "inline-grid",
+        fontVariantNumeric: "tabular-nums",
+        inlineSize: "100%",
+        maxInlineSize: "100%",
+        minInlineSize: "7ch",
+        overflow: "hidden",
+        whiteSpace: "nowrap",
+      }}
+      title={finalLabel}
     >
-      <span aria-hidden="true" style={{ visibility: "hidden" }}>
+      <span
+        aria-hidden="true"
+        style={{
+          gridArea: "1 / 1",
+          minInlineSize: 0,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          visibility: "hidden",
+        }}
+      >
         {finalLabel}
       </span>
       <span
         aria-hidden="true"
         ref={valueRef}
-        style={{ inset: 0, position: "absolute" }}
+        style={{
+          gridArea: "1 / 1",
+          minInlineSize: 0,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}
       >
         {finalLabel}
       </span>

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -4,24 +4,36 @@ import { LiquidGlassFilter } from "@/components/liquid-glass-filter";
 import { MobileNavigation, SiteHeader } from "@/components/site-navigation";
 import { RouteTransition } from "@/components/route-transition";
 import { SiteFooter } from "@/components/site-footer";
+import {
+  ViewChainProvider,
+  type ViewChainId,
+} from "@/components/view-chain";
 import { WalletProvider } from "@/components/wallet-provider";
 
-export function AppShell({ children }: { children: ReactNode }) {
+export function AppShell({
+  children,
+  initialViewChainId = 1,
+}: Readonly<{
+  children: ReactNode;
+  initialViewChainId?: ViewChainId;
+}>) {
   return (
-    <WalletProvider>
-      <div className="app-frame">
-        <LiquidGlassFilter />
-        <AtmosphereBackdrop />
-        <a className="skip-link" href="#main-content">
-          Skip to content
-        </a>
-        <SiteHeader />
-        <main id="main-content" tabIndex={-1}>
-          <RouteTransition>{children}</RouteTransition>
-        </main>
-        <SiteFooter />
-        <MobileNavigation />
-      </div>
-    </WalletProvider>
+    <ViewChainProvider initialViewChainId={initialViewChainId}>
+      <WalletProvider>
+        <div className="app-frame">
+          <LiquidGlassFilter />
+          <AtmosphereBackdrop />
+          <a className="skip-link" href="#main-content">
+            Skip to content
+          </a>
+          <SiteHeader />
+          <main id="main-content" tabIndex={-1}>
+            <RouteTransition>{children}</RouteTransition>
+          </main>
+          <SiteFooter />
+          <MobileNavigation />
+        </div>
+      </WalletProvider>
+    </ViewChainProvider>
   );
 }

--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -1299,7 +1299,7 @@
 .runnerMeta {
   border-top: 1px solid var(--webde-line);
   gap: 4px;
-  min-height: 48px;
+  min-height: 70px;
   padding: 1px 8px 1px 14px;
 }
 
@@ -1693,6 +1693,14 @@
   height: 12px;
   margin-inline-start: auto;
   width: 92px;
+}
+
+.skeletonPartner {
+  flex: 1 0 100%;
+  height: 11px;
+  margin-block: 2px 7px;
+  order: 5;
+  width: min(44%, 132px);
 }
 
 @media (max-width: 700px) {

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -12,6 +12,8 @@ import {
   X as CloseIcon,
 } from "lucide-react";
 import {
+  type SetStateAction,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -20,7 +22,7 @@ import {
 } from "react";
 
 import {
-  formatMarketCapMetric,
+  AnimatedMarketCap,
   type MarketCapMetric,
 } from "@/components/animated-market-cap";
 import { XBrandIcon } from "@/components/brand-icons";
@@ -30,6 +32,10 @@ import {
   useInterfacePreview,
 } from "@/components/interface-preview";
 import { WebsiteLinkIcon } from "@/components/website-link-icon";
+import {
+  useViewChain,
+  type ViewChainId,
+} from "@/components/view-chain";
 import { PartnerLaunchAttribution } from
   "@/components/partner-launch-attribution";
 import { parseDiscoverableMarketTradeCapabilityV1 } from "@/lib/custom-launch/trade-capability-v1";
@@ -43,7 +49,6 @@ import {
   type ExploreValuation,
   type ValuedExploreEntry,
 } from "@/lib/explore-financial-data";
-import { DEFAULT_EXPLORE_VIEW_SORT } from "@/lib/explore-defaults";
 import {
   CLASSIC_V4_PUBLIC_RELEASE_BINDING,
   isClassicV4AnchoredPublicReleaseBinding,
@@ -327,21 +332,34 @@ function preserveKnownMarketObservation(
   previous: ValuedExploreEntry,
   incoming: ValuedExploreEntry,
 ): ValuedExploreEntry {
-  const valuation =
+  const acceptIncoming =
     incoming.valuation.status === "available" ||
-      previous.valuation.status !== "available"
-      ? incoming.valuation
-      : previous.valuation;
-  const marketData = incoming.marketData ?? previous.marketData;
-  const liquidityEvidence =
-    incoming.liquidityEvidence ?? previous.liquidityEvidence;
+      previous.valuation.status !== "available";
+  if (!acceptIncoming) return previous;
 
+  const {
+    marketData: _previousMarketData,
+    liquidityEvidence: _previousLiquidityEvidence,
+    fdvUsdWad: _previousFdvUsdWad,
+    ...identity
+  } = previous as ValuedExploreEntry & Readonly<{ fdvUsdWad?: string }>;
+  const incomingCompatibility = incoming as ValuedExploreEntry &
+    Readonly<{ fdvUsdWad?: string }>;
+  void _previousMarketData;
+  void _previousLiquidityEvidence;
+  void _previousFdvUsdWad;
   return {
-    ...previous,
-    ...incoming,
-    valuation,
-    ...(marketData ? { marketData } : {}),
-    ...(liquidityEvidence ? { liquidityEvidence } : {}),
+    ...identity,
+    valuation: incoming.valuation,
+    ...(incoming.marketData === undefined
+      ? {}
+      : { marketData: incoming.marketData }),
+    ...(incoming.liquidityEvidence === undefined
+      ? {}
+      : { liquidityEvidence: incoming.liquidityEvidence }),
+    ...(incomingCompatibility.fdvUsdWad === undefined
+      ? {}
+      : { fdvUsdWad: incomingCompatibility.fdvUsdWad }),
   } as ValuedExploreEntry;
 }
 
@@ -353,26 +371,27 @@ export function stabilizeExploreRevalidationPayload(
     previous.status !== "ready" ||
     incoming.status !== "ready" ||
     previous.page !== incoming.page ||
-    previous.pageSize !== incoming.pageSize
+    previous.pageSize !== incoming.pageSize ||
+    previous.catalog?.identityCommitment !==
+      incoming.catalog?.identityCommitment
   ) {
     return incoming;
   }
 
-  const previousIds = new Set(previous.tokens.map((token) => token.id));
   const incomingById = new Map(
     incoming.tokens.map((token) => [token.id, token] as const),
   );
-  const newTokens = incoming.tokens.filter((token) => !previousIds.has(token.id));
   const stableTokens = previous.tokens.map((token) => {
     const next = incomingById.get(token.id);
     return next ? preserveKnownMarketObservation(token, next) : token;
   });
 
   return {
-    ...incoming,
-    tokens: [...newTokens, ...stableTokens].slice(0, incoming.pageSize),
-    total: Math.max(previous.total, incoming.total),
-    totalPages: Math.max(previous.totalPages, incoming.totalPages),
+    ...previous,
+    tokens: stableTokens,
+    dataQuality: incoming.dataQuality ?? previous.dataQuality,
+    marketRead: incoming.marketRead ?? previous.marketRead,
+    ranking: incoming.ranking ?? previous.ranking,
   };
 }
 
@@ -382,7 +401,7 @@ export const EXPLORE_TOKENS_PER_PAGE = 9;
 export const EXPLORE_MOBILE_TOKENS_PER_PAGE = 4;
 export const EXPLORE_MOBILE_BREAKPOINT_PX = 700;
 export const EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE = 100;
-export const EXPLORE_REVALIDATION_INTERVAL_MS = 15_000;
+export const EXPLORE_REVALIDATION_INTERVAL_MS = 45_000;
 const EXPLORE_REVALIDATION_MIN_INTERVAL_MS = 1_000;
 const EXPLORE_REVALIDATION_MAX_INTERVAL_MS = 60_000;
 
@@ -563,8 +582,7 @@ function useExploreTokensPerPage() {
 }
 const QUERY_DEBOUNCE_MS = 200;
 const EXPLORE_REQUEST_TIMEOUT_MS = 12_000;
-const DEFAULT_EXPLORE_VALUATION_SORT: ExploreValuationSort =
-  DEFAULT_EXPLORE_VIEW_SORT === "market-cap" ? "highest" : "none";
+const DEFAULT_EXPLORE_VALUATION_SORT: ExploreValuationSort = "none";
 const fallbackTokenImages = [
   "/brand/programmable-token-card-fallback-night-garden-01.webp",
   "/brand/programmable-token-card-fallback-night-garden-02.webp",
@@ -1457,6 +1475,27 @@ function parseExplorePayload(value: unknown): ExplorePayload {
   if (!Array.isArray(value.tokens)) {
     throw new Error("The token registry returned invalid token data");
   }
+  if (value.status === "not-deployed") {
+    if (
+      value.tokens.length !== 0 ||
+      value.page !== 1 ||
+      typeof value.pageSize !== "number" ||
+      !Number.isSafeInteger(value.pageSize) ||
+      value.pageSize < 1 ||
+      value.total !== 0 ||
+      value.totalPages !== 0
+    ) {
+      throw new Error("The token registry returned invalid deployment data");
+    }
+    return {
+      status: "not-deployed",
+      tokens: [],
+      page: 1,
+      pageSize: value.pageSize,
+      total: 0,
+      totalPages: 0,
+    };
+  }
   if (
     value.dataQuality !== undefined &&
     !isExploreDataQuality(value.dataQuality)
@@ -1625,7 +1664,8 @@ export function createResponsiveExploreInitialState(
   }>,
 ): ExploreState | null {
   if (!input.reuseAvailable || !input.isInitialRequest) return null;
-  return createExploreInitialState(response, input);
+  const initialState = createExploreInitialState(response, input);
+  return initialState?.phase === "ready" ? initialState : null;
 }
 
 type PendingExploreRequest = {
@@ -2522,6 +2562,10 @@ function ExploreCardSkeleton() {
           className={`${styles.skeletonLine} ${styles.skeletonContract}`}
           data-skeleton="true"
         />
+        <span
+          className={`${styles.skeletonLine} ${styles.skeletonPartner}`}
+          data-skeleton="true"
+        />
       </div>
     </article>
   );
@@ -2554,16 +2598,31 @@ function resultRangeLabel(payload: ExplorePayload | null) {
 
 export function ExploreView({
   initialResponse,
+  initialResponseChainId,
   initialModelFilter = "all",
   loadingOnly = false,
   embedded = false,
 }: Readonly<{
   initialResponse?: ExploreInitialResponse;
+  initialResponseChainId?: ViewChainId;
   initialModelFilter?: ExploreModelFilter;
   loadingOnly?: boolean;
   embedded?: boolean;
 }> = {}) {
   const preview = useInterfacePreview();
+  const {
+    hydrated: viewChainReady,
+    viewChainId: resolvedViewChainId,
+  } = useViewChain();
+  const viewChainId =
+    !viewChainReady && initialResponseChainId !== undefined
+      ? initialResponseChainId
+      : resolvedViewChainId;
+  const activeInitialResponse =
+    initialResponseChainId === undefined ||
+      initialResponseChainId === viewChainId
+      ? initialResponse
+      : undefined;
   const [query, setQuery] = useState("");
   const normalizedQuery = query.trim();
   const [debouncedQuery, setDebouncedQuery] = useState("");
@@ -2575,12 +2634,34 @@ export function ExploreView({
   const [modelFilter, setModelFilter] = useState<ExploreModelFilter>(
     initialModelFilter,
   );
-  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSelection, setPageSelection] = useState({
+    chainId: viewChainId,
+    page: 1,
+  });
+  const currentPage = pageSelection.chainId === viewChainId
+    ? pageSelection.page
+    : 1;
+  const setCurrentPage = useCallback(
+    (nextPage: SetStateAction<number>) => {
+      setPageSelection((current) => {
+        const activePage = current.chainId === viewChainId ? current.page : 1;
+        const page = typeof nextPage === "function"
+          ? nextPage(activePage)
+          : nextPage;
+        return current.chainId === viewChainId && current.page === page
+          ? current
+          : { chainId: viewChainId, page };
+      });
+    },
+    [viewChainId],
+  );
   const pageSize = useExploreTokensPerPage();
   const [retryKey, setRetryKey] = useState(0);
+  const [revalidationKey, setRevalidationKey] = useState(0);
   const [copyFeedback, setCopyFeedback] = useState("");
   const [copiedTokenId, setCopiedTokenId] = useState<string | null>(null);
   const activeExploreContentKey = useRef<string | null>(null);
+  const backgroundRevalidationTarget = useRef<string | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const resultStatusRef = useRef<HTMLParagraphElement>(null);
   const copyFeedbackTimerRef = useRef<number | null>(null);
@@ -2595,13 +2676,14 @@ export function ExploreView({
     valuationSort,
     ageSort,
   );
-  const contentKey = `${debouncedQuery}\u0000${valuationSort}\u0000${ageSort}\u0000${socialFilter}\u0000${modelFilter}\u0000${currentPage}\u0000${pageSize}`;
+  const chainContentKey = `${viewChainId}`;
+  const contentKey = `${chainContentKey}\u0000${debouncedQuery}\u0000${valuationSort}\u0000${ageSort}\u0000${socialFilter}\u0000${modelFilter}\u0000${currentPage}\u0000${pageSize}`;
   const requestKey = `${contentKey}\u0000${retryKey}`;
-  const modelDatasetKey = `${debouncedQuery}\u0000${valuationSort}\u0000${ageSort}\u0000${socialFilter}\u0000${modelFilter}\u0000${retryKey}`;
+  const modelDatasetKey = `${chainContentKey}\u0000${debouncedQuery}\u0000${valuationSort}\u0000${ageSort}\u0000${socialFilter}\u0000${modelFilter}\u0000${retryKey}`;
   const activeRequestContentKey =
     requiresCompleteDataset ? modelDatasetKey : contentKey;
   const [initialState] = useState(() =>
-    createExploreInitialState(initialResponse, {
+    createExploreInitialState(activeInitialResponse, {
       requestKey,
       contentKey,
       pageSize,
@@ -2667,11 +2749,11 @@ export function ExploreView({
     }, QUERY_DEBOUNCE_MS);
 
     return () => window.clearTimeout(timer);
-  }, [debouncedQuery, normalizedQuery]);
+  }, [debouncedQuery, normalizedQuery, setCurrentPage]);
 
   useEffect(() => {
     return subscribeToExploreViewport(() => setCurrentPage(1));
-  }, []);
+  }, [setCurrentPage]);
 
   useEffect(() => {
     function closeFilter(event: PointerEvent | KeyboardEvent) {
@@ -2703,6 +2785,52 @@ export function ExploreView({
     if (
       preview ||
       loadingOnly ||
+      isInterfacePreviewHost(window.location.hostname)
+    ) return;
+
+    const schedulerStartedAt = Date.now();
+    const scheduler = createExploreRevalidationScheduler({
+      visibilityState: () => document.visibilityState,
+      online: () => navigator.onLine,
+      now: () => Date.now(),
+      setTimeout: (callback, delayMs) => window.setTimeout(callback, delayMs),
+      clearTimeout: (timer) => window.clearTimeout(timer),
+      onRevalidate: () => {
+        if (!explorePageSizeMatchesViewport(pageSize, window.innerWidth)) return;
+        backgroundRevalidationTarget.current = activeRequestContentKey;
+        modelDatasetCache.current = null;
+        expireResolvedExplorePayloadCache(activeRequestContentKey);
+        setRevalidationKey((value) => value + 1);
+      },
+      lastRevalidationAt: exploreRevalidationCacheTimestamp({
+        activeKey: activeRequestContentKey,
+        fallback: schedulerStartedAt,
+        resolvedUpdatedAt: resolvedExplorePayloadUpdatedAt(
+          activeRequestContentKey,
+          schedulerStartedAt,
+        ),
+        modelDataset: modelDatasetCache.current,
+      }),
+    });
+    const syncScheduler = () => scheduler.sync();
+
+    document.addEventListener("visibilitychange", syncScheduler);
+    window.addEventListener("focus", syncScheduler);
+    window.addEventListener("online", syncScheduler);
+    window.addEventListener("offline", syncScheduler);
+    return () => {
+      scheduler.dispose();
+      document.removeEventListener("visibilitychange", syncScheduler);
+      window.removeEventListener("focus", syncScheduler);
+      window.removeEventListener("online", syncScheduler);
+      window.removeEventListener("offline", syncScheduler);
+    };
+  }, [activeRequestContentKey, loadingOnly, pageSize, preview]);
+
+  useEffect(() => {
+    if (
+      preview ||
+      loadingOnly ||
       (typeof window !== "undefined" &&
         isInterfacePreviewHost(window.location.hostname))
     ) {
@@ -2717,6 +2845,7 @@ export function ExploreView({
     }
 
     const search = new URLSearchParams({
+      chain: String(viewChainId),
       q: debouncedQuery,
       sort,
       page: String(currentPage),
@@ -2740,9 +2869,10 @@ export function ExploreView({
       socialFilter === "all" &&
       modelFilter === initialModelFilter &&
       currentPage === 1 &&
-      retryKey === 0;
+      retryKey === 0 &&
+      revalidationKey === 0;
     const responsiveInitialState = createResponsiveExploreInitialState(
-      initialResponse,
+      activeInitialResponse,
       {
         reuseAvailable: initialResponseReuseAvailable.current,
         isInitialRequest,
@@ -2770,6 +2900,11 @@ export function ExploreView({
     initialResponseReuseAvailable.current = false;
 
     let ignore = false;
+    const isBackgroundRevalidation =
+      backgroundRevalidationTarget.current === activeRequestContentKey;
+    if (isBackgroundRevalidation) {
+      backgroundRevalidationTarget.current = null;
+    }
     const previousContentKey = activeExploreContentKey.current;
     if (previousContentKey && previousContentKey !== activeRequestContentKey) {
       abortExplorePayload(previousContentKey);
@@ -2778,7 +2913,7 @@ export function ExploreView({
     async function loadTokens() {
       try {
         let payload: ExplorePayload;
-        if (!requiresCompleteDataset) {
+        if (isBackgroundRevalidation || !requiresCompleteDataset) {
           payload = await loadExplorePage(
             activeRequestContentKey,
             search,
@@ -2823,12 +2958,17 @@ export function ExploreView({
           setCurrentPage(payload.page);
         }
         handledRequestKey.current = requestKey;
-        setState({
+        setState((current) => ({
           phase: "ready",
-          payload,
+          payload:
+            isBackgroundRevalidation &&
+              current.phase === "ready" &&
+              current.contentKey === contentKey
+              ? stabilizeExploreRevalidationPayload(current.payload, payload)
+              : payload,
           requestKey,
           contentKey,
-        });
+        }));
       } catch (error) {
         if (ignore) return;
         const message =
@@ -2857,17 +2997,20 @@ export function ExploreView({
     modelDatasetKey,
     modelFilter,
     pageSize,
-    initialResponse,
+    activeInitialResponse,
     initialModelFilter,
     initialState,
     loadingOnly,
     preview,
+    revalidationKey,
     requestKey,
     retryKey,
     requiresCompleteDataset,
     socialFilter,
     sort,
+    setCurrentPage,
     valuationSort,
+    viewChainId,
     ageSort,
   ]);
 
@@ -2907,6 +3050,11 @@ export function ExploreView({
     valuationSort,
   ]);
 
+  const activeChainState: ExploreState =
+    state.phase === "loading" ||
+      state.contentKey.startsWith(`${chainContentKey}\u0000`)
+      ? state
+      : { phase: "loading" };
   const displayState: ExploreState = preview
     ? {
         phase: "ready",
@@ -2914,7 +3062,7 @@ export function ExploreView({
         requestKey,
         contentKey,
       }
-    : state;
+    : activeChainState;
 
   const payload = displayState.phase === "ready" ? displayState.payload : null;
   const cards = useMemo(
@@ -2997,8 +3145,16 @@ export function ExploreView({
       return (
         <div className={`${styles.emptyState} liquid-glass-surface`}>
           <div>
-            <h2>Explore is getting ready</h2>
-            <p>The launch index is not available in this environment yet.</p>
+            <h2>
+              {viewChainId === 4663
+                ? "Robinhood Explore is planned"
+                : "Explore is getting ready"}
+            </h2>
+            <p>
+              {viewChainId === 4663
+                ? "Robinhood Chain launches are not deployed yet."
+                : "The launch index is not available in this environment yet."}
+            </p>
           </div>
         </div>
       );
@@ -3025,7 +3181,7 @@ export function ExploreView({
                 setQuery("");
                 setSocialFilter("all");
                 updateModelFilter("all");
-                setValuationSort("highest");
+                setValuationSort(DEFAULT_EXPLORE_VALUATION_SORT);
                 setAgeSort("none");
                 searchInputRef.current?.focus();
               }}
@@ -3080,9 +3236,6 @@ export function ExploreView({
           const imageSource = getTokenCardImageSource(token.imageUrl);
           const preserveArtworkAspectRatio =
             imageSource === SHARD_ORIGINAL_ARTWORK_SOURCE;
-          const valuationLabel = token.valuation
-            ? formatMarketCapMetric(token.valuation)
-            : null;
           const eagerImage = !embedded && index < Math.min(pageSize, 4);
           const cardContent = (
             <>
@@ -3126,9 +3279,14 @@ export function ExploreView({
                 <div className={styles.runnerData}>
                   <span>
                     <small title="Fully diluted valuation">FDV</small>
-                    <strong>
-                      {valuationLabel ?? token.marketStatus ?? "Unavailable"}
-                    </strong>
+                    {token.valuation ? (
+                      <AnimatedMarketCap
+                        metric={token.valuation}
+                        replayKey={token.id}
+                      />
+                    ) : (
+                      <strong>{token.marketStatus ?? "Unavailable"}</strong>
+                    )}
                   </span>
                 </div>
               </div>

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -1343,7 +1343,7 @@
 
 .profileSkeletonInline {
   margin-block-start: 34px;
-  min-height: 398px;
+  min-height: 360px;
   padding-block-start: 0;
 }
 
@@ -1369,8 +1369,8 @@
 .profileSkeletonBar,
 .profileSkeletonTabs,
 .profileSkeletonRow > span {
-  animation: profile-skeleton-pulse 1.4s ease-in-out infinite alternate;
-  background: color-mix(in srgb, var(--text) 9%, transparent);
+  animation: profile-skeleton-pulse 1.35s ease-in-out infinite alternate;
+  background: var(--skeleton-base);
 }
 
 .profileSkeletonBanner {
@@ -1420,7 +1420,7 @@
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  min-height: 398px;
+  min-height: 360px;
 }
 
 .profileSkeletonWorkspacePage {
@@ -1441,6 +1441,11 @@
 .profileSkeletonSummary,
 .profileSkeletonClaims {
   min-height: 360px;
+}
+
+.profileSkeletonClaims {
+  align-content: start;
+  gap: 12px;
 }
 
 .profileSkeletonSection {
@@ -1515,9 +1520,24 @@
   height: 44px;
 }
 
+.profileSkeletonLaunch .profileSkeletonRow {
+  gap: 9px;
+  grid-template-columns: 42px minmax(0, 1fr) 364px;
+  min-height: 71px;
+  padding: 7px 8px;
+}
+
+.profileSkeletonLaunch .profileSkeletonRow > span:first-child {
+  border-radius: 10px;
+  height: 42px;
+}
+
+.profileSkeletonLaunch .profileSkeletonRow > span:last-child {
+  border-radius: 10px;
+}
+
 @keyframes profile-skeleton-pulse {
-  from { opacity: 0.48; }
-  to { opacity: 0.9; }
+  to { background-color: var(--skeleton-highlight); }
 }
 
 .accountState {
@@ -2644,8 +2664,8 @@
   }
 
   .profileSkeletonLaunch .profileSkeletonRow {
-    grid-template-columns: 44px minmax(0, 1fr);
-    min-height: 142.5px;
+    grid-template-columns: 42px minmax(0, 1fr);
+    min-height: 143px;
   }
 
   .profileSkeletonLaunch .profileSkeletonRow > span:last-child {

--- a/components/profile-projects.module.css
+++ b/components/profile-projects.module.css
@@ -347,8 +347,8 @@
 .skeletonArt,
 .skeletonCopy span,
 .skeletonAction {
-  animation: profile-project-skeleton 1.4s ease-in-out infinite alternate;
-  background: color-mix(in srgb, var(--text, #fff) 9%, transparent);
+  animation: profile-project-skeleton 1.35s ease-in-out infinite alternate;
+  background: var(--skeleton-base);
 }
 
 .skeletonArt {
@@ -393,8 +393,7 @@
 }
 
 @keyframes profile-project-skeleton {
-  from { opacity: 0.48; }
-  to { opacity: 0.9; }
+  to { background-color: var(--skeleton-highlight); }
 }
 
 .actions {

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -1397,7 +1397,13 @@ export function formatBannerPositionStatus(position: {
 }
 
 export function ProfileView({ onchainData }: ProfileViewProps = {}) {
-  const { wallet, openWallet, sendTransaction, connecting } = useWallet();
+  const {
+    wallet,
+    openWallet,
+    sendTransaction,
+    connecting,
+    hasSession,
+  } = useWallet();
   const searchParams = useSearchParams();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const bannerInputRef = useRef<HTMLInputElement>(null);
@@ -3387,13 +3393,24 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
   }
 
   const sessionView = getProfileSessionView(connecting, account);
+  const requestedProfileAccount = publicProfileAccountFromQuery(
+    searchParams.getAll("account"),
+  );
   const publicProfileAccount = publicProfileAccountFromQuery(
     searchParams.getAll("account"),
     account,
   );
 
   if (!clientHydrated || sessionView === "loading") {
-    return <ProfileSessionLoadingState />;
+    return (
+      <ProfileSessionLoadingState
+        showDashboard={
+          clientHydrated &&
+          requestedProfileAccount === null &&
+          (hasSession || Boolean(account))
+        }
+      />
+    );
   }
 
   if (publicProfileAccount) {
@@ -4500,29 +4517,35 @@ export function profileRewardsForAccount<
   );
 }
 
-export function ProfileSessionLoadingState() {
+export function ProfileSessionLoadingState({
+  showDashboard = false,
+}: Readonly<{ showDashboard?: boolean }> = {}) {
   return (
     <div className={`${styles.page} page-width`}>
-      <section
-        className={`${styles.connectCard} liquid-glass-surface`}
-        aria-busy="true"
-        aria-label="Loading profile"
-      >
-        <Image
-          className={styles.connectMark}
-          src="/brand/loop/programmable-loop-mark-warm-ivory-v1-1536.png"
-          alt=""
-          width={512}
-          height={512}
-          sizes="(max-width: 700px) 72px, 188px"
-          priority
-        />
-        <h1>Profile</h1>
-        <p role="status">Loading profile…</p>
-        <button className={styles.connectButton} type="button" disabled>
-          Loading
-        </button>
-      </section>
+      {showDashboard ? (
+        <ProfileLoadingSkeleton label="Loading profile" showHero />
+      ) : (
+        <section
+          className={`${styles.connectCard} liquid-glass-surface`}
+          aria-busy="true"
+          aria-label="Loading profile"
+        >
+          <Image
+            className={styles.connectMark}
+            src="/brand/loop/programmable-loop-mark-warm-ivory-v1-1536.png"
+            alt=""
+            width={512}
+            height={512}
+            sizes="(max-width: 700px) 72px, 188px"
+            priority
+          />
+          <h1>Profile</h1>
+          <p role="status">Loading profile…</p>
+          <button className={styles.connectButton} type="button" disabled>
+            Loading
+          </button>
+        </section>
+      )}
     </div>
   );
 }
@@ -4591,14 +4614,18 @@ function ProfileLoadingSkeleton({
           <span className={styles.profileSkeletonBar} />
         </div>
         <div className={styles.profileSkeletonClaims}>
-          <span className={styles.profileSkeletonHeading} />
-          {Array.from({ length: profileClaimPageSize }, (_, item) => (
-            <span className={styles.profileSkeletonRow} key={item}>
-              <span />
-              <span />
-              <span />
-            </span>
-          ))}
+          <span className={styles.profileSkeletonSectionHeader}>
+            <span className={styles.profileSkeletonHeading} />
+          </span>
+          <span className={styles.profileSkeletonRows}>
+            {Array.from({ length: profileClaimPageSize }, (_, item) => (
+              <span className={styles.profileSkeletonRow} key={item}>
+                <span />
+                <span />
+                <span />
+              </span>
+            ))}
+          </span>
         </div>
       </div>
     </section>

--- a/components/route-transition.tsx
+++ b/components/route-transition.tsx
@@ -2,11 +2,30 @@
 
 import { usePathname } from "next/navigation";
 import { useEffect, useLayoutEffect, useRef, type ReactNode } from "react";
+import { useViewChain } from "@/components/view-chain";
+import {
+  isRobinhoodUnavailableRoute,
+  ViewChainPending,
+  ViewChainUnavailable,
+} from "@/components/view-chain-unavailable";
 
 export function RouteTransition({ children }: { children: ReactNode }) {
   const pathname = usePathname();
+  const { hydrated, viewChainId } = useViewChain();
   const contentRef = useRef<HTMLDivElement>(null);
-  const previousPathname = useRef(pathname);
+  const routeRequiresResolvedChain = isRobinhoodUnavailableRoute(pathname);
+  const showChainPending = routeRequiresResolvedChain && !hydrated;
+  const showRobinhoodUnavailable =
+    hydrated && viewChainId === 4663 && routeRequiresResolvedChain;
+  const focusContext = `${pathname}\u0000${
+    showChainPending
+      ? "pending"
+      : showRobinhoodUnavailable
+        ? "unavailable"
+        : "route"
+  }`;
+  const previousFocusContext = useRef(focusContext);
+  const previousHydrated = useRef(hydrated);
   const previousMotionPathname = useRef(pathname);
   const routeAnimationRef = useRef<Animation | null>(null);
   const isDocsPath = pathname.startsWith("/docs");
@@ -58,8 +77,14 @@ export function RouteTransition({ children }: { children: ReactNode }) {
   }, [pathname]);
 
   useEffect(() => {
-    if (previousPathname.current === pathname) return;
-    previousPathname.current = pathname;
+    const resolvedInitialChain = !previousHydrated.current && hydrated;
+    previousHydrated.current = hydrated;
+    if (resolvedInitialChain) {
+      previousFocusContext.current = focusContext;
+      return;
+    }
+    if (previousFocusContext.current === focusContext) return;
+    previousFocusContext.current = focusContext;
     if (pathname.startsWith("/docs") && window.location.hash) return;
     const heading = contentRef.current?.querySelector<HTMLElement>("h1");
     if (heading) {
@@ -76,14 +101,20 @@ export function RouteTransition({ children }: { children: ReactNode }) {
     document.querySelector<HTMLElement>("#main-content")?.focus({
       preventScroll: true,
     });
-  }, [pathname]);
+  }, [focusContext, hydrated, pathname]);
 
   return (
     <div
       className={`route-transition${isDocsPath ? " route-transition-docs" : ""}`}
       ref={contentRef}
     >
-      {children}
+      {showChainPending ? (
+        <ViewChainPending />
+      ) : showRobinhoodUnavailable ? (
+        <ViewChainUnavailable />
+      ) : (
+        children
+      )}
     </div>
   );
 }

--- a/components/site-navigation.module.css
+++ b/components/site-navigation.module.css
@@ -7,7 +7,7 @@
 }
 
 .headerActions.headerActions {
-  gap: 0;
+  gap: 4px;
   grid-column: 3;
 }
 
@@ -44,6 +44,172 @@
 .menuButton:focus-visible {
   outline: 2px solid var(--brand-ivory);
   outline-offset: 2px;
+}
+
+.chainSelector {
+  flex: none;
+  position: relative;
+}
+
+.chainTrigger {
+  align-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  color: var(--navigation-glass-ink);
+  display: inline-flex;
+  flex: none;
+  height: 48px;
+  justify-content: center;
+  padding: 0;
+  transition:
+    background-color 180ms cubic-bezier(0.32, 0.72, 0, 1),
+    border-color 180ms cubic-bezier(0.32, 0.72, 0, 1),
+    transform 180ms cubic-bezier(0.32, 0.72, 0, 1);
+  width: 48px;
+}
+
+.chainTrigger:active {
+  transform: scale(0.96);
+}
+
+.chainTrigger:disabled {
+  cursor: wait;
+}
+
+.chainTrigger:focus-visible {
+  outline: 2px solid var(--brand-ivory);
+  outline-offset: 2px;
+}
+
+.ethereumChainMark {
+  display: block;
+  height: 23px;
+  width: 23px;
+}
+
+.chainMarkPlaceholder {
+  border: 1px solid rgb(255 255 255 / 0.14);
+  border-radius: 50%;
+  display: block;
+  height: 20px;
+  width: 20px;
+}
+
+.robinhoodChainMark {
+  align-items: center;
+  border: 1px solid currentColor;
+  border-radius: 7px;
+  display: inline-flex;
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 13px;
+  font-weight: 600;
+  height: 23px;
+  justify-content: center;
+  line-height: 1;
+  width: 23px;
+}
+
+.chainPopover {
+  inset-inline-end: -52px;
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  top: calc(100% + 4px);
+  transform: translate3d(0, -4px, 0) scale(0.98);
+  transform-origin: top right;
+  transition:
+    opacity 180ms cubic-bezier(0.32, 0.72, 0, 1),
+    transform 180ms cubic-bezier(0.32, 0.72, 0, 1),
+    visibility 0s linear 180ms;
+  visibility: hidden;
+  width: min(236px, calc(100vw - 32px));
+  z-index: 100;
+}
+
+.chainPopoverOpen {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate3d(0, 0, 0) scale(1);
+  transition:
+    opacity 180ms cubic-bezier(0.32, 0.72, 0, 1),
+    transform 180ms cubic-bezier(0.32, 0.72, 0, 1),
+    visibility 0s linear 0s;
+  visibility: visible;
+}
+
+.chainPopoverSurface {
+  -webkit-backdrop-filter: blur(28px) saturate(1.08);
+  backdrop-filter: blur(28px) saturate(1.08);
+  background: rgb(14 15 18 / 0.96);
+  border: 1px solid rgb(255 255 255 / 0.1);
+  border-radius: 16px;
+  box-shadow: 0 20px 52px rgb(0 0 0 / 0.52);
+  padding: 6px;
+}
+
+.chainOption {
+  align-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 11px;
+  color: var(--navigation-glass-ink);
+  display: flex;
+  font-family: var(--font-instrument), sans-serif;
+  gap: 10px;
+  min-height: 54px;
+  padding: 6px 9px;
+  text-align: start;
+  transition:
+    background-color 160ms cubic-bezier(0.32, 0.72, 0, 1),
+    border-color 160ms cubic-bezier(0.32, 0.72, 0, 1),
+    transform 160ms cubic-bezier(0.32, 0.72, 0, 1);
+  width: 100%;
+}
+
+.chainOption:active {
+  transform: scale(0.98);
+}
+
+.chainOption:focus-visible {
+  outline: 2px solid var(--brand-ivory);
+  outline-offset: -2px;
+}
+
+.chainOptionMark {
+  align-items: center;
+  background: rgb(255 255 255 / 0.055);
+  border: 1px solid rgb(255 255 255 / 0.09);
+  border-radius: 10px;
+  display: inline-flex;
+  flex: none;
+  height: 38px;
+  justify-content: center;
+  width: 38px;
+}
+
+.chainOptionMark .ethereumChainMark,
+.chainOptionMark .robinhoodChainMark {
+  height: 20px;
+  width: 20px;
+}
+
+.chainOptionCopy {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.chainOptionCopy strong {
+  font-size: 14px;
+  font-weight: 620;
+  line-height: 1.1;
+}
+
+.chainOptionCopy small {
+  color: var(--navigation-glass-ink-muted);
+  font-size: 11px;
+  line-height: 1.2;
 }
 
 .menuIcon {
@@ -332,9 +498,15 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .menuButton:hover {
+  .menuButton:hover,
+  .chainTrigger:hover {
     background: rgb(255 255 255 / 0.06);
     border-color: rgb(255 255 255 / 0.08);
+  }
+
+  .chainOption:hover {
+    background: rgb(255 255 255 / 0.065);
+    border-color: rgb(255 255 255 / 0.07);
   }
 
   .mobileSheet.mobileSheet :global(.mobile-nav a:hover) {
@@ -389,6 +561,9 @@
 @media (prefers-reduced-motion: reduce) {
   .menuButton,
   .menuIcon svg,
+  .chainTrigger,
+  .chainPopover,
+  .chainOption,
   .mobileSheet,
   .mobileSheet.mobileSheet :global(.mobile-nav a),
   .disconnectWallet {
@@ -400,12 +575,17 @@
 
 @media (forced-colors: active) {
   .menuButton,
+  .chainTrigger,
+  .chainPopoverSurface,
+  .chainOption,
   .mobileSheetSurface {
     border-color: CanvasText;
     box-shadow: none;
   }
 
   .menuButton:focus-visible,
+  .chainTrigger:focus-visible,
+  .chainOption:focus-visible,
   .mobileSheet.mobileSheet :global(.mobile-nav a:focus-visible),
   .disconnectWallet:focus-visible,
   .connectWallet:focus-visible {

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
   type FocusEvent,
+  type RefObject,
 } from "react";
 import Image from "next/image";
 import Link from "next/link";
@@ -20,6 +21,9 @@ import {
   NavigationCloseIcon,
   NavigationMenuIcon,
 } from "@/components/navigation-icons";
+import { useViewChain, type ViewChainId } from "@/components/view-chain";
+import { isRobinhoodUnavailableRoute } from
+  "@/components/view-chain-unavailable";
 import { useWallet } from "@/components/wallet-provider";
 import styles from "@/components/site-navigation.module.css";
 
@@ -275,30 +279,182 @@ function DesktopNavigation() {
   );
 }
 
+function ViewChainMark({ viewChainId }: { viewChainId: ViewChainId }) {
+  if (viewChainId === 4663) {
+    return (
+      <span className={styles.robinhoodChainMark} aria-hidden="true">
+        R
+      </span>
+    );
+  }
+
+  return (
+    <svg
+      className={styles.ethereumChainMark}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M12 2 5.5 12.2 12 9.25l6.5 2.95L12 2Z" fill="currentColor" />
+      <path
+        d="m5.5 13.35 6.5 3.7 6.5-3.7L12 22 5.5 13.35Z"
+        fill="currentColor"
+        opacity="0.72"
+      />
+      <path d="m12 9.25-6.5 2.95L12 15.9l6.5-3.7L12 9.25Z" fill="currentColor" opacity="0.9" />
+    </svg>
+  );
+}
+
+function viewChainLabel(viewChainId: ViewChainId) {
+  return viewChainId === 1 ? "Ethereum" : "Robinhood";
+}
+
+function HeaderChainSelector({
+  open,
+  panelId,
+  rootRef,
+  triggerRef,
+  onDismiss,
+  onToggle,
+  onSelect,
+}: Readonly<{
+  open: boolean;
+  panelId: string;
+  rootRef: RefObject<HTMLDivElement | null>;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+  onDismiss: () => void;
+  onToggle: () => void;
+  onSelect: () => void;
+}>) {
+  const { hydrated, viewChainId, setViewChainId } = useViewChain();
+  const alternateViewChainId: ViewChainId = viewChainId === 1 ? 4663 : 1;
+  const currentLabel = viewChainLabel(viewChainId);
+  const alternateLabel = viewChainLabel(alternateViewChainId);
+  const alternateStatus =
+    alternateViewChainId === 4663
+      ? "Public index coming soon"
+      : "View Ethereum Chain";
+
+  function closeOnFocusLeave(event: FocusEvent<HTMLDivElement>) {
+    if (!open) return;
+    if (
+      event.relatedTarget instanceof Node &&
+      event.currentTarget.contains(event.relatedTarget)
+    ) {
+      return;
+    }
+
+    const root = event.currentTarget;
+    window.requestAnimationFrame(() => {
+      if (!root.contains(document.activeElement)) onDismiss();
+    });
+  }
+
+  return (
+    <div
+      ref={rootRef}
+      className={styles.chainSelector}
+      onBlur={closeOnFocusLeave}
+    >
+      <button
+        ref={triggerRef}
+        className={styles.chainTrigger}
+        type="button"
+        aria-controls={panelId}
+        aria-expanded={open}
+        aria-busy={!hydrated || undefined}
+        aria-label={
+          hydrated ? `Viewing ${currentLabel}. Change network` : "Loading network"
+        }
+        disabled={!hydrated}
+        title={hydrated ? currentLabel : undefined}
+        onClick={onToggle}
+      >
+        {hydrated ? (
+          <ViewChainMark viewChainId={viewChainId} />
+        ) : (
+          <span className={styles.chainMarkPlaceholder} aria-hidden="true" />
+        )}
+      </button>
+
+      <div
+        className={`${styles.chainPopover} ${
+          open ? styles.chainPopoverOpen : ""
+        }`}
+        aria-hidden={!open}
+        inert={open ? undefined : true}
+      >
+        <div
+          className={styles.chainPopoverSurface}
+          id={panelId}
+          role="group"
+          aria-label="Choose network"
+        >
+          <button
+            className={styles.chainOption}
+            type="button"
+            tabIndex={open ? undefined : -1}
+            data-view-chain-id={alternateViewChainId}
+            onClick={() => {
+              setViewChainId(alternateViewChainId);
+              onSelect();
+            }}
+          >
+            <span className={styles.chainOptionMark} aria-hidden="true">
+              <ViewChainMark viewChainId={alternateViewChainId} />
+            </span>
+            <span className={styles.chainOptionCopy}>
+              <strong>{alternateLabel}</strong>
+              <small>{alternateStatus}</small>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function SiteHeader() {
   const pathname = usePathname();
   const menuId = useId();
+  const chainPanelId = useId();
   const headerRef = useRef<HTMLElement>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const chainSelectorRef = useRef<HTMLDivElement>(null);
+  const chainButtonRef = useRef<HTMLButtonElement>(null);
   const [menuPath, setMenuPath] = useState<string | null>(null);
+  const [chainSelectorOpen, setChainSelectorOpen] = useState(false);
   const menuOpen = menuPath === pathname;
 
   useEffect(() => {
-    if (!menuOpen) return;
+    if (!menuOpen && !chainSelectorOpen) return;
 
     const closeOnOutsidePress = (event: PointerEvent) => {
-      if (
-        event.target instanceof Node &&
-        !headerRef.current?.contains(event.target)
-      ) {
+      if (!(event.target instanceof Node)) return;
+      if (menuOpen && !headerRef.current?.contains(event.target)) {
         setMenuPath(null);
+      }
+      if (
+        chainSelectorOpen &&
+        !chainSelectorRef.current?.contains(event.target)
+      ) {
+        setChainSelectorOpen(false);
       }
     };
 
     const closeOnEscape = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
-      setMenuPath(null);
-      menuButtonRef.current?.focus();
+      if (chainSelectorOpen) {
+        setChainSelectorOpen(false);
+        chainButtonRef.current?.focus();
+        return;
+      }
+      if (menuOpen) {
+        setMenuPath(null);
+        menuButtonRef.current?.focus();
+      }
     };
 
     document.addEventListener("pointerdown", closeOnOutsidePress);
@@ -308,7 +464,7 @@ export function SiteHeader() {
       document.removeEventListener("pointerdown", closeOnOutsidePress);
       document.removeEventListener("keydown", closeOnEscape);
     };
-  }, [menuOpen]);
+  }, [chainSelectorOpen, menuOpen]);
 
   function closeOnFocusLeave(event: FocusEvent<HTMLElement>) {
     if (!menuOpen) return;
@@ -354,6 +510,24 @@ export function SiteHeader() {
         <DesktopNavigation />
 
         <div className={`header-actions ${styles.headerActions}`}>
+          <HeaderChainSelector
+            open={chainSelectorOpen}
+            panelId={chainPanelId}
+            rootRef={chainSelectorRef}
+            triggerRef={chainButtonRef}
+            onDismiss={() => setChainSelectorOpen(false)}
+            onToggle={() => {
+              setMenuPath(null);
+              setChainSelectorOpen((open) => !open);
+            }}
+            onSelect={() => {
+              setChainSelectorOpen(false);
+              if (isRobinhoodUnavailableRoute(pathname)) return;
+              window.requestAnimationFrame(() => {
+                chainButtonRef.current?.focus({ preventScroll: true });
+              });
+            }}
+          />
           <button
             ref={menuButtonRef}
             className={styles.menuButton}
@@ -361,7 +535,10 @@ export function SiteHeader() {
             aria-controls={menuId}
             aria-expanded={menuOpen}
             aria-label={menuOpen ? "Close menu" : "Open menu"}
-            onClick={() => setMenuPath(menuOpen ? null : pathname)}
+            onClick={() => {
+              setChainSelectorOpen(false);
+              setMenuPath(menuOpen ? null : pathname);
+            }}
           >
             <span className={styles.menuIcon} aria-hidden="true">
               <NavigationMenuIcon

--- a/components/view-chain-unavailable.module.css
+++ b/components/view-chain-unavailable.module.css
@@ -1,0 +1,163 @@
+.page {
+  align-items: center;
+  display: grid;
+  min-height: calc(100svh - var(--header-height));
+  padding: clamp(44px, 8vw, 104px) max(20px, 4vw);
+  width: 100%;
+}
+
+.pending {
+  min-height: calc(100svh - var(--header-height));
+  width: 100%;
+}
+
+.pendingStatus {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.panel {
+  background:
+    radial-gradient(
+      circle at 18% 0%,
+      rgb(248 240 233 / 0.07),
+      transparent 42%
+    ),
+    rgb(14 15 18 / 0.82);
+  border: 1px solid rgb(248 240 233 / 0.12);
+  border-radius: 24px;
+  box-shadow:
+    0 28px 90px rgb(0 0 0 / 0.28),
+    inset 0 1px 0 rgb(255 255 255 / 0.035);
+  margin: 0 auto;
+  max-width: 680px;
+  overflow: hidden;
+  padding: clamp(28px, 6vw, 52px);
+  position: relative;
+  width: 100%;
+}
+
+.panel::before {
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgb(248 240 233 / 0.44),
+    transparent
+  );
+  content: "";
+  height: 1px;
+  inset: 0 12% auto;
+  position: absolute;
+}
+
+.chainStatus {
+  align-items: center;
+  color: var(--brand-ivory-muted, rgb(248 240 233 / 0.58));
+  display: flex;
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 11px;
+  font-weight: 650;
+  gap: 8px;
+  letter-spacing: 0.1em;
+  margin-bottom: 20px;
+  text-transform: uppercase;
+}
+
+.statusDot {
+  background: var(--brand-ivory, #f8f0e9);
+  border-radius: 999px;
+  box-shadow: 0 0 0 4px rgb(248 240 233 / 0.08);
+  height: 7px;
+  width: 7px;
+}
+
+.panel h1 {
+  color: var(--brand-ivory, #f8f0e9);
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: clamp(34px, 5vw, 52px);
+  font-weight: 560;
+  letter-spacing: -0.045em;
+  line-height: 1;
+  margin: 0;
+  max-width: 13ch;
+  text-wrap: balance;
+}
+
+.description {
+  color: var(--brand-ivory-soft, rgb(248 240 233 / 0.76));
+  font-size: 15px;
+  line-height: 1.6;
+  margin: 20px 0 0;
+  max-width: 58ch;
+  text-wrap: pretty;
+}
+
+.action {
+  align-items: center;
+  background: var(--brand-ivory, #f8f0e9);
+  border: 1px solid var(--brand-ivory, #f8f0e9);
+  border-radius: 12px;
+  color: #0b0c0e;
+  display: inline-flex;
+  font-family: var(--font-instrument), Arial, sans-serif;
+  font-size: 14px;
+  font-weight: 650;
+  justify-content: center;
+  margin-top: 30px;
+  min-height: 44px;
+  padding: 10px 17px;
+  transition:
+    background-color 180ms cubic-bezier(0.23, 1, 0.32, 1),
+    border-color 180ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 180ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.action:active {
+  transform: scale(0.98);
+}
+
+.action:focus-visible {
+  outline: 2px solid var(--brand-ivory, #f8f0e9);
+  outline-offset: 3px;
+}
+
+.walletNote {
+  color: var(--brand-ivory-muted, rgb(248 240 233 / 0.58));
+  font-size: 12px;
+  line-height: 1.45;
+  margin: 13px 0 0;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .action:hover {
+    background: #ffffff;
+    border-color: #ffffff;
+    transform: translateY(-1px);
+  }
+}
+
+@media (max-width: 540px) {
+  .page {
+    align-items: start;
+    padding-block: 28px 64px;
+  }
+
+  .panel {
+    border-radius: 20px;
+  }
+
+  .action {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .action {
+    transition: none;
+  }
+}

--- a/components/view-chain-unavailable.tsx
+++ b/components/view-chain-unavailable.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import styles from "@/components/view-chain-unavailable.module.css";
+import { useViewChain } from "@/components/view-chain";
+
+export function isRobinhoodUnavailableRoute(pathname: string): boolean {
+  return ["/profile", "/launch", "/token"].some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`),
+  );
+}
+
+export function ViewChainUnavailable() {
+  const { setViewChainId } = useViewChain();
+
+  return (
+    <section
+      aria-labelledby="view-chain-unavailable-title"
+      className={styles.page}
+    >
+      <div className={styles.panel}>
+        <div className={styles.chainStatus} role="status">
+          <span className={styles.statusDot} aria-hidden="true" />
+          Robinhood Chain
+        </div>
+
+        <h1 id="view-chain-unavailable-title">
+          This view is being prepared for Robinhood.
+        </h1>
+        <p className={styles.description}>
+          The public Robinhood deployment and index are being prepared.
+          Ethereum remains live for launches, profiles and token data.
+        </p>
+
+        <button
+          className={styles.action}
+          onClick={() => setViewChainId(1)}
+          type="button"
+        >
+          View on Ethereum
+        </button>
+        <p className={styles.walletNote}>
+          Your connected wallet stays connected when you change this view.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+export function ViewChainPending() {
+  return (
+    <div className={styles.pending} aria-busy="true">
+      <span className={styles.pendingStatus} role="status">
+        Loading network view
+      </span>
+    </div>
+  );
+}

--- a/components/view-chain.tsx
+++ b/components/view-chain.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+import {
+  DEFAULT_VIEW_CHAIN_ID,
+  VIEW_CHAIN_CHANGE_EVENT,
+  VIEW_CHAIN_COOKIE_NAME,
+  VIEW_CHAIN_STORAGE_KEY,
+  serializeViewChainCookie,
+  tryParseViewChainId,
+  type ViewChainId,
+} from "@/lib/view-chain";
+
+export type { ViewChainId } from "@/lib/view-chain";
+export {
+  DEFAULT_VIEW_CHAIN_ID,
+  VIEW_CHAIN_COOKIE_NAME,
+} from "@/lib/view-chain";
+
+type ViewChainContextValue = Readonly<{
+  hydrated: boolean;
+  viewChainId: ViewChainId;
+  setViewChainId: (viewChainId: ViewChainId) => void;
+}>;
+
+const ViewChainContext = createContext<ViewChainContextValue | null>(null);
+
+function readViewChainCookie(): ViewChainId | null {
+  const encodedName = `${VIEW_CHAIN_COOKIE_NAME}=`;
+  for (const cookiePart of document.cookie.split(";")) {
+    const normalizedPart = cookiePart.trim();
+    if (!normalizedPart.startsWith(encodedName)) continue;
+    return tryParseViewChainId(normalizedPart.slice(encodedName.length));
+  }
+  return null;
+}
+
+function readStoredViewChain(): ViewChainId | null {
+  try {
+    return tryParseViewChainId(
+      window.localStorage.getItem(VIEW_CHAIN_STORAGE_KEY),
+    );
+  } catch {
+    return null;
+  }
+}
+
+function subscribeToViewChain(onStoreChange: () => void) {
+  const syncFromStorage = (event: StorageEvent) => {
+    if (event.key === VIEW_CHAIN_STORAGE_KEY) onStoreChange();
+  };
+  const syncFromSameTab = () => onStoreChange();
+
+  window.addEventListener("storage", syncFromStorage);
+  window.addEventListener(VIEW_CHAIN_CHANGE_EVENT, syncFromSameTab);
+
+  return () => {
+    window.removeEventListener("storage", syncFromStorage);
+    window.removeEventListener(VIEW_CHAIN_CHANGE_EVENT, syncFromSameTab);
+  };
+}
+
+function persistViewChain(viewChainId: ViewChainId) {
+  try {
+    window.localStorage.setItem(VIEW_CHAIN_STORAGE_KEY, String(viewChainId));
+  } catch {
+    // A functional cookie remains available when browser storage is blocked.
+  }
+
+  document.cookie = serializeViewChainCookie(viewChainId);
+  window.dispatchEvent(
+    new CustomEvent<ViewChainId>(VIEW_CHAIN_CHANGE_EVENT, {
+      detail: viewChainId,
+    }),
+  );
+}
+
+export function ViewChainProvider({
+  children,
+  initialViewChainId = DEFAULT_VIEW_CHAIN_ID,
+}: Readonly<{
+  children: ReactNode;
+  initialViewChainId?: ViewChainId;
+}>) {
+  const getViewChainSnapshot = useCallback(
+    (): ViewChainId | null =>
+      readViewChainCookie() ?? readStoredViewChain() ?? initialViewChainId,
+    [initialViewChainId],
+  );
+  const getServerSnapshot = useCallback((): ViewChainId | null => null, []);
+  const resolvedViewChainId = useSyncExternalStore(
+    subscribeToViewChain,
+    getViewChainSnapshot,
+    getServerSnapshot,
+  );
+  const hydrated = resolvedViewChainId !== null;
+  const viewChainId = resolvedViewChainId ?? initialViewChainId;
+
+  useEffect(() => {
+    if (!hydrated) return;
+    if (
+      readViewChainCookie() !== viewChainId ||
+      readStoredViewChain() !== viewChainId
+    ) {
+      persistViewChain(viewChainId);
+    }
+  }, [hydrated, viewChainId]);
+
+  const setViewChainId = useCallback((nextViewChainId: ViewChainId) => {
+    persistViewChain(nextViewChainId);
+  }, []);
+
+  const value = useMemo(
+    () => ({ hydrated, viewChainId, setViewChainId }),
+    [hydrated, setViewChainId, viewChainId],
+  );
+
+  return (
+    <ViewChainContext.Provider value={value}>
+      {children}
+    </ViewChainContext.Provider>
+  );
+}
+
+export function useViewChain(): ViewChainContextValue {
+  const value = useContext(ViewChainContext);
+  if (!value) {
+    throw new Error("useViewChain must be used within ViewChainProvider");
+  }
+  return value;
+}

--- a/lib/explore-defaults.ts
+++ b/lib/explore-defaults.ts
@@ -1,3 +1,3 @@
 import type { ExploreSort } from "@/lib/onchain/types";
 
-export const DEFAULT_EXPLORE_VIEW_SORT = "market-cap" satisfies ExploreSort;
+export const DEFAULT_EXPLORE_VIEW_SORT = "newest" satisfies ExploreSort;

--- a/lib/view-chain.ts
+++ b/lib/view-chain.ts
@@ -1,0 +1,33 @@
+export type ViewChainId = 1 | 4663;
+
+export const DEFAULT_VIEW_CHAIN_ID: ViewChainId = 1;
+export const VIEW_CHAIN_COOKIE_NAME = "programmable-view-chain";
+export const VIEW_CHAIN_STORAGE_KEY = "programmable:view-chain:v1";
+export const VIEW_CHAIN_CHANGE_EVENT = "programmable:view-chain-change";
+export const VIEW_CHAIN_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+export const VIEW_CHAIN_OPTIONS = [
+  { id: 1, label: "Ethereum" },
+  { id: 4663, label: "Robinhood" },
+] as const satisfies ReadonlyArray<{
+  id: ViewChainId;
+  label: string;
+}>;
+
+export function tryParseViewChainId(value: unknown): ViewChainId | null {
+  if (value === 1 || value === "1") return 1;
+  if (value === 4663 || value === "4663") return 4663;
+  return null;
+}
+
+export function isViewChainId(value: unknown): value is ViewChainId {
+  return value === 1 || value === 4663;
+}
+
+export function parseViewChainId(value: unknown): ViewChainId {
+  return tryParseViewChainId(value) ?? DEFAULT_VIEW_CHAIN_ID;
+}
+
+export function serializeViewChainCookie(viewChainId: ViewChainId): string {
+  return `${VIEW_CHAIN_COOKIE_NAME}=${viewChainId}; Path=/; Max-Age=${VIEW_CHAIN_COOKIE_MAX_AGE_SECONDS}; SameSite=Lax`;
+}

--- a/tests/animated-market-cap.test.ts
+++ b/tests/animated-market-cap.test.ts
@@ -1,9 +1,36 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import {
+  AnimatedMarketCap,
   formatMarketCapMetric,
-  getMarketCapAnimationKey,
+  interpolateMarketCapValue,
+  MARKET_CAP_ANIMATION_DURATION_MS,
+  shouldAnimateMarketCapChange,
+  type MarketCapMetric,
 } from "../components/animated-market-cap";
+
+function shouldAnimate(
+  previousMetric: MarketCapMetric | null,
+  nextMetric: MarketCapMetric,
+  options: Readonly<{
+    nextReplayKey?: string;
+    previousReplayKey?: string | null;
+    reducedMotion?: boolean;
+  }> = {},
+) {
+  return shouldAnimateMarketCapChange({
+    nextMetric,
+    nextReplayKey: options.nextReplayKey ?? "token-1",
+    previousMetric,
+    previousReplayKey:
+      options.previousReplayKey === undefined
+        ? "token-1"
+        : options.previousReplayKey,
+    reducedMotion: options.reducedMotion ?? false,
+  });
+}
 
 describe("market cap formatting", () => {
   it("keeps the Explore USD format while values animate", () => {
@@ -26,28 +53,131 @@ describe("market cap formatting", () => {
       }),
     ).toBe("4.2K NVDAon");
   });
+});
 
-  it("replays only when the metric or visible result set changes", () => {
+describe("market cap animation decisions", () => {
+  it("renders the first value immediately", () => {
+    expect(
+      shouldAnimate(null, { kind: "usd", value: 194_000 }, {
+        previousReplayKey: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("animates genuine increases and decreases for the same metric", () => {
+    expect(
+      shouldAnimate(
+        { kind: "usd", value: 194_000 },
+        { kind: "usd", value: 220_000 },
+      ),
+    ).toBe(true);
+    expect(
+      shouldAnimate(
+        { kind: "usd", value: 220_000 },
+        { kind: "usd", value: 194_000 },
+      ),
+    ).toBe(true);
+  });
+
+  it("does not animate no-ops or changes hidden by compact formatting", () => {
+    expect(
+      shouldAnimate(
+        { kind: "usd", value: 194_000 },
+        { kind: "usd", value: 194_000 },
+      ),
+    ).toBe(false);
+    expect(
+      shouldAnimate(
+        { kind: "usd", value: 194_000 },
+        { kind: "usd", value: 194_100 },
+      ),
+    ).toBe(false);
+  });
+
+  it("does not let replayKey changes trigger or bridge animations", () => {
     const metric = { kind: "usd", value: 194_000 } as const;
-    const stableKey = getMarketCapAnimationKey(
-      metric,
-      "1:market-cap:",
+
+    expect(
+      shouldAnimate(metric, metric, {
+        nextReplayKey: "token-2",
+        previousReplayKey: "token-1",
+      }),
+    ).toBe(false);
+    expect(
+      shouldAnimate(metric, { kind: "usd", value: 220_000 }, {
+        nextReplayKey: "token-2",
+        previousReplayKey: "token-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("snaps for reduced motion, metric changes, and quote-symbol changes", () => {
+    expect(
+      shouldAnimate(
+        { kind: "usd", value: 194_000 },
+        { kind: "usd", value: 220_000 },
+        { reducedMotion: true },
+      ),
+    ).toBe(false);
+    expect(
+      shouldAnimate(
+        { kind: "usd", value: 194_000 },
+        { kind: "eth", value: 220_000 },
+      ),
+    ).toBe(false);
+    expect(
+      shouldAnimate(
+        { kind: "quote", symbol: "ETH", value: 194_000 },
+        { kind: "quote", symbol: "HOOD", value: 220_000 },
+      ),
+    ).toBe(false);
+  });
+
+  it("snaps for non-positive and non-finite values", () => {
+    expect(
+      shouldAnimate(
+        { kind: "usd", value: 0 },
+        { kind: "usd", value: 220_000 },
+      ),
+    ).toBe(false);
+    expect(
+      shouldAnimate(
+        { kind: "usd", value: 194_000 },
+        { kind: "usd", value: Number.POSITIVE_INFINITY },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("market cap interpolation", () => {
+  it("uses a 220ms cubic ease-out in both directions", () => {
+    expect(MARKET_CAP_ANIMATION_DURATION_MS).toBe(220);
+    expect(interpolateMarketCapValue(100, 200, 0)).toBe(100);
+    expect(interpolateMarketCapValue(100, 200, 0.5)).toBe(187.5);
+    expect(interpolateMarketCapValue(100, 200, 1)).toBe(200);
+    expect(interpolateMarketCapValue(200, 100, 0.5)).toBe(112.5);
+  });
+
+  it("clamps late or early animation frames to their endpoints", () => {
+    expect(interpolateMarketCapValue(100, 200, -1)).toBe(100);
+    expect(interpolateMarketCapValue(100, 200, 2)).toBe(200);
+  });
+});
+
+describe("market cap accessibility and sizing", () => {
+  it("keeps the visual counter hidden from assistive tech and exposes the final value", () => {
+    const html = renderToStaticMarkup(
+      createElement(AnimatedMarketCap, {
+        metric: { kind: "usd", value: 194_000 },
+        replayKey: "token-1",
+      }),
     );
 
-    expect(
-      getMarketCapAnimationKey(metric, "1:market-cap:"),
-    ).toBe(stableKey);
-    expect(
-      getMarketCapAnimationKey(
-        { kind: "usd", value: 195_000 },
-        "1:market-cap:",
-      ),
-    ).not.toBe(stableKey);
-    expect(
-      getMarketCapAnimationKey(metric, "2:market-cap:"),
-    ).not.toBe(stableKey);
-    expect(
-      getMarketCapAnimationKey(metric, "1:newest:"),
-    ).not.toBe(stableKey);
+    expect(html.match(/aria-hidden="true"/g)).toHaveLength(2);
+    expect(html).toContain('<span class="sr-only">$194K</span>');
+    expect(html).toContain("font-variant-numeric:tabular-nums");
+    expect(html).toContain("inline-size:100%");
+    expect(html).toContain("min-inline-size:7ch");
+    expect(html).toContain('title="$194K"');
   });
 });

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -280,6 +280,72 @@ describe("Explore static identity and Dexscreener market contract", () => {
     }));
   });
 
+  it("returns an honest planned Robinhood state without reading Ethereum", async () => {
+    const response = await GET(
+      request("chain=4663&sort=newest&page=1&limit=9"),
+    );
+    const body = await json(response);
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual(expect.objectContaining({
+      status: "not-deployed",
+      activationStage: "planned-not-deployed",
+      chainId: 4663,
+      tokens: [],
+      page: 1,
+      pageSize: 9,
+      total: 0,
+      totalPages: 0,
+      sort: "newest",
+    }));
+    expect(response.headers.get("x-programmable-chain-id")).toBe("4663");
+    expect(mocks.readCatalog).not.toHaveBeenCalled();
+    expect(mocks.readLastGoodCatalog).not.toHaveBeenCalled();
+    expect(mocks.readCustom).not.toHaveBeenCalled();
+    expect(mocks.readRouter).not.toHaveBeenCalled();
+    expect(mocks.readDex).not.toHaveBeenCalled();
+  });
+
+  it("defaults omitted chain and sort to the visible Ethereum Newest page", async () => {
+    const response = await GET(request("page=1&limit=9"));
+    const body = await json(response);
+
+    expect(response.status).toBe(200);
+    expect(body.chainId).toBe(1);
+    expect(body.sort).toBe("newest");
+    expect(body.tokens).toHaveLength(9);
+    expect(mocks.readDex.mock.calls[0]?.[0]).toHaveLength(9);
+  });
+
+  it("excludes identities from other chains before Ethereum enrichment", async () => {
+    const foreignBase = token(99);
+    const foreignId = `4663:${foreignBase.tokenAddress}`;
+    const foreign = {
+      ...foreignBase,
+      id: foreignId,
+      launchCategoryProvenance: {
+        ...foreignBase.launchCategoryProvenance,
+        recordId: foreignId,
+      },
+    } as ExploreEntry;
+    mocks.readCatalog.mockResolvedValueOnce(catalog({
+      entries: [...entries, foreign],
+    }));
+
+    const response = await GET(
+      request("chain=1&sort=newest&page=1&limit=100"),
+    );
+    const body = await json(response);
+
+    expect(response.status).toBe(200);
+    expect(body.total).toBe(TOKEN_COUNT);
+    expect(body.catalog.identityCount).toBe(TOKEN_COUNT);
+    expect(body.tokens).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: foreignId }),
+    ]));
+    expect(mocks.readDex.mock.calls[0]?.[0]).toHaveLength(TOKEN_COUNT);
+  });
+
   it("merges the independently verified Custom Registry lane when ready", async () => {
     const custom = token(99);
     mocks.customEnabled.mockReturnValue(true);
@@ -650,7 +716,7 @@ describe("Explore static identity and Dexscreener market contract", () => {
       catalog: {
         source: "envio-classic-v3",
         status: "last-known-good",
-        lastIndexedAt: NOW,
+        lastIndexedAt: "2026-08-16T08:00:01.000Z",
         identityCount: TOKEN_COUNT,
       },
     });
@@ -784,7 +850,7 @@ describe("Explore static identity and Dexscreener market contract", () => {
     expect(mocks.readDex.mock.calls[0]?.[0]).toHaveLength(9);
   });
 
-  it("discloses a stale validated Envio catalog and its exact timestamp", async () => {
+  it("uses the timestamp owned by the selected aggregate boundary", async () => {
     mocks.readCatalog.mockResolvedValueOnce(catalog({
       source: "envio-classic-v3",
       status: "last-known-good",
@@ -795,12 +861,12 @@ describe("Explore static identity and Dexscreener market contract", () => {
     expect(body.catalog).toMatchObject({
       source: "envio-classic-v3",
       status: "last-known-good",
-      lastIndexedAt: "2026-08-01T04:20:58.618Z",
+      lastIndexedAt: "2026-08-16T08:00:01.000Z",
       identityCount: 12,
     });
     expect(body.dataQuality).toMatchObject({
       status: "partial",
-      generatedAt: "2026-08-01T04:20:58.618Z",
+      generatedAt: "2026-08-16T08:00:01.000Z",
       launchIdentity: { custom: "unavailable" },
     });
   });
@@ -812,6 +878,7 @@ describe("Explore static identity and Dexscreener market contract", () => {
     "q=a&q=b",
     "socials=maybe",
     "model=anything",
+    "chain=10",
   ])(
     "rejects unsupported query shape: %s",
     async (query) => {

--- a/tests/explore-background-revalidation.test.ts
+++ b/tests/explore-background-revalidation.test.ts
@@ -113,12 +113,78 @@ describe("Explore background revalidation", () => {
     );
 
     expect(stable.tokens.map((token) => token.id)).toEqual([
-      "1:added",
       "1:known",
       "1:second",
     ]);
-    expect(stable.tokens[1]?.valuation).toEqual(known.valuation);
-    expect(stable.total).toBe(3);
+    expect(stable.tokens[0]?.valuation).toEqual(known.valuation);
+    expect(stable.total).toBe(2);
+  });
+
+  it("updates the public FDV compatibility value with an accepted observation", () => {
+    const previousToken = {
+      exploreKind: "token" as const,
+      id: "1:known",
+      tokenAddress: `0x${"11".repeat(20)}` as const,
+      fdvUsdWad: "1000000000000000000",
+      valuation: {
+        status: "available" as const,
+        metric: "fdv" as const,
+        supplyBasis: "total" as const,
+        currency: "usd" as const,
+        valueWad: "1000000000000000000",
+        freshness: "current" as const,
+      },
+    };
+    const incomingToken = {
+      ...previousToken,
+      fdvUsdWad: "2000000000000000000",
+      valuation: {
+        ...previousToken.valuation,
+        valueWad: "2000000000000000000",
+      },
+    };
+    const previous = {
+      ...explorePayload("ready"),
+      tokens: [previousToken],
+      total: 1,
+      totalPages: 1,
+    };
+    const incoming = {
+      ...previous,
+      tokens: [incomingToken],
+    };
+
+    const stable = stabilizeExploreRevalidationPayload(
+      previous as never,
+      incoming as never,
+    );
+
+    expect(stable.tokens[0]?.valuation).toEqual(incomingToken.valuation);
+    expect(
+      (stable.tokens[0] as typeof incomingToken | undefined)?.fdvUsdWad,
+    ).toBe(incomingToken.fdvUsdWad);
+  });
+
+  it("accepts an authoritative identity replacement when the commitment changes", () => {
+    const previous = {
+      ...explorePayload("ready"),
+      tokens: [{ id: "1:old", valuation: { status: "unavailable" } }],
+      total: 1,
+      totalPages: 1,
+    };
+    const incoming = {
+      ...previous,
+      tokens: [{ id: "1:new", valuation: { status: "unavailable" } }],
+      catalog: {
+        ...catalog,
+        identityCommitment: `sha256:${"ef".repeat(32)}`,
+      },
+    };
+
+    expect(stabilizeExploreRevalidationPayload(
+      previous as never,
+      incoming as never,
+    )).toBe(incoming);
   });
 
   it("runs only when the tab is visible, online and due", () => {
@@ -212,7 +278,7 @@ describe("Explore background revalidation", () => {
     const scheduler = createExploreRevalidationScheduler({
       visibilityState: () => "visible",
       online: () => true,
-      now: () => 20_000,
+      now: () => 5_000 + EXPLORE_REVALIDATION_INTERVAL_MS,
       lastRevalidationAt: 5_000,
       setTimeout(callback, delayMs) {
         timers.push({ callback, delayMs });
@@ -234,10 +300,18 @@ describe("Explore background revalidation", () => {
     };
 
     expect(
-      isExploreModelDatasetCacheFresh(cached, "combined-sort", 19_999),
+      isExploreModelDatasetCacheFresh(
+        cached,
+        "combined-sort",
+        5_000 + EXPLORE_REVALIDATION_INTERVAL_MS - 1,
+      ),
     ).toBe(true);
     expect(
-      isExploreModelDatasetCacheFresh(cached, "combined-sort", 20_000),
+      isExploreModelDatasetCacheFresh(
+        cached,
+        "combined-sort",
+        5_000 + EXPLORE_REVALIDATION_INTERVAL_MS,
+      ),
     ).toBe(false);
     expect(isExploreModelDatasetCacheFresh(cached, "other", 5_001)).toBe(
       false,
@@ -347,13 +421,13 @@ describe("Explore background revalidation", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
-  it("does not reorder a visible Explore page on an automatic timer", () => {
+  it("refreshes without putting background work in the visible request key", () => {
     const source = readFileSync(
       join(process.cwd(), "components/explore-view.tsx"),
       "utf8",
     );
 
-    expect(source).not.toContain(
+    expect(source).toContain(
       "const [revalidationKey, setRevalidationKey] = useState(0)",
     );
     expect(source).toContain(
@@ -367,10 +441,12 @@ describe("Explore background revalidation", () => {
     );
     expect(source).toContain("modelDatasetCache.current = null;");
     expect(source).toContain("updatedAt: Date.now(),");
-    expect(source).not.toContain("revalidationKey === 0");
-    expect(source).not.toContain('document.addEventListener("visibilitychange"');
-    expect(source).not.toContain('window.addEventListener("online"');
-    expect(source).not.toContain('window.addEventListener("offline"');
-    expect(source).not.toContain("scheduler.dispose();");
+    expect(source).toContain("revalidationKey === 0");
+    expect(source).toContain('document.addEventListener("visibilitychange"');
+    expect(source).toContain('window.addEventListener("focus"');
+    expect(source).toContain('window.addEventListener("online"');
+    expect(source).toContain('window.addEventListener("offline"');
+    expect(source).toContain("stabilizeExploreRevalidationPayload(");
+    expect(source).toContain("scheduler.dispose();");
   });
 });

--- a/tests/explore-page-ssr.test.ts
+++ b/tests/explore-page-ssr.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/app/api/explore/route", () => ({ GET: vi.fn() }));
 vi.mock("@/components/explore-view", () => ({ ExploreView: () => null }));
-vi.mock("next/headers", () => ({ headers: vi.fn() }));
+vi.mock("next/headers", () => ({ cookies: vi.fn(), headers: vi.fn() }));
 
 import {
   INITIAL_EXPLORE_TIMEOUT_MS,
@@ -23,10 +23,11 @@ describe("Explore initial server read", () => {
     expect(INITIAL_EXPLORE_TIMEOUT_MS).toBeLessThanOrEqual(9_000);
   });
 
-  it("starts with the highest available FDV ranking", () => {
+  it("starts with the newest Ethereum identity page", () => {
     const query = new URLSearchParams(INITIAL_EXPLORE_QUERY);
 
-    expect(DEFAULT_EXPLORE_VIEW_SORT).toBe("market-cap");
+    expect(DEFAULT_EXPLORE_VIEW_SORT).toBe("newest");
+    expect(query.get("chain")).toBe("1");
     expect(query.get("sort")).toBe(DEFAULT_EXPLORE_VIEW_SORT);
   });
 
@@ -43,6 +44,9 @@ describe("Explore initial server read", () => {
     ).toBe("custom");
     expect(new URLSearchParams(initialExploreQuery("all")).has("model"))
       .toBe(false);
+    expect(
+      new URLSearchParams(initialExploreQuery("all", 4663)).get("chain"),
+    ).toBe("4663");
   });
 
   it("returns at the total deadline and safely consumes the aborted read", async () => {

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -24,7 +24,20 @@ describe("Explore UI contract", () => {
     expect(page).not.toContain("AbortSignal.timeout(");
     expect(page).not.toContain('fetch("https://programmable.market');
     expect(page).toContain("initialResponse={initialResponse}");
+    expect(page).toContain("initialResponseChainId={viewChainId}");
     expect(page).toContain("initialModelFilter={modelFilter}");
+    expect(page).toContain("requestCookies.get(VIEW_CHAIN_COOKIE_NAME)");
+    expect(page).toContain("initialExploreQuery(modelFilter, viewChainId)");
+    expect(source).toContain("hydrated: viewChainReady");
+    expect(source).toContain("viewChainId: resolvedViewChainId");
+    expect(source).toContain(
+      "!viewChainReady && initialResponseChainId !== undefined",
+    );
+    expect(source).toContain("chain: String(viewChainId)");
+    expect(source).toContain("const chainContentKey = `${viewChainId}`");
+    expect(source).toContain(
+      'initialState?.phase === "ready" ? initialState : null',
+    );
     expect(source).not.toContain(
       "if (handledRequestKey.current === requestKey)",
     );
@@ -252,7 +265,7 @@ describe("Explore UI contract", () => {
       /@media \(max-width: 700px\)[\s\S]*?\.runnerHeading > span\s*\{[^}]*font-size:\s*12px;[\s\S]*?\.runnerData small\s*\{[^}]*font-size:\s*12px;[\s\S]*?\.runnerCategory,[\s\S]*?font-size:\s*12px;[\s\S]*?\.runnerContract code\s*\{[^}]*font-size:\s*12px;/s,
     );
     expect(source).toMatch(
-      /<small title="Fully diluted valuation">FDV<\/small>[\s\S]*?valuationLabel \?\? token\.marketStatus \?\? "Unavailable"/,
+      /<small title="Fully diluted valuation">FDV<\/small>[\s\S]*?<AnimatedMarketCap[\s\S]*?replayKey=\{token\.id\}[\s\S]*?token\.marketStatus \?\? "Unavailable"/,
     );
     expect(source).not.toContain(
       "exploreUnavailableFdvLabel(token.marketStatus)",

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -664,7 +664,7 @@ describe("Explore refresh state", () => {
     ).toBe("initial-mobile-request");
   });
 
-  it("keeps a responsive initial failure explicit instead of refetching it", () => {
+  it("falls through once to the bounded client read after an initial failure", () => {
     expect(createResponsiveExploreInitialState(
       { ok: false, body: { error: "Launch index is catching up" } },
       {
@@ -674,12 +674,7 @@ describe("Explore refresh state", () => {
         requestKey: "initial-mobile-error-request",
         pageSize: EXPLORE_MOBILE_TOKENS_PER_PAGE,
       },
-    )).toEqual({
-      phase: "error",
-      message: "Launch index is catching up",
-      contentKey: "initial-mobile-error-content",
-      requestKey: "initial-mobile-error-request",
-    });
+    )).toBeNull();
   });
 
   it("stops reusing the server page after the first non-initial request", () => {
@@ -946,15 +941,15 @@ describe("Explore refresh state", () => {
     });
   });
 
-  it("announces when the default valuation sort is turned off", () => {
+  it("announces Newest as the default and FDV ranking as an override", () => {
     expect(exploreActiveSelectionState({
       valuationSort: "highest",
       ageSort: "none",
       socialFilter: "all",
       modelFilter: "all",
     })).toEqual({
-      count: 0,
-      summary: "Default sorting applied",
+      count: 1,
+      summary: "Highest FDV selected",
     });
     expect(exploreActiveSelectionState({
       valuationSort: "none",
@@ -962,8 +957,8 @@ describe("Explore refresh state", () => {
       socialFilter: "all",
       modelFilter: "all",
     })).toEqual({
-      count: 1,
-      summary: "Newest launch order selected",
+      count: 0,
+      summary: "Default sorting applied",
     });
   });
 

--- a/tests/interaction-state-regressions.test.ts
+++ b/tests/interaction-state-regressions.test.ts
@@ -219,8 +219,11 @@ describe("interaction state regressions", () => {
     expect(exploreSource).toContain(
       '<small title="Fully diluted valuation">FDV</small>',
     );
-    expect(exploreSource).toMatch(
-      /<small title="Fully diluted valuation">FDV<\/small>[\s\S]*?valuationLabel \?\? token\.marketStatus \?\? "Unavailable"/,
+    expect(exploreSource).toContain("token.valuation ? (");
+    expect(exploreSource).toContain("<AnimatedMarketCap");
+    expect(exploreSource).toContain("metric={token.valuation}");
+    expect(exploreSource).toContain(
+      '<strong>{token.marketStatus ?? "Unavailable"}</strong>',
     );
     expect(exploreSource).not.toContain(
       "exploreUnavailableFdvLabel(token.marketStatus)",

--- a/tests/profile-view.test.ts
+++ b/tests/profile-view.test.ts
@@ -74,6 +74,10 @@ const profileExperienceCss = readFileSync(
   new URL("../components/profile-experience.module.css", import.meta.url),
   "utf8",
 );
+const profileProjectsCss = readFileSync(
+  new URL("../components/profile-projects.module.css", import.meta.url),
+  "utf8",
+);
 const profileViewSource = readFileSync(
   new URL("../components/profile-view.tsx", import.meta.url),
   "utf8",
@@ -534,6 +538,18 @@ describe("profile workspace loading state", () => {
 
   it("holds cold profile geometry until wallet and local profile hydration settle", () => {
     expect(profileViewSource).toContain(
+      "clientHydrated &&",
+    );
+    expect(profileViewSource).toContain(
+      "requestedProfileAccount === null &&",
+    );
+    expect(profileViewSource).toContain(
+      "(hasSession || Boolean(account))",
+    );
+    expect(profileViewSource).toMatch(
+      /showDashboard \? \([\s\S]*?<ProfileLoadingSkeleton label="Loading profile" showHero \/>[\s\S]*?\) : \([\s\S]*?className=\{`\$\{styles\.connectCard\}/,
+    );
+    expect(profileViewSource).toContain(
       "showHero ? styles.profileSkeletonPage : styles.profileSkeletonInline",
     );
     expect(profileViewSource).toContain(
@@ -563,6 +579,9 @@ describe("profile workspace loading state", () => {
     expect(profileViewSource).toContain(
       "Array.from({ length: profileClaimPageSize }, (_, item)",
     );
+    expect(profileViewSource).toMatch(
+      /className=\{styles\.profileSkeletonClaims\}[\s\S]*?className=\{styles\.profileSkeletonSectionHeader\}[\s\S]*?className=\{styles\.profileSkeletonRows\}[\s\S]*?Array\.from\(\{ length: profileClaimPageSize \}/,
+    );
     expect(profileExperienceCss).toMatch(
       /\.profileSkeletonLaunch\s*\{[^}]*min-height:\s*463px;/s,
     );
@@ -574,7 +593,16 @@ describe("profile workspace loading state", () => {
       /\.profileSkeletonHero\s*\{[^}]*min-height:\s*282px;/s,
     );
     expect(profileExperienceCss).toMatch(
-      /\.profileSkeletonWorkspace\s*\{[^}]*min-height:\s*398px;/s,
+      /\.profileSkeletonWorkspace\s*\{[^}]*min-height:\s*360px;/s,
+    );
+    expect(profileExperienceCss).toMatch(
+      /\.profileSkeletonInline\s*\{[^}]*min-height:\s*360px;/s,
+    );
+    expect(profileExperienceCss).toMatch(
+      /\.profileSkeletonClaims\s*\{[^}]*align-content:\s*start;[^}]*gap:\s*12px;/s,
+    );
+    expect(profileExperienceCss).toMatch(
+      /\.profileSkeletonLaunch \.profileSkeletonRow\s*\{[^}]*gap:\s*9px;[^}]*grid-template-columns:\s*42px minmax\(0, 1fr\) 364px;[^}]*min-height:\s*71px;[^}]*padding:\s*7px 8px;/s,
     );
     expect(profileExperienceCss).toMatch(
       /\.profileSkeletonHero\s*\{[^}]*min-height:\s*350px;/s,
@@ -592,10 +620,25 @@ describe("profile workspace loading state", () => {
       /\.claimablePanel\[data-visible-count="4"\]\s*\{[^}]*min-height:\s*591px;/s,
     );
     expect(profileExperienceCss).toMatch(
-      /@media \(max-width:\s*42rem\)[\s\S]*?\.profileSkeletonLaunch \.profileSkeletonRow\s*\{[^}]*min-height:\s*142\.5px;/s,
+      /@media \(max-width:\s*42rem\)[\s\S]*?\.profileSkeletonLaunch \.profileSkeletonRow\s*\{[^}]*grid-template-columns:\s*42px minmax\(0, 1fr\);[^}]*min-height:\s*143px;/s,
     );
     expect(profileExperienceCss).not.toContain("profile-content-reveal");
-    expect(profileExperienceCss).toContain("profile-skeleton-pulse");
+    expect(profileExperienceCss).toContain(
+      "animation: profile-skeleton-pulse 1.35s ease-in-out infinite alternate",
+    );
+    expect(profileProjectsCss).toContain(
+      "animation: profile-project-skeleton 1.35s ease-in-out infinite alternate",
+    );
+    expect(profileExperienceCss).toContain("background: var(--skeleton-base)");
+    expect(profileProjectsCss).toContain("background: var(--skeleton-base)");
+    expect(profileExperienceCss).toContain(
+      "to { background-color: var(--skeleton-highlight); }",
+    );
+    expect(profileProjectsCss).toContain(
+      "to { background-color: var(--skeleton-highlight); }",
+    );
+    expect(profileExperienceCss).not.toContain("from { opacity: 0.48; }");
+    expect(profileProjectsCss).not.toContain("from { opacity: 0.48; }");
   });
 
   it("keeps warm reward refreshes visible, announced and motion-safe", () => {

--- a/tests/view-chain-scope-gate.test.ts
+++ b/tests/view-chain-scope-gate.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { isRobinhoodUnavailableRoute } from "../components/view-chain-unavailable";
+
+const root = process.cwd();
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+
+describe("Robinhood view-chain scope gate", () => {
+  it("gates only Ethereum-bound product data routes", () => {
+    expect(isRobinhoodUnavailableRoute("/profile")).toBe(true);
+    expect(isRobinhoodUnavailableRoute("/profile/settings")).toBe(true);
+    expect(isRobinhoodUnavailableRoute("/launch")).toBe(true);
+    expect(isRobinhoodUnavailableRoute("/launch/history")).toBe(true);
+    expect(isRobinhoodUnavailableRoute("/token/0x1234")).toBe(true);
+
+    expect(isRobinhoodUnavailableRoute("/explore")).toBe(false);
+    expect(isRobinhoodUnavailableRoute("/docs")).toBe(false);
+    expect(isRobinhoodUnavailableRoute("/developers")).toBe(false);
+    expect(isRobinhoodUnavailableRoute("/")).toBe(false);
+    expect(isRobinhoodUnavailableRoute("/tokens")).toBe(false);
+  });
+
+  it("switches only the view preference and leaves wallet state untouched", () => {
+    const component = read("components/view-chain-unavailable.tsx");
+    const transition = read("components/route-transition.tsx");
+    const navigation = read("components/site-navigation.tsx");
+    const styles = read("components/view-chain-unavailable.module.css");
+
+    expect(transition).toContain("viewChainId === 4663");
+    expect(transition).toContain("isRobinhoodUnavailableRoute(pathname)");
+    expect(transition).toMatch(/showChainPending\s*\? "pending"/);
+    expect(transition).toContain("<ViewChainPending />");
+    expect(transition).toContain(
+      "const resolvedInitialChain = !previousHydrated.current && hydrated",
+    );
+    expect(transition).toContain(
+      "previousFocusContext.current = focusContext",
+    );
+    expect(component).toContain("setViewChainId(1)");
+    expect(component).toContain("Ethereum remains live");
+    expect(component).toContain("Your connected wallet stays connected");
+    expect(component).not.toMatch(/useWallet|switchChain|switchNetwork|disconnect/);
+    expect(navigation).toContain(
+      "if (isRobinhoodUnavailableRoute(pathname)) return;",
+    );
+    expect(styles).toMatch(/\.action\s*\{[^}]*min-height:\s*44px;/s);
+    expect(styles).toMatch(/\.action:focus-visible\s*\{/);
+    expect(styles).toContain("@media (prefers-reduced-motion: reduce)");
+  });
+});

--- a/tests/view-chain.test.ts
+++ b/tests/view-chain.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_VIEW_CHAIN_ID,
+  VIEW_CHAIN_COOKIE_NAME,
+  VIEW_CHAIN_STORAGE_KEY,
+  isViewChainId,
+  parseViewChainId,
+  serializeViewChainCookie,
+  tryParseViewChainId,
+} from "../lib/view-chain";
+
+const root = process.cwd();
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+
+describe("view chain", () => {
+  it("accepts only Ethereum and Robinhood and fails invalid state to Ethereum", () => {
+    expect(DEFAULT_VIEW_CHAIN_ID).toBe(1);
+    expect(isViewChainId(1)).toBe(true);
+    expect(isViewChainId(4663)).toBe(true);
+    expect(isViewChainId("4663")).toBe(false);
+    expect(tryParseViewChainId("1")).toBe(1);
+    expect(tryParseViewChainId("4663")).toBe(4663);
+    expect(tryParseViewChainId("11155111")).toBeNull();
+    expect(parseViewChainId(null)).toBe(1);
+    expect(parseViewChainId("invalid")).toBe(1);
+  });
+
+  it("serializes a long-lived, site-wide preference cookie", () => {
+    expect(VIEW_CHAIN_COOKIE_NAME).toBe("programmable-view-chain");
+    expect(VIEW_CHAIN_STORAGE_KEY).toBe("programmable:view-chain:v1");
+    expect(serializeViewChainCookie(4663)).toContain(
+      "programmable-view-chain=4663",
+    );
+    expect(serializeViewChainCookie(4663)).toContain("Path=/");
+    expect(serializeViewChainCookie(4663)).toContain("SameSite=Lax");
+  });
+
+  it("keeps view persistence outside the wallet provider without making the root layout dynamic", () => {
+    const provider = read("components/view-chain.tsx");
+    const shell = read("components/app-shell.tsx");
+    const layout = read("app/layout.tsx");
+
+    expect(provider).toContain("window.localStorage.getItem");
+    expect(provider).toContain(
+      "readViewChainCookie() ?? readStoredViewChain() ?? initialViewChainId",
+    );
+    expect(provider).toContain("window.addEventListener(\"storage\"");
+    expect(provider).toContain("document.cookie = serializeViewChainCookie");
+    expect(provider).not.toContain("useWallet");
+    expect(provider).not.toContain("switchNetwork");
+    expect(provider).not.toContain("disconnect");
+    expect(shell.indexOf("<ViewChainProvider")).toBeLessThan(
+      shell.indexOf("<WalletProvider>"),
+    );
+    expect(provider).toContain(
+      "const resolvedViewChainId = useSyncExternalStore(",
+    );
+    expect(provider).toContain(
+      "const getServerSnapshot = useCallback((): ViewChainId | null => null",
+    );
+    expect(provider).toContain(
+      "const hydrated = resolvedViewChainId !== null",
+    );
+    expect(provider).toContain(
+      "const viewChainId = resolvedViewChainId ?? initialViewChainId",
+    );
+    expect(provider).toContain("persistViewChain(viewChainId)");
+    expect(layout).not.toContain('from "next/headers"');
+    expect(layout).not.toContain("cookies()");
+  });
+
+  it("renders one alternate-chain option before the hamburger as an accessible disclosure", () => {
+    const navigation = read("components/site-navigation.tsx");
+    const styles = read("components/site-navigation.module.css");
+
+    expect(navigation.indexOf("<HeaderChainSelector")).toBeLessThan(
+      navigation.indexOf("ref={menuButtonRef}"),
+    );
+    expect(navigation).toContain("viewChainId === 1 ? 4663 : 1");
+    expect(navigation).toContain("Public index coming soon");
+    expect(navigation).toContain("aria-controls={panelId}");
+    expect(navigation).toContain("aria-expanded={open}");
+    expect(navigation).toContain('role="group"');
+    expect(navigation).not.toContain('role="menu"');
+    expect(navigation).toContain("inert={open ? undefined : true}");
+    expect(navigation).toContain('if (event.key !== "Escape") return;');
+    expect(navigation).toContain("chainButtonRef.current?.focus()");
+    expect(navigation).toContain("!chainSelectorRef.current?.contains");
+    expect(navigation).not.toContain("setViewChainId(alternateViewChainId);\n              disconnect");
+    expect(styles).toMatch(
+      /\.chainTrigger\s*\{[^}]*height:\s*48px;[^}]*width:\s*48px;/s,
+    );
+    expect(styles).toMatch(
+      /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.chainPopover,/,
+    );
+  });
+});


### PR DESCRIPTION
Stabilizes Explore identity ordering and background market refreshes, adds the truthful Ethereum and Robinhood view selector without switching the connected wallet, aligns Profile loading geometry, and animates same-token market-cap updates. Robinhood remains explicitly planned and not deployed. The unpublished migration page is excluded.