### PR TITLE
fix(web): disable analytics redirect prefetch

### DIFF
--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -104,7 +104,7 @@ export function SiteFooter() {
                     {link.label}
                   </a>
                 ) : (
-                  <Link href={link.href}>
+                  <Link href={link.href} prefetch={false}>
                     {link.label}
                   </Link>
                 )}

--- a/tests/site-footer.test.ts
+++ b/tests/site-footer.test.ts
@@ -22,12 +22,14 @@ describe("Site footer", () => {
     expect(footerSource).toContain('label: "Analytics"');
   });
 
-  it("does not eagerly prefetch repeated internal footer destinations", () => {
-    expect(footerSource.match(/prefetch=\{false\}/gu)).toHaveLength(2);
+  it("does not prefetch internal footer destinations, including the analytics redirect", () => {
+    expect(footerSource.match(/prefetch=\{false\}/gu)).toHaveLength(3);
     expect(footerSource).toMatch(
       /className=\{styles\.brandLink\}[\s\S]{0,100}prefetch=\{false\}/u,
     );
-    expect(footerSource).toContain("<Link href={link.href}>");
+    expect(footerSource).toContain(
+      "<Link href={link.href} prefetch={false}>",
+    );
   });
 
   it("links the official Discord from Resources", () => {


### PR DESCRIPTION
## Summary

- disable Next.js prefetch for the internal `/analytics` redirect link in the shared site footer
- prevent desktop `/profile` from issuing a Next-RSC request that follows the redirect to Dune and fails CORS
- add focused regression coverage for every internal footer destination

## Evidence

- focused regression was red before the component change and is now 8/8 green
- `npx vitest run tests/site-footer.test.ts tests/analytics-redirect.test.ts`
- `npm run lint` (0 errors; existing warnings only)
- `npm run typecheck`
- `npm run build`
- local desktop `/profile` QA at 1440x1000: 0 `/analytics` or `dune.com` network requests after reload, 0 console errors

## Release boundary

Stage-only after green production merge. All activation flags remain false. No production promotion, wallet action, or onchain mutation.