### PR TITLE
fix(contracts): bind owner handoff to QuickNode

### DIFF
--- a/contracts/scripts/commit-robinhood-custom-launch-provider-endpoints.mjs
+++ b/contracts/scripts/commit-robinhood-custom-launch-provider-endpoints.mjs
@@ -13,7 +13,7 @@ try {
   const derivedEndpointCommitments = [
     robinhoodFoundationRpcEndpointCommitment({
       role: "primary",
-      providerId: "drpc",
+      providerId: "quicknode",
       rpcUrl: rpcUrls[0],
     }),
     robinhoodFoundationRpcEndpointCommitment({

--- a/contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs
+++ b/contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs
@@ -108,8 +108,8 @@ const EXPECTED_DEPENDENCY_BINDINGS = Object.freeze({
 const EXPECTED_PROVIDER_PINS = Object.freeze([
   Object.freeze({
     role: "primary",
-    providerId: "drpc",
-    trustDomain: "drpc.org",
+    providerId: "quicknode",
+    trustDomain: "quicknode.com",
   }),
   Object.freeze({
     role: "secondary",
@@ -530,25 +530,21 @@ function authenticatedProviderBinding(pin, rpcUrl) {
   ) {
     fail(`${pin.providerId} RPC endpoint violates its provider pin`);
   }
-  const keyPattern = /^[A-Za-z0-9_-]{8,512}$/u;
-  const drpcLive =
-    /^https:\/\/lb\.drpc\.live\/robinhood\/[A-Za-z0-9_-]{8,512}$/u.test(
+  const quicknode =
+    /^https:\/\/[a-z0-9](?:[a-z0-9-]{0,62})\.quiknode\.pro\/[A-Za-z0-9_-]{16,256}\/$/u.test(
       rpcUrl,
     ) &&
-    !/docs[-_]?demo/iu.test(url.pathname);
-  const drpcOrg =
-    /^https:\/\/lb\.drpc\.org\/ogrpc\?network=robinhood(?:-mainnet)?&dkey=[A-Za-z0-9_-]{8,512}$/u.test(
-      rpcUrl,
-    ) &&
-    keyPattern.test(url.searchParams.get("dkey") ?? "") &&
-    !/docs[-_]?demo/iu.test(url.searchParams.get("dkey") ?? "");
+    !url.hostname.startsWith("docs-demo.") &&
+    !/^(?:demo|example|placeholder|token|key)$/iu.test(
+      url.pathname.slice(1, -1),
+    );
   const alchemy =
-    /^https:\/\/robinhood-mainnet\.g\.alchemy\.com\/v2\/[A-Za-z0-9_-]{8,256}$/u.test(
+    /^https:\/\/robinhood-mainnet\.g\.alchemy\.com\/v2\/[A-Za-z0-9_-]{16,256}$/u.test(
       rpcUrl,
     ) &&
     !/docs[-_]?demo/iu.test(url.pathname);
   const authenticated =
-    pin.providerId === "alchemy" ? alchemy : drpcLive || drpcOrg;
+    pin.providerId === "alchemy" ? alchemy : quicknode;
   if (!authenticated) {
     fail(`${pin.providerId} RPC endpoint is not credential-bearing`);
   }

--- a/contracts/scripts/test/robinhood-custom-launch-owner-envelope.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-owner-envelope.test.mjs
@@ -55,13 +55,13 @@ const PREPARED_ADDRESSES = Object.freeze({
   router: "0x34965F2A2ee9254522232C32F02056E92BE0C98a",
 });
 const RPC_URLS = Object.freeze([
-  "https://lb.drpc.live/robinhood/0123456789abcdef",
+  "https://hood-explorer-indexer.quiknode.pro/0123456789abcdef/",
   "https://robinhood-mainnet.g.alchemy.com/v2/abcdef0123456789",
 ]);
 const RPC_COMMITMENTS = Object.freeze([
   robinhoodFoundationRpcEndpointCommitment({
     role: "primary",
-    providerId: "drpc",
+    providerId: "quicknode",
     rpcUrl: RPC_URLS[0],
   }),
   robinhoodFoundationRpcEndpointCommitment({
@@ -195,7 +195,7 @@ function mockRpc(options = {}) {
     if (method === "eth_chainId") return provider.chainId ?? "0x1237";
     if (method === "eth_getBlockByNumber") {
       if (params[0] === "latest") {
-        return providerId === "drpc"
+        return providerId === "quicknode"
           ? block(1_000, "11")
           : block(provider.headNumber ?? 1_002, "22");
       }
@@ -383,15 +383,15 @@ test("provider pins reject public, same-origin, unauthenticated, and unsafe endp
   assert.deepEqual(
     assertRobinhoodFoundationRpcProviders({
       rpcUrls: [
-        "https://lb.drpc.org/ogrpc?network=robinhood&dkey=credential_0123456789",
+        "https://hood-explorer-indexer-alt.quiknode.pro/credential_0123456789/",
         RPC_URLS[1],
       ],
       endpointCommitments: [
         robinhoodFoundationRpcEndpointCommitment({
           role: "primary",
-          providerId: "drpc",
+          providerId: "quicknode",
           rpcUrl:
-            "https://lb.drpc.org/ogrpc?network=robinhood&dkey=credential_0123456789",
+            "https://hood-explorer-indexer-alt.quiknode.pro/credential_0123456789/",
         }),
         RPC_COMMITMENTS[1],
       ],
@@ -399,14 +399,14 @@ test("provider pins reject public, same-origin, unauthenticated, and unsafe endp
     [
       {
         role: "primary",
-        providerId: "drpc",
-        trustDomain: "drpc.org",
+        providerId: "quicknode",
+        trustDomain: "quicknode.com",
         authentication: "provider-credential",
         endpointCommitment: robinhoodFoundationRpcEndpointCommitment({
           role: "primary",
-          providerId: "drpc",
+          providerId: "quicknode",
           rpcUrl:
-            "https://lb.drpc.org/ogrpc?network=robinhood&dkey=credential_0123456789",
+            "https://hood-explorer-indexer-alt.quiknode.pro/credential_0123456789/",
         }),
       },
       {
@@ -420,14 +420,17 @@ test("provider pins reject public, same-origin, unauthenticated, and unsafe endp
   );
   const invalid = [
     ["https://rpc.mainnet.chain.robinhood.com", RPC_URLS[1]],
-    ["http://lb.drpc.live/robinhood/0123456789abcdef", RPC_URLS[1]],
+    ["https://lb.drpc.live/robinhood/0123456789abcdef", RPC_URLS[1]],
+    ["http://hood-explorer-indexer.quiknode.pro/0123456789abcdef/", RPC_URLS[1]],
     [
-      "https://user:secret@lb.drpc.live/robinhood/0123456789abcdef",
+      "https://user:secret@hood-explorer-indexer.quiknode.pro/0123456789abcdef/",
       RPC_URLS[1],
     ],
-    ["https://lb.drpc.live/", RPC_URLS[1]],
-    ["https://lb.drpc.live/robinhood/DOCS-DEMO", RPC_URLS[1]],
-    ["https://lb.drpc.org/ogrpc?network=robinhood&dkey=docs-demo", RPC_URLS[1]],
+    ["https://hood-explorer-indexer.quiknode.pro/", RPC_URLS[1]],
+    ["https://docs-demo.quiknode.pro/0123456789abcdef/", RPC_URLS[1]],
+    ["https://hood-explorer-indexer.quiknode.pro/short/", RPC_URLS[1]],
+    ["https://hood-explorer-indexer.quiknode.pro/0123456789abcdef", RPC_URLS[1]],
+    [`${RPC_URLS[0]}?extra=1`, RPC_URLS[1]],
     [
       RPC_URLS[0],
       "https://robinhood-mainnet.g.alchemy.com/v1/abcdef0123456789",
@@ -530,12 +533,12 @@ test("preflight fails closed on provider, pin, vacancy, nonce, simulation, gas, 
     ],
     [
       "occupied target",
-      { providers: { drpc: { occupiedCodeKey: "router" } } },
+      { providers: { quicknode: { occupiedCodeKey: "router" } } },
       /predicted address is occupied/u,
     ],
     [
       "target nonce",
-      { providers: { drpc: { targetNonceKey: "graphFactory" } } },
+      { providers: { quicknode: { targetNonceKey: "graphFactory" } } },
       /nonce is non-zero/u,
     ],
     [
@@ -555,12 +558,16 @@ test("preflight fails closed on provider, pin, vacancy, nonce, simulation, gas, 
     ],
     [
       "closing nonce",
-      { providers: { drpc: { closingNonce: "0x8" } } },
+      { providers: { quicknode: { closingNonce: "0x8" } } },
       /state changed/u,
     ],
     [
       "closing parent",
-      { providers: { drpc: { closingParentHash: `0x${"bb".repeat(32)}` } } },
+      {
+        providers: {
+          quicknode: { closingParentHash: `0x${"bb".repeat(32)}` },
+        },
+      },
       /state changed/u,
     ],
     [
@@ -590,7 +597,7 @@ test("owner fee and total-cost ceilings fail closed", async () => {
         },
         options: {
           providers: {
-            drpc: { priorityFee: "0x1" },
+            quicknode: { priorityFee: "0x1" },
             alchemy: { priorityFee: "0x1" },
           },
         },
@@ -614,8 +621,8 @@ test("RPC transport is strict, bounded, and redacts endpoint/error content", asy
   const secret = "credential-canary-0123456789";
   const responseBudget = { consumed: 0, limit: 4 * 1024 * 1024 };
   const result = await robinhoodFoundationRpc({
-    providerId: "drpc",
-    rpcUrl: `https://lb.drpc.live/robinhood/${secret}`,
+    providerId: "quicknode",
+    rpcUrl: `https://hood-explorer-indexer.quiknode.pro/${secret}/`,
     method: "eth_chainId",
     responseBudget,
     fetchImpl: async () =>
@@ -631,8 +638,8 @@ test("RPC transport is strict, bounded, and redacts endpoint/error content", asy
   await assert.rejects(
     () =>
       robinhoodFoundationRpc({
-        providerId: "drpc",
-        rpcUrl: `https://lb.drpc.live/robinhood/${secret}`,
+        providerId: "quicknode",
+        rpcUrl: `https://hood-explorer-indexer.quiknode.pro/${secret}/`,
         method: "eth_chainId",
         responseBudget: { consumed: 0, limit: 4 * 1024 * 1024 },
         fetchImpl: async () =>
@@ -784,15 +791,15 @@ test("read-only action-time verifier rebinds source, hosted CI, endpoints, and l
       ],
     );
     const requestsByProvider = Object.fromEntries(
-      ["drpc", "alchemy"].map((providerId) => [
+      ["quicknode", "alchemy"].map((providerId) => [
         providerId,
         actionTimeMock.requestInventory
           .filter((request) => request.providerId === providerId)
           .map(({ method, params }) => ({ method, params })),
       ]),
     );
-    assert.equal(requestsByProvider.drpc.length, 19);
-    assert.deepEqual(requestsByProvider.drpc, requestsByProvider.alchemy);
+    assert.equal(requestsByProvider.quicknode.length, 19);
+    assert.deepEqual(requestsByProvider.quicknode, requestsByProvider.alchemy);
     assert.ok(
       actionTimeMock.requestInventory.every(
         ({ method }) =>
@@ -807,7 +814,7 @@ test("read-only action-time verifier rebinds source, hosted CI, endpoints, and l
           env: {
             ...env,
             ROBINHOOD_MAINNET_RPC_URL_PRIMARY:
-              "https://lb.drpc.live/robinhood/substitute_0123456789",
+              "https://hood-explorer-indexer.quiknode.pro/substitute_0123456789/",
           },
           nowMilliseconds: FIXED_TIMESTAMP * 1_000,
           sourceIdentity: () => ({
@@ -855,12 +862,12 @@ test("read-only action-time verifier rebinds source, hosted CI, endpoints, and l
       ],
       [
         "target code",
-        { providers: { drpc: { occupiedCodeKey: "router" } } },
+        { providers: { quicknode: { occupiedCodeKey: "router" } } },
         /predicted address is occupied/u,
       ],
       [
         "target nonce",
-        { providers: { drpc: { targetNonceKey: "graphFactory" } } },
+        { providers: { quicknode: { targetNonceKey: "graphFactory" } } },
         /nonce is non-zero/u,
       ],
       [
@@ -875,7 +882,7 @@ test("read-only action-time verifier rebinds source, hosted CI, endpoints, and l
       ],
       [
         "closing owner nonce",
-        { providers: { drpc: { closingNonce: "0x8" } } },
+        { providers: { quicknode: { closingNonce: "0x8" } } },
         /state changed during wallet verification/u,
       ],
     ];

--- a/contracts/scripts/test/robinhood-custom-launch-release-docs.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-release-docs.test.mjs
@@ -11,7 +11,16 @@ async function repositoryText(relativePath) {
 }
 
 test("operator runbooks use repo-root commands and independently frozen provider commitments", async () => {
-  const [security, handoff, commitmentHelper, packageBytes] = await Promise.all([
+  const [
+    security,
+    handoff,
+    commitmentHelper,
+    packageBytes,
+    ownerEnvelopeCore,
+    postdeployment,
+    releaseReadme,
+    phaseACapture,
+  ] = await Promise.all([
     repositoryText("contracts/security/ROBINHOOD-CUSTOM-LAUNCH.md"),
     repositoryText(
       "docs/operations/releases/custom-launch-v4/OWNER-WALLET-HANDOFF.md",
@@ -20,6 +29,16 @@ test("operator runbooks use repo-root commands and independently frozen provider
       "contracts/scripts/commit-robinhood-custom-launch-provider-endpoints.mjs",
     ),
     repositoryText("package.json"),
+    repositoryText(
+      "contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs",
+    ),
+    repositoryText(
+      "docs/operations/releases/custom-launch-v4/POSTDEPLOYMENT.md",
+    ),
+    repositoryText("docs/operations/releases/custom-launch-v4/README.md"),
+    repositoryText(
+      "contracts/scripts/capture-robinhood-custom-launch-postdeployment.mjs",
+    ),
   ]);
   const packageJson = JSON.parse(packageBytes);
 
@@ -62,6 +81,34 @@ test("operator runbooks use repo-root commands and independently frozen provider
     /ROBINHOOD_RPC_PROVIDER_COMMITMENTS_MATCH_REVIEW/u,
   );
   assert.match(commitmentHelper, /reviewedCount !== 2/u);
+  assert.match(
+    commitmentHelper,
+    /role: "primary",\s+providerId: "quicknode"/u,
+  );
+  assert.doesNotMatch(commitmentHelper, /providerId: "drpc"/u);
+  assert.match(
+    ownerEnvelopeCore,
+    /role: "primary",\s+providerId: "quicknode",\s+trustDomain: "quicknode\.com"/u,
+  );
+  assert.match(handoff, /Hood Explorer\s+Indexer/u);
+  assert.match(handoff, /Programmable Production 3/u);
+  assert.match(
+    handoff,
+    /sha256:c03afd37c077e78bea30f69d1ce139d026cb4fad86fa74122257bba8f5e9a910/u,
+  );
+  for (const historicalBoundary of [postdeployment, releaseReadme]) {
+    assert.match(historicalBoundary, /historical Phase A/u);
+    assert.match(historicalBoundary, /dRPC then\s+Alchemy/u);
+    assert.match(historicalBoundary, /QuickNode[\s\S]*Programmable Production 3/u);
+  }
+  assert.match(
+    phaseACapture,
+    /collectL2\(endpoints\.l2\[0\], \{ role: "primary", providerId: "drpc"/u,
+  );
+  assert.match(
+    phaseACapture,
+    /collectL2\(endpoints\.l2\[1\], \{ role: "secondary", providerId: "alchemy"/u,
+  );
   assert.doesNotMatch(security, /=<[^>]+>/u);
   assert.match(
     security,

--- a/contracts/security/ROBINHOOD-CUSTOM-LAUNCH.md
+++ b/contracts/security/ROBINHOOD-CUSTOM-LAUNCH.md
@@ -254,12 +254,13 @@ npm run contracts:robinhood:source-inputs:verify
 
 Immediately before the owner opens the wallet, follow the complete
 [owner-wallet handoff](../../docs/operations/releases/custom-launch-v4/OWNER-WALLET-HANDOFF.md)
-from the repository root. It reads the exact credentialed dRPC-primary and
-Alchemy-secondary endpoints without placing them in shell history or command
-arguments, binds reviewed endpoint commitments, requires clean `HEAD` to equal
-canonical `origin/production`, and binds the successful protected hosted
-`Verify` run and immutable proof artifact for that exact commit and tree. The
-strict action-time verifier compares every canonical wallet request field.
+from the repository root. It reads the exact credentialed QuickNode **Hood
+Explorer Indexer** primary and Alchemy **Programmable Production 3** secondary
+endpoints without placing them in shell history or command arguments, binds
+reviewed endpoint commitments, requires clean `HEAD` to equal canonical
+`origin/production`, and binds the successful protected hosted `Verify` run and
+immutable proof artifact for that exact commit and tree. The strict action-time
+verifier compares every canonical wallet request field.
 There is intentionally no balance read, wallet opening, signature, broadcast,
 bridge or transaction retry in that path.
 
@@ -272,7 +273,8 @@ npm run contracts:robinhood:postdeploy:test
 npm run release:custom-launch:v4:test
 ```
 
-The production assembler pins the prepared artifact bytes, requires ordered dRPC/Alchemy L2 evidence and
+The production assembler pins the prepared artifact bytes, requires the retained ordered
+dRPC/Alchemy historical Phase A L2 evidence and
 dRPC/QuickNode Ethereum evidence, checks the exact Multicall3 envelope, proves D-1 to D code
 transitions, checks the Router getters and full fresh Safe state, binds source closure, and derives
 the live descriptor plus digest. Applying the reviewed bundle is a separate explicit local command.

--- a/docs/operations/releases/custom-launch-v4/OWNER-WALLET-HANDOFF.md
+++ b/docs/operations/releases/custom-launch-v4/OWNER-WALLET-HANDOFF.md
@@ -67,14 +67,35 @@ export ROBINHOOD_MAINNET_RPC_URL_SECONDARY
 npm run --silent contracts:robinhood:provider-commitments
 ```
 
-The commitment helper accepts only the exact credential-bearing dRPC-primary
-and Alchemy-secondary Robinhood URL forms. With the two review-frozen variables
-present, it prints only `ROBINHOOD_RPC_PROVIDER_COMMITMENTS_MATCH_REVIEW` after
-an exact match. Replacing a credential URL, changing dRPC query order, reversing
-provider roles, or substituting two new otherwise valid credential URLs fails
-against the independently frozen commitments.
+The commitment helper accepts only the exact credential-bearing QuickNode
+primary and Alchemy secondary Robinhood URL forms:
 
-Public Robinhood RPC is not a substitute. A public endpoint may return
+```text
+https://<HOOD_EXPLORER_INDEXER_ENDPOINT>.quiknode.pro/<TOKEN>/
+https://robinhood-mainnet.g.alchemy.com/v2/<ALCHEMY_API_KEY>
+```
+
+The primary URL must be copied from the existing QuickNode **Hood Explorer
+Indexer** project. The secondary URL must be copied from the existing Alchemy
+**Programmable Production 3** app. The helper can validate the authenticated
+provider URL shape, role, provider ID and trust domain; it cannot prove either
+dashboard display name, account ownership, plan or archive entitlement. Those
+facts and both providers' required historical reads remain separate release
+checks.
+
+This ordered role pair is compatible with backend provider-profile digest
+`sha256:c03afd37c077e78bea30f69d1ce139d026cb4fad86fa74122257bba8f5e9a910`.
+That digest is not owner-envelope or backend-release evidence by itself; the
+cross-repository promotion must still bind the exact backend artifact and its
+attested runtime readiness. With the two review-frozen commitment variables
+present, the helper prints only
+`ROBINHOOD_RPC_PROVIDER_COMMITMENTS_MATCH_REVIEW` after an exact match.
+Replacing a credential URL, changing the QuickNode endpoint host or credential
+path, reversing provider roles, or substituting two new otherwise valid
+credential URLs fails against the independently frozen commitments.
+
+Public Robinhood RPC, dRPC and provider demo endpoints are not substitutes for
+the current owner action-time pair. A public endpoint may return
 `safe`/`finalized` headers while failing historical state reads at that same
 block. The credentialed providers must pass the exact fixed-block code, nonce,
 pending-state, simulation and closing-state inventory.

--- a/docs/operations/releases/custom-launch-v4/POSTDEPLOYMENT.md
+++ b/docs/operations/releases/custom-launch-v4/POSTDEPLOYMENT.md
@@ -169,6 +169,15 @@ fragments, extra or reordered query parameters, wrong-chain paths and public end
 the first network request. Ethereum chain ID and the complete retained readback inventory bind the
 QuickNode endpoint to mainnet. Credential values and full URLs are never serialized or printed.
 
+These are the historical Phase A capture identities: Robinhood dRPC then
+Alchemy, and Ethereum dRPC then QuickNode. They intentionally remain byte-for-byte
+separate from the next owner action-time pair, which is Robinhood
+QuickNode **Hood Explorer Indexer** then Alchemy **Programmable Production 3**.
+Never reinterpret, rewrite or re-hash an existing Phase A readback as if it came
+from the current action-time pair. The action-time endpoint commitments prove
+only the fresh wallet-preparation reads; the retained Phase A identities prove
+only the deployment observations they actually performed.
+
 The protected workflow is the canonical production invocation. A manual production-equivalent
 stage assembly must supply all portable Phase A proof coordinates:
 
@@ -425,8 +434,9 @@ The release-authoritative exact claim is a separate
 binds the protected revision/tree and capture authorization, the attested hosted Verify proof and
 pinned Linux solc binary, both Standard JSON/compiler-settings digests, exact creation-code hashes,
 the owner transaction hash/data hash and finalized block, and exact deployed runtime hashes observed
-by both dRPC and Alchemy. A Sourcify response cannot replace or weaken this binding. Provider URLs
-are code-owned HTTPS dRPC/Alchemy for Robinhood and HTTPS dRPC/QuickNode for Ethereum. Only
+by both dRPC and Alchemy. A Sourcify response cannot replace or weaken this binding. These retained
+historical Phase A provider URLs are code-owned HTTPS dRPC/Alchemy for Robinhood and HTTPS
+dRPC/QuickNode for Ethereum; they are not the current owner action-time endpoint commitments. Only
 sanitized hostnames enter evidence.
 
 ### Optional Blockscout observation

--- a/docs/operations/releases/custom-launch-v4/README.md
+++ b/docs/operations/releases/custom-launch-v4/README.md
@@ -40,6 +40,20 @@ The four artifacts at that tree are:
 Changing the merge commit, tree, path, role, or digest changes the release identity and must fail
 closed.
 
+## Provider timeline separation
+
+The next owner-wallet action-time envelope uses the ordered,
+credentialed Robinhood pair QuickNode **Hood Explorer Indexer** primary and
+Alchemy **Programmable Production 3** secondary. Its provider identities are
+compatible with backend provider-profile digest
+`sha256:c03afd37c077e78bea30f69d1ce139d026cb4fad86fa74122257bba8f5e9a910`,
+but that digest is not backend readiness evidence by itself.
+
+The historical Phase A deployment evidence below remains ordered dRPC then
+Alchemy on Robinhood, while Ethereum remains dRPC then QuickNode. Those retained
+observations describe the providers that actually performed those reads. The
+current owner endpoint commitments must never relabel, replace or re-hash them.
+
 ## Per-contract deployment provenance
 
 The deployment evidence must preserve the source model of each root. A global “all contracts are


### PR DESCRIPTION
## Summary

- bind the future Robinhood owner action-time endpoint commitment to QuickNode Hood Explorer Indexer primary and Alchemy Programmable Production 3 secondary
- keep Ethereum on dRPC primary and QuickNode secondary
- preserve historical Robinhood Phase-A dRPC-to-Alchemy evidence without relabeling or re-hashing it
- harden the canonical endpoint parser and role/provider/URL commitment tests to fail closed

## Exact release binding

- reviewed head: aa809ccfeb2f58d072de42e8b2d3e013f197e536
- tree: 246e05c8d75169b3e07a82d8a0a8752ab8330df7
- sole production parent: 6c412febfba41613d9c45de2ccefd38dfd276c34
- binary diff SHA-256: c23a8673538d9535dff56597d4b09e19ddb34eb4a6cdbde23b16cfbba2ee2e86
- independent review: P0=0, P1=0, P2=0
- signed commit and clean worktree verified before push

## Preserved authority and payload

- both allowed owners remain unchanged
- Multicall3 target and selector remain unchanged
- owner calldata remains byte-identical: 33,412 bytes
- calldata hash remains 0x3ba04469085b17e12843a94c154a335c9c384837f8f6531f179cb4915fd237d9
- no balance read, private-key access, signing, broadcast, deployment, funding, or onchain mutation was performed

## Verification

- owner-envelope suite: 68/68
- postdeployment suite: 18/18
- V4 clean-room suite: 12/12
- combined release suite: 46/46
- Robinhood bindings verifier: pass
- router ABI verifier: pass
- source-input verifier: pass
- typecheck: pass
- lint: 0 errors
- CI-scope tests: 15/15
- actionlint, gitleaks, and git diff check: pass
- npm audit high-severity gate: 0 high/critical findings (existing low-severity advisories remain)

## Release boundary

The backend provider-profile digest sha256:c03afd37c077e78bea30f69d1ce139d026cb4fad86fa74122257bba8f5e9a910 is documented only as identity compatibility, not as backend readiness or live provider evidence. This PR does not change the backend receipt schema or historical evidence artifacts. Final cross-repository release readiness remains dependent on the separately reviewed backend migration/provider-profile/generated-release stack.
