### PR TITLE
fix(trade): prevent stale intent during quote preparation

### DIFF
--- a/components/custom-market-trade.tsx
+++ b/components/custom-market-trade.tsx
@@ -97,10 +97,12 @@ function preferredCustomTradeSide(
 function CustomMarketSelector({
   markets,
   value,
+  disabled,
   onChange,
 }: {
   markets: readonly CustomMarket[];
   value: string;
+  disabled: boolean;
   onChange(nextMarketId: string): void;
 }) {
   const groupName = useId();
@@ -137,6 +139,7 @@ function CustomMarketSelector({
                 name={groupName}
                 value={market.marketId}
                 checked={selectedOption}
+                disabled={disabled}
                 onChange={() => onChange(market.marketId)}
               />
               <span>{customMarketLabel(market)}</span>
@@ -213,7 +216,7 @@ export function CustomMarketTrade({
   const outputSymbol = assetLabel(outputAsset);
 
   async function applyMax() {
-    if (!owner || inputDecimals === undefined) return;
+    if (pending || !owner || inputDecimals === undefined) return;
     setPending(true);
     setError("");
     try {
@@ -242,6 +245,7 @@ export function CustomMarketTrade({
 
   async function prepare(event?: FormEvent<HTMLFormElement>) {
     event?.preventDefault();
+    if (pending) return;
     if (!owner) {
       onConnect();
       return;
@@ -388,7 +392,9 @@ export function CustomMarketTrade({
       <CustomMarketSelector
         markets={tradableMarkets}
         value={marketId}
+        disabled={pending}
         onChange={(nextMarketId) => {
+          if (pending) return;
           const nextCapability = tradableMarkets.find(
             (candidate) => candidate.marketId === nextMarketId,
           )?.tradeCapability;
@@ -421,6 +427,7 @@ export function CustomMarketTrade({
               type="button"
               aria-pressed={side === candidate}
               key={candidate}
+              disabled={pending}
               onClick={() => {
                 setSelectedSide(candidate);
                 setAmount("");
@@ -438,7 +445,7 @@ export function CustomMarketTrade({
           <button className={styles.maxButton} type="button" disabled={!owner || pending || inputDecimals === undefined} onClick={() => void applyMax()}>Max</button>
         </div>
         <div className={styles.amountInputRow}>
-          <input id={amountId} className={styles.amountInput} inputMode="decimal" autoComplete="off" value={amount} onChange={(event) => setAmount(event.target.value)} placeholder="0" aria-describedby={error ? errorId : undefined} />
+          <input id={amountId} className={styles.amountInput} inputMode="decimal" autoComplete="off" value={amount} disabled={pending} onChange={(event) => setAmount(event.target.value)} placeholder="0" aria-describedby={error ? errorId : undefined} />
           <span className={styles.asset}>{inputSymbol}</span>
         </div>
       </div>
@@ -447,7 +454,7 @@ export function CustomMarketTrade({
         <div>
           <dt><label htmlFor={slippageId}>Max slippage</label></dt>
           <dd className={styles.slippageControl}>
-            <input id={slippageId} inputMode="decimal" value={slippage} onChange={(event) => setSlippage(event.target.value)} />
+            <input id={slippageId} inputMode="decimal" value={slippage} disabled={pending} onChange={(event) => setSlippage(event.target.value)} />
             <span aria-hidden="true">%</span>
           </dd>
         </div>

--- a/components/token-experience.module.css
+++ b/components/token-experience.module.css
@@ -599,6 +599,11 @@
   width: 100%;
 }
 
+.customMarketOption:has(.customMarketOptionInput:disabled) {
+  cursor: default;
+  opacity: 0.65;
+}
+
 .customMarketOption[data-selected="true"] {
   background: var(--liquid-glass-control-background-hover);
   border-color: color-mix(in srgb, var(--token-accent) 46%, var(--liquid-glass-border));
@@ -1062,6 +1067,11 @@
 
 .sideButtonSelected {
   color: var(--text);
+}
+
+.sideButton:disabled {
+  color: var(--dim);
+  cursor: default;
 }
 
 .sideIndicator {

--- a/components/token-trade.tsx
+++ b/components/token-trade.tsx
@@ -385,6 +385,7 @@ export function TokenTrade({
   const [maxPending, setMaxPending] = useState(false);
   const [balanceState, setBalanceState] =
     useState<WalletTradeBalanceState | null>(null);
+  const formBusy = pending || maxPending;
   const amountInputId = useId();
   const amountErrorId = useId();
   const slippageInputId = useId();
@@ -464,6 +465,7 @@ export function TokenTrade({
   }, [activeInputAsset, owner, readBalances]);
 
   async function applyMaximumBalance() {
+    if (formBusy) return;
     setError("");
     setAmountInvalid(false);
     setSlippageInvalid(false);
@@ -513,6 +515,7 @@ export function TokenTrade({
 
   async function prepare(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (formBusy) return;
     setError("");
     setAmountInvalid(false);
     setSlippageInvalid(false);
@@ -654,7 +657,7 @@ export function TokenTrade({
       className={styles.tradeForm}
       onSubmit={prepare}
       aria-label={`Trade ${symbol}`}
-      aria-busy={pending}
+      aria-busy={formBusy}
     >
       <div className={styles.sideControl} role="group" aria-label="Trade side">
         <span
@@ -671,6 +674,7 @@ export function TokenTrade({
             key={option}
             type="button"
             aria-pressed={side === option}
+            disabled={formBusy}
             onClick={() => {
               setSide(option);
               setAmount("");
@@ -698,7 +702,7 @@ export function TokenTrade({
             <button
               className={styles.maxButton}
               type="button"
-              disabled={maxPending || !owner}
+              disabled={formBusy || !owner}
               aria-label={`Use maximum ${
                 side === "buy" ? "ETH" : symbol
               } balance`}
@@ -718,6 +722,7 @@ export function TokenTrade({
             aria-invalid={amountInvalid || undefined}
             aria-describedby={amountInvalid ? amountErrorId : undefined}
             value={amount}
+            disabled={formBusy}
             onChange={(event) => {
               setAmount(event.target.value);
               if (error) setError("");
@@ -764,6 +769,7 @@ export function TokenTrade({
                 list={slippagePresetsId}
                 maxLength={5}
                 value={slippagePercent}
+                disabled={formBusy}
                 onChange={(event) => {
                   setSlippagePercent(event.target.value);
                   if (error) setError("");
@@ -797,7 +803,7 @@ export function TokenTrade({
         <button
           className={styles.primaryAction}
           type={owner ? "submit" : "button"}
-          disabled={pending}
+          disabled={formBusy}
           onClick={owner ? undefined : onConnect}
         >
           {pending

--- a/tests/custom-market-selector-ui.test.ts
+++ b/tests/custom-market-selector-ui.test.ts
@@ -33,6 +33,24 @@ describe("Custom market selector UI", () => {
     expect(tradeStyles).not.toContain(".customMarketSelect select");
   });
 
+  it("locks market and trade controls while preparation is pending", () => {
+    expect(tradeSource).toContain("disabled: boolean;");
+    expect(tradeSource).toContain("disabled={disabled}");
+    expect(tradeSource).toContain(
+      "aria-pressed={side === candidate}\n              key={candidate}\n              disabled={pending}",
+    );
+    expect(tradeSource).toContain(
+      "value={amount} disabled={pending} onChange=",
+    );
+    expect(tradeSource).toContain(
+      "value={slippage} disabled={pending} onChange=",
+    );
+    expect(tradeSource).toContain("if (pending) return;");
+    expect(tradeStyles).toContain(
+      ".customMarketOption:has(.customMarketOptionInput:disabled)",
+    );
+  });
+
   it("opens the canonical two-sided market on Buy and lists Buy first", () => {
     expect(tradeSource).toContain(
       'supported.includes("quote-to-base")',

--- a/tests/token-trade-interface.test.ts
+++ b/tests/token-trade-interface.test.ts
@@ -38,6 +38,15 @@ describe("token trade amount interface", () => {
     );
   });
 
+  it("locks every editable control during balance or quote preparation", () => {
+    expect(source).toContain("const formBusy = pending || maxPending;");
+    expect(source).toContain("if (formBusy) return;");
+    expect(source.match(/disabled=\{formBusy\}/gu)).toHaveLength(4);
+    expect(source).toContain("disabled={formBusy || !owner}");
+    expect(source).toContain("aria-busy={formBusy}");
+    expect(styles).toContain(".sideButton:disabled");
+  });
+
   it("uses a compact amount surface without shrinking touch controls", () => {
     expect(styles).toMatch(
       /\.amountCard\s*\{[^}]*min-height:\s*116px;[^}]*padding:\s*10px 14px 9px;/s,


### PR DESCRIPTION
Lock editable Classic and Custom trade controls while balance and quote preparation is pending.

Without the lock, users can change the side, amount, slippage, or selected market while an async preparation is still running, allowing the submitted intent to become stale or triggering overlapping preparation.

The change disables mutable controls, adds preparation guards, preserves existing wallet/API/contract flows, and adds focused coverage.

Closes #565 