### PR TITLE
fix(contracts): tolerate fast Robinhood pending heads

### DIFF
--- a/contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs
+++ b/contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs
@@ -1216,8 +1216,14 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
 
   const closings = await Promise.all(
     providers.map(async (provider) => {
-      const [latestNonceValue, pendingNonceValue, codes, vacancyNonces] =
-        await Promise.all([
+      const [
+        latestNonceValue,
+        pendingNonceValue,
+        codes,
+        vacancyNonces,
+        callResultValue,
+        estimateValue,
+      ] = await Promise.all([
           rpc(
             provider,
             "eth_getTransactionCount",
@@ -1246,6 +1252,20 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
             rpcClient,
             requestTimeoutMs,
           }),
+          rpc(
+            provider,
+            "eth_call",
+            [simulationRequest, "pending"],
+            rpcClient,
+            requestTimeoutMs,
+          ),
+          rpc(
+            provider,
+            "eth_estimateGas",
+            [simulationRequest, "pending"],
+            rpcClient,
+            requestTimeoutMs,
+          ),
         ]);
       return {
         latestNonce: parseQuantity(
@@ -1258,6 +1278,14 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
         ),
         codes,
         vacancyNonces,
+        callResult: exactCode(
+          callResultValue,
+          `${provider.providerId} action-time closing simulation result`,
+        ),
+        estimatedGas: parseQuantity(
+          estimateValue,
+          `${provider.providerId} action-time closing gas estimate`,
+        ),
       };
     }),
   );
@@ -1270,7 +1298,12 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
       closing.pendingNonce !== snapshots[index].pendingNonce ||
       JSON.stringify(closing.codes) !== JSON.stringify(snapshots[index].codes) ||
       JSON.stringify(closing.vacancyNonces) !==
-        JSON.stringify(snapshots[index].vacancyNonces)
+        JSON.stringify(snapshots[index].vacancyNonces) ||
+      closing.callResult !== snapshots[index].callResult ||
+      closing.callResult !== snapshots[0].callResult ||
+      closing.estimatedGas !== snapshots[index].estimatedGas ||
+      closing.estimatedGas !== expectedGasEstimate ||
+      closing.estimatedGas > reviewedGasLimit
     ) {
       fail(`${providerId} action-time state changed during wallet verification`);
     }
@@ -1292,7 +1325,9 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
     closings[0].pendingNonce !== closings[1].pendingNonce ||
     JSON.stringify(closings[0].codes) !== JSON.stringify(closings[1].codes) ||
     JSON.stringify(closings[0].vacancyNonces) !==
-      JSON.stringify(closings[1].vacancyNonces)
+      JSON.stringify(closings[1].vacancyNonces) ||
+    closings[0].callResult !== closings[1].callResult ||
+    closings[0].estimatedGas !== closings[1].estimatedGas
   ) {
     fail("Robinhood RPCs disagree on action-time closing owner-wallet state");
   }
@@ -1304,6 +1339,8 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
     preparedAddressCount: Object.keys(preparedBindings).length,
     pendingSimulationVerified: true,
     pendingGasEstimate: expectedGasEstimate.toString(),
+    closingSimulationVerified: true,
+    closingGasEstimate: expectedGasEstimate.toString(),
     closingVacancyVerified: true,
     rpcResponseBytesConsumed: responseBudget.consumed,
   });
@@ -1629,17 +1666,7 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
       };
     }),
   );
-  const pendingBlockAgreement =
-    pendingSnapshots[0].pendingBlock.parentHash ===
-      pendingSnapshots[1].pendingBlock.parentHash &&
-    pendingSnapshots[0].pendingBlock.timestamp ===
-      pendingSnapshots[1].pendingBlock.timestamp &&
-    pendingSnapshots[0].pendingBlock.gasLimit ===
-      pendingSnapshots[1].pendingBlock.gasLimit &&
-    pendingSnapshots[0].pendingBlock.baseFeePerGas ===
-      pendingSnapshots[1].pendingBlock.baseFeePerGas;
   if (
-    !pendingBlockAgreement ||
     JSON.stringify(pendingSnapshots[0].codes) !==
       JSON.stringify(pendingSnapshots[1].codes) ||
     JSON.stringify(pendingSnapshots[0].vacancyNonces) !==
@@ -1673,6 +1700,8 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
         priorityFeeValue,
         codes,
         vacancyNonces,
+        callResult,
+        estimateValue,
       ] = await Promise.all([
         rpc(
           provider,
@@ -1705,7 +1734,7 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
         ),
         readCodes({
           provider,
-          bindings: release.preparedBindings,
+          bindings: allBindings,
           blockTag: "pending",
           rpcClient,
           requestTimeoutMs,
@@ -1717,6 +1746,36 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
           rpcClient,
           requestTimeoutMs,
         }),
+        rpc(
+          provider,
+          "eth_call",
+          [
+            {
+              from: transaction.owner,
+              to: transaction.to,
+              value: "0x0",
+              data: transaction.data,
+            },
+            "pending",
+          ],
+          rpcClient,
+          requestTimeoutMs,
+        ),
+        rpc(
+          provider,
+          "eth_estimateGas",
+          [
+            {
+              from: transaction.owner,
+              to: transaction.to,
+              value: "0x0",
+              data: transaction.data,
+            },
+            "pending",
+          ],
+          rpcClient,
+          requestTimeoutMs,
+        ),
       ]);
       return {
         anchor: exactBlock(
@@ -1741,6 +1800,14 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
         ),
         codes,
         vacancyNonces,
+        callResult: exactCode(
+          callResult,
+          `${provider.providerId} closing simulation result`,
+        ),
+        estimatedGas: parseQuantity(
+          estimateValue,
+          `${provider.providerId} closing gas estimate`,
+        ),
       };
     }),
   );
@@ -1749,18 +1816,20 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
       closing.anchor.number !== commonBlockNumber ||
       closing.anchor.hash !== commonBlocks[0].hash ||
       closing.pendingNonce !== nonce ||
-      closing.pendingBlock.parentHash !==
-        pendingSnapshots[0].pendingBlock.parentHash ||
-      closing.pendingBlock.baseFeePerGas !==
-        pendingSnapshots[0].pendingBlock.baseFeePerGas ||
-      closing.pendingBlock.gasLimit !==
-        pendingSnapshots[0].pendingBlock.gasLimit
+      JSON.stringify(closing.codes) !==
+        JSON.stringify(pendingSnapshots[index].codes) ||
+      JSON.stringify(closing.vacancyNonces) !==
+        JSON.stringify(pendingSnapshots[index].vacancyNonces) ||
+      closing.callResult !== pendingSnapshots[index].callResult ||
+      closing.estimatedGas !== pendingSnapshots[index].estimatedGas ||
+      closing.estimatedGas !== estimatedGas ||
+      gasLimit > closing.pendingBlock.gasLimit
     ) {
       fail(`${providers[index].providerId} state changed during preflight`);
     }
     verifyCodeSnapshot({
       snapshot: closing.codes,
-      dependencies: {},
+      dependencies: release.dependencyBindings,
       prepared: release.preparedBindings,
       label: `${providers[index].providerId} closing`,
       runtimeCodeHash,
@@ -1773,26 +1842,36 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
   }
   if (
     closings[0].pendingNonce !== closings[1].pendingNonce ||
-    closings[0].gasPrice !== closings[1].gasPrice ||
-    closings[0].priorityFee !== closings[1].priorityFee ||
-    closings[0].pendingBlock.parentHash !==
-      closings[1].pendingBlock.parentHash ||
-    closings[0].pendingBlock.timestamp !== closings[1].pendingBlock.timestamp ||
-    closings[0].pendingBlock.baseFeePerGas !==
-      closings[1].pendingBlock.baseFeePerGas ||
-    closings[0].pendingBlock.gasLimit !== closings[1].pendingBlock.gasLimit ||
     JSON.stringify(closings[0].codes) !== JSON.stringify(closings[1].codes) ||
     JSON.stringify(closings[0].vacancyNonces) !==
-      JSON.stringify(closings[1].vacancyNonces)
+      JSON.stringify(closings[1].vacancyNonces) ||
+    closings[0].callResult !== closings[1].callResult ||
+    closings[0].estimatedGas !== closings[1].estimatedGas
   ) {
-    fail("Robinhood RPCs disagree on closing nonce, fees, or vacancy");
+    fail(
+      "Robinhood RPCs disagree on closing nonce, code, vacancy, simulation, or gas",
+    );
   }
-  const maxPriorityFeePerGas = closings[0].priorityFee;
-  const baseFeePerGas = closings[0].pendingBlock.baseFeePerGas;
+  const maxPriorityFeePerGas = closings.reduce(
+    (maximum, { priorityFee }) =>
+      priorityFee > maximum ? priorityFee : maximum,
+    0n,
+  );
+  const baseFeePerGas = closings.reduce(
+    (maximum, { pendingBlock }) =>
+      pendingBlock.baseFeePerGas > maximum
+        ? pendingBlock.baseFeePerGas
+        : maximum,
+    0n,
+  );
+  const observedGasPrice = closings.reduce(
+    (maximum, { gasPrice }) => (gasPrice > maximum ? gasPrice : maximum),
+    0n,
+  );
   const doubledBaseFeeEnvelope = 2n * baseFeePerGas + maxPriorityFeePerGas;
   const maxFeePerGas =
-    closings[0].gasPrice > doubledBaseFeeEnvelope
-      ? closings[0].gasPrice
+    observedGasPrice > doubledBaseFeeEnvelope
+      ? observedGasPrice
       : doubledBaseFeeEnvelope;
   if (
     maxFeePerGas <= 0n ||
@@ -1872,13 +1951,20 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
         blockHash: commonBlocks[0].hash,
         blockTimestamp: commonBlocks[0].timestamp.toString(),
       },
-      pendingBlock: {
-        parentHash: pendingSnapshots[0].pendingBlock.parentHash,
-        blockTimestamp: pendingSnapshots[0].pendingBlock.timestamp.toString(),
-        gasLimit: pendingSnapshots[0].pendingBlock.gasLimit.toString(),
-        baseFeePerGas:
-          pendingSnapshots[0].pendingBlock.baseFeePerGas.toString(),
-      },
+      openingPendingBlocks: pendingSnapshots.map(({ pendingBlock }, index) => ({
+        providerId: providerBindings[index].providerId,
+        parentHash: pendingBlock.parentHash,
+        blockTimestamp: pendingBlock.timestamp.toString(),
+        gasLimit: pendingBlock.gasLimit.toString(),
+        baseFeePerGas: pendingBlock.baseFeePerGas.toString(),
+      })),
+      closingPendingBlocks: closings.map(({ pendingBlock }, index) => ({
+        providerId: providerBindings[index].providerId,
+        parentHash: pendingBlock.parentHash,
+        blockTimestamp: pendingBlock.timestamp.toString(),
+        gasLimit: pendingBlock.gasLimit.toString(),
+        baseFeePerGas: pendingBlock.baseFeePerGas.toString(),
+      })),
     },
     preparedAddresses: EXPECTED_PREPARED_ADDRESSES,
     transaction: {
@@ -1908,6 +1994,9 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
       gasEstimates: pendingSnapshots.map(({ estimatedGas: value }) =>
         value.toString(),
       ),
+      closingGasEstimates: closings.map(({ estimatedGas: value }) =>
+        value.toString(),
+      ),
       agreedGasEstimate: estimatedGas.toString(),
     },
     gasPolicy: {
@@ -1919,7 +2008,7 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
         ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_MAX_GAS_LIMIT.toString(),
       reviewedGasLimit: gasLimit.toString(),
       observedPendingBaseFeePerGasWei: baseFeePerGas.toString(),
-      observedGasPriceWei: closings[0].gasPrice.toString(),
+      observedGasPriceWei: observedGasPrice.toString(),
       observedMaxPriorityFeePerGasWei: maxPriorityFeePerGas.toString(),
       reviewedMaxFeePerGasWei: maxFeePerGas.toString(),
       maximumGasCostWei: reviewedMaximumGasCostWei.toString(),
@@ -1936,14 +2025,18 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
       exactFreshDeterministicCompilation: true,
       independentAuthenticatedRpcCount: 2,
       commonBlockAgreement: true,
-      pendingBlockAgreement: true,
+      movingPendingHeadsTolerated: true,
+      stateRelevantOpeningAgreement: true,
+      stateRelevantClosingAgreement: true,
       dependencyRuntimePinsVerified: true,
       fixedAndPendingCodeAndNonceVacancyVerified: true,
       pendingSimulationAgreement: true,
       pendingGasAgreement: true,
       pendingNonceAgreement: true,
       noPendingOwnerTransaction: true,
-      closingFeeAgreement: true,
+      closingSimulationAgreement: true,
+      closingGasAgreement: true,
+      closingFeeCeilingUsesProviderMaxima: true,
       closingVacancyVerified: true,
       boundedTimeout: true,
       rpcResponseBudgetBytes: RPC_AGGREGATE_RESPONSE_LIMIT_BYTES,

--- a/contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs
+++ b/contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs
@@ -11,7 +11,7 @@ import {
 import { canonicalizeJson } from "../../packages/launch/src/canonical-json.mjs";
 
 export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_SCHEMA =
-  "programmable.robinhood-custom-launch.owner-envelope.v1";
+  "programmable.robinhood-custom-launch.owner-envelope.v2";
 export const ROBINHOOD_FOUNDATION_HOSTED_VERIFY_SCHEMA =
   "programmable.robinhood-custom-launch.hosted-verify-binding.v1";
 export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_TTL_SECONDS = 300;
@@ -153,6 +153,125 @@ const EXPECTED_RECEIPT_TOP_LEVEL_KEYS = Object.freeze([
   "status",
   "transaction",
 ]);
+const EXPECTED_SOURCE_KEYS = Object.freeze([
+  "chainProfileSha256",
+  "clean",
+  "commit",
+  "foundationSourceCommitment",
+  "predeploymentSha256",
+  "productionBaseCommit",
+  "productionBaseTree",
+  "tree",
+]);
+const EXPECTED_PREPARED_ARTIFACT_KEYS = Object.freeze([
+  "foundationSourceCommitment",
+  "path",
+  "sha256",
+]);
+const EXPECTED_OBSERVATION_KEYS = Object.freeze([
+  "closingFeeObservations",
+  "closingPendingBlocks",
+  "commonAnchor",
+  "createdAtTimestamp",
+  "elapsedMilliseconds",
+  "expiresAtTimestamp",
+  "minimumRemainingTtlSeconds",
+  "openingHeads",
+  "openingPendingBlocks",
+  "operationStartedAtTimestamp",
+  "ttlSeconds",
+]);
+const EXPECTED_PENDING_OBSERVATION_KEYS = Object.freeze([
+  "baseFeePerGas",
+  "blockTimestamp",
+  "gasLimit",
+  "parentHash",
+  "providerId",
+]);
+const EXPECTED_OPENING_HEAD_KEYS = Object.freeze([
+  "blockHash",
+  "blockNumber",
+  "blockTimestamp",
+  "providerId",
+]);
+const EXPECTED_COMMON_ANCHOR_KEYS = Object.freeze([
+  "blockHash",
+  "blockNumber",
+  "blockTimestamp",
+]);
+const EXPECTED_FEE_OBSERVATION_KEYS = Object.freeze([
+  "gasPrice",
+  "maxPriorityFeePerGas",
+  "providerId",
+]);
+const EXPECTED_SIMULATION_KEYS = Object.freeze([
+  "agreedGasEstimate",
+  "allComponentsSucceeded",
+  "blockTag",
+  "closingGasEstimates",
+  "gasEstimates",
+  "returnDataKeccak256",
+  "returnedAddresses",
+]);
+const EXPECTED_CHECK_KEYS = Object.freeze([
+  "boundedTimeout",
+  "closingFeeCeilingUsesProviderMaxima",
+  "closingGasAgreement",
+  "closingSimulationAgreement",
+  "closingVacancyVerified",
+  "commonBlockAgreement",
+  "dependencyRuntimePinsVerified",
+  "exactCleanSource",
+  "exactFreshDeterministicCompilation",
+  "exactPreparedArtifact",
+  "fixedAndPendingCodeAndNonceVacancyVerified",
+  "independentAuthenticatedRpcCount",
+  "movingPendingHeadsTolerated",
+  "noPendingOwnerTransaction",
+  "pendingGasAgreement",
+  "pendingNonceAgreement",
+  "pendingSimulationAgreement",
+  "rpcMethodInventory",
+  "rpcResponseBudgetBytes",
+  "rpcResponseBytesConsumed",
+  "stateRelevantClosingAgreement",
+  "stateRelevantOpeningAgreement",
+]);
+const EXPECTED_GAS_POLICY_KEYS = Object.freeze([
+  "balanceReadPerformed",
+  "fixedHeadroomGas",
+  "fundingVerified",
+  "headroomBasisPoints",
+  "maximumGasCostWei",
+  "maximumGasLimit",
+  "observedGasPriceWei",
+  "observedMaxPriorityFeePerGasWei",
+  "observedPendingBaseFeePerGasWei",
+  "ownerMaximumFeePerGasWei",
+  "ownerMaximumGasCostWei",
+  "ownerMaximumPriorityFeePerGasWei",
+  "reviewedGasLimit",
+  "reviewedMaxFeePerGasWei",
+]);
+const EXPECTED_TRANSACTION_KEYS = Object.freeze([
+  "chainId",
+  "from",
+  "gasLimit",
+  "gasQuantity",
+  "input",
+  "inputBytes",
+  "inputKeccak256",
+  "maxFeePerGas",
+  "maxFeePerGasQuantity",
+  "maxPriorityFeePerGas",
+  "maxPriorityFeePerGasQuantity",
+  "nonce",
+  "nonceQuantity",
+  "selector",
+  "to",
+  "type",
+  "valueWei",
+]);
 const RPC_RESPONSE_LIMIT_BYTES = Object.freeze({
   eth_chainId: 8 * 1024,
   eth_getBlockByNumber: 128 * 1024,
@@ -173,11 +292,21 @@ function sha256(value) {
   return `sha256:${createHash("sha256").update(value).digest("hex")}`;
 }
 
+function hasExactKeys(value, expectedKeys) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value).sort().join("\0") ===
+      [...expectedKeys].sort().join("\0")
+  );
+}
+
 function ownerEnvelopeReceiptDigest(receipt) {
   return sha256(
     Buffer.concat([
       Buffer.from(
-        "programmable.robinhood-custom-launch.owner-envelope.receipt.v1",
+        "programmable.robinhood-custom-launch.owner-envelope.receipt.v2",
         "utf8",
       ),
       Buffer.from([0]),
@@ -253,6 +382,7 @@ export function assertFreshRobinhoodFoundationOwnerEnvelope(
   const nowTimestamp = Math.floor(nowMilliseconds / 1_000);
   let transactionIsExact = false;
   const releaseIsExact =
+    hasExactKeys(receipt.source, EXPECTED_SOURCE_KEYS) &&
     /^[0-9a-f]{40}$/u.test(receipt.source?.commit ?? "") &&
     /^[0-9a-f]{40}$/u.test(receipt.source?.tree ?? "") &&
     receipt.source?.clean === true &&
@@ -262,6 +392,12 @@ export function assertFreshRobinhoodFoundationOwnerEnvelope(
     receipt.source?.predeploymentSha256 === PREDEPLOYMENT_SHA256 &&
     receipt.source?.foundationSourceCommitment ===
       FOUNDATION_SOURCE_COMMITMENT &&
+    hasExactKeys(
+      receipt.preparedArtifact,
+      EXPECTED_PREPARED_ARTIFACT_KEYS,
+    ) &&
+    receipt.preparedArtifact?.path ===
+      "contracts/deployments/robinhood-custom-launch-v1.predeployment.json" &&
     receipt.preparedArtifact?.sha256 === PREDEPLOYMENT_SHA256 &&
     receipt.preparedArtifact?.foundationSourceCommitment ===
       FOUNDATION_SOURCE_COMMITMENT &&
@@ -294,6 +430,276 @@ export function assertFreshRobinhoodFoundationOwnerEnvelope(
   } catch {
     hostedVerifyIsExact = false;
   }
+  let evidenceIsExact = false;
+  try {
+    const providerIds = EXPECTED_PROVIDER_PINS.map(({ providerId }) => providerId);
+    const observation = receipt.observation;
+    const openingHeads = observation.openingHeads.map((head, index) => {
+      if (
+        !hasExactKeys(head, EXPECTED_OPENING_HEAD_KEYS) ||
+        head.providerId !== providerIds[index]
+      ) {
+        fail("receipt opening head is invalid");
+      }
+      return {
+        number: parseDecimalWei(head.blockNumber, "receipt opening block"),
+        hash: exactHash(head.blockHash, "receipt opening block hash"),
+        timestamp: parseDecimalWei(
+          head.blockTimestamp,
+          "receipt opening block timestamp",
+        ),
+      };
+    });
+    if (openingHeads.length !== providerIds.length) {
+      fail("receipt opening head count is invalid");
+    }
+    if (!hasExactKeys(observation.commonAnchor, EXPECTED_COMMON_ANCHOR_KEYS)) {
+      fail("receipt common anchor is invalid");
+    }
+    const commonAnchor = {
+      number: parseDecimalWei(
+        observation.commonAnchor.blockNumber,
+        "receipt common block",
+      ),
+      hash: exactHash(
+        observation.commonAnchor.blockHash,
+        "receipt common block hash",
+      ),
+      timestamp: parseDecimalWei(
+        observation.commonAnchor.blockTimestamp,
+        "receipt common block timestamp",
+      ),
+    };
+    const openingMinimum = openingHeads.reduce(
+      (minimum, { number }) => (number < minimum ? number : minimum),
+      openingHeads[0].number,
+    );
+    if (
+      commonAnchor.number !== openingMinimum ||
+      openingHeads.some(
+        ({ number, hash, timestamp }) =>
+          number === commonAnchor.number &&
+          (hash !== commonAnchor.hash || timestamp !== commonAnchor.timestamp),
+      )
+    ) {
+      fail("receipt common anchor differs from the opening heads");
+    }
+    const normalizePendingObservations = (values, label) => {
+      if (!Array.isArray(values) || values.length !== providerIds.length) {
+        fail(`receipt ${label} pending observation count is invalid`);
+      }
+      return values.map((value, index) => {
+        if (
+          !hasExactKeys(value, EXPECTED_PENDING_OBSERVATION_KEYS) ||
+          value.providerId !== providerIds[index]
+        ) {
+          fail(`receipt ${label} pending observation is invalid`);
+        }
+        return {
+          parentHash: exactHash(
+            value.parentHash,
+            `receipt ${label} pending parent hash`,
+          ),
+          timestamp: parseDecimalWei(
+            value.blockTimestamp,
+            `receipt ${label} pending timestamp`,
+          ),
+          gasLimit: parseDecimalWei(
+            value.gasLimit,
+            `receipt ${label} pending gas limit`,
+          ),
+          baseFeePerGas: parseDecimalWei(
+            value.baseFeePerGas,
+            `receipt ${label} pending base fee`,
+            { positive: false },
+          ),
+        };
+      });
+    };
+    const openingPendingBlocks = normalizePendingObservations(
+      observation.openingPendingBlocks,
+      "opening",
+    );
+    const closingPendingBlocks = normalizePendingObservations(
+      observation.closingPendingBlocks,
+      "closing",
+    );
+    if (
+      !Array.isArray(observation.closingFeeObservations) ||
+      observation.closingFeeObservations.length !== providerIds.length
+    ) {
+      fail("receipt closing fee observation count is invalid");
+    }
+    const closingFees = observation.closingFeeObservations.map(
+      (value, index) => {
+        if (
+          !hasExactKeys(value, EXPECTED_FEE_OBSERVATION_KEYS) ||
+          value.providerId !== providerIds[index]
+        ) {
+          fail("receipt closing fee observation is invalid");
+        }
+        return {
+          gasPrice: parseDecimalWei(
+            value.gasPrice,
+            "receipt closing gas price",
+          ),
+          priorityFee: parseDecimalWei(
+            value.maxPriorityFeePerGas,
+            "receipt closing priority fee",
+            { positive: false },
+          ),
+        };
+      },
+    );
+    const simulation = receipt.simulation;
+    const agreedGasEstimate = parseDecimalWei(
+      simulation.agreedGasEstimate,
+      "receipt agreed gas estimate",
+    );
+    const reviewedGasLimit = parseDecimalWei(
+      receipt.transaction?.gasLimit,
+      "receipt reviewed gas limit",
+    );
+    const gasEstimateArrays = [
+      simulation.gasEstimates,
+      simulation.closingGasEstimates,
+    ];
+    const expectedReturnedAddresses = Object.values(EXPECTED_PREPARED_ADDRESSES);
+    const pendingBaseFeeMaximum = [
+      ...openingPendingBlocks,
+      ...closingPendingBlocks,
+    ].reduce(
+      (maximum, { baseFeePerGas }) =>
+        baseFeePerGas > maximum ? baseFeePerGas : maximum,
+      0n,
+    );
+    const gasPriceMaximum = closingFees.reduce(
+      (maximum, { gasPrice }) => (gasPrice > maximum ? gasPrice : maximum),
+      0n,
+    );
+    const priorityFeeMaximum = closingFees.reduce(
+      (maximum, { priorityFee }) =>
+        priorityFee > maximum ? priorityFee : maximum,
+      0n,
+    );
+    const observedBaseFee = parseDecimalWei(
+      receipt.gasPolicy?.observedPendingBaseFeePerGasWei,
+      "receipt observed pending base fee",
+      { positive: false },
+    );
+    const observedGasPrice = parseDecimalWei(
+      receipt.gasPolicy?.observedGasPriceWei,
+      "receipt observed gas price",
+    );
+    const observedPriorityFee = parseDecimalWei(
+      receipt.gasPolicy?.observedMaxPriorityFeePerGasWei,
+      "receipt observed priority fee",
+      { positive: false },
+    );
+    const reviewedMaxFee = parseDecimalWei(
+      receipt.gasPolicy?.reviewedMaxFeePerGasWei,
+      "receipt reviewed maximum fee",
+    );
+    const expectedMaxFee =
+      observedGasPrice > 2n * observedBaseFee + observedPriorityFee
+        ? observedGasPrice
+        : 2n * observedBaseFee + observedPriorityFee;
+    const ownerMaximumFee = parseDecimalWei(
+      receipt.gasPolicy?.ownerMaximumFeePerGasWei,
+      "receipt owner maximum fee",
+    );
+    const ownerMaximumPriorityFee = parseDecimalWei(
+      receipt.gasPolicy?.ownerMaximumPriorityFeePerGasWei,
+      "receipt owner maximum priority fee",
+      { positive: false },
+    );
+    const ownerMaximumGasCost = parseDecimalWei(
+      receipt.gasPolicy?.ownerMaximumGasCostWei,
+      "receipt owner maximum gas cost",
+    );
+    const checks = receipt.checks;
+    const booleanCheckKeys = EXPECTED_CHECK_KEYS.filter(
+      (key) =>
+        ![
+          "independentAuthenticatedRpcCount",
+          "rpcMethodInventory",
+          "rpcResponseBudgetBytes",
+          "rpcResponseBytesConsumed",
+        ].includes(key),
+    );
+    evidenceIsExact =
+      hasExactKeys(observation, EXPECTED_OBSERVATION_KEYS) &&
+      Number.isSafeInteger(observation.operationStartedAtTimestamp) &&
+      observation.operationStartedAtTimestamp >= 0 &&
+      Number.isSafeInteger(observation.createdAtTimestamp) &&
+      observation.createdAtTimestamp >= observation.operationStartedAtTimestamp &&
+      observation.createdAtTimestamp -
+        observation.operationStartedAtTimestamp <=
+        Math.ceil(ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_MAX_OPERATION_MS / 1_000) &&
+      Math.abs(
+        observation.createdAtTimestamp - Number(commonAnchor.timestamp),
+      ) <= 120 &&
+      Number.isSafeInteger(observation.expiresAtTimestamp) &&
+      observation.ttlSeconds ===
+        ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_TTL_SECONDS &&
+      observation.minimumRemainingTtlSeconds ===
+        ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_MINIMUM_REMAINING_TTL_SECONDS &&
+      Number.isSafeInteger(observation.elapsedMilliseconds) &&
+      observation.elapsedMilliseconds >= 0 &&
+      observation.elapsedMilliseconds <=
+        ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_MAX_OPERATION_MS &&
+      hasExactKeys(simulation, EXPECTED_SIMULATION_KEYS) &&
+      simulation.blockTag === "pending" &&
+      simulation.returnDataKeccak256 === EXPECTED_CALL_RETURN_HASH &&
+      simulation.allComponentsSucceeded === true &&
+      Array.isArray(simulation.returnedAddresses) &&
+      simulation.returnedAddresses.length ===
+        expectedReturnedAddresses.length &&
+      simulation.returnedAddresses.every((address, index) =>
+        sameAddress(address, expectedReturnedAddresses[index]),
+      ) &&
+      gasEstimateArrays.every(
+        (values) =>
+          Array.isArray(values) &&
+          values.length === providerIds.length &&
+          values.every((value) => value === agreedGasEstimate.toString()),
+      ) &&
+      reviewedRobinhoodFoundationGasLimit(agreedGasEstimate) ===
+        reviewedGasLimit &&
+      [...openingPendingBlocks, ...closingPendingBlocks].every(
+        ({ gasLimit }) => reviewedGasLimit <= gasLimit,
+      ) &&
+      hasExactKeys(receipt.gasPolicy, EXPECTED_GAS_POLICY_KEYS) &&
+      receipt.gasPolicy.headroomBasisPoints ===
+        ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_GAS_HEADROOM_BPS.toString() &&
+      receipt.gasPolicy.fixedHeadroomGas ===
+        ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_FIXED_GAS_HEADROOM.toString() &&
+      receipt.gasPolicy.maximumGasLimit ===
+        ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_MAX_GAS_LIMIT.toString() &&
+      receipt.gasPolicy.reviewedGasLimit === reviewedGasLimit.toString() &&
+      observedBaseFee === pendingBaseFeeMaximum &&
+      observedGasPrice === gasPriceMaximum &&
+      observedPriorityFee === priorityFeeMaximum &&
+      reviewedMaxFee === expectedMaxFee &&
+      ownerMaximumFee >= reviewedMaxFee &&
+      ownerMaximumPriorityFee >= observedPriorityFee &&
+      ownerMaximumGasCost >= reviewedGasLimit * reviewedMaxFee &&
+      receipt.gasPolicy.maximumGasCostWei ===
+        (reviewedGasLimit * reviewedMaxFee).toString() &&
+      receipt.gasPolicy.balanceReadPerformed === false &&
+      receipt.gasPolicy.fundingVerified === false &&
+      hasExactKeys(checks, EXPECTED_CHECK_KEYS) &&
+      booleanCheckKeys.every((key) => checks[key] === true) &&
+      checks.independentAuthenticatedRpcCount === providerIds.length &&
+      checks.rpcResponseBudgetBytes === RPC_AGGREGATE_RESPONSE_LIMIT_BYTES &&
+      Number.isSafeInteger(checks.rpcResponseBytesConsumed) &&
+      checks.rpcResponseBytesConsumed >= 0 &&
+      checks.rpcResponseBytesConsumed <= RPC_AGGREGATE_RESPONSE_LIMIT_BYTES &&
+      JSON.stringify(checks.rpcMethodInventory) ===
+        JSON.stringify(Object.keys(RPC_RESPONSE_LIMIT_BYTES));
+  } catch {
+    evidenceIsExact = false;
+  }
   try {
     const input = exactCode(receipt.transaction?.input, "receipt input");
     const from = exactAddress(receipt.transaction?.from, "receipt sender");
@@ -314,6 +720,7 @@ export function assertFreshRobinhoodFoundationOwnerEnvelope(
       { positive: false },
     );
     transactionIsExact =
+      hasExactKeys(receipt.transaction, EXPECTED_TRANSACTION_KEYS) &&
       ALLOWED_OWNERS.includes(from.toLowerCase()) &&
       receipt.transaction?.type === "0x2" &&
       receipt.transaction?.chainId === CHAIN_ID_HEX &&
@@ -354,8 +761,7 @@ export function assertFreshRobinhoodFoundationOwnerEnvelope(
     transactionIsExact = false;
   }
   if (
-    Object.keys(receipt).sort().join("\0") !==
-      EXPECTED_RECEIPT_TOP_LEVEL_KEYS.join("\0") ||
+    !hasExactKeys(receipt, EXPECTED_RECEIPT_TOP_LEVEL_KEYS) ||
     receipt.schemaVersion !== ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_SCHEMA ||
     receipt.state !== "prepared-not-signed-not-broadcast" ||
     receipt.status !==
@@ -378,6 +784,7 @@ export function assertFreshRobinhoodFoundationOwnerEnvelope(
     receipt.checks?.boundedTimeout !== true ||
     !releaseIsExact ||
     !hostedVerifyIsExact ||
+    !evidenceIsExact ||
     !transactionIsExact ||
     !Number.isSafeInteger(issuedAtTimestamp) ||
     !Number.isSafeInteger(expiresAtTimestamp) ||
@@ -1217,6 +1624,7 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
   const closings = await Promise.all(
     providers.map(async (provider) => {
       const [
+        chainIdValue,
         latestNonceValue,
         pendingNonceValue,
         codes,
@@ -1224,6 +1632,7 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
         callResultValue,
         estimateValue,
       ] = await Promise.all([
+          rpc(provider, "eth_chainId", [], rpcClient, requestTimeoutMs),
           rpc(
             provider,
             "eth_getTransactionCount",
@@ -1268,6 +1677,10 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
           ),
         ]);
       return {
+        chainId: parseQuantity(
+          chainIdValue,
+          `${provider.providerId} action-time closing chain ID`,
+        ),
         latestNonce: parseQuantity(
           latestNonceValue,
           `${provider.providerId} action-time closing latest nonce`,
@@ -1292,6 +1705,8 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
   for (const [index, closing] of closings.entries()) {
     const providerId = providers[index].providerId;
     if (
+      closing.chainId !== CHAIN_ID ||
+      closing.chainId !== snapshots[index].chainId ||
       closing.latestNonce !== expectedNonce ||
       closing.pendingNonce !== expectedNonce ||
       closing.latestNonce !== snapshots[index].latestNonce ||
@@ -1321,6 +1736,7 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
     });
   }
   if (
+    closings[0].chainId !== closings[1].chainId ||
     closings[0].latestNonce !== closings[1].latestNonce ||
     closings[0].pendingNonce !== closings[1].pendingNonce ||
     JSON.stringify(closings[0].codes) !== JSON.stringify(closings[1].codes) ||
@@ -1857,11 +2273,11 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
       priorityFee > maximum ? priorityFee : maximum,
     0n,
   );
-  const baseFeePerGas = closings.reduce(
-    (maximum, { pendingBlock }) =>
-      pendingBlock.baseFeePerGas > maximum
-        ? pendingBlock.baseFeePerGas
-        : maximum,
+  const baseFeePerGas = [
+    ...pendingSnapshots.map(({ pendingBlock }) => pendingBlock.baseFeePerGas),
+    ...closings.map(({ pendingBlock }) => pendingBlock.baseFeePerGas),
+  ].reduce(
+    (maximum, value) => (value > maximum ? value : maximum),
     0n,
   );
   const observedGasPrice = closings.reduce(
@@ -1965,6 +2381,13 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
         gasLimit: pendingBlock.gasLimit.toString(),
         baseFeePerGas: pendingBlock.baseFeePerGas.toString(),
       })),
+      closingFeeObservations: closings.map(
+        ({ gasPrice, priorityFee }, index) => ({
+          providerId: providerBindings[index].providerId,
+          gasPrice: gasPrice.toString(),
+          maxPriorityFeePerGas: priorityFee.toString(),
+        }),
+      ),
     },
     preparedAddresses: EXPECTED_PREPARED_ADDRESSES,
     transaction: {

--- a/contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs
+++ b/contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs
@@ -176,6 +176,7 @@ const EXPECTED_OBSERVATION_KEYS = Object.freeze([
   "elapsedMilliseconds",
   "expiresAtTimestamp",
   "minimumRemainingTtlSeconds",
+  "openingFeeObservations",
   "openingHeads",
   "openingPendingBlocks",
   "operationStartedAtTimestamp",
@@ -215,7 +216,6 @@ const EXPECTED_SIMULATION_KEYS = Object.freeze([
 ]);
 const EXPECTED_CHECK_KEYS = Object.freeze([
   "boundedTimeout",
-  "closingFeeCeilingUsesProviderMaxima",
   "closingGasAgreement",
   "closingSimulationAgreement",
   "closingVacancyVerified",
@@ -224,6 +224,7 @@ const EXPECTED_CHECK_KEYS = Object.freeze([
   "exactCleanSource",
   "exactFreshDeterministicCompilation",
   "exactPreparedArtifact",
+  "feeCeilingUsesOpeningAndClosingProviderMaxima",
   "fixedAndPendingCodeAndNonceVacancyVerified",
   "independentAuthenticatedRpcCount",
   "movingPendingHeadsTolerated",
@@ -474,7 +475,13 @@ export function assertFreshRobinhoodFoundationOwnerEnvelope(
       (minimum, { number }) => (number < minimum ? number : minimum),
       openingHeads[0].number,
     );
+    const openingMaximum = openingHeads.reduce(
+      (maximum, { number }) => (number > maximum ? number : maximum),
+      openingHeads[0].number,
+    );
     if (
+      openingMaximum - openingMinimum >
+        ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_MAX_HEAD_GAP ||
       commonAnchor.number !== openingMinimum ||
       openingHeads.some(
         ({ number, hash, timestamp }) =>
@@ -524,33 +531,39 @@ export function assertFreshRobinhoodFoundationOwnerEnvelope(
       observation.closingPendingBlocks,
       "closing",
     );
-    if (
-      !Array.isArray(observation.closingFeeObservations) ||
-      observation.closingFeeObservations.length !== providerIds.length
-    ) {
-      fail("receipt closing fee observation count is invalid");
-    }
-    const closingFees = observation.closingFeeObservations.map(
-      (value, index) => {
+    const normalizeFeeObservations = (values, label) => {
+      if (!Array.isArray(values) || values.length !== providerIds.length) {
+        fail(`receipt ${label} fee observation count is invalid`);
+      }
+      return values.map((value, index) => {
         if (
           !hasExactKeys(value, EXPECTED_FEE_OBSERVATION_KEYS) ||
           value.providerId !== providerIds[index]
         ) {
-          fail("receipt closing fee observation is invalid");
+          fail(`receipt ${label} fee observation is invalid`);
         }
         return {
           gasPrice: parseDecimalWei(
             value.gasPrice,
-            "receipt closing gas price",
+            `receipt ${label} gas price`,
           ),
           priorityFee: parseDecimalWei(
             value.maxPriorityFeePerGas,
-            "receipt closing priority fee",
+            `receipt ${label} priority fee`,
             { positive: false },
           ),
         };
-      },
+      });
+    };
+    const openingFees = normalizeFeeObservations(
+      observation.openingFeeObservations,
+      "opening",
     );
+    const closingFees = normalizeFeeObservations(
+      observation.closingFeeObservations,
+      "closing",
+    );
+    const feeObservations = [...openingFees, ...closingFees];
     const simulation = receipt.simulation;
     const agreedGasEstimate = parseDecimalWei(
       simulation.agreedGasEstimate,
@@ -573,11 +586,11 @@ export function assertFreshRobinhoodFoundationOwnerEnvelope(
         baseFeePerGas > maximum ? baseFeePerGas : maximum,
       0n,
     );
-    const gasPriceMaximum = closingFees.reduce(
+    const gasPriceMaximum = feeObservations.reduce(
       (maximum, { gasPrice }) => (gasPrice > maximum ? gasPrice : maximum),
       0n,
     );
-    const priorityFeeMaximum = closingFees.reduce(
+    const priorityFeeMaximum = feeObservations.reduce(
       (maximum, { priorityFee }) =>
         priorityFee > maximum ? priorityFee : maximum,
       0n,
@@ -1995,6 +2008,8 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
     providers.map(async (provider) => {
       const [
         pendingBlockValue,
+        gasPriceValue,
+        priorityFeeValue,
         codes,
         vacancyNonces,
         callResult,
@@ -2004,6 +2019,14 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
           provider,
           "eth_getBlockByNumber",
           ["pending", false],
+          rpcClient,
+          requestTimeoutMs,
+        ),
+        rpc(provider, "eth_gasPrice", [], rpcClient, requestTimeoutMs),
+        rpc(
+          provider,
+          "eth_maxPriorityFeePerGas",
+          [],
           rpcClient,
           requestTimeoutMs,
         ),
@@ -2069,6 +2092,14 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
           pendingBlockValue,
           `${provider.providerId} pending block`,
         ),
+        gasPrice: parseQuantity(
+          gasPriceValue,
+          `${provider.providerId} opening gas price`,
+        ),
+        priorityFee: parseQuantity(
+          priorityFeeValue,
+          `${provider.providerId} opening priority fee`,
+        ),
         codes,
         vacancyNonces,
         callResult: exactCode(
@@ -2109,6 +2140,7 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
   const closings = await Promise.all(
     providers.map(async (provider) => {
       const [
+        chainIdValue,
         anchorValue,
         pendingBlockValue,
         pendingNonceValue,
@@ -2119,6 +2151,7 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
         callResult,
         estimateValue,
       ] = await Promise.all([
+        rpc(provider, "eth_chainId", [], rpcClient, requestTimeoutMs),
         rpc(
           provider,
           "eth_getBlockByNumber",
@@ -2194,6 +2227,10 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
         ),
       ]);
       return {
+        chainId: parseQuantity(
+          chainIdValue,
+          `${provider.providerId} closing chain ID`,
+        ),
         anchor: exactBlock(
           anchorValue,
           `${provider.providerId} closing anchor`,
@@ -2229,6 +2266,7 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
   );
   for (const [index, closing] of closings.entries()) {
     if (
+      closing.chainId !== CHAIN_ID ||
       closing.anchor.number !== commonBlockNumber ||
       closing.anchor.hash !== commonBlocks[0].hash ||
       closing.pendingNonce !== nonce ||
@@ -2257,6 +2295,7 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
     });
   }
   if (
+    closings[0].chainId !== closings[1].chainId ||
     closings[0].pendingNonce !== closings[1].pendingNonce ||
     JSON.stringify(closings[0].codes) !== JSON.stringify(closings[1].codes) ||
     JSON.stringify(closings[0].vacancyNonces) !==
@@ -2268,7 +2307,8 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
       "Robinhood RPCs disagree on closing nonce, code, vacancy, simulation, or gas",
     );
   }
-  const maxPriorityFeePerGas = closings.reduce(
+  const feeObservations = [...pendingSnapshots, ...closings];
+  const maxPriorityFeePerGas = feeObservations.reduce(
     (maximum, { priorityFee }) =>
       priorityFee > maximum ? priorityFee : maximum,
     0n,
@@ -2280,7 +2320,7 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
     (maximum, value) => (value > maximum ? value : maximum),
     0n,
   );
-  const observedGasPrice = closings.reduce(
+  const observedGasPrice = feeObservations.reduce(
     (maximum, { gasPrice }) => (gasPrice > maximum ? gasPrice : maximum),
     0n,
   );
@@ -2374,6 +2414,13 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
         gasLimit: pendingBlock.gasLimit.toString(),
         baseFeePerGas: pendingBlock.baseFeePerGas.toString(),
       })),
+      openingFeeObservations: pendingSnapshots.map(
+        ({ gasPrice, priorityFee }, index) => ({
+          providerId: providerBindings[index].providerId,
+          gasPrice: gasPrice.toString(),
+          maxPriorityFeePerGas: priorityFee.toString(),
+        }),
+      ),
       closingPendingBlocks: closings.map(({ pendingBlock }, index) => ({
         providerId: providerBindings[index].providerId,
         parentHash: pendingBlock.parentHash,
@@ -2459,7 +2506,7 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
       noPendingOwnerTransaction: true,
       closingSimulationAgreement: true,
       closingGasAgreement: true,
-      closingFeeCeilingUsesProviderMaxima: true,
+      feeCeilingUsesOpeningAndClosingProviderMaxima: true,
       closingVacancyVerified: true,
       boundedTimeout: true,
       rpcResponseBudgetBytes: RPC_AGGREGATE_RESPONSE_LIMIT_BYTES,

--- a/contracts/scripts/test/robinhood-custom-launch-owner-envelope.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-owner-envelope.test.mjs
@@ -180,6 +180,8 @@ function mockRpc(options = {}) {
   const chainReads = new Map();
   const targetNonceReads = new Map();
   const codeReads = new Map();
+  const gasPriceReads = new Map();
+  const priorityFeeReads = new Map();
   const callReads = new Map();
   const estimateReads = new Map();
   const codeByAddress = new Map();
@@ -313,9 +315,19 @@ function mockRpc(options = {}) {
         ? provider.closingEstimate
         : (provider.estimate ?? "0x6d66aa");
     }
-    if (method === "eth_gasPrice") return provider.gasPrice ?? "0x77359400";
+    if (method === "eth_gasPrice") {
+      const count = (gasPriceReads.get(providerId) ?? 0) + 1;
+      gasPriceReads.set(providerId, count);
+      return count > 1 && provider.closingGasPrice
+        ? provider.closingGasPrice
+        : (provider.gasPrice ?? "0x77359400");
+    }
     if (method === "eth_maxPriorityFeePerGas") {
-      return provider.priorityFee ?? "0x0";
+      const count = (priorityFeeReads.get(providerId) ?? 0) + 1;
+      priorityFeeReads.set(providerId, count);
+      return count > 1 && provider.closingPriorityFee
+        ? provider.closingPriorityFee
+        : (provider.priorityFee ?? "0x0");
     }
     assert.fail(`unexpected RPC method ${method}`);
   };
@@ -426,6 +438,8 @@ test("moving pending heads and provider fee differences use conservative maxima"
           closingBaseFeePerGas: "0x4190ab00",
           gasPrice: "0xcaa7e200",
           priorityFee: "0x5f5e100",
+          closingGasPrice: "0x77359400",
+          closingPriorityFee: "0x2faf080",
         },
         alchemy: {
           pendingParentHash: openingParents[1],
@@ -436,6 +450,8 @@ test("moving pending heads and provider fee differences use conservative maxima"
           closingBaseFeePerGas: "0x53724e00",
           gasPrice: "0xa0eebb00",
           priorityFee: "0x1dcd6500",
+          closingGasPrice: "0x83215600",
+          closingPriorityFee: "0x5f5e100",
         },
       },
     },
@@ -473,6 +489,30 @@ test("moving pending heads and provider fee differences use conservative maxima"
       baseFeePerGas: "1400000000",
     },
   ]);
+  assert.deepEqual(receipt.observation.openingFeeObservations, [
+    {
+      providerId: "quicknode",
+      gasPrice: "3400000000",
+      maxPriorityFeePerGas: "100000000",
+    },
+    {
+      providerId: "alchemy",
+      gasPrice: "2700000000",
+      maxPriorityFeePerGas: "500000000",
+    },
+  ]);
+  assert.deepEqual(receipt.observation.closingFeeObservations, [
+    {
+      providerId: "quicknode",
+      gasPrice: "2000000000",
+      maxPriorityFeePerGas: "50000000",
+    },
+    {
+      providerId: "alchemy",
+      gasPrice: "2200000000",
+      maxPriorityFeePerGas: "100000000",
+    },
+  ]);
   assert.ok(!Object.hasOwn(receipt.observation, "pendingBlock"));
   assert.deepEqual(receipt.simulation.closingGasEstimates, [
     "7169706",
@@ -488,7 +528,10 @@ test("moving pending heads and provider fee differences use conservative maxima"
   assert.equal(receipt.checks.stateRelevantClosingAgreement, true);
   assert.equal(receipt.checks.closingSimulationAgreement, true);
   assert.equal(receipt.checks.closingGasAgreement, true);
-  assert.equal(receipt.checks.closingFeeCeilingUsesProviderMaxima, true);
+  assert.equal(
+    receipt.checks.feeCeilingUsesOpeningAndClosingProviderMaxima,
+    true,
+  );
   assert.ok(!Object.hasOwn(receipt.checks, "pendingBlockAgreement"));
   assert.ok(!Object.hasOwn(receipt.checks, "closingFeeAgreement"));
 });
@@ -767,6 +810,11 @@ test("preflight fails closed on provider, pin, vacancy, nonce, simulation, and g
     [
       "closing nonce",
       { providers: { quicknode: { closingNonce: "0x8" } } },
+      /state changed/u,
+    ],
+    [
+      "closing chain",
+      { providers: { quicknode: { closingChainId: "0x1" } } },
       /state changed/u,
     ],
     [
@@ -1335,14 +1383,24 @@ test("freshness validation and protected output reject tampering, expiry, and ov
         BigInt(candidate.observation.commonAnchor.blockNumber) - 1n
       ).toString();
     }],
+    ["opening head gap", (candidate) => {
+      candidate.observation.openingHeads[1].blockNumber = (
+        BigInt(candidate.observation.openingHeads[0].blockNumber) + 5n
+      ).toString();
+    }],
     ["opening fee maximum", (candidate) => {
       candidate.observation.openingPendingBlocks[0].baseFeePerGas = (
         BigInt(candidate.gasPolicy.observedPendingBaseFeePerGasWei) + 1n
       ).toString();
     }],
-    ["closing fee maximum", (candidate) => {
-      candidate.observation.closingFeeObservations[0].gasPrice = (
+    ["opening gas-price maximum", (candidate) => {
+      candidate.observation.openingFeeObservations[0].gasPrice = (
         BigInt(candidate.gasPolicy.observedGasPriceWei) + 1n
+      ).toString();
+    }],
+    ["closing priority-fee maximum", (candidate) => {
+      candidate.observation.closingFeeObservations[0].maxPriorityFeePerGas = (
+        BigInt(candidate.gasPolicy.observedMaxPriorityFeePerGasWei) + 1n
       ).toString();
     }],
     ["simulation gas agreement", (candidate) => {

--- a/contracts/scripts/test/robinhood-custom-launch-owner-envelope.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-owner-envelope.test.mjs
@@ -157,6 +157,8 @@ function mockRpc(options = {}) {
   const requestInventory = [];
   const pendingOwnerNonceReads = new Map();
   const pendingBlockReads = new Map();
+  const callReads = new Map();
+  const estimateReads = new Map();
   const codeByAddress = new Map();
   const hashByCode = new Map();
   Object.entries(dependencyBindings()).forEach(([key, binding], index) => {
@@ -183,9 +185,18 @@ function mockRpc(options = {}) {
         count > 1 && provider.closingParentHash
           ? provider.closingParentHash
           : (provider.pendingParentHash ?? `0x${"aa".repeat(32)}`),
-      timestamp: `0x${FIXED_TIMESTAMP.toString(16)}`,
-      gasLimit: provider.pendingGasLimit ?? "0x1c9c380",
-      baseFeePerGas: provider.baseFeePerGas ?? "0x3b9aca00",
+      timestamp:
+        count > 1 && provider.closingPendingTimestamp
+          ? provider.closingPendingTimestamp
+          : (provider.pendingTimestamp ?? `0x${FIXED_TIMESTAMP.toString(16)}`),
+      gasLimit:
+        count > 1 && provider.closingPendingGasLimit
+          ? provider.closingPendingGasLimit
+          : (provider.pendingGasLimit ?? "0x1c9c380"),
+      baseFeePerGas:
+        count > 1 && provider.closingBaseFeePerGas
+          ? provider.closingBaseFeePerGas
+          : (provider.baseFeePerGas ?? "0x3b9aca00"),
     };
   };
   const rpcClient = async ({ providerId, method, params }) => {
@@ -231,10 +242,19 @@ function mockRpc(options = {}) {
       if (provider.occupiedCodeKey === entry.key) return "0x6001";
       return entry.code;
     }
-    if (method === "eth_call")
-      return provider.callResult ?? EXPECTED_SIMULATION;
+    if (method === "eth_call") {
+      const count = (callReads.get(providerId) ?? 0) + 1;
+      callReads.set(providerId, count);
+      return count > 1 && provider.closingCallResult !== undefined
+        ? provider.closingCallResult
+        : (provider.callResult ?? EXPECTED_SIMULATION);
+    }
     if (method === "eth_estimateGas") {
-      return provider.estimate ?? "0x6d66aa";
+      const count = (estimateReads.get(providerId) ?? 0) + 1;
+      estimateReads.set(providerId, count);
+      return count > 1 && provider.closingEstimate !== undefined
+        ? provider.closingEstimate
+        : (provider.estimate ?? "0x6d66aa");
     }
     if (method === "eth_gasPrice") return provider.gasPrice ?? "0x77359400";
     if (method === "eth_maxPriorityFeePerGas") {
@@ -318,6 +338,95 @@ test("both reviewed owners produce a protected, digest-bound envelope", async ()
     assert.ok(!rendered.includes("0123456789abcdef"));
     assert.ok(!rendered.includes("abcdef0123456789"));
   }
+});
+
+test("moving pending heads and provider fee differences use conservative maxima", async () => {
+  const openingParents = [
+    `0x${"a1".repeat(32)}`,
+    `0x${"b2".repeat(32)}`,
+  ];
+  const closingParents = [
+    `0x${"c3".repeat(32)}`,
+    `0x${"d4".repeat(32)}`,
+  ];
+  const { receipt } = await prepareEnvelope({
+    ceilings: { maximumFeePerGasWei: "4000000000" },
+    options: {
+      providers: {
+        quicknode: {
+          pendingParentHash: openingParents[0],
+          pendingTimestamp: `0x${FIXED_TIMESTAMP.toString(16)}`,
+          baseFeePerGas: "0x3b9aca00",
+          closingParentHash: closingParents[0],
+          closingPendingTimestamp: `0x${(FIXED_TIMESTAMP + 2).toString(16)}`,
+          closingBaseFeePerGas: "0x4190ab00",
+          gasPrice: "0xcaa7e200",
+          priorityFee: "0x5f5e100",
+        },
+        alchemy: {
+          pendingParentHash: openingParents[1],
+          pendingTimestamp: `0x${(FIXED_TIMESTAMP + 1).toString(16)}`,
+          baseFeePerGas: "0x47868c00",
+          closingParentHash: closingParents[1],
+          closingPendingTimestamp: `0x${(FIXED_TIMESTAMP + 3).toString(16)}`,
+          closingBaseFeePerGas: "0x53724e00",
+          gasPrice: "0xa0eebb00",
+          priorityFee: "0x1dcd6500",
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(receipt.observation.openingPendingBlocks, [
+    {
+      providerId: "quicknode",
+      parentHash: openingParents[0],
+      blockTimestamp: FIXED_TIMESTAMP.toString(),
+      gasLimit: "30000000",
+      baseFeePerGas: "1000000000",
+    },
+    {
+      providerId: "alchemy",
+      parentHash: openingParents[1],
+      blockTimestamp: (FIXED_TIMESTAMP + 1).toString(),
+      gasLimit: "30000000",
+      baseFeePerGas: "1200000000",
+    },
+  ]);
+  assert.deepEqual(receipt.observation.closingPendingBlocks, [
+    {
+      providerId: "quicknode",
+      parentHash: closingParents[0],
+      blockTimestamp: (FIXED_TIMESTAMP + 2).toString(),
+      gasLimit: "30000000",
+      baseFeePerGas: "1100000000",
+    },
+    {
+      providerId: "alchemy",
+      parentHash: closingParents[1],
+      blockTimestamp: (FIXED_TIMESTAMP + 3).toString(),
+      gasLimit: "30000000",
+      baseFeePerGas: "1400000000",
+    },
+  ]);
+  assert.ok(!Object.hasOwn(receipt.observation, "pendingBlock"));
+  assert.deepEqual(receipt.simulation.closingGasEstimates, [
+    "7169706",
+    "7169706",
+  ]);
+  assert.equal(receipt.gasPolicy.observedPendingBaseFeePerGasWei, "1400000000");
+  assert.equal(receipt.gasPolicy.observedGasPriceWei, "3400000000");
+  assert.equal(receipt.gasPolicy.observedMaxPriorityFeePerGasWei, "500000000");
+  assert.equal(receipt.transaction.maxPriorityFeePerGas, "500000000");
+  assert.equal(receipt.transaction.maxFeePerGas, "3400000000");
+  assert.equal(receipt.checks.movingPendingHeadsTolerated, true);
+  assert.equal(receipt.checks.stateRelevantOpeningAgreement, true);
+  assert.equal(receipt.checks.stateRelevantClosingAgreement, true);
+  assert.equal(receipt.checks.closingSimulationAgreement, true);
+  assert.equal(receipt.checks.closingGasAgreement, true);
+  assert.equal(receipt.checks.closingFeeCeilingUsesProviderMaxima, true);
+  assert.ok(!Object.hasOwn(receipt.checks, "pendingBlockAgreement"));
+  assert.ok(!Object.hasOwn(receipt.checks, "closingFeeAgreement"));
 });
 
 test("implementation inventory contains no balance, signing, or broadcast primitive", async () => {
@@ -548,7 +657,7 @@ test("provider commitment helper separates review derivation from live exact mat
   assert.doesNotMatch(substituted.stderr, /0123456789abcdef|abcdef0123456789/u);
 });
 
-test("preflight fails closed on provider, pin, vacancy, nonce, simulation, gas, and fee drift", async (t) => {
+test("preflight fails closed on provider, pin, vacancy, nonce, simulation, and gas drift", async (t) => {
   const cases = [
     ["chain", { providers: { alchemy: { chainId: "0x1" } } }, /not Robinhood/u],
     [
@@ -597,18 +706,14 @@ test("preflight fails closed on provider, pin, vacancy, nonce, simulation, gas, 
       /state changed/u,
     ],
     [
-      "closing parent",
-      {
-        providers: {
-          quicknode: { closingParentHash: `0x${"bb".repeat(32)}` },
-        },
-      },
-      /state changed/u,
+      "closing simulation",
+      { providers: { quicknode: { closingCallResult: "0x" } } },
+      /simulation|state changed/u,
     ],
     [
-      "fee",
-      { providers: { alchemy: { gasPrice: "0x77359401" } } },
-      /disagree on closing/u,
+      "closing gas estimate",
+      { providers: { quicknode: { closingEstimate: "0x6d66ab" } } },
+      /gas|state changed/u,
     ],
   ];
   for (const [name, options, pattern] of cases) {
@@ -809,6 +914,8 @@ test("read-only action-time verifier rebinds source, hosted CI, endpoints, and l
       preparedAddressCount: 3,
       pendingSimulationVerified: true,
       pendingGasEstimate: receipt.simulation.agreedGasEstimate,
+      closingSimulationVerified: true,
+      closingGasEstimate: receipt.simulation.agreedGasEstimate,
       closingVacancyVerified: true,
       rpcResponseBytesConsumed: 0,
     });
@@ -833,7 +940,7 @@ test("read-only action-time verifier rebinds source, hosted CI, endpoints, and l
           .map(({ method, params }) => ({ method, params })),
       ]),
     );
-    assert.equal(requestsByProvider.quicknode.length, 19);
+    assert.equal(requestsByProvider.quicknode.length, 21);
     assert.deepEqual(requestsByProvider.quicknode, requestsByProvider.alchemy);
     assert.ok(
       actionTimeMock.requestInventory.every(
@@ -1023,6 +1130,72 @@ test("read-only action-time verifier rebinds source, hosted CI, endpoints, and l
       /source changed during hosted Verify revalidation/u,
     );
     assert.equal(finalSourceReads, 3);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("action-time closing simulation and gas drift fail closed", async (t) => {
+  const { receipt } = await prepareEnvelope();
+  const root = await mkdtemp(
+    path.join(os.homedir(), ".robinhood-wallet-closing-test-"),
+  );
+  await chmod(root, 0o700);
+  const envelopePath = path.join(root, "envelope.json");
+  const walletRequestPath = path.join(root, "wallet-request.json");
+  const env = {
+    ROBINHOOD_OWNER_ENVELOPE_ROOT: root,
+    ROBINHOOD_MAINNET_RPC_URL_PRIMARY: RPC_URLS[0],
+    ROBINHOOD_MAINNET_RPC_URL_SECONDARY: RPC_URLS[1],
+    ROBINHOOD_MAINNET_RPC_COMMITMENT_PRIMARY: RPC_COMMITMENTS[0],
+    ROBINHOOD_MAINNET_RPC_COMMITMENT_SECONDARY: RPC_COMMITMENTS[1],
+  };
+  try {
+    await Promise.all([
+      writeFile(envelopePath, `${JSON.stringify(receipt, null, 2)}\n`, {
+        mode: 0o600,
+        flag: "wx",
+      }),
+      writeFile(
+        walletRequestPath,
+        `${JSON.stringify(walletRequest(receipt), null, 2)}\n`,
+        { mode: 0o600, flag: "wx" },
+      ),
+    ]);
+    const cases = [
+      [
+        "closing eth_call drift",
+        { providers: { quicknode: { closingCallResult: "0x" } } },
+        /simulation|state changed during wallet verification/u,
+      ],
+      [
+        "closing eth_estimateGas drift",
+        { providers: { quicknode: { closingEstimate: "0x6d66ab" } } },
+        /gas|state changed during wallet verification/u,
+      ],
+    ];
+    for (const [name, rpcOptions, pattern] of cases) {
+      await t.test(name, async () => {
+        await assert.rejects(
+          () =>
+            verifyRobinhoodOwnerWalletRequest({
+              envelopePath,
+              walletRequestPath,
+              env,
+              nowMilliseconds: FIXED_TIMESTAMP * 1_000,
+              sourceIdentity: () => ({
+                commit: receipt.source.commit,
+                tree: receipt.source.tree,
+                clean: true,
+              }),
+              hostedVerifyResolver: async () => receipt.hostedVerify,
+              rpcClient: mockRpc(rpcOptions).rpcClient,
+              clock: () => FIXED_TIMESTAMP * 1_000,
+            }),
+          pattern,
+        );
+      });
+    }
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/contracts/scripts/test/robinhood-custom-launch-owner-envelope.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-owner-envelope.test.mjs
@@ -9,8 +9,10 @@ import test from "node:test";
 
 import { encodeAbiParameters, keccak256, parseAbiParameters } from "viem";
 
+import { canonicalizeJson } from "../../../packages/launch/src/canonical-json.mjs";
 import { prepareOwnerTransactionFromCreationCode } from "../prepare-robinhood-custom-launch-owner-transaction.mjs";
 import {
+  ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_SCHEMA,
   assertRobinhoodFoundationRpcProviders,
   assertFreshRobinhoodFoundationOwnerEnvelope,
   prepareRobinhoodFoundationOwnerEnvelope,
@@ -106,6 +108,24 @@ function sha256(bytes) {
   return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
 }
 
+function redigestOwnerEnvelope(receipt) {
+  const subject = structuredClone(receipt);
+  delete subject.receiptDigest;
+  return {
+    ...subject,
+    receiptDigest: sha256(
+      Buffer.concat([
+        Buffer.from(
+          "programmable.robinhood-custom-launch.owner-envelope.receipt.v2",
+          "utf8",
+        ),
+        Buffer.from([0]),
+        Buffer.from(canonicalizeJson(subject), "utf8"),
+      ]),
+    ),
+  };
+}
+
 function prepared(owner = OWNER_0) {
   return prepareOwnerTransactionFromCreationCode(owner, {
     graphCreationCode: verifiedCompilation.commitments.graph.creationCode,
@@ -157,6 +177,9 @@ function mockRpc(options = {}) {
   const requestInventory = [];
   const pendingOwnerNonceReads = new Map();
   const pendingBlockReads = new Map();
+  const chainReads = new Map();
+  const targetNonceReads = new Map();
+  const codeReads = new Map();
   const callReads = new Map();
   const estimateReads = new Map();
   const codeByAddress = new Map();
@@ -203,11 +226,21 @@ function mockRpc(options = {}) {
     methodInventory.push(method);
     requestInventory.push({ providerId, method, params: structuredClone(params) });
     const provider = providerOption(providerId);
-    if (method === "eth_chainId") return provider.chainId ?? "0x1237";
+    if (method === "eth_chainId") {
+      const count = (chainReads.get(providerId) ?? 0) + 1;
+      chainReads.set(providerId, count);
+      return count > 1 && provider.closingChainId
+        ? provider.closingChainId
+        : (provider.chainId ?? "0x1237");
+    }
     if (method === "eth_getBlockByNumber") {
       if (params[0] === "latest") {
         return providerId === "quicknode"
-          ? block(1_000, "11")
+          ? block(
+              1_000,
+              provider.commonHashByte ?? "33",
+              provider.commonTimestamp ?? FIXED_TIMESTAMP,
+            )
           : block(provider.headNumber ?? 1_002, "22");
       }
       if (params[0] === "pending") return pendingBlock(providerId);
@@ -226,6 +259,15 @@ function mockRpc(options = {}) {
           (value) => value.toLowerCase() === address,
         )
       ) {
+        const targetReadKey = `${providerId}:${address}`;
+        const count = (targetNonceReads.get(targetReadKey) ?? 0) + 1;
+        targetNonceReads.set(targetReadKey, count);
+        if (
+          provider.closingTargetNonceKey === target.key &&
+          count > (provider.closingTargetNonceAfterReads ?? 2)
+        ) {
+          return "0x1";
+        }
         return provider.targetNonceKey === target.key ? "0x1" : "0x0";
       }
       if (params[1] === "latest") return provider.latestNonce ?? "0x7";
@@ -238,6 +280,21 @@ function mockRpc(options = {}) {
     if (method === "eth_getCode") {
       const entry = codeByAddress.get(params[0].toLowerCase());
       assert.ok(entry, `unexpected code address ${params[0]}`);
+      const codeReadKey = `${providerId}:${params[0].toLowerCase()}`;
+      const count = (codeReads.get(codeReadKey) ?? 0) + 1;
+      codeReads.set(codeReadKey, count);
+      if (
+        provider.closingCodeDriftKey === entry.key &&
+        count > (provider.closingCodeAfterReads ?? 2)
+      ) {
+        return "0x6000";
+      }
+      if (
+        provider.closingOccupiedCodeKey === entry.key &&
+        count > (provider.closingCodeAfterReads ?? 2)
+      ) {
+        return "0x6001";
+      }
       if (provider.codeDriftKey === entry.key) return "0x6000";
       if (provider.occupiedCodeKey === entry.key) return "0x6001";
       return entry.code;
@@ -317,6 +374,10 @@ test("reviewed gas headroom is exact and fails instead of clamping", () => {
 test("both reviewed owners produce a protected, digest-bound envelope", async () => {
   for (const owner of [OWNER_0, OWNER_1]) {
     const { receipt, methodInventory } = await prepareEnvelope({ owner });
+    assert.equal(
+      receipt.schemaVersion,
+      ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_SCHEMA,
+    );
     assert.equal(receipt.state, "prepared-not-signed-not-broadcast");
     assert.equal(receipt.transaction.from.toLowerCase(), owner.toLowerCase());
     assert.equal(receipt.transaction.to, deployment.atomicOwnerTransaction.to);
@@ -350,7 +411,10 @@ test("moving pending heads and provider fee differences use conservative maxima"
     `0x${"d4".repeat(32)}`,
   ];
   const { receipt } = await prepareEnvelope({
-    ceilings: { maximumFeePerGasWei: "4000000000" },
+    ceilings: {
+      maximumFeePerGasWei: "4000000000",
+      maximumGasCostWei: "31000000000000000",
+    },
     options: {
       providers: {
         quicknode: {
@@ -366,7 +430,7 @@ test("moving pending heads and provider fee differences use conservative maxima"
         alchemy: {
           pendingParentHash: openingParents[1],
           pendingTimestamp: `0x${(FIXED_TIMESTAMP + 1).toString(16)}`,
-          baseFeePerGas: "0x47868c00",
+          baseFeePerGas: "0x59682f00",
           closingParentHash: closingParents[1],
           closingPendingTimestamp: `0x${(FIXED_TIMESTAMP + 3).toString(16)}`,
           closingBaseFeePerGas: "0x53724e00",
@@ -390,7 +454,7 @@ test("moving pending heads and provider fee differences use conservative maxima"
       parentHash: openingParents[1],
       blockTimestamp: (FIXED_TIMESTAMP + 1).toString(),
       gasLimit: "30000000",
-      baseFeePerGas: "1200000000",
+      baseFeePerGas: "1500000000",
     },
   ]);
   assert.deepEqual(receipt.observation.closingPendingBlocks, [
@@ -414,11 +478,11 @@ test("moving pending heads and provider fee differences use conservative maxima"
     "7169706",
     "7169706",
   ]);
-  assert.equal(receipt.gasPolicy.observedPendingBaseFeePerGasWei, "1400000000");
+  assert.equal(receipt.gasPolicy.observedPendingBaseFeePerGasWei, "1500000000");
   assert.equal(receipt.gasPolicy.observedGasPriceWei, "3400000000");
   assert.equal(receipt.gasPolicy.observedMaxPriorityFeePerGasWei, "500000000");
   assert.equal(receipt.transaction.maxPriorityFeePerGas, "500000000");
-  assert.equal(receipt.transaction.maxFeePerGas, "3400000000");
+  assert.equal(receipt.transaction.maxFeePerGas, "3500000000");
   assert.equal(receipt.checks.movingPendingHeadsTolerated, true);
   assert.equal(receipt.checks.stateRelevantOpeningAgreement, true);
   assert.equal(receipt.checks.stateRelevantClosingAgreement, true);
@@ -706,6 +770,21 @@ test("preflight fails closed on provider, pin, vacancy, nonce, simulation, and g
       /state changed/u,
     ],
     [
+      "closing dependency code",
+      { providers: { quicknode: { closingCodeDriftKey: "poolManager" } } },
+      /state changed/u,
+    ],
+    [
+      "closing occupied target",
+      { providers: { quicknode: { closingOccupiedCodeKey: "router" } } },
+      /state changed/u,
+    ],
+    [
+      "closing target nonce",
+      { providers: { quicknode: { closingTargetNonceKey: "graphFactory" } } },
+      /state changed/u,
+    ],
+    [
       "closing simulation",
       { providers: { quicknode: { closingCallResult: "0x" } } },
       /simulation|state changed/u,
@@ -940,7 +1019,7 @@ test("read-only action-time verifier rebinds source, hosted CI, endpoints, and l
           .map(({ method, params }) => ({ method, params })),
       ]),
     );
-    assert.equal(requestsByProvider.quicknode.length, 21);
+    assert.equal(requestsByProvider.quicknode.length, 22);
     assert.deepEqual(requestsByProvider.quicknode, requestsByProvider.alchemy);
     assert.ok(
       actionTimeMock.requestInventory.every(
@@ -1135,7 +1214,7 @@ test("read-only action-time verifier rebinds source, hosted CI, endpoints, and l
   }
 });
 
-test("action-time closing simulation and gas drift fail closed", async (t) => {
+test("action-time closing chain, target, simulation, and gas drift fail closed", async (t) => {
   const { receipt } = await prepareEnvelope();
   const root = await mkdtemp(
     path.join(os.homedir(), ".robinhood-wallet-closing-test-"),
@@ -1163,6 +1242,35 @@ test("action-time closing simulation and gas drift fail closed", async (t) => {
       ),
     ]);
     const cases = [
+      [
+        "closing chain ID drift",
+        { providers: { quicknode: { closingChainId: "0x1" } } },
+        /state changed during wallet verification/u,
+      ],
+      [
+        "closing occupied target",
+        {
+          providers: {
+            quicknode: {
+              closingOccupiedCodeKey: "router",
+              closingCodeAfterReads: 1,
+            },
+          },
+        },
+        /state changed during wallet verification/u,
+      ],
+      [
+        "closing target nonce",
+        {
+          providers: {
+            quicknode: {
+              closingTargetNonceKey: "graphFactory",
+              closingTargetNonceAfterReads: 1,
+            },
+          },
+        },
+        /state changed during wallet verification/u,
+      ],
       [
         "closing eth_call drift",
         { providers: { quicknode: { closingCallResult: "0x" } } },
@@ -1210,6 +1318,58 @@ test("freshness validation and protected output reject tampering, expiry, and ov
     ),
     receipt.receiptDigest,
   );
+  assert.equal(redigestOwnerEnvelope(receipt).receiptDigest, receipt.receiptDigest);
+  const semanticallyInvalidReceipts = [
+    ["schema", (candidate) => {
+      candidate.schemaVersion =
+        "programmable.robinhood-custom-launch.owner-envelope.v1";
+    }],
+    ["source key inventory", (candidate) => {
+      candidate.source.unexpected = true;
+    }],
+    ["transaction key inventory", (candidate) => {
+      candidate.transaction.gasPrice = "1";
+    }],
+    ["common anchor", (candidate) => {
+      candidate.observation.commonAnchor.blockNumber = (
+        BigInt(candidate.observation.commonAnchor.blockNumber) - 1n
+      ).toString();
+    }],
+    ["opening fee maximum", (candidate) => {
+      candidate.observation.openingPendingBlocks[0].baseFeePerGas = (
+        BigInt(candidate.gasPolicy.observedPendingBaseFeePerGasWei) + 1n
+      ).toString();
+    }],
+    ["closing fee maximum", (candidate) => {
+      candidate.observation.closingFeeObservations[0].gasPrice = (
+        BigInt(candidate.gasPolicy.observedGasPriceWei) + 1n
+      ).toString();
+    }],
+    ["simulation gas agreement", (candidate) => {
+      candidate.simulation.gasEstimates[0] = (
+        BigInt(candidate.simulation.agreedGasEstimate) + 1n
+      ).toString();
+    }],
+    ["boolean check", (candidate) => {
+      candidate.checks.closingGasAgreement = false;
+    }],
+    ["RPC method inventory", (candidate) => {
+      candidate.checks.rpcMethodInventory.push("eth_sendTransaction");
+    }],
+  ];
+  for (const [name, mutate] of semanticallyInvalidReceipts) {
+    const candidate = structuredClone(receipt);
+    mutate(candidate);
+    assert.throws(
+      () =>
+        assertFreshRobinhoodFoundationOwnerEnvelope(
+          redigestOwnerEnvelope(candidate),
+          FIXED_TIMESTAMP * 1_000,
+        ),
+      /stale, unsafe, or digest-invalid/u,
+      name,
+    );
+  }
   assert.throws(
     () =>
       assertFreshRobinhoodFoundationOwnerEnvelope(

--- a/contracts/scripts/test/robinhood-custom-launch-release-docs.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-release-docs.test.mjs
@@ -119,7 +119,12 @@ test("operator runbooks use repo-root commands and independently frozen provider
     security,
     /contracts\/spec\/robinhood-custom-launch\/standard-json\//u,
   );
-  assert.match(handoff, /second closing nonce\/vacancy snapshot/u);
+  assert.match(
+    handoff,
+    /second closing\s+nonce\/code\/vacancy\/simulation\/gas snapshot/u,
+  );
+  assert.match(handoff, /two identical state-relevant snapshots/u);
+  assert.match(handoff, /highest base fee, gas price and priority fee/u);
   assert.doesNotMatch(
     security,
     /contracts:robinhood:postdeploy:(?:assemble|verify)\s/u,

--- a/docs/operations/releases/custom-launch-v4/OWNER-WALLET-HANDOFF.md
+++ b/docs/operations/releases/custom-launch-v4/OWNER-WALLET-HANDOFF.md
@@ -99,7 +99,13 @@ Public Robinhood RPC, dRPC and provider demo endpoints are not substitutes for
 the current owner action-time pair. A public endpoint may return
 `safe`/`finalized` headers while failing historical state reads at that same
 block. The credentialed providers must pass the exact fixed-block code, nonce,
-pending-state, simulation and closing-state inventory.
+pending-state, simulation and closing-state inventory. Robinhood produces blocks
+fast enough that authenticated providers can legitimately observe different
+pending parents or fees during one bounded preflight. The guard therefore
+requires two identical state-relevant snapshots (runtime code, target vacancy,
+owner nonce, simulation return and gas estimate) while recording both pending
+observations. Fee fields use the highest base fee, gas price and priority fee
+reported by either provider and remain bounded by the owner's explicit ceilings.
 
 ## Fresh envelope
 
@@ -161,7 +167,8 @@ verifier. It rechecks freshness, the protected source and production ref, the
 exact hosted Verify proof, provider commitments and every wallet field. It then
 uses both frozen credentialed providers to re-read chain ID, owner `latest` and
 `pending` nonce, pending code and nonce vacancy for all three targets, the exact
-pending simulation and gas estimate, and a second closing nonce/vacancy snapshot.
+pending simulation and gas estimate, and a second closing
+nonce/code/vacancy/simulation/gas snapshot.
 It then re-reads the canonical GitHub `production` ref and revalidates the same
 persisted immutable Verify run, attempt and artifact before one final local
 source/freshness guard. Its output contains only a bounded safe summary, never


### PR DESCRIPTION
## Summary

- tolerate provider-specific pending parent, timestamp, and fee movement during Robinhood fast-block preflight
- require two exact state-relevant snapshots across both authenticated providers: runtime code, target vacancy, owner nonce, simulation result, and gas estimate
- derive fee caps from the maximum observed provider values while retaining owner ceilings
- repeat simulation and gas verification at action time and document the invariant

## Verification

- Robinhood owner-envelope and release suite: 72/72 passed
- focused owner-envelope and docs suite: 30/30 passed
- Foundry build: 512 files, Solc 0.8.26, successful
- ESLint: passed
- git diff --check: passed

No signing, broadcast, provider mutation, deployment, or onchain mutation.