### PR TITLE
Clarify failed fee refresh state

### DIFF
--- a/ops/protocol-fee-claim/app.js
+++ b/ops/protocol-fee-claim/app.js
@@ -3090,6 +3090,9 @@ async function refreshClaimsOnce() {
             ? `Aktuell · Block ${BigInt(blockTag).toString()}`
             : `${failedClaims} Guthaben konnten nicht gelesen werden`,
     );
+  } catch (error) {
+    setStatus("Prüfung unvollständig");
+    throw error;
   } finally {
     state.scanInProgress = false;
     renderSummary();

--- a/ops/protocol-fee-claim/logic.test.mjs
+++ b/ops/protocol-fee-claim/logic.test.mjs
@@ -469,6 +469,10 @@ test("discovers MetaMask with EIP-6963 and safe legacy fallbacks", () => {
 
 test("keeps the static Vercel scanner on wallet RPC and serializes refreshes", () => {
   const app = readFileSync(new URL("./app.js", import.meta.url), "utf8");
+  const refreshClaimsOnce = app.slice(
+    app.indexOf("async function refreshClaimsOnce()"),
+    app.indexOf("const refreshClaims = createRefreshQueue(refreshClaimsOnce);"),
+  );
   assert.match(
     app,
     /const walletProvider = await requireMetaMaskProvider\(\);\s*const operation = walletProvider\.request\(\{ method, params \}\);/,
@@ -535,6 +539,10 @@ test("keeps the static Vercel scanner on wallet RPC and serializes refreshes", (
     /const batch = await preflightClaimBatch\(claims\);\s*await requireActiveRewardWallet\(expectedAccount\);\s*requireConfirmedBatchStorage\(\);/,
   );
   assert.doesNotMatch(app, /fetch\(["']\/rpc/);
+  assert.match(
+    refreshClaimsOnce,
+    /catch \(error\) \{\s*setStatus\("Prüfung unvollständig"\);\s*throw error;\s*\} finally/,
+  );
   assert.match(app, /const refreshClaims = createRefreshQueue\(refreshClaimsOnce\);/);
   assert.match(app, /await refreshClaims\(\);/);
   assert.match(app, /async function preflightClaimBatch\(claims\)/);


### PR DESCRIPTION
## Summary
- replace the stale “Fees werden geprüft” status after a failed refresh with “Prüfung unvollständig”
- preserve fail-closed rethrow, queue semantics, and the connected reward-wallet state
- add a regression assertion for the terminal refresh status

## Verification
- npm run check: 44/44 tests and static build
- git diff --check
- independent read-only code audit: PASS
- mock MetaMask retry QA: PASS; no send or signature RPCs