### PR TITLE
Stop wallet preload render feedback

### DIFF
--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import {
   createContext,
+  memo,
   useCallback,
   useContext,
   useEffect,
@@ -1071,7 +1072,9 @@ function getServerThemeSnapshot(): ColorTheme {
   return "light";
 }
 
-function ConfiguredWalletProvider({
+// Adopting the bridge value rerenders WalletProvider. Keep that parent update
+// from feeding back through Privy's hook callbacks and emitting it again.
+const ConfiguredWalletProvider = memo(function ConfiguredWalletProvider({
   appId,
   autoAction,
   linkedWalletOnly,
@@ -1118,7 +1121,7 @@ function ConfiguredWalletProvider({
       />
     </PrivyProvider>
   );
-}
+});
 
 function PrivyWalletBridge({
   autoAction,

--- a/tests/wallet-state.test.ts
+++ b/tests/wallet-state.test.ts
@@ -199,6 +199,9 @@ describe("wallet recovery state", () => {
       "configuredSnapshot?.linkedWalletOnly === linkedWalletOnly",
     );
     expect(provider).toContain("onValueChange={acceptConfiguredValue}");
+    expect(provider).toContain(
+      "const ConfiguredWalletProvider = memo(function ConfiguredWalletProvider",
+    );
     expect(provider).not.toContain("if (!runtime) {");
     expect(provider).toContain("const hydrationPending = !authReady");
     expect(provider).toContain(


### PR DESCRIPTION
## Outcome
- stop the Privy bridge snapshot from feeding parent rerenders back into the configured wallet subtree
- preserve wallet runtime behavior while preventing the React maximum-update-depth crash on mobile-menu preload and API-key routes
- add a focused regression contract for the memo boundary

## Evidence
- 36/36 focused wallet tests
- focused ESLint
- TypeScript clean from a clean generated-state baseline
- production build clean
- independent 390x844 browser replay: menu opens, Escape closes, focus returns, no React #185
- git diff --check clean