### PR TITLE
Explore: add bounded GMGN market enrichment

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -9,6 +9,15 @@ import {
 import { readDexscreenerExploreEntriesV1 } from
   "../../../lib/market-data/dexscreener-explore.server";
 import {
+  exploreMarketProviderHeaderV1,
+  exploreMarketPriceSourcesV1,
+  exploreMarketSourcesV1,
+  readExploreMarketEntriesV1,
+  type ExploreMarketReadV1,
+} from "../../../lib/market-data/explore-market.server";
+import { gmgnMarketDataConfiguredV1 } from
+  "../../../lib/market-data/gmgn.server";
+import {
   envioClassicV3IdentityCommitmentV1,
   mergeEnvioClassicV3CatalogEntriesV1,
   readEnvioClassicV3CatalogV1,
@@ -574,9 +583,7 @@ export async function GET(request: NextRequest) {
     }
     if (routerAvailable) includedSources.add(ROUTER_CUSTOM_LAUNCH_SOURCE);
     let paginated: ReturnType<typeof paginateExploreEntriesV1>;
-    let marketRead: Awaited<
-      ReturnType<typeof readDexscreenerExploreEntriesV1>
-    >["marketRead"];
+    let marketRead: ExploreMarketReadV1;
     let marketQualifiedEntryCount = 0;
     if (options.sort === "market-cap" || options.sort === "market-cap-asc") {
       const filtered = filterExploreEntries(
@@ -585,6 +592,9 @@ export async function GET(request: NextRequest) {
         options.socials,
         options.model,
       );
+      // Market-cap ranking and displayed FDV remain one coherent Dexscreener
+      // snapshot. GMGN's one-token endpoint enriches only non-market-cap pages
+      // and single-token detail reads.
       const valued = await readDexscreenerExploreEntriesV1(filtered, {
         signal: readSignal,
         deadlineMs,
@@ -604,7 +614,7 @@ export async function GET(request: NextRequest) {
         presentedPublicEntries,
         options,
       );
-      const valued = await readDexscreenerExploreEntriesV1(
+      const valued = await readExploreMarketEntriesV1(
         identityPage.tokens,
         { signal: readSignal, deadlineMs },
       );
@@ -633,6 +643,9 @@ export async function GET(request: NextRequest) {
       : qualifiedCount === paginated.total
         ? "complete" as const
         : "partial" as const;
+    const marketProvider = exploreMarketProviderHeaderV1(marketRead);
+    const marketSources = exploreMarketSourcesV1(marketRead);
+    const priceSources = exploreMarketPriceSourcesV1(marketRead);
 
     return NextResponse.json(
       {
@@ -716,16 +729,18 @@ export async function GET(request: NextRequest) {
           "X-Programmable-Data-Quality": dataQuality.status,
           "X-Programmable-Chain-Id": String(options.chain),
           "X-Programmable-Launch-Source": launchSource,
-          "X-Programmable-Read-Source": `${launchSource}+dexscreener`,
+          "X-Programmable-Read-Source": `${launchSource}+${marketProvider}`,
           "X-Programmable-Market-Read-Status": marketRead.status,
-          "X-Programmable-Market-Provider": "dexscreener",
+          "X-Programmable-Market-Provider": marketProvider,
           "X-Programmable-Canonical-Read-Status": canonicalStatus,
           "X-Programmable-Router-Read-Status": routerCustomStatus,
-          ...(marketRead.observedCount > 0
+          ...(marketSources.length > 0
             ? {
-                "X-Programmable-Market-Source": "dexscreener",
-                "X-Programmable-Price-Source": "dexscreener",
+                "X-Programmable-Market-Source": marketSources.join("+"),
               }
+            : {}),
+          ...(priceSources.length > 0
+            ? { "X-Programmable-Price-Source": priceSources.join("+") }
             : {}),
           ...(dataQuality.valuation.asOfTime
             ? { "X-Programmable-Market-As-Of": dataQuality.valuation.asOfTime }
@@ -736,6 +751,9 @@ export async function GET(request: NextRequest) {
     );
   } catch (error) {
     console.error("Explore read failed", safeOperationalRpcError(error));
+    const configuredProvider = gmgnMarketDataConfiguredV1()
+      ? "gmgn+dexscreener"
+      : "dexscreener";
     return NextResponse.json(
       { error: "Token data is temporarily unavailable" },
       {
@@ -744,8 +762,9 @@ export async function GET(request: NextRequest) {
           "Cache-Control": "no-store",
           "Retry-After": "5",
           "X-Programmable-Launch-Source": "envio-classic-v3",
-          "X-Programmable-Read-Source": "envio-classic-v3+dexscreener",
-          "X-Programmable-Market-Provider": "dexscreener",
+          "X-Programmable-Read-Source":
+            `envio-classic-v3+${configuredProvider}`,
+          "X-Programmable-Market-Provider": configuredProvider,
         },
       },
     );

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -4,8 +4,14 @@ import { getAddress, isAddress } from "viem";
 import {
   publicExploreEntryV1,
 } from "../../../../lib/explore-financial-data";
-import { readDexscreenerExploreEntriesV1 } from
-  "../../../../lib/market-data/dexscreener-explore.server";
+import {
+  exploreMarketProviderHeaderV1,
+  exploreMarketPriceSourcesV1,
+  exploreMarketSourcesV1,
+  readExploreMarketEntriesV1,
+} from "../../../../lib/market-data/explore-market.server";
+import { gmgnMarketDataConfiguredV1 } from
+  "../../../../lib/market-data/gmgn.server";
 import {
   envioClassicV3IdentityCommitmentV1,
   mergeEnvioClassicV3CatalogEntriesV1,
@@ -57,33 +63,43 @@ function tokenAddress(entry: ExploreEntry): string | null {
 
 function canonicalResponseHeaders(input: Readonly<{
   marketAsOf?: string;
-  hasDexscreenerPrice: boolean;
+  hasMarketPrice: boolean;
   marketStatus: "complete" | "partial" | "unavailable";
+  marketProvider?: "dexscreener" | "gmgn" | "gmgn+dexscreener";
+  marketSources?: string;
+  priceSources?: string;
   launchSource: string;
   lastIndexedAt: string;
   canonicalStatus: "current" | "last-known-good" | "unavailable";
   routerStatus: "current" | "last-known-good" | "unavailable";
 }>) {
+  const marketProvider = input.marketProvider ?? configuredMarketProviderV1();
+  const marketSources = input.marketSources;
+  const priceSources = input.priceSources;
   return {
     "Cache-Control": SUCCESS_CACHE_CONTROL,
     "X-Programmable-Chain-Id": "1",
     "X-Programmable-Launch-Source": input.launchSource,
-    "X-Programmable-Read-Source": `${input.launchSource}+dexscreener`,
-    "X-Programmable-Market-Provider": "dexscreener",
+    "X-Programmable-Read-Source": `${input.launchSource}+${marketProvider}`,
+    "X-Programmable-Market-Provider": marketProvider,
     "X-Programmable-Market-Read-Status": input.marketStatus,
     "X-Programmable-Canonical-Read-Status": input.canonicalStatus,
     "X-Programmable-Router-Read-Status": input.routerStatus,
     "X-Programmable-Identity-Last-Indexed-At": input.lastIndexedAt,
-    ...(input.hasDexscreenerPrice
-      ? { "X-Programmable-Market-Source": "dexscreener" }
+    ...(marketSources
+      ? { "X-Programmable-Market-Source": marketSources }
       : {}),
     ...(input.marketAsOf
       ? { "X-Programmable-Market-As-Of": input.marketAsOf }
       : {}),
-    ...(input.hasDexscreenerPrice
-      ? { "X-Programmable-Price-Source": "dexscreener" }
+    ...(input.hasMarketPrice && priceSources
+      ? { "X-Programmable-Price-Source": priceSources }
       : {}),
   };
+}
+
+function configuredMarketProviderV1(): "dexscreener" | "gmgn+dexscreener" {
+  return gmgnMarketDataConfiguredV1() ? "gmgn+dexscreener" : "dexscreener";
 }
 
 function unavailableResponse(
@@ -403,8 +419,9 @@ export async function GET(request: NextRequest) {
   ) {
     return unavailableResponse({
       "X-Programmable-Launch-Source": launchSource,
-      "X-Programmable-Read-Source": `${launchSource}+dexscreener`,
-      "X-Programmable-Market-Provider": "dexscreener",
+      "X-Programmable-Read-Source":
+        `${launchSource}+${configuredMarketProviderV1()}`,
+      "X-Programmable-Market-Provider": configuredMarketProviderV1(),
       "X-Programmable-Router-Read-Status": routerCustomStatus,
     });
   }
@@ -412,8 +429,9 @@ export async function GET(request: NextRequest) {
     if (canonicalReadFailed || registryReadFailed || routerReadFailed) {
       return unavailableResponse({
         "X-Programmable-Launch-Source": launchSource,
-        "X-Programmable-Read-Source": `${launchSource}+dexscreener`,
-        "X-Programmable-Market-Provider": "dexscreener",
+        "X-Programmable-Read-Source":
+          `${launchSource}+${configuredMarketProviderV1()}`,
+        "X-Programmable-Market-Provider": configuredMarketProviderV1(),
         "X-Programmable-Router-Read-Status": routerCustomStatus,
       });
     }
@@ -432,7 +450,7 @@ export async function GET(request: NextRequest) {
       {
         status: 404,
         headers: canonicalResponseHeaders({
-          hasDexscreenerPrice: false,
+          hasMarketPrice: false,
           marketStatus: "complete",
           launchSource,
           lastIndexedAt: identityGeneratedAt,
@@ -462,13 +480,18 @@ export async function GET(request: NextRequest) {
     const creatorArticlePromise = readPublicCreatorArticleV1(
       entry.tokenAddress!,
     );
-    const market = await readDexscreenerExploreEntriesV1([entry], {
+    const market = await readExploreMarketEntriesV1([entry], {
       signal: readSignal,
       deadlineMs,
     });
     const valuedEntry = market.entries[0];
-    if (!valuedEntry) throw new Error("Dexscreener identity mapping failed");
-    const hasDexscreenerPrice = valuedEntry.valuation.status === "available";
+    if (!valuedEntry) throw new Error("Market identity mapping failed");
+    const hasMarketPrice = valuedEntry.valuation.status === "available";
+    const marketProvider = exploreMarketProviderHeaderV1(market.marketRead);
+    const marketSources = exploreMarketSourcesV1(market.marketRead).join("+");
+    const priceSources = exploreMarketPriceSourcesV1(
+      market.marketRead,
+    ).join("+");
     const marketAsOf = valuedEntry.valuation.status === "available"
       ? valuedEntry.valuation.asOfTime
       : undefined;
@@ -497,8 +520,11 @@ export async function GET(request: NextRequest) {
       },
       {
         headers: canonicalResponseHeaders({
-          hasDexscreenerPrice,
+          hasMarketPrice,
           marketStatus: market.marketRead.status,
+          marketProvider,
+          ...(marketSources ? { marketSources } : {}),
+          ...(priceSources ? { priceSources } : {}),
           launchSource,
           lastIndexedAt: identityGeneratedAt,
           canonicalStatus: catalog?.status ?? "unavailable",
@@ -540,7 +566,7 @@ export async function GET(request: NextRequest) {
       },
       {
         headers: canonicalResponseHeaders({
-          hasDexscreenerPrice: false,
+          hasMarketPrice: false,
           marketStatus: "unavailable",
           launchSource,
           lastIndexedAt: identityGeneratedAt,

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -58,6 +58,8 @@ import {
   isTokenMarketDataV1,
   marketDataStatusLabel,
 } from "@/lib/market-data/market-data-v1";
+import { isGmgnMarketSnapshotV1 } from
+  "@/lib/market-data/gmgn-market-data-v1";
 import {
   applyTokenImageFallback,
   canOptimizeTokenImage,
@@ -151,6 +153,23 @@ type DexscreenerExploreMarketRead = Readonly<{
   newestFetchedAt: string | null;
 }>;
 
+type GmgnExploreMarketRead = Readonly<{
+  provider: "gmgn";
+  fallbackProvider: "dexscreener";
+  status: "complete" | "partial" | "unavailable";
+  currency: "USD";
+  requestedCount: number;
+  observedCount: number;
+  qualifiedCount: number;
+  unavailableCount: number;
+  gmgnObservedCount: number;
+  gmgnQualifiedCount: number;
+  fallbackRequestedCount: number;
+  fallbackQualifiedCount: number;
+  oldestFetchedAt: string | null;
+  newestFetchedAt: string | null;
+}>;
+
 type LegacyBitqueryExploreMarketRead = Readonly<{
   provider: "bitquery";
   status: "unavailable";
@@ -162,6 +181,7 @@ type LegacyBitqueryExploreMarketRead = Readonly<{
 
 type ExploreMarketRead =
   | DexscreenerExploreMarketRead
+  | GmgnExploreMarketRead
   | LegacyBitqueryExploreMarketRead;
 
 type ExploreRanking = Readonly<{
@@ -340,6 +360,7 @@ function preserveKnownMarketObservation(
 
   const {
     marketData: _previousMarketData,
+    gmgnMarketData: _previousGmgnMarketData,
     liquidityEvidence: _previousLiquidityEvidence,
     fdvUsdWad: _previousFdvUsdWad,
     ...identity
@@ -347,6 +368,7 @@ function preserveKnownMarketObservation(
   const incomingCompatibility = incoming as ValuedExploreEntry &
     Readonly<{ fdvUsdWad?: string }>;
   void _previousMarketData;
+  void _previousGmgnMarketData;
   void _previousLiquidityEvidence;
   void _previousFdvUsdWad;
   return {
@@ -355,6 +377,9 @@ function preserveKnownMarketObservation(
     ...(incoming.marketData === undefined
       ? {}
       : { marketData: incoming.marketData }),
+    ...(incoming.gmgnMarketData === undefined
+      ? {}
+      : { gmgnMarketData: incoming.gmgnMarketData }),
     ...(incoming.liquidityEvidence === undefined
       ? {}
       : { liquidityEvidence: incoming.liquidityEvidence }),
@@ -1097,12 +1122,19 @@ function parseExploreEntry(value: unknown): ValuedExploreEntry | null {
           ? value.marketData
           : null
         : undefined;
-    return valuation === null || marketData === null
+    const gmgnMarketData =
+      isRecord(value) && value.gmgnMarketData !== undefined
+        ? isGmgnMarketSnapshotV1(value.gmgnMarketData)
+          ? value.gmgnMarketData
+          : null
+        : undefined;
+    return valuation === null || marketData === null || gmgnMarketData === null
       ? null
       : {
           ...entry,
           valuation,
           ...(marketData === undefined ? {} : { marketData }),
+          ...(gmgnMarketData === undefined ? {} : { gmgnMarketData }),
         };
   };
   if (isRecord(value) && value.exploreKind === "custom-project") {
@@ -1189,7 +1221,7 @@ function parseExploreMarketRead(value: unknown): ExploreMarketRead | null {
   }
   if (
     !isRecord(value) ||
-    value.provider !== "dexscreener" ||
+    (value.provider !== "dexscreener" && value.provider !== "gmgn") ||
     !["complete", "partial", "unavailable"].includes(String(value.status)) ||
     value.currency !== "USD" ||
     !["requestedCount", "observedCount", "qualifiedCount", "unavailableCount"]
@@ -1205,6 +1237,26 @@ function parseExploreMarketRead(value: unknown): ExploreMarketRead | null {
       (typeof value.newestFetchedAt !== "string" ||
         !Number.isFinite(Date.parse(value.newestFetchedAt))))
   ) return null;
+  if (value.provider === "gmgn") {
+    if (
+      value.fallbackProvider !== "dexscreener" ||
+      ![
+        "gmgnObservedCount",
+        "gmgnQualifiedCount",
+        "fallbackRequestedCount",
+        "fallbackQualifiedCount",
+      ].every((field) =>
+        Number.isSafeInteger(value[field]) && Number(value[field]) >= 0
+      ) ||
+      Number(value.gmgnQualifiedCount) > Number(value.gmgnObservedCount) ||
+      Number(value.gmgnObservedCount) > Number(value.requestedCount) ||
+      Number(value.fallbackQualifiedCount) >
+        Number(value.fallbackRequestedCount) ||
+      Number(value.fallbackRequestedCount) > Number(value.requestedCount) ||
+      Number(value.qualifiedCount) !==
+        Number(value.gmgnQualifiedCount) + Number(value.fallbackQualifiedCount)
+    ) return null;
+  }
   const observed = Number(value.observedCount);
   // Transport completion and pair coverage are independent. A complete
   // Dexscreener read can honestly observe only a small subset of the known
@@ -1904,7 +1956,8 @@ async function fetchExplorePayload(
             : "response-unavailable"
           : null;
       if (
-        payload.marketRead?.provider === "dexscreener" &&
+        (payload.marketRead?.provider === "dexscreener" ||
+          payload.marketRead?.provider === "gmgn") &&
         marketReadStatus !== payload.marketRead.status
       ) {
         throw new Error("The token registry returned inconsistent market read data");
@@ -2077,6 +2130,11 @@ async function loadExploreModelDatasetAttempt(
       (payload.marketRead?.provider !== "dexscreener" ||
         degradedPage.marketRead?.provider !== "dexscreener" ||
         payload.marketRead.currency === degradedPage.marketRead.currency) &&
+      (payload.marketRead?.provider !== "gmgn" ||
+        degradedPage.marketRead?.provider !== "gmgn" ||
+        (payload.marketRead.currency === degradedPage.marketRead.currency &&
+          payload.marketRead.fallbackProvider ===
+            degradedPage.marketRead.fallbackProvider)) &&
       (payload.marketRead?.provider !== "bitquery" ||
         degradedPage.marketRead?.provider !== "bitquery" ||
         (payload.marketRead.category === degradedPage.marketRead.category &&
@@ -2098,11 +2156,13 @@ async function loadExploreModelDatasetAttempt(
       if (entry.exploreKind === "custom-project") {
         const {
           marketData: _marketData,
+          gmgnMarketData: _gmgnMarketData,
           liquidityEvidence: _liquidityEvidence,
           fdvUsdWad: _fdvUsdWad,
           ...identity
         } = entry as typeof entry & Readonly<{ fdvUsdWad?: string }>;
         void _marketData;
+        void _gmgnMarketData;
         void _liquidityEvidence;
         void _fdvUsdWad;
         return {
@@ -2117,11 +2177,13 @@ async function loadExploreModelDatasetAttempt(
       }
       const {
         marketData: _marketData,
+        gmgnMarketData: _gmgnMarketData,
         liquidityEvidence: _liquidityEvidence,
         fdvUsdWad: _fdvUsdWad,
         ...identity
       } = entry;
       void _marketData;
+      void _gmgnMarketData;
       void _liquidityEvidence;
       void _fdvUsdWad;
       return {

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -58,6 +58,10 @@ import {
   type TokenMarketDataV1,
 } from "@/lib/market-data/market-data-v1";
 import {
+  isGmgnMarketSnapshotV1,
+  type GmgnMarketSnapshotV1,
+} from "@/lib/market-data/gmgn-market-data-v1";
+import {
   applyTokenImageFallback,
   canOptimizeTokenImage,
   getTokenCardImageSource,
@@ -95,11 +99,13 @@ import styles from "./token-experience.module.css";
 type DetailToken = LauncherToken & Readonly<{
   valuation: ExploreValuation;
   marketData?: TokenMarketDataV1;
+  gmgnMarketData?: GmgnMarketSnapshotV1;
 }>;
 
 type DetailCustomProject = CustomProjectExploreEntry & Readonly<{
   valuation?: ExploreValuation;
   marketData?: TokenMarketDataV1;
+  gmgnMarketData?: GmgnMarketSnapshotV1;
 }>;
 
 type RouterTradeProject = Pick<
@@ -549,12 +555,18 @@ function parseLauncherToken(value: unknown): DetailToken | null {
     : isTokenMarketDataV1(value.marketData)
       ? value.marketData
       : null;
-  return valuation === null || marketData === null
+  const gmgnMarketData = value.gmgnMarketData === undefined
+    ? undefined
+    : isGmgnMarketSnapshotV1(value.gmgnMarketData)
+      ? value.gmgnMarketData
+      : null;
+  return valuation === null || marketData === null || gmgnMarketData === null
     ? null
     : {
         ...token,
         valuation,
         ...(marketData === undefined ? {} : { marketData }),
+        ...(gmgnMarketData === undefined ? {} : { gmgnMarketData }),
       };
 }
 
@@ -720,7 +732,14 @@ function parseCustomProject(value: unknown): DetailCustomProject | null {
     : isTokenMarketDataV1(value.marketData)
       ? value.marketData
       : null;
-  if (valuation === null || marketData === null) return null;
+  const gmgnMarketData = value.gmgnMarketData === undefined
+    ? undefined
+    : isGmgnMarketSnapshotV1(value.gmgnMarketData)
+      ? value.gmgnMarketData
+      : null;
+  if (valuation === null || marketData === null || gmgnMarketData === null) {
+    return null;
+  }
   return {
     exploreKind: "custom-project",
     id: value.id,
@@ -754,6 +773,7 @@ function parseCustomProject(value: unknown): DetailCustomProject | null {
     launchCategoryProvenance: value.launchCategoryProvenance as CustomProjectExploreEntry["launchCategoryProvenance"],
     ...(valuation === undefined ? {} : { valuation }),
     ...(marketData === undefined ? {} : { marketData }),
+    ...(gmgnMarketData === undefined ? {} : { gmgnMarketData }),
   };
 }
 
@@ -1266,6 +1286,7 @@ export function buildTokenDetailMetrics(
   token: LauncherToken & Readonly<{
     valuation?: ExploreValuation;
     marketData?: TokenMarketDataV1;
+    gmgnMarketData?: GmgnMarketSnapshotV1;
   }>,
   fdvOverride?: string | null,
   volumeOverride?: TokenMetric,
@@ -1273,10 +1294,15 @@ export function buildTokenDetailMetrics(
   const primaryMarket = token.marketData?.pools.find(
     (pool) => pool.identity.poolId === token.marketData?.primaryPoolId,
   );
-  const marketVolumeUsd = formatUsdWadAmount(primaryMarket?.volume24hUsdWad);
-  const marketLiquidityUsd = primaryMarket?.liquidity?.freshness === "current"
-    ? formatUsdWadAmount(primaryMarket.liquidity.valueUsdWad)
-    : null;
+  const marketVolumeUsd = formatUsdWadAmount(
+    token.gmgnMarketData?.volume24hUsdWad ?? primaryMarket?.volume24hUsdWad,
+  );
+  const marketLiquidityUsd = formatUsdWadAmount(
+    token.gmgnMarketData?.liquidityUsdWad ??
+      (primaryMarket?.liquidity?.freshness === "current"
+        ? primaryMarket.liquidity.valueUsdWad
+        : undefined),
+  );
   const explicitValuation = (token as { valuation?: unknown }).valuation;
   const valuation = isExploreValuation(explicitValuation)
     ? explicitValuation
@@ -2403,16 +2429,23 @@ function customMarketMetrics(project: DetailCustomProject): TokenMetric[] {
       value: valuationValue ?? "",
     },
     { label: "Market data", value: marketStatus },
-    ...(primary?.volume24hUsdWad
+    ...((project.gmgnMarketData?.volume24hUsdWad ?? primary?.volume24hUsdWad)
       ? [{
           label: "24h volume",
-          value: formatUsdWadAmount(primary.volume24hUsdWad) ?? "",
+          value: formatUsdWadAmount(
+            project.gmgnMarketData?.volume24hUsdWad ??
+              primary?.volume24hUsdWad,
+          ) ?? "",
         }]
       : []),
-    ...(primary?.liquidity?.freshness === "current"
+    ...((project.gmgnMarketData?.liquidityUsdWad ||
+      primary?.liquidity?.freshness === "current")
       ? [{
           label: "Liquidity",
-          value: formatUsdWadAmount(primary.liquidity.valueUsdWad) ?? "",
+          value: formatUsdWadAmount(
+            project.gmgnMarketData?.liquidityUsdWad ??
+              primary?.liquidity?.valueUsdWad,
+          ) ?? "",
         }]
       : []),
   ];

--- a/lib/explore-financial-data.ts
+++ b/lib/explore-financial-data.ts
@@ -19,6 +19,8 @@ import {
   type MarketPoolDataV1,
   type TokenMarketDataV1,
 } from "./market-data/market-data-v1";
+import type { GmgnMarketSnapshotV1 } from
+  "./market-data/gmgn-market-data-v1";
 
 export const EXPLORE_DATA_QUALITY_SCHEMA_VERSION =
   "programmable.explore-data-quality.v1" as const;
@@ -60,7 +62,7 @@ export type ExploreValuation =
       valueWad: string;
       quoteSymbol?: string;
       freshness: "current" | "provider-recent" | "stale" | "unknown";
-      source?: "bitquery" | "dexscreener" | "stateview-chainlink";
+      source?: "bitquery" | "dexscreener" | "gmgn" | "stateview-chainlink";
       asOfTime?: string;
       asOfBlock?: string;
       asOfBlockHash?: `0x${string}`;
@@ -83,6 +85,7 @@ export type ValuedExploreEntry<T extends ExploreEntry = ExploreEntry> =
   T & Readonly<{
     valuation: ExploreValuation;
     marketData?: TokenMarketDataV1;
+    gmgnMarketData?: GmgnMarketSnapshotV1;
     liquidityEvidence?: OfficialV4LiquidityEvidenceV1;
   }>;
 
@@ -822,7 +825,8 @@ export function isExploreValuationQualifiedV1(
 ): value is Extract<ExploreValuation, { status: "available" }> {
   return value.status === "available" && (
     value.freshness === "current" ||
-    (value.freshness === "provider-recent" && value.source === "dexscreener")
+    (value.freshness === "provider-recent" &&
+      (value.source === "dexscreener" || value.source === "gmgn"))
   );
 }
 
@@ -979,7 +983,7 @@ export function isExploreValuation(value: unknown): value is ExploreValuation {
       String(candidate.freshness),
     ) &&
     (candidate.freshness !== "provider-recent" ||
-      (candidate.source === "dexscreener" &&
+      ((candidate.source === "dexscreener" || candidate.source === "gmgn") &&
         typeof candidate.asOfTime === "string")) &&
     (candidate.currency !== "quote" ||
       (typeof candidate.quoteSymbol === "string" &&
@@ -987,6 +991,7 @@ export function isExploreValuation(value: unknown): value is ExploreValuation {
     (candidate.source === undefined ||
       candidate.source === "bitquery" ||
       candidate.source === "dexscreener" ||
+      candidate.source === "gmgn" ||
       candidate.source === "stateview-chainlink") &&
     (candidate.asOfTime === undefined ||
       (typeof candidate.asOfTime === "string" &&

--- a/lib/market-data/explore-market.server.ts
+++ b/lib/market-data/explore-market.server.ts
@@ -1,0 +1,217 @@
+import "server-only";
+
+import type {
+  ExploreValuation,
+  ValuedExploreEntry,
+} from "../explore-financial-data";
+import type { ExploreEntry } from "../tokens";
+import {
+  DEXSCREENER_CURRENT_MAXIMUM_AGE_MS,
+  readDexscreenerExploreEntriesV1,
+  type DexscreenerExploreReadV1,
+} from "./dexscreener-explore.server";
+import { exploreEntryMarketIdentitiesV1 } from
+  "./explore-market-identities";
+import {
+  gmgnMarketDataConfiguredV1,
+  readGmgnExploreSnapshotsV1,
+  type GmgnReadWaitV1,
+} from "./gmgn.server";
+import type { GmgnMarketSnapshotV1 } from "./gmgn-market-data-v1";
+import { MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD } from
+  "./market-data-v1";
+
+export type GmgnExploreReadV1 = Readonly<{
+  provider: "gmgn";
+  fallbackProvider: "dexscreener";
+  status: "complete" | "partial" | "unavailable";
+  currency: "USD";
+  requestedCount: number;
+  observedCount: number;
+  qualifiedCount: number;
+  unavailableCount: number;
+  gmgnObservedCount: number;
+  gmgnQualifiedCount: number;
+  fallbackRequestedCount: number;
+  fallbackQualifiedCount: number;
+  oldestFetchedAt: string | null;
+  newestFetchedAt: string | null;
+}>;
+
+export type ExploreMarketReadV1 = DexscreenerExploreReadV1 | GmgnExploreReadV1;
+
+export type ExploreMarketResultV1 = Readonly<{
+  entries: readonly ValuedExploreEntry[];
+  marketRead: ExploreMarketReadV1;
+}>;
+
+export async function readExploreMarketEntriesV1(
+  entries: readonly ExploreEntry[],
+  wait: GmgnReadWaitV1 = {},
+): Promise<ExploreMarketResultV1> {
+  // GMGN token/info is one weighted request per token. Catalog-wide ranking
+  // remains on the existing bounded Dexscreener batch reader; GMGN only
+  // enriches the visible page or one detail resource.
+  if (!gmgnMarketDataConfiguredV1() || entries.length > 9) {
+    return readDexscreenerExploreEntriesV1(entries, wait);
+  }
+
+  let snapshots: ReadonlyMap<string, GmgnMarketSnapshotV1>;
+  try {
+    snapshots = await readGmgnExploreSnapshotsV1(entries, wait);
+  } catch {
+    return readDexscreenerExploreEntriesV1(entries, wait);
+  }
+  const nowMs = (wait.now ?? (() => new Date()))().getTime();
+  const gmgnEntries = new Map<string, ValuedExploreEntry>();
+  const fallbackEntries: ExploreEntry[] = [];
+  let gmgnQualifiedCount = 0;
+  for (const entry of entries) {
+    const snapshot = snapshots.get(entry.id);
+    if (snapshot && gmgnSnapshotQualified(snapshot, nowMs)) {
+      gmgnEntries.set(entry.id, {
+        ...entry,
+        valuation: gmgnValuation(snapshot),
+        gmgnMarketData: snapshot,
+      });
+      gmgnQualifiedCount += 1;
+    } else {
+      fallbackEntries.push(entry);
+      if (snapshot) {
+        gmgnEntries.set(entry.id, {
+          ...entry,
+          valuation: { status: "unavailable", reason: "liquidity-unavailable" },
+          gmgnMarketData: snapshot,
+        });
+      }
+    }
+  }
+
+  const fallback = await readDexscreenerExploreEntriesV1(fallbackEntries, wait);
+  const fallbackById = new Map(fallback.entries.map((entry) => [entry.id, entry]));
+  let fallbackQualifiedCount = 0;
+  const valuedEntries = entries.map((entry): ValuedExploreEntry => {
+    const gmgn = gmgnEntries.get(entry.id);
+    if (gmgn?.valuation.status === "available") return gmgn;
+    const dexscreener = fallbackById.get(entry.id);
+    if (dexscreener?.valuation.status === "available") {
+      fallbackQualifiedCount += 1;
+      return gmgn?.gmgnMarketData
+        ? { ...dexscreener, gmgnMarketData: gmgn.gmgnMarketData }
+        : dexscreener;
+    }
+    return gmgn ?? dexscreener ?? unavailableEntry(entry);
+  });
+  const qualifiedCount = gmgnQualifiedCount + fallbackQualifiedCount;
+  const gmgnTimes = [...snapshots.values()].map((snapshot) => snapshot.fetchedAt);
+  const sourceTimes = [
+    ...gmgnTimes,
+    ...(fallback.marketRead.oldestFetchedAt
+      ? [fallback.marketRead.oldestFetchedAt]
+      : []),
+    ...(fallback.marketRead.newestFetchedAt
+      ? [fallback.marketRead.newestFetchedAt]
+      : []),
+  ].sort();
+  const providerHealthy = snapshots.size === entries.length ||
+    fallback.marketRead.status === "complete";
+  const observedCount = entries.filter((entry) =>
+    snapshots.has(entry.id) ||
+    fallbackById.get(entry.id)?.valuation.status === "available"
+  ).length;
+  return {
+    entries: valuedEntries,
+    marketRead: {
+      provider: "gmgn",
+      fallbackProvider: "dexscreener",
+      status: providerHealthy
+        ? "complete"
+        : observedCount > 0 || fallback.marketRead.status === "partial"
+          ? "partial"
+          : "unavailable",
+      currency: "USD",
+      requestedCount: entries.length,
+      observedCount,
+      qualifiedCount,
+      unavailableCount: entries.length - qualifiedCount,
+      gmgnObservedCount: snapshots.size,
+      gmgnQualifiedCount,
+      fallbackRequestedCount: fallbackEntries.length,
+      fallbackQualifiedCount,
+      oldestFetchedAt: sourceTimes[0] ?? null,
+      newestFetchedAt: sourceTimes.at(-1) ?? null,
+    },
+  };
+}
+
+export function exploreMarketProviderHeaderV1(
+  marketRead: ExploreMarketReadV1,
+): "dexscreener" | "gmgn" | "gmgn+dexscreener" {
+  if (marketRead.provider === "dexscreener") return "dexscreener";
+  return marketRead.fallbackRequestedCount > 0
+    ? "gmgn+dexscreener"
+    : "gmgn";
+}
+
+export function exploreMarketSourcesV1(
+  marketRead: ExploreMarketReadV1,
+): readonly ("dexscreener" | "gmgn")[] {
+  if (marketRead.provider === "dexscreener") {
+    return marketRead.observedCount > 0 ? ["dexscreener"] : [];
+  }
+  const sources: ("dexscreener" | "gmgn")[] = [];
+  if (marketRead.gmgnObservedCount > 0) sources.push("gmgn");
+  if (marketRead.fallbackQualifiedCount > 0) sources.push("dexscreener");
+  return sources;
+}
+
+export function exploreMarketPriceSourcesV1(
+  marketRead: ExploreMarketReadV1,
+): readonly ("dexscreener" | "gmgn")[] {
+  if (marketRead.provider === "dexscreener") {
+    return marketRead.qualifiedCount > 0 ? ["dexscreener"] : [];
+  }
+  const sources: ("dexscreener" | "gmgn")[] = [];
+  if (marketRead.gmgnQualifiedCount > 0) sources.push("gmgn");
+  if (marketRead.fallbackQualifiedCount > 0) sources.push("dexscreener");
+  return sources;
+}
+
+function gmgnSnapshotQualified(
+  snapshot: NonNullable<ValuedExploreEntry["gmgnMarketData"]>,
+  nowMs: number,
+) {
+  const fetchedAtMs = Date.parse(snapshot.fetchedAt);
+  return BigInt(snapshot.liquidityUsdWad) >=
+      BigInt(MARKET_DATA_MINIMUM_FDV_LIQUIDITY_USD_WAD) &&
+    Number.isFinite(fetchedAtMs) &&
+    nowMs >= fetchedAtMs &&
+    nowMs - fetchedAtMs <= DEXSCREENER_CURRENT_MAXIMUM_AGE_MS;
+}
+
+function gmgnValuation(
+  snapshot: NonNullable<ValuedExploreEntry["gmgnMarketData"]>,
+): ExploreValuation {
+  return {
+    status: "available",
+    metric: "fdv",
+    supplyBasis: "total",
+    currency: "usd",
+    valueWad: snapshot.fdvUsdWad,
+    freshness: "provider-recent",
+    source: "gmgn",
+    asOfTime: snapshot.fetchedAt,
+  };
+}
+
+function unavailableEntry(entry: ExploreEntry): ValuedExploreEntry {
+  return {
+    ...entry,
+    valuation: {
+      status: "unavailable",
+      reason: exploreEntryMarketIdentitiesV1(entry).length === 0
+        ? "no-market"
+        : "source-unavailable",
+    },
+  };
+}

--- a/lib/market-data/gmgn-market-data-v1.ts
+++ b/lib/market-data/gmgn-market-data-v1.ts
@@ -1,0 +1,72 @@
+import type { MarketChartIdentityV1 } from "./market-data-v1";
+
+export const PROGRAMMABLE_GMGN_MARKET_SNAPSHOT_SCHEMA_VERSION =
+  "programmable.gmgn-market-snapshot.v1" as const;
+
+export type GmgnMarketSnapshotV1 = Readonly<{
+  schemaVersion: typeof PROGRAMMABLE_GMGN_MARKET_SNAPSHOT_SCHEMA_VERSION;
+  source: "gmgn";
+  currency: "USD";
+  fetchedAt: string;
+  identity: MarketChartIdentityV1;
+  priceUsdWad: string;
+  fdvUsdWad: string;
+  liquidityUsdWad: string;
+  volume24hUsdWad: string;
+  swapCount24h: number;
+}>;
+
+const ADDRESS = /^0x[0-9a-f]{40}$/u;
+const BYTES32 = /^0x[0-9a-f]{64}$/u;
+const UNSIGNED_INTEGER = /^(?:0|[1-9][0-9]*)$/u;
+
+export function isGmgnMarketSnapshotV1(
+  value: unknown,
+): value is GmgnMarketSnapshotV1 {
+  if (!isRecord(value) || !isMarketIdentity(value.identity)) return false;
+  return value.schemaVersion ===
+      PROGRAMMABLE_GMGN_MARKET_SNAPSHOT_SCHEMA_VERSION &&
+    value.source === "gmgn" &&
+    value.currency === "USD" &&
+    exactIsoTime(value.fetchedAt) &&
+    positiveInteger(value.priceUsdWad) &&
+    positiveInteger(value.fdvUsdWad) &&
+    positiveInteger(value.liquidityUsdWad) &&
+    unsignedInteger(value.volume24hUsdWad) &&
+    Number.isSafeInteger(value.swapCount24h) &&
+    Number(value.swapCount24h) >= 0;
+}
+
+function isMarketIdentity(value: unknown): value is MarketChartIdentityV1 {
+  if (!isRecord(value)) return false;
+  return value.chainId === "1" &&
+    typeof value.tokenAddress === "string" &&
+    ADDRESS.test(value.tokenAddress) &&
+    value.tokenAddress === value.tokenAddress.toLowerCase() &&
+    typeof value.poolId === "string" &&
+    BYTES32.test(value.poolId) &&
+    value.poolId === value.poolId.toLowerCase() &&
+    typeof value.quoteAddress === "string" &&
+    ADDRESS.test(value.quoteAddress) &&
+    value.quoteAddress === value.quoteAddress.toLowerCase() &&
+    value.quoteAddress !== value.tokenAddress &&
+    value.protocol === "uniswap_v4";
+}
+
+function exactIsoTime(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value;
+}
+
+function unsignedInteger(value: unknown): value is string {
+  return typeof value === "string" && UNSIGNED_INTEGER.test(value);
+}
+
+function positiveInteger(value: unknown): value is string {
+  return unsignedInteger(value) && BigInt(value) > 0n;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/lib/market-data/gmgn.server.ts
+++ b/lib/market-data/gmgn.server.ts
@@ -1,0 +1,592 @@
+import "server-only";
+
+import {
+  CANONICAL_LAUNCH_STAMP_V1,
+  type ExploreEntry,
+} from "../tokens";
+import {
+  exactPositiveDecimalUsdToWadV1,
+} from "./dexscreener-shadow-v1";
+import { exploreEntryMarketIdentitiesV1 } from
+  "./explore-market-identities";
+import {
+  PROGRAMMABLE_GMGN_MARKET_SNAPSHOT_SCHEMA_VERSION,
+  isGmgnMarketSnapshotV1,
+  type GmgnMarketSnapshotV1,
+} from "./gmgn-market-data-v1";
+import type { MarketChartIdentityV1 } from "./market-data-v1";
+
+const GMGN_API_ORIGIN = "https://openapi.gmgn.ai" as const;
+const GMGN_REQUEST_TIMEOUT_MS = 1_500;
+const GMGN_RESPONSE_MAXIMUM_BYTES = 1_000_000;
+const GMGN_MARKET_CACHE_TTL_MS = 30_000;
+const GMGN_FAILURE_CACHE_TTL_MS = 5_000;
+const GMGN_MAXIMUM_CACHE_ENTRIES = 512;
+const GMGN_MAXIMUM_CONCURRENCY = 3;
+const UINT256_MAX = (1n << 256n) - 1n;
+const USD_WAD = 10n ** 18n;
+const ADDRESS = /^0x[0-9a-f]{40}$/u;
+const BYTES32 = /^0x[0-9a-f]{64}$/u;
+const CANONICAL_INTEGER = /^(?:0|[1-9][0-9]*)$/u;
+const POSITIVE_DECIMAL = /^(?:0|[1-9][0-9]*)(?:\.([0-9]+))?$/u;
+
+type FetchImplementation = typeof fetch;
+
+export type GmgnReadWaitV1 = Readonly<{
+  signal?: AbortSignal;
+  deadlineMs?: number;
+  fetchImpl?: FetchImplementation;
+  now?: () => Date;
+}>;
+
+type CachedValue<T> = Readonly<{
+  expiresAtMs: number;
+  value: T;
+}>;
+
+const snapshotCache = new Map<string, CachedValue<GmgnMarketSnapshotV1 | null>>();
+const snapshotInFlight = new Map<string, Promise<GmgnMarketSnapshotV1 | null>>();
+let providerCooldownUntilMs = 0;
+let nextProviderRequestStartMs = 0;
+let providerRequestSchedule = Promise.resolve();
+
+export function gmgnMarketDataConfiguredV1(): boolean {
+  return readApiKey() !== null;
+}
+
+export function gmgnChainSlugV1(chainId: string | number):
+  | "eth"
+  | null {
+  return String(chainId) === "1" ? "eth" : null;
+}
+
+export async function readGmgnExploreSnapshotsV1(
+  entries: readonly ExploreEntry[],
+  wait: GmgnReadWaitV1 = {},
+): Promise<ReadonlyMap<string, GmgnMarketSnapshotV1>> {
+  if (!gmgnMarketDataConfiguredV1()) return new Map();
+  const results = await mapWithConcurrency(
+    entries,
+    GMGN_MAXIMUM_CONCURRENCY,
+    async (entry) => [entry.id, await readGmgnMarketSnapshotV1(entry, wait)] as const,
+  );
+  return new Map(
+    results.filter(
+      (result): result is readonly [string, GmgnMarketSnapshotV1] =>
+        result[1] !== null,
+    ),
+  );
+}
+
+export async function readGmgnMarketSnapshotV1(
+  entry: ExploreEntry,
+  wait: GmgnReadWaitV1 = {},
+): Promise<GmgnMarketSnapshotV1 | null> {
+  const apiKey = readApiKey();
+  const canonicalSupply = canonicalSupplyV1(entry);
+  const identities = exploreEntryMarketIdentitiesV1(entry);
+  if (
+    apiKey === null ||
+    canonicalSupply === null ||
+    !productionPoolManagerBoundV1(entry) ||
+    identities.length === 0
+  ) {
+    return null;
+  }
+  const chain = gmgnChainSlugV1(identities[0]?.chainId ?? "");
+  if (chain === null || identities.some((identity) =>
+    gmgnChainSlugV1(identity.chainId) !== chain
+  )) return null;
+
+  const cacheKey = snapshotCacheKey(entry, identities, canonicalSupply);
+  const nowMs = (wait.now ?? (() => new Date()))().getTime();
+  const cached = currentCacheValue(snapshotCache, cacheKey, nowMs);
+  if (cached !== undefined) return cached;
+  const active = snapshotInFlight.get(cacheKey);
+  if (active) return active;
+
+  const promise = (async () => {
+    const value = await gmgnJsonRequest(
+      "/v1/token/info",
+      { chain, address: identities[0]!.tokenAddress },
+      apiKey,
+      wait,
+    );
+    const snapshot = parseGmgnMarketSnapshotV1(
+      value,
+      identities,
+      canonicalSupply,
+      (wait.now ?? (() => new Date()))(),
+    );
+    setCacheValue(
+      snapshotCache,
+      cacheKey,
+      snapshot,
+      (wait.now ?? (() => new Date()))().getTime() +
+        (snapshot === null ? GMGN_FAILURE_CACHE_TTL_MS : GMGN_MARKET_CACHE_TTL_MS),
+    );
+    return snapshot;
+  })().finally(() => {
+    if (snapshotInFlight.get(cacheKey) === promise) {
+      snapshotInFlight.delete(cacheKey);
+    }
+  });
+  snapshotInFlight.set(cacheKey, promise);
+  return promise;
+}
+
+export function parseGmgnMarketSnapshotV1(
+  response: unknown,
+  identities: readonly MarketChartIdentityV1[],
+  canonicalSupply: Readonly<{ raw: bigint; decimals: number }>,
+  fetchedAt: Date,
+): GmgnMarketSnapshotV1 | null {
+  const data = unwrapData(response);
+  if (!isRecord(data) || !isRecord(data.price) || !isRecord(data.pool)) {
+    return null;
+  }
+  const tokenAddress = canonicalAddress(data.address);
+  const poolId = canonicalBytes32(data.pool.pool_address);
+  const quoteAddress = canonicalAddress(data.pool.quote_address);
+  const identity = identities.find((candidate) =>
+    candidate.protocol === "uniswap_v4" &&
+    candidate.tokenAddress === tokenAddress &&
+    candidate.poolId === poolId &&
+    candidate.quoteAddress === quoteAddress
+  );
+  if (
+    identity === undefined ||
+    String(data.pool.exchange).toLowerCase() !== "uniswap_v4" ||
+    !poolBaseQuoteMatchesV1(data.pool, identity) ||
+    (data.biggest_pool_address !== undefined &&
+      canonicalBytes32(data.biggest_pool_address) !== identity.poolId) ||
+    !providerSupplyMatchesCanonical(
+      data.total_supply,
+      canonicalSupply.raw,
+      canonicalSupply.decimals,
+    )
+  ) return null;
+
+  const priceUsdWad = exactPositiveDecimalUsdToWadV1(data.price.price);
+  const liquidityUsdWad = exactPositiveDecimalUsdToWadV1(data.pool.liquidity);
+  const volume24hUsdWad = exactNonNegativeDecimalUsdToWadV1(
+    data.price.volume_24h,
+  );
+  const swapCount24h = canonicalSafeInteger(data.price.swaps_24h);
+  if (
+    priceUsdWad === null ||
+    liquidityUsdWad === null ||
+    volume24hUsdWad === null ||
+    swapCount24h === null ||
+    !Number.isFinite(fetchedAt.getTime())
+  ) return null;
+  const divisor = 10n ** BigInt(canonicalSupply.decimals);
+  const fdvUsdWad = (BigInt(priceUsdWad) * canonicalSupply.raw) / divisor;
+  if (fdvUsdWad <= 0n || fdvUsdWad > UINT256_MAX) return null;
+
+  const snapshot: GmgnMarketSnapshotV1 = {
+    schemaVersion: PROGRAMMABLE_GMGN_MARKET_SNAPSHOT_SCHEMA_VERSION,
+    source: "gmgn",
+    currency: "USD",
+    fetchedAt: fetchedAt.toISOString(),
+    identity,
+    priceUsdWad,
+    fdvUsdWad: fdvUsdWad.toString(),
+    liquidityUsdWad,
+    volume24hUsdWad,
+    swapCount24h,
+  };
+  return isGmgnMarketSnapshotV1(snapshot) ? snapshot : null;
+}
+
+function canonicalSupplyV1(
+  entry: ExploreEntry,
+): Readonly<{ raw: bigint; decimals: number }> | null {
+  if (
+    entry.exploreKind !== "token" ||
+    typeof entry.totalSupplyRaw !== "string" ||
+    !CANONICAL_INTEGER.test(entry.totalSupplyRaw) ||
+    typeof entry.tokenDecimals !== "number" ||
+    !Number.isSafeInteger(entry.tokenDecimals) ||
+    entry.tokenDecimals < 0 || entry.tokenDecimals > 255
+  ) return null;
+  try {
+    const raw = BigInt(entry.totalSupplyRaw);
+    return raw > 0n && raw <= UINT256_MAX
+      ? { raw, decimals: entry.tokenDecimals }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function productionPoolManagerBoundV1(entry: ExploreEntry): boolean {
+  if (entry.exploreKind !== "token") return false;
+  const provenance = entry.launchCategoryProvenance;
+  if (provenance.source === "canonical-launch-read-model") return true;
+  const stamp = entry.launchStampProvenance;
+  return provenance.source === "canonical-launch-stamp-router" &&
+    stamp !== undefined &&
+    canonicalAddress(stamp.poolManagerAddress) ===
+      canonicalAddress(CANONICAL_LAUNCH_STAMP_V1.poolManagerAddress) &&
+    canonicalAddress(stamp.poolProof.poolManagerAddress) ===
+      canonicalAddress(CANONICAL_LAUNCH_STAMP_V1.poolManagerAddress);
+}
+
+function providerSupplyMatchesCanonical(
+  value: unknown,
+  raw: bigint,
+  decimals: number,
+): boolean {
+  const parsed = decimalParts(value);
+  if (parsed === null) return false;
+  return parsed.coefficient * 10n ** BigInt(decimals) ===
+    raw * parsed.scale;
+}
+
+function poolBaseQuoteMatchesV1(
+  pool: Record<string, unknown>,
+  identity: MarketChartIdentityV1,
+): boolean {
+  const declaredBases = [pool.base_address, pool.token_address]
+    .filter((value) => value !== undefined)
+    .map(tokenLocatorAddress);
+  if (declaredBases.some((value) => value !== identity.tokenAddress)) {
+    return false;
+  }
+  const tokenPair = [pool.token0_address, pool.token1_address].filter(
+    (value) => value !== undefined,
+  );
+  if (tokenPair.length === 0) return true;
+  if (tokenPair.length !== 2) return false;
+  const addresses = tokenPair.map(tokenLocatorAddress);
+  return addresses.every((address): address is `0x${string}` => address !== null) &&
+    new Set(addresses).size === 2 &&
+    addresses.includes(identity.tokenAddress) &&
+    addresses.includes(identity.quoteAddress);
+}
+
+function tokenLocatorAddress(value: unknown): `0x${string}` | null {
+  if (isRecord(value)) {
+    return canonicalAddress(value.address ?? value.token_address);
+  }
+  return canonicalAddress(value);
+}
+
+async function gmgnJsonRequest(
+  path: "/v1/token/info",
+  query: Readonly<Record<string, string>>,
+  apiKey: string,
+  wait: GmgnReadWaitV1,
+): Promise<unknown | null> {
+  const fetchImpl = wait.fetchImpl ?? fetch;
+  const enforceAccountControls = fetchImpl === fetch;
+  const implicitDeadlineMs = (wait.now ?? (() => new Date()))().getTime() +
+    GMGN_REQUEST_TIMEOUT_MS;
+  if (wait.signal?.aborted) return null;
+  const now = wait.now ?? (() => new Date());
+  const queueTimeMs = now().getTime();
+  if (enforceAccountControls && queueTimeMs < providerCooldownUntilMs) {
+    return null;
+  }
+  if ((wait.deadlineMs ?? implicitDeadlineMs) <= queueTimeMs) return null;
+  if (enforceAccountControls && !await scheduleProviderRequest(wait.signal)) {
+    return null;
+  }
+  const nowMs = now().getTime();
+  if (enforceAccountControls && nowMs < providerCooldownUntilMs) return null;
+  const remaining = (wait.deadlineMs ?? implicitDeadlineMs) - nowMs;
+  if (!Number.isFinite(remaining) || remaining <= 0) return null;
+  const url = new URL(path, GMGN_API_ORIGIN);
+  for (const [key, value] of Object.entries(query)) {
+    url.searchParams.set(key, value);
+  }
+  url.searchParams.set("timestamp", String(Math.floor(nowMs / 1_000)));
+  url.searchParams.set("client_id", crypto.randomUUID());
+  const timeout = AbortSignal.timeout(
+    Math.max(1, Math.min(GMGN_REQUEST_TIMEOUT_MS, remaining)),
+  );
+  const signal = wait.signal
+    ? AbortSignal.any([wait.signal, timeout])
+    : timeout;
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: "GET",
+      headers: { Accept: "application/json", "X-APIKEY": apiKey },
+      cache: "no-store",
+      signal,
+    });
+  } catch {
+    return null;
+  }
+  const declaredLength = Number(response.headers.get("Content-Length"));
+  if (
+    Number.isFinite(declaredLength) &&
+    declaredLength > GMGN_RESPONSE_MAXIMUM_BYTES
+  ) return null;
+  const bytes = await readBoundedResponseBytes(
+    response,
+    GMGN_RESPONSE_MAXIMUM_BYTES,
+  );
+  if (bytes === null) return null;
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+  const value = safeJson(text);
+  const rateLimited = response.status === 429 || isRateLimitedEnvelope(value);
+  if (rateLimited && enforceAccountControls) {
+    providerCooldownUntilMs = Math.max(
+      providerCooldownUntilMs,
+      providerCooldownFromHeaders(response.headers, nowMs),
+    );
+  }
+  if (!response.ok || rateLimited || value === null) return null;
+  if (!isRecord(value) || value.code !== 0 || !isRecord(value.data)) {
+    return null;
+  }
+  return value.data;
+}
+
+async function readBoundedResponseBytes(
+  response: Response,
+  maximumBytes: number,
+): Promise<Uint8Array | null> {
+  if (response.body === null) return new Uint8Array();
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value.byteLength > maximumBytes - total) {
+        await reader.cancel();
+        return null;
+      }
+      chunks.push(value);
+      total += value.byteLength;
+    }
+  } catch {
+    return null;
+  } finally {
+    reader.releaseLock();
+  }
+  const output = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return output;
+}
+
+function readApiKey(): string | null {
+  const value = process.env.GMGN_API_KEY?.trim();
+  return value ? value : null;
+}
+
+function configuredRequestsPerSecond(): number {
+  const value = Number(process.env.GMGN_MAX_REQUESTS_PER_SECOND ?? "5");
+  return Number.isSafeInteger(value) && value >= 1 && value <= 50 ? value : 5;
+}
+
+async function scheduleProviderRequest(signal?: AbortSignal): Promise<boolean> {
+  const intervalMs = Math.ceil(1_000 / configuredRequestsPerSecond());
+  const turn = providerRequestSchedule.then(async () => {
+    const waitMs = Math.max(0, nextProviderRequestStartMs - Date.now());
+    if (waitMs > 0 && !await delay(waitMs, signal)) return false;
+    if (signal?.aborted) return false;
+    nextProviderRequestStartMs = Date.now() + intervalMs;
+    return true;
+  });
+  providerRequestSchedule = turn.then(() => undefined, () => undefined);
+  return turn;
+}
+
+function unwrapData(value: unknown): unknown {
+  return isRecord(value) && value.data !== undefined ? value.data : value;
+}
+
+function isRateLimitedEnvelope(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  const joined = [value.code, value.error, value.message]
+    .map((item) => String(item ?? "").toUpperCase())
+    .join(":");
+  return joined.includes("429") ||
+    joined.includes("RATE_LIMIT_EXCEEDED") || joined.includes("BANNED");
+}
+
+function providerCooldownFromHeaders(headers: Headers, nowMs: number): number {
+  const maximum = nowMs + 60_000;
+  const retryAfter = headers.get("Retry-After")?.trim();
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+    const dateMs = Date.parse(retryAfter);
+    const candidate = Number.isFinite(seconds)
+      ? nowMs + Math.max(0, Math.ceil(seconds * 1_000)) + 250
+      : Number.isFinite(dateMs)
+        ? Math.max(nowMs, dateMs) + 250
+        : Number.NaN;
+    if (Number.isFinite(candidate)) return Math.min(maximum, candidate);
+  }
+  const resetHeader = headers.get("x-ratelimit-reset")?.trim();
+  const reset = resetHeader ? Number(resetHeader) : Number.NaN;
+  if (Number.isFinite(reset)) {
+    return Math.min(
+      maximum,
+      Math.max(nowMs, Math.ceil(reset * 1_000)) + 250,
+    );
+  }
+  return nowMs + 2_000;
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<boolean> {
+  if (signal?.aborted) return Promise.resolve(false);
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", abort);
+      resolve(true);
+    }, ms);
+    const abort = () => {
+      clearTimeout(timeout);
+      resolve(false);
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+  });
+}
+
+function safeJson(value: string): unknown | null {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function exactNonNegativeDecimalUsdToWadV1(value: unknown): string | null {
+  if (value === "0" || value === "0.0") return "0";
+  const parsed = decimalParts(value);
+  if (parsed === null || parsed.coefficient < 0n || parsed.scale > USD_WAD) {
+    return null;
+  }
+  const wad = parsed.coefficient * (USD_WAD / parsed.scale);
+  return wad <= UINT256_MAX ? wad.toString() : null;
+}
+
+function decimalParts(value: unknown): Readonly<{
+  coefficient: bigint;
+  scale: bigint;
+}> | null {
+  if (typeof value !== "string" || value.length > 160) return null;
+  const match = POSITIVE_DECIMAL.exec(value);
+  if (!match) return null;
+  const [whole, fraction = ""] = value.split(".");
+  if (whole.length > 78 || fraction.length > 18) return null;
+  try {
+    return {
+      coefficient: BigInt(`${whole}${fraction}`),
+      scale: 10n ** BigInt(fraction.length),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function canonicalSafeInteger(value: unknown): number | null {
+  const normalized = typeof value === "number" && Number.isSafeInteger(value)
+    ? String(value)
+    : typeof value === "string" && CANONICAL_INTEGER.test(value)
+      ? value
+      : null;
+  if (normalized === null) return null;
+  const parsed = Number(normalized);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function canonicalAddress(value: unknown): `0x${string}` | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.toLowerCase();
+  return ADDRESS.test(normalized) ? normalized as `0x${string}` : null;
+}
+
+function canonicalBytes32(value: unknown): `0x${string}` | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.toLowerCase();
+  return BYTES32.test(normalized) ? normalized as `0x${string}` : null;
+}
+
+function identityKey(identity: MarketChartIdentityV1) {
+  return [
+    identity.chainId,
+    identity.protocol,
+    identity.tokenAddress,
+    identity.poolId,
+    identity.quoteAddress,
+  ].join(":");
+}
+
+function snapshotCacheKey(
+  entry: ExploreEntry,
+  identities: readonly MarketChartIdentityV1[],
+  supply: Readonly<{ raw: bigint; decimals: number }>,
+) {
+  return [
+    entry.id,
+    supply.raw,
+    supply.decimals,
+    ...identities.map(identityKey).sort(),
+  ].join(":");
+}
+
+function currentCacheValue<T>(
+  cache: ReadonlyMap<string, CachedValue<T>>,
+  key: string,
+  nowMs: number,
+): T | undefined {
+  const cached = cache.get(key);
+  return cached && cached.expiresAtMs > nowMs ? cached.value : undefined;
+}
+
+function setCacheValue<T>(
+  cache: Map<string, CachedValue<T>>,
+  key: string,
+  value: T,
+  expiresAtMs: number,
+) {
+  cache.delete(key);
+  cache.set(key, { expiresAtMs, value });
+  while (cache.size > GMGN_MAXIMUM_CACHE_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+}
+
+async function mapWithConcurrency<T, R>(
+  values: readonly T[],
+  concurrency: number,
+  callback: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const output = new Array<R>(values.length);
+  let next = 0;
+  await Promise.all(Array.from(
+    { length: Math.min(concurrency, values.length) },
+    async () => {
+      for (;;) {
+        const index = next;
+        next += 1;
+        if (index >= values.length) return;
+        output[index] = await callback(values[index]!);
+      }
+    },
+  ));
+  return output;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/lib/public-openapi.ts
+++ b/lib/public-openapi.ts
@@ -1489,7 +1489,7 @@ export const programmablePublicOpenApi = {
               },
               source: {
                 type: "string",
-                enum: ["bitquery", "dexscreener", "stateview-chainlink"],
+                enum: ["bitquery", "dexscreener", "gmgn", "stateview-chainlink"],
               },
               asOfTime: { type: "string", format: "date-time" },
             },

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1951,6 +1951,11 @@ export function evaluateReadModelOperationsSourceContracts(
     source("lib/market-data/dexscreener-explore.server.ts") ?? "";
   const dexscreenerShadow =
     source("lib/market-data/dexscreener-shadow.server.ts") ?? "";
+  const exploreMarket =
+    source("lib/market-data/explore-market.server.ts") ?? "";
+  const gmgnMarket = source("lib/market-data/gmgn.server.ts") ?? "";
+  const gmgnSnapshot =
+    source("lib/market-data/gmgn-market-data-v1.ts") ?? "";
   const stagedPublicSmokeScript =
     source("scripts/smoke-static-dexscreener-public-apis.mjs") ?? "";
   const publicCreatorProfile = source("app/api/explore/profile/route.ts") ?? "";
@@ -2216,6 +2221,45 @@ export function evaluateReadModelOperationsSourceContracts(
       "const cache = new Map<string, CachedSnapshot>()",
       "const inFlight = new Map<string, Promise<DexscreenerShadowSnapshotV1>>()",
     ]) &&
+    includesEverySourceFragment(exploreMarket, [
+      "if (!gmgnMarketDataConfiguredV1() || entries.length > 9)",
+      "return readDexscreenerExploreEntriesV1(entries, wait);",
+      "snapshots = await readGmgnExploreSnapshotsV1(entries, wait);",
+      "const fallback = await readDexscreenerExploreEntriesV1(fallbackEntries, wait);",
+      "const valuedEntries = entries.map((entry): ValuedExploreEntry => {",
+      'provider: "gmgn"',
+      'fallbackProvider: "dexscreener"',
+      "if (marketRead.gmgnQualifiedCount > 0) sources.push(\"gmgn\");",
+      "if (marketRead.fallbackQualifiedCount > 0) sources.push(\"dexscreener\");",
+    ]) &&
+    includesEverySourceFragment(gmgnMarket, [
+      'const GMGN_API_ORIGIN = "https://openapi.gmgn.ai" as const',
+      "const GMGN_REQUEST_TIMEOUT_MS = 1_500",
+      "const GMGN_RESPONSE_MAXIMUM_BYTES = 1_000_000",
+      "const GMGN_MAXIMUM_CONCURRENCY = 3",
+      'return String(chainId) === "1" ? "eth" : null;',
+      "!productionPoolManagerBoundV1(entry)",
+      '"/v1/token/info"',
+      'candidate.protocol === "uniswap_v4"',
+      "candidate.tokenAddress === tokenAddress",
+      "candidate.poolId === poolId",
+      "candidate.quoteAddress === quoteAddress",
+      'String(data.pool.exchange).toLowerCase() !== "uniswap_v4"',
+      "!poolBaseQuoteMatchesV1(data.pool, identity)",
+      "!providerSupplyMatchesCanonical(",
+      'headers: { Accept: "application/json", "X-APIKEY": apiKey }',
+      "const bytes = await readBoundedResponseBytes(",
+      "const rateLimited = response.status === 429 || isRateLimitedEnvelope(value);",
+      "process.env.GMGN_API_KEY?.trim()",
+    ]) &&
+    includesEverySourceFragment(gmgnSnapshot, [
+      '"programmable.gmgn-market-snapshot.v1" as const',
+      'return value.chainId === "1"',
+      'value.protocol === "uniswap_v4"',
+      "positiveInteger(value.priceUsdWad)",
+      "positiveInteger(value.fdvUsdWad)",
+      "positiveInteger(value.liquidityUsdWad)",
+    ]) &&
     includesEverySourceFragment(publicExplore, [
       "readEnvioClassicV3CatalogV1({",
       "readProductionCustomExploreDirectoryV1(",
@@ -2227,15 +2271,15 @@ export function evaluateReadModelOperationsSourceContracts(
       'routerCustomStatus === "last-known-good"',
       "envioClassicV3IdentityCommitmentV1(",
       "readDexscreenerExploreEntriesV1(filtered, {",
-      "readDexscreenerExploreEntriesV1(\n        identityPage.tokens,",
+      "readExploreMarketEntriesV1(\n        identityPage.tokens,",
       'registryCustomStatus === "current" && routerCustomStatus === "current"',
       'requested: "fdv" as const',
       'applied: rankingStatus === "complete"',
       '"qualified-fdv-then-launch-order" as const',
       '"launch-order" as const',
       '"X-Programmable-Launch-Source": launchSource',
-      '"X-Programmable-Read-Source": `${launchSource}+dexscreener`',
-      '"X-Programmable-Market-Provider": "dexscreener"',
+      '"X-Programmable-Read-Source": `${launchSource}+${marketProvider}`',
+      '"X-Programmable-Market-Provider": marketProvider',
       '"X-Programmable-Router-Read-Status": routerCustomStatus',
       '"X-Programmable-Identity-Last-Indexed-At": identityGeneratedAt',
     ]) &&
@@ -2257,10 +2301,10 @@ export function evaluateReadModelOperationsSourceContracts(
       "identityCount: publicIdentityEntries.length",
       "const projectedRouterIdentityCount = publicIdentityEntries.filter(",
       "const entry: ExploreEntry | null = identityEntries.find(",
-      "readDexscreenerExploreEntriesV1([entry], {",
+      "readExploreMarketEntriesV1([entry], {",
       '"X-Programmable-Launch-Source": input.launchSource',
-      '"X-Programmable-Read-Source": `${input.launchSource}+dexscreener`',
-      '"X-Programmable-Market-Provider": "dexscreener"',
+      '"X-Programmable-Read-Source": `${input.launchSource}+${marketProvider}`',
+      '"X-Programmable-Market-Provider": marketProvider',
       '"X-Programmable-Router-Read-Status": input.routerStatus',
       'valuation: { status: "unavailable", reason: "source-unavailable" }',
     ]) &&
@@ -2306,7 +2350,7 @@ export function evaluateReadModelOperationsSourceContracts(
   check(
     "ops-public-provider-split-source-contract",
     fastLanePublicProviderContract,
-    "Explore list, token detail and creator identity combine the validated Envio Classic V3 catalog with the bounded durable Router Custom snapshot; Dexscreener remains bounded exact-identity enrichment, charts bind one exact pool through Bitquery and action routes retain their commitment-bound Website RPC semantics",
+    "Explore list, token detail and creator identity combine the validated Envio Classic V3 catalog with the bounded durable Router Custom snapshot; Ethereum-only GMGN and Dexscreener remain bounded exact-identity enrichment, market-cap ordering stays Dexscreener-bound, charts bind one exact pool through Bitquery and action routes retain their commitment-bound Website RPC semantics",
   );
   const publicProfileAndActionRoutes = [
     publicCreatorProfile,

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -786,7 +786,7 @@ describe("read-model operations source contract", () => {
     );
   });
 
-  it("accepts the exact Envio identity and Dexscreener split", () => {
+  it("accepts the exact Envio identity and bounded Ethereum market-provider split", () => {
     const result = evaluateReadModelOperationsSourceContracts(ROOT);
     expect(result.failures.map(({ id }: { id: string }) => id)).not.toContain(
       "ops-public-provider-split-source-contract",
@@ -811,7 +811,7 @@ describe("read-model operations source contract", () => {
     ],
     [
       "a different market provider",
-      '"X-Programmable-Market-Provider": "dexscreener"',
+      '"X-Programmable-Market-Provider": marketProvider',
       '"X-Programmable-Market-Provider": "unknown"',
     ],
     [
@@ -825,6 +825,36 @@ describe("read-model operations source contract", () => {
     expect(route).toContain(needle);
     const result = evaluateReadModelOperationsSourceContracts(ROOT, {
       sourceOverrides: { [path]: route.replaceAll(needle, replacement) },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-public-provider-split-source-contract",
+    );
+  });
+
+  it.each([
+    [
+      "a Robinhood GMGN slug",
+      "lib/market-data/gmgn.server.ts",
+      'return String(chainId) === "1" ? "eth" : null;',
+      'return String(chainId) === "4663" ? "robinhood" : null;',
+    ],
+    [
+      "an unbounded visible-page fanout",
+      "lib/market-data/explore-market.server.ts",
+      "if (!gmgnMarketDataConfiguredV1() || entries.length > 9)",
+      "if (!gmgnMarketDataConfiguredV1())",
+    ],
+    [
+      "a missing production PoolManager provenance gate",
+      "lib/market-data/gmgn.server.ts",
+      "!productionPoolManagerBoundV1(entry)",
+      "false",
+    ],
+  ])("rejects GMGN enrichment with %s", (_label, path, needle, replacement) => {
+    const source = readFileSync(resolve(ROOT, path), "utf8");
+    expect(source).toContain(needle);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: { [path]: source.replace(needle, replacement) },
     });
     expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
       "ops-public-provider-split-source-contract",

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -24,6 +24,8 @@ const mocks = vi.hoisted(() => ({
   readCustom: vi.fn(),
   readRouter: vi.fn(),
   routerStatus: vi.fn((): "current" | "last-known-good" => "current"),
+  gmgnConfigured: vi.fn(() => false),
+  readGmgn: vi.fn(),
 }));
 
 vi.mock("../lib/market-data/envio-classic-v3-catalog.server", () => ({
@@ -37,6 +39,10 @@ vi.mock("../lib/market-data/last-good-launch-catalog.server", () => ({
 }));
 vi.mock("../lib/market-data/dexscreener-explore.server", () => ({
   readDexscreenerExploreEntriesV1: mocks.readDex,
+}));
+vi.mock("../lib/market-data/gmgn.server", () => ({
+  gmgnMarketDataConfiguredV1: mocks.gmgnConfigured,
+  readGmgnExploreSnapshotsV1: mocks.readGmgn,
 }));
 vi.mock("../lib/server/custom-launch/public-readiness", () => ({
   isCustomLaunchRegistryPublicReadEnabled: mocks.customEnabled,
@@ -274,6 +280,7 @@ describe("Explore static identity and Dexscreener market contract", () => {
     mocks.readCustom.mockResolvedValue([]);
     mocks.readRouter.mockResolvedValue([]);
     mocks.routerStatus.mockReturnValue("current");
+    mocks.gmgnConfigured.mockReturnValue(false);
     mocks.readDex.mockImplementation(async (input: readonly ExploreEntry[]) => ({
       entries: valued(input),
       marketRead: marketRead({ requested: input.length, qualified: input.length }),
@@ -899,7 +906,9 @@ describe("Explore static identity and Dexscreener market contract", () => {
       expect(source).not.toMatch(/bitquery/iu);
       expect(source).not.toContain("readPrimaryRpcExploreEntriesV1");
       expect(source).toContain("readEnvioClassicV3CatalogV1");
-      expect(source).toContain("readDexscreenerExploreEntriesV1");
+      expect(source).toMatch(
+        /read(?:DexscreenerExploreEntriesV1|ExploreMarketEntriesV1)/u,
+      );
     }
   });
 });

--- a/tests/explore-market-gmgn.test.ts
+++ b/tests/explore-market-gmgn.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  configured: vi.fn(),
+  readGmgn: vi.fn(),
+  readDex: vi.fn(),
+}));
+
+vi.mock("../lib/market-data/gmgn.server", () => ({
+  gmgnMarketDataConfiguredV1: mocks.configured,
+  readGmgnExploreSnapshotsV1: mocks.readGmgn,
+}));
+
+vi.mock("../lib/market-data/dexscreener-explore.server", () => ({
+  DEXSCREENER_CURRENT_MAXIMUM_AGE_MS: 300_000,
+  readDexscreenerExploreEntriesV1: mocks.readDex,
+}));
+
+import {
+  exploreMarketPriceSourcesV1,
+  readExploreMarketEntriesV1,
+} from
+  "../lib/market-data/explore-market.server";
+import type { GmgnMarketSnapshotV1 } from
+  "../lib/market-data/gmgn-market-data-v1";
+import type { ExploreEntry, LauncherToken } from "../lib/tokens";
+
+const NOW = "2026-08-30T12:00:00.000Z";
+const QUOTE = "0x0000000000000000000000000000000000000000" as const;
+
+function entry(index: number): Extract<ExploreEntry, { exploreKind: "token" }> {
+  const tokenAddress = `0x${index.toString(16).padStart(40, "0")}` as const;
+  const value = {
+    id: `1:${tokenAddress}`,
+    name: `Token ${index}`,
+    symbol: `T${index}`,
+    tokenAddress,
+    hookAddress: "0x3333333333333333333333333333333333333333",
+    poolId: `0x${index.toString(16).padStart(64, "0")}` as const,
+    launchedAt: NOW,
+    totalSupplyRaw: "1000000000000000000000",
+    tokenDecimals: 18,
+    totalSwapFeeBps: 100,
+    liquidityPath: "meme",
+    launchModel: "classic",
+  } satisfies LauncherToken;
+  return {
+    ...value,
+    exploreKind: "token",
+    launchCategoryProvenance: {
+      schemaVersion: "programmable.explore-launch-category-provenance.v1",
+      category: "classic",
+      source: "canonical-launch-read-model",
+      recordId: value.id,
+      modelId: "classic",
+      modelVersion: null,
+    },
+  };
+}
+
+function snapshot(
+  value: ReturnType<typeof entry>,
+  liquidityUsdWad: string,
+): GmgnMarketSnapshotV1 {
+  return {
+    schemaVersion: "programmable.gmgn-market-snapshot.v1",
+    source: "gmgn",
+    currency: "USD",
+    fetchedAt: NOW,
+    identity: {
+      chainId: "1",
+      protocol: "uniswap_v4",
+      tokenAddress: value.tokenAddress,
+      poolId: value.poolId,
+      quoteAddress: QUOTE,
+    },
+    priceUsdWad: "2000000000000000000",
+    fdvUsdWad: "2000000000000000000000",
+    liquidityUsdWad,
+    volume24hUsdWad: "100000000000000000000",
+    swapCount24h: 3,
+  };
+}
+
+function dexRead(tokens: readonly ReturnType<typeof entry>[]) {
+  return {
+    entries: tokens.map((token) => ({
+      ...token,
+      valuation: {
+        status: "available" as const,
+        metric: "fdv" as const,
+        supplyBasis: "total" as const,
+        currency: "usd" as const,
+        valueWad: "1900000000000000000000",
+        freshness: "provider-recent" as const,
+        source: "dexscreener" as const,
+        asOfTime: NOW,
+      },
+    })),
+    marketRead: {
+      provider: "dexscreener" as const,
+      status: "complete" as const,
+      currency: "USD" as const,
+      requestedCount: tokens.length,
+      observedCount: tokens.length,
+      qualifiedCount: tokens.length,
+      unavailableCount: 0,
+      oldestFetchedAt: tokens.length ? NOW : null,
+      newestFetchedAt: tokens.length ? NOW : null,
+    },
+  };
+}
+
+describe("Explore GMGN primary with Dexscreener fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    mocks.configured.mockReturnValue(true);
+    mocks.readDex.mockImplementation(async (tokens) => dexRead(tokens));
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it("keeps canonical order and falls back per unqualified identity", async () => {
+    const first = entry(1);
+    const second = entry(2);
+    mocks.readGmgn.mockResolvedValue(new Map([
+      [first.id, snapshot(first, "12000000000000000000000")],
+      [second.id, snapshot(second, "8000000000000000000000")],
+    ]));
+
+    const result = await readExploreMarketEntriesV1([first, second]);
+    expect(result.entries.map((item) => item.id)).toEqual([first.id, second.id]);
+    expect(result.entries[0]?.valuation).toMatchObject({
+      source: "gmgn",
+      valueWad: "2000000000000000000000",
+    });
+    expect(result.entries[1]?.valuation).toMatchObject({
+      source: "dexscreener",
+      valueWad: "1900000000000000000000",
+    });
+    expect(result.entries[1]?.gmgnMarketData?.liquidityUsdWad).toBe(
+      "8000000000000000000000",
+    );
+    expect(mocks.readDex).toHaveBeenCalledWith(
+      [second],
+      expect.any(Object),
+    );
+    expect(result.marketRead).toMatchObject({
+      provider: "gmgn",
+      fallbackProvider: "dexscreener",
+      status: "complete",
+      requestedCount: 2,
+      observedCount: 2,
+      qualifiedCount: 2,
+      gmgnObservedCount: 2,
+      gmgnQualifiedCount: 1,
+      fallbackRequestedCount: 1,
+      fallbackQualifiedCount: 1,
+    });
+    expect(exploreMarketPriceSourcesV1(result.marketRead)).toEqual([
+      "gmgn",
+      "dexscreener",
+    ]);
+  });
+
+  it("retains the bounded batch provider for catalog-wide reads", async () => {
+    const entries = Array.from({ length: 10 }, (_, index) => entry(index + 10));
+    await readExploreMarketEntriesV1(entries);
+    expect(mocks.readGmgn).not.toHaveBeenCalled();
+    expect(mocks.readDex).toHaveBeenCalledWith(entries, {});
+  });
+
+  it("falls back without changing canonical order when GMGN rejects", async () => {
+    const first = entry(41);
+    const second = entry(42);
+    mocks.readGmgn.mockRejectedValue(new Error("provider unavailable"));
+
+    const result = await readExploreMarketEntriesV1([first, second]);
+
+    expect(result.entries.map((item) => item.id)).toEqual([first.id, second.id]);
+    expect(result.entries).toHaveLength(2);
+    expect(result.marketRead.provider).toBe("dexscreener");
+    expect(mocks.readDex).toHaveBeenCalledWith([first, second], {});
+  });
+});

--- a/tests/gmgn-market-data.test.ts
+++ b/tests/gmgn-market-data.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  gmgnChainSlugV1,
+  parseGmgnMarketSnapshotV1,
+  readGmgnMarketSnapshotV1,
+} from "../lib/market-data/gmgn.server";
+import type { MarketChartIdentityV1 } from
+  "../lib/market-data/market-data-v1";
+import type { ExploreEntry, LauncherToken } from "../lib/tokens";
+
+const NOW = new Date("2026-08-30T12:00:00.000Z");
+const QUOTE = "0x0000000000000000000000000000000000000000" as const;
+
+function token(index = 1): Extract<ExploreEntry, { exploreKind: "token" }> {
+  const tokenAddress = `0x${index.toString(16).padStart(40, "0")}` as const;
+  const value = {
+    id: `1:${tokenAddress}`,
+    name: "SHARD",
+    symbol: "SHARD",
+    tokenAddress,
+    hookAddress: "0x3333333333333333333333333333333333333333",
+    poolId: `0x${index.toString(16).padStart(64, "0")}` as const,
+    launchedAt: NOW.toISOString(),
+    totalSupplyRaw: "10000000000000000000000",
+    tokenDecimals: 18,
+    totalSwapFeeBps: 100,
+    liquidityPath: "meme",
+    launchModel: "classic",
+  } satisfies LauncherToken;
+  return {
+    ...value,
+    exploreKind: "token",
+    launchCategoryProvenance: {
+      schemaVersion: "programmable.explore-launch-category-provenance.v1",
+      category: "classic",
+      source: "canonical-launch-read-model",
+      recordId: value.id,
+      modelId: "classic",
+      modelVersion: null,
+    },
+  };
+}
+
+function identity(entry: ReturnType<typeof token>): MarketChartIdentityV1 {
+  return {
+    chainId: "1",
+    protocol: "uniswap_v4",
+    tokenAddress: entry.tokenAddress,
+    poolId: entry.poolId,
+    quoteAddress: QUOTE,
+  };
+}
+
+function providerData(entry: ReturnType<typeof token>) {
+  return {
+    address: entry.tokenAddress,
+    biggest_pool_address: entry.poolId,
+    total_supply: "10000",
+    price: {
+      price: "3.3111698",
+      volume_24h: "123.45",
+      swaps_24h: "17",
+    },
+    pool: {
+      pool_address: entry.poolId,
+      base_address: entry.tokenAddress,
+      token0_address: QUOTE,
+      token1_address: entry.tokenAddress,
+      quote_address: QUOTE,
+      exchange: "uniswap_v4",
+      liquidity: "12000.5",
+    },
+  };
+}
+
+describe("GMGN canonical market enrichment", () => {
+  beforeEach(() => {
+    vi.stubEnv("GMGN_API_KEY", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("maps only Ethereum mainnet", () => {
+    expect(gmgnChainSlugV1(1)).toBe("eth");
+    expect(gmgnChainSlugV1("4663")).toBeNull();
+    expect(gmgnChainSlugV1(8453)).toBeNull();
+  });
+
+  it("computes FDV from canonical raw supply and exact provider price", () => {
+    const entry = token();
+    const snapshot = parseGmgnMarketSnapshotV1(
+      providerData(entry),
+      [identity(entry)],
+      { raw: 10_000n * 10n ** 18n, decimals: 18 },
+      NOW,
+    );
+    expect(snapshot).toEqual({
+      schemaVersion: "programmable.gmgn-market-snapshot.v1",
+      source: "gmgn",
+      currency: "USD",
+      fetchedAt: NOW.toISOString(),
+      identity: identity(entry),
+      priceUsdWad: "3311169800000000000",
+      fdvUsdWad: "33111698000000000000000",
+      liquidityUsdWad: "12000500000000000000000",
+      volume24hUsdWad: "123450000000000000000",
+      swapCount24h: 17,
+    });
+  });
+
+  it.each([
+    ["token", (data: ReturnType<typeof providerData>) => {
+      data.address = "0x9999999999999999999999999999999999999999";
+    }],
+    ["pool", (data: ReturnType<typeof providerData>) => {
+      data.pool.pool_address = `0x${"99".repeat(32)}`;
+    }],
+    ["biggest pool", (data: ReturnType<typeof providerData>) => {
+      data.biggest_pool_address = `0x${"99".repeat(32)}`;
+    }],
+    ["quote", (data: ReturnType<typeof providerData>) => {
+      Reflect.set(
+        data.pool,
+        "quote_address",
+        "0x9999999999999999999999999999999999999999",
+      );
+    }],
+    ["exchange", (data: ReturnType<typeof providerData>) => {
+      data.pool.exchange = "uniswap_v3";
+    }],
+    ["base", (data: ReturnType<typeof providerData>) => {
+      data.pool.base_address = "0x9999999999999999999999999999999999999999";
+    }],
+    ["token pair", (data: ReturnType<typeof providerData>) => {
+      data.pool.token1_address =
+        "0x9999999999999999999999999999999999999999";
+    }],
+    ["supply", (data: ReturnType<typeof providerData>) => {
+      data.total_supply = "10001";
+    }],
+  ])("rejects a mismatched %s identity binding", (_label, mutate) => {
+    const entry = token();
+    const data = providerData(entry);
+    mutate(data);
+    expect(parseGmgnMarketSnapshotV1(
+      data,
+      [identity(entry)],
+      { raw: 10_000n * 10n ** 18n, decimals: 18 },
+      NOW,
+    )).toBeNull();
+  });
+
+  it("does not call GMGN without a server-side API key", async () => {
+    const fetchImpl = vi.fn();
+    await expect(readGmgnMarketSnapshotV1(token(2), {
+      fetchImpl,
+      now: () => NOW,
+    })).resolves.toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("requires the official numeric-zero envelope and binds auth server-side", async () => {
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    const entry = token(3);
+    const fetchMock = vi.fn(async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      void input;
+      void init;
+      return new Response(JSON.stringify({
+        code: 0,
+        data: providerData(entry),
+      }), { status: 200, headers: { "Content-Type": "application/json" } });
+    });
+    const snapshot = await readGmgnMarketSnapshotV1(entry, {
+      fetchImpl: fetchMock as typeof fetch,
+      now: () => NOW,
+      deadlineMs: NOW.getTime() + 2_000,
+    });
+    expect(snapshot?.source).toBe("gmgn");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [request, init] = fetchMock.mock.calls[0]!;
+    const url = new URL(String(request));
+    expect(url.origin).toBe("https://openapi.gmgn.ai");
+    expect(url.pathname).toBe("/v1/token/info");
+    expect(url.searchParams.get("chain")).toBe("eth");
+    expect(url.searchParams.get("address")).toBe(entry.tokenAddress);
+    expect(url.searchParams.get("timestamp")).toBe("1788091200");
+    expect(url.searchParams.get("client_id")).toMatch(/^[0-9a-f-]{36}$/u);
+    expect(new Headers(init?.headers).get("X-APIKEY")).toBe("test-server-key");
+  });
+
+  it("fails closed on an unsealed provider response", async () => {
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    const entry = token(4);
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      data: providerData(entry),
+    }), { status: 200 }));
+    await expect(readGmgnMarketSnapshotV1(entry, {
+      fetchImpl: fetchImpl as typeof fetch,
+      now: () => NOW,
+      deadlineMs: NOW.getTime() + 2_000,
+    })).resolves.toBeNull();
+  });
+
+  it("fails soft without a same-request retry after a 429", async () => {
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    const entry = token(5);
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        code: 429,
+        error: "RATE_LIMIT_EXCEEDED",
+        data: {},
+      }), { status: 429, headers: { "Retry-After": "1" } }));
+    await expect(readGmgnMarketSnapshotV1(entry, {
+      fetchImpl: fetchImpl as typeof fetch,
+      now: () => NOW,
+      deadlineMs: NOW.getTime() + 2_000,
+    })).resolves.toBeNull();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds the shared cooldown when a 429 omits reset headers", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      code: 429,
+      error: "RATE_LIMIT_EXCEEDED",
+      data: {},
+    }), { status: 429 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(readGmgnMarketSnapshotV1(token(6), {
+      now: () => new Date(Date.now()),
+      deadlineMs: NOW.getTime() + 5_000,
+    })).resolves.toBeNull();
+    vi.setSystemTime(NOW.getTime() + 600);
+    await expect(readGmgnMarketSnapshotV1(token(7), {
+      now: () => new Date(Date.now()),
+      deadlineMs: NOW.getTime() + 5_000,
+    })).resolves.toBeNull();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["provider 500", 500, JSON.stringify({ code: 0, data: {} })],
+    ["oversized UTF-8 body", 200, "é".repeat(500_001)],
+  ])("fails soft for a bounded %s response", async (_label, status, body) => {
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    const entry = token(status + 10);
+    const fetchImpl = vi.fn(async () => new Response(body, { status }));
+    await expect(readGmgnMarketSnapshotV1(entry, {
+      fetchImpl: fetchImpl as typeof fetch,
+      now: () => NOW,
+      deadlineMs: NOW.getTime() + 2_000,
+    })).resolves.toBeNull();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- enrich canonical Ethereum Explore cards and token detail reads with GMGN price, FDV, liquidity and 24h volume
- preserve Programmable Registry/Router/Indexer identity and Dexscreener market-cap ranking as the sole card/order source
- fail soft to Dexscreener with strict pool/token/supply binding, bounded streaming reads, cache/dedupe, and 429 cooldown
- keep Robinhood GMGN disabled until canonical 4663 launches and exact pool coverage are proven

## Configuration
- `GMGN_API_KEY` (server-only) enables the integration
- optional `GMGN_MAX_REQUESTS_PER_SECOND` accepts 1-50 and defaults to 5

## Verification
- focused Vitest: 188 passed
- TypeScript: passed
- ESLint changed files: passed
- production build and candidate-neutral bundle checks: passed
- `git diff --check`: passed