### PR TITLE
Fix wallet-first fee claim flow

### DIFF
--- a/ops/protocol-fee-claim/app.js
+++ b/ops/protocol-fee-claim/app.js
@@ -62,6 +62,11 @@ import {
   walletSendDuplicateBatchId,
   withTimeout,
 } from "./logic.mjs";
+import {
+  SCAN_SNAPSHOT_STORAGE_KEY,
+  createScanSnapshot,
+  parseScanSnapshot,
+} from "./view-state.mjs";
 
 const DEMO_MODE = new URLSearchParams(window.location.search).has("demo");
 const EVENT_LOG_CHUNK_SIZE = 10_000n;
@@ -76,6 +81,7 @@ const ROUTER_QUORUM_RPC_GROUPS = Object.freeze([
 ]);
 const ROUTER_QUORUM_TIMEOUT_MS = 20_000;
 const WALLET_DISCOVERY_TIMEOUT_MS = 1_500;
+const AUTO_REFRESH_AFTER_MS = 60_000;
 const CONFIRMED_BATCH_STORAGE_KEY =
   "programmable.fee-claim.confirmed-batch.v2";
 const CONFIRMED_BATCH_SCHEMA = "programmable.confirmed-claim-batch.v2";
@@ -90,6 +96,7 @@ const INTERACTIVE_WALLET_METHODS = new Set([
 const announcedWalletProviders = new Map();
 let boundWalletProvider = null;
 let walletAuthorizationRevision = 0;
+let walletSyncGeneration = 0;
 
 function rememberAnnouncedWalletProvider(event) {
   const detail = event?.detail;
@@ -243,13 +250,31 @@ function requireConfirmedBatchStorage() {
   }
 }
 
+function loadScanSnapshot() {
+  try {
+    const stored = window.localStorage.getItem(SCAN_SNAPSHOT_STORAGE_KEY);
+    if (stored === null) return null;
+    return parseScanSnapshot(stored, {
+      expectedAccount: TREASURY,
+      expectedChainId: MAINNET_CHAIN_ID,
+    });
+  } catch {
+    return null;
+  }
+}
+
+const initialScanSnapshot = DEMO_MODE ? null : loadScanSnapshot();
+
 const state = {
   account: null,
   chainId: null,
   blockTag: null,
   capability: null,
+  capabilityStatus: "idle",
   walletMissing: false,
   confirmedBatch: DEMO_MODE ? null : loadConfirmedBatchLock(),
+  scanSnapshot: initialScanSnapshot,
+  scanInProgress: false,
   claims: new Map(),
   hooks: new Map(),
   custom: {
@@ -420,21 +445,26 @@ const elements = {
   claimRows: document.querySelector("[data-claim-rows]"),
   content: document.querySelector(".content"),
   error: document.querySelector("[data-error]"),
+  errorDetail: document.querySelector("[data-error-detail]"),
   metamaskOpen: document.querySelector("[data-metamask-open]"),
   network: document.querySelector("[data-network]"),
-  refresh: document.querySelector("[data-refresh]"),
   status: document.querySelector("[data-status]"),
   total: document.querySelector("[data-total]"),
+  totalCard: document.querySelector("[data-total-card]"),
+  totalLabel: document.querySelector("[data-total-label]"),
+  walletState: document.querySelector("[data-wallet-state]"),
 };
 
 function clearWalletAuthorizationState() {
   state.account = null;
   state.chainId = null;
   state.capability = null;
+  state.capabilityStatus = "idle";
 }
 
 function invalidateWalletAuthorizationState() {
   walletAuthorizationRevision += 1;
+  walletSyncGeneration += 1;
   clearWalletAuthorizationState();
   return walletAuthorizationRevision;
 }
@@ -619,6 +649,11 @@ async function routerQuorumRequest(method, params = []) {
 function setError(message = "") {
   elements.error.textContent = message;
   elements.error.hidden = message.length === 0;
+}
+
+function setDetailedError(message = "") {
+  elements.errorDetail.textContent = message;
+  elements.errorDetail.hidden = message.length === 0;
 }
 
 function setStatus(message) {
@@ -967,7 +1002,17 @@ function buildClassicLaunchGroup() {
   const routerClassic = state.router.launches.filter(
     ({ launchKind }) => launchKind === 2,
   );
-  const launches = [...routerClassic, ...state.classic.launches];
+  const launches = [...routerClassic, ...state.classic.launches].sort(
+    (left, right) => {
+      const coverageOrder =
+        Number(left.claimMode !== "unsupported") -
+        Number(right.claimMode !== "unsupported");
+      if (coverageOrder !== 0) return coverageOrder;
+      return (left.symbol ?? left.name ?? left.token).localeCompare(
+        right.symbol ?? right.name ?? right.token,
+      );
+    },
+  );
   const group = document.createElement("li");
   group.className = "asset-group classic-launch-group";
   const details = document.createElement("details");
@@ -1128,6 +1173,11 @@ function claimSafetyError({ ignoreConfirmedBatch = false } = {}) {
   if (state.router.status !== "ready" || state.router.verified !== true)
     return "Der Launch-Stamp-Router ist nicht vollständig verifiziert";
   if (
+    state.classic.status !== "ready" ||
+    state.classic.launchersVerified !== true
+  )
+    return "Die Classic-Launchliste ist nicht vollständig verifiziert";
+  if (
     !["ready", "retired"].includes(state.custom.status) ||
     state.custom.registryVerified !== true
   )
@@ -1159,12 +1209,14 @@ function claimSafetyError({ ignoreConfirmedBatch = false } = {}) {
     return "Mindestens ein Router-Launch hat noch kein freigegebenes Claim-Profil";
   if (HOOKS.some(({ id }) => state.hooks.get(id)?.verified !== true))
     return "Mindestens eine Classic- oder Stock-Bindung stimmt nicht";
+  if (CLAIMS.some(({ id }) => state.claims.get(id)?.status === "failed"))
+    return "Mindestens ein bekanntes Guthaben konnte nicht gelesen werden";
   if (claimableClaims({ ignoreConfirmedBatch }).length > MAX_BATCH_CALLS)
     return `Mehr als ${MAX_BATCH_CALLS} offene Claims passen nicht sicher in einen atomaren Batch`;
   return null;
 }
 
-function renderSummary() {
+function claimInventoryTotals() {
   const claimable = claimableClaims();
   const nativeTotal = claimable
     .filter(
@@ -1183,6 +1235,60 @@ function renderSummary() {
     claimable.filter(
       (claim) => (state.claims.get(claim.id)?.secondaryAmount ?? 0n) > 0n,
     ).length;
+  return { assetCount, claimable, nativeTotal };
+}
+
+function scanIsLoading() {
+  return (
+    state.scanInProgress ||
+    state.custom.status === "loading" ||
+    state.customV2.status === "loading" ||
+    state.classic.status === "loading" ||
+    state.router.status === "loading"
+  );
+}
+
+function scanNeedsRetry(verifiedHooks) {
+  return (
+    !["ready", "retired"].includes(state.custom.status) ||
+    state.custom.registryVerified !== true ||
+    !["ready", "hold"].includes(state.customV2.status) ||
+    state.classic.status !== "ready" ||
+    state.classic.launchersVerified !== true ||
+    state.router.status !== "ready" ||
+    state.router.verified !== true ||
+    verifiedHooks !== HOOKS.length ||
+    CLAIMS.some(({ id }) => state.claims.get(id)?.status === "failed")
+  );
+}
+
+function currentInventoryIsDisplayReady(verifiedHooks) {
+  return !scanIsLoading() && !scanNeedsRetry(verifiedHooks);
+}
+
+function saveCurrentScanSnapshot(blockTag) {
+  const { assetCount, claimable, nativeTotal } = claimInventoryTotals();
+  try {
+    const snapshot = createScanSnapshot({
+      account: TREASURY,
+      chainId: MAINNET_CHAIN_ID,
+      blockNumber: BigInt(blockTag),
+      nativeWei: nativeTotal,
+      claimCount: claimable.length,
+      assetCount,
+    });
+    state.scanSnapshot = snapshot;
+    window.localStorage.setItem(
+      SCAN_SNAPSHOT_STORAGE_KEY,
+      JSON.stringify(snapshot),
+    );
+  } catch {
+    // The snapshot is display-only. Claim authorization never depends on it.
+  }
+}
+
+function renderSummary() {
+  const { assetCount, claimable, nativeTotal } = claimInventoryTotals();
   const verifiedHooks = HOOKS.filter(
     ({ id }) => state.hooks.get(id)?.verified === true,
   ).length;
@@ -1202,12 +1308,54 @@ function renderSummary() {
       (launch.launchKind === 2 && launch.claimMode === "unsupported"),
   );
 
-  elements.total.textContent = state.account
-    ? `${formatEth(nativeTotal)} ETH`
-    : "—";
-  elements.claimCount.textContent = state.account
-    ? `${claimable.length} ${claimable.length === 1 ? "Claim" : "Claims"}${assetCount > 0 ? ` · +${assetCount} Assets` : ""}`
-    : "Noch nicht geprüft";
+  const connected = state.account !== null;
+  const correctWallet = connected && isTreasury(state.account);
+  const correctNetwork = state.chainId === MAINNET_CHAIN_ID;
+  const loading = scanIsLoading();
+  const displayCurrent =
+    correctWallet &&
+    correctNetwork &&
+    currentInventoryIsDisplayReady(verifiedHooks);
+  const snapshotMatchesVisibleWallet =
+    !connected || (correctWallet && correctNetwork);
+  const displaySnapshot =
+    displayCurrent || !snapshotMatchesVisibleWallet ? null : state.scanSnapshot;
+  const displayNative = displayCurrent
+    ? nativeTotal
+    : displaySnapshot
+      ? BigInt(displaySnapshot.nativeWei)
+      : null;
+  const displayClaimCount = displayCurrent
+    ? claimable.length
+    : displaySnapshot?.claimCount ?? null;
+  const displayAssetCount = displayCurrent
+    ? assetCount
+    : displaySnapshot?.assetCount ?? 0;
+
+  elements.total.textContent =
+    displayNative === null ? (loading ? "…" : "—") : `${formatEth(displayNative)} ETH`;
+  elements.claimCount.textContent =
+    displayClaimCount === null
+      ? loading
+        ? "Fees werden geprüft"
+        : "Noch nicht geprüft"
+      : `${displayClaimCount} ${displayClaimCount === 1 ? "Claim" : "Claims"}${displayAssetCount > 0 ? ` · +${displayAssetCount} Assets` : ""}`;
+  elements.totalLabel.textContent = displayCurrent
+    ? "Jetzt offen"
+    : displaySnapshot
+      ? loading
+        ? "Letzter Stand · wird aktualisiert"
+        : "Letzter Stand"
+      : loading
+        ? "Wird geprüft"
+        : "Zu claimen";
+  elements.totalCard.dataset.state = displayCurrent
+    ? "ready"
+    : displaySnapshot
+      ? "cached"
+      : loading
+        ? "loading"
+        : "idle";
   elements.account.textContent = state.account
     ? shortAddress(state.account)
     : "Nicht verbunden";
@@ -1220,31 +1368,36 @@ function renderSummary() {
         : "Ethereum";
   elements.batchMode.textContent = state.capability
     ? "Eine MetaMask-Bestätigung"
-    : state.account
+    : state.capabilityStatus === "failed"
+      ? "Erneut prüfen"
+      : state.account
       ? "Nicht verfügbar"
       : "Batch wird geprüft";
-
-  const connected = state.account !== null;
-  const correctWallet = connected && isTreasury(state.account);
-  const correctNetwork = state.chainId === MAINNET_CHAIN_ID;
-  const loading =
-    state.custom.status === "loading" ||
-    state.customV2.status === "loading" ||
-    state.classic.status === "loading" ||
-    state.router.status === "loading";
   elements.content.setAttribute("aria-busy", String(state.busy || loading));
   elements.network.dataset.state = !connected
     ? "idle"
     : correctNetwork
       ? "ready"
       : "wrong";
-  elements.refresh.hidden = !correctWallet || !correctNetwork;
   elements.metamaskOpen.hidden = !state.walletMissing;
+  elements.walletState.textContent = !connected
+    ? "Reward Wallet nicht verbunden"
+    : !correctNetwork
+      ? "Ethereum Mainnet auswählen"
+      : !correctWallet
+        ? "Falsches MetaMask-Konto"
+        : `Reward Wallet verbunden · ${shortAddress(state.account)}`;
+  elements.walletState.dataset.state =
+    correctWallet && correctNetwork
+      ? "ready"
+      : connected
+        ? "wrong"
+        : "idle";
 
   if (!connected) {
     elements.actionLabel.textContent = state.walletMissing
       ? "MetaMask erneut suchen"
-      : "MetaMask verbinden";
+      : "Reward Wallet verbinden";
     elements.actionDetail.textContent = "Reward Wallet · endet 376C";
     elements.action.disabled = state.busy;
   } else if (!correctNetwork) {
@@ -1256,8 +1409,10 @@ function renderSummary() {
     elements.actionDetail.textContent = "Wallet · endet 376C";
     elements.action.disabled = state.busy;
   } else if (loading) {
-    elements.actionLabel.textContent = "Fees werden gesucht";
-    elements.actionDetail.textContent = "Einen Moment";
+    elements.actionLabel.textContent = "Fees werden geprüft";
+    elements.actionDetail.textContent = displaySnapshot
+      ? "Letzter Stand bleibt sichtbar"
+      : "Automatisch nach der Verbindung";
     elements.action.disabled = true;
   } else if (state.confirmedBatch) {
     const resumable =
@@ -1276,21 +1431,10 @@ function renderSummary() {
           ? "Exakt dieselbe Batch-ID · kein zweiter Claim"
           : `Neuer Scan erst nach finalisiertem Block ${highestConfirmedReceiptBlock()?.toString()}`;
     elements.action.disabled = state.busy || !resumable;
-  } else if (
-    state.custom.status === "failed" ||
-    state.custom.registryVerified !== true
-  ) {
-    elements.actionLabel.textContent = "Scan fehlgeschlagen";
-    elements.actionDetail.textContent = "Bitte neu scannen";
-    elements.action.disabled = true;
-  } else if (state.customV2.status === "failed") {
-    elements.actionLabel.textContent = "Scan fehlgeschlagen";
-    elements.actionDetail.textContent = "Bitte neu scannen";
-    elements.action.disabled = true;
-  } else if (state.router.status === "failed" || state.router.verified !== true) {
-    elements.actionLabel.textContent = "Scan fehlgeschlagen";
-    elements.actionDetail.textContent = "Bitte neu scannen";
-    elements.action.disabled = true;
+  } else if (scanNeedsRetry(verifiedHooks)) {
+    elements.actionLabel.textContent = "Erneut prüfen";
+    elements.actionDetail.textContent = "Reward Wallet bleibt verbunden";
+    elements.action.disabled = state.busy;
   } else if (customBindingBlockers.length > 0) {
     elements.actionLabel.textContent = "Neue Quelle prüfen";
     elements.actionDetail.textContent = "Claim bleibt sicher gesperrt";
@@ -1305,23 +1449,23 @@ function renderSummary() {
     elements.action.disabled = true;
   } else if (routerBindingBlockers.length > 0) {
     elements.actionLabel.textContent = "Neue Quelle prüfen";
-    elements.actionDetail.textContent = "Claim bleibt sicher gesperrt";
-    elements.action.disabled = true;
-  } else if (verifiedHooks !== HOOKS.length) {
-    elements.actionLabel.textContent = "Scan fehlgeschlagen";
-    elements.actionDetail.textContent = "Bitte neu scannen";
+    elements.actionDetail.textContent = `${routerBindingBlockers.length} neue ${routerBindingBlockers.length === 1 ? "Quelle" : "Quellen"} noch nicht freigegeben`;
     elements.action.disabled = true;
   } else if (claimable.length > MAX_BATCH_CALLS) {
     elements.actionLabel.textContent = "Zu viele offene Claims";
     elements.actionDetail.textContent = "Details prüfen";
     elements.action.disabled = true;
   } else if (claimable.length === 0) {
-    elements.actionLabel.textContent = "Nichts offen";
-    elements.actionDetail.textContent = "Später erneut scannen";
-    elements.action.disabled = true;
+    elements.actionLabel.textContent = "Fees aktualisieren";
+    elements.actionDetail.textContent = "Aktuell nichts offen";
+    elements.action.disabled = state.busy;
+  } else if (state.capabilityStatus === "failed") {
+    elements.actionLabel.textContent = "Erneut prüfen";
+    elements.actionDetail.textContent = "MetaMask-Verbindung aktualisieren";
+    elements.action.disabled = state.busy;
   } else if (!state.capability) {
-    elements.actionLabel.textContent = "MetaMask aktualisieren";
-    elements.actionDetail.textContent = "Gemeinsamer Claim nicht verfügbar";
+    elements.actionLabel.textContent = "MetaMask nicht kompatibel";
+    elements.actionDetail.textContent = "Gemeinsamer Claim nicht unterstützt";
     elements.action.disabled = true;
   } else {
     elements.actionLabel.textContent = "Alles claimen";
@@ -1330,7 +1474,6 @@ function renderSummary() {
     elements.action.disabled = state.busy;
   }
 
-  elements.refresh.disabled = state.busy || !correctWallet || !correctNetwork;
   renderRows();
 }
 
@@ -2679,16 +2822,20 @@ async function readClaim(claim, blockTag) {
 async function readCapabilities() {
   if (!state.account || state.chainId !== MAINNET_CHAIN_ID) {
     state.capability = null;
+    state.capabilityStatus = "idle";
     return;
   }
+  state.capabilityStatus = "loading";
   try {
     const capabilities = await request("wallet_getCapabilities", [
       state.account,
       [MAINNET_CHAIN_ID],
     ]);
     state.capability = atomicCapabilityStatus(capabilities);
+    state.capabilityStatus = state.capability ? "ready" : "unsupported";
   } catch {
     state.capability = null;
+    state.capabilityStatus = "failed";
   }
 }
 
@@ -2837,96 +2984,115 @@ async function reconcileConfirmedBatchLock() {
 
 async function refreshClaimsOnce() {
   if (!state.account || state.chainId !== MAINNET_CHAIN_ID) return;
+  state.scanInProgress = true;
   setError();
-  setStatus("Contract-Bindungen und Guthaben werden geprüft");
-  await readLaunchStampRouter();
-  const blockTag =
-    state.router.status === "ready" &&
-    state.router.verified === true &&
-    typeof state.router.finalizedBlock === "bigint"
-      ? toQuantityHex(state.router.finalizedBlock)
-      : await request("eth_blockNumber");
-  state.blockTag = blockTag;
-
-  await Promise.all([
-    readCustomRegistry(blockTag),
-    readCustomV2(blockTag),
-    readClassicLaunches(blockTag),
-  ]);
-
-  const hookResults = await mapWithConcurrency(HOOKS, 4, async (hook) => {
-    try {
-      return { status: "fulfilled", value: await readHook(hook, blockTag) };
-    } catch (reason) {
-      return { status: "rejected", reason };
-    }
-  });
-  hookResults.forEach((result, index) => {
-    const hook = HOOKS[index];
-    state.hooks.set(
-      hook.id,
-      result.status === "fulfilled" ? result.value : { verified: false },
-    );
-  });
-
-  const claimResults = await mapWithConcurrency(CLAIMS, 4, async (claim) => {
-    try {
-      return { status: "fulfilled", value: await readClaim(claim, blockTag) };
-    } catch (reason) {
-      return { status: "rejected", reason };
-    }
-  });
-  claimResults.forEach((result, index) => {
-    const claim = CLAIMS[index];
-    state.claims.set(
-      claim.id,
-      result.status === "fulfilled"
-        ? result.value
-        : { amount: 0n, recipientMatches: false, status: "failed" },
-    );
-  });
-
-  await readCapabilities();
-  await reconcileConfirmedBatchLock();
-  const verified = hookResults.filter(
-    ({ status }, index) =>
-      status === "fulfilled" && state.hooks.get(HOOKS[index].id)?.verified,
-  ).length;
-  const failedClaims = claimResults.filter(
-    ({ status }) => status === "rejected",
-  ).length;
-  const errors = [];
-  if (verified !== HOOKS.length)
-    errors.push(
-      "Mindestens eine Contract-Bindung stimmt nicht. Claims bleiben gesperrt.",
-    );
-  if (state.custom.error)
-    errors.push(
-      "Die Custom Registry konnte nicht vollständig verifiziert werden. Claims bleiben gesperrt.",
-    );
-  if (state.customV2.error)
-    errors.push(
-      "Das aktive Custom-V2-Release konnte nicht vollständig verifiziert werden. Claims bleiben gesperrt.",
-    );
-  if (state.classic.error)
-    errors.push(
-      "Die Classic-Launchliste konnte nicht vollständig gelesen werden. Der verifizierte gemeinsame Hook-Claim bleibt verfügbar.",
-    );
-  if (state.router.error)
-    errors.push(
-      "Der offizielle Launch-Stamp-Router konnte nicht vollständig verifiziert werden. Alle Claims bleiben gesperrt.",
-    );
-  setError(errors.join(" "));
-  setStatus(
-    state.confirmedBatch
-      ? confirmedBatchStatus()
-      : state.custom.error || state.customV2.error || state.router.error
-        ? "Ecosystem-Scan konnte nicht vollständig gelesen werden"
-        : failedClaims === 0
-          ? `Stand Block ${BigInt(blockTag).toString()} · ${state.classic.launches.length + state.router.launches.filter(({ launchKind }) => launchKind === 2).length} Classic · ${state.custom.launches.length + state.customV2.sources.length + state.router.launches.filter(({ launchKind }) => launchKind === 1).length} Custom`
-          : `${failedClaims} Guthaben konnten nicht gelesen werden`,
-  );
+  setDetailedError();
+  setStatus("Fees werden geprüft");
   renderSummary();
+  try {
+    await readLaunchStampRouter();
+    const blockTag =
+      state.router.status === "ready" &&
+      state.router.verified === true &&
+      typeof state.router.finalizedBlock === "bigint"
+        ? toQuantityHex(state.router.finalizedBlock)
+        : await request("eth_blockNumber");
+    state.blockTag = blockTag;
+
+    await Promise.all([
+      readCustomRegistry(blockTag),
+      readCustomV2(blockTag),
+      readClassicLaunches(blockTag),
+    ]);
+
+    const hookResults = await mapWithConcurrency(HOOKS, 4, async (hook) => {
+      try {
+        return { status: "fulfilled", value: await readHook(hook, blockTag) };
+      } catch (reason) {
+        return { status: "rejected", reason };
+      }
+    });
+    hookResults.forEach((result, index) => {
+      const hook = HOOKS[index];
+      state.hooks.set(
+        hook.id,
+        result.status === "fulfilled" ? result.value : { verified: false },
+      );
+    });
+
+    const claimResults = await mapWithConcurrency(CLAIMS, 4, async (claim) => {
+      try {
+        return { status: "fulfilled", value: await readClaim(claim, blockTag) };
+      } catch (reason) {
+        return { status: "rejected", reason };
+      }
+    });
+    claimResults.forEach((result, index) => {
+      const claim = CLAIMS[index];
+      state.claims.set(
+        claim.id,
+        result.status === "fulfilled"
+          ? result.value
+          : { amount: 0n, recipientMatches: false, status: "failed" },
+      );
+    });
+
+    await readCapabilities();
+    await reconcileConfirmedBatchLock();
+    const verified = hookResults.filter(
+      ({ status }, index) =>
+        status === "fulfilled" && state.hooks.get(HOOKS[index].id)?.verified,
+    ).length;
+    const failedClaims = claimResults.filter(
+      ({ status }) => status === "rejected",
+    ).length;
+    const errors = [];
+    if (verified !== HOOKS.length)
+      errors.push(
+        "Mindestens eine Contract-Bindung stimmt nicht. Claims bleiben gesperrt.",
+      );
+    if (state.custom.error)
+      errors.push(
+        "Die Custom Registry konnte nicht vollständig verifiziert werden. Claims bleiben gesperrt.",
+      );
+    if (state.customV2.error)
+      errors.push(
+        "Das aktive Custom-V2-Release konnte nicht vollständig verifiziert werden. Claims bleiben gesperrt.",
+      );
+    if (state.classic.error)
+      errors.push(
+        "Die Classic-Launchliste konnte nicht vollständig gelesen werden. Claims bleiben gesperrt.",
+      );
+    if (state.router.error)
+      errors.push(
+        "Der offizielle Launch-Stamp-Router konnte nicht vollständig verifiziert werden. Alle Claims bleiben gesperrt.",
+      );
+    setDetailedError(errors.join(" "));
+    setError(
+      errors.length > 0
+        ? "Nicht alle Gebührenquellen konnten geprüft werden. Erneut versuchen."
+        : "",
+    );
+    if (
+      !state.confirmedBatch &&
+      errors.length === 0 &&
+      failedClaims === 0 &&
+      !scanNeedsRetry(verified)
+    )
+      saveCurrentScanSnapshot(blockTag);
+    setStatus(
+      state.confirmedBatch
+        ? confirmedBatchStatus()
+        : errors.length > 0
+          ? "Prüfung unvollständig"
+          : failedClaims === 0
+            ? `Aktuell · Block ${BigInt(blockTag).toString()}`
+            : `${failedClaims} Guthaben konnten nicht gelesen werden`,
+    );
+  } finally {
+    state.scanInProgress = false;
+    renderSummary();
+  }
 }
 
 const refreshClaims = createRefreshQueue(refreshClaimsOnce);
@@ -2935,12 +3101,17 @@ async function syncWallet({
   requestAccounts = false,
   expectedRevision = walletAuthorizationRevision,
 } = {}) {
+  const syncGeneration = ++walletSyncGeneration;
   const method = requestAccounts ? "eth_requestAccounts" : "eth_accounts";
   const [accounts, chainId] = await Promise.all([
     request(method),
     request("eth_chainId"),
   ]);
-  if (expectedRevision !== walletAuthorizationRevision) return;
+  if (
+    expectedRevision !== walletAuthorizationRevision ||
+    syncGeneration !== walletSyncGeneration
+  )
+    return false;
   state.account = Array.isArray(accounts) ? accounts[0] ?? null : null;
   state.chainId = chainId;
   renderSummary();
@@ -2956,8 +3127,18 @@ async function syncWallet({
     state.chainId !== MAINNET_CHAIN_ID ||
     !isTreasury(state.account)
   )
-    return;
-  await refreshClaims();
+    return true;
+  try {
+    await refreshClaims();
+  } catch (error) {
+    setError("Fees konnten nicht aktualisiert werden. Erneut versuchen.");
+    setDetailedError(
+      error instanceof Error ? error.message : "Fee-Prüfung fehlgeschlagen",
+    );
+    setStatus("Reward Wallet bleibt verbunden");
+    renderSummary();
+  }
+  return true;
 }
 
 async function chooseRewardWallet() {
@@ -3257,7 +3438,18 @@ async function handlePrimaryAction() {
         ["submitting", "pending"].includes(state.confirmedBatch.phase)
       )
         await resumeStoredBatch();
-      else await claimAll();
+      else {
+        const verifiedHooks = HOOKS.filter(
+          ({ id }) => state.hooks.get(id)?.verified === true,
+        ).length;
+        if (
+          scanNeedsRetry(verifiedHooks) ||
+          claimableClaims().length === 0 ||
+          state.capabilityStatus === "failed"
+        )
+          await refreshClaims();
+        else await claimAll();
+      }
     }
   } catch (error) {
     const message =
@@ -3294,31 +3486,53 @@ window.addEventListener("storage", (event) => {
     });
 });
 
-elements.action.addEventListener("click", handlePrimaryAction);
-elements.refresh.addEventListener("click", async () => {
-  if (DEMO_MODE) {
-    setStatus("QA-Vorschau wurde neu geladen · keine Wallet-Aktion");
+let lastPassiveWalletSyncAt = 0;
+let passiveWalletSyncTimer = null;
+let forceNextPassiveWalletSync = false;
+
+async function passiveWalletSync({ force = false } = {}) {
+  if (
+    DEMO_MODE ||
+    state.busy ||
+    state.scanInProgress ||
+    document.visibilityState === "hidden"
+  )
     return;
-  }
-  state.busy = true;
-  renderSummary();
-  try {
-    await refreshClaims();
-  } catch (error) {
-    setError(
-      error instanceof Error ? error.message : "Aktualisierung fehlgeschlagen",
-    );
-  } finally {
-    state.busy = false;
-    renderSummary();
-  }
+  const now = Date.now();
+  if (!force && now - lastPassiveWalletSyncAt < AUTO_REFRESH_AFTER_MS) return;
+  const synchronized = await syncWallet();
+  if (synchronized) lastPassiveWalletSyncAt = Date.now();
+}
+
+function schedulePassiveWalletSync({ force = false } = {}) {
+  if (DEMO_MODE) return;
+  forceNextPassiveWalletSync ||= force;
+  if (passiveWalletSyncTimer !== null) return;
+  passiveWalletSyncTimer = window.setTimeout(() => {
+    passiveWalletSyncTimer = null;
+    const forceSync = forceNextPassiveWalletSync;
+    forceNextPassiveWalletSync = false;
+    passiveWalletSync({ force: forceSync }).catch(() => undefined);
+  }, 250);
+}
+
+window.addEventListener("eip6963:announceProvider", () =>
+  schedulePassiveWalletSync({ force: true }),
+);
+window.addEventListener("focus", () => schedulePassiveWalletSync());
+window.addEventListener("pageshow", () => schedulePassiveWalletSync());
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "visible") schedulePassiveWalletSync();
 });
+
+elements.action.addEventListener("click", handlePrimaryAction);
 
 function seedDemoState() {
   state.account = TREASURY;
   state.chainId = MAINNET_CHAIN_ID;
   state.blockTag = "0x189f510";
   state.capability = "ready";
+  state.capabilityStatus = "ready";
   for (const hook of HOOKS) {
     state.hooks.set(hook.id, {
       actualCodeHash: hook.runtimeCodeHash,
@@ -3438,7 +3652,7 @@ if (DEMO_MODE) {
   seedDemoState();
 } else {
   renderSummary();
-  syncWallet().catch(() => {
+  passiveWalletSync({ force: true }).catch(() => {
     setStatus("MetaMask verbinden");
     renderSummary();
   });

--- a/ops/protocol-fee-claim/app.js
+++ b/ops/protocol-fee-claim/app.js
@@ -18,6 +18,7 @@ import {
   buildWalletSendCalls,
   confirmedBatchReceiptProof,
   confirmedTransactionReceiptMatches,
+  createLatestOperationGuard,
   createRefreshQueue,
   customClaimDefinitionClassification,
   customLaunchClassification,
@@ -96,7 +97,7 @@ const INTERACTIVE_WALLET_METHODS = new Set([
 const announcedWalletProviders = new Map();
 let boundWalletProvider = null;
 let walletAuthorizationRevision = 0;
-let walletSyncGeneration = 0;
+const walletSyncGuard = createLatestOperationGuard();
 
 function rememberAnnouncedWalletProvider(event) {
   const detail = event?.detail;
@@ -464,7 +465,7 @@ function clearWalletAuthorizationState() {
 
 function invalidateWalletAuthorizationState() {
   walletAuthorizationRevision += 1;
-  walletSyncGeneration += 1;
+  walletSyncGuard.invalidate();
   clearWalletAuthorizationState();
   return walletAuthorizationRevision;
 }
@@ -3101,15 +3102,26 @@ async function syncWallet({
   requestAccounts = false,
   expectedRevision = walletAuthorizationRevision,
 } = {}) {
-  const syncGeneration = ++walletSyncGeneration;
+  const syncOperation = walletSyncGuard.begin();
   const method = requestAccounts ? "eth_requestAccounts" : "eth_accounts";
-  const [accounts, chainId] = await Promise.all([
-    request(method),
-    request("eth_chainId"),
-  ]);
+  let accounts;
+  let chainId;
+  try {
+    [accounts, chainId] = await Promise.all([
+      request(method),
+      request("eth_chainId"),
+    ]);
+  } catch (error) {
+    if (
+      expectedRevision !== walletAuthorizationRevision ||
+      !syncOperation.isCurrent()
+    )
+      return false;
+    throw error;
+  }
   if (
     expectedRevision !== walletAuthorizationRevision ||
-    syncGeneration !== walletSyncGeneration
+    !syncOperation.isCurrent()
   )
     return false;
   state.account = Array.isArray(accounts) ? accounts[0] ?? null : null;

--- a/ops/protocol-fee-claim/build.mjs
+++ b/ops/protocol-fee-claim/build.mjs
@@ -10,6 +10,7 @@ const files = [
   "index.html",
   "logic.mjs",
   "styles.css",
+  "view-state.mjs",
 ];
 
 await rm(output, { force: true, recursive: true });
@@ -17,6 +18,10 @@ await mkdir(output, { recursive: true });
 
 await Promise.all(
   files.map((file) => cp(new URL(file, root), new URL(file, output))),
+);
+await cp(
+  new URL("./assets/programmable-loop-mark-64.png", root),
+  new URL("./favicon.ico", output),
 );
 await Promise.all(
   ["assets", "fonts"].map(async (directory) => {

--- a/ops/protocol-fee-claim/claim-discovery.json
+++ b/ops/protocol-fee-claim/claim-discovery.json
@@ -164,6 +164,24 @@
   },
   "classic": {
     "claimMode": "one_aggregate_claim_per_hook_version",
+    "routerAggregateClaims": [
+      {
+        "version": "v4",
+        "releaseStatus": "publicly-available",
+        "releaseCommit": "707d438576dcf47dc2667125789fd35eb1c3de50",
+        "publicAvailabilityCommit": "ff51e713feb52e4e13f3c553d1c726f3c8f2858c",
+        "indexerCatalogStatus": "indexer-activated",
+        "sourceCommitment": "0x038f0dec0856e2638eac146af373a388bf18fd40c6891fece4c9490b9dac18ca",
+        "launcher": "0xBBDF30a2fE1394e4AA864aC269C6cF09b518E699",
+        "feeHook": "0xADF955a44FD7F009380240d56D71dFAfB46020cc",
+        "feeHookDeploymentBlock": "25851137",
+        "feeHookRuntimeCodeHash": "0xf3a1a628ce898c527f24569b426aa795ec65ff9d97afa2b89e8ea5a2b99ad280",
+        "recipientSelector": "0x4c50e2c4",
+        "expectedRecipient": "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c",
+        "accruedSelector": "0x1497233e",
+        "claimSelector": "0x64d46b85"
+      }
+    ],
     "launchDiscovery": [
       {
         "version": "v3",

--- a/ops/protocol-fee-claim/index.html
+++ b/ops/protocol-fee-claim/index.html
@@ -6,7 +6,11 @@
     <meta name="robots" content="noindex,nofollow,noarchive" />
     <meta name="color-scheme" content="light" />
     <title>Programmable Fee Claim</title>
-    <link rel="icon" href="./assets/programmable-loop-mark-64.png" />
+    <link
+      rel="icon"
+      type="image/png"
+      href="./assets/programmable-loop-mark-64.png"
+    />
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
@@ -28,13 +32,11 @@
         <div class="hero">
           <p class="eyebrow">Fee Claim</p>
           <h1 id="claim-title">Alles claimen.</h1>
-          <p class="intro">
-            Reward Wallet verbinden. Offene Fees werden automatisch gefunden.
-          </p>
+          <p class="intro">Mit der Reward Wallet verbinden und claimen.</p>
         </div>
 
-        <div class="total-line" aria-label="Offene Gebühren">
-          <span>Offen</span>
+        <div class="total-line" aria-label="Offene Gebühren" data-total-card>
+          <span data-total-label>Wird geprüft</span>
           <strong data-total>0 ETH</strong>
           <small data-claim-count>Noch nicht gescannt</small>
         </div>
@@ -49,10 +51,11 @@
         </p>
         <p class="error" role="alert" data-error hidden></p>
 
-        <div class="quick-actions">
-          <button class="refresh" type="button" data-refresh hidden disabled>
-            Neu scannen
-          </button>
+        <div class="wallet-state" data-wallet-state data-state="idle">
+          Reward Wallet nicht verbunden
+        </div>
+
+        <div class="wallet-link">
           <a
             href="https://link.metamask.io/dapp/claimhazard.vercel.app/"
             data-metamask-open
@@ -60,7 +63,6 @@
           >
             In MetaMask öffnen
           </a>
-          <span>Nur die Reward Wallet kann claimen</span>
         </div>
 
         <details class="details">
@@ -76,6 +78,8 @@
                 <strong data-batch-mode>Wird geprüft</strong>
               </div>
             </div>
+
+            <p class="detail-error" data-error-detail hidden></p>
 
             <ul
               class="claim-list"

--- a/ops/protocol-fee-claim/logic.mjs
+++ b/ops/protocol-fee-claim/logic.mjs
@@ -1181,6 +1181,23 @@ export function createRefreshQueue(run) {
   };
 }
 
+export function createLatestOperationGuard() {
+  let generation = 0;
+  return Object.freeze({
+    begin() {
+      const operationGeneration = ++generation;
+      return Object.freeze({
+        isCurrent() {
+          return operationGeneration === generation;
+        },
+      });
+    },
+    invalidate() {
+      generation += 1;
+    },
+  });
+}
+
 export function formatEth(value, maximumFractionDigits = 6) {
   return formatUnits(value, 18, maximumFractionDigits);
 }

--- a/ops/protocol-fee-claim/logic.mjs
+++ b/ops/protocol-fee-claim/logic.mjs
@@ -270,9 +270,18 @@ export const TOKEN_SELECTORS = Object.freeze({
 
 export const HOOKS = Object.freeze([
   {
+    id: "classic-v4",
+    name: "Classic V4",
+    detail: "Aktuell",
+    kind: "native",
+    address: "0xADF955a44FD7F009380240d56D71dFAfB46020cc",
+    runtimeCodeHash:
+      "0xf3a1a628ce898c527f24569b426aa795ec65ff9d97afa2b89e8ea5a2b99ad280",
+  },
+  {
     id: "classic-v3",
     name: "Classic V3",
-    detail: "Aktuell",
+    detail: "Frühere Version",
     kind: "native",
     address: "0x35Fe236EA82F7cF525c9719d7df8F49F94D720CC",
     runtimeCodeHash:
@@ -1155,7 +1164,11 @@ export function createRefreshQueue(run) {
           try {
             while (requested) {
               requested = false;
-              await run();
+              try {
+                await run();
+              } catch (error) {
+                if (!requested) throw error;
+              }
             }
           } finally {
             active = null;

--- a/ops/protocol-fee-claim/logic.test.mjs
+++ b/ops/protocol-fee-claim/logic.test.mjs
@@ -68,10 +68,15 @@ import {
   walletSendDuplicateBatchId,
   withTimeout,
 } from "./logic.mjs";
+import {
+  SCAN_SNAPSHOT_SCHEMA,
+  createScanSnapshot,
+  parseScanSnapshot,
+} from "./view-state.mjs";
 
 test("binds exactly Classic and deployed Stock fee sources", () => {
-  assert.equal(HOOKS.length, 5);
-  assert.equal(CLAIMS.filter(({ kind }) => kind === "native").length, 3);
+  assert.equal(HOOKS.length, 6);
+  assert.equal(CLAIMS.filter(({ kind }) => kind === "native").length, 4);
   assert.equal(CLAIMS.filter(({ kind }) => kind === "asset").length, 18);
   assert.ok(
     HOOKS.every(
@@ -83,6 +88,124 @@ test("binds exactly Classic and deployed Stock fee sources", () => {
   assert.equal(
     HOOKS.some(({ id }) => id.includes("deep")),
     false,
+  );
+});
+
+test("round-trips a display-only scan snapshot for the exact reward wallet", () => {
+  const scannedAt = Date.UTC(2026, 7, 30, 16, 0, 0);
+  const snapshot = createScanSnapshot({
+    account: TREASURY,
+    chainId: MAINNET_CHAIN_ID,
+    blockNumber: 25_869_574n,
+    nativeWei: 558_522_000_000_000_000n,
+    claimCount: 12,
+    assetCount: 7,
+    scannedAt,
+  });
+  assert.equal(snapshot.schema, SCAN_SNAPSHOT_SCHEMA);
+  const parsed = parseScanSnapshot(
+    JSON.stringify({
+      ...snapshot,
+      claims: [{ claimData: "0xdeadbeef", verified: true }],
+      calls: [{ to: TREASURY, data: "0xdeadbeef" }],
+      claimData: "0xdeadbeef",
+    }),
+    {
+      expectedAccount: TREASURY,
+      expectedChainId: MAINNET_CHAIN_ID,
+      now: scannedAt + 1_000,
+    },
+  );
+  assert.deepEqual(parsed, snapshot);
+  assert.deepEqual(Object.keys(parsed).sort(), [
+    "account",
+    "assetCount",
+    "blockNumber",
+    "chainId",
+    "claimCount",
+    "nativeWei",
+    "scannedAt",
+    "schema",
+  ]);
+  assert.equal(Object.isFrozen(parsed), true);
+});
+
+test("rejects stale, foreign or malformed scan snapshots", () => {
+  const scannedAt = Date.UTC(2026, 7, 30, 16, 0, 0);
+  const snapshot = createScanSnapshot({
+    account: TREASURY,
+    chainId: MAINNET_CHAIN_ID,
+    blockNumber: 25_869_574n,
+    nativeWei: 1n,
+    claimCount: 1,
+    assetCount: 0,
+    scannedAt,
+  });
+  assert.throws(() =>
+    parseScanSnapshot(snapshot, {
+      expectedAccount: "0x0000000000000000000000000000000000000001",
+      expectedChainId: MAINNET_CHAIN_ID,
+      now: scannedAt,
+    }),
+  );
+  assert.throws(() =>
+    parseScanSnapshot(snapshot, {
+      expectedAccount: TREASURY,
+      expectedChainId: "0x2",
+      now: scannedAt,
+    }),
+  );
+  assert.throws(() =>
+    parseScanSnapshot(
+      { ...snapshot, nativeWei: "-1" },
+      {
+        expectedAccount: TREASURY,
+        expectedChainId: MAINNET_CHAIN_ID,
+        now: scannedAt,
+      },
+    ),
+  );
+  assert.throws(() =>
+    parseScanSnapshot(
+      { ...snapshot, nativeWei: "9".repeat(79) },
+      {
+        expectedAccount: TREASURY,
+        expectedChainId: MAINNET_CHAIN_ID,
+        now: scannedAt,
+      },
+    ),
+  );
+  assert.throws(() =>
+    parseScanSnapshot(snapshot, {
+      expectedAccount: TREASURY,
+      expectedChainId: MAINNET_CHAIN_ID,
+      now: scannedAt + 31 * 24 * 60 * 60 * 1_000,
+    }),
+  );
+});
+
+test("keeps the cached scan display-only and the main action wallet-first", () => {
+  const app = readFileSync(new URL("./app.js", import.meta.url), "utf8");
+  const index = readFileSync(new URL("./index.html", import.meta.url), "utf8");
+  const claimAll = app.slice(
+    app.indexOf("async function claimAll()"),
+    app.indexOf("async function resumeStoredBatch()"),
+  );
+  const primaryAction = app.slice(
+    app.indexOf("async function handlePrimaryAction()"),
+    app.indexOf('window.addEventListener("storage"'),
+  );
+
+  assert.equal((index.match(/data-action(?:\s|>)/g) ?? []).length, 1);
+  assert.doesNotMatch(index, /data-refresh|Neu scannen/);
+  assert.match(index, /Mit der Reward Wallet verbinden und claimen\./);
+  assert.match(app, /elements\.actionLabel\.textContent = "Erneut prüfen"/);
+  assert.match(app, /elements\.actionDetail\.textContent = "Reward Wallet bleibt verbunden"/);
+  assert.match(claimAll, /await refreshClaims\(\);/);
+  assert.doesNotMatch(claimAll, /scanSnapshot|SCAN_SNAPSHOT/);
+  assert.match(
+    primaryAction,
+    /if \([\s\S]*scanNeedsRetry\(verifiedHooks\)[\s\S]*claimableClaims\(\)\.length === 0[\s\S]*state\.capabilityStatus === "failed"[\s\S]*\)\s*await refreshClaims\(\);\s*else await claimAll\(\);/,
   );
 });
 
@@ -113,6 +236,26 @@ test("keeps the public claim discovery manifest aligned with the scanner", () =>
     manifest.classic.legacyAggregateClaim.feeHook.toLowerCase(),
     HOOKS.find(({ id }) => id === "classic-v1").address.toLowerCase(),
   );
+  assert.deepEqual(manifest.classic.routerAggregateClaims, [
+    {
+      version: "v4",
+      releaseStatus: "publicly-available",
+      releaseCommit: "707d438576dcf47dc2667125789fd35eb1c3de50",
+      publicAvailabilityCommit: "ff51e713feb52e4e13f3c553d1c726f3c8f2858c",
+      indexerCatalogStatus: "indexer-activated",
+      sourceCommitment:
+        "0x038f0dec0856e2638eac146af373a388bf18fd40c6891fece4c9490b9dac18ca",
+      launcher: "0xBBDF30a2fE1394e4AA864aC269C6cF09b518E699",
+      feeHook: HOOKS.find(({ id }) => id === "classic-v4").address,
+      feeHookDeploymentBlock: "25851137",
+      feeHookRuntimeCodeHash: HOOKS.find(({ id }) => id === "classic-v4")
+        .runtimeCodeHash,
+      recipientSelector: SELECTORS.launcherFeeRecipient,
+      expectedRecipient: TREASURY,
+      accruedSelector: SELECTORS.launcherFeesAccrued,
+      claimSelector: SELECTORS.claimLauncherFees,
+    },
+  ]);
   assert.equal(
     manifest.stock.claimLegCount,
     CLAIMS.filter(({ kind }) => kind === "asset").length,
@@ -349,9 +492,26 @@ test("keeps the static Vercel scanner on wallet RPC and serializes refreshes", (
     app,
     /async function syncAfterWalletEvent\(\) \{\s*const revision = invalidateWalletAuthorizationState\(\);[\s\S]*await syncWallet\(\{ expectedRevision: revision \}\);\s*\} catch \{\s*if \(revision !== walletAuthorizationRevision\) return;\s*clearWalletAuthorizationState\(\);/,
   );
+  assert.match(app, /const syncGeneration = \+\+walletSyncGeneration;/);
   assert.match(
     app,
-    /if \(expectedRevision !== walletAuthorizationRevision\) return;\s*state\.account =/,
+    /expectedRevision !== walletAuthorizationRevision \|\|\s*syncGeneration !== walletSyncGeneration/,
+  );
+  assert.match(
+    app,
+    /const synchronized = await syncWallet\(\);\s*if \(synchronized\) lastPassiveWalletSyncAt = Date\.now\(\);/,
+  );
+  assert.match(
+    app,
+    /"eip6963:announceProvider", \(\) =>\s*schedulePassiveWalletSync\(\{ force: true \}\)/,
+  );
+  assert.match(
+    app,
+    /state\.capabilityStatus = state\.capability \? "ready" : "unsupported";[\s\S]*state\.capabilityStatus = "failed";/,
+  );
+  assert.match(
+    app,
+    /state\.capabilityStatus === "failed"[\s\S]*elements\.action\.disabled = state\.busy;/,
   );
   assert.match(
     app,
@@ -582,6 +742,28 @@ test("queues one fresh scan when refresh is requested during an active scan", as
   const third = refresh();
   releaseFirst();
   await Promise.all([first, second, third]);
+
+  assert.deepEqual(runs, [1, 2]);
+});
+
+test("runs a queued retry after the active refresh fails", async () => {
+  let releaseFirst;
+  const firstGate = new Promise((resolve) => {
+    releaseFirst = resolve;
+  });
+  const runs = [];
+  const refresh = createRefreshQueue(async () => {
+    runs.push(runs.length + 1);
+    if (runs.length !== 1) return;
+    await firstGate;
+    throw new Error("first refresh failed");
+  });
+
+  const first = refresh();
+  await Promise.resolve();
+  const queued = refresh();
+  releaseFirst();
+  await Promise.all([first, queued]);
 
   assert.deepEqual(runs, [1, 2]);
 });

--- a/ops/protocol-fee-claim/logic.test.mjs
+++ b/ops/protocol-fee-claim/logic.test.mjs
@@ -23,6 +23,7 @@ import {
   confirmedBatchReceiptProof,
   confirmedTransactionReceiptMatches,
   claimData,
+  createLatestOperationGuard,
   createRefreshQueue,
   customClaimDefinitionClassification,
   customLaunchClassification,
@@ -492,10 +493,14 @@ test("keeps the static Vercel scanner on wallet RPC and serializes refreshes", (
     app,
     /async function syncAfterWalletEvent\(\) \{\s*const revision = invalidateWalletAuthorizationState\(\);[\s\S]*await syncWallet\(\{ expectedRevision: revision \}\);\s*\} catch \{\s*if \(revision !== walletAuthorizationRevision\) return;\s*clearWalletAuthorizationState\(\);/,
   );
-  assert.match(app, /const syncGeneration = \+\+walletSyncGeneration;/);
+  assert.match(app, /const syncOperation = walletSyncGuard\.begin\(\);/);
   assert.match(
     app,
-    /expectedRevision !== walletAuthorizationRevision \|\|\s*syncGeneration !== walletSyncGeneration/,
+    /catch \(error\) \{\s*if \(\s*expectedRevision !== walletAuthorizationRevision \|\|\s*!syncOperation\.isCurrent\(\)[\s\S]*return false;\s*throw error;/,
+  );
+  assert.match(
+    app,
+    /expectedRevision !== walletAuthorizationRevision \|\|\s*!syncOperation\.isCurrent\(\)/,
   );
   assert.match(
     app,
@@ -766,6 +771,30 @@ test("runs a queued retry after the active refresh fails", async () => {
   await Promise.all([first, queued]);
 
   assert.deepEqual(runs, [1, 2]);
+});
+
+test("ignores an older wallet sync that rejects after the newest sync succeeds", async () => {
+  const guard = createLatestOperationGuard();
+  let rejectOlder;
+  const olderResponse = new Promise((_, reject) => {
+    rejectOlder = reject;
+  });
+  const publish = async (response) => {
+    const operation = guard.begin();
+    try {
+      const value = await response;
+      return operation.isCurrent() ? value : "stale";
+    } catch (error) {
+      if (!operation.isCurrent()) return "stale";
+      throw error;
+    }
+  };
+
+  const older = publish(olderResponse);
+  const newest = publish(Promise.resolve("reward-wallet"));
+  assert.equal(await newest, "reward-wallet");
+  rejectOlder(new Error("late wallet timeout"));
+  assert.equal(await older, "stale");
 });
 
 test("uses the deployed claim and read selectors", () => {

--- a/ops/protocol-fee-claim/styles.css
+++ b/ops/protocol-fee-claim/styles.css
@@ -166,6 +166,18 @@ h1 {
   margin-bottom: 16px;
   min-height: 160px;
   padding: 26px;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease;
+}
+
+.total-line[data-state="cached"] {
+  background: var(--paper);
+  border-color: var(--line);
+}
+
+.total-line[data-state="loading"] strong {
+  color: var(--ink-soft);
 }
 
 .total-line span {
@@ -307,7 +319,10 @@ h1 {
   border-top: 1px solid var(--line);
   list-style: none;
   margin: 0 -16px;
+  max-height: 420px;
+  overflow-y: auto;
   padding: 0 16px;
+  overscroll-behavior: contain;
 }
 
 .asset-list .claim-row {
@@ -343,19 +358,6 @@ h1 {
   white-space: nowrap;
 }
 
-.refresh {
-  background: transparent;
-  border: 0;
-  color: var(--pink-dark);
-  min-height: 44px;
-  padding: 0 6px;
-}
-
-.refresh:disabled {
-  color: var(--ink-soft);
-  opacity: 0.52;
-}
-
 .primary {
   align-items: center;
   background: var(--pink);
@@ -366,8 +368,8 @@ h1 {
   flex-direction: column;
   gap: 5px;
   justify-content: center;
-  min-height: 68px;
-  padding: 10px 18px;
+  min-height: 78px;
+  padding: 12px 20px;
   transition:
     background-color 140ms ease,
     transform 140ms ease;
@@ -385,23 +387,22 @@ h1 {
   opacity: 0.55;
 }
 .primary strong {
-  font-size: 16px;
+  font-size: 19px;
   font-weight: 720;
 }
 .primary span {
   font:
-    500 11px/1 "Geist Mono",
+    500 12px/1.2 "Geist Mono",
     monospace;
   opacity: 0.72;
 }
 
 .status {
   color: var(--ink-soft);
-  font:
-    500 11px/1.45 "Geist Mono",
-    monospace;
-  margin: 14px 0 0;
-  min-height: 16px;
+  font-size: 13px;
+  line-height: 1.4;
+  margin: 16px 0 0;
+  min-height: 18px;
   text-align: center;
 }
 
@@ -417,28 +418,55 @@ h1 {
   text-align: center;
 }
 
-.quick-actions {
+.wallet-state {
   align-items: center;
   color: var(--ink-soft);
   display: flex;
-  font:
-    500 10px/1.4 "Geist Mono",
-    monospace;
+  font-size: 12px;
+  gap: 8px;
   justify-content: center;
   margin: 10px 0 28px;
   min-height: 44px;
 }
-.quick-actions a {
+
+.wallet-state::before {
+  background: var(--ink-soft);
+  border-radius: 50%;
+  content: "";
+  height: 7px;
+  width: 7px;
+}
+
+.wallet-state[data-state="ready"]::before {
+  background: var(--success);
+}
+
+.wallet-state[data-state="wrong"]::before {
+  background: var(--danger);
+}
+
+.wallet-link {
+  display: flex;
+  justify-content: center;
+  margin: -18px 0 28px;
+}
+
+.wallet-link:empty,
+.wallet-link:has(> [hidden]) {
+  display: none;
+}
+
+.wallet-link a {
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: 10px;
   color: var(--pink-dark);
+  display: inline-flex;
+  justify-content: center;
   min-height: 44px;
-  padding: 14px 6px;
+  padding: 0 16px;
   text-decoration-thickness: 1px;
   text-underline-offset: 3px;
-}
-.quick-actions > :not([hidden]) + span::before {
-  color: var(--line);
-  content: "·";
-  margin: 0 8px 0 4px;
 }
 
 .details {
@@ -467,6 +495,17 @@ h1 {
 }
 .details-body {
   padding: 8px 0 0;
+}
+
+.detail-error {
+  background: #fff7f2;
+  border: 1px solid #eadbd2;
+  border-radius: 8px;
+  color: var(--warning);
+  font-size: 11px;
+  line-height: 1.5;
+  margin: 0 0 14px;
+  padding: 10px 12px;
 }
 
 .trust {
@@ -542,9 +581,14 @@ h1 {
   .disclosure-indicator {
     margin-left: 0;
   }
-  .quick-actions {
-    flex-wrap: wrap;
+  .wallet-state {
     margin-bottom: 22px;
+  }
+  .wallet-link {
+    margin-bottom: 22px;
+  }
+  .wallet-link a {
+    width: 100%;
   }
   .trust {
     margin-top: 16px;

--- a/ops/protocol-fee-claim/view-state.mjs
+++ b/ops/protocol-fee-claim/view-state.mjs
@@ -1,0 +1,95 @@
+export const SCAN_SNAPSHOT_SCHEMA =
+  "programmable.fee-claim-scan-snapshot.v1";
+export const SCAN_SNAPSHOT_STORAGE_KEY =
+  "programmable.fee-claim.scan-snapshot.v1";
+
+const MAX_SNAPSHOT_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_FUTURE_SKEW_MS = 5 * 60 * 1000;
+const MAX_DISPLAY_COUNT = 100_000;
+const MAX_UINT256_DECIMAL_DIGITS = 78;
+
+function parseNonNegativeInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 0 || value > MAX_DISPLAY_COUNT)
+    throw new Error(`${label} ist ungültig`);
+  return value;
+}
+
+function parsePositiveDecimal(value, label) {
+  if (
+    typeof value !== "string" ||
+    value.length > MAX_UINT256_DECIMAL_DIGITS ||
+    !/^[1-9][0-9]*$/.test(value)
+  )
+    throw new Error(`${label} ist ungültig`);
+  return BigInt(value).toString();
+}
+
+function parseNonNegativeDecimal(value, label) {
+  if (
+    typeof value !== "string" ||
+    value.length > MAX_UINT256_DECIMAL_DIGITS ||
+    !/^(?:0|[1-9][0-9]*)$/.test(value)
+  )
+    throw new Error(`${label} ist ungültig`);
+  return BigInt(value).toString();
+}
+
+export function parseScanSnapshot(
+  value,
+  { expectedAccount, expectedChainId, now = Date.now() },
+) {
+  const parsed = typeof value === "string" ? JSON.parse(value) : value;
+  if (!parsed || typeof parsed !== "object")
+    throw new Error("Scan-Snapshot fehlt");
+  if (parsed.schema !== SCAN_SNAPSHOT_SCHEMA)
+    throw new Error("Scan-Snapshot-Schema stimmt nicht");
+  if (
+    typeof expectedAccount !== "string" ||
+    parsed.account?.toLowerCase() !== expectedAccount.toLowerCase()
+  )
+    throw new Error("Scan-Snapshot-Wallet stimmt nicht");
+  if (parsed.chainId !== expectedChainId)
+    throw new Error("Scan-Snapshot-Netzwerk stimmt nicht");
+  if (
+    !Number.isSafeInteger(parsed.scannedAt) ||
+    parsed.scannedAt <= 0 ||
+    parsed.scannedAt > now + MAX_FUTURE_SKEW_MS ||
+    now - parsed.scannedAt > MAX_SNAPSHOT_AGE_MS
+  )
+    throw new Error("Scan-Snapshot ist nicht mehr aktuell genug");
+
+  return Object.freeze({
+    schema: SCAN_SNAPSHOT_SCHEMA,
+    account: expectedAccount.toLowerCase(),
+    chainId: expectedChainId,
+    blockNumber: parsePositiveDecimal(parsed.blockNumber, "Blocknummer"),
+    nativeWei: parseNonNegativeDecimal(parsed.nativeWei, "ETH-Betrag"),
+    claimCount: parseNonNegativeInteger(parsed.claimCount, "Claim-Anzahl"),
+    assetCount: parseNonNegativeInteger(parsed.assetCount, "Asset-Anzahl"),
+    scannedAt: parsed.scannedAt,
+  });
+}
+
+export function createScanSnapshot({
+  account,
+  chainId,
+  blockNumber,
+  nativeWei,
+  claimCount,
+  assetCount,
+  scannedAt = Date.now(),
+}) {
+  return parseScanSnapshot(
+    {
+      schema: SCAN_SNAPSHOT_SCHEMA,
+      account,
+      chainId,
+      blockNumber: BigInt(blockNumber).toString(),
+      nativeWei: BigInt(nativeWei).toString(),
+      claimCount,
+      assetCount,
+      scannedAt,
+    },
+    { expectedAccount: account, expectedChainId: chainId, now: scannedAt },
+  );
+}


### PR DESCRIPTION
## Outcome

Simplifies Claimhazard to one wallet-first action: connect the reward wallet, scan automatically, and claim through the same large primary button.

## Changes

- persists only a validated display snapshot so reloads no longer flash a false zero
- keeps cached data completely outside claim selection, calldata, safety gates, and wallet sends
- separates retry from claim so a retry click can never open a claim confirmation
- prevents stale passive wallet syncs, including late failures, from overwriting a fresh MetaMask connection
- retries late EIP-6963 discovery and transient capability failures through the primary action
- bounds long launch lists and keeps technical failures inside collapsed details
- adds the exact publicly released Classic V4 aggregate hook binding and public-availability provenance
- keeps every claim fail-closed behind a fresh scan, wallet recheck, runtime/recipient verification, simulation, and atomic batch lock

## Verification

- npm ci
- npm run check: 44 passed, 0 failed; static build passed
- git diff --check
- independent post-fix code audit passed
- desktop 1440x900, mobile 390x844, narrow 320x700 browser QA
- reload/correction pass, focus order, console, network, overflow, and favicon checks
- no wallet prompt, signature, or transaction was triggered during QA