### PR TITLE
Launch V4 migration deposit page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,34 @@ PROGRAMMABLE_PREDICTION_V2_SETTLEMENT_RPC_ENDPOINT_COMMITMENT=
 # Required by server routes that verify Privy access tokens.
 PRIVY_APP_SECRET=
 
+# V4 migration page release controls. The public route and landing-page entry
+# must be enabled together only after the checked-in 96-hour activation window
+# is finalized. Local preview never enables production transfers.
+PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_ENABLED=false
+NEXT_PUBLIC_PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_VISIBLE=false
+PROGRAMMABLE_MAIN_TOKEN_MIGRATION_LOCAL_PREVIEW=false
+
+# Optional, server-only V4 migration gas sponsor for the reviewed 96-hour
+# release. This remains fail-closed until
+# the signed migration activation manifest is enabled and every value below is
+# configured. Use a dedicated, policy-limited Privy EOA with a deliberately
+# bounded ETH balance. Never use the migration recipient wallet as the sponsor.
+# The Privy wallet must have exactly the configured policy attached. That policy
+# must permit only Ethereum Mainnet native eth_sendTransaction top-ups with a
+# value ceiling no higher than 0.002 ETH. Privy's transaction policy does not
+# attest calldata or the dynamic holder recipient; runtime binds both itself.
+# Runtime also enforces a 20 gwei max-fee ceiling, a 125% transfer-gas quote multiplier, a
+# fixed 21,000-gas sponsor transfer and a 1 ETH absolute release-budget ceiling.
+# Keep all operational values blank in committed files; inject them only through
+# the deployment secret manager. The complete activation and readiness contract
+# is docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-V1.md.
+MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ENABLED=false
+MAIN_TOKEN_MIGRATION_GAS_SPONSOR_PRIVY_WALLET_ID=
+MAIN_TOKEN_MIGRATION_GAS_SPONSOR_PRIVY_POLICY_ID=
+MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ADDRESS=
+MAIN_TOKEN_MIGRATION_GAS_SPONSOR_MAX_TOP_UP_WEI=
+MAIN_TOKEN_MIGRATION_GAS_SPONSOR_TOTAL_BUDGET_WEI=
+
 # GitHub App user-to-server launch authority. The Website receives `ghu_`
 # tokens only through the registered PKCE callback, seals them in an HttpOnly
 # cookie, revalidates them with GitHub, and signs a 30-second release-bound

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -54,6 +54,16 @@ regexes = [
 ]
 
 [[allowlists]]
+description = "Migration activation pins the public V4 token address and runtime code hash"
+condition = "AND"
+regexTarget = "match"
+paths = ['''config/main-token-migration-activation\.v1\.json''']
+regexes = [
+  '''(?i)0x7987f03462200b3d8a072e02c89a8a41dcb124ee''',
+  '''(?i)0x4fe466386aeebe507f6bcfc58e046a0632e4687699fa5bd28c4b7ec6333141ad''',
+]
+
+[[allowlists]]
 description = "Public documentation pins the public V4 token address"
 condition = "AND"
 regexTarget = "match"

--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ npm run contracts:verify
 These commands prove only the local revision that was checked. They do not prove deployment, production activation,
 provider availability or onchain lifecycle completion.
 
+The reviewed 96-hour Ethereum-to-Robinhood main-token migration and its optional gas sponsor are currently
+release-dark. Their checked-in activation manifest remains disabled and contains no live window or opening block.
+Operator preparation is defined by the
+[gas sponsor runbook](./docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-V1.md) and the separate
+[readiness checklist](./docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-READINESS-V1.md); neither document authorizes
+publication, wallet spending or production activation.
+
 ## Public interfaces
 
 | Surface                      | Canonical location                                                                                       |

--- a/app/api/main-token-migration/gas-sponsorship/route.ts
+++ b/app/api/main-token-migration/gas-sponsorship/route.ts
@@ -1,0 +1,16 @@
+import {
+  handleProductionMainTokenMigrationGasSponsorGetV1,
+  handleProductionMainTokenMigrationGasSponsorPostV1,
+} from "@/lib/server/main-token-migration-gas-sponsor-v1";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+export const runtime = "nodejs";
+
+export function GET(request: Request): Promise<Response> {
+  return handleProductionMainTokenMigrationGasSponsorGetV1(request);
+}
+
+export function POST(request: Request): Promise<Response> {
+  return handleProductionMainTokenMigrationGasSponsorPostV1(request);
+}

--- a/app/api/main-token-migration/window-time/route.ts
+++ b/app/api/main-token-migration/window-time/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      schema: "programmable-main-token-migration-window-time/v1",
+      serverTimeMs: Date.now(),
+    },
+    {
+      headers: {
+        "cache-control": "no-store, max-age=0",
+      },
+    },
+  );
+}

--- a/app/migration/page.tsx
+++ b/app/migration/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { MainTokenMigration } from "@/components/main-token-migration";
+import migrationActivationManifest from "@/config/main-token-migration-activation.v1.json";
+
+export const metadata: Metadata = {
+  title: "V4 migration | Programmable",
+  description:
+    "Prepare an Ethereum V4 transfer for an equal token-unit allocation to the same address on Robinhood Chain.",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function MigrationPage() {
+  const localPreview =
+    process.env.NODE_ENV !== "production" &&
+    process.env.PROGRAMMABLE_MAIN_TOKEN_MIGRATION_LOCAL_PREVIEW === "true";
+  const publicReleaseEnabled =
+    process.env.PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_ENABLED === "true" &&
+    migrationActivationManifest.enabled === true;
+  if (!localPreview && !publicReleaseEnabled) {
+    notFound();
+  }
+  return <MainTokenMigration />;
+}

--- a/components/landing-page.module.css
+++ b/components/landing-page.module.css
@@ -142,6 +142,41 @@
   margin: 24px 0 0;
 }
 
+.migrationCta {
+  align-items: center;
+  background: rgb(0 0 0 / 0.56);
+  border: 1px solid rgb(255 255 255 / 0.22);
+  border-radius: 16px;
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.12),
+    0 20px 56px rgb(0 0 0 / 0.28);
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  margin-top: 40px;
+  min-height: 72px;
+  min-width: min(320px, calc(100vw - 40px));
+  padding: 12px 24px;
+  transition:
+    background 700ms var(--webde-ease),
+    border-color 700ms var(--webde-ease),
+    transform 700ms var(--webde-ease);
+}
+
+.migrationCta span {
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.migrationCta small {
+  color: #c9c9c6;
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 12px;
+  line-height: 1.4;
+  margin-top: 2px;
+}
+
 .scrollCue {
   align-items: center;
   bottom: 25px;
@@ -404,6 +439,12 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
+  .migrationCta:hover {
+    background: rgb(20 20 20 / 0.78);
+    border-color: rgb(255 255 255 / 0.42);
+    transform: translateY(-2px);
+  }
+
   .scrollCue:hover,
   .docsLink:hover,
   .inlineLink:hover {
@@ -415,7 +456,8 @@
 @media (prefers-reduced-motion: no-preference) {
   .heroLogo,
   .hero h1,
-  .heroContent > p {
+  .heroContent > p,
+  .migrationCta {
     animation: hero-reveal 1700ms cubic-bezier(0.23, 1, 0.32, 1) both;
   }
 
@@ -429,6 +471,10 @@
 
   .heroContent > p {
     animation-delay: 520ms;
+  }
+
+  .migrationCta {
+    animation-delay: 680ms;
   }
 
   .scrollCue {

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -6,9 +6,14 @@ import Link from "next/link";
 
 import { LandingExploreGate } from "@/components/landing-explore-gate";
 import styles from "@/components/landing-page.module.css";
+import migrationActivationManifest from "@/config/main-token-migration-activation.v1.json";
 
 const loopMark = "/brand/loop/programmable-loop-mark-header-white-v1-1536.png";
 const HERO_TWINKLE_COUNT = 120;
+const migrationAnnouncementVisible =
+  migrationActivationManifest.enabled === true &&
+  process.env.NEXT_PUBLIC_PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_VISIBLE ===
+  "true";
 
 type HeroStarStyle = CSSProperties & {
   "--hero-star-delay": string;
@@ -155,6 +160,12 @@ export function LandingPage() {
           />
           <h1 id="landing-title">Programmable</h1>
           <p>Build and launch custom Uniswap v4 hooks</p>
+          {migrationAnnouncementVisible ? (
+            <Link className={styles.migrationCta} href="/migration">
+              <span>We are migrating</span>
+              <small>Ethereum → Robinhood Chain</small>
+            </Link>
+          ) : null}
         </div>
 
         <a className={styles.scrollCue} href="#what-is-programmable">

--- a/components/main-token-migration.module.css
+++ b/components/main-token-migration.module.css
@@ -1,0 +1,1105 @@
+:global(body .app-frame):has(.page) {
+  height: auto;
+  min-height: 100svh;
+  overflow-x: clip;
+  overflow-y: visible;
+}
+
+:global(body .app-frame):has(.page) > :global(main),
+:global(body .app-frame):has(.page) :global(.route-transition) {
+  height: auto;
+  min-height: 0;
+  overflow-x: clip;
+  overflow-y: visible;
+}
+
+.page {
+  color: var(--webde-ink);
+  min-height: 100svh;
+  min-width: 0;
+  overflow-x: clip;
+  padding-bottom: 96px;
+  position: relative;
+}
+
+.hero {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: calc(100svh - 88px);
+  padding: 80px max(24px, calc((100% - 1280px) / 2)) 96px;
+  position: relative;
+  text-align: center;
+}
+
+.previewFlag {
+  background: rgb(255 255 255 / 0.08);
+  border: 1px solid rgb(255 255 255 / 0.14);
+  border-radius: 999px;
+  color: var(--webde-muted);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  line-height: 1.35;
+  margin-bottom: 32px;
+  padding: 8px 12px;
+  text-transform: uppercase;
+}
+
+.loopMark {
+  filter: grayscale(1) brightness(0) invert(1);
+  height: 48px;
+  margin-bottom: 24px;
+  object-fit: contain;
+  width: 38px;
+}
+
+.eyebrow,
+.panelHeader > p,
+.process header > p {
+  color: var(--webde-dim);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1.35;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  background: linear-gradient(90deg, #fff, #9b9b9b);
+  background-clip: text;
+  color: transparent;
+  font-size: clamp(48px, 7vw, 96px);
+  font-weight: 560;
+  letter-spacing: -0.045em;
+  line-height: 1.08;
+  margin: 24px 0 0;
+  max-width: none;
+  padding-bottom: 0.08em;
+  text-wrap: balance;
+  white-space: nowrap;
+}
+
+.chainFlow {
+  align-items: center;
+  display: flex;
+  gap: clamp(18px, 3vw, 36px);
+  justify-content: center;
+  margin-top: 22px;
+}
+
+.chainName {
+  align-items: center;
+  color: #fff;
+  display: inline-flex;
+  font-size: clamp(18px, 2vw, 24px);
+  font-weight: 600;
+  gap: 10px;
+  line-height: 1.2;
+}
+
+.ethereumMark {
+  fill: currentColor;
+  height: 30px;
+  width: 19px;
+}
+
+.ethereumMark path:first-child {
+  opacity: 0.9;
+}
+
+.ethereumMark path:last-child {
+  opacity: 0.62;
+}
+
+.chainArrow {
+  color: #fff;
+  font-family: var(--font-plex-mono), monospace;
+  font-size: clamp(36px, 5vw, 56px);
+  font-weight: 650;
+  line-height: 0.8;
+}
+
+.heroCopy {
+  color: var(--webde-muted);
+  font-size: 20px;
+  line-height: 1.5;
+  margin: 32px auto 0;
+  max-width: 680px;
+  text-wrap: pretty;
+}
+
+.criticalCopy {
+  color: #fff;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.5;
+  margin: 16px auto 0;
+  max-width: 680px;
+  text-wrap: pretty;
+}
+
+.officialNotice {
+  background: rgb(255 255 255 / 0.055);
+  border: 1px solid rgb(255 255 255 / 0.11);
+  border-radius: 8px;
+  color: var(--webde-muted);
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 20px auto 0;
+  max-width: 620px;
+  padding: 12px 16px;
+  text-wrap: pretty;
+}
+
+.officialNotice strong {
+  color: #fff;
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 0.93em;
+  font-weight: 500;
+  overflow-wrap: anywhere;
+}
+
+.countdown {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  margin-top: 40px;
+  min-width: 0;
+}
+
+.countdownLabel,
+.absoluteDeadline {
+  color: var(--webde-muted);
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.clock {
+  align-items: start;
+  display: grid;
+  gap: clamp(8px, 2vw, 24px);
+  grid-template-columns: 1fr auto 1fr auto 1fr;
+  margin: 16px 0;
+}
+
+.clock > span {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  min-width: clamp(68px, 10vw, 128px);
+}
+
+.clock strong,
+.clock i {
+  color: #fff;
+  font-family: var(--font-plex-mono), monospace;
+  font-size: clamp(40px, 6vw, 72px);
+  font-style: normal;
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  letter-spacing: -0.06em;
+  line-height: 1;
+}
+
+.clock i {
+  color: var(--webde-dim);
+}
+
+.clock small {
+  color: var(--webde-dim);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  line-height: 1.35;
+  margin-top: 8px;
+  text-transform: uppercase;
+}
+
+.migrationPanel,
+.process {
+  margin-inline: auto;
+  width: min(calc(100% - 48px), 1120px);
+}
+
+.migrationPanel {
+  background: #181818;
+  border: 1px solid var(--webde-line);
+  border-radius: 16px;
+  box-shadow: 0 32px 80px rgb(0 0 0 / 0.32);
+  overflow: hidden;
+}
+
+.closedNotice {
+  align-items: center;
+  background: #2b1717;
+  border-bottom: 1px solid #593030;
+  color: #ffd3d3;
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  padding: 16px 24px;
+  text-align: center;
+}
+
+.closedNotice strong {
+  color: #fff;
+  flex: none;
+}
+
+.closedNotice span {
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.summary > div {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 24px;
+}
+
+.summary > div + div {
+  border-inline-start: 1px solid var(--webde-line);
+}
+
+.summary span,
+.walletRow span,
+.balanceRow span,
+.transferReview span {
+  color: var(--webde-dim);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.summary strong {
+  color: #fff;
+  font-size: 16px;
+  font-weight: 560;
+  line-height: 1.45;
+  margin-top: 6px;
+}
+
+.panelGrid {
+  border-top: 1px solid var(--webde-line);
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+}
+
+.transferColumn,
+.destinationColumn {
+  min-width: 0;
+  padding: 48px;
+}
+
+.destinationColumn {
+  background: #131313;
+  border-inline-start: 1px solid var(--webde-line);
+}
+
+.panelHeader h2,
+.process h2 {
+  color: #fff;
+  font-size: 30px;
+  font-weight: 560;
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+  margin: 8px 0 0;
+  text-wrap: balance;
+}
+
+.connectPrompt,
+.destinationColumn > p {
+  color: var(--webde-muted);
+  font-size: 16px;
+  line-height: 1.55;
+  margin: 32px 0 0;
+  text-wrap: pretty;
+}
+
+.walletRow,
+.balanceRow {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 32px;
+  min-height: 24px;
+}
+
+.walletRow + .balanceRow {
+  margin-top: 12px;
+}
+
+.walletTypeStatus {
+  background: #111;
+  border: 1px solid var(--webde-line);
+  border-radius: 8px;
+  display: grid;
+  gap: 5px;
+  margin-top: 16px;
+  padding: 14px 16px;
+}
+
+.walletTypeStatus strong {
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.walletTypeStatus span {
+  color: var(--webde-muted);
+  font-size: 13px;
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+
+.walletTypeStatus[data-status="eoa"] {
+  background: #152019;
+  border-color: #2d4935;
+}
+
+.walletTypeStatus[data-status="eoa"] strong {
+  color: #dff7e5;
+}
+
+.walletTypeStatus[data-status="contract"],
+.walletTypeStatus[data-status="unavailable"] {
+  background: #241c13;
+  border-color: #49351f;
+}
+
+.walletTypeStatus[data-status="contract"] strong,
+.walletTypeStatus[data-status="unavailable"] strong {
+  color: #ffe3bb;
+}
+
+.walletRow strong,
+.balanceRow strong {
+  color: #fff;
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.45;
+}
+
+.balanceLoading {
+  animation: balance-pulse 1.2s var(--webde-ease) infinite alternate;
+}
+
+.amountGroup {
+  margin-top: 32px;
+}
+
+.amountGroup > label {
+  color: #fff;
+  display: block;
+  font-size: 14px;
+  font-weight: 560;
+  line-height: 1.4;
+  margin-bottom: 8px;
+}
+
+.amountControl {
+  align-items: center;
+  background: #0f0f0f;
+  border: 1px solid var(--webde-line);
+  border-radius: 8px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  min-height: 56px;
+  padding-inline: 16px 8px;
+  transition:
+    border-color 300ms var(--webde-ease),
+    box-shadow 300ms var(--webde-ease);
+}
+
+.amountControl:focus-within {
+  border-color: #fff;
+  box-shadow: 0 0 0 2px rgb(255 255 255 / 0.12);
+}
+
+.amountControl input {
+  background: transparent;
+  border: 0;
+  color: #fff;
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 20px;
+  line-height: 1.4;
+  min-width: 0;
+  outline: 0;
+  padding: 12px 0;
+  width: 100%;
+}
+
+.amountControl > span {
+  color: var(--webde-muted);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 13px;
+  margin-inline: 12px;
+}
+
+.amountControl button,
+.addressBlock button {
+  background: #272727;
+  border: 1px solid #383838;
+  border-radius: 8px;
+  color: #fff;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  min-height: 44px;
+  padding: 8px 12px;
+  transition:
+    background 300ms var(--webde-ease),
+    transform 300ms var(--webde-ease);
+}
+
+.amountControl button:active,
+.addressBlock button:active,
+.primaryAction:active,
+.backLink:active {
+  transform: scale(0.98);
+}
+
+.amountControl button:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+.addressBlock button:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+.amountGroup > p,
+.walletBoundary {
+  color: var(--webde-dim);
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 8px 0 0;
+  text-wrap: pretty;
+}
+
+.acknowledgement {
+  align-items: flex-start;
+  color: var(--webde-muted);
+  cursor: pointer;
+  display: grid;
+  font-size: 14px;
+  gap: 12px;
+  grid-template-columns: 20px minmax(0, 1fr);
+  line-height: 1.5;
+  margin-top: 32px;
+  min-height: 44px;
+  padding-block: 4px;
+}
+
+.acknowledgement input {
+  appearance: none;
+  accent-color: #fff;
+  background: #0f0f0f;
+  border: 1px solid #666;
+  border-radius: 4px;
+  display: grid;
+  height: 20px;
+  margin: 1px 0 0;
+  place-content: center;
+  width: 20px;
+}
+
+.acknowledgement input::before {
+  background: #000;
+  clip-path: polygon(14% 44%, 0 59%, 38% 100%, 100% 20%, 84% 7%, 36% 70%);
+  content: "";
+  height: 10px;
+  transform: scale(0);
+  transition: transform 160ms var(--webde-ease);
+  width: 10px;
+}
+
+.acknowledgement input:checked {
+  background: #fff;
+  border-color: #fff;
+}
+
+.acknowledgement input:checked::before {
+  transform: scale(1);
+}
+
+.acknowledgement input:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 3px;
+}
+
+.acknowledgement:has(input:disabled) {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.transferReview {
+  background: #131313;
+  border-radius: 8px;
+  display: grid;
+  gap: 12px;
+  margin-top: 32px;
+  padding: 16px;
+}
+
+.transferReview > div {
+  align-items: center;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.transferReview strong {
+  color: #fff;
+  font-size: 14px;
+  font-weight: 560;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+  text-align: end;
+}
+
+.addressReviewRow {
+  align-items: flex-start !important;
+  flex-direction: column;
+}
+
+.addressReviewRow code {
+  color: #fff;
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+  text-align: start;
+}
+
+.destinationUnavailable {
+  background: #101010;
+  border: 1px dashed #343434;
+  border-radius: 8px;
+  display: grid;
+  gap: 6px;
+  margin-top: 32px;
+  padding: 16px;
+}
+
+.destinationUnavailable strong {
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.destinationUnavailable span {
+  color: var(--webde-muted);
+  font-size: 13px;
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+
+.primaryAction {
+  background: #fff;
+  border: 1px solid #fff;
+  border-radius: 8px;
+  color: #000;
+  cursor: pointer;
+  font-size: 16px;
+  font-weight: 650;
+  margin-top: 24px;
+  min-height: 52px;
+  padding: 12px 16px;
+  transition:
+    background 300ms var(--webde-ease),
+    color 300ms var(--webde-ease),
+    transform 300ms var(--webde-ease);
+  width: 100%;
+}
+
+.primaryAction:disabled {
+  background: #272727;
+  border-color: #383838;
+  color: var(--webde-dim);
+  cursor: not-allowed;
+}
+
+.status:empty {
+  display: none;
+}
+
+.inlineError {
+  color: #ffb4b4;
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 12px 0 0;
+}
+
+.transactionStatus {
+  border-radius: 8px;
+  margin-top: 24px;
+  padding: 16px;
+}
+
+.transactionStatus strong {
+  color: #fff;
+  font-size: 16px;
+  line-height: 1.4;
+}
+
+.transactionStatus p {
+  color: var(--webde-muted);
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 8px 0 0;
+  text-wrap: pretty;
+}
+
+.pendingStatus {
+  background: #211e16;
+  border: 1px solid #4b4227;
+}
+
+.pendingStatus strong {
+  color: #f7edca;
+}
+
+.confirmedStatus {
+  background: #1d2b21;
+  border: 1px solid #304c37;
+}
+
+.confirmedStatus strong {
+  color: #dff7e5;
+}
+
+.confirmedStatus p {
+  color: #b7d1bd;
+}
+
+.revertedStatus {
+  background: #2b1717;
+  border: 1px solid #593030;
+}
+
+.revertedStatus strong {
+  color: #ffd3d3;
+}
+
+.transactionStatus a,
+.backLink {
+  color: #fff;
+  display: inline-flex;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.4;
+  min-height: 44px;
+  padding-block: 12px;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.secondaryAction {
+  background: #fff;
+  border: 1px solid #fff;
+  border-radius: 8px;
+  color: #000;
+  cursor: pointer;
+  display: block;
+  font-size: 14px;
+  font-weight: 650;
+  margin-top: 8px;
+  min-height: 44px;
+  padding: 10px 14px;
+  transition:
+    background 300ms var(--webde-ease),
+    transform 300ms var(--webde-ease);
+  width: 100%;
+}
+
+.secondaryAction:active {
+  transform: scale(0.98);
+}
+
+.confirmationIssue {
+  background: #241c13;
+  border: 1px solid #49351f;
+  border-radius: 8px;
+  color: #ffe3bb;
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 12px 0 0;
+  padding: 12px 14px;
+  text-wrap: pretty;
+}
+
+.addressBlock {
+  background: #0c0c0c;
+  border: 1px solid var(--webde-line);
+  border-radius: 8px;
+  margin-top: 24px;
+  padding: 16px;
+}
+
+.addressBlock code,
+.contractFacts code {
+  color: #fff;
+  display: block;
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 13px;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+
+.addressBlock button {
+  margin-top: 16px;
+  width: 100%;
+}
+
+.copyStatus {
+  color: var(--webde-muted);
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 10px 0 0;
+  min-height: 20px;
+}
+
+.clockIssue {
+  color: #ffe3bb;
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 12px auto 0;
+  text-align: center;
+}
+
+.contractFacts {
+  margin: 32px 0 0;
+}
+
+.contractFacts > div + div {
+  margin-top: 20px;
+}
+
+.contractFacts dt {
+  color: var(--webde-dim);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.contractFacts dd {
+  color: #fff;
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 6px 0 0;
+}
+
+.warning {
+  background: #241c13;
+  border: 1px solid #49351f;
+  border-radius: 8px;
+  margin-top: 32px;
+  padding: 16px;
+}
+
+.closedAddressNote {
+  color: var(--webde-muted);
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 16px 0 0;
+}
+
+.warning strong {
+  color: #ffe3bb;
+  font-size: 15px;
+}
+
+.warning p {
+  color: #d2b994;
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 10px 0 0;
+  text-wrap: pretty;
+}
+
+.process {
+  padding-block: 96px 0;
+}
+
+.process header {
+  text-align: center;
+}
+
+.process ol {
+  display: grid;
+  gap: 48px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  list-style: none;
+  margin: 64px 0 0;
+  padding: 0;
+}
+
+.process li {
+  counter-increment: migration-step;
+}
+
+.process ol {
+  counter-reset: migration-step;
+}
+
+.process li::before {
+  color: var(--webde-dim);
+  content: "0" counter(migration-step);
+  display: block;
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 13px;
+  line-height: 1.4;
+  margin-bottom: 16px;
+}
+
+.process li strong,
+.process li span {
+  display: block;
+}
+
+.process li strong {
+  color: #fff;
+  font-size: 18px;
+  font-weight: 560;
+  line-height: 1.45;
+}
+
+.process li span,
+.finalNote {
+  color: var(--webde-muted);
+  font-size: 15px;
+  line-height: 1.6;
+  margin-top: 8px;
+  text-wrap: pretty;
+}
+
+.finalNote {
+  margin: 64px auto 0;
+  max-width: 680px;
+  text-align: center;
+}
+
+.backLink {
+  margin: 24px auto 0;
+  width: max-content;
+}
+
+.page :is(button, a, input):focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 3px;
+}
+
+@keyframes balance-pulse {
+  from { opacity: 0.42; }
+  to { opacity: 0.9; }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .amountControl button:hover:not(:disabled),
+  .addressBlock button:hover:not(:disabled) {
+    background: #313131;
+  }
+
+  .primaryAction:hover:not(:disabled) {
+    background: #e9e9e9;
+  }
+
+  .transactionStatus a:hover,
+  .backLink:hover {
+    color: var(--webde-muted);
+  }
+
+  .secondaryAction:hover {
+    background: #e9e9e9;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .balanceLoading {
+    animation: none;
+  }
+
+  .amountControl,
+  .amountControl button,
+  .addressBlock button,
+  .primaryAction,
+  .secondaryAction {
+    transition: none;
+  }
+}
+
+@media (max-width: 56rem) {
+  .summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .summary > div:nth-child(3) {
+    border-inline-start: 0;
+    border-top: 1px solid var(--webde-line);
+  }
+
+  .summary > div:nth-child(4) {
+    border-top: 1px solid var(--webde-line);
+  }
+
+  .panelGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .destinationColumn {
+    border-inline-start: 0;
+    border-top: 1px solid var(--webde-line);
+  }
+
+  .process ol {
+    gap: 40px;
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 40rem) {
+  .page {
+    padding-bottom: 64px;
+  }
+
+  .hero {
+    min-height: auto;
+    padding: 64px 20px 80px;
+  }
+
+  .hero h1 {
+    font-size: clamp(36px, 11vw, 48px);
+  }
+
+  .chainFlow {
+    gap: 14px;
+    margin-top: 18px;
+  }
+
+  .chainName {
+    font-size: 17px;
+    gap: 8px;
+  }
+
+  .ethereumMark {
+    height: 25px;
+    width: 16px;
+  }
+
+  .chainArrow {
+    font-size: 34px;
+  }
+
+  .heroCopy {
+    font-size: 18px;
+    margin-top: 24px;
+  }
+
+  .countdown {
+    margin-top: 32px;
+    width: 100%;
+  }
+
+  .clock {
+    gap: 6px;
+    width: 100%;
+  }
+
+  .clock > span {
+    min-width: 0;
+  }
+
+  .clock strong,
+  .clock i {
+    font-size: 36px;
+  }
+
+  .migrationPanel,
+  .process {
+    width: min(calc(100% - 32px), 1120px);
+  }
+
+  .summary > div {
+    padding: 16px;
+  }
+
+  .closedNotice {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
+    text-align: start;
+  }
+
+  .transferColumn,
+  .destinationColumn {
+    padding: 32px 20px;
+  }
+
+  .walletRow,
+  .balanceRow {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .amountControl {
+    padding-inline: 12px 8px;
+  }
+
+  .amountControl input {
+    font-size: 18px;
+  }
+
+  .amountControl > span {
+    margin-inline: 8px;
+  }
+
+  .transferReview > div {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .transferReview strong {
+    text-align: start;
+  }
+
+  .process {
+    padding-top: 80px;
+  }
+}
+
+@media (max-width: 22rem) {
+  .hero {
+    padding-inline: 16px;
+  }
+
+  .migrationPanel,
+  .process {
+    width: calc(100% - 24px);
+  }
+
+  .summary {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .summary > div + div,
+  .summary > div:nth-child(3) {
+    border-inline-start: 0;
+    border-top: 1px solid var(--webde-line);
+  }
+}

--- a/components/main-token-migration.tsx
+++ b/components/main-token-migration.tsx
@@ -1,0 +1,2174 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+} from "react";
+import { formatUnits, getAddress, isAddress, type Hex } from "viem";
+
+import styles from "@/components/main-token-migration.module.css";
+import { useWallet } from "@/components/wallet-provider";
+import migrationActivationManifest from "@/config/main-token-migration-activation.v1.json";
+import {
+  assertMainTokenMigrationBalance,
+  assertMainTokenMigrationTransaction,
+  buildMainTokenMigrationTransaction,
+  MAIN_TOKEN_ADDRESS,
+  MAIN_TOKEN_DECIMALS,
+  MAIN_TOKEN_MIGRATION_CHAIN_ID,
+  MAIN_TOKEN_MIGRATION_RELEASE_ID,
+  MAIN_TOKEN_MIGRATION_WALLET,
+  MAIN_TOKEN_MIGRATION_WINDOW_SECONDS,
+  MAIN_TOKEN_RUNTIME_CODE_KECCAK256,
+  MAIN_TOKEN_SYMBOL,
+  MAIN_TOKEN_TOTAL_SUPPLY_RAW,
+  parseMainTokenMigrationAmount,
+} from "@/lib/main-token-migration";
+
+const loopMark = "/brand/loop/programmable-loop-mark-header-white-v1-1536.png";
+const decimalIntegerPattern = /^(?:0|[1-9][0-9]*)$/u;
+const positiveIntegerPattern = /^[1-9][0-9]*$/u;
+const bytes32Pattern = /^0x[0-9a-fA-F]{64}$/u;
+
+type MigrationPhase =
+  | "checking"
+  | "preview"
+  | "upcoming"
+  | "active"
+  | "closed";
+
+type MigrationWindow = Readonly<{
+  enabled: boolean;
+  startAt: number | null;
+  deadlineAt: number | null;
+  startBlock: bigint | null;
+  startBlockHash: Hex | null;
+}>;
+
+type TrustedClock = Readonly<{
+  serverTimeMs: number;
+  monotonicMs: number;
+  uncertaintyMs: number;
+}>;
+
+type SubmissionState =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "submitted"; hash: Hex; amount: string; account: string }
+  | {
+      kind: "confirmed";
+      hash: Hex;
+      amount: string;
+      account: string;
+      blockNumber: string;
+    }
+  | { kind: "reverted"; hash: Hex; amount: string; account: string }
+  | { kind: "error"; message: string };
+
+type AccountCodeObservation = Readonly<{
+  account: string;
+  status: "eoa" | "contract" | "unavailable";
+}>;
+
+const gasSponsorshipEndpoint =
+  "/api/main-token-migration/gas-sponsorship" as const;
+const gasSponsorshipSchema =
+  "programmable-main-token-migration-gas-sponsorship/v1" as const;
+// A V4 transfer currently uses roughly 52k gas. This conservative client-side
+// reserve only decides whether the UI can skip the sponsor endpoint entirely;
+// the server independently estimates and caps every sponsored top-up.
+const migrationTransferGasReserve = 100_000n;
+const trustedClockMaximumAgeMs = 90_000;
+const trustedClockRequestTimeoutMs = 8_000;
+const migrationTransferSafetyMs = 5 * 60 * 1_000;
+const trustedClockEndpoint =
+  "/api/main-token-migration/window-time" as const;
+
+export function hasEnoughMigrationGas(
+  nativeBalanceWei: bigint,
+  gasPriceWei: bigint,
+) {
+  if (nativeBalanceWei < 0n || gasPriceWei <= 0n) return false;
+  return nativeBalanceWei >= gasPriceWei * migrationTransferGasReserve;
+}
+
+export type MainTokenGasSponsorshipStatus =
+  | "eligible"
+  | "submitted"
+  | "pending"
+  | "confirmed"
+  | "not_needed";
+
+export type MainTokenGasSponsorshipRequest = Readonly<{
+  walletAddress: string;
+  amountRaw: string;
+}>;
+
+export type MainTokenGasSponsorshipResponse = Readonly<{
+  schema: typeof gasSponsorshipSchema;
+  status: MainTokenGasSponsorshipStatus;
+  walletAddress: string;
+  topUpWei: string | null;
+  transactionHash: Hex | null;
+  estimatedTransferGas: string | null;
+}>;
+
+export type GasSponsorshipState =
+  | { kind: "idle" }
+  | { kind: "checking"; account: string }
+  | { kind: "eligible"; account: string }
+  | { kind: "requesting"; account: string }
+  | { kind: "requested"; account: string; transactionHash: Hex | null }
+  | {
+      kind: "funding-confirming";
+      account: string;
+      transactionHash: Hex | null;
+    }
+  | {
+      kind: "balance-confirming";
+      account: string;
+      transactionHash: Hex | null;
+    }
+  | { kind: "ready"; account: string; transactionHash: Hex | null }
+  | { kind: "not-needed"; account: string }
+  | {
+      kind: "error";
+      account: string;
+      message: string;
+      retryable: boolean;
+    };
+
+type GasSponsorshipEndpointResult = Readonly<{
+  body: MainTokenGasSponsorshipResponse;
+  retryAfterMs: number;
+}>;
+
+export type GasSponsorshipFailure = Readonly<{
+  message: string;
+  retryable: boolean;
+}>;
+
+class GasSponsorshipEndpointError extends Error {
+  constructor(message: string, readonly retryable: boolean) {
+    super(message);
+    this.name = "GasSponsorshipEndpointError";
+  }
+}
+
+const migrationTransferStorageKey =
+  `programmable:main-token-migration:${MAIN_TOKEN_MIGRATION_WALLET.toLowerCase()}`;
+const transactionHashPattern = /^0x[0-9a-fA-F]{64}$/u;
+const sponsorshipIntegerPattern = /^(?:0|[1-9][0-9]*)$/u;
+
+export function sponsorshipRetryAfterMs(response: Response) {
+  const value = response.headers.get("retry-after");
+  if (!value) return 3_000;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(Math.max(Math.ceil(seconds * 1_000), 1_000), 15_000);
+  }
+  const date = Date.parse(value);
+  if (!Number.isFinite(date)) return 3_000;
+  return Math.min(Math.max(date - Date.now(), 1_000), 15_000);
+}
+
+export function parseGasSponsorshipResponse(
+  input: unknown,
+  expectedAccount: string,
+): MainTokenGasSponsorshipResponse {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("The gas sponsorship response is invalid.");
+  }
+  const value = input as Record<string, unknown>;
+  const statuses: readonly MainTokenGasSponsorshipStatus[] = [
+    "eligible",
+    "submitted",
+    "pending",
+    "confirmed",
+    "not_needed",
+  ];
+  const status = value.status as MainTokenGasSponsorshipStatus;
+  const exactKeys = [
+    "estimatedTransferGas",
+    "schema",
+    "status",
+    "topUpWei",
+    "transactionHash",
+    "walletAddress",
+  ];
+  const topUpIsInteger =
+    typeof value.topUpWei === "string" &&
+    sponsorshipIntegerPattern.test(value.topUpWei);
+  const transferGasIsPositiveInteger =
+    typeof value.estimatedTransferGas === "string" &&
+    positiveIntegerPattern.test(value.estimatedTransferGas);
+  const transactionHashIsValid =
+    typeof value.transactionHash === "string" &&
+    transactionHashPattern.test(value.transactionHash);
+  const statusFieldsAreValid = status === "not_needed"
+    ? value.topUpWei === "0" && value.transactionHash === null
+    : status === "eligible"
+      ? topUpIsInteger && value.topUpWei !== "0" && value.transactionHash === null
+      : topUpIsInteger && value.topUpWei !== "0" && transactionHashIsValid;
+  if (
+    Object.keys(value).sort().join("\0") !== exactKeys.sort().join("\0") ||
+    value.schema !== gasSponsorshipSchema ||
+    !statuses.includes(status) ||
+    typeof value.walletAddress !== "string" ||
+    !isAddress(value.walletAddress, { strict: true }) ||
+    !isAddress(expectedAccount, { strict: true }) ||
+    getAddress(value.walletAddress).toLowerCase() !==
+      getAddress(expectedAccount).toLowerCase() ||
+    !transferGasIsPositiveInteger ||
+    !statusFieldsAreValid
+  ) {
+    throw new Error("The gas sponsorship response is invalid.");
+  }
+  return Object.freeze({
+    schema: gasSponsorshipSchema,
+    status,
+    walletAddress: getAddress(value.walletAddress),
+    topUpWei: value.topUpWei as string,
+    transactionHash:
+      value.transactionHash === null
+        ? null
+        : (value.transactionHash as string).toLowerCase() as Hex,
+    estimatedTransferGas: value.estimatedTransferGas as string,
+  });
+}
+
+export async function gasSponsorshipFailure(
+  response: Response,
+): Promise<GasSponsorshipFailure> {
+  let code = "";
+  let message = "";
+  let requestId = "";
+  try {
+    const body = await response.json() as {
+      error?: unknown;
+      message?: unknown;
+      requestId?: unknown;
+    };
+    const nestedError =
+      body.error && typeof body.error === "object" && !Array.isArray(body.error)
+        ? body.error as {
+            code?: unknown;
+            message?: unknown;
+            requestId?: unknown;
+          }
+        : null;
+    const responseMessage =
+      typeof body.error === "string"
+        ? body.error
+        : typeof body.message === "string"
+          ? body.message
+          : typeof nestedError?.message === "string"
+            ? nestedError.message
+          : "";
+    code = typeof nestedError?.code === "string" ? nestedError.code : "";
+    message = responseMessage.length <= 240 ? responseMessage : "";
+    const responseRequestId = nestedError?.requestId ?? body.requestId;
+    requestId =
+      typeof responseRequestId === "string" &&
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu
+        .test(responseRequestId)
+        ? responseRequestId
+        : "";
+  } catch {
+    // Use a stable status-specific recovery message below.
+  }
+
+  const terminal = [
+    "submission_unknown",
+    "sponsorship_closed",
+    "sponsorship_failed",
+  ].includes(code);
+  const fallback = response.status === 401 || response.status === 403
+    ? "Reconnect this wallet before requesting sponsored gas."
+    : response.status === 429
+      ? "Gas sponsorship is temporarily rate limited. Wait a moment and try again."
+      : code === "submission_unknown"
+        ? "The gas top-up needs a status review. No second top-up was sent."
+        : code === "sponsorship_closed"
+          ? "Gas sponsorship is closed for this migration window."
+          : code === "sponsorship_failed"
+            ? "The gas top-up could not be confirmed. Contact migration support before trying again."
+            : "Unable to request sponsored gas. Check your connection and try again.";
+  const publicMessage = message || fallback;
+  return {
+    message: requestId
+      ? `${publicMessage} Request ID: ${requestId}`
+      : publicMessage,
+    retryable: !terminal,
+  };
+}
+
+export async function gasSponsorshipErrorMessage(response: Response) {
+  return (await gasSponsorshipFailure(response)).message;
+}
+
+function gasSponsorshipError(error: unknown, account: string): GasSponsorshipState {
+  return {
+    kind: "error",
+    account,
+    message: migrationErrorMessage(error),
+    retryable:
+      !(error instanceof GasSponsorshipEndpointError) || error.retryable,
+  };
+}
+
+export function gasSponsorshipState(
+  body: MainTokenGasSponsorshipResponse,
+): GasSponsorshipState {
+  const account = body.walletAddress.toLowerCase();
+  if (body.status === "eligible") return { kind: "eligible", account };
+  if (body.status === "submitted") {
+    return {
+      kind: "requested",
+      account,
+      transactionHash: body.transactionHash,
+    };
+  }
+  if (body.status === "pending") {
+    return {
+      kind: "funding-confirming",
+      account,
+      transactionHash: body.transactionHash,
+    };
+  }
+  if (body.status === "confirmed") {
+    return {
+      kind: "balance-confirming",
+      account,
+      transactionHash: body.transactionHash,
+    };
+  }
+  return { kind: "not-needed", account };
+}
+
+export function gasSponsorshipDisplayKind(
+  state: GasSponsorshipState,
+  hasEnoughObservedGas: boolean,
+): GasSponsorshipState["kind"] {
+  if (state.kind === "balance-confirming") {
+    return hasEnoughObservedGas ? "ready" : "balance-confirming";
+  }
+  if (state.kind === "ready" && !hasEnoughObservedGas) {
+    return "balance-confirming";
+  }
+  return state.kind;
+}
+
+function gasSponsorshipIdempotencyKey(account: string) {
+  const normalizedAccount = getAddress(account).toLowerCase();
+  const storageKey =
+    `programmable:main-token-migration:gas-sponsor:${MAIN_TOKEN_MIGRATION_RELEASE_ID}:${normalizedAccount}`;
+  try {
+    const stored = window.localStorage.getItem(storageKey);
+    if (stored && /^[a-zA-Z0-9:_-]{16,200}$/u.test(stored)) return stored;
+    const random = window.crypto.randomUUID();
+    const created = `migration-${MAIN_TOKEN_MIGRATION_RELEASE_ID}-${random}`;
+    window.localStorage.setItem(storageKey, created);
+    return created;
+  } catch {
+    return `migration-${MAIN_TOKEN_MIGRATION_RELEASE_ID}-${window.crypto.randomUUID()}`;
+  }
+}
+
+type StoredMigrationTransfer = Readonly<{
+  schema: "programmable-main-token-migration-ui/v1";
+  status: "submitted" | "confirmed";
+  chainId: number;
+  tokenAddress: string;
+  migrationWallet: string;
+  account: string;
+  amount: string;
+  hash: Hex;
+  blockNumber: string | null;
+}>;
+
+function storedMigrationTransfer(
+  value: string | null,
+): Extract<SubmissionState, { kind: "submitted" | "confirmed" }> | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as Partial<StoredMigrationTransfer>;
+    if (
+      parsed.schema !== "programmable-main-token-migration-ui/v1" ||
+      (parsed.status !== "submitted" && parsed.status !== "confirmed") ||
+      parsed.chainId !== MAIN_TOKEN_MIGRATION_CHAIN_ID ||
+      parsed.tokenAddress?.toLowerCase() !== MAIN_TOKEN_ADDRESS.toLowerCase() ||
+      parsed.migrationWallet?.toLowerCase() !==
+        MAIN_TOKEN_MIGRATION_WALLET.toLowerCase() ||
+      typeof parsed.account !== "string" ||
+      typeof parsed.amount !== "string" ||
+      typeof parsed.hash !== "string" ||
+      !transactionHashPattern.test(parsed.hash)
+    ) {
+      return null;
+    }
+    const account = getAddress(parsed.account);
+    parseMainTokenMigrationAmount(parsed.amount);
+    if (parsed.status === "confirmed") {
+      if (
+        typeof parsed.blockNumber !== "string" ||
+        !decimalIntegerPattern.test(parsed.blockNumber)
+      ) {
+        return null;
+      }
+    }
+    // Re-check every restored hash against Ethereum before showing a terminal state.
+    return {
+      kind: "submitted",
+      account,
+      amount: parsed.amount,
+      hash: parsed.hash as Hex,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function persistMigrationTransfer(
+  submission: Extract<SubmissionState, { kind: "submitted" | "confirmed" }>,
+) {
+  try {
+    const value: StoredMigrationTransfer = {
+      schema: "programmable-main-token-migration-ui/v1",
+      status: submission.kind,
+      chainId: MAIN_TOKEN_MIGRATION_CHAIN_ID,
+      tokenAddress: MAIN_TOKEN_ADDRESS,
+      migrationWallet: MAIN_TOKEN_MIGRATION_WALLET,
+      account: submission.account,
+      amount: submission.amount,
+      hash: submission.hash,
+      blockNumber:
+        submission.kind === "confirmed" ? submission.blockNumber : null,
+    };
+    window.localStorage.setItem(
+      migrationTransferStorageKey,
+      JSON.stringify(value),
+    );
+  } catch {
+    // Transaction tracking still works for the current page session.
+  }
+}
+
+function clearPersistedMigrationTransfer() {
+  try {
+    window.localStorage.removeItem(migrationTransferStorageKey);
+  } catch {
+    // A reverted transaction remains visible for the current page session.
+  }
+}
+
+function parseMigrationWindow(): MigrationWindow {
+  const manifest = migrationActivationManifest as Readonly<{
+    schema: string;
+    releaseId: string;
+    enabled: boolean;
+    sourceChainId: string;
+    sourceTokenAddress: string;
+    sourceTokenRuntimeCodeKeccak256: string;
+    sourceTokenDecimals: string;
+    sourceTokenTotalSupplyRaw: string;
+    migrationWallet: string;
+    windowDurationSeconds: string;
+    windowStartTimestamp: string | null;
+    deadlineTimestampExclusive: string | null;
+    startBlockNumber: string | null;
+    startBlockHash: string | null;
+  }>;
+  const startSeconds =
+    manifest.windowStartTimestamp !== null &&
+    decimalIntegerPattern.test(manifest.windowStartTimestamp)
+      ? Number(manifest.windowStartTimestamp)
+      : Number.NaN;
+  const deadlineSeconds =
+    manifest.deadlineTimestampExclusive !== null &&
+    decimalIntegerPattern.test(manifest.deadlineTimestampExclusive)
+      ? Number(manifest.deadlineTimestampExclusive)
+      : Number.NaN;
+  const startAt = startSeconds * 1_000;
+  const deadlineAt = deadlineSeconds * 1_000;
+  const safeStartSeconds =
+    Number.isSafeInteger(startSeconds) &&
+    startSeconds <= Math.floor(Number.MAX_SAFE_INTEGER / 1_000);
+  const safeDeadlineSeconds =
+    Number.isSafeInteger(deadlineSeconds) &&
+    deadlineSeconds <= Math.floor(Number.MAX_SAFE_INTEGER / 1_000);
+  const startBlock =
+    manifest.startBlockNumber !== null &&
+    positiveIntegerPattern.test(manifest.startBlockNumber)
+      ? BigInt(manifest.startBlockNumber)
+    : null;
+  const startBlockHash =
+    manifest.startBlockHash !== null && bytes32Pattern.test(manifest.startBlockHash)
+      ? manifest.startBlockHash.toLowerCase() as Hex
+      : null;
+  const exactPolicy =
+    manifest.schema === "programmable-main-token-migration-activation/v1" &&
+    manifest.releaseId === MAIN_TOKEN_MIGRATION_RELEASE_ID &&
+    manifest.sourceChainId === String(MAIN_TOKEN_MIGRATION_CHAIN_ID) &&
+    manifest.sourceTokenAddress.toLowerCase() === MAIN_TOKEN_ADDRESS.toLowerCase() &&
+    manifest.sourceTokenRuntimeCodeKeccak256.toLowerCase() ===
+      MAIN_TOKEN_RUNTIME_CODE_KECCAK256 &&
+    manifest.sourceTokenDecimals === String(MAIN_TOKEN_DECIMALS) &&
+    manifest.sourceTokenTotalSupplyRaw === MAIN_TOKEN_TOTAL_SUPPLY_RAW.toString() &&
+    manifest.migrationWallet.toLowerCase() ===
+      MAIN_TOKEN_MIGRATION_WALLET.toLowerCase() &&
+    manifest.windowDurationSeconds ===
+      String(MAIN_TOKEN_MIGRATION_WINDOW_SECONDS);
+  const exactWindow =
+    safeStartSeconds &&
+    safeDeadlineSeconds &&
+    deadlineAt - startAt === MAIN_TOKEN_MIGRATION_WINDOW_SECONDS * 1_000;
+
+  return Object.freeze({
+    enabled:
+      manifest.enabled === true &&
+      exactPolicy &&
+      exactWindow &&
+      startBlock !== null &&
+      startBlockHash !== null,
+    startAt: safeStartSeconds ? startAt : null,
+    deadlineAt: safeDeadlineSeconds ? deadlineAt : null,
+    startBlock,
+    startBlockHash,
+  });
+}
+
+const migrationWindow = parseMigrationWindow();
+
+function normalizeChainId(value: string) {
+  if (value.startsWith("eip155:")) {
+    const parsed = Number(value.slice("eip155:".length));
+    return Number.isSafeInteger(parsed) ? parsed : null;
+  }
+  if (value.startsWith("0x")) {
+    const parsed = Number.parseInt(value.slice(2), 16);
+    return Number.isSafeInteger(parsed) ? parsed : null;
+  }
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function phaseAt(now: number): MigrationPhase {
+  if (
+    !migrationWindow.enabled ||
+    migrationWindow.startAt === null ||
+    migrationWindow.deadlineAt === null
+  ) {
+    return "preview";
+  }
+  if (now < migrationWindow.startAt) return "upcoming";
+  if (now >= migrationWindow.deadlineAt) return "closed";
+  return "active";
+}
+
+function transferWindowOpenAt(now: number, uncertaintyMs = 0) {
+  if (
+    !migrationWindow.enabled ||
+    migrationWindow.startAt === null ||
+    migrationWindow.deadlineAt === null ||
+    !Number.isFinite(uncertaintyMs) ||
+    uncertaintyMs < 0
+  ) return false;
+  return (
+    now - uncertaintyMs >= migrationWindow.startAt &&
+    now + uncertaintyMs <
+      migrationWindow.deadlineAt - migrationTransferSafetyMs
+  );
+}
+
+function remainingAt(now: number, phase: MigrationPhase) {
+  if (phase === "preview") return MAIN_TOKEN_MIGRATION_WINDOW_SECONDS;
+  const target =
+    phase === "upcoming"
+      ? migrationWindow.startAt
+      : migrationWindow.deadlineAt;
+  if (target === null) return 0;
+  return Math.max(0, Math.ceil((target - now) / 1_000));
+}
+
+function clockParts(totalSeconds: number) {
+  const hours = Math.floor(totalSeconds / 3_600);
+  const minutes = Math.floor((totalSeconds % 3_600) / 60);
+  const seconds = totalSeconds % 60;
+  return {
+    hours: String(hours).padStart(2, "0"),
+    minutes: String(minutes).padStart(2, "0"),
+    seconds: String(seconds).padStart(2, "0"),
+  };
+}
+
+function formatUtc(value: number | null) {
+  if (value === null) return "Set before activation";
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "UTC",
+  }).format(value) + " UTC";
+}
+
+function shortenAddress(address: string) {
+  return `${address.slice(0, 8)}…${address.slice(-6)}`;
+}
+
+function formatTokenAmount(value: bigint) {
+  const amount = formatUnits(value, MAIN_TOKEN_DECIMALS);
+  const [whole, fraction = ""] = amount.split(".");
+  const trimmedFraction = fraction.replace(/0+$/u, "");
+  return trimmedFraction.length > 8
+    ? `${whole}.${trimmedFraction.slice(0, 8)}…`
+    : trimmedFraction
+      ? `${whole}.${trimmedFraction}`
+      : whole;
+}
+
+function migrationErrorMessage(error: unknown) {
+  const message = error instanceof Error ? error.message : "";
+  if (/rejected|denied|cancelled|canceled/u.test(message.toLowerCase())) {
+    return "Wallet request rejected. No tokens were sent.";
+  }
+  return message || "Unable to prepare the transfer. Check your wallet and try again.";
+}
+
+function Countdown({ phase, remaining }: Readonly<{
+  phase: MigrationPhase;
+  remaining: number | null;
+}>) {
+  const parts = remaining === null ? null : clockParts(remaining);
+  const label =
+    phase === "checking"
+      ? "Checking migration window"
+      : phase === "closed"
+      ? "Migration closed"
+      : phase === "upcoming"
+        ? "Migration opens in"
+        : phase === "preview"
+          ? "Planned migration window"
+          : "Migration closes in";
+
+  return (
+    <div
+      className={styles.countdown}
+      aria-label={
+        parts === null
+          ? label
+          : `${label}: ${parts.hours} hours, ${parts.minutes} minutes, ${parts.seconds} seconds`
+      }
+    >
+      <span className={styles.countdownLabel}>{label}</span>
+      <div className={styles.clock} aria-hidden="true">
+        <span><strong>{parts?.hours ?? "––"}</strong><small>Hours</small></span>
+        <i>:</i>
+        <span><strong>{parts?.minutes ?? "––"}</strong><small>Minutes</small></span>
+        <i>:</i>
+        <span><strong>{parts?.seconds ?? "––"}</strong><small>Seconds</small></span>
+      </div>
+      <span className={styles.absoluteDeadline}>
+        {phase === "checking"
+          ? "Verifying the published UTC window"
+          : phase === "preview"
+          ? "96-hour transfer window"
+          : `${phase === "upcoming" ? "Opens" : "Closes"} ${formatUtc(
+              phase === "upcoming"
+                ? migrationWindow.startAt
+                : migrationWindow.deadlineAt,
+            )}`}
+      </span>
+    </div>
+  );
+}
+
+export function MainTokenMigration() {
+  const {
+    wallet,
+    connecting,
+    switchingNetwork,
+    openWallet,
+    switchNetwork,
+    getAccessToken,
+    readConnectedAccountCode,
+    readTradeBalances,
+    sendTransaction,
+  } = useWallet();
+  const [now, setNow] = useState<number | null>(null);
+  const [clockUncertaintyMs, setClockUncertaintyMs] = useState<number | null>(
+    null,
+  );
+  const [amount, setAmount] = useState("");
+  const [balance, setBalance] = useState<bigint | null>(null);
+  const [nativeBalance, setNativeBalance] = useState<bigint | null>(null);
+  const [gasPrice, setGasPrice] = useState<bigint | null>(null);
+  const [balanceLoading, setBalanceLoading] = useState(false);
+  const [balanceError, setBalanceError] = useState("");
+  const [acknowledged, setAcknowledged] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [copyStatus, setCopyStatus] = useState("");
+  const [clockIssue, setClockIssue] = useState("");
+  const [confirmationIssue, setConfirmationIssue] = useState("");
+  const [submission, setSubmission] = useState<SubmissionState>({ kind: "idle" });
+  const [gasSponsorship, setGasSponsorship] =
+    useState<GasSponsorshipState>({ kind: "idle" });
+  const [accountCodeObservation, setAccountCodeObservation] =
+    useState<AccountCodeObservation | null>(null);
+  const amountInputRef = useRef<HTMLInputElement>(null);
+  const acknowledgementRef = useRef<HTMLInputElement>(null);
+  const sponsorButtonRef = useRef<HTMLButtonElement>(null);
+  const sponsorshipRegionRef = useRef<HTMLDivElement>(null);
+  const trustedClockRef = useRef<TrustedClock | null>(null);
+
+  const readTrustedNow = useCallback(() => {
+    const clock = trustedClockRef.current;
+    if (!clock) return null;
+    const elapsed = performance.now() - clock.monotonicMs;
+    if (elapsed < 0 || elapsed > trustedClockMaximumAgeMs) return null;
+    return clock.serverTimeMs + elapsed;
+  }, []);
+
+  const trustedTransferWindowOpen = useCallback(() => {
+    const trustedNow = readTrustedNow();
+    const clock = trustedClockRef.current;
+    return trustedNow !== null && clock !== null
+      ? transferWindowOpenAt(trustedNow, clock.uncertaintyMs)
+      : false;
+  }, [readTrustedNow]);
+
+  const focusSponsorshipActionOrStatus = useCallback(() => {
+    window.requestAnimationFrame(() => {
+      (sponsorButtonRef.current ?? sponsorshipRegionRef.current)?.focus();
+    });
+  }, []);
+
+  const phase = now === null ? "checking" : phaseAt(now);
+  const remaining = now === null
+    ? null
+    : remainingAt(now, phase);
+  const onMainnet = wallet !== null &&
+    normalizeChainId(wallet.chainId) === MAIN_TOKEN_MIGRATION_CHAIN_ID;
+  const accountCodeStatus = !wallet || !onMainnet
+    ? "idle"
+    : accountCodeObservation?.account === wallet.account.toLowerCase()
+      ? accountCodeObservation.status
+      : "checking";
+  const hasTrackedTransfer =
+    submission.kind === "submitted" || submission.kind === "confirmed";
+  const transferWindowOpen =
+    now !== null &&
+    clockUncertaintyMs !== null &&
+    transferWindowOpenAt(now, clockUncertaintyMs);
+  const canRevealDestination = transferWindowOpen || hasTrackedTransfer;
+  const canCopyDestination = transferWindowOpen;
+  const transferSender =
+    submission.kind === "submitted" || submission.kind === "confirmed"
+    ? submission.account
+    : wallet?.account ?? null;
+  const connectedAccount = wallet?.account.toLowerCase() ?? null;
+  const hasEnoughObservedGas =
+    nativeBalance !== null &&
+    gasPrice !== null &&
+    hasEnoughMigrationGas(nativeBalance, gasPrice);
+  const sponsorshipForConnectedAccount =
+    connectedAccount !== null &&
+    "account" in gasSponsorship &&
+    gasSponsorship.account === connectedAccount;
+  const sponsorshipInProgressOrReady =
+    sponsorshipForConnectedAccount &&
+    (gasSponsorship.kind === "requesting" ||
+      gasSponsorship.kind === "requested" ||
+      gasSponsorship.kind === "funding-confirming" ||
+      gasSponsorship.kind === "balance-confirming" ||
+      gasSponsorship.kind === "ready");
+  const sponsorshipKind = sponsorshipInProgressOrReady
+    ? gasSponsorshipDisplayKind(gasSponsorship, hasEnoughObservedGas)
+    : hasEnoughObservedGas
+      ? "not-needed"
+      : sponsorshipForConnectedAccount
+        ? gasSponsorship.kind
+        : "idle";
+  const terminalSponsorshipFailure =
+    sponsorshipForConnectedAccount &&
+    gasSponsorship.kind === "error" &&
+    !gasSponsorship.retryable;
+  const sponsorReceiptConfirmed =
+    sponsorshipForConnectedAccount &&
+    (gasSponsorship.kind === "balance-confirming" ||
+      gasSponsorship.kind === "ready");
+  const sponsorshipTransactionHash =
+    sponsorshipForConnectedAccount &&
+    (gasSponsorship.kind === "requested" ||
+      gasSponsorship.kind === "funding-confirming" ||
+      gasSponsorship.kind === "balance-confirming" ||
+      gasSponsorship.kind === "ready")
+      ? gasSponsorship.transactionHash
+      : null;
+  const sponsoredGasReady = hasEnoughObservedGas;
+  const parsedAmount = useMemo(() => {
+    if (!amount.trim()) return null;
+    try {
+      return parseMainTokenMigrationAmount(amount);
+    } catch {
+      return null;
+    }
+  }, [amount]);
+  const amountError = useMemo(() => {
+    if (!amount.trim()) return "";
+    try {
+      const amountRaw = parseMainTokenMigrationAmount(amount);
+      if (balance !== null) {
+        assertMainTokenMigrationBalance(amountRaw, balance);
+      }
+      return "";
+    } catch (error) {
+      return migrationErrorMessage(error);
+    }
+  }, [amount, balance]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const synchronize = async () => {
+      const requestStartedAt = performance.now();
+      const controller = new AbortController();
+      const requestTimeout = window.setTimeout(
+        () => controller.abort(),
+        trustedClockRequestTimeoutMs,
+      );
+      try {
+        const response = await fetch(trustedClockEndpoint, {
+          cache: "no-store",
+          headers: { accept: "application/json" },
+          signal: controller.signal,
+        });
+        const body = await response.json() as Record<string, unknown>;
+        const requestFinishedAt = performance.now();
+        if (
+          !response.ok ||
+          Object.keys(body).sort().join("\0") !==
+            ["schema", "serverTimeMs"].sort().join("\0") ||
+          body.schema !== "programmable-main-token-migration-window-time/v1" ||
+          !Number.isSafeInteger(body.serverTimeMs) ||
+          (body.serverTimeMs as number) <= 0
+        ) {
+          throw new Error("Invalid migration clock response");
+        }
+        if (cancelled) return;
+        const oneWayEstimate = (requestFinishedAt - requestStartedAt) / 2;
+        const uncertaintyMs = Math.max(oneWayEstimate, 250);
+        trustedClockRef.current = {
+          serverTimeMs: (body.serverTimeMs as number) + oneWayEstimate,
+          monotonicMs: requestFinishedAt,
+          uncertaintyMs,
+        };
+        setClockUncertaintyMs(uncertaintyMs);
+        setClockIssue("");
+        setNow(readTrustedNow());
+      } catch {
+        if (!cancelled && readTrustedNow() === null) {
+          setNow(null);
+          setClockUncertaintyMs(null);
+          setClockIssue("Unable to verify the migration window · Retrying");
+        }
+      } finally {
+        window.clearTimeout(requestTimeout);
+      }
+    };
+    void synchronize();
+    const synchronizationInterval = window.setInterval(
+      () => void synchronize(),
+      30_000,
+    );
+    const tickInterval = window.setInterval(
+      () => setNow(readTrustedNow()),
+      1_000,
+    );
+    return () => {
+      cancelled = true;
+      window.clearInterval(synchronizationInterval);
+      window.clearInterval(tickInterval);
+    };
+  }, [readTrustedNow]);
+
+  useEffect(() => {
+    if (!wallet || !onMainnet) return;
+    const account = wallet.account.toLowerCase();
+    let cancelled = false;
+    void readConnectedAccountCode()
+      .then((code) => {
+        if (!cancelled) {
+          setAccountCodeObservation({
+            account,
+            status: code === "0x" ? "eoa" : "contract",
+          });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAccountCodeObservation({ account, status: "unavailable" });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [onMainnet, readConnectedAccountCode, wallet]);
+
+  useEffect(() => {
+    const restore = window.setTimeout(() => {
+      let stored: ReturnType<typeof storedMigrationTransfer> = null;
+      try {
+        stored = storedMigrationTransfer(
+          window.localStorage.getItem(migrationTransferStorageKey),
+        );
+      } catch {
+        stored = null;
+      }
+      if (stored) {
+        setSubmission(stored);
+        setAmount(stored.amount);
+        setAcknowledged(true);
+      }
+    }, 0);
+    return () => window.clearTimeout(restore);
+  }, []);
+
+  const refreshBalance = useCallback(async () => {
+    if (!wallet || !onMainnet) {
+      setBalance(null);
+      setNativeBalance(null);
+      setGasPrice(null);
+      return;
+    }
+    setBalanceLoading(true);
+    setBalanceError("");
+    try {
+      const next = await readTradeBalances(MAIN_TOKEN_ADDRESS);
+      setBalance(next.tokenBalanceRaw);
+      setNativeBalance(next.nativeBalanceWei);
+      setGasPrice(next.gasPriceWei);
+    } catch (error) {
+      setBalance(null);
+      setNativeBalance(null);
+      setGasPrice(null);
+      setBalanceError(migrationErrorMessage(error));
+    } finally {
+      setBalanceLoading(false);
+    }
+  }, [onMainnet, readTradeBalances, wallet]);
+
+  useEffect(() => {
+    const pendingRefresh = window.setTimeout(() => void refreshBalance(), 0);
+    return () => window.clearTimeout(pendingRefresh);
+  }, [refreshBalance]);
+
+  const readGasSponsorship = useCallback(async (
+    account: string,
+    signal: AbortSignal,
+  ): Promise<GasSponsorshipEndpointResult> => {
+    const accessToken = await getAccessToken();
+    if (!accessToken) {
+      throw new GasSponsorshipEndpointError(
+        "Reconnect this wallet before requesting sponsored gas.",
+        true,
+      );
+    }
+    const search = new URLSearchParams({ walletAddress: getAddress(account) });
+    const response = await fetch(`${gasSponsorshipEndpoint}?${search}`, {
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      signal,
+    });
+    if (!response.ok) {
+      const failure = await gasSponsorshipFailure(response);
+      throw new GasSponsorshipEndpointError(
+        failure.message,
+        failure.retryable,
+      );
+    }
+    return {
+      body: parseGasSponsorshipResponse(await response.json(), account),
+      retryAfterMs: sponsorshipRetryAfterMs(response),
+    };
+  }, [getAccessToken]);
+
+  useEffect(() => {
+    if (
+      !transferWindowOpen ||
+      !wallet ||
+      !onMainnet ||
+      accountCodeStatus !== "eoa" ||
+      nativeBalance === null ||
+      gasPrice === null ||
+      hasEnoughObservedGas ||
+      hasTrackedTransfer ||
+      submission.kind === "submitting"
+    ) {
+      return;
+    }
+
+    const account = wallet.account.toLowerCase();
+    const controller = new AbortController();
+    void readGasSponsorship(account, controller.signal)
+      .then(({ body }) => {
+        if (controller.signal.aborted) return;
+        setGasSponsorship(gasSponsorshipState(body));
+        if (body.status === "confirmed" || body.status === "not_needed") {
+          void refreshBalance();
+        }
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setGasSponsorship(gasSponsorshipError(error, account));
+      });
+    return () => controller.abort();
+  }, [
+    accountCodeStatus,
+    gasPrice,
+    hasEnoughObservedGas,
+    hasTrackedTransfer,
+    nativeBalance,
+    onMainnet,
+    transferWindowOpen,
+    readGasSponsorship,
+    refreshBalance,
+    submission.kind,
+    wallet,
+  ]);
+
+  useEffect(() => {
+    if (
+      !sponsorshipForConnectedAccount ||
+      (gasSponsorship.kind !== "requested" &&
+        gasSponsorship.kind !== "funding-confirming")
+    ) {
+      return;
+    }
+
+    const account = gasSponsorship.account;
+    const controller = new AbortController();
+    let retryTimer: number | undefined;
+
+    const poll = async () => {
+      try {
+        const result = await readGasSponsorship(account, controller.signal);
+        if (controller.signal.aborted) return;
+        const next = gasSponsorshipState(result.body);
+        setGasSponsorship((previous) => {
+          if (
+            previous.kind === next.kind &&
+            "account" in previous &&
+            "account" in next &&
+            previous.account === next.account &&
+            (previous.kind !== "requested" &&
+            previous.kind !== "funding-confirming" &&
+            previous.kind !== "ready"
+              ? true
+              : next.kind === "requested" ||
+                  next.kind === "funding-confirming" ||
+                  next.kind === "ready"
+                ? previous.transactionHash === next.transactionHash
+                : false)
+          ) {
+            return previous;
+          }
+          return next;
+        });
+        if (
+          result.body.status === "confirmed" ||
+          result.body.status === "not_needed"
+        ) {
+          void refreshBalance();
+          return;
+        }
+        if (
+          result.body.status === "submitted" ||
+          result.body.status === "pending"
+        ) {
+          retryTimer = window.setTimeout(() => void poll(), result.retryAfterMs);
+        }
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        setGasSponsorship(gasSponsorshipError(error, account));
+      }
+    };
+
+    retryTimer = window.setTimeout(() => void poll(), 2_000);
+    return () => {
+      controller.abort();
+      if (retryTimer !== undefined) window.clearTimeout(retryTimer);
+    };
+  }, [
+    gasSponsorship,
+    readGasSponsorship,
+    refreshBalance,
+    sponsorshipForConnectedAccount,
+  ]);
+
+  useEffect(() => {
+    if (
+      !transferWindowOpen ||
+      !sponsorshipForConnectedAccount ||
+      (gasSponsorship.kind !== "balance-confirming" &&
+        gasSponsorship.kind !== "ready") ||
+      hasEnoughObservedGas
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    let retryTimer: number | undefined;
+    const refreshUntilObserved = async () => {
+      await refreshBalance();
+      if (!cancelled) {
+        retryTimer = window.setTimeout(
+          () => void refreshUntilObserved(),
+          3_000,
+        );
+      }
+    };
+    retryTimer = window.setTimeout(() => void refreshUntilObserved(), 2_000);
+    return () => {
+      cancelled = true;
+      if (retryTimer !== undefined) window.clearTimeout(retryTimer);
+    };
+  }, [
+    gasSponsorship,
+    hasEnoughObservedGas,
+    transferWindowOpen,
+    refreshBalance,
+    sponsorshipForConnectedAccount,
+  ]);
+
+  useEffect(() => {
+    if (submission.kind !== "submitted") return;
+
+    const tracked = submission;
+    const controller = new AbortController();
+    let retryTimer: number | undefined;
+
+    const poll = async () => {
+      let retryDelay = 3_000;
+      const requestController = new AbortController();
+      const abortRequest = () => requestController.abort();
+      controller.signal.addEventListener("abort", abortRequest, { once: true });
+      const requestTimeout = window.setTimeout(
+        () => requestController.abort(),
+        15_000,
+      );
+      try {
+        const response = await fetch(
+          `/api/transaction-status?hash=${encodeURIComponent(
+            tracked.hash,
+          )}&chainId=${MAIN_TOKEN_MIGRATION_CHAIN_ID}`,
+          {
+            cache: "no-store",
+            headers: { Accept: "application/json" },
+            signal: requestController.signal,
+          },
+        );
+        const body = (await response.json()) as {
+          status?: "pending" | "not-found" | "confirmed" | "reverted";
+          blockNumber?: string | null;
+        };
+        if (
+          !response.ok ||
+          !body ||
+          !["pending", "not-found", "confirmed", "reverted"].includes(
+            String(body.status),
+          )
+        ) {
+          throw new Error("Transaction status is unavailable");
+        }
+
+        setConfirmationIssue("");
+        if (body.status === "confirmed") {
+          if (
+            typeof body.blockNumber !== "string" ||
+            !decimalIntegerPattern.test(body.blockNumber)
+          ) {
+            throw new Error("Transaction confirmation is incomplete");
+          }
+          const confirmed: Extract<SubmissionState, { kind: "confirmed" }> = {
+            kind: "confirmed",
+            account: tracked.account,
+            amount: tracked.amount,
+            blockNumber: body.blockNumber,
+            hash: tracked.hash,
+          };
+          persistMigrationTransfer(confirmed);
+          setSubmission(confirmed);
+          void refreshBalance();
+          return;
+        }
+        if (body.status === "reverted") {
+          clearPersistedMigrationTransfer();
+          setSubmission({
+            kind: "reverted",
+            account: tracked.account,
+            amount: tracked.amount,
+            hash: tracked.hash,
+          });
+          return;
+        }
+      } catch {
+        if (controller.signal.aborted) return;
+        retryDelay = 8_000;
+        setConfirmationIssue(
+          "Confirmation check paused. Verify the transaction on Etherscan before sending again.",
+        );
+      } finally {
+        window.clearTimeout(requestTimeout);
+        controller.signal.removeEventListener("abort", abortRequest);
+      }
+
+      retryTimer = window.setTimeout(() => void poll(), retryDelay);
+    };
+
+    void poll();
+    return () => {
+      controller.abort();
+      if (retryTimer !== undefined) window.clearTimeout(retryTimer);
+    };
+  }, [refreshBalance, submission]);
+
+  function onAmountChange(event: ChangeEvent<HTMLInputElement>) {
+    setAmount(event.target.value);
+    setConfirmationIssue("");
+    setSubmission({ kind: "idle" });
+  }
+
+  function chooseMax() {
+    if (balance === null) return;
+    setAmount(formatUnits(balance, MAIN_TOKEN_DECIMALS));
+    setConfirmationIssue("");
+    setSubmission({ kind: "idle" });
+  }
+
+  function prepareAnotherTransfer() {
+    if (submission.kind !== "confirmed" || !trustedTransferWindowOpen()) return;
+    clearPersistedMigrationTransfer();
+    setAmount("");
+    setAcknowledged(false);
+    setConfirmationIssue("");
+    setSubmission({ kind: "idle" });
+    window.setTimeout(() => amountInputRef.current?.focus(), 0);
+  }
+
+  async function copyMigrationWallet() {
+    if (!trustedTransferWindowOpen()) {
+      setCopyStatus("The migration transfer window is not open.");
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(MAIN_TOKEN_MIGRATION_WALLET);
+      setCopied(true);
+      setCopyStatus("Migration address copied.");
+      window.setTimeout(() => {
+        setCopied(false);
+        setCopyStatus("");
+      }, 1_600);
+    } catch {
+      setCopyStatus("Unable to copy the migration address.");
+    }
+  }
+
+  async function requestSponsoredGas() {
+    if (
+      !trustedTransferWindowOpen() ||
+      !wallet ||
+      !onMainnet ||
+      parsedAmount === null ||
+      amountError ||
+      balance === null
+    ) {
+      setSubmission({
+        kind: "error",
+        message:
+          amountError ||
+          "Connect on Ethereum and enter the V4 amount before requesting sponsored gas.",
+      });
+      amountInputRef.current?.focus();
+      return;
+    }
+    const account = getAddress(wallet.account);
+    if (accountCodeStatus !== "eoa") {
+      setGasSponsorship({
+        kind: "error",
+        account: account.toLowerCase(),
+        message:
+          "Sponsored gas is available only for a directly controlled wallet.",
+        retryable: false,
+      });
+      focusSponsorshipActionOrStatus();
+      return;
+    }
+
+    setSubmission({ kind: "idle" });
+    setGasSponsorship({
+      kind: "requesting",
+      account: account.toLowerCase(),
+    });
+    focusSponsorshipActionOrStatus();
+    try {
+      const accessToken = await getAccessToken();
+      if (!accessToken) {
+        throw new Error(
+          "Reconnect this wallet before requesting sponsored gas.",
+        );
+      }
+      const body: MainTokenGasSponsorshipRequest = {
+        walletAddress: account,
+        amountRaw: parsedAmount.toString(),
+      };
+      const response = await fetch(gasSponsorshipEndpoint, {
+        method: "POST",
+        cache: "no-store",
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+          "Idempotency-Key": gasSponsorshipIdempotencyKey(account),
+        },
+        body: JSON.stringify(body),
+      });
+      if (!response.ok) {
+        const failure = await gasSponsorshipFailure(response);
+        throw new GasSponsorshipEndpointError(
+          failure.message,
+          failure.retryable,
+        );
+      }
+      const result = parseGasSponsorshipResponse(await response.json(), account);
+      setGasSponsorship(gasSponsorshipState(result));
+      if (result.status === "confirmed" || result.status === "not_needed") {
+        void refreshBalance();
+      }
+      focusSponsorshipActionOrStatus();
+    } catch (error) {
+      setGasSponsorship(gasSponsorshipError(error, account.toLowerCase()));
+      focusSponsorshipActionOrStatus();
+    }
+  }
+
+  async function recheckSponsoredGas() {
+    if (!wallet || !onMainnet) {
+      setSubmission({
+        kind: "error",
+        message: "Connect this wallet on Ethereum before checking sponsored gas.",
+      });
+      return;
+    }
+    const account = getAddress(wallet.account);
+    const controller = new AbortController();
+    setGasSponsorship({
+      kind: "checking",
+      account: account.toLowerCase(),
+    });
+    focusSponsorshipActionOrStatus();
+    try {
+      const result = await readGasSponsorship(account, controller.signal);
+      setGasSponsorship(gasSponsorshipState(result.body));
+      if (
+        result.body.status === "confirmed" ||
+        result.body.status === "not_needed"
+      ) {
+        await refreshBalance();
+      }
+      focusSponsorshipActionOrStatus();
+    } catch (error) {
+      setGasSponsorship(gasSponsorshipError(error, account.toLowerCase()));
+      focusSponsorshipActionOrStatus();
+    }
+  }
+
+  async function reviewTransfer() {
+    if (!trustedTransferWindowOpen()) {
+      setSubmission({
+        kind: "error",
+        message:
+          phase === "checking"
+            ? "The migration window is still being checked. Nothing can be sent yet."
+            : phase === "preview"
+              ? "Transfers remain disabled until the exact UTC window and start block are published."
+              : phase === "upcoming"
+                ? "The migration window has not opened yet."
+                : phase === "active"
+                  ? "New transfers are closed so they can confirm before the deadline."
+                  : "The migration window is closed. Do not send tokens to the migration wallet.",
+      });
+      return;
+    }
+    if (hasTrackedTransfer) return;
+    if (!wallet) {
+      openWallet();
+      return;
+    }
+    if (!onMainnet) {
+      try {
+        await switchNetwork(String(MAIN_TOKEN_MIGRATION_CHAIN_ID));
+      } catch (error) {
+        setSubmission({
+          kind: "error",
+          message: migrationErrorMessage(error),
+        });
+      }
+      return;
+    }
+    if (!amount.trim() || parsedAmount === null || amountError) {
+      setSubmission({
+        kind: "error",
+        message: amountError || "Enter the V4 amount to send.",
+      });
+      amountInputRef.current?.focus();
+      return;
+    }
+    if (balance === null) {
+      setSubmission({
+        kind: "error",
+        message: "Unable to verify your V4 balance. Refresh and try again.",
+      });
+      return;
+    }
+    if (!acknowledged) {
+      setSubmission({
+        kind: "error",
+        message:
+          "Confirm that you control this same wallet address on Robinhood.",
+      });
+      acknowledgementRef.current?.focus();
+      return;
+    }
+
+    try {
+      let code: Hex;
+      try {
+        code = await readConnectedAccountCode();
+      } catch {
+        throw new Error(
+          "Unable to verify this wallet for the automatic path. Nothing was sent. Try again before the window closes.",
+        );
+      }
+      if (code !== "0x") {
+        setAccountCodeObservation({
+          account: wallet.account.toLowerCase(),
+          status: "contract",
+        });
+        throw new Error(
+          "Smart-contract wallets are not eligible for the automatic allocation path. Contact support for manual review before sending.",
+        );
+      }
+      setAccountCodeObservation({
+        account: wallet.account.toLowerCase(),
+        status: "eoa",
+      });
+      const amountRaw = parsedAmount;
+      const freshBalances = await readTradeBalances(MAIN_TOKEN_ADDRESS);
+      setBalance(freshBalances.tokenBalanceRaw);
+      setNativeBalance(freshBalances.nativeBalanceWei);
+      setGasPrice(freshBalances.gasPriceWei);
+      assertMainTokenMigrationBalance(amountRaw, freshBalances.tokenBalanceRaw);
+      if (
+        !hasEnoughMigrationGas(
+          freshBalances.nativeBalanceWei,
+          freshBalances.gasPriceWei,
+        )
+      ) {
+        setSubmission({
+          kind: "error",
+          message:
+            sponsorshipKind === "requesting" ||
+            sponsorshipKind === "requested" ||
+            sponsorshipKind === "funding-confirming" ||
+            sponsorshipKind === "balance-confirming"
+              ? "The sponsored ETH is not available yet. Wait for confirmation and try again."
+              : sponsorshipKind === "ready"
+                ? "This wallet no longer has enough ETH for the transfer. Add ETH and try again."
+                : "This wallet needs ETH for gas. Request sponsored gas before sending V4.",
+        });
+        focusSponsorshipActionOrStatus();
+        return;
+      }
+      const finalCheckTime = readTrustedNow();
+      if (finalCheckTime === null || !trustedTransferWindowOpen()) {
+        setSubmission({
+          kind: "error",
+          message:
+            "New transfers are closed so they can confirm before the deadline. Nothing was sent.",
+        });
+        return;
+      }
+      const account = getAddress(wallet.account);
+      const prepared = buildMainTokenMigrationTransaction({
+        from: account,
+        amountRaw,
+      });
+      const checked = assertMainTokenMigrationTransaction(prepared, account);
+      const walletReviewTime = readTrustedNow();
+      if (walletReviewTime === null || !trustedTransferWindowOpen()) {
+        setSubmission({
+          kind: "error",
+          message:
+            "New transfers are closed before wallet review so they can confirm before the deadline. Nothing was sent.",
+        });
+        return;
+      }
+      setSubmission({ kind: "submitting" });
+      const hash = await sendTransaction(checked);
+      const submitted: Extract<SubmissionState, { kind: "submitted" }> = {
+        kind: "submitted",
+        account,
+        hash,
+        amount: formatUnits(amountRaw, MAIN_TOKEN_DECIMALS),
+      };
+      persistMigrationTransfer(submitted);
+      setConfirmationIssue("");
+      setSubmission(submitted);
+    } catch (error) {
+      setSubmission({ kind: "error", message: migrationErrorMessage(error) });
+    }
+  }
+
+  const primaryLabel = phase === "checking"
+    ? "Checking migration window"
+    : phase === "preview"
+      ? "Migration not open"
+      : phase === "upcoming"
+        ? "Migration opens soon"
+        : phase === "closed"
+    ? "Migration closed"
+    : !transferWindowOpen
+      ? "New transfers closed"
+    : submission.kind === "submitted"
+      ? "Waiting for Ethereum confirmation"
+      : submission.kind === "confirmed"
+        ? "Transfer confirmed"
+    : !wallet
+    ? connecting
+      ? "Opening wallet"
+      : "Connect wallet"
+    : !onMainnet
+      ? switchingNetwork
+        ? "Switching network"
+        : "Switch to Ethereum"
+      : submission.kind === "submitting"
+        ? "Confirm in your wallet"
+        : accountCodeStatus === "checking"
+          ? "Checking wallet type"
+          : accountCodeStatus === "contract"
+            ? "Manual review required"
+            : !amount.trim()
+              ? "Enter amount"
+              : amountError
+                ? "Check amount"
+                : balance === null
+                  ? "Balance unavailable"
+                  : !acknowledged
+                    ? "Confirm address control"
+                    : !sponsoredGasReady
+                      ? sponsorshipKind === "eligible"
+                        ? "Request sponsored gas first"
+                        : sponsorshipKind === "requesting"
+                          ? "Requesting sponsored gas"
+                          : sponsorshipKind === "requested" ||
+                              sponsorshipKind === "funding-confirming" ||
+                              sponsorshipKind === "balance-confirming"
+                            ? "Waiting for sponsored gas"
+                            : sponsorshipKind === "error"
+                              ? terminalSponsorshipFailure
+                                ? "Check ETH and continue"
+                                : "Check gas sponsorship"
+                              : "Checking gas balance"
+                    : "Review transfer in wallet";
+
+  return (
+    <article className={styles.page}>
+      <section className={styles.hero} aria-labelledby="migration-title">
+        <div className={styles.previewFlag} hidden={phase !== "preview"}>
+          Local preview · transfers disabled
+        </div>
+        <Image
+          className={styles.loopMark}
+          src={loopMark}
+          alt=""
+          width={1168}
+          height={1536}
+          loading="eager"
+          priority
+        />
+        <h1 id="migration-title">We are migrating</h1>
+        <div className={styles.chainFlow} aria-label="Ethereum to Robinhood">
+          <span className={styles.chainName}>
+            <svg
+              aria-hidden="true"
+              className={styles.ethereumMark}
+              viewBox="0 0 32 52"
+            >
+              <path d="M16 0 0 26.2 16 35.6 32 26.2 16 0Z" />
+              <path d="m0 29.2 16 22.6 16-22.6-16 9.4-16-9.4Z" />
+            </svg>
+            Ethereum
+          </span>
+          <span className={styles.chainArrow} aria-hidden="true">→</span>
+          <span className={styles.chainName}>Robinhood</span>
+        </div>
+        <Countdown phase={phase} remaining={remaining} />
+        {clockIssue ? (
+          <p className={styles.clockIssue} role="status">{clockIssue}</p>
+        ) : null}
+        <p className={styles.heroCopy}>
+          Send your V4 during the 96-hour window. You get the same number of V4
+          tokens sent to the same wallet when V4 launches on Robinhood.
+        </p>
+        <p className={styles.criticalCopy}>
+          V4 launched with a total supply of 1 billion on Ethereum. V4 on
+          Robinhood will also have a total supply of 1 billion.
+        </p>
+        <p className={styles.officialNotice}>
+          Use only <strong>programmable.market/migration</strong>. Programmable
+          will never send a migration address by DM.
+        </p>
+      </section>
+
+      <section className={styles.migrationPanel} aria-labelledby="send-v4-title">
+        {phase === "closed" ? (
+          <div className={styles.closedNotice} role="alert">
+            <strong>Migration closed</strong>
+            <span>
+              Do not send tokens to the migration wallet. Transfers confirmed
+              after the published deadline are not eligible.
+            </span>
+          </div>
+        ) : null}
+        <div className={styles.summary} aria-label="Migration terms">
+          <div><span>Window</span><strong>96 hours</strong></div>
+          <div><span>You receive</span><strong>The same V4 amount</strong></div>
+          <div><span>Robinhood wallet</span><strong>The same address</strong></div>
+          <div><span>Total supply</span><strong>1 billion V4</strong></div>
+        </div>
+
+        <div className={styles.panelGrid}>
+          <div className={styles.transferColumn}>
+            <header className={styles.panelHeader}>
+              <p>Send with your wallet</p>
+              <h2 id="send-v4-title">Send V4 for migration</h2>
+            </header>
+
+            {wallet ? (
+              <div className={styles.walletRow}>
+                <span>Connected wallet</span>
+                <strong>{shortenAddress(wallet.account)}</strong>
+              </div>
+            ) : (
+              <p className={styles.connectPrompt}>
+                Connect the wallet that holds your V4.
+              </p>
+            )}
+
+            {wallet && onMainnet ? (
+              <div
+                className={styles.walletTypeStatus}
+                data-status={accountCodeStatus}
+                role="status"
+              >
+                <strong>
+                  {accountCodeStatus === "eoa"
+                    ? "Wallet ready"
+                    : accountCodeStatus === "contract"
+                      ? "Smart-contract wallet detected"
+                      : accountCodeStatus === "unavailable"
+                        ? "Wallet type unavailable"
+                        : "Checking wallet type"}
+                </strong>
+                <span>
+                  {accountCodeStatus === "eoa"
+                    ? "This address can use the automatic migration path. It is checked again before sending."
+                    : accountCodeStatus === "contract"
+                      ? "Do not send. Multisigs and smart-contract wallets require manual review and are not guaranteed an automatic allocation."
+                      : accountCodeStatus === "unavailable"
+                        ? "The automatic path remains blocked until the wallet type can be checked."
+                        : "Checking whether this address can use the automatic migration path."}
+                </span>
+              </div>
+            ) : null}
+
+            <div className={styles.balanceRow} aria-live="polite">
+              <span>Available balance</span>
+              <strong className={balanceLoading ? styles.balanceLoading : undefined}>
+                {balanceLoading
+                  ? "Reading balance"
+                  : balance === null
+                    ? "Connect on Ethereum"
+                    : `${formatTokenAmount(balance)} ${MAIN_TOKEN_SYMBOL}`}
+              </strong>
+            </div>
+            {balanceError ? <p className={styles.inlineError}>{balanceError}</p> : null}
+
+            <div className={styles.amountGroup}>
+              <label htmlFor="migration-amount">Amount to send</label>
+              <div className={styles.amountControl}>
+                <input
+                  ref={amountInputRef}
+                  id="migration-amount"
+                  name="migration-amount"
+                  type="text"
+                  inputMode="decimal"
+                  autoComplete="off"
+                  placeholder="0.0"
+                  value={amount}
+                  onChange={onAmountChange}
+                  disabled={
+                    !transferWindowOpen ||
+                    hasTrackedTransfer ||
+                    submission.kind === "submitting"
+                  }
+                  aria-describedby={
+                    amountError
+                      ? "migration-amount-help migration-amount-error"
+                      : "migration-amount-help"
+                  }
+                  aria-invalid={amountError ? "true" : undefined}
+                />
+                <span>{MAIN_TOKEN_SYMBOL}</span>
+                <button
+                  type="button"
+                  onClick={chooseMax}
+                  disabled={
+                    balance === null ||
+                    balance === 0n ||
+                    balanceLoading ||
+                    !transferWindowOpen ||
+                    hasTrackedTransfer ||
+                    submission.kind === "submitting"
+                  }
+                >
+                  Max
+                </button>
+              </div>
+              <p id="migration-amount-help">
+                Max selects your full V4 balance. If this wallet needs ETH for
+                gas, a one-time sponsorship option appears below.
+              </p>
+              {amountError ? (
+                <p className={styles.inlineError} id="migration-amount-error">
+                  {amountError}
+                </p>
+              ) : null}
+            </div>
+
+            {wallet &&
+            onMainnet &&
+            accountCodeStatus === "eoa" &&
+            parsedAmount !== null &&
+            !amountError &&
+            balance !== null ? (
+              <div
+                ref={sponsorshipRegionRef}
+                tabIndex={-1}
+                aria-label="Gas sponsorship status"
+              >
+                {sponsorshipKind === "not-needed" ? (
+                  <div
+                    className={styles.walletTypeStatus}
+                    data-status="eoa"
+                    role="status"
+                  >
+                    <strong>Ethereum gas ready</strong>
+                    <span>
+                      This wallet has enough ETH for the V4 transfer. No
+                      sponsored gas was requested.
+                    </span>
+                  </div>
+                ) : sponsorshipKind === "idle" ||
+                  sponsorshipKind === "checking" ? (
+                  <div
+                    className={styles.walletTypeStatus}
+                    data-status="unavailable"
+                    role="status"
+                  >
+                    <strong>Checking gas sponsorship eligibility</strong>
+                    <span>
+                      Your V4 remains in your wallet while this check runs.
+                    </span>
+                  </div>
+                ) : sponsorshipKind === "eligible" ? (
+                  <div
+                    className={styles.walletTypeStatus}
+                    data-status="unavailable"
+                    role="status"
+                  >
+                    <strong>Sponsored gas available</strong>
+                    <span>
+                      This wallet needs ETH for gas. Request a one-time top-up,
+                      wait for confirmation, then sign the normal V4 transfer
+                      in your wallet.
+                    </span>
+                    <button
+                      ref={sponsorButtonRef}
+                      className={styles.secondaryAction}
+                      type="button"
+                      onClick={() => void requestSponsoredGas()}
+                    >
+                      Request sponsored gas
+                    </button>
+                  </div>
+                ) : sponsorshipKind === "requesting" ? (
+                  <div
+                    className={`${styles.transactionStatus} ${styles.pendingStatus}`}
+                    role="status"
+                  >
+                    <strong>Requesting sponsored gas</strong>
+                    <p>
+                      Verifying this wallet and preparing the one-time ETH
+                      top-up. No V4 transfer has been requested or signed.
+                    </p>
+                  </div>
+                ) : sponsorshipKind === "requested" ? (
+                  <div
+                    className={`${styles.transactionStatus} ${styles.pendingStatus}`}
+                    role="status"
+                  >
+                    <strong>Gas top-up requested</strong>
+                    <p>
+                      The sponsor transaction was submitted. Your V4 remains
+                      in this wallet while Ethereum confirms the top-up.
+                    </p>
+                    {sponsorshipTransactionHash ? (
+                      <a
+                        href={`https://etherscan.io/tx/${sponsorshipTransactionHash}`}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        View gas top-up on Etherscan
+                      </a>
+                    ) : null}
+                  </div>
+                ) : sponsorshipKind === "funding-confirming" ||
+                  sponsorshipKind === "balance-confirming" ? (
+                  <div
+                    className={`${styles.transactionStatus} ${styles.pendingStatus}`}
+                    role="status"
+                  >
+                    <strong>
+                      {sponsorReceiptConfirmed
+                        ? "Verifying sponsored gas"
+                        : "Confirming sponsored gas"}
+                    </strong>
+                    <p>
+                      {sponsorReceiptConfirmed
+                        ? "Ethereum confirmed the top-up. The V4 transfer stays disabled until this wallet's refreshed ETH balance covers the required gas."
+                        : "Wait for the ETH top-up to confirm before reviewing the V4 transfer. You have not signed or sent V4 yet."}
+                    </p>
+                    {sponsorshipTransactionHash ? (
+                      <a
+                        href={`https://etherscan.io/tx/${sponsorshipTransactionHash}`}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        View gas top-up on Etherscan
+                      </a>
+                    ) : null}
+                  </div>
+                ) : sponsorshipKind === "ready" ? (
+                  <div
+                    className={`${styles.transactionStatus} ${styles.confirmedStatus}`}
+                    role="status"
+                  >
+                    <strong>Sponsored gas confirmed</strong>
+                    <p>
+                      This wallet has enough observed ETH for the normal V4
+                      transfer. Nothing has been sent until you review and sign
+                      in your wallet.
+                    </p>
+                    {sponsorshipTransactionHash ? (
+                      <a
+                        href={`https://etherscan.io/tx/${sponsorshipTransactionHash}`}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        View gas top-up on Etherscan
+                      </a>
+                    ) : null}
+                  </div>
+                ) : sponsorshipKind === "error" ? (
+                  <div
+                    className={`${styles.transactionStatus} ${styles.revertedStatus}`}
+                    role="alert"
+                  >
+                    <strong>Sponsored gas unavailable</strong>
+                    <p>
+                      {sponsorshipForConnectedAccount &&
+                      gasSponsorship.kind === "error"
+                        ? gasSponsorship.message
+                        : "Unable to check sponsored gas. Try again."}
+                    </p>
+                    {sponsorshipForConnectedAccount &&
+                    gasSponsorship.kind === "error" &&
+                    gasSponsorship.retryable ? (
+                      <button
+                        ref={sponsorButtonRef}
+                        className={styles.secondaryAction}
+                        type="button"
+                        onClick={() => void recheckSponsoredGas()}
+                      >
+                        Check sponsorship status
+                      </button>
+                    ) : (
+                      <a
+                        href="https://discord.com/invite/programmable"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Contact migration support
+                      </a>
+                    )}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+
+            <label className={styles.acknowledgement}>
+              <input
+                ref={acknowledgementRef}
+                type="checkbox"
+                checked={acknowledged}
+                onChange={(event) => setAcknowledged(event.target.checked)}
+                disabled={
+                  !transferWindowOpen ||
+                  hasTrackedTransfer ||
+                  submission.kind === "submitting"
+                }
+              />
+              <span>
+                I control this wallet on Ethereum and will use the same address
+                on Robinhood. I understand the allocation cannot be redirected.
+              </span>
+            </label>
+
+            {canRevealDestination ? (
+              <div className={styles.transferReview}>
+                <div>
+                  <span>From</span>
+                  <strong>
+                    {transferSender
+                      ? shortenAddress(transferSender)
+                      : "Connected sender"}
+                  </strong>
+                </div>
+                <div className={styles.addressReviewRow}>
+                  <span>Ethereum recipient</span>
+                  <code>{MAIN_TOKEN_MIGRATION_WALLET}</code>
+                </div>
+                <div>
+                  <span>You send</span>
+                  <strong>{parsedAmount === null ? "Enter amount" : `${formatUnits(parsedAmount, MAIN_TOKEN_DECIMALS)} ${MAIN_TOKEN_SYMBOL}`}</strong>
+                </div>
+                <div>
+                  <span>Robinhood allocation</span>
+                  <strong>{parsedAmount === null ? "1:1 V4 amount" : `${formatUnits(parsedAmount, MAIN_TOKEN_DECIMALS)} ${MAIN_TOKEN_SYMBOL}`}</strong>
+                </div>
+              </div>
+            ) : (
+              <div className={styles.destinationUnavailable}>
+                <strong>Transfer destination is not available yet</strong>
+                <span>
+                  The full migration wallet appears here only while the
+                  published window is active. Do not use an address from a DM.
+                </span>
+              </div>
+            )}
+
+            <button
+              className={styles.primaryAction}
+              type="button"
+              onClick={() => void reviewTransfer()}
+              disabled={
+                !transferWindowOpen ||
+                connecting ||
+                switchingNetwork ||
+                submission.kind === "submitting" ||
+                hasTrackedTransfer ||
+                accountCodeStatus === "checking" ||
+                accountCodeStatus === "contract"
+              }
+            >
+              {primaryLabel}
+            </button>
+            <p className={styles.walletBoundary}>
+              This is an irreversible ERC-20 transfer on Ethereum, not a
+              bridge. Nothing is sent until you confirm the transfer in your wallet.
+              The optional gas sponsor only sends ETH to this wallet and never
+              initiates the V4 transfer. Verify the network, V4 token contract,
+              full recipient and amount.
+            </p>
+
+            <div className={styles.status} role="status" aria-live="polite" aria-atomic="true">
+              {submission.kind === "error" ? (
+                <p className={styles.inlineError}>{submission.message}</p>
+              ) : null}
+              {submission.kind === "submitted" ? (
+                <div className={`${styles.transactionStatus} ${styles.pendingStatus}`}>
+                  <strong>Transaction submitted — not confirmed</strong>
+                  <p>
+                    Waiting for Ethereum confirmation. Do not send again. The
+                    migration list counts only confirmed V4 transfers whose
+                    Ethereum block timestamp is inside the published window.
+                  </p>
+                  <a
+                    href={`https://etherscan.io/tx/${submission.hash}`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    View on Etherscan
+                  </a>
+                </div>
+              ) : null}
+              {submission.kind === "confirmed" ? (
+                <div className={`${styles.transactionStatus} ${styles.confirmedStatus}`}>
+                  <strong>Wallet transaction confirmed on Ethereum</strong>
+                  <p>
+                    The transaction was confirmed in block {submission.blockNumber}.
+                    After the window closes, we will verify the transfer,
+                    amount, sender, recipient and block timestamp before the
+                    Robinhood allocation is sent.
+                  </p>
+                  <a
+                    href={`https://etherscan.io/tx/${submission.hash}`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    View on Etherscan
+                  </a>
+                  {transferWindowOpen ? (
+                    <button
+                      className={styles.secondaryAction}
+                      type="button"
+                      onClick={prepareAnotherTransfer}
+                    >
+                      Send another amount
+                    </button>
+                  ) : null}
+                </div>
+              ) : null}
+              {submission.kind === "reverted" ? (
+                <div className={`${styles.transactionStatus} ${styles.revertedStatus}`}>
+                  <strong>Transaction reverted</strong>
+                  <p>
+                    No V4 was transferred. Review the transaction before trying
+                    again while the migration window is active.
+                  </p>
+                  <a
+                    href={`https://etherscan.io/tx/${submission.hash}`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    View on Etherscan
+                  </a>
+                </div>
+              ) : null}
+              {confirmationIssue ? (
+                <p className={styles.confirmationIssue}>{confirmationIssue}</p>
+              ) : null}
+            </div>
+          </div>
+
+          <aside className={styles.destinationColumn} aria-labelledby="migration-wallet-title">
+            <header className={styles.panelHeader}>
+              <p>Fixed destination</p>
+              <h2 id="migration-wallet-title">Migration wallet</h2>
+            </header>
+            <>
+              <p>
+                Send only V4 from the wallet that should receive the Robinhood
+                allocation. This address is fixed for the migration.
+              </p>
+              {canRevealDestination ? (
+                <>
+                <div className={styles.addressBlock}>
+                  <code>{MAIN_TOKEN_MIGRATION_WALLET}</code>
+                  <button
+                    type="button"
+                    onClick={() => void copyMigrationWallet()}
+                    disabled={!canCopyDestination}
+                  >
+                    {copied ? "Address copied" : "Copy address"}
+                  </button>
+                  <p className={styles.copyStatus} aria-live="polite">
+                    {copyStatus}
+                  </p>
+                </div>
+                <dl className={styles.contractFacts}>
+                  <div>
+                    <dt>Eligible token contract</dt>
+                    <dd><code>{MAIN_TOKEN_ADDRESS}</code></dd>
+                  </div>
+                  <div>
+                    <dt>Network</dt>
+                    <dd>Ethereum Mainnet</dd>
+                  </div>
+                  <div>
+                    <dt>Allocation identity</dt>
+                    <dd>Ethereum Transfer event sender</dd>
+                  </div>
+                  <div>
+                    <dt>Eligibility cutoff</dt>
+                    <dd>
+                      Ethereum block timestamp at or after opening and before
+                      the deadline
+                    </dd>
+                  </div>
+                </dl>
+                <div className={styles.warning}>
+                  <strong>Before you send</strong>
+                  <p>Do not send ETH or another token.</p>
+                  <p>
+                    Do not send from an exchange, custodian or router. The
+                    Transfer event sender would receive the record, not your
+                    wallet.
+                  </p>
+                  <p>
+                    Multisigs and smart-contract wallets require manual review
+                    and have no automatic allocation guarantee.
+                  </p>
+                </div>
+                </>
+              ) : (
+                <p className={styles.closedAddressNote}>
+                  The address and copy action unlock only during the published
+                  96-hour window. Do not send before it opens or after it closes.
+                </p>
+              )}
+            </>
+          </aside>
+        </div>
+      </section>
+
+      <section className={styles.process} aria-labelledby="migration-process-title">
+        <header>
+          <p>One address. One allocation.</p>
+          <h2 id="migration-process-title">How it works</h2>
+        </header>
+        <ol>
+          <li><strong>Send while active</strong><span>If needed, request sponsored gas first. Then transfer V4 directly from your wallet during the published window.</span></li>
+          <li><strong>Confirm on Ethereum</strong><span>Only confirmed transfers inside the window can enter the migration list.</span></li>
+          <li><strong>We verify the list</strong><span>After 96 hours, confirmed amounts are totaled by exact sender address before the Robinhood allocation is sent.</span></li>
+        </ol>
+        <p className={styles.finalNote}>
+          Your Robinhood allocation matches the exact V4 token amount recorded
+          from your Ethereum wallet.
+        </p>
+        <Link className={styles.backLink} href="/">
+          Back to Programmable
+        </Link>
+      </section>
+    </article>
+  );
+}

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -56,6 +56,7 @@ import {
 } from "@/lib/custom-launch/wallet-handoff-v4";
 import { parseLocalProfile } from "@/lib/profile/local-profile";
 import { robinhoodChain } from "@/lib/chains";
+import { assertMainTokenMigrationTransaction } from "@/lib/main-token-migration";
 import {
   buildPredictionPermitTypedData,
   buildUsdgPermitTypedData,
@@ -199,6 +200,7 @@ type WalletContextValue = {
     transaction: ParsedPredictionV2PreparedTransactionV2,
   ) => Promise<Hex>;
   readNativeBalance: () => Promise<WalletNativeBalance>;
+  readConnectedAccountCode: () => Promise<Hex>;
   readTradeBalances: (token: `0x${string}`) => Promise<WalletTradeBalances>;
 };
 
@@ -221,6 +223,7 @@ function loadWalletProviderRuntime() {
 export function shouldEagerLoadWalletRuntime(pathname: string) {
   return [
     "/launch",
+    "/migration",
     "/profile",
     "/token",
     "/developers/api-keys",
@@ -1045,6 +1048,9 @@ function DeferredWalletProvider({
       readNativeBalance: async () => {
         throw new Error("Wallet sign-in is still loading");
       },
+      readConnectedAccountCode: async () => {
+        throw new Error("Wallet sign-in is still loading");
+      },
       readTradeBalances: async () => {
         throw new Error("Wallet sign-in is still loading");
       },
@@ -1728,6 +1734,9 @@ function PrivyWalletBridge({
         transaction,
         wallet.account,
       );
+      if (prepared.kind === "main-token-migration") {
+        assertMainTokenMigrationTransaction(prepared, wallet.account);
+      }
       const target =
         prepared.kind === "prediction-market-launch" ||
         prepared.kind === "prediction-market-action"
@@ -2456,6 +2465,35 @@ function PrivyWalletBridge({
     };
   }, [connectedWallet, wallet]);
 
+  const readConnectedAccountCode = useCallback(async () => {
+    if (!connectedWallet || !wallet) {
+      throw new Error("Connect an Ethereum wallet before continuing");
+    }
+
+    const provider = await connectedWallet.getEthereumProvider();
+    const providerChainId = await provider.request({
+      method: "eth_chainId",
+    });
+    if (
+      typeof providerChainId !== "string" ||
+      normalizeChainId(providerChainId) !== appChainHex
+    ) {
+      throw new Error(`Switch your wallet to ${appNetworkName}`);
+    }
+
+    const code = await provider.request({
+      method: "eth_getCode",
+      params: [wallet.account, "latest"],
+    });
+    if (
+      typeof code !== "string" ||
+      !/^0x(?:[0-9a-fA-F]{2})*$/u.test(code)
+    ) {
+      throw new Error("The wallet account type could not be verified");
+    }
+    return code.toLowerCase() as Hex;
+  }, [connectedWallet, wallet]);
+
   const value = useMemo<WalletContextValue>(
     () => ({
       wallet,
@@ -2494,6 +2532,7 @@ function PrivyWalletBridge({
       sendTransaction,
       sendPredictionV2Transaction,
       readNativeBalance,
+      readConnectedAccountCode,
       readTradeBalances,
     }),
     [
@@ -2513,6 +2552,7 @@ function PrivyWalletBridge({
       openWallet,
       openWalletWithError,
       providerTimedOut,
+      readConnectedAccountCode,
       readNativeBalance,
       readTradeBalances,
       ready,
@@ -2641,6 +2681,9 @@ function UnconfiguredWalletProvider({ children }: { children: ReactNode }) {
         throw new Error("Wallet sign-in is unavailable");
       },
       readNativeBalance: async () => {
+        throw new Error("Wallet sign-in is unavailable");
+      },
+      readConnectedAccountCode: async () => {
         throw new Error("Wallet sign-in is unavailable");
       },
       readTradeBalances: async () => {

--- a/config/main-token-migration-activation.v1.json
+++ b/config/main-token-migration-activation.v1.json
@@ -1,0 +1,16 @@
+{
+  "schema": "programmable-main-token-migration-activation/v1",
+  "releaseId": "v4-ethereum-to-robinhood-96h-2026-v1",
+  "enabled": true,
+  "sourceChainId": "1",
+  "sourceTokenAddress": "0x7987f03462200b3D8A072E02C89A8A41dCB124EE",
+  "sourceTokenRuntimeCodeKeccak256": "0x4fe466386aeebe507f6bcfc58e046a0632e4687699fa5bd28c4b7ec6333141ad",
+  "sourceTokenDecimals": "18",
+  "sourceTokenTotalSupplyRaw": "1000000000000000000000000000",
+  "migrationWallet": "0x228Be90653fDDAa408fB6cf9ca0AEC311dbE9A0D",
+  "windowDurationSeconds": "345600",
+  "windowStartTimestamp": "1788125400",
+  "deadlineTimestampExclusive": "1788471000",
+  "startBlockNumber": "25870405",
+  "startBlockHash": "0xe4f50afeba1884b8354b3c962f99a258f2901f9768ec8da8ad05391761ff57de"
+}

--- a/config/main-token-migration-gas-sponsor-contract.v1.json
+++ b/config/main-token-migration-gas-sponsor-contract.v1.json
@@ -1,0 +1,72 @@
+{
+  "schema": "programmable-main-token-migration-gas-sponsor-activation-contract/v1",
+  "releaseId": "v4-ethereum-to-robinhood-96h-2026-v1",
+  "activationManifestPath": "config/main-token-migration-activation.v1.json",
+  "route": "/api/main-token-migration/gas-sponsorship",
+  "serverOnly": true,
+  "chainId": "1",
+  "caip2": "eip155:1",
+  "environment": {
+    "enabled": {
+      "name": "MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ENABLED",
+      "disabledValue": "false",
+      "activationValue": "true"
+    },
+    "privyWalletId": "MAIN_TOKEN_MIGRATION_GAS_SPONSOR_PRIVY_WALLET_ID",
+    "privyPolicyId": "MAIN_TOKEN_MIGRATION_GAS_SPONSOR_PRIVY_POLICY_ID",
+    "walletAddress": "MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ADDRESS",
+    "maximumTopUpWei": "MAIN_TOKEN_MIGRATION_GAS_SPONSOR_MAX_TOP_UP_WEI",
+    "totalBudgetWei": "MAIN_TOKEN_MIGRATION_GAS_SPONSOR_TOTAL_BUDGET_WEI"
+  },
+  "walletBinding": {
+    "chainType": "ethereum",
+    "attachedPolicyCount": "1",
+    "transactionMethod": "eth_sendTransaction",
+    "transactionType": "2",
+    "transactionData": "0x",
+    "sponsorGasLimit": "21000",
+    "providerPolicyEnforces": [
+      "method",
+      "chainId",
+      "maximumValue"
+    ],
+    "serverEnforces": [
+      "holderRecipient",
+      "emptyCalldata",
+      "sender",
+      "transactionType",
+      "gasAndFeeBounds",
+      "exactValue"
+    ]
+  },
+  "limits": {
+    "estimatedTokenTransferGasCeiling": "100000",
+    "gasQuoteMultiplierBps": "12500",
+    "maximumFeePerGasWei": "20000000000",
+    "absoluteMaximumTopUpWei": "2000000000000000",
+    "absoluteMaximumTotalBudgetWei": "1000000000000000000",
+    "deadlineSafetySeconds": "300"
+  },
+  "feeRules": {
+    "useHigherIndependentProviderQuote": true,
+    "maximumPriorityFeeMustNotExceedMaximumFee": true
+  },
+  "budgetRules": {
+    "maximumTopUpMustBePositive": true,
+    "totalBudgetMustCoverMaximumTopUp": true,
+    "reservationIncludesSponsorTransactionFee": true
+  },
+  "runtimeDependencies": [
+    "NEXT_PUBLIC_PRIVY_APP_ID",
+    "PRIVY_APP_SECRET",
+    "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL",
+    "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM",
+    "PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE",
+    "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_PROVIDER",
+    "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_URL",
+    "PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_ENDPOINT_COMMITMENT",
+    "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_PROVIDER",
+    "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_URL",
+    "PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_ENDPOINT_COMMITMENT"
+  ]
+}

--- a/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-READINESS-V1.md
+++ b/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-READINESS-V1.md
@@ -1,0 +1,57 @@
+# Main Token Migration Gas Sponsor V1 Readiness
+
+This checklist is an activation gate, not an activation record. The committed migration manifest is currently
+disabled. Replace no placeholders in the repository; operational values belong only in the deployment secret manager
+and private release evidence.
+
+## Candidate identity
+
+- [ ] The candidate is an immutable build from the exact reviewed `production` commit.
+- [ ] `config/main-token-migration-activation.v1.json` binds the reviewed release and has a 345,600-second window,
+      exact finalized pre-window eligibility block number and hash.
+- [ ] The sponsor contract matches
+      `config/main-token-migration-gas-sponsor-contract.v1.json` byte-for-byte in the candidate.
+
+## Server configuration
+
+- [ ] `MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ENABLED=true` exists only in the intended deployment environment.
+- [ ] The exact Privy wallet ID, exact single policy ID and checksummed wallet address all identify the same dedicated
+      Ethereum EOA.
+- [ ] Maximum top-up is positive and no greater than 2,000,000,000,000,000 wei.
+- [ ] Total budget is at least the maximum top-up, no greater than 1,000,000,000,000,000,000 wei, and below the
+      wallet's funded balance after a deliberate safety margin.
+- [ ] Privy app secret, projection database URL/CA/role, and the committed independent dRPC/QuickNode pair are present
+      and remain server-only.
+
+## Wallet policy
+
+- [ ] The wallet readback reports `chain_type=ethereum`, the configured address and exactly one attached policy.
+- [ ] The attached policy ID exactly matches the configured policy ID.
+- [ ] The policy permits only Ethereum Mainnet `eth_sendTransaction` native transfers, caps value at or below the
+      configured maximum top-up, and defaults to deny for unrelated wallet methods.
+- [ ] Server tests and the reviewed candidate independently bind the exact linked holder recipient, empty calldata,
+      sender, type-2 fee/gas limits and exact calculated value; these fields are not attributed to the Privy policy.
+- [ ] The sponsor address differs from both the V4 token and migration recipient addresses and has empty runtime code.
+
+## Focused behavior
+
+- [ ] Disabled manifest or disabled environment switch returns a fail-closed unavailable response and spends nothing.
+- [ ] An authenticated linked EOA that held the requested V4 amount at the eligibility block can receive only its bounded
+      current gas deficit.
+- [ ] Unlinked wallets, smart-contract wallets, insufficient eligibility/current token balances, wrong eligibility block,
+      RPC disagreement, quotes above 20 gwei, exhausted budget and the final five minutes all fail closed.
+- [ ] Concurrent duplicate requests reserve and broadcast no more than one transfer.
+- [ ] An ambiguous Privy response is recorded as unknown and is not rebroadcast.
+- [ ] Dual-RPC readback confirms the exact transaction fields and successful receipt before status becomes confirmed.
+
+## Release evidence
+
+- [ ] Focused sponsor unit/configuration tests, typecheck and `git diff --check` pass on the reviewed commit.
+- [ ] Privy wallet/policy readback is captured privately without credentials.
+- [ ] Candidate route readback, sponsor balance, durable-store readiness and independent RPC identity are captured at
+      the activation time.
+- [ ] Public page visibility is enabled only after the activation manifest, server-time readback and sponsor readiness
+      gates pass.
+- [ ] Post-window disablement and Privy policy revocation have named owners.
+
+If any item is false or unknown, leave the manifest or sponsor switch disabled.

--- a/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-V1.md
+++ b/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-V1.md
@@ -1,0 +1,131 @@
+# Main Token Migration Gas Sponsor V1
+
+Status: release-dark. The checked-in migration activation manifest remains disabled, no production activation is
+authorized by this document, and no committed file contains the operational Privy wallet ID, policy ID, sponsor
+address or release budget.
+
+## Purpose
+
+This runbook defines the server-only activation contract for one bounded Ethereum Mainnet gas top-up per eligible
+V4 holder during the exact 96-hour migration window. The sponsor sends native ETH only to the authenticated holder
+wallet so that the holder can separately approve the exact V4 token transfer in their own wallet. It never sends V4,
+never submits the holder's token transfer, and never uses the migration recipient wallet as the sponsor.
+
+The machine-readable companion is
+[`config/main-token-migration-gas-sponsor-contract.v1.json`](../../config/main-token-migration-gas-sponsor-contract.v1.json).
+The release activation source is
+[`config/main-token-migration-activation.v1.json`](../../config/main-token-migration-activation.v1.json).
+
+## Activation contract
+
+All six sponsor settings are server-only deployment values. None may use a `NEXT_PUBLIC_` prefix or be committed with
+an operational value.
+
+| Environment variable | Required activation value |
+| --- | --- |
+| `MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ENABLED` | Exact string `true`; any other value disables the sponsor |
+| `MAIN_TOKEN_MIGRATION_GAS_SPONSOR_PRIVY_WALLET_ID` | Exact ID of the dedicated Privy Ethereum wallet |
+| `MAIN_TOKEN_MIGRATION_GAS_SPONSOR_PRIVY_POLICY_ID` | Exact ID of the wallet's single attached Privy policy |
+| `MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ADDRESS` | Checksummed address returned for that exact wallet ID |
+| `MAIN_TOKEN_MIGRATION_GAS_SPONSOR_MAX_TOP_UP_WEI` | Positive decimal wei, at most `2000000000000000` (0.002 ETH) |
+| `MAIN_TOKEN_MIGRATION_GAS_SPONSOR_TOTAL_BUDGET_WEI` | Decimal wei, at least the top-up cap and at most `1000000000000000000` (1 ETH) |
+
+Activation additionally requires the normal runtime dependencies:
+
+| Dependency | Purpose |
+| --- | --- |
+| `NEXT_PUBLIC_PRIVY_APP_ID` | Public identifier of the same deployed Privy app that owns the sponsor wallet |
+| `PRIVY_APP_SECRET` | Server-only Privy authentication secret |
+| `PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL` | Server-only attested durable reservation database |
+| `PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM` | Server-only database trust root |
+| `PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE` | Exact least-privilege runtime role |
+| `PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_PROVIDER` | Exact provider label; production requires dRPC |
+| `PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_URL` | Server-only primary Ethereum endpoint |
+| `PROGRAMMABLE_WEBSITE_MAINNET_RPC_PRIMARY_ENDPOINT_COMMITMENT` | Commitment to the primary endpoint |
+| `PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_PROVIDER` | Exact provider label; production requires QuickNode |
+| `PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_URL` | Server-only independent secondary Ethereum endpoint |
+| `PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_ENDPOINT_COMMITMENT` | Commitment to the secondary endpoint |
+
+The root migration manifest must independently bind the exact release, token, runtime-code hash, migration wallet,
+96-hour timestamps, finalized pre-window eligibility block number and block hash. Sponsor configuration is accepted only while that
+manifest has `enabled: true`, the current time is inside the window, and at least five minutes remain. In this branch
+the manifest deliberately remains `enabled: false` with null timing and block fields.
+
+## Privy wallet and policy
+
+Use a dedicated Privy Ethereum EOA. It must not be the V4 token contract or the migration recipient wallet. Before
+every eligibility response and transfer, the server re-reads the wallet from Privy and requires all of the following:
+
+- the returned wallet ID equals `MAIN_TOKEN_MIGRATION_GAS_SPONSOR_PRIVY_WALLET_ID`;
+- `chain_type` is `ethereum` and the returned address equals the configured checksummed address; and
+- exactly one policy is attached and its ID equals `MAIN_TOKEN_MIGRATION_GAS_SPONSOR_PRIVY_POLICY_ID`.
+
+The attached policy must allow only `eth_sendTransaction` for Ethereum Mainnet (`eip155:1`), native value no greater
+than the configured top-up cap and never greater than 0.002 ETH; its default action must deny unrelated wallet
+methods. Privy's transaction-policy fields do not attest calldata or the dynamic holder recipient. The server
+therefore independently constructs a type-2 transaction with chain ID 1, empty calldata, fixed
+21,000 gas, the sponsor as `from`, the authenticated eligible holder as `to`, and the exact calculated deficit as
+`value`. A broader policy is not activation-ready even though these server checks remain in place.
+
+## Fixed fee and budget boundaries
+
+These limits are code-bound and are not operator-tunable:
+
+| Boundary | Exact value | Behavior at or beyond the boundary |
+| --- | ---: | --- |
+| Token-transfer gas ceiling | `100000` gas | A larger estimate fails closed |
+| Quote multiplier | `12500` bps (125%) | Applied to the conservative transfer-gas quote |
+| Maximum fee per gas | `20000000000` wei (20 gwei) | A higher quote returns unavailable; it never increases the cap |
+| Sponsor transaction gas | `21000` gas | Fixed native transfer with empty calldata |
+| Absolute top-up cap | `2000000000000000` wei (0.002 ETH) | The configured cap may be lower, never higher |
+| Absolute release budget cap | `1000000000000000000` wei (1 ETH) | The configured budget may be lower, never higher |
+| Deadline safety margin | `300` seconds | New sponsorship closes before the migration deadline |
+
+The calculated requirement is `ceil(100000 * maxFeePerGas * 12500 / 10000)`. Existing holder ETH is subtracted, so
+only the deficit is sent. The quote uses the higher max fee and higher priority fee observed across the two
+independent providers, and the priority fee must not exceed the max fee. Each durable budget reservation includes
+both that top-up and the sponsor's own
+`21000 * maxFeePerGas` transaction cost. The total budget must cover the configured maximum top-up. It must also be
+chosen below the wallet's funded balance with an operator-owned safety margin; the absolute code cap is not a funding
+recommendation.
+
+## Eligibility and replay boundary
+
+The endpoint authenticates the Privy access token and requires the requested address to be linked to that Privy
+principal. Both independent Ethereum providers must agree on chain ID, canonical head, the finalized pre-window
+eligibility block and the pinned V4 runtime code. The holder and sponsor must be EOAs. The holder must own at least
+the requested V4 amount both at the eligibility block and at the current canonical read.
+
+The POST is same-origin, request-size bounded and idempotency-bound. The durable store reserves at most one sponsor
+intent per release and holder under a database advisory lock. An ambiguous provider response is never automatically
+rebroadcast. Confirmation requires both RPCs to read back the exact sender, recipient, value, fee fields, gas limit,
+empty calldata and successful receipt on the same block.
+
+## Staging and activation
+
+1. Keep `MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ENABLED=false` and the activation manifest disabled while preparing the
+   immutable candidate.
+2. Read back the dedicated wallet from Privy. Capture its ID, checksummed address, exact single policy ID and policy
+   definition without logging an app secret.
+3. Confirm the policy has the restrictions above and that the dedicated wallet contains only the deliberately
+   bounded funding amount.
+4. Choose explicit decimal-wei values for maximum top-up and total budget. Verify the budget is no greater than the
+   funded balance after the retained safety margin.
+5. Configure the Privy secret, projection database bindings and exact independent RPC commitments on the immutable
+   deployment candidate.
+6. Before the migration opens, record one exact block number/hash already finalized by both providers and calculate
+   timestamps whose exclusive deadline is exactly 345,600 seconds after the start.
+7. Only the integration owner may change the reviewed activation manifest to `enabled: true`, inject all six sponsor
+   values with `MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ENABLED=true`, and deploy the exact reviewed `production` commit.
+8. Run the separate readiness checklist before exposing the migration entry point.
+
+## Disable and incident response
+
+Set `MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ENABLED=false` to stop new sponsor handling. A manifest with `enabled: false`, a
+closed window, a missing dependency, a wallet/policy mismatch, exhausted budget, RPC disagreement or fee quote above
+the cap also fails closed. After the window, disable the deployment value and revoke or detach the dedicated Privy
+policy through the normal owner-controlled Privy process. Do not repeat a top-up after an ambiguous submission; use
+the stored request ID and onchain transaction readback for review.
+
+Never include the Privy app secret, database credentials, RPC URLs, holder access tokens or operational wallet IDs in
+public logs, screenshots or release evidence.

--- a/lib/main-token-migration.ts
+++ b/lib/main-token-migration.ts
@@ -1,0 +1,157 @@
+import {
+  decodeFunctionData,
+  encodeFunctionData,
+  getAddress,
+  parseAbi,
+  parseUnits,
+  type Address,
+} from "viem";
+
+import {
+  parsePreparedTransactionForAccount,
+  type PreparedTransaction,
+} from "./prepared-transaction";
+
+export const MAIN_TOKEN_MIGRATION_CHAIN_ID = 1 as const;
+export const MAIN_TOKEN_MIGRATION_WINDOW_SECONDS = 96 * 60 * 60;
+export const MAIN_TOKEN_MIGRATION_RELEASE_ID =
+  "v4-ethereum-to-robinhood-96h-2026-v1" as const;
+export const MAIN_TOKEN_DECIMALS = 18;
+export const MAIN_TOKEN_SYMBOL = "V4";
+export const MAIN_TOKEN_TOTAL_SUPPLY_RAW =
+  1_000_000_000_000_000_000_000_000_000n;
+export const MAIN_TOKEN_RUNTIME_CODE_KECCAK256 =
+  "0x4fe466386aeebe507f6bcfc58e046a0632e4687699fa5bd28c4b7ec6333141ad" as const;
+export const MAIN_TOKEN_ADDRESS = getAddress(
+  "0x7987f03462200b3D8A072E02C89A8A41dCB124EE",
+);
+export const MAIN_TOKEN_MIGRATION_WALLET = getAddress(
+  "0x228Be90653fDDAa408fB6cf9ca0AEC311dbE9A0D",
+);
+
+const UINT256_MAX = (1n << 256n) - 1n;
+const erc20TransferAbi = parseAbi([
+  "function transfer(address to,uint256 amount) returns (bool)",
+]);
+
+export type MainTokenMigrationTransaction = Extract<
+  PreparedTransaction,
+  { kind: "main-token-migration" }
+>;
+
+export function parseMainTokenMigrationAmount(value: string): bigint {
+  const normalized = value.trim();
+  if (
+    !/^(?:0|[1-9][0-9]*)(?:\.[0-9]{1,18})?$/u.test(normalized)
+  ) {
+    throw new Error("Enter a V4 amount with up to 18 decimal places");
+  }
+
+  const amount = parseUnits(normalized, MAIN_TOKEN_DECIMALS);
+  if (amount <= 0n) {
+    throw new Error("Enter an amount greater than zero");
+  }
+  if (amount > UINT256_MAX) {
+    throw new Error("The V4 amount is too large");
+  }
+  return amount;
+}
+
+export function assertMainTokenMigrationBalance(
+  amountRaw: bigint,
+  balanceRaw: bigint,
+) {
+  if (balanceRaw < 0n) {
+    throw new Error("The V4 balance is invalid");
+  }
+  if (amountRaw <= 0n) {
+    throw new Error("Enter an amount greater than zero");
+  }
+  if (amountRaw > balanceRaw) {
+    throw new Error("Amount exceeds your available V4 balance");
+  }
+  return amountRaw;
+}
+
+export function assertMainTokenMigrationTransaction(
+  input: unknown,
+  connectedAccount: string,
+): MainTokenMigrationTransaction {
+  const transaction = parsePreparedTransactionForAccount(
+    input,
+    connectedAccount,
+  );
+  if (transaction.kind !== "main-token-migration") {
+    throw new Error("The transaction is not a V4 migration transfer");
+  }
+  if (
+    transaction.chainId !== MAIN_TOKEN_MIGRATION_CHAIN_ID ||
+    transaction.to.toLowerCase() !== MAIN_TOKEN_ADDRESS.toLowerCase() ||
+    transaction.value !== "0"
+  ) {
+    throw new Error("The V4 migration transaction binding is invalid");
+  }
+
+  let decoded: ReturnType<typeof decodeFunctionData>;
+  try {
+    decoded = decodeFunctionData({
+      abi: erc20TransferAbi,
+      data: transaction.data,
+    });
+  } catch {
+    throw new Error("The V4 migration transfer calldata is invalid");
+  }
+  if (
+    decoded.functionName !== "transfer" ||
+    decoded.args === undefined ||
+    decoded.args.length !== 2
+  ) {
+    throw new Error("The V4 migration transfer calldata is invalid");
+  }
+
+  const [recipient, amount] = decoded.args as readonly [Address, bigint];
+  if (
+    getAddress(recipient).toLowerCase() !==
+      MAIN_TOKEN_MIGRATION_WALLET.toLowerCase() ||
+    typeof amount !== "bigint" ||
+    amount <= 0n
+  ) {
+    throw new Error("The V4 migration recipient or amount is invalid");
+  }
+
+  const canonicalData = encodeFunctionData({
+    abi: erc20TransferAbi,
+    functionName: "transfer",
+    args: [MAIN_TOKEN_MIGRATION_WALLET, amount],
+  });
+  if (canonicalData.toLowerCase() !== transaction.data.toLowerCase()) {
+    throw new Error("The V4 migration transfer calldata is not canonical");
+  }
+
+  return Object.freeze(transaction);
+}
+
+export function buildMainTokenMigrationTransaction(input: Readonly<{
+  from: Address;
+  amountRaw: bigint;
+}>): MainTokenMigrationTransaction {
+  if (input.amountRaw <= 0n || input.amountRaw > UINT256_MAX) {
+    throw new Error("The V4 migration amount is invalid");
+  }
+
+  return assertMainTokenMigrationTransaction(
+    {
+      kind: "main-token-migration",
+      chainId: MAIN_TOKEN_MIGRATION_CHAIN_ID,
+      from: getAddress(input.from),
+      to: MAIN_TOKEN_ADDRESS,
+      data: encodeFunctionData({
+        abi: erc20TransferAbi,
+        functionName: "transfer",
+        args: [MAIN_TOKEN_MIGRATION_WALLET, input.amountRaw],
+      }),
+      value: "0",
+    },
+    input.from,
+  );
+}

--- a/lib/prepared-transaction.ts
+++ b/lib/prepared-transaction.ts
@@ -16,6 +16,7 @@ export type PreparedTransactionChainId =
 
 export type PreparedTransactionKind =
   | "launch"
+  | "main-token-migration"
   | "prediction-market-launch"
   | "prediction-market-action"
   | "token-to-permit2"
@@ -61,6 +62,12 @@ type PreparedLaunchTransaction = PreparedTransactionBase & {
   from?: never;
 };
 
+type PreparedMainTokenMigrationTransaction = PreparedTransactionBase & {
+  kind: "main-token-migration";
+  from: Address;
+  gasLimit?: string;
+};
+
 type PreparedPredictionMarketTransaction = PreparedTransactionBase & {
   kind: "prediction-market-launch" | "prediction-market-action";
   gasLimit: string;
@@ -96,6 +103,7 @@ type PreparedClaimTransaction =
 export type PreparedTransaction =
   | PreparedTradeTransaction
   | PreparedLaunchTransaction
+  | PreparedMainTokenMigrationTransaction
   | PreparedPredictionMarketTransaction
   | PreparedClaimTransaction;
 
@@ -109,6 +117,7 @@ const UINT256_MAX = (1n << 256n) - 1n;
 const zeroAddress = "0x0000000000000000000000000000000000000000";
 const kinds = new Set<PreparedTransactionKind>([
   "launch",
+  "main-token-migration",
   "prediction-market-launch",
   "prediction-market-action",
   "token-to-permit2",
@@ -205,6 +214,7 @@ export function parsePreparedTransaction(
   }
   const kind = record.kind as PreparedTransactionKind;
   const allowedFields =
+    kind === "main-token-migration" ||
     kind === "claim-creator-fees" ||
     kind === "claim-classic-v3-rewards" ||
     kind === "update-classic-v3-payout" ||
@@ -223,6 +233,12 @@ export function parsePreparedTransaction(
     );
   }
   if (
+    kind === "main-token-migration"
+  ) {
+    if (record.chainId !== ETHEREUM_MAINNET_CHAIN_ID) {
+      throw new Error("Main token migration is limited to Ethereum Mainnet");
+    }
+  } else if (
     kind === "prediction-market-launch" ||
     kind === "prediction-market-action"
   ) {
@@ -252,6 +268,18 @@ export function parsePreparedTransaction(
       ...base,
       kind,
       gasLimit: readUintString(record.gasLimit, "gas limit", false),
+    };
+  }
+  if (
+    kind === "main-token-migration"
+  ) {
+    return {
+      ...base,
+      kind,
+      from: readAddress(record.from, "sender"),
+      ...(record.gasLimit === undefined
+        ? {}
+        : { gasLimit: readUintString(record.gasLimit, "gas limit", false) }),
     };
   }
   if (
@@ -300,7 +328,8 @@ export function parsePreparedTransactionForAccount(
   const transaction = parsePreparedTransaction(input);
   const connectedAccount = readAddress(account, "connected wallet");
   if (
-    (transaction.kind === "claim-creator-fees" ||
+    (transaction.kind === "main-token-migration" ||
+      transaction.kind === "claim-creator-fees" ||
       transaction.kind === "claim-classic-v3-rewards" ||
       transaction.kind === "update-classic-v3-payout" ||
       transaction.kind === "claim-deep-rewards" ||
@@ -310,7 +339,9 @@ export function parsePreparedTransactionForAccount(
     transaction.from.toLowerCase() !== connectedAccount.toLowerCase()
   ) {
     throw new Error(
-      "The creator fee claim does not match the connected wallet",
+      transaction.kind === "main-token-migration"
+        ? "The migration sender does not match the connected wallet"
+        : "The creator fee claim does not match the connected wallet",
     );
   }
   return transaction;
@@ -360,6 +391,13 @@ export function parseSubmittedTransactionHash(value: unknown): Hex {
 export function getPreparedTransactionReview(
   kind: PreparedTransactionKind,
 ): PreparedTransactionReview {
+  if (kind === "main-token-migration") {
+    return {
+      description: "Send V4 to the fixed migration wallet on Ethereum",
+      buttonText: "Send V4",
+      successHeader: "Migration transfer submitted",
+    };
+  }
   if (kind === "launch") {
     return {
       description: "Submit the prepared token launch on Ethereum",

--- a/lib/server/main-token-migration-gas-sponsor-store-v1.ts
+++ b/lib/server/main-token-migration-gas-sponsor-store-v1.ts
@@ -1,0 +1,679 @@
+import "server-only";
+
+import { getAddress, isAddress, type Address, type Hex } from "viem";
+
+import {
+  canonicalizeJson,
+  parseStrictJson,
+  type JsonValue,
+} from "./projection-target/canonical-json";
+import type {
+  ProjectionTargetPostgresClientV1,
+  ProjectionTargetPostgresPoolV1,
+} from "./projection-target/postgres-store";
+import {
+  createProductionProjectionTargetPostgresPoolV1,
+} from "./projection-target/website-target";
+import { canonicalSha256 } from "./projection-target/hashing";
+
+const DIGEST = /^sha256:[0-9a-f]{64}$/u;
+const HASH = /^0x[0-9a-f]{64}$/u;
+const DECIMAL = /^(?:0|[1-9][0-9]*)$/u;
+const SAFE_RELEASE_ID = /^[a-z0-9][a-z0-9.-]{0,127}$/u;
+const SAFE_REFERENCE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u;
+const PREFIX = "main-token-migration-gas-sponsor:v1";
+const ADMISSION_WINDOW_SECONDS = 60;
+const ADMISSION_LIMITS = Object.freeze({
+  read: Object.freeze({ holder: 8, principal: 12 }),
+  submit: Object.freeze({ holder: 2, principal: 3 }),
+});
+
+export const MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1 = 21_000n;
+
+export type MainTokenMigrationGasSponsorIntentV1 = Readonly<{
+  schema: "programmable-main-token-migration-gas-sponsorship-intent/v1";
+  releaseId: string;
+  walletAddress: Address;
+  sponsorAddress: Address;
+  amountRaw: string;
+  topUpWei: string;
+  totalBudgetWei: string;
+  sponsorGasLimit: string;
+  sponsorMaxFeePerGasWei: string;
+  sponsorMaxPriorityFeePerGasWei: string;
+  reservedTotalWei: string;
+  estimatedTransferGas: string;
+  feePerGasWei: string;
+  requestBindingHash: `sha256:${string}`;
+  providerIdempotencyKey: string;
+  providerReferenceId: string;
+  reservedAt: string;
+}>;
+
+export type MainTokenMigrationGasSponsorRecordV1 = Readonly<{
+  intent: MainTokenMigrationGasSponsorIntentV1;
+  transactionHash: Hex | null;
+}>;
+
+type CompletionV1 = Readonly<{
+  schema: "programmable-main-token-migration-gas-sponsorship-completion/v1";
+  providerReferenceId: string;
+  transactionHash: Hex;
+}>;
+
+type AliasV1 = Readonly<{
+  schema: "programmable-main-token-migration-gas-sponsorship-idempotency/v1";
+  holderCredentialId: string;
+  requestBindingHash: `sha256:${string}`;
+}>;
+
+type AdmissionOperation = "read" | "submit";
+type AdmissionInput = Readonly<{
+  releaseId: string;
+  principalBindingHash: `sha256:${string}`;
+  walletAddress: Address;
+  operation: AdmissionOperation;
+}>;
+
+type AdmissionV1 = Readonly<{
+  schema: "programmable-main-token-migration-gas-sponsorship-admission/v1";
+  holderAddress: Address;
+  operation: AdmissionOperation;
+  principalBindingHash: `sha256:${string}`;
+  releaseId: string;
+  scope: "holder" | "principal";
+  slot: string;
+  windowId: string;
+}>;
+
+type Row = Readonly<{
+  credential_id: string;
+  request_binding_hash: string;
+  canonical_use: string;
+}> & Record<string, unknown>;
+
+type AttestedPool = ProjectionTargetPostgresPoolV1 & Readonly<{
+  assertProductionReadiness(): Promise<void>;
+}>;
+
+export interface MainTokenMigrationGasSponsorStoreV1 {
+  admit(input: AdmissionInput): Promise<void>;
+  get(input: Lookup): Promise<MainTokenMigrationGasSponsorRecordV1 | null>;
+  reserve(input: Readonly<{
+    lookup: Lookup;
+    idempotencyBindingHash: `sha256:${string}`;
+    requestBindingHash: `sha256:${string}`;
+    intent: MainTokenMigrationGasSponsorIntentV1;
+  }>): Promise<Readonly<{
+    kind: "created" | "existing";
+    record: MainTokenMigrationGasSponsorRecordV1;
+  }>>;
+  complete(input: Readonly<{
+    lookup: Lookup;
+    providerReferenceId: string;
+    transactionHash: Hex;
+  }>): Promise<MainTokenMigrationGasSponsorRecordV1>;
+}
+
+type Lookup = Readonly<{ releaseId: string; walletAddress: Address }>;
+type ReserveInput = Readonly<{
+  lookup: Lookup;
+  idempotencyBindingHash: `sha256:${string}`;
+  requestBindingHash: `sha256:${string}`;
+  intent: MainTokenMigrationGasSponsorIntentV1;
+}>;
+type CompleteInput = Readonly<{
+  lookup: Lookup;
+  providerReferenceId: string;
+  transactionHash: Hex;
+}>;
+
+export class MainTokenMigrationGasSponsorStoreErrorV1 extends Error {
+  constructor(
+    readonly code:
+      | "budget_exhausted"
+      | "conflict"
+      | "rate_limited"
+      | "unavailable",
+    readonly retryAfterSeconds?: number,
+  ) {
+    super("Main token migration gas sponsor store failed closed");
+    this.name = "MainTokenMigrationGasSponsorStoreErrorV1";
+  }
+}
+
+export function createMainTokenMigrationGasSponsorPostgresStoreV1(
+  pool: AttestedPool,
+): MainTokenMigrationGasSponsorStoreV1 {
+  if (!pool || typeof pool.connect !== "function"
+    || typeof pool.assertProductionReadiness !== "function") {
+    throw new TypeError("Gas sponsor PostgreSQL pool is invalid");
+  }
+  return Object.freeze({
+    async admit(input: AdmissionInput) {
+      validateAdmission(input);
+      await pool.assertProductionReadiness();
+      await transaction(pool, input.releaseId, async (client) => {
+        const window = await admissionWindow(client);
+        const limits = ADMISSION_LIMITS[input.operation];
+        const principalPrefix = admissionPrefix({
+          ...input,
+          scope: "principal",
+          windowId: window.windowId,
+        });
+        const holderPrefix = admissionPrefix({
+          ...input,
+          scope: "holder",
+          windowId: window.windowId,
+        });
+        const [principalCount, holderCount] = await Promise.all([
+          admissionCount(client, principalPrefix),
+          admissionCount(client, holderPrefix),
+        ]);
+        if (principalCount >= limits.principal || holderCount >= limits.holder) {
+          throw rateLimited(window.retryAfterSeconds);
+        }
+        await insertAdmission(client, {
+          ...input,
+          scope: "principal",
+          slot: String(principalCount + 1),
+          windowId: window.windowId,
+        });
+        await insertAdmission(client, {
+          ...input,
+          scope: "holder",
+          slot: String(holderCount + 1),
+          windowId: window.windowId,
+        });
+      });
+    },
+
+    async get(input: Lookup) {
+      validateLookup(input);
+      await pool.assertProductionReadiness();
+      const rows = await pool.query<Row>(`
+        SELECT credential_id, request_binding_hash, canonical_use
+          FROM programmable_website_projection_v1.credential_uses
+         WHERE credential_id = ANY($1::text[])
+         ORDER BY credential_id
+      `, [[holderId(input), completionId(input)]]);
+      return recordFromRows(rows.rows, input);
+    },
+
+    async reserve(input: ReserveInput) {
+      validateLookup(input.lookup);
+      if (!DIGEST.test(input.idempotencyBindingHash)
+        || !DIGEST.test(input.requestBindingHash)) {
+        throw new TypeError("Gas sponsor reservation is invalid");
+      }
+      const intent = validateIntent(input.intent, input.lookup);
+      if (intent.requestBindingHash !== input.requestBindingHash) {
+        throw new TypeError("Gas sponsor reservation binding is invalid");
+      }
+      await pool.assertProductionReadiness();
+      return transaction(pool, input.lookup.releaseId, async (client) => {
+        const holder = holderId(input.lookup);
+        const alias = aliasId(input.lookup.releaseId, input.idempotencyBindingHash);
+        const ids = [holder, completionId(input.lookup), alias];
+        const existing = await selectRows(client, ids);
+        const aliasRow = existing.find((row) => row.credential_id === alias);
+        const holderRow = existing.find((row) => row.credential_id === holder);
+        if (aliasRow) {
+          const value = parseAlias(aliasRow);
+          if (value.holderCredentialId !== holder
+            || value.requestBindingHash !== input.requestBindingHash
+            || !holderRow) throw conflict();
+        }
+        const existingRecord = recordFromRows(existing, input.lookup);
+        if (existingRecord) {
+          return Object.freeze({ kind: "existing" as const, record: existingRecord });
+        }
+        if (aliasRow) throw conflict();
+        const releaseIntents = await selectReleaseIntents(
+          client,
+          input.lookup.releaseId,
+        );
+        const reservedWei = releaseIntents.reduce((total, row) => {
+          const existingIntent = parseIntent(row);
+          if (existingIntent.releaseId !== input.lookup.releaseId
+            || existingIntent.totalBudgetWei !== intent.totalBudgetWei) {
+            throw unavailable();
+          }
+          return total + BigInt(existingIntent.reservedTotalWei);
+        }, 0n);
+        if (reservedWei + BigInt(intent.reservedTotalWei)
+          > BigInt(intent.totalBudgetWei)) {
+          throw budgetExhausted();
+        }
+        await insertRow(client, holder, input.requestBindingHash, intent);
+        await insertAlias(client, alias, holder, input.requestBindingHash);
+        return Object.freeze({
+          kind: "created" as const,
+          record: Object.freeze({ intent, transactionHash: null }),
+        });
+      });
+    },
+
+    async complete(input: CompleteInput) {
+      validateLookup(input.lookup);
+      if (!SAFE_REFERENCE_ID.test(input.providerReferenceId)
+        || !HASH.test(input.transactionHash)) {
+        throw new TypeError("Gas sponsor completion is invalid");
+      }
+      await pool.assertProductionReadiness();
+      return transaction(pool, input.lookup.releaseId, async (client) => {
+        const existing = await selectRows(client, [
+          holderId(input.lookup),
+          completionId(input.lookup),
+        ]);
+        const current = recordFromRows(existing, input.lookup);
+        if (!current
+          || current.intent.providerReferenceId !== input.providerReferenceId) {
+          throw unavailable();
+        }
+        if (current.transactionHash !== null) {
+          if (current.transactionHash !== input.transactionHash) throw conflict();
+          return current;
+        }
+        const completion: CompletionV1 = Object.freeze({
+          schema:
+            "programmable-main-token-migration-gas-sponsorship-completion/v1",
+          providerReferenceId: input.providerReferenceId,
+          transactionHash: input.transactionHash,
+        });
+        await insertRow(
+          client,
+          completionId(input.lookup),
+          current.intent.requestBindingHash,
+          completion,
+        );
+        return Object.freeze({
+          intent: current.intent,
+          transactionHash: input.transactionHash,
+        });
+      });
+    },
+  });
+}
+
+async function admissionWindow(client: ProjectionTargetPostgresClientV1) {
+  const result = await client.query<{
+    retry_after_seconds: string;
+    window_id: string;
+  }>(`
+    SELECT (floor(observed.epoch_seconds / $1)::bigint)::text AS window_id,
+           (greatest(
+             1,
+             ceil($1 - mod(observed.epoch_seconds, $1))
+           )::integer)::text AS retry_after_seconds
+      FROM (
+        SELECT extract(epoch FROM clock_timestamp()) AS epoch_seconds
+      ) AS observed
+  `, [ADMISSION_WINDOW_SECONDS]);
+  const row = result.rows[0];
+  if (result.rows.length !== 1 || !row
+    || !DECIMAL.test(row.window_id)
+    || !DECIMAL.test(row.retry_after_seconds)) throw unavailable();
+  const retryAfterSeconds = Number(row.retry_after_seconds);
+  if (!Number.isSafeInteger(retryAfterSeconds)
+    || retryAfterSeconds < 1
+    || retryAfterSeconds > ADMISSION_WINDOW_SECONDS) throw unavailable();
+  return Object.freeze({
+    retryAfterSeconds,
+    windowId: row.window_id,
+  });
+}
+
+async function admissionCount(
+  client: ProjectionTargetPostgresClientV1,
+  prefix: string,
+) {
+  const result = await client.query<{ count: string }>(`
+    SELECT count(*)::text AS count
+      FROM programmable_website_projection_v1.credential_uses
+     WHERE credential_id LIKE $1
+  `, [`${prefix}%`]);
+  const row = result.rows[0];
+  if (result.rows.length !== 1 || !row || !DECIMAL.test(row.count)) {
+    throw unavailable();
+  }
+  const count = Number(row.count);
+  if (!Number.isSafeInteger(count) || count < 0) throw unavailable();
+  return count;
+}
+
+async function insertAdmission(
+  client: ProjectionTargetPostgresClientV1,
+  input: Readonly<{
+    releaseId: string;
+    principalBindingHash: `sha256:${string}`;
+    walletAddress: Address;
+    operation: AdmissionOperation;
+    scope: "holder" | "principal";
+    slot: string;
+    windowId: string;
+  }>,
+) {
+  const prefix = admissionPrefix(input);
+  const admission: AdmissionV1 = Object.freeze({
+    schema:
+      "programmable-main-token-migration-gas-sponsorship-admission/v1",
+    holderAddress: getAddress(input.walletAddress),
+    operation: input.operation,
+    principalBindingHash: input.principalBindingHash,
+    releaseId: input.releaseId,
+    scope: input.scope,
+    slot: input.slot,
+    windowId: input.windowId,
+  });
+  const binding = canonicalSha256(
+    "programmable.main-token-migration.gas-sponsor.admission.v1",
+    admission,
+  );
+  await insertRow(client, `${prefix}${input.slot}`, binding, admission);
+}
+
+function admissionPrefix(input: Readonly<{
+  releaseId: string;
+  principalBindingHash: `sha256:${string}`;
+  walletAddress: Address;
+  operation: AdmissionOperation;
+  scope: "holder" | "principal";
+  windowId: string;
+}>) {
+  const subject = input.scope === "principal"
+    ? input.principalBindingHash.slice("sha256:".length)
+    : input.walletAddress.toLowerCase().slice(2);
+  return `${PREFIX}:admission:${input.releaseId}:${input.operation}:` +
+    `${input.windowId}:${input.scope}:${subject}:`;
+}
+
+async function transaction<T>(
+  pool: AttestedPool,
+  releaseId: string,
+  work: (client: ProjectionTargetPostgresClientV1) => Promise<T>,
+) {
+  const client = await pool.connect();
+  let open = false;
+  try {
+    await client.query("BEGIN");
+    open = true;
+    await client.query(
+      "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+      [`${PREFIX}:lock:${releaseId}`],
+    );
+    const value = await work(client);
+    await client.query("COMMIT");
+    open = false;
+    return value;
+  } catch (error) {
+    if (open) await client.query("ROLLBACK").catch(() => undefined);
+    if (error instanceof MainTokenMigrationGasSponsorStoreErrorV1) throw error;
+    throw unavailable();
+  } finally {
+    client.release();
+  }
+}
+
+async function selectRows(client: ProjectionTargetPostgresClientV1, ids: string[]) {
+  const result = await client.query<Row>(`
+    SELECT credential_id, request_binding_hash, canonical_use
+      FROM programmable_website_projection_v1.credential_uses
+     WHERE credential_id = ANY($1::text[])
+     ORDER BY credential_id
+  `, [ids]);
+  return result.rows;
+}
+
+async function selectReleaseIntents(
+  client: ProjectionTargetPostgresClientV1,
+  releaseId: string,
+) {
+  const result = await client.query<Row>(`
+    SELECT credential_id, request_binding_hash, canonical_use
+      FROM programmable_website_projection_v1.credential_uses
+     WHERE credential_id LIKE $1
+     ORDER BY credential_id
+  `, [`${PREFIX}:holder:${releaseId}:%`]);
+  return result.rows;
+}
+
+async function insertRow(
+  client: ProjectionTargetPostgresClientV1,
+  credentialId: string,
+  requestBindingHash: string,
+  value: JsonValue,
+) {
+  const inserted = await client.query<Row>(`
+    INSERT INTO programmable_website_projection_v1.credential_uses
+      (credential_id, request_binding_hash, canonical_use)
+    VALUES ($1, $2, $3)
+    ON CONFLICT DO NOTHING
+    RETURNING credential_id, request_binding_hash, canonical_use
+  `, [credentialId, requestBindingHash, canonicalizeJson(value)]);
+  if (inserted.rowCount !== 1) throw conflict();
+}
+
+async function insertAlias(
+  client: ProjectionTargetPostgresClientV1,
+  credentialId: string,
+  holderCredentialId: string,
+  requestBindingHash: `sha256:${string}`,
+) {
+  const alias: AliasV1 = Object.freeze({
+    schema: "programmable-main-token-migration-gas-sponsorship-idempotency/v1",
+    holderCredentialId,
+    requestBindingHash,
+  });
+  await insertRow(client, credentialId, requestBindingHash, alias);
+}
+
+function recordFromRows(rows: readonly Row[], lookup: Lookup) {
+  const holder = rows.find((row) => row.credential_id === holderId(lookup));
+  if (!holder) return null;
+  const intent = parseIntent(holder);
+  if (intent.releaseId !== lookup.releaseId
+    || intent.walletAddress.toLowerCase() !== lookup.walletAddress.toLowerCase()
+    || holder.request_binding_hash !== intent.requestBindingHash) {
+    throw unavailable();
+  }
+  const completionRow = rows.find(
+    (row) => row.credential_id === completionId(lookup),
+  );
+  if (!completionRow) return Object.freeze({ intent, transactionHash: null });
+  const completion = parseCompletion(completionRow);
+  if (completion.providerReferenceId !== intent.providerReferenceId
+    || completionRow.request_binding_hash !== intent.requestBindingHash) {
+    throw unavailable();
+  }
+  return Object.freeze({ intent, transactionHash: completion.transactionHash });
+}
+
+function validateIntent(value: MainTokenMigrationGasSponsorIntentV1, lookup: Lookup) {
+  const parsed = parseIntentValue(parseCanonical(canonicalizeJson(value)));
+  if (parsed.releaseId !== lookup.releaseId
+    || parsed.walletAddress.toLowerCase() !== lookup.walletAddress.toLowerCase()) {
+    throw new TypeError("Gas sponsor intent lookup is invalid");
+  }
+  return parsed;
+}
+
+function parseIntent(row: Row) {
+  return parseIntentValue(parseCanonical(row.canonical_use));
+}
+
+function parseIntentValue(input: JsonValue): MainTokenMigrationGasSponsorIntentV1 {
+  const value = object(input);
+  exactKeys(value, [
+    "amountRaw", "estimatedTransferGas", "feePerGasWei", "providerIdempotencyKey",
+    "providerReferenceId", "releaseId", "requestBindingHash", "reservedAt",
+    "reservedTotalWei", "schema", "sponsorAddress", "sponsorGasLimit",
+    "sponsorMaxFeePerGasWei", "sponsorMaxPriorityFeePerGasWei", "topUpWei",
+    "totalBudgetWei", "walletAddress",
+  ]);
+  if (value.schema !== "programmable-main-token-migration-gas-sponsorship-intent/v1"
+    || typeof value.releaseId !== "string" || !SAFE_RELEASE_ID.test(value.releaseId)
+    || typeof value.walletAddress !== "string" || !isAddress(value.walletAddress, { strict: true })
+    || typeof value.sponsorAddress !== "string" || !isAddress(value.sponsorAddress, { strict: true })
+    || !positiveDecimal(value.amountRaw) || !positiveDecimal(value.topUpWei)
+    || !positiveDecimal(value.totalBudgetWei)
+    || !positiveDecimal(value.sponsorGasLimit)
+    || !positiveDecimal(value.sponsorMaxFeePerGasWei)
+    || !decimal(value.sponsorMaxPriorityFeePerGasWei)
+    || !positiveDecimal(value.reservedTotalWei)
+    || !positiveDecimal(value.estimatedTransferGas) || !positiveDecimal(value.feePerGasWei)
+    || typeof value.requestBindingHash !== "string" || !DIGEST.test(value.requestBindingHash)
+    || typeof value.providerIdempotencyKey !== "string" || !SAFE_REFERENCE_ID.test(value.providerIdempotencyKey)
+    || typeof value.providerReferenceId !== "string" || !SAFE_REFERENCE_ID.test(value.providerReferenceId)
+    || typeof value.reservedAt !== "string"
+    || new Date(value.reservedAt).toISOString() !== value.reservedAt) throw unavailable();
+  const sponsorGasLimit = BigInt(value.sponsorGasLimit);
+  const sponsorMaxFeePerGasWei = BigInt(value.sponsorMaxFeePerGasWei);
+  const sponsorMaxPriorityFeePerGasWei = BigInt(value.sponsorMaxPriorityFeePerGasWei);
+  if (sponsorGasLimit !== MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1
+    || sponsorMaxPriorityFeePerGasWei > sponsorMaxFeePerGasWei
+    || BigInt(value.reservedTotalWei)
+      !== BigInt(value.topUpWei) + sponsorGasLimit * sponsorMaxFeePerGasWei
+    || BigInt(value.reservedTotalWei) > BigInt(value.totalBudgetWei)) {
+    throw unavailable();
+  }
+  return Object.freeze({
+    schema: value.schema,
+    releaseId: value.releaseId,
+    walletAddress: getAddress(value.walletAddress),
+    sponsorAddress: getAddress(value.sponsorAddress),
+    amountRaw: value.amountRaw as string,
+    topUpWei: value.topUpWei as string,
+    totalBudgetWei: value.totalBudgetWei as string,
+    sponsorGasLimit: value.sponsorGasLimit as string,
+    sponsorMaxFeePerGasWei: value.sponsorMaxFeePerGasWei as string,
+    sponsorMaxPriorityFeePerGasWei:
+      value.sponsorMaxPriorityFeePerGasWei as string,
+    reservedTotalWei: value.reservedTotalWei as string,
+    estimatedTransferGas: value.estimatedTransferGas as string,
+    feePerGasWei: value.feePerGasWei as string,
+    requestBindingHash: value.requestBindingHash as `sha256:${string}`,
+    providerIdempotencyKey: value.providerIdempotencyKey,
+    providerReferenceId: value.providerReferenceId,
+    reservedAt: value.reservedAt,
+  });
+}
+
+function parseCompletion(row: Row): CompletionV1 {
+  const value = object(parseCanonical(row.canonical_use));
+  exactKeys(value, ["providerReferenceId", "schema", "transactionHash"]);
+  if (value.schema !== "programmable-main-token-migration-gas-sponsorship-completion/v1"
+    || typeof value.providerReferenceId !== "string" || !SAFE_REFERENCE_ID.test(value.providerReferenceId)
+    || typeof value.transactionHash !== "string" || !HASH.test(value.transactionHash)) throw unavailable();
+  return Object.freeze({
+    schema: value.schema,
+    providerReferenceId: value.providerReferenceId,
+    transactionHash: value.transactionHash as Hex,
+  });
+}
+
+function parseAlias(row: Row): AliasV1 {
+  const value = object(parseCanonical(row.canonical_use));
+  exactKeys(value, ["holderCredentialId", "requestBindingHash", "schema"]);
+  if (value.schema !== "programmable-main-token-migration-gas-sponsorship-idempotency/v1"
+    || typeof value.holderCredentialId !== "string"
+    || typeof value.requestBindingHash !== "string" || !DIGEST.test(value.requestBindingHash)
+    || row.request_binding_hash !== value.requestBindingHash) throw unavailable();
+  return Object.freeze({
+    schema: value.schema,
+    holderCredentialId: value.holderCredentialId,
+    requestBindingHash: value.requestBindingHash as `sha256:${string}`,
+  });
+}
+
+function parseCanonical(source: string) {
+  const value = parseStrictJson(source, { maximumBytes: 16_384, maximumDepth: 8 });
+  if (canonicalizeJson(value) !== source) throw unavailable();
+  return value;
+}
+
+function object(value: JsonValue): Readonly<Record<string, JsonValue>> {
+  if (!value || Array.isArray(value) || typeof value !== "object") throw unavailable();
+  return value;
+}
+
+function exactKeys(value: Readonly<Record<string, JsonValue>>, keys: string[]) {
+  if (Object.keys(value).sort().join("\0") !== [...keys].sort().join("\0")) throw unavailable();
+}
+
+function positiveDecimal(value: JsonValue): value is string {
+  return typeof value === "string" && DECIMAL.test(value) && BigInt(value) > 0n;
+}
+
+function decimal(value: JsonValue): value is string {
+  return typeof value === "string" && DECIMAL.test(value);
+}
+
+function validateLookup(input: Lookup) {
+  if (!SAFE_RELEASE_ID.test(input.releaseId)
+    || !isAddress(input.walletAddress, { strict: true })) {
+    throw new TypeError("Gas sponsor lookup is invalid");
+  }
+}
+
+function validateAdmission(input: AdmissionInput) {
+  validateLookup({
+    releaseId: input.releaseId,
+    walletAddress: input.walletAddress,
+  });
+  if (!DIGEST.test(input.principalBindingHash)
+    || (input.operation !== "read" && input.operation !== "submit")) {
+    throw new TypeError("Gas sponsor admission is invalid");
+  }
+}
+
+function holderId(input: Lookup) {
+  return `${PREFIX}:holder:${input.releaseId}:${input.walletAddress.toLowerCase()}`;
+}
+
+function completionId(input: Lookup) {
+  return `${PREFIX}:completion:${input.releaseId}:${input.walletAddress.toLowerCase()}`;
+}
+
+function aliasId(releaseId: string, binding: string) {
+  return `${PREFIX}:idempotency:${releaseId}:${binding.slice("sha256:".length)}`;
+}
+
+function conflict() {
+  return new MainTokenMigrationGasSponsorStoreErrorV1("conflict");
+}
+
+function budgetExhausted() {
+  return new MainTokenMigrationGasSponsorStoreErrorV1("budget_exhausted");
+}
+
+function rateLimited(retryAfterSeconds: number) {
+  return new MainTokenMigrationGasSponsorStoreErrorV1(
+    "rate_limited",
+    retryAfterSeconds,
+  );
+}
+
+function unavailable() {
+  return new MainTokenMigrationGasSponsorStoreErrorV1("unavailable");
+}
+
+let productionStore: MainTokenMigrationGasSponsorStoreV1 | null = null;
+
+export function getProductionMainTokenMigrationGasSponsorStoreV1():
+MainTokenMigrationGasSponsorStoreV1 {
+  if (productionStore) return productionStore;
+  const pool = createProductionProjectionTargetPostgresPoolV1(
+    requiredEnv("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL"),
+    requiredEnv("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM").replaceAll("\\n", "\n"),
+    requiredEnv("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE"),
+  );
+  productionStore = createMainTokenMigrationGasSponsorPostgresStoreV1(pool);
+  return productionStore;
+}
+
+function requiredEnv(name: string) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new TypeError(`${name} is not configured`);
+  return value;
+}

--- a/lib/server/main-token-migration-gas-sponsor-v1.ts
+++ b/lib/server/main-token-migration-gas-sponsor-v1.ts
@@ -1,0 +1,1002 @@
+import "server-only";
+
+import { randomUUID } from "node:crypto";
+
+import { PrivyClient } from "@privy-io/node";
+import {
+  createPublicClient,
+  getAddress,
+  http,
+  isAddress,
+  keccak256,
+  parseAbi,
+  toHex,
+  type Address,
+  type Hex,
+  type PublicClient,
+} from "viem";
+import { mainnet } from "viem/chains";
+
+import activationManifest from "@/config/main-token-migration-activation.v1.json";
+import {
+  MAIN_TOKEN_ADDRESS,
+  MAIN_TOKEN_MIGRATION_CHAIN_ID,
+  MAIN_TOKEN_MIGRATION_RELEASE_ID,
+  MAIN_TOKEN_MIGRATION_WALLET,
+  MAIN_TOKEN_MIGRATION_WINDOW_SECONDS,
+  MAIN_TOKEN_RUNTIME_CODE_KECCAK256,
+  MAIN_TOKEN_TOTAL_SUPPLY_RAW,
+} from "@/lib/main-token-migration";
+import {
+  createPrivyWalletPrincipalAuthenticatorV1,
+  WalletPrincipalAuthenticationErrorV1,
+  type WalletPrincipalAuthenticatorV1,
+} from "./creator-article/wallet-principal.server";
+import { tradeActionRpcProviders } from "./action-rpc-quorum.server";
+import { canonicalizeJson, parseStrictJson } from
+  "./projection-target/canonical-json";
+import { canonicalSha256 } from "./projection-target/hashing";
+import {
+  getProductionMainTokenMigrationGasSponsorStoreV1,
+  MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1,
+  MainTokenMigrationGasSponsorStoreErrorV1,
+  type MainTokenMigrationGasSponsorIntentV1,
+  type MainTokenMigrationGasSponsorRecordV1,
+  type MainTokenMigrationGasSponsorStoreV1,
+} from "./main-token-migration-gas-sponsor-store-v1";
+
+const ERC20_ABI = parseAbi([
+  "function balanceOf(address account) view returns (uint256)",
+  "function transfer(address to,uint256 amount) returns (bool)",
+]);
+const IDEMPOTENCY_KEY = /^[A-Za-z0-9][A-Za-z0-9._~-]{15,127}$/u;
+const DECIMAL = /^[1-9][0-9]{0,77}$/u;
+const HASH = /^0x[0-9a-f]{64}$/u;
+const MAXIMUM_BODY_BYTES = 4_096;
+const GAS_MULTIPLIER_BPS = 12_500n;
+const BPS = 10_000n;
+const MAXIMUM_TRANSFER_GAS = 100_000n;
+const MAXIMUM_FEE_PER_GAS_WEI = 20_000_000_000n;
+const ABSOLUTE_TOP_UP_CAP_WEI = 2_000_000_000_000_000n;
+const ABSOLUTE_TOTAL_BUDGET_CAP_WEI = 1_000_000_000_000_000_000n;
+const DEADLINE_SAFETY_SECONDS = 5 * 60;
+
+type Environment = Readonly<Record<string, string | undefined>>;
+
+export type MainTokenMigrationGasSponsorConfigurationV1 = Readonly<{
+  releaseId: typeof MAIN_TOKEN_MIGRATION_RELEASE_ID;
+  windowStartTimestamp: number;
+  startBlockNumber: bigint;
+  startBlockHash: Hex;
+  deadlineTimestampExclusive: number;
+  sponsorWalletId: string;
+  sponsorPolicyId: string;
+  sponsorAddress: Address;
+  maximumTopUpWei: bigint;
+  totalBudgetWei: bigint;
+}>;
+
+export type MainTokenMigrationGasSponsorRequestV1 = Readonly<{
+  walletAddress: Address;
+  amountRaw: bigint;
+}>;
+
+export type MainTokenMigrationGasSponsorObservationV1 = Readonly<{
+  walletAddress: Address;
+  amountRaw: bigint;
+  estimatedTransferGas: bigint;
+  feePerGasWei: bigint;
+  maxPriorityFeePerGasWei: bigint;
+  nativeBalanceWei: bigint;
+  sponsorBalanceWei: bigint;
+}>;
+
+export interface MainTokenMigrationGasSponsorChainV1 {
+  observe(input: Readonly<{
+    configuration: MainTokenMigrationGasSponsorConfigurationV1;
+    request: MainTokenMigrationGasSponsorRequestV1;
+  }>): Promise<MainTokenMigrationGasSponsorObservationV1>;
+  status(
+    record: MainTokenMigrationGasSponsorRecordV1,
+  ): Promise<"pending" | "confirmed" | "failed">;
+}
+
+export interface MainTokenMigrationGasSponsorSenderV1 {
+  assertReady(): Promise<void>;
+  send(intent: MainTokenMigrationGasSponsorIntentV1): Promise<Hex>;
+}
+
+type PrivySponsorWalletAttestationV1 = Readonly<{
+  address?: unknown;
+  chain_type?: unknown;
+  id?: unknown;
+  policy_ids?: unknown;
+}>;
+
+export class MainTokenMigrationGasSponsorErrorV1 extends Error {
+  constructor(
+    readonly status: 400 | 401 | 403 | 409 | 413 | 422 | 429 | 503,
+    readonly code: string,
+    readonly retryAfterSeconds?: number,
+  ) {
+    super("Main token migration gas sponsorship failed closed");
+    this.name = "MainTokenMigrationGasSponsorErrorV1";
+  }
+}
+
+export function parseMainTokenMigrationSponsorRequestV1(
+  input: unknown,
+): MainTokenMigrationGasSponsorRequestV1 {
+  if (!input || Array.isArray(input) || typeof input !== "object") {
+    throw new MainTokenMigrationGasSponsorErrorV1(400, "request_invalid");
+  }
+  const value = input as Record<string, unknown>;
+  if (
+    Object.keys(value).sort().join("\0") !==
+      ["amountRaw", "walletAddress"].sort().join("\0")
+    || typeof value.walletAddress !== "string"
+    || !isAddress(value.walletAddress, { strict: true })
+    || typeof value.amountRaw !== "string"
+    || !DECIMAL.test(value.amountRaw)
+  ) throw new MainTokenMigrationGasSponsorErrorV1(400, "request_invalid");
+  const amountRaw = BigInt(value.amountRaw);
+  if (amountRaw <= 0n || amountRaw > MAIN_TOKEN_TOTAL_SUPPLY_RAW) {
+    throw new MainTokenMigrationGasSponsorErrorV1(400, "request_invalid");
+  }
+  return Object.freeze({
+    walletAddress: getAddress(value.walletAddress),
+    amountRaw,
+  });
+}
+
+export function calculateMainTokenMigrationTopUpWeiV1(input: Readonly<{
+  estimatedGas: bigint;
+  feePerGas: bigint;
+  multiplierBps?: bigint;
+  hardCapWei: bigint;
+  nativeBalanceWei?: bigint;
+}>) {
+  const multiplier = input.multiplierBps ?? GAS_MULTIPLIER_BPS;
+  const nativeBalance = input.nativeBalanceWei ?? 0n;
+  if (
+    input.estimatedGas <= 0n
+    || input.estimatedGas > MAXIMUM_TRANSFER_GAS
+    || input.feePerGas <= 0n
+    || input.feePerGas > MAXIMUM_FEE_PER_GAS_WEI
+    || multiplier < BPS
+    || multiplier > 20_000n
+    || input.hardCapWei <= 0n
+    || input.hardCapWei > ABSOLUTE_TOP_UP_CAP_WEI
+    || nativeBalance < 0n
+  ) throw new MainTokenMigrationGasSponsorErrorV1(503, "gas_quote_unavailable");
+  const requiredWei = divCeil(
+    input.estimatedGas * input.feePerGas * multiplier,
+    BPS,
+  );
+  if (requiredWei > input.hardCapWei) {
+    throw new MainTokenMigrationGasSponsorErrorV1(503, "gas_quote_above_cap");
+  }
+  return Object.freeze({
+    requiredWei,
+    topUpWei: requiredWei > nativeBalance ? requiredWei - nativeBalance : 0n,
+  });
+}
+
+export function deriveMainTokenMigrationSponsorBindingsV1(input: Readonly<{
+  releaseId: string;
+  walletAddress: Address;
+  amountRaw: bigint;
+  idempotencyKey: string;
+}>) {
+  if (!IDEMPOTENCY_KEY.test(input.idempotencyKey)) {
+    throw new MainTokenMigrationGasSponsorErrorV1(400, "idempotency_key_invalid");
+  }
+  const idempotencyBindingHash = canonicalSha256(
+    "programmable.main-token-migration.gas-sponsor.idempotency.v1",
+    { idempotencyKey: input.idempotencyKey },
+  );
+  const requestBindingHash = canonicalSha256(
+    "programmable.main-token-migration.gas-sponsor.request.v1",
+    {
+      amountRaw: input.amountRaw.toString(),
+      releaseId: input.releaseId,
+      walletAddress: input.walletAddress.toLowerCase(),
+      idempotencyBindingHash,
+    },
+  );
+  const providerBinding = canonicalSha256(
+    "programmable.main-token-migration.gas-sponsor.provider.v1",
+    {
+      releaseId: input.releaseId,
+      walletAddress: input.walletAddress.toLowerCase(),
+    },
+  ).slice("sha256:".length);
+  return Object.freeze({
+    idempotencyBindingHash,
+    requestBindingHash,
+    providerIdempotencyKey: `mtmgs-${providerBinding}`,
+    providerReferenceId: `mtmgs-${providerBinding}`,
+  });
+}
+
+export function deriveMainTokenMigrationSponsorPrincipalBindingV1(
+  privyUserId: string,
+) {
+  if (!privyUserId || privyUserId.length > 512
+    || /[\u0000-\u001f\u007f]/u.test(privyUserId)) {
+    throw new MainTokenMigrationGasSponsorErrorV1(503, "principal_invalid");
+  }
+  return canonicalSha256(
+    "programmable.main-token-migration.gas-sponsor.principal.v1",
+    { privyUserId },
+  );
+}
+
+export function assertMainTokenMigrationPrivySponsorWalletV1(
+  wallet: PrivySponsorWalletAttestationV1,
+  configuration: MainTokenMigrationGasSponsorConfigurationV1,
+) {
+  const policyIds = Array.isArray(wallet.policy_ids)
+    && wallet.policy_ids.every((policyId) => typeof policyId === "string")
+    ? wallet.policy_ids
+    : [];
+  if (wallet.id !== configuration.sponsorWalletId
+    || wallet.chain_type !== "ethereum"
+    || typeof wallet.address !== "string"
+    || !isAddress(wallet.address, { strict: true })
+    || getAddress(wallet.address) !== configuration.sponsorAddress
+    || policyIds.length !== 1
+    || policyIds[0] !== configuration.sponsorPolicyId) {
+    throw new MainTokenMigrationGasSponsorErrorV1(
+      503,
+      "sponsor_wallet_mismatch",
+    );
+  }
+}
+
+export function readMainTokenMigrationGasSponsorConfigurationV1(input: Readonly<{
+  environment: Environment;
+  manifest: unknown;
+  nowMs: number;
+}>): MainTokenMigrationGasSponsorConfigurationV1 | null {
+  if (input.environment.MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ENABLED !== "true") {
+    return null;
+  }
+  const manifest = input.manifest as Record<string, unknown>;
+  if (
+    !manifest || typeof manifest !== "object"
+    || manifest.schema !== "programmable-main-token-migration-activation/v1"
+    || manifest.releaseId !== MAIN_TOKEN_MIGRATION_RELEASE_ID
+    || manifest.enabled !== true
+    || manifest.sourceChainId !== String(MAIN_TOKEN_MIGRATION_CHAIN_ID)
+    || typeof manifest.sourceTokenAddress !== "string"
+    || manifest.sourceTokenAddress.toLowerCase() !== MAIN_TOKEN_ADDRESS.toLowerCase()
+    || manifest.sourceTokenRuntimeCodeKeccak256 !== MAIN_TOKEN_RUNTIME_CODE_KECCAK256
+    || manifest.migrationWallet !== MAIN_TOKEN_MIGRATION_WALLET
+    || manifest.windowDurationSeconds !== String(MAIN_TOKEN_MIGRATION_WINDOW_SECONDS)
+    || typeof manifest.windowStartTimestamp !== "string"
+    || !/^[1-9][0-9]*$/u.test(manifest.windowStartTimestamp)
+    || typeof manifest.deadlineTimestampExclusive !== "string"
+    || !/^[1-9][0-9]*$/u.test(manifest.deadlineTimestampExclusive)
+    || typeof manifest.startBlockNumber !== "string"
+    || !/^[1-9][0-9]*$/u.test(manifest.startBlockNumber)
+    || typeof manifest.startBlockHash !== "string"
+    || !HASH.test(manifest.startBlockHash)
+  ) return null;
+  const start = Number(manifest.windowStartTimestamp);
+  const deadline = Number(manifest.deadlineTimestampExclusive);
+  const now = Math.floor(input.nowMs / 1_000);
+  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(deadline)
+    || deadline - start !== MAIN_TOKEN_MIGRATION_WINDOW_SECONDS
+    || now < start || now >= deadline - DEADLINE_SAFETY_SECONDS) return null;
+  const walletId = input.environment.MAIN_TOKEN_MIGRATION_GAS_SPONSOR_PRIVY_WALLET_ID?.trim() ?? "";
+  const policyId = input.environment.MAIN_TOKEN_MIGRATION_GAS_SPONSOR_PRIVY_POLICY_ID?.trim() ?? "";
+  const sponsorAddressValue = input.environment.MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ADDRESS?.trim() ?? "";
+  const maximumTopUp = input.environment.MAIN_TOKEN_MIGRATION_GAS_SPONSOR_MAX_TOP_UP_WEI?.trim() ?? "";
+  const totalBudget = input.environment.MAIN_TOKEN_MIGRATION_GAS_SPONSOR_TOTAL_BUDGET_WEI?.trim() ?? "";
+  if (!/^[A-Za-z0-9_-]{8,256}$/u.test(walletId)
+    || !/^[A-Za-z0-9_-]{8,256}$/u.test(policyId)
+    || !isAddress(sponsorAddressValue, { strict: true })
+    || !DECIMAL.test(maximumTopUp)
+    || !DECIMAL.test(totalBudget)) {
+    throw new MainTokenMigrationGasSponsorErrorV1(503, "configuration_invalid");
+  }
+  const sponsorAddress = getAddress(sponsorAddressValue);
+  const maximumTopUpWei = BigInt(maximumTopUp);
+  const totalBudgetWei = BigInt(totalBudget);
+  if (maximumTopUpWei > ABSOLUTE_TOP_UP_CAP_WEI
+    || totalBudgetWei < maximumTopUpWei
+    || totalBudgetWei > ABSOLUTE_TOTAL_BUDGET_CAP_WEI
+    || [MAIN_TOKEN_ADDRESS, MAIN_TOKEN_MIGRATION_WALLET].some(
+      (address) => address.toLowerCase() === sponsorAddress.toLowerCase(),
+    )) throw new MainTokenMigrationGasSponsorErrorV1(503, "configuration_invalid");
+  return Object.freeze({
+    releaseId: MAIN_TOKEN_MIGRATION_RELEASE_ID,
+    windowStartTimestamp: start,
+    startBlockNumber: BigInt(manifest.startBlockNumber),
+    startBlockHash: manifest.startBlockHash as Hex,
+    deadlineTimestampExclusive: deadline,
+    sponsorWalletId: walletId,
+    sponsorPolicyId: policyId,
+    sponsorAddress,
+    maximumTopUpWei,
+    totalBudgetWei,
+  });
+}
+
+export function assertMainTokenMigrationSponsorEligibilityAnchorV1(
+  configuration: MainTokenMigrationGasSponsorConfigurationV1,
+  observations: readonly [
+    Readonly<{
+      number: bigint | null;
+      hash: Hex | null;
+      timestamp: bigint;
+      finalizedBlockNumber: bigint | null;
+    }>,
+    Readonly<{
+      number: bigint | null;
+      hash: Hex | null;
+      timestamp: bigint;
+      finalizedBlockNumber: bigint | null;
+    }>,
+  ],
+) {
+  for (const observation of observations) {
+    if (
+      observation.number !== configuration.startBlockNumber ||
+      observation.hash !== configuration.startBlockHash ||
+      observation.timestamp >= BigInt(configuration.windowStartTimestamp) ||
+      observation.finalizedBlockNumber === null ||
+      observation.finalizedBlockNumber < configuration.startBlockNumber
+    ) {
+      throw new MainTokenMigrationGasSponsorErrorV1(
+        503,
+        "rpc_quorum_unavailable",
+      );
+    }
+  }
+}
+
+export function createMainTokenMigrationGasSponsorV1(input: Readonly<{
+  configuration: MainTokenMigrationGasSponsorConfigurationV1;
+  authenticator: WalletPrincipalAuthenticatorV1;
+  store: MainTokenMigrationGasSponsorStoreV1;
+  chain: MainTokenMigrationGasSponsorChainV1;
+  sender: MainTokenMigrationGasSponsorSenderV1;
+  now?: () => Date;
+}>) {
+  const now = input.now ?? (() => new Date());
+  return Object.freeze({
+    async get(request: Request) {
+      try {
+        assertSponsorshipWindowOpen(input.configuration, now());
+        const principal = await input.authenticator.authenticate(request);
+        const url = new URL(request.url);
+        if ([...url.searchParams.keys()].some((key) => key !== "walletAddress")) {
+          throw new MainTokenMigrationGasSponsorErrorV1(400, "request_invalid");
+        }
+        const rawWallet = url.searchParams.get("walletAddress") ?? "";
+        if (!isAddress(rawWallet, { strict: true })) {
+          throw new MainTokenMigrationGasSponsorErrorV1(400, "request_invalid");
+        }
+        const walletAddress = getAddress(rawWallet);
+        assertLinkedWallet(principal.wallets, walletAddress);
+        const existing = await input.store.get({
+          releaseId: input.configuration.releaseId,
+          walletAddress,
+        });
+        await input.store.admit({
+          releaseId: input.configuration.releaseId,
+          principalBindingHash:
+            deriveMainTokenMigrationSponsorPrincipalBindingV1(
+              principal.privyUserId,
+            ),
+          walletAddress,
+          operation: "read",
+        });
+        if (existing) return await existingResponse(existing, input.chain);
+        await input.sender.assertReady();
+        const currentBalance = await readCurrentTokenBalance(
+          input.chain,
+          input.configuration,
+          walletAddress,
+        );
+        return response({
+          status: currentBalance.topUpWei === 0n ? "not_needed" : "eligible",
+          walletAddress,
+          topUpWei: currentBalance.topUpWei.toString(),
+          transactionHash: null,
+          estimatedTransferGas: currentBalance.estimatedTransferGas.toString(),
+        });
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+
+    async post(request: Request) {
+      try {
+        assertSponsorshipWindowOpen(input.configuration, now());
+        requireSameOrigin(request);
+        const principal = await input.authenticator.authenticate(request);
+        const body = await boundedJson(request);
+        const sponsorRequest = parseMainTokenMigrationSponsorRequestV1(body);
+        assertLinkedWallet(principal.wallets, sponsorRequest.walletAddress);
+        const idempotencyKey = request.headers.get("idempotency-key") ?? "";
+        const bindings = deriveMainTokenMigrationSponsorBindingsV1({
+          releaseId: input.configuration.releaseId,
+          walletAddress: sponsorRequest.walletAddress,
+          amountRaw: sponsorRequest.amountRaw,
+          idempotencyKey,
+        });
+        const existing = await input.store.get({
+          releaseId: input.configuration.releaseId,
+          walletAddress: sponsorRequest.walletAddress,
+        });
+        await input.store.admit({
+          releaseId: input.configuration.releaseId,
+          principalBindingHash:
+            deriveMainTokenMigrationSponsorPrincipalBindingV1(
+              principal.privyUserId,
+            ),
+          walletAddress: sponsorRequest.walletAddress,
+          operation: "submit",
+        });
+        if (existing) return await existingResponse(existing, input.chain);
+        await input.sender.assertReady();
+        const observation = await input.chain.observe({
+          configuration: input.configuration,
+          request: sponsorRequest,
+        });
+        const quote = calculateMainTokenMigrationTopUpWeiV1({
+          estimatedGas: observation.estimatedTransferGas,
+          feePerGas: observation.feePerGasWei,
+          hardCapWei: input.configuration.maximumTopUpWei,
+          nativeBalanceWei: observation.nativeBalanceWei,
+        });
+        if (quote.topUpWei === 0n) {
+          return response({
+            status: "not_needed",
+            walletAddress: sponsorRequest.walletAddress,
+            topUpWei: "0",
+            transactionHash: null,
+            estimatedTransferGas: observation.estimatedTransferGas.toString(),
+          });
+        }
+        if (observation.maxPriorityFeePerGasWei < 0n
+          || observation.maxPriorityFeePerGasWei > observation.feePerGasWei) {
+          throw new MainTokenMigrationGasSponsorErrorV1(
+            503,
+            "gas_quote_unavailable",
+          );
+        }
+        const reservedTotalWei = quote.topUpWei
+          + MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1
+            * observation.feePerGasWei;
+        if (observation.sponsorBalanceWei < reservedTotalWei) {
+          throw new MainTokenMigrationGasSponsorErrorV1(503, "sponsor_balance_low");
+        }
+        const intent: MainTokenMigrationGasSponsorIntentV1 = Object.freeze({
+          schema: "programmable-main-token-migration-gas-sponsorship-intent/v1",
+          releaseId: input.configuration.releaseId,
+          walletAddress: sponsorRequest.walletAddress,
+          sponsorAddress: input.configuration.sponsorAddress,
+          amountRaw: sponsorRequest.amountRaw.toString(),
+          topUpWei: quote.topUpWei.toString(),
+          totalBudgetWei: input.configuration.totalBudgetWei.toString(),
+          sponsorGasLimit:
+            MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1.toString(),
+          sponsorMaxFeePerGasWei: observation.feePerGasWei.toString(),
+          sponsorMaxPriorityFeePerGasWei:
+            observation.maxPriorityFeePerGasWei.toString(),
+          reservedTotalWei: reservedTotalWei.toString(),
+          estimatedTransferGas: observation.estimatedTransferGas.toString(),
+          feePerGasWei: observation.feePerGasWei.toString(),
+          requestBindingHash: bindings.requestBindingHash,
+          providerIdempotencyKey: bindings.providerIdempotencyKey,
+          providerReferenceId: bindings.providerReferenceId,
+          reservedAt: now().toISOString(),
+        });
+        const reservation = await input.store.reserve({
+          lookup: {
+            releaseId: input.configuration.releaseId,
+            walletAddress: sponsorRequest.walletAddress,
+          },
+          idempotencyBindingHash: bindings.idempotencyBindingHash,
+          requestBindingHash: bindings.requestBindingHash,
+          intent,
+        });
+        if (reservation.record.transactionHash !== null) {
+          return await existingResponse(reservation.record, input.chain);
+        }
+        if (reservation.kind !== "created") {
+          throw new MainTokenMigrationGasSponsorErrorV1(
+            503,
+            "submission_unknown",
+          );
+        }
+        let hash: Hex;
+        try {
+          hash = await input.sender.send(reservation.record.intent);
+        } catch {
+          throw new MainTokenMigrationGasSponsorErrorV1(503, "submission_unknown");
+        }
+        const completed = await input.store.complete({
+          lookup: {
+            releaseId: input.configuration.releaseId,
+            walletAddress: sponsorRequest.walletAddress,
+          },
+          providerReferenceId: reservation.record.intent.providerReferenceId,
+          transactionHash: hash,
+        });
+        return response({
+          status: "submitted",
+          walletAddress: completed.intent.walletAddress,
+          topUpWei: completed.intent.topUpWei,
+          transactionHash: completed.transactionHash,
+          estimatedTransferGas: completed.intent.estimatedTransferGas,
+        });
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  });
+}
+
+async function readCurrentTokenBalance(
+  chain: MainTokenMigrationGasSponsorChainV1,
+  configuration: MainTokenMigrationGasSponsorConfigurationV1,
+  walletAddress: Address,
+) {
+  const observation = await chain.observe({
+    configuration,
+    request: { walletAddress, amountRaw: 1n },
+  });
+  const quote = calculateMainTokenMigrationTopUpWeiV1({
+    estimatedGas: observation.estimatedTransferGas,
+    feePerGas: observation.feePerGasWei,
+    hardCapWei: configuration.maximumTopUpWei,
+    nativeBalanceWei: observation.nativeBalanceWei,
+  });
+  return { ...observation, topUpWei: quote.topUpWei };
+}
+
+async function existingResponse(
+  record: MainTokenMigrationGasSponsorRecordV1,
+  chain: MainTokenMigrationGasSponsorChainV1,
+) {
+  if (record.transactionHash === null) {
+    throw new MainTokenMigrationGasSponsorErrorV1(503, "submission_unknown");
+  }
+  const status = await chain.status(record);
+  if (status === "failed") {
+    throw new MainTokenMigrationGasSponsorErrorV1(503, "sponsorship_failed");
+  }
+  return response({
+    status: status === "confirmed" ? "confirmed" : "pending",
+    walletAddress: record.intent.walletAddress,
+    topUpWei: record.intent.topUpWei,
+    transactionHash: record.transactionHash,
+    estimatedTransferGas: record.intent.estimatedTransferGas,
+  });
+}
+
+function response(input: Readonly<{
+  status: "eligible" | "submitted" | "pending" | "confirmed" | "not_needed";
+  walletAddress: Address;
+  topUpWei: string | null;
+  transactionHash: Hex | null;
+  estimatedTransferGas: string | null;
+}>) {
+  return json({
+    schema: "programmable-main-token-migration-gas-sponsorship/v1",
+    ...input,
+  }, 200, input.status === "submitted" || input.status === "pending"
+    ? { "retry-after": "10" }
+    : {});
+}
+
+function errorResponse(error: unknown) {
+  const requestId = randomUUID();
+  const failure = error instanceof WalletPrincipalAuthenticationErrorV1
+    ? new MainTokenMigrationGasSponsorErrorV1(error.status, error.code)
+    : error instanceof MainTokenMigrationGasSponsorStoreErrorV1
+      ? new MainTokenMigrationGasSponsorErrorV1(
+          error.code === "conflict"
+            ? 409
+            : error.code === "rate_limited"
+              ? 429
+              : 503,
+          error.code === "conflict"
+            ? "idempotency_conflict"
+            : error.code === "budget_exhausted"
+              ? "sponsor_budget_exhausted"
+              : error.code === "rate_limited"
+                ? "rate_limited"
+                : "store_unavailable",
+          error.retryAfterSeconds,
+        )
+      : error instanceof MainTokenMigrationGasSponsorErrorV1
+        ? error
+        : new MainTokenMigrationGasSponsorErrorV1(503, "sponsorship_unavailable");
+  if (failure.status >= 500) {
+    console.error("Main token migration gas sponsorship unavailable", {
+      code: failure.code,
+      requestId,
+    });
+  }
+  return json({
+    error: {
+      code: failure.code,
+      message: publicGasSponsorshipFailureMessage(failure),
+      requestId,
+    },
+  }, failure.status, failure.status === 429
+    ? { "retry-after": String(failure.retryAfterSeconds ?? 60) }
+    : failure.status === 503
+      ? { "retry-after": "5" }
+      : {});
+}
+
+function publicGasSponsorshipFailureMessage(
+  failure: MainTokenMigrationGasSponsorErrorV1,
+) {
+  if (failure.status === 401 || failure.status === 403) {
+    return "Reconnect this wallet and try again.";
+  }
+  if (failure.status === 400) {
+    return "The gas sponsorship request is invalid.";
+  }
+  if (failure.status === 409) {
+    return "This request conflicts with the wallet's existing sponsorship.";
+  }
+  if (failure.status === 422) {
+    return "This wallet is not eligible for automatic gas sponsorship.";
+  }
+  if (failure.code === "submission_unknown") {
+    return "The gas top-up needs a status review. No second top-up was sent.";
+  }
+  if (failure.code === "sponsorship_closed") {
+    return "Gas sponsorship is closed for this migration window.";
+  }
+  if (failure.code === "sponsor_budget_exhausted") {
+    return "The migration gas sponsorship budget is currently exhausted.";
+  }
+  if (failure.code === "rate_limited") {
+    return "Too many gas sponsorship checks. Wait briefly and try again.";
+  }
+  return "Gas sponsorship is temporarily unavailable.";
+}
+
+function json(value: unknown, status: number, headers: Record<string, string> = {}) {
+  return new Response(canonicalizeJson(value), {
+    status,
+    headers: {
+      "cache-control": "no-store",
+      "content-type": "application/json; charset=utf-8",
+      "x-content-type-options": "nosniff",
+      ...headers,
+    },
+  });
+}
+
+function assertLinkedWallet(wallets: readonly `0x${string}`[], wallet: Address) {
+  if (!wallets.some((candidate) => candidate.toLowerCase() === wallet.toLowerCase())) {
+    throw new MainTokenMigrationGasSponsorErrorV1(403, "wallet_not_linked");
+  }
+}
+
+function requireSameOrigin(request: Request) {
+  const origin = request.headers.get("origin");
+  let expected: string;
+  try {
+    expected = new URL(request.url).origin;
+  } catch {
+    throw new MainTokenMigrationGasSponsorErrorV1(403, "origin_forbidden");
+  }
+  if (origin !== expected || request.headers.get("sec-fetch-site") !== "same-origin") {
+    throw new MainTokenMigrationGasSponsorErrorV1(403, "origin_forbidden");
+  }
+}
+
+async function boundedJson(request: Request) {
+  const length = request.headers.get("content-length");
+  if (length && (!/^[0-9]+$/u.test(length) || Number(length) > MAXIMUM_BODY_BYTES)) {
+    throw new MainTokenMigrationGasSponsorErrorV1(413, "request_too_large");
+  }
+  const reader = request.body?.getReader();
+  if (!reader) throw new MainTokenMigrationGasSponsorErrorV1(400, "request_invalid");
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+  while (true) {
+    const part = await reader.read();
+    if (part.done) break;
+    bytes += part.value.byteLength;
+    if (bytes > MAXIMUM_BODY_BYTES) {
+      await reader.cancel().catch(() => undefined);
+      throw new MainTokenMigrationGasSponsorErrorV1(413, "request_too_large");
+    }
+    chunks.push(part.value);
+  }
+  let source: string;
+  try {
+    source = new TextDecoder("utf-8", { fatal: true }).decode(
+      Buffer.concat(chunks, bytes),
+    );
+  } catch {
+    throw new MainTokenMigrationGasSponsorErrorV1(400, "request_invalid");
+  }
+  return parseStrictJson(source, { maximumBytes: MAXIMUM_BODY_BYTES, maximumDepth: 4 });
+}
+
+function divCeil(value: bigint, denominator: bigint) {
+  return (value + denominator - 1n) / denominator;
+}
+
+function assertSponsorshipWindowOpen(
+  configuration: MainTokenMigrationGasSponsorConfigurationV1,
+  now: Date,
+) {
+  const nowSeconds = Math.floor(now.getTime() / 1_000);
+  if (!Number.isFinite(nowSeconds)
+    || nowSeconds >= configuration.deadlineTimestampExclusive
+      - DEADLINE_SAFETY_SECONDS) {
+    throw new MainTokenMigrationGasSponsorErrorV1(503, "sponsorship_closed");
+  }
+}
+
+function createProductionSender(
+  configuration: MainTokenMigrationGasSponsorConfigurationV1,
+  environment: Environment,
+): MainTokenMigrationGasSponsorSenderV1 {
+  const appId = requiredEnv(environment, "NEXT_PUBLIC_PRIVY_APP_ID");
+  const appSecret = requiredEnv(environment, "PRIVY_APP_SECRET");
+  const privy = new PrivyClient({ appId, appSecret });
+  return Object.freeze({
+    async assertReady() {
+      const wallet = await privy.wallets().get(configuration.sponsorWalletId);
+      assertMainTokenMigrationPrivySponsorWalletV1(wallet, configuration);
+    },
+    async send(intent: MainTokenMigrationGasSponsorIntentV1) {
+      if (intent.sponsorAddress !== configuration.sponsorAddress
+        || intent.releaseId !== configuration.releaseId
+        || BigInt(intent.topUpWei) > configuration.maximumTopUpWei
+        || BigInt(intent.totalBudgetWei) !== configuration.totalBudgetWei
+        || BigInt(intent.sponsorGasLimit)
+          !== MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1
+        || BigInt(intent.sponsorMaxFeePerGasWei)
+          > MAXIMUM_FEE_PER_GAS_WEI
+        || BigInt(intent.sponsorMaxPriorityFeePerGasWei)
+          > BigInt(intent.sponsorMaxFeePerGasWei)
+        || BigInt(intent.reservedTotalWei) !== BigInt(intent.topUpWei)
+          + BigInt(intent.sponsorGasLimit)
+            * BigInt(intent.sponsorMaxFeePerGasWei)) {
+        throw new MainTokenMigrationGasSponsorErrorV1(503, "sponsor_intent_mismatch");
+      }
+      const result = await privy.wallets().ethereum().sendTransaction(
+        configuration.sponsorWalletId,
+        {
+          caip2: "eip155:1",
+          params: {
+            transaction: {
+              chain_id: MAIN_TOKEN_MIGRATION_CHAIN_ID,
+              data: "0x",
+              from: configuration.sponsorAddress,
+              gas_limit: toHex(BigInt(intent.sponsorGasLimit)),
+              max_fee_per_gas: toHex(BigInt(intent.sponsorMaxFeePerGasWei)),
+              max_priority_fee_per_gas:
+                toHex(BigInt(intent.sponsorMaxPriorityFeePerGasWei)),
+              to: intent.walletAddress,
+              type: 2,
+              value: toHex(BigInt(intent.topUpWei)),
+            },
+          },
+          idempotency_key: intent.providerIdempotencyKey,
+          reference_id: intent.providerReferenceId,
+          request_expiry: Date.now() + 30_000,
+        },
+      );
+      if (result.caip2 !== "eip155:1" || !HASH.test(result.hash)
+        || result.reference_id !== intent.providerReferenceId) {
+        throw new MainTokenMigrationGasSponsorErrorV1(503, "provider_response_invalid");
+      }
+      return result.hash as Hex;
+    },
+  });
+}
+
+export function createMainTokenMigrationGasSponsorChainV1(
+  providers = tradeActionRpcProviders(1),
+): MainTokenMigrationGasSponsorChainV1 {
+  if (providers.length !== 2) throw new TypeError("Gas sponsor RPC quorum is invalid");
+  const clients: [PublicClient, PublicClient] = [
+    createPublicClient({
+      chain: mainnet,
+      transport: http(providers[0]!.endpoint, { retryCount: 1, timeout: 12_000 }),
+    }),
+    createPublicClient({
+      chain: mainnet,
+      transport: http(providers[1]!.endpoint, { retryCount: 1, timeout: 12_000 }),
+    }),
+  ];
+  return Object.freeze({
+    async observe({ configuration, request }: Readonly<{
+      configuration: MainTokenMigrationGasSponsorConfigurationV1;
+      request: MainTokenMigrationGasSponsorRequestV1;
+    }>) {
+      try {
+        const heads = await Promise.all(clients.map((client) => client.getBlockNumber()));
+        const blockNumber = heads[0] < heads[1] ? heads[0] : heads[1];
+        const observations = await Promise.all(clients.map(async (client) => {
+          const [chainId, block, finalizedBlock, startBlock,
+            tokenCode, holderCode, startHolderCode,
+            sponsorCode, currentBalance, openingBalance, nativeBalance, sponsorBalance,
+            fees] = await Promise.all([
+            client.getChainId(),
+            client.getBlock({ blockNumber }),
+            client.getBlock({ blockTag: "finalized" }),
+            client.getBlock({ blockNumber: configuration.startBlockNumber }),
+            client.getCode({ address: MAIN_TOKEN_ADDRESS, blockNumber }),
+            client.getCode({ address: request.walletAddress, blockNumber }),
+            client.getCode({ address: request.walletAddress, blockNumber: configuration.startBlockNumber }),
+            client.getCode({ address: configuration.sponsorAddress, blockNumber }),
+            client.readContract({ address: MAIN_TOKEN_ADDRESS, abi: ERC20_ABI,
+              functionName: "balanceOf", args: [request.walletAddress], blockNumber }),
+            client.readContract({ address: MAIN_TOKEN_ADDRESS, abi: ERC20_ABI,
+              functionName: "balanceOf", args: [request.walletAddress],
+              blockNumber: configuration.startBlockNumber }),
+            client.getBalance({ address: request.walletAddress, blockNumber }),
+            client.getBalance({ address: configuration.sponsorAddress, blockNumber }),
+            client.estimateFeesPerGas(),
+          ]);
+          return { chainId, block, finalizedBlock, startBlock,
+            tokenCode, holderCode, startHolderCode,
+            sponsorCode,
+            currentBalance, openingBalance, nativeBalance, sponsorBalance,
+            fee: fees.maxFeePerGas,
+            priorityFee: fees.maxPriorityFeePerGas };
+        }));
+        const [left, right] = observations;
+        if (left && right) {
+          assertMainTokenMigrationSponsorEligibilityAnchorV1(
+            configuration,
+            [
+              {
+                number: left.startBlock.number,
+                hash: left.startBlock.hash,
+                timestamp: left.startBlock.timestamp,
+                finalizedBlockNumber: left.finalizedBlock.number,
+              },
+              {
+                number: right.startBlock.number,
+                hash: right.startBlock.hash,
+                timestamp: right.startBlock.timestamp,
+                finalizedBlockNumber: right.finalizedBlock.number,
+              },
+            ],
+          );
+        }
+        if (!left || !right || left.chainId !== 1 || right.chainId !== 1
+          || left.block.hash !== right.block.hash
+          || !left.tokenCode || !right.tokenCode
+          || keccak256(left.tokenCode) !== MAIN_TOKEN_RUNTIME_CODE_KECCAK256
+          || keccak256(right.tokenCode) !== MAIN_TOKEN_RUNTIME_CODE_KECCAK256
+          || !left.fee || !right.fee
+          || left.priorityFee === undefined || right.priorityFee === undefined) {
+          throw new MainTokenMigrationGasSponsorErrorV1(
+            503,
+            "rpc_quorum_unavailable",
+          );
+        }
+        if (left.holderCode !== "0x" || right.holderCode !== "0x"
+          || left.startHolderCode !== "0x" || right.startHolderCode !== "0x"
+          || left.sponsorCode !== "0x" || right.sponsorCode !== "0x"
+          || left.currentBalance < request.amountRaw || right.currentBalance < request.amountRaw
+          || left.openingBalance < request.amountRaw || right.openingBalance < request.amountRaw) {
+          throw new MainTokenMigrationGasSponsorErrorV1(422, "wallet_not_eligible");
+        }
+        return Object.freeze({
+          walletAddress: request.walletAddress,
+          amountRaw: request.amountRaw,
+          // This token is runtime-hash pinned above. A conservative fixed ceiling
+          // avoids eth_estimateGas rejecting the exact holder transaction solely
+          // because the holder has no ETH yet (the condition this endpoint fixes).
+          estimatedTransferGas: MAXIMUM_TRANSFER_GAS,
+          feePerGasWei: left.fee > right.fee ? left.fee : right.fee,
+          maxPriorityFeePerGasWei: left.priorityFee > right.priorityFee
+            ? left.priorityFee : right.priorityFee,
+          nativeBalanceWei: left.nativeBalance > right.nativeBalance
+            ? left.nativeBalance : right.nativeBalance,
+          sponsorBalanceWei: left.sponsorBalance < right.sponsorBalance
+            ? left.sponsorBalance : right.sponsorBalance,
+        });
+      } catch (error) {
+        if (error instanceof MainTokenMigrationGasSponsorErrorV1) throw error;
+        throw new MainTokenMigrationGasSponsorErrorV1(503, "rpc_quorum_unavailable");
+      }
+    },
+    async status(record: MainTokenMigrationGasSponsorRecordV1) {
+      if (!record.transactionHash) return "pending";
+      const states = await Promise.all(clients.map(async (client) => {
+        try {
+          const [transaction, receipt] = await Promise.all([
+            client.getTransaction({ hash: record.transactionHash! }),
+            client.getTransactionReceipt({ hash: record.transactionHash! }),
+          ]);
+          const exact = transaction.hash === record.transactionHash
+            && transaction.from.toLowerCase()
+              === record.intent.sponsorAddress.toLowerCase()
+            && transaction.to?.toLowerCase()
+              === record.intent.walletAddress.toLowerCase()
+            && transaction.value === BigInt(record.intent.topUpWei)
+            && transaction.gas === BigInt(record.intent.sponsorGasLimit)
+            && transaction.maxFeePerGas
+              === BigInt(record.intent.sponsorMaxFeePerGasWei)
+            && transaction.maxPriorityFeePerGas
+              === BigInt(record.intent.sponsorMaxPriorityFeePerGasWei)
+            && transaction.input === "0x"
+            && receipt.transactionHash === record.transactionHash;
+          if (!exact || receipt.status !== "success") return "failed" as const;
+          return { status: "confirmed" as const, blockHash: receipt.blockHash,
+            blockNumber: receipt.blockNumber };
+        } catch {
+          return "pending" as const;
+        }
+      }));
+      if (states.some((state) => state === "failed")) return "failed";
+      const [left, right] = states;
+      if (typeof left === "object" && typeof right === "object"
+        && left.blockHash === right.blockHash && left.blockNumber === right.blockNumber) {
+        return "confirmed";
+      }
+      return "pending";
+    },
+  });
+}
+
+let productionHandler: ReturnType<typeof createMainTokenMigrationGasSponsorV1> | null = null;
+
+export function getProductionMainTokenMigrationGasSponsorV1() {
+  if (productionHandler) return productionHandler;
+  const configuration = readMainTokenMigrationGasSponsorConfigurationV1({
+    environment: process.env,
+    manifest: activationManifest,
+    nowMs: Date.now(),
+  });
+  if (!configuration) {
+    throw new MainTokenMigrationGasSponsorErrorV1(503, "sponsorship_disabled");
+  }
+  productionHandler = createMainTokenMigrationGasSponsorV1({
+    configuration,
+    authenticator: createPrivyWalletPrincipalAuthenticatorV1(),
+    store: getProductionMainTokenMigrationGasSponsorStoreV1(),
+    chain: createMainTokenMigrationGasSponsorChainV1(),
+    sender: createProductionSender(configuration, process.env),
+  });
+  return productionHandler;
+}
+
+export async function handleProductionMainTokenMigrationGasSponsorGetV1(
+  request: Request,
+) {
+  try {
+    return await getProductionMainTokenMigrationGasSponsorV1().get(request);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function handleProductionMainTokenMigrationGasSponsorPostV1(
+  request: Request,
+) {
+  try {
+    return await getProductionMainTokenMigrationGasSponsorV1().post(request);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+function requiredEnv(environment: Environment, name: string) {
+  const value = environment[name]?.trim();
+  if (!value) throw new MainTokenMigrationGasSponsorErrorV1(503, "configuration_invalid");
+  return value;
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "verify:uniswap-launcher-sdk": "node scripts/verify-uniswap-liquidity-launcher-sdk.mjs",
     "brand:favicons": "node scripts/generate-programmable-favicons.mjs",
     "creator-article:programmable:seed": "node scripts/seed-programmable-creator-article.mjs",
+    "migration:main-token:test": "vitest run tests/main-token-migration.test.ts tests/main-token-migration-gas-sponsor-contract.test.ts tests/main-token-migration-gas-sponsor-v1.test.ts tests/main-token-migration-gas-sponsorship-ui.test.ts",
     "audit:prod": "npm audit --omit=dev --audit-level=moderate",
     "release:custom-launch:record:verify": "node scripts/verify-custom-launch-release-record.mjs",
     "release:custom-launch:v2:record:verify": "node scripts/verify-custom-launch-release-record-v2.mjs",

--- a/tests/main-token-migration-gas-sponsor-contract.test.ts
+++ b/tests/main-token-migration-gas-sponsor-contract.test.ts
@@ -1,0 +1,171 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+type SponsorContract = Readonly<{
+  schema: string;
+  releaseId: string;
+  activationManifestPath: string;
+  route: string;
+  serverOnly: boolean;
+  chainId: string;
+  caip2: string;
+  environment: Readonly<{
+    enabled: Readonly<{
+      name: string;
+      disabledValue: string;
+      activationValue: string;
+    }>;
+    privyWalletId: string;
+    privyPolicyId: string;
+    walletAddress: string;
+    maximumTopUpWei: string;
+    totalBudgetWei: string;
+  }>;
+  walletBinding: Readonly<Record<string, string | readonly string[]>>;
+  limits: Readonly<Record<string, string>>;
+  feeRules: Readonly<Record<string, boolean>>;
+  budgetRules: Readonly<Record<string, boolean>>;
+  runtimeDependencies: readonly string[];
+}>;
+
+const read = (path: string) =>
+  readFileSync(join(process.cwd(), path), "utf8");
+const parse = <T>(path: string) => JSON.parse(read(path)) as T;
+
+describe("main token migration gas sponsor activation contract", () => {
+  const contract = parse<SponsorContract>(
+    "config/main-token-migration-gas-sponsor-contract.v1.json",
+  );
+  const manifest = parse<Record<string, unknown>>(
+    "config/main-token-migration-activation.v1.json",
+  );
+  const environment = read(".env.example");
+  const implementation = read(
+    "lib/server/main-token-migration-gas-sponsor-v1.ts",
+  );
+  const store = read(
+    "lib/server/main-token-migration-gas-sponsor-store-v1.ts",
+  );
+  const runbook = read(
+    "docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-V1.md",
+  );
+  const readiness = read(
+    "docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-READINESS-V1.md",
+  );
+
+  it("pins the checked-in release window while keeping operational sponsor values blank", () => {
+    expect(contract.releaseId).toBe(
+      "v4-ethereum-to-robinhood-96h-2026-v1",
+    );
+    expect(manifest).toMatchObject({
+      schema: "programmable-main-token-migration-activation/v1",
+      releaseId: contract.releaseId,
+      enabled: true,
+      windowDurationSeconds: "345600",
+      windowStartTimestamp: "1788125400",
+      deadlineTimestampExclusive: "1788471000",
+      startBlockNumber: "25870405",
+      startBlockHash:
+        "0xe4f50afeba1884b8354b3c962f99a258f2901f9768ec8da8ad05391761ff57de",
+    });
+
+    expect(environment).toContain(
+      `${contract.environment.enabled.name}=${contract.environment.enabled.disabledValue}`,
+    );
+    for (const name of [
+      contract.environment.privyWalletId,
+      contract.environment.privyPolicyId,
+      contract.environment.walletAddress,
+      contract.environment.maximumTopUpWei,
+      contract.environment.totalBudgetWei,
+    ]) {
+      expect(environment).toMatch(new RegExp(`^${name}=$`, "mu"));
+    }
+  });
+
+  it("documents every server-only binding and runtime dependency", () => {
+    expect(contract).toMatchObject({
+      schema:
+        "programmable-main-token-migration-gas-sponsor-activation-contract/v1",
+      activationManifestPath:
+        "config/main-token-migration-activation.v1.json",
+      route: "/api/main-token-migration/gas-sponsorship",
+      serverOnly: true,
+      chainId: "1",
+      caip2: "eip155:1",
+    });
+    for (const name of [
+      contract.environment.enabled.name,
+      contract.environment.privyWalletId,
+      contract.environment.privyPolicyId,
+      contract.environment.walletAddress,
+      contract.environment.maximumTopUpWei,
+      contract.environment.totalBudgetWei,
+      ...contract.runtimeDependencies,
+    ]) {
+      expect(runbook).toContain(`\`${name}\``);
+    }
+    expect(readiness).toContain("If any item is false or unknown");
+    expect(runbook).toContain("exact 96-hour migration window");
+    expect(runbook).toContain("exactly 345,600 seconds after the start");
+    expect(readiness).toContain("has a 345,600-second window");
+  });
+
+  it("binds the documented wallet, fee, budget and deadline limits to code", () => {
+    expect(contract.walletBinding).toEqual({
+      chainType: "ethereum",
+      attachedPolicyCount: "1",
+      transactionMethod: "eth_sendTransaction",
+      transactionType: "2",
+      transactionData: "0x",
+      sponsorGasLimit: "21000",
+      providerPolicyEnforces: ["method", "chainId", "maximumValue"],
+      serverEnforces: [
+        "holderRecipient",
+        "emptyCalldata",
+        "sender",
+        "transactionType",
+        "gasAndFeeBounds",
+        "exactValue",
+      ],
+    });
+    expect(contract.limits).toEqual({
+      estimatedTokenTransferGasCeiling: "100000",
+      gasQuoteMultiplierBps: "12500",
+      maximumFeePerGasWei: "20000000000",
+      absoluteMaximumTopUpWei: "2000000000000000",
+      absoluteMaximumTotalBudgetWei: "1000000000000000000",
+      deadlineSafetySeconds: "300",
+    });
+    expect(contract.budgetRules).toEqual({
+      maximumTopUpMustBePositive: true,
+      totalBudgetMustCoverMaximumTopUp: true,
+      reservationIncludesSponsorTransactionFee: true,
+    });
+    expect(contract.feeRules).toEqual({
+      useHigherIndependentProviderQuote: true,
+      maximumPriorityFeeMustNotExceedMaximumFee: true,
+    });
+
+    expect(implementation).toContain("const GAS_MULTIPLIER_BPS = 12_500n;");
+    expect(implementation).toContain("const MAXIMUM_TRANSFER_GAS = 100_000n;");
+    expect(implementation).toContain(
+      "const MAXIMUM_FEE_PER_GAS_WEI = 20_000_000_000n;",
+    );
+    expect(implementation).toContain(
+      "const ABSOLUTE_TOP_UP_CAP_WEI = 2_000_000_000_000_000n;",
+    );
+    expect(implementation).toContain(
+      "const ABSOLUTE_TOTAL_BUDGET_CAP_WEI = 1_000_000_000_000_000_000n;",
+    );
+    expect(implementation).toContain("const DEADLINE_SAFETY_SECONDS = 5 * 60;");
+    expect(implementation).toContain(
+      "observation.maxPriorityFeePerGasWei > observation.feePerGasWei",
+    );
+    expect(store).toContain(
+      "MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1 = 21_000n",
+    );
+  });
+});

--- a/tests/main-token-migration-gas-sponsor-v1.test.ts
+++ b/tests/main-token-migration-gas-sponsor-v1.test.ts
@@ -1,0 +1,693 @@
+import { PGlite } from "@electric-sql/pglite";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  MainTokenMigrationGasSponsorErrorV1,
+  assertMainTokenMigrationSponsorEligibilityAnchorV1,
+  assertMainTokenMigrationPrivySponsorWalletV1,
+  calculateMainTokenMigrationTopUpWeiV1,
+  createMainTokenMigrationGasSponsorV1,
+  deriveMainTokenMigrationSponsorBindingsV1,
+  deriveMainTokenMigrationSponsorPrincipalBindingV1,
+  parseMainTokenMigrationSponsorRequestV1,
+  readMainTokenMigrationGasSponsorConfigurationV1,
+  type MainTokenMigrationGasSponsorChainV1,
+  type MainTokenMigrationGasSponsorConfigurationV1,
+  type MainTokenMigrationGasSponsorSenderV1,
+} from "../lib/server/main-token-migration-gas-sponsor-v1";
+import {
+  MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1,
+  MainTokenMigrationGasSponsorStoreErrorV1,
+  createMainTokenMigrationGasSponsorPostgresStoreV1,
+  type MainTokenMigrationGasSponsorIntentV1,
+  type MainTokenMigrationGasSponsorRecordV1,
+  type MainTokenMigrationGasSponsorStoreV1,
+} from "../lib/server/main-token-migration-gas-sponsor-store-v1";
+import {
+  MAIN_TOKEN_ADDRESS,
+  MAIN_TOKEN_MIGRATION_CHAIN_ID,
+  MAIN_TOKEN_MIGRATION_RELEASE_ID,
+  MAIN_TOKEN_MIGRATION_WALLET,
+  MAIN_TOKEN_MIGRATION_WINDOW_SECONDS,
+  MAIN_TOKEN_RUNTIME_CODE_KECCAK256,
+} from "../lib/main-token-migration";
+import type {
+  ProjectionTargetPostgresClientV1,
+  ProjectionTargetPostgresQueryResultV1,
+} from "../lib/server/projection-target/postgres-store";
+
+const WALLET = "0x1111111111111111111111111111111111111111" as const;
+const SECOND_WALLET = "0x3333333333333333333333333333333333333333" as const;
+const SPONSOR = "0x2222222222222222222222222222222222222222" as const;
+const TX_HASH = `0x${"ab".repeat(32)}` as const;
+const NOW = new Date("2026-08-30T12:00:00.000Z");
+const IDEMPOTENCY_KEY = "migration-request-00000001";
+const CONFIGURATION: MainTokenMigrationGasSponsorConfigurationV1 = {
+  releaseId: "v4-ethereum-to-robinhood-96h-2026-v1",
+  windowStartTimestamp: 1_899_654_400,
+  startBlockNumber: 100n,
+  startBlockHash: `0x${"12".repeat(32)}`,
+  deadlineTimestampExclusive: 1_900_000_000,
+  sponsorWalletId: "sponsor-wallet-id",
+  sponsorPolicyId: "sponsor-policy-id",
+  sponsorAddress: SPONSOR,
+  maximumTopUpWei: 2_000_000_000_000_000n,
+  totalBudgetWei: 172_000_000_000_000n,
+};
+
+function key(releaseId: string, walletAddress: string) {
+  return `${releaseId}:${walletAddress.toLowerCase()}`;
+}
+
+class MemoryStore implements MainTokenMigrationGasSponsorStoreV1 {
+  readonly records = new Map<string, MainTokenMigrationGasSponsorRecordV1>();
+  readonly aliases = new Map<string, string>();
+  readonly admissions:
+    Parameters<MainTokenMigrationGasSponsorStoreV1["admit"]>[0][] = [];
+  rateLimited = false;
+  private gate: Promise<void> = Promise.resolve();
+
+  async admit(input: Parameters<MainTokenMigrationGasSponsorStoreV1["admit"]>[0]) {
+    this.admissions.push(input);
+    if (this.rateLimited) {
+      throw new MainTokenMigrationGasSponsorStoreErrorV1("rate_limited", 17);
+    }
+  }
+
+  async get(input: { releaseId: string; walletAddress: `0x${string}` }) {
+    return this.records.get(key(input.releaseId, input.walletAddress)) ?? null;
+  }
+
+  async reserve(input: Parameters<MainTokenMigrationGasSponsorStoreV1["reserve"]>[0]) {
+    let unlock: () => void = () => {};
+    const previous = this.gate;
+    this.gate = new Promise<void>((resolve) => {
+      unlock = resolve;
+    });
+    await previous;
+    try {
+      const recordKey = key(input.lookup.releaseId, input.lookup.walletAddress);
+      const alias = this.aliases.get(input.idempotencyBindingHash);
+      if (alias !== undefined && alias !== input.requestBindingHash) {
+        throw new MainTokenMigrationGasSponsorStoreErrorV1("conflict");
+      }
+      const existing = this.records.get(recordKey);
+      if (existing) {
+        return { kind: "existing" as const, record: existing };
+      }
+      const reservedWei = [...this.records.values()]
+        .filter((record) => record.intent.releaseId === input.lookup.releaseId)
+        .reduce(
+          (total, record) => total + BigInt(record.intent.reservedTotalWei),
+          0n,
+        );
+      if (reservedWei + BigInt(input.intent.reservedTotalWei)
+        > BigInt(input.intent.totalBudgetWei)) {
+        throw new MainTokenMigrationGasSponsorStoreErrorV1("budget_exhausted");
+      }
+      this.aliases.set(
+        input.idempotencyBindingHash,
+        input.requestBindingHash,
+      );
+      const record = Object.freeze({
+        intent: input.intent,
+        transactionHash: null,
+      });
+      this.records.set(recordKey, record);
+      return { kind: "created" as const, record };
+    } finally {
+      unlock();
+    }
+  }
+
+  async complete(input: Parameters<MainTokenMigrationGasSponsorStoreV1["complete"]>[0]) {
+    const recordKey = key(input.lookup.releaseId, input.lookup.walletAddress);
+    const current = this.records.get(recordKey);
+    if (!current || current.intent.providerReferenceId !== input.providerReferenceId) {
+      throw new MainTokenMigrationGasSponsorStoreErrorV1("unavailable");
+    }
+    if (current.transactionHash !== null &&
+      current.transactionHash !== input.transactionHash) {
+      throw new MainTokenMigrationGasSponsorStoreErrorV1("conflict");
+    }
+    const completed = Object.freeze({
+      intent: current.intent,
+      transactionHash: input.transactionHash,
+    });
+    this.records.set(recordKey, completed);
+    return completed;
+  }
+}
+
+class IdempotentSender implements MainTokenMigrationGasSponsorSenderV1 {
+  readonly calls: MainTokenMigrationGasSponsorIntentV1[] = [];
+  readonly hashes = new Map<string, typeof TX_HASH>();
+  actualTransfers = 0;
+  throwAfterFirstBroadcast = false;
+  private threwAmbiguous = false;
+
+  async assertReady() {}
+
+  async send(intent: MainTokenMigrationGasSponsorIntentV1) {
+    this.calls.push(intent);
+    let hash = this.hashes.get(intent.providerIdempotencyKey);
+    if (!hash) {
+      hash = TX_HASH;
+      this.hashes.set(intent.providerIdempotencyKey, hash);
+      this.actualTransfers += 1;
+    }
+    await Promise.resolve();
+    if (this.throwAfterFirstBroadcast && !this.threwAmbiguous) {
+      this.threwAmbiguous = true;
+      throw new Error("provider response lost after broadcast");
+    }
+    return hash;
+  }
+}
+
+function chain(): MainTokenMigrationGasSponsorChainV1 {
+  return {
+    async observe({ request }) {
+      return {
+        walletAddress: request.walletAddress,
+        amountRaw: request.amountRaw,
+        estimatedTransferGas: 52_000n,
+        feePerGasWei: 2_000_000_000n,
+        maxPriorityFeePerGasWei: 1_000_000_000n,
+        nativeBalanceWei: 0n,
+        sponsorBalanceWei: 1_000_000_000_000_000_000n,
+      };
+    },
+    async status() {
+      return "confirmed";
+    },
+  };
+}
+
+function request(
+  walletAddress: `0x${string}` = WALLET,
+  idempotencyKey = IDEMPOTENCY_KEY,
+) {
+  return new Request(
+    "https://programmable.market/api/main-token-migration/gas-sponsorship",
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer privy-access-token",
+        "content-type": "application/json",
+        "idempotency-key": idempotencyKey,
+        origin: "https://programmable.market",
+        "sec-fetch-site": "same-origin",
+      },
+      body: JSON.stringify({ walletAddress, amountRaw: "100" }),
+    },
+  );
+}
+
+function sponsor(
+  store: MemoryStore,
+  sender: IdempotentSender,
+  now: () => Date = () => NOW,
+) {
+  return createMainTokenMigrationGasSponsorV1({
+    configuration: CONFIGURATION,
+    authenticator: {
+      async authenticate() {
+        return {
+          privyUserId: "did:privy:test-user",
+          privySessionId: "session-1",
+          wallets: [WALLET, SECOND_WALLET],
+        };
+      },
+    },
+    store,
+    chain: chain(),
+    sender,
+    now,
+  });
+}
+
+describe("main token migration gas sponsor", () => {
+  it("accepts only the exact finalized eligibility block before the window", () => {
+    const exact = {
+      number: CONFIGURATION.startBlockNumber,
+      hash: CONFIGURATION.startBlockHash,
+      timestamp: BigInt(CONFIGURATION.windowStartTimestamp - 1),
+      finalizedBlockNumber: CONFIGURATION.startBlockNumber,
+    } as const;
+    expect(() =>
+      assertMainTokenMigrationSponsorEligibilityAnchorV1(
+        CONFIGURATION,
+        [exact, exact],
+      ),
+    ).not.toThrow();
+
+    for (const changed of [
+      { ...exact, number: CONFIGURATION.startBlockNumber + 1n },
+      { ...exact, hash: `0x${"34".repeat(32)}` as const },
+      {
+        ...exact,
+        timestamp: BigInt(CONFIGURATION.windowStartTimestamp),
+      },
+      {
+        ...exact,
+        finalizedBlockNumber: CONFIGURATION.startBlockNumber - 1n,
+      },
+    ]) {
+      expect(() =>
+        assertMainTokenMigrationSponsorEligibilityAnchorV1(
+          CONFIGURATION,
+          [exact, changed],
+        ),
+      ).toThrowError(
+        expect.objectContaining({
+          status: 503,
+          code: "rpc_quorum_unavailable",
+        }),
+      );
+    }
+  });
+
+  it("accepts only the exact 96-hour release identity and window", () => {
+    const start = Math.floor(NOW.getTime() / 1_000) - 60;
+    const manifest = {
+      schema: "programmable-main-token-migration-activation/v1",
+      releaseId: MAIN_TOKEN_MIGRATION_RELEASE_ID,
+      enabled: true,
+      sourceChainId: String(MAIN_TOKEN_MIGRATION_CHAIN_ID),
+      sourceTokenAddress: MAIN_TOKEN_ADDRESS,
+      sourceTokenRuntimeCodeKeccak256: MAIN_TOKEN_RUNTIME_CODE_KECCAK256,
+      migrationWallet: MAIN_TOKEN_MIGRATION_WALLET,
+      windowDurationSeconds: String(MAIN_TOKEN_MIGRATION_WINDOW_SECONDS),
+      windowStartTimestamp: String(start),
+      deadlineTimestampExclusive: String(
+        start + MAIN_TOKEN_MIGRATION_WINDOW_SECONDS,
+      ),
+      startBlockNumber: "100",
+      startBlockHash: `0x${"12".repeat(32)}`,
+    };
+    const environment = {
+      MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ENABLED: "true",
+      MAIN_TOKEN_MIGRATION_GAS_SPONSOR_PRIVY_WALLET_ID:
+        CONFIGURATION.sponsorWalletId,
+      MAIN_TOKEN_MIGRATION_GAS_SPONSOR_PRIVY_POLICY_ID:
+        CONFIGURATION.sponsorPolicyId,
+      MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ADDRESS:
+        CONFIGURATION.sponsorAddress,
+      MAIN_TOKEN_MIGRATION_GAS_SPONSOR_MAX_TOP_UP_WEI:
+        CONFIGURATION.maximumTopUpWei.toString(),
+      MAIN_TOKEN_MIGRATION_GAS_SPONSOR_TOTAL_BUDGET_WEI:
+        "20000000000000000",
+    };
+
+    expect(readMainTokenMigrationGasSponsorConfigurationV1({
+      environment,
+      manifest,
+      nowMs: NOW.getTime(),
+    })).toMatchObject({
+      releaseId: "v4-ethereum-to-robinhood-96h-2026-v1",
+      deadlineTimestampExclusive: start + 96 * 60 * 60,
+    });
+    expect(readMainTokenMigrationGasSponsorConfigurationV1({
+      environment,
+      manifest: {
+        ...manifest,
+        releaseId: "v4-ethereum-to-robinhood-48h-2026-v1",
+        windowDurationSeconds: String(48 * 60 * 60),
+        deadlineTimestampExclusive: String(start + 48 * 60 * 60),
+      },
+      nowMs: NOW.getTime(),
+    })).toBeNull();
+  });
+
+  it("strictly binds the request, deficit quote, and provider idempotency", () => {
+    expect(parseMainTokenMigrationSponsorRequestV1({
+      walletAddress: WALLET,
+      amountRaw: "100",
+    })).toEqual({ walletAddress: WALLET, amountRaw: 100n });
+    expect(() => parseMainTokenMigrationSponsorRequestV1({
+      walletAddress: WALLET,
+      amountRaw: "100",
+      extra: true,
+    })).toThrow(MainTokenMigrationGasSponsorErrorV1);
+
+    expect(calculateMainTokenMigrationTopUpWeiV1({
+      estimatedGas: 52_000n,
+      feePerGas: 2_000_000_000n,
+      hardCapWei: CONFIGURATION.maximumTopUpWei,
+      nativeBalanceWei: 30_000_000_000_000n,
+    })).toEqual({
+      requiredWei: 130_000_000_000_000n,
+      topUpWei: 100_000_000_000_000n,
+    });
+
+    const first = deriveMainTokenMigrationSponsorBindingsV1({
+      releaseId: CONFIGURATION.releaseId,
+      walletAddress: WALLET,
+      amountRaw: 100n,
+      idempotencyKey: IDEMPOTENCY_KEY,
+    });
+    const replayWithDifferentClientKey =
+      deriveMainTokenMigrationSponsorBindingsV1({
+        releaseId: CONFIGURATION.releaseId,
+        walletAddress: WALLET,
+        amountRaw: 100n,
+        idempotencyKey: "migration-request-00000002",
+      });
+    expect(first.requestBindingHash).not.toBe(
+      replayWithDifferentClientKey.requestBindingHash,
+    );
+    expect(first.providerIdempotencyKey).toBe(
+      replayWithDifferentClientKey.providerIdempotencyKey,
+    );
+    expect(first.providerReferenceId).toBe(
+      replayWithDifferentClientKey.providerReferenceId,
+    );
+    expect(deriveMainTokenMigrationSponsorPrincipalBindingV1(
+      "did:privy:test-user",
+    )).toMatch(/^sha256:[0-9a-f]{64}$/u);
+  });
+
+  it("attests the exact Privy wallet, chain, address, and sole policy", () => {
+    const wallet = {
+      id: CONFIGURATION.sponsorWalletId,
+      chain_type: "ethereum",
+      address: CONFIGURATION.sponsorAddress,
+      policy_ids: [CONFIGURATION.sponsorPolicyId],
+    };
+    expect(() => assertMainTokenMigrationPrivySponsorWalletV1(
+      wallet,
+      CONFIGURATION,
+    )).not.toThrow();
+    for (const policy_ids of [
+      [],
+      [CONFIGURATION.sponsorPolicyId, "unexpected-policy-id"],
+      ["unexpected-policy-id"],
+      undefined,
+    ]) {
+      expect(() => assertMainTokenMigrationPrivySponsorWalletV1(
+        { ...wallet, policy_ids },
+        CONFIGURATION,
+      )).toThrowError(MainTokenMigrationGasSponsorErrorV1);
+    }
+    for (const mismatch of [
+      { id: "unexpected-wallet-id" },
+      { chain_type: "solana" },
+      { address: SECOND_WALLET },
+    ]) {
+      expect(() => assertMainTokenMigrationPrivySponsorWalletV1(
+        { ...wallet, ...mismatch },
+        CONFIGURATION,
+      )).toThrowError(MainTokenMigrationGasSponsorErrorV1);
+    }
+  });
+
+  it("durably admits the authenticated principal before sender or RPC work", async () => {
+    const store = new MemoryStore();
+    store.rateLimited = true;
+    const sender = new IdempotentSender();
+    sender.assertReady = vi.fn();
+    const observed = vi.fn();
+    const handler = createMainTokenMigrationGasSponsorV1({
+      configuration: CONFIGURATION,
+      authenticator: {
+        async authenticate() {
+          return {
+            privyUserId: "did:privy:test-user",
+            privySessionId: "session-1",
+            wallets: [WALLET],
+          };
+        },
+      },
+      store,
+      chain: {
+        async observe(input) {
+          observed(input);
+          return chain().observe(input);
+        },
+        async status() {
+          return "confirmed";
+        },
+      },
+      sender,
+      now: () => NOW,
+    });
+
+    const blocked = await handler.post(request());
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get("retry-after")).toBe("17");
+    expect((await blocked.json()).error.code).toBe("rate_limited");
+    expect(store.admissions).toHaveLength(1);
+    expect(store.admissions[0]).toMatchObject({
+      operation: "submit",
+      releaseId: CONFIGURATION.releaseId,
+      walletAddress: WALLET,
+    });
+    expect(sender.assertReady).not.toHaveBeenCalled();
+    expect(observed).not.toHaveBeenCalled();
+  });
+
+  it("persists bounded principal and holder admission slots in PostgreSQL", async () => {
+    const database = new PGlite();
+    try {
+      await database.exec(`
+        CREATE SCHEMA programmable_website_projection_v1;
+        CREATE TABLE programmable_website_projection_v1.credential_uses (
+          credential_id text PRIMARY KEY,
+          request_binding_hash text NOT NULL,
+          canonical_use text NOT NULL,
+          created_at timestamptz NOT NULL DEFAULT clock_timestamp()
+        );
+      `);
+      const store = createMainTokenMigrationGasSponsorPostgresStoreV1(
+        new SponsorTestPool(database),
+      );
+      const principalBindingHash =
+        deriveMainTokenMigrationSponsorPrincipalBindingV1(
+          "did:privy:persistent-rate-test",
+        );
+      for (let index = 0; index < 8; index += 1) {
+        await store.admit({
+          releaseId: CONFIGURATION.releaseId,
+          principalBindingHash,
+          walletAddress: WALLET,
+          operation: "read",
+        });
+      }
+      await expect(store.admit({
+        releaseId: CONFIGURATION.releaseId,
+        principalBindingHash,
+        walletAddress: WALLET,
+        operation: "read",
+      })).rejects.toMatchObject({
+        code: "rate_limited",
+      });
+
+      const rows = await database.query<{ count: string }>(`
+        SELECT count(*)::text AS count
+          FROM programmable_website_projection_v1.credential_uses
+         WHERE credential_id LIKE '%:admission:%'
+      `);
+      expect(rows.rows[0]?.count).toBe("16");
+
+      const firstBindings = deriveMainTokenMigrationSponsorBindingsV1({
+        releaseId: CONFIGURATION.releaseId,
+        walletAddress: WALLET,
+        amountRaw: 100n,
+        idempotencyKey: "migration-request-00000011",
+      });
+      const firstIntent = testIntent(firstBindings.requestBindingHash);
+      expect((await store.reserve({
+        lookup: {
+          releaseId: CONFIGURATION.releaseId,
+          walletAddress: WALLET,
+        },
+        idempotencyBindingHash: firstBindings.idempotencyBindingHash,
+        requestBindingHash: firstBindings.requestBindingHash,
+        intent: firstIntent,
+      })).kind).toBe("created");
+
+      const replayBindings = deriveMainTokenMigrationSponsorBindingsV1({
+        releaseId: CONFIGURATION.releaseId,
+        walletAddress: WALLET,
+        amountRaw: 100n,
+        idempotencyKey: "migration-request-00000012",
+      });
+      expect((await store.reserve({
+        lookup: {
+          releaseId: CONFIGURATION.releaseId,
+          walletAddress: WALLET,
+        },
+        idempotencyBindingHash: replayBindings.idempotencyBindingHash,
+        requestBindingHash: replayBindings.requestBindingHash,
+        intent: testIntent(replayBindings.requestBindingHash),
+      })).kind).toBe("existing");
+      const aliases = await database.query<{ count: string }>(`
+        SELECT count(*)::text AS count
+          FROM programmable_website_projection_v1.credential_uses
+         WHERE credential_id LIKE '%:idempotency:%'
+      `);
+      expect(aliases.rows[0]?.count).toBe("1");
+    } finally {
+      await database.close();
+    }
+  }, 10_000);
+
+  it("reserves concurrent duplicates once and never broadcasts twice", async () => {
+    const store = new MemoryStore();
+    const sender = new IdempotentSender();
+    const handler = sponsor(store, sender);
+
+    const [left, right] = await Promise.all([
+      handler.post(request()),
+      handler.post(request()),
+    ]);
+
+    expect([left.status, right.status].sort()).toEqual([200, 503]);
+    const bodies = await Promise.all([left.json(), right.json()]);
+    expect(bodies.some((body) => body.transactionHash === TX_HASH)).toBe(true);
+    expect(bodies.some(
+      (body) => body.error?.code === "submission_unknown",
+    )).toBe(true);
+    expect([left, right].find((response) => response.status === 200)
+      ?.headers.get("retry-after")).toBe("10");
+    expect(sender.actualTransfers).toBe(1);
+    expect(sender.calls).toHaveLength(1);
+    expect([...store.records.values()][0]?.transactionHash).toBe(TX_HASH);
+  });
+
+  it("returns the holder record without growing aliases for fresh client keys", async () => {
+    const store = new MemoryStore();
+    const sender = new IdempotentSender();
+    const handler = sponsor(store, sender);
+
+    expect((await handler.post(request())).status).toBe(200);
+    expect((await handler.post(request(
+      WALLET,
+      "migration-request-00000002",
+    ))).status).toBe(200);
+
+    expect(store.aliases.size).toBe(1);
+    expect(sender.calls).toHaveLength(1);
+    expect(sender.actualTransfers).toBe(1);
+  });
+
+  it("atomically refuses a second holder once the release budget is reserved", async () => {
+    const store = new MemoryStore();
+    const sender = new IdempotentSender();
+    const handler = sponsor(store, sender);
+
+    const responses = await Promise.all([
+      handler.post(request(WALLET, "migration-request-00000001")),
+      handler.post(request(SECOND_WALLET, "migration-request-00000002")),
+    ]);
+    expect(responses.map((response) => response.status).sort()).toEqual([
+      200,
+      503,
+    ]);
+    const bodies = await Promise.all(responses.map((response) => response.json()));
+    expect(bodies.some(
+      (body) => body.error?.code === "sponsor_budget_exhausted",
+    )).toBe(true);
+    expect(sender.calls).toHaveLength(1);
+    expect(sender.actualTransfers).toBe(1);
+    expect(store.records.size).toBe(1);
+    expect(sender.calls[0]).toMatchObject({
+      topUpWei: "130000000000000",
+      sponsorGasLimit:
+        MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1.toString(),
+      sponsorMaxFeePerGasWei: "2000000000",
+      sponsorMaxPriorityFeePerGasWei: "1000000000",
+      reservedTotalWei: "172000000000000",
+      totalBudgetWei: "172000000000000",
+    });
+  });
+
+  it("never resends after an ambiguous provider outcome", async () => {
+    const store = new MemoryStore();
+    const sender = new IdempotentSender();
+    sender.throwAfterFirstBroadcast = true;
+    const handler = sponsor(store, sender);
+
+    const unknown = await handler.post(request());
+    expect(unknown.status).toBe(503);
+    expect((await unknown.json()).error.code).toBe("submission_unknown");
+    expect(sender.actualTransfers).toBe(1);
+    expect([...store.records.values()][0]?.transactionHash).toBeNull();
+
+    const duplicate = await handler.post(request());
+    expect(duplicate.status).toBe(503);
+    expect((await duplicate.json()).error.code).toBe("submission_unknown");
+    expect(sender.actualTransfers).toBe(1);
+    expect(sender.calls).toHaveLength(1);
+    expect([...store.records.values()][0]?.transactionHash).toBeNull();
+  });
+
+  it("rechecks the deadline on every request from a cached handler", async () => {
+    const store = new MemoryStore();
+    const sender = new IdempotentSender();
+    let current = NOW;
+    const handler = sponsor(store, sender, () => current);
+
+    current = new Date(CONFIGURATION.deadlineTimestampExclusive * 1_000);
+    const expired = await handler.post(request());
+
+    expect(expired.status).toBe(503);
+    expect(sender.calls).toHaveLength(0);
+    expect(store.records.size).toBe(0);
+  });
+});
+
+function testIntent(
+  requestBindingHash: `sha256:${string}`,
+): MainTokenMigrationGasSponsorIntentV1 {
+  return Object.freeze({
+    schema: "programmable-main-token-migration-gas-sponsorship-intent/v1",
+    releaseId: CONFIGURATION.releaseId,
+    walletAddress: WALLET,
+    sponsorAddress: SPONSOR,
+    amountRaw: "100",
+    topUpWei: "130000000000000",
+    totalBudgetWei: CONFIGURATION.totalBudgetWei.toString(),
+    sponsorGasLimit:
+      MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1.toString(),
+    sponsorMaxFeePerGasWei: "2000000000",
+    sponsorMaxPriorityFeePerGasWei: "1000000000",
+    reservedTotalWei: "172000000000000",
+    estimatedTransferGas: "52000",
+    feePerGasWei: "2000000000",
+    requestBindingHash,
+    providerIdempotencyKey: "mtmgs-test-provider-idempotency",
+    providerReferenceId: "mtmgs-test-provider-reference",
+    reservedAt: NOW.toISOString(),
+  });
+}
+
+class SponsorTestPool {
+  constructor(private readonly database: PGlite) {}
+
+  async assertProductionReadiness() {}
+
+  async connect(): Promise<ProjectionTargetPostgresClientV1> {
+    return Object.freeze({
+      query: <Row extends Record<string, unknown>>(
+        text: string,
+        values: readonly unknown[] = [],
+      ) => this.query<Row>(text, values),
+      release() {},
+    });
+  }
+
+  async query<Row extends Record<string, unknown> = Record<string, unknown>>(
+    text: string,
+    values: readonly unknown[] = [],
+  ): Promise<ProjectionTargetPostgresQueryResultV1<Row>> {
+    const result = await this.database.query<Row>(text, [...values]);
+    return Object.freeze({
+      rows: result.rows,
+      rowCount: result.affectedRows ?? result.rows.length,
+    });
+  }
+}

--- a/tests/main-token-migration-gas-sponsorship-ui.test.ts
+++ b/tests/main-token-migration-gas-sponsorship-ui.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  gasSponsorshipDisplayKind,
+  gasSponsorshipErrorMessage,
+  gasSponsorshipFailure,
+  gasSponsorshipState,
+  hasEnoughMigrationGas,
+  parseGasSponsorshipResponse,
+  sponsorshipRetryAfterMs,
+  type MainTokenGasSponsorshipResponse,
+  type MainTokenGasSponsorshipStatus,
+} from "../components/main-token-migration";
+
+const SCHEMA =
+  "programmable-main-token-migration-gas-sponsorship/v1" as const;
+const WALLET = "0x1111111111111111111111111111111111111111";
+const OTHER_WALLET = "0x2222222222222222222222222222222222222222";
+const TX_HASH = `0x${"ab".repeat(32)}` as const;
+
+function response(
+  status: MainTokenGasSponsorshipStatus,
+  overrides: Partial<MainTokenGasSponsorshipResponse> = {},
+) {
+  return {
+    schema: SCHEMA,
+    status,
+    walletAddress: WALLET,
+    topUpWei: "42000",
+    transactionHash: TX_HASH,
+    estimatedTransferGas: "100000",
+    ...overrides,
+  };
+}
+
+describe("main token migration gas sponsorship UI contract", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("accepts only the exact schema and connected wallet", () => {
+    expect(parseGasSponsorshipResponse(response("confirmed"), WALLET)).toEqual({
+      schema: SCHEMA,
+      status: "confirmed",
+      walletAddress: WALLET,
+      topUpWei: "42000",
+      transactionHash: TX_HASH,
+      estimatedTransferGas: "100000",
+    });
+
+    for (const malformed of [
+      response("confirmed", { walletAddress: OTHER_WALLET }),
+      { ...response("confirmed"), schema: "wrong" },
+      { ...response("confirmed"), status: "ready" },
+      { ...response("confirmed"), topUpWei: "-1" },
+      { ...response("confirmed"), topUpWei: "01" },
+      { ...response("confirmed"), estimatedTransferGas: "1e5" },
+      { ...response("confirmed"), transactionHash: "0x1234" },
+      { ...response("confirmed"), transactionHash: null },
+      { ...response("not_needed"), topUpWei: "1", transactionHash: null },
+      { ...response("eligible"), transactionHash: TX_HASH },
+      { ...response("confirmed"), unexpected: true },
+    ]) {
+      expect(() => parseGasSponsorshipResponse(malformed, WALLET)).toThrow(
+        "gas sponsorship response is invalid",
+      );
+    }
+  });
+
+  it("maps every server status without treating submitted funding as ready", () => {
+    expect(gasSponsorshipState(response("eligible"))).toEqual({
+      kind: "eligible",
+      account: WALLET,
+    });
+    expect(gasSponsorshipState(response("submitted"))).toEqual({
+      kind: "requested",
+      account: WALLET,
+      transactionHash: TX_HASH,
+    });
+    expect(gasSponsorshipState(response("pending"))).toEqual({
+      kind: "funding-confirming",
+      account: WALLET,
+      transactionHash: TX_HASH,
+    });
+    expect(gasSponsorshipState(response("confirmed"))).toEqual({
+      kind: "balance-confirming",
+      account: WALLET,
+      transactionHash: TX_HASH,
+    });
+    expect(gasSponsorshipState(response("not_needed"))).toEqual({
+      kind: "not-needed",
+      account: WALLET,
+    });
+    const confirmed = gasSponsorshipState(response("confirmed"));
+    expect(gasSponsorshipDisplayKind(confirmed, false)).toBe(
+      "balance-confirming",
+    );
+    expect(gasSponsorshipDisplayKind(confirmed, true)).toBe("ready");
+  });
+
+  it("requires the freshly observed ETH balance to cover the full reserve", () => {
+    const gasPriceWei = 2_000_000_000n;
+    const exactReserveWei = gasPriceWei * 100_000n;
+
+    expect(hasEnoughMigrationGas(exactReserveWei, gasPriceWei)).toBe(true);
+    expect(hasEnoughMigrationGas(exactReserveWei - 1n, gasPriceWei)).toBe(false);
+    expect(hasEnoughMigrationGas(0n, gasPriceWei)).toBe(false);
+    expect(hasEnoughMigrationGas(exactReserveWei, 0n)).toBe(false);
+    expect(hasEnoughMigrationGas(-1n, gasPriceWei)).toBe(false);
+  });
+
+  it("bounds Retry-After polling and falls back safely", () => {
+    expect(sponsorshipRetryAfterMs(new Response())).toBe(3_000);
+    expect(sponsorshipRetryAfterMs(new Response(null, {
+      headers: { "retry-after": "0" },
+    }))).toBe(1_000);
+    expect(sponsorshipRetryAfterMs(new Response(null, {
+      headers: { "retry-after": "2.2" },
+    }))).toBe(2_200);
+    expect(sponsorshipRetryAfterMs(new Response(null, {
+      headers: { "retry-after": "999" },
+    }))).toBe(15_000);
+    expect(sponsorshipRetryAfterMs(new Response(null, {
+      headers: { "retry-after": "not-a-date" },
+    }))).toBe(3_000);
+
+    vi.spyOn(Date, "now").mockReturnValue(
+      Date.parse("2026-08-30T12:00:00.000Z"),
+    );
+    expect(sponsorshipRetryAfterMs(new Response(null, {
+      headers: { "retry-after": "Sun, 30 Aug 2026 12:00:07 GMT" },
+    }))).toBe(7_000);
+  });
+
+  it("preserves the safe server message and request ID", async () => {
+    const response = () => new Response(JSON.stringify({
+      error: {
+        code: "submission_unknown",
+        message:
+          "The gas top-up needs a status review. No second top-up was sent.",
+        requestId: "123e4567-e89b-12d3-a456-426614174000",
+      },
+    }), {
+      status: 503,
+      headers: { "content-type": "application/json" },
+    });
+    await expect(gasSponsorshipErrorMessage(response())).resolves.toBe(
+      "The gas top-up needs a status review. No second top-up was sent. " +
+      "Request ID: 123e4567-e89b-12d3-a456-426614174000",
+    );
+    await expect(gasSponsorshipFailure(response())).resolves.toEqual({
+      message:
+        "The gas top-up needs a status review. No second top-up was sent. " +
+        "Request ID: 123e4567-e89b-12d3-a456-426614174000",
+      retryable: false,
+    });
+  });
+
+  it("keeps terminal failures terminal even without usable server copy", async () => {
+    const requestId = "123e4567-e89b-12d3-a456-426614174000";
+    for (const [code, expected] of [
+      [
+        "submission_unknown",
+        "The gas top-up needs a status review. No second top-up was sent.",
+      ],
+      [
+        "sponsorship_closed",
+        "Gas sponsorship is closed for this migration window.",
+      ],
+      [
+        "sponsorship_failed",
+        "The gas top-up could not be confirmed. Contact migration support before trying again.",
+      ],
+    ] as const) {
+      const failure = await gasSponsorshipFailure(new Response(JSON.stringify({
+        error: { code, message: "x".repeat(241), requestId },
+      }), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      }));
+      expect(failure).toEqual({
+        message: `${expected} Request ID: ${requestId}`,
+        retryable: false,
+      });
+    }
+  });
+});

--- a/tests/main-token-migration.test.ts
+++ b/tests/main-token-migration.test.ts
@@ -1,0 +1,412 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { decodeFunctionData, parseAbi } from "viem";
+import { describe, expect, it } from "vitest";
+
+import {
+  assertMainTokenMigrationBalance,
+  assertMainTokenMigrationTransaction,
+  buildMainTokenMigrationTransaction,
+  MAIN_TOKEN_ADDRESS,
+  MAIN_TOKEN_DECIMALS,
+  MAIN_TOKEN_MIGRATION_CHAIN_ID,
+  MAIN_TOKEN_MIGRATION_RELEASE_ID,
+  MAIN_TOKEN_MIGRATION_WALLET,
+  MAIN_TOKEN_MIGRATION_WINDOW_SECONDS,
+  parseMainTokenMigrationAmount,
+} from "../lib/main-token-migration";
+import {
+  buildEip1193TransactionRequest,
+  getPreparedTransactionReview,
+} from "../lib/prepared-transaction";
+
+const sender = "0x2222222222222222222222222222222222222222";
+const other = "0x3333333333333333333333333333333333333333";
+const transferAbi = parseAbi([
+  "function transfer(address to,uint256 amount) returns (bool)",
+]);
+const migrationWallet = "0x228Be90653fDDAa408fB6cf9ca0AEC311dbE9A0D";
+const migrationWindowSeconds = 96 * 60 * 60;
+
+describe("main token migration transfer", () => {
+  it("freezes the 96-hour Ethereum migration identities", () => {
+    expect(MAIN_TOKEN_MIGRATION_CHAIN_ID).toBe(1);
+    expect(MAIN_TOKEN_ADDRESS).toBe(
+      "0x7987f03462200b3D8A072E02C89A8A41dCB124EE",
+    );
+    expect(MAIN_TOKEN_MIGRATION_WALLET).toBe(migrationWallet);
+    expect(MAIN_TOKEN_DECIMALS).toBe(18);
+    expect(MAIN_TOKEN_MIGRATION_WINDOW_SECONDS).toBe(migrationWindowSeconds);
+
+    expect(MAIN_TOKEN_MIGRATION_RELEASE_ID).toBe(
+      "v4-ethereum-to-robinhood-96h-2026-v1",
+    );
+  });
+
+  it("binds the exact token, fixed receiver, sender, chain and raw token units", () => {
+    const amountRaw = parseMainTokenMigrationAmount("12345.670000000000000001");
+    const prepared = buildMainTokenMigrationTransaction({
+      from: sender,
+      amountRaw,
+    });
+
+    expect(prepared).toMatchObject({
+      kind: "main-token-migration",
+      chainId: 1,
+      from: sender,
+      to: MAIN_TOKEN_ADDRESS,
+      value: "0",
+    });
+    expect(
+      decodeFunctionData({ abi: transferAbi, data: prepared.data }),
+    ).toEqual({
+      functionName: "transfer",
+      args: [MAIN_TOKEN_MIGRATION_WALLET, amountRaw],
+    });
+    expect(buildEip1193TransactionRequest(prepared, sender)).toEqual({
+      from: sender,
+      to: MAIN_TOKEN_ADDRESS,
+      data: prepared.data,
+      value: "0x0",
+    });
+  });
+
+  it("rejects sender, chain, token, value and calldata changes", () => {
+    const prepared = buildMainTokenMigrationTransaction({
+      from: sender,
+      amountRaw: 100n,
+    });
+
+    expect(() => assertMainTokenMigrationTransaction(prepared, other)).toThrow(
+      "connected wallet",
+    );
+    expect(() =>
+      assertMainTokenMigrationTransaction(
+        { ...prepared, chainId: 11_155_111 },
+        sender,
+      ),
+    ).toThrow("Ethereum Mainnet");
+    expect(() =>
+      assertMainTokenMigrationTransaction(
+        { ...prepared, to: other },
+        sender,
+      ),
+    ).toThrow("binding");
+    expect(() =>
+      assertMainTokenMigrationTransaction(
+        { ...prepared, value: "1" },
+        sender,
+      ),
+    ).toThrow("binding");
+
+    const redirected = buildMainTokenMigrationTransaction({
+      from: sender,
+      amountRaw: 100n,
+    });
+    const redirectedData = redirected.data.replace(
+      MAIN_TOKEN_MIGRATION_WALLET.slice(2).toLowerCase(),
+      other.slice(2).toLowerCase(),
+    ) as `0x${string}`;
+    expect(() =>
+      assertMainTokenMigrationTransaction(
+        { ...redirected, data: redirectedData },
+        sender,
+      ),
+    ).toThrow("recipient or amount");
+  });
+
+  it("accepts positive decimal units only and never more than the refreshed balance", () => {
+    expect(parseMainTokenMigrationAmount("1")).toBe(10n ** 18n);
+    expect(parseMainTokenMigrationAmount("0.000000000000000001")).toBe(1n);
+    for (const value of ["", "0", "1.", ".1", "01", "1e2", "1,000", "-1"]) {
+      expect(() => parseMainTokenMigrationAmount(value)).toThrow();
+    }
+    expect(assertMainTokenMigrationBalance(100n, 100n)).toBe(100n);
+    expect(() => assertMainTokenMigrationBalance(101n, 100n)).toThrow(
+      "exceeds",
+    );
+  });
+
+  it("uses explicit wallet review copy for the irreversible transfer", () => {
+    expect(getPreparedTransactionReview("main-token-migration")).toEqual({
+      description: "Send V4 to the fixed migration wallet on Ethereum",
+      buttonText: "Send V4",
+      successHeader: "Migration transfer submitted",
+    });
+  });
+
+  it("revalidates the exact migration transfer at the wallet provider boundary", () => {
+    const walletProvider = readFileSync(
+      join(process.cwd(), "components/wallet-provider.tsx"),
+      "utf8",
+    );
+    const parsed = walletProvider.indexOf(
+      "const prepared = parsePreparedTransactionForAccount",
+    );
+    const exactMigrationCheck = walletProvider.indexOf(
+      "assertMainTokenMigrationTransaction(prepared, wallet.account)",
+    );
+    const walletSend = walletProvider.indexOf('method: "eth_sendTransaction"');
+
+    expect(parsed).toBeGreaterThan(0);
+    expect(exactMigrationCheck).toBeGreaterThan(parsed);
+    expect(walletSend).toBeGreaterThan(exactMigrationCheck);
+  });
+});
+
+describe("main token migration page contract", () => {
+  const read = (path: string) => readFileSync(join(process.cwd(), path), "utf8");
+  const page = read("components/main-token-migration.tsx");
+
+  it("derives the countdown from one absolute window across reloads", () => {
+    const startAt = Date.parse("2026-08-30T12:00:00.000Z");
+    const deadlineAt = startAt + migrationWindowSeconds * 1_000;
+    const remainingAt = (now: number) =>
+      Math.max(0, Math.ceil((deadlineAt - now) / 1_000));
+
+    expect(remainingAt(startAt)).toBe(migrationWindowSeconds);
+    expect(remainingAt(startAt + 12 * 60 * 60 * 1_000)).toBe(84 * 60 * 60);
+    expect(remainingAt(startAt + 85 * 60 * 60 * 1_000)).toBe(11 * 60 * 60);
+    expect(page).toContain("trustedClockEndpoint");
+    expect(page).toContain("performance.now()");
+    expect(page).toContain("setNow(readTrustedNow())");
+    expect(page).toContain("phase === \"upcoming\"");
+    expect(page).toContain("migrationWindow.startAt");
+    expect(page).toContain("migrationWindow.deadlineAt");
+    expect(page).not.toMatch(
+      /Date\.now\(\)\s*\+\s*MAIN_TOKEN_MIGRATION_WINDOW_SECONDS/u,
+    );
+    expect(page).toContain("const hours = Math.floor(totalSeconds / 3_600)");
+    expect(page).toContain('<small>Hours</small>');
+    expect(page).toContain('<small>Minutes</small>');
+    expect(page).toContain('<small>Seconds</small>');
+    expect(page).not.toContain("<small>Days</small>");
+  });
+
+  it("keeps the published phase active through the deadline while closing new transfers five minutes early", () => {
+    const startAt = Date.parse("2026-08-30T12:00:00.000Z");
+    const deadlineAt = startAt + migrationWindowSeconds * 1_000;
+    const transferSafetyMs = 5 * 60 * 1_000;
+    const phaseAt = (now: number) => {
+      if (now < startAt) return "upcoming";
+      if (now >= deadlineAt) return "closed";
+      return "active";
+    };
+    const transferWindowOpenAt = (
+      now: number,
+      uncertaintyMs = 0,
+      enabled = true,
+    ) =>
+      enabled &&
+      now - uncertaintyMs >= startAt &&
+      now + uncertaintyMs < deadlineAt - transferSafetyMs;
+
+    expect(phaseAt(deadlineAt - 1)).toBe("active");
+    expect(phaseAt(deadlineAt)).toBe("closed");
+    expect(phaseAt(deadlineAt + 1)).toBe("closed");
+    expect(page).toContain(
+      'if (now < migrationWindow.startAt) return "upcoming";',
+    );
+    expect(page).toContain(
+      'if (now >= migrationWindow.deadlineAt) return "closed";',
+    );
+    expect(transferWindowOpenAt(deadlineAt - transferSafetyMs - 1)).toBe(true);
+    expect(transferWindowOpenAt(deadlineAt - transferSafetyMs)).toBe(false);
+    expect(transferWindowOpenAt(startAt + 249, 250)).toBe(false);
+    expect(transferWindowOpenAt(startAt + 250, 250)).toBe(true);
+    expect(transferWindowOpenAt(startAt + 250, 250, false)).toBe(false);
+    expect(page).toContain("const migrationTransferSafetyMs = 5 * 60 * 1_000;");
+    expect(page).toContain("!migrationWindow.enabled ||");
+    expect(page).toContain("transferWindowOpenAt(trustedNow, clock.uncertaintyMs)");
+    const firstFinalWindowCheck = page.indexOf("const finalCheckTime = readTrustedNow()");
+    const finalWindowCheck = page.indexOf("const walletReviewTime = readTrustedNow()");
+    const finalTransactionBinding = page.indexOf(
+      "const checked = assertMainTokenMigrationTransaction",
+    );
+    const walletPrompt = page.indexOf("const hash = await sendTransaction");
+    expect(firstFinalWindowCheck).toBeGreaterThan(0);
+    expect(finalWindowCheck).toBeGreaterThan(firstFinalWindowCheck);
+    expect(page.slice(firstFinalWindowCheck, finalTransactionBinding)).toContain(
+      "!trustedTransferWindowOpen()",
+    );
+    expect(page.slice(finalWindowCheck, walletPrompt)).toContain(
+      "!trustedTransferWindowOpen()",
+    );
+    expect(finalWindowCheck).toBeGreaterThan(finalTransactionBinding);
+    expect(walletPrompt).toBeGreaterThan(finalWindowCheck);
+  });
+
+  it("keeps keyboard focus in the sponsorship flow", () => {
+    expect(page).toContain("focusSponsorshipActionOrStatus");
+    expect(
+      page.match(/focusSponsorshipActionOrStatus\(\);/gu)?.length ?? 0,
+    ).toBeGreaterThanOrEqual(6);
+    expect(page).toContain(
+      "(sponsorButtonRef.current ?? sponsorshipRegionRef.current)?.focus()",
+    );
+  });
+
+  it("reveals the fixed destination only during the active window or for a tracked transfer", () => {
+    expect(page).toContain(
+      "transferWindowOpenAt(now, clockUncertaintyMs)",
+    );
+    expect(page).toContain(
+      "const canRevealDestination = transferWindowOpen || hasTrackedTransfer;",
+    );
+    expect(page).toContain("const canCopyDestination = transferWindowOpen;");
+    expect(page).toContain("{canRevealDestination ? (");
+    expect(page).toContain("Copy address");
+    expect(page).toContain("disabled={!canCopyDestination}");
+    expect(page).toContain(
+      "The address and copy action unlock only during the published",
+    );
+  });
+
+  it("activates only with the exact 96-hour window, start block and release", () => {
+    const startAt = Date.parse("2026-08-30T12:00:00.000Z");
+    const activation = (
+      requested: boolean,
+      deadlineAt: number,
+      startBlock: bigint | null,
+      startBlockHash: string | null,
+      releaseId: string,
+    ) =>
+      requested &&
+      deadlineAt - startAt === migrationWindowSeconds * 1_000 &&
+      startBlock !== null &&
+      /^0x[0-9a-f]{64}$/u.test(startBlockHash ?? "") &&
+      releaseId === MAIN_TOKEN_MIGRATION_RELEASE_ID;
+    const blockHash = `0x${"1".repeat(64)}`;
+
+    expect(
+      activation(
+        true,
+        startAt + migrationWindowSeconds * 1_000,
+        1n,
+        blockHash,
+        MAIN_TOKEN_MIGRATION_RELEASE_ID,
+      ),
+    ).toBe(true);
+    expect(
+      activation(
+        false,
+        startAt + migrationWindowSeconds * 1_000,
+        1n,
+        blockHash,
+        MAIN_TOKEN_MIGRATION_RELEASE_ID,
+      ),
+    ).toBe(false);
+    expect(
+      activation(
+        true,
+        startAt + migrationWindowSeconds * 1_000,
+        null,
+        blockHash,
+        MAIN_TOKEN_MIGRATION_RELEASE_ID,
+      ),
+    ).toBe(false);
+    expect(
+      activation(
+        true,
+        startAt + migrationWindowSeconds * 1_000 - 1,
+        1n,
+        blockHash,
+        MAIN_TOKEN_MIGRATION_RELEASE_ID,
+      ),
+    ).toBe(false);
+    expect(
+      activation(
+        true,
+        startAt + migrationWindowSeconds * 1_000 + 1,
+        1n,
+        blockHash,
+        MAIN_TOKEN_MIGRATION_RELEASE_ID,
+      ),
+    ).toBe(false);
+    expect(
+      activation(
+        true,
+        startAt + migrationWindowSeconds * 1_000,
+        1n,
+        blockHash,
+        "wrong-release",
+      ),
+    ).toBe(false);
+    expect(
+      activation(
+        true,
+        startAt + migrationWindowSeconds * 1_000,
+        1n,
+        null,
+        MAIN_TOKEN_MIGRATION_RELEASE_ID,
+      ),
+    ).toBe(false);
+    expect(page).toContain("manifest.enabled === true &&");
+    expect(page).toContain("exactPolicy &&");
+    expect(page).toContain("exactWindow &&");
+    expect(page).toContain("startBlock !== null &&");
+    expect(page).toContain("startBlockHash !== null");
+  });
+
+  it("binds the public page to the exact 96-hour window and finalized Ethereum anchor", () => {
+    const route = read("app/migration/page.tsx");
+    const landing = read("components/landing-page.tsx");
+    const activationManifest = JSON.parse(
+      read("config/main-token-migration-activation.v1.json"),
+    ) as {
+      enabled: boolean;
+      releaseId: string;
+      windowDurationSeconds: string;
+      windowStartTimestamp: string | null;
+      deadlineTimestampExclusive: string | null;
+      startBlockNumber: string | null;
+      startBlockHash: string | null;
+    };
+
+    expect(page).toContain("main-token-migration-activation.v1.json");
+    expect(page).toContain("deadlineAt - startAt ===");
+    expect(page).toContain("startBlock !== null");
+    expect(page).toContain("Local preview · transfers disabled");
+    expect(page).toContain("96-hour");
+    expect(page).toContain("<strong>96 hours</strong>");
+    expect(page).toContain(
+      "Nothing is sent until you confirm the transfer in your wallet.",
+    );
+    expect(page).toContain("1:1 V4 amount");
+    expect(page).toContain("Do not send from an exchange, custodian or router");
+    expect(route).toContain("index: false");
+    expect(route).toContain("follow: false");
+    expect(route).toContain(
+      "PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_ENABLED",
+    );
+    expect(route).toContain(
+      "PROGRAMMABLE_MAIN_TOKEN_MIGRATION_LOCAL_PREVIEW",
+    );
+    expect(route).toContain("migrationActivationManifest.enabled");
+    expect(route).toContain("notFound()");
+    expect(landing).toContain('href="/migration"');
+    expect(landing).toContain("We are migrating");
+    expect(landing).toContain(
+      "NEXT_PUBLIC_PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_VISIBLE",
+    );
+    expect(landing).toContain("migrationActivationManifest.enabled");
+    expect(read("app/api/main-token-migration/window-time/route.ts")).toContain(
+      "programmable-main-token-migration-window-time/v1",
+    );
+    expect(activationManifest).toMatchObject({
+      enabled: true,
+      releaseId: MAIN_TOKEN_MIGRATION_RELEASE_ID,
+      windowDurationSeconds: String(MAIN_TOKEN_MIGRATION_WINDOW_SECONDS),
+      windowStartTimestamp: "1788125400",
+      deadlineTimestampExclusive: "1788471000",
+      startBlockNumber: "25870405",
+      startBlockHash:
+        "0xe4f50afeba1884b8354b3c962f99a258f2901f9768ec8da8ad05391761ff57de",
+    });
+    expect(
+      Number(activationManifest.deadlineTimestampExclusive) -
+        Number(activationManifest.windowStartTimestamp),
+    ).toBe(MAIN_TOKEN_MIGRATION_WINDOW_SECONDS);
+  });
+});

--- a/tests/wallet-state.test.ts
+++ b/tests/wallet-state.test.ts
@@ -154,6 +154,7 @@ describe("wallet recovery state", () => {
     for (const pathname of [
       "/launch",
       "/launch/review",
+      "/migration",
       "/profile",
       "/profile/settings",
       "/token/0x7987f03462200b3d8a072e02c89a8a41dcb124ee",


### PR DESCRIPTION
## Outcome
- adds the 96-hour `/migration` deposit page for Ethereum V4 holders
- binds the fixed V4 contract, fixed migration wallet, exact same-address token-unit allocation, finalized pre-window Ethereum anchor and server-synchronized countdown
- adds connect/amount/Max/wallet review plus bounded one-time ETH gas sponsorship for eligible EOAs
- exposes the landing CTA only with the activation manifest and production page gate

## Scope boundary
This is page-only migration intake. It does not deploy a Robinhood token, distributor, launch API, or any target-chain contract.

## Release window
- opens: 2026-08-30 21:30:00 UTC
- closes: 2026-09-03 21:30:00 UTC
- destination: `0x228Be90653fDDAa408fB6cf9ca0AEC311dbE9A0D`

## Evidence
- `npm run migration:main-token:test` — 32/32 passed
- focused ESLint — passed
- `npm run typecheck` — passed
- `git diff --check` — passed
- gitleaks exact base..head — no leaks
- browser QA: 1440x900 and 390x844, no console errors or horizontal overflow
- local Turbopack build could not run only because this isolated worktree uses an external `node_modules` symlink; hosted CI runs with a normal checkout
