### PR TITLE
Fix Robinhood QuickNode network-qualified endpoint pin

### DIFF
--- a/contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs
+++ b/contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs
@@ -531,7 +531,7 @@ function authenticatedProviderBinding(pin, rpcUrl) {
     fail(`${pin.providerId} RPC endpoint violates its provider pin`);
   }
   const quicknode =
-    /^https:\/\/[a-z0-9](?:[a-z0-9-]{0,62})\.quiknode\.pro\/[A-Za-z0-9_-]{16,256}\/$/u.test(
+    /^https:\/\/[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.robinhood-mainnet\.quiknode\.pro\/[A-Za-z0-9_-]{16,256}\/$/u.test(
       rpcUrl,
     ) &&
     !url.hostname.startsWith("docs-demo.") &&

--- a/contracts/scripts/test/robinhood-custom-launch-owner-envelope.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-owner-envelope.test.mjs
@@ -55,7 +55,7 @@ const PREPARED_ADDRESSES = Object.freeze({
   router: "0x34965F2A2ee9254522232C32F02056E92BE0C98a",
 });
 const RPC_URLS = Object.freeze([
-  "https://hood-explorer-indexer.quiknode.pro/0123456789abcdef/",
+  "https://hood-explorer-indexer.robinhood-mainnet.quiknode.pro/0123456789abcdef/",
   "https://robinhood-mainnet.g.alchemy.com/v2/abcdef0123456789",
 ]);
 const RPC_COMMITMENTS = Object.freeze([
@@ -379,11 +379,11 @@ test("implementation inventory contains no balance, signing, or broadcast primit
   );
 });
 
-test("provider pins reject public, same-origin, unauthenticated, and unsafe endpoints", () => {
+test("provider pins accept the exact Robinhood QuickNode host and reject cross-network or unsafe endpoints", () => {
   assert.deepEqual(
     assertRobinhoodFoundationRpcProviders({
       rpcUrls: [
-        "https://hood-explorer-indexer-alt.quiknode.pro/credential_0123456789/",
+        "https://hood-explorer-indexer-alt.robinhood-mainnet.quiknode.pro/credential_0123456789/",
         RPC_URLS[1],
       ],
       endpointCommitments: [
@@ -391,7 +391,7 @@ test("provider pins reject public, same-origin, unauthenticated, and unsafe endp
           role: "primary",
           providerId: "quicknode",
           rpcUrl:
-            "https://hood-explorer-indexer-alt.quiknode.pro/credential_0123456789/",
+            "https://hood-explorer-indexer-alt.robinhood-mainnet.quiknode.pro/credential_0123456789/",
         }),
         RPC_COMMITMENTS[1],
       ],
@@ -406,7 +406,7 @@ test("provider pins reject public, same-origin, unauthenticated, and unsafe endp
           role: "primary",
           providerId: "quicknode",
           rpcUrl:
-            "https://hood-explorer-indexer-alt.quiknode.pro/credential_0123456789/",
+            "https://hood-explorer-indexer-alt.robinhood-mainnet.quiknode.pro/credential_0123456789/",
         }),
       },
       {
@@ -421,15 +421,50 @@ test("provider pins reject public, same-origin, unauthenticated, and unsafe endp
   const invalid = [
     ["https://rpc.mainnet.chain.robinhood.com", RPC_URLS[1]],
     ["https://lb.drpc.live/robinhood/0123456789abcdef", RPC_URLS[1]],
-    ["http://hood-explorer-indexer.quiknode.pro/0123456789abcdef/", RPC_URLS[1]],
     [
-      "https://user:secret@hood-explorer-indexer.quiknode.pro/0123456789abcdef/",
+      "http://hood-explorer-indexer.robinhood-mainnet.quiknode.pro/0123456789abcdef/",
       RPC_URLS[1],
     ],
-    ["https://hood-explorer-indexer.quiknode.pro/", RPC_URLS[1]],
-    ["https://docs-demo.quiknode.pro/0123456789abcdef/", RPC_URLS[1]],
-    ["https://hood-explorer-indexer.quiknode.pro/short/", RPC_URLS[1]],
-    ["https://hood-explorer-indexer.quiknode.pro/0123456789abcdef", RPC_URLS[1]],
+    [
+      "https://user:secret@hood-explorer-indexer.robinhood-mainnet.quiknode.pro/0123456789abcdef/",
+      RPC_URLS[1],
+    ],
+    [
+      "https://hood-explorer-indexer.robinhood-mainnet.quiknode.pro/",
+      RPC_URLS[1],
+    ],
+    [
+      "https://docs-demo.robinhood-mainnet.quiknode.pro/0123456789abcdef/",
+      RPC_URLS[1],
+    ],
+    [
+      "https://hood-explorer-indexer.robinhood-mainnet.quiknode.pro/short/",
+      RPC_URLS[1],
+    ],
+    [
+      "https://hood-explorer-indexer.robinhood-mainnet.quiknode.pro/0123456789abcdef",
+      RPC_URLS[1],
+    ],
+    [
+      "https://hood-explorer-indexer.robinhood-mainnet.quiknode.pro:443/0123456789abcdef/",
+      RPC_URLS[1],
+    ],
+    [
+      "https://hood-explorer-indexer.robinhood-mainnet.quiknode.pro/0123456789abcdef/extra/",
+      RPC_URLS[1],
+    ],
+    [
+      "https://hood-explorer-indexer.quiknode.pro/0123456789abcdef/",
+      RPC_URLS[1],
+    ],
+    [
+      "https://hood-explorer-indexer.ethereum-mainnet.quiknode.pro/0123456789abcdef/",
+      RPC_URLS[1],
+    ],
+    [
+      "https://hood-explorer-indexer-.robinhood-mainnet.quiknode.pro/0123456789abcdef/",
+      RPC_URLS[1],
+    ],
     [`${RPC_URLS[0]}?extra=1`, RPC_URLS[1]],
     [
       RPC_URLS[0],
@@ -622,7 +657,7 @@ test("RPC transport is strict, bounded, and redacts endpoint/error content", asy
   const responseBudget = { consumed: 0, limit: 4 * 1024 * 1024 };
   const result = await robinhoodFoundationRpc({
     providerId: "quicknode",
-    rpcUrl: `https://hood-explorer-indexer.quiknode.pro/${secret}/`,
+    rpcUrl: `https://hood-explorer-indexer.robinhood-mainnet.quiknode.pro/${secret}/`,
     method: "eth_chainId",
     responseBudget,
     fetchImpl: async () =>
@@ -639,7 +674,7 @@ test("RPC transport is strict, bounded, and redacts endpoint/error content", asy
     () =>
       robinhoodFoundationRpc({
         providerId: "quicknode",
-        rpcUrl: `https://hood-explorer-indexer.quiknode.pro/${secret}/`,
+        rpcUrl: `https://hood-explorer-indexer.robinhood-mainnet.quiknode.pro/${secret}/`,
         method: "eth_chainId",
         responseBudget: { consumed: 0, limit: 4 * 1024 * 1024 },
         fetchImpl: async () =>
@@ -814,7 +849,7 @@ test("read-only action-time verifier rebinds source, hosted CI, endpoints, and l
           env: {
             ...env,
             ROBINHOOD_MAINNET_RPC_URL_PRIMARY:
-              "https://hood-explorer-indexer.quiknode.pro/substitute_0123456789/",
+              "https://hood-explorer-indexer.robinhood-mainnet.quiknode.pro/substitute_0123456789/",
           },
           nowMilliseconds: FIXED_TIMESTAMP * 1_000,
           sourceIdentity: () => ({

--- a/contracts/scripts/test/robinhood-custom-launch-release-docs.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-release-docs.test.mjs
@@ -94,6 +94,11 @@ test("operator runbooks use repo-root commands and independently frozen provider
   assert.match(handoff, /Programmable Production 3/u);
   assert.match(
     handoff,
+    /https:\/\/<HOOD_EXPLORER_INDEXER_ENDPOINT>\.robinhood-mainnet\.quiknode\.pro\/<TOKEN>\//u,
+  );
+  assert.match(handoff, /\.ethereum-mainnet\.quiknode\.pro` is rejected/u);
+  assert.match(
+    handoff,
     /sha256:c03afd37c077e78bea30f69d1ce139d026cb4fad86fa74122257bba8f5e9a910/u,
   );
   for (const historicalBoundary of [postdeployment, releaseReadme]) {

--- a/docs/operations/releases/custom-launch-v4/OWNER-WALLET-HANDOFF.md
+++ b/docs/operations/releases/custom-launch-v4/OWNER-WALLET-HANDOFF.md
@@ -71,7 +71,7 @@ The commitment helper accepts only the exact credential-bearing QuickNode
 primary and Alchemy secondary Robinhood URL forms:
 
 ```text
-https://<HOOD_EXPLORER_INDEXER_ENDPOINT>.quiknode.pro/<TOKEN>/
+https://<HOOD_EXPLORER_INDEXER_ENDPOINT>.robinhood-mainnet.quiknode.pro/<TOKEN>/
 https://robinhood-mainnet.g.alchemy.com/v2/<ALCHEMY_API_KEY>
 ```
 
@@ -81,7 +81,8 @@ Indexer** project. The secondary URL must be copied from the existing Alchemy
 provider URL shape, role, provider ID and trust domain; it cannot prove either
 dashboard display name, account ownership, plan or archive entitlement. Those
 facts and both providers' required historical reads remain separate release
-checks.
+checks. A legacy one-label QuickNode host or an Ethereum endpoint ending in
+`.ethereum-mainnet.quiknode.pro` is rejected in this Robinhood-only slot.
 
 This ordered role pair is compatible with backend provider-profile digest
 `sha256:c03afd37c077e78bea30f69d1ce139d026cb4fad86fa74122257bba8f5e9a910`.


### PR DESCRIPTION
## Outcome

Accept the actual credential-bearing QuickNode endpoint shape emitted by the existing Hood Explorer Indexer project while keeping the owner handoff fail-closed and Robinhood-only.

## Security boundary

- accepts only `https://<slug>.robinhood-mainnet.quiknode.pro/<credential>/`
- rejects legacy one-label QuickNode hosts and Ethereum cross-network substitution
- rejects demo hosts, trailing-hyphen slugs, HTTP, userinfo, explicit ports, query or fragment data, missing credentials and extra path segments
- leaves the existing Ethereum postdeployment QuickNode pin unchanged
- no provider credential, wallet data, transaction signature or onchain mutation is included

## Exact source

- base at creation: `0ac1671e5028b889cd68822431c78788a99d9529`
- signed head: `9438908f5934fb8101fd0b4ff6e029add20eee17`
- tree: `23a48e1b2f76dae206938630cde2187d0c929b73`

This branch will be rebound to the current `production` head before guarded merge if another production PR lands first.

## Verification

- owner-envelope and release tests: 68/68 pass
- Ethereum postdeployment provider tests: 18/18 pass
- Foundry build: pass, 512 files, pinned Solidity 0.8.26
- focused ESLint: pass
- `git diff --check`: pass
- protected real QuickNode plus Alchemy URL forms accepted by the exact signed validator without returning either credential URL
- independent same-block provider readback before this PR: chain 4663, six dependency runtime hashes matched and all three prepared deployment addresses remained vacant on both providers

No wallet was opened from the pre-fix validator, and no signing or broadcast occurred.