### PR TITLE
Fix migration page first-view actions

### DIFF
--- a/components/main-token-migration.module.css
+++ b/components/main-token-migration.module.css
@@ -18,7 +18,7 @@
   min-height: 100svh;
   min-width: 0;
   overflow-x: clip;
-  padding-bottom: 96px;
+  padding-bottom: 48px;
   position: relative;
 }
 
@@ -26,9 +26,9 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  min-height: calc(100svh - 88px);
-  padding: 80px max(24px, calc((100% - 1280px) / 2)) 96px;
+  justify-content: flex-start;
+  min-height: 0;
+  padding: 16px max(24px, calc((100% - 1280px) / 2)) 12px;
   position: relative;
   text-align: center;
 }
@@ -49,15 +49,14 @@
 
 .loopMark {
   filter: grayscale(1) brightness(0) invert(1);
-  height: 48px;
-  margin-bottom: 24px;
+  height: 24px;
+  margin-bottom: 8px;
   object-fit: contain;
-  width: 38px;
+  width: 19px;
 }
 
 .eyebrow,
-.panelHeader > p,
-.process header > p {
+.panelHeader > p {
   color: var(--webde-dim);
   font-family: var(--font-plex-mono), monospace;
   font-size: 12px;
@@ -72,11 +71,11 @@
   background: linear-gradient(90deg, #fff, #9b9b9b);
   background-clip: text;
   color: transparent;
-  font-size: clamp(48px, 7vw, 96px);
+  font-size: clamp(40px, 5vw, 60px);
   font-weight: 560;
   letter-spacing: -0.045em;
   line-height: 1.08;
-  margin: 24px 0 0;
+  margin: 0;
   max-width: none;
   padding-bottom: 0.08em;
   text-wrap: balance;
@@ -86,16 +85,16 @@
 .chainFlow {
   align-items: center;
   display: flex;
-  gap: clamp(18px, 3vw, 36px);
+  gap: clamp(16px, 2vw, 24px);
   justify-content: center;
-  margin-top: 22px;
+  margin-top: 8px;
 }
 
 .chainName {
   align-items: center;
   color: #fff;
   display: inline-flex;
-  font-size: clamp(18px, 2vw, 24px);
+  font-size: clamp(16px, 1.6vw, 20px);
   font-weight: 600;
   gap: 10px;
   line-height: 1.2;
@@ -103,8 +102,8 @@
 
 .ethereumMark {
   fill: currentColor;
-  height: 30px;
-  width: 19px;
+  height: 24px;
+  width: 15px;
 }
 
 .ethereumMark path:first-child {
@@ -118,27 +117,17 @@
 .chainArrow {
   color: #fff;
   font-family: var(--font-plex-mono), monospace;
-  font-size: clamp(36px, 5vw, 56px);
+  font-size: clamp(30px, 4vw, 40px);
   font-weight: 650;
   line-height: 0.8;
 }
 
 .heroCopy {
   color: var(--webde-muted);
-  font-size: 20px;
-  line-height: 1.5;
-  margin: 32px auto 0;
-  max-width: 680px;
-  text-wrap: pretty;
-}
-
-.criticalCopy {
-  color: #fff;
   font-size: 16px;
-  font-weight: 600;
   line-height: 1.5;
-  margin: 16px auto 0;
-  max-width: 680px;
+  margin: 12px auto 0;
+  max-width: 640px;
   text-wrap: pretty;
 }
 
@@ -147,11 +136,11 @@
   border: 1px solid rgb(255 255 255 / 0.11);
   border-radius: 8px;
   color: var(--webde-muted);
-  font-size: 14px;
+  font-size: 12px;
   line-height: 1.5;
-  margin: 20px auto 0;
+  margin: 8px auto 0;
   max-width: 620px;
-  padding: 12px 16px;
+  padding: 8px 12px;
   text-wrap: pretty;
 }
 
@@ -167,37 +156,37 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  margin-top: 40px;
+  margin-top: 12px;
   min-width: 0;
 }
 
 .countdownLabel,
 .absoluteDeadline {
   color: var(--webde-muted);
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1.45;
 }
 
 .clock {
   align-items: start;
   display: grid;
-  gap: clamp(8px, 2vw, 24px);
+  gap: clamp(8px, 1.5vw, 16px);
   grid-template-columns: 1fr auto 1fr auto 1fr;
-  margin: 16px 0;
+  margin: 6px 0;
 }
 
 .clock > span {
   align-items: center;
   display: flex;
   flex-direction: column;
-  min-width: clamp(68px, 10vw, 128px);
+  min-width: clamp(56px, 7vw, 84px);
 }
 
 .clock strong,
 .clock i {
   color: #fff;
   font-family: var(--font-plex-mono), monospace;
-  font-size: clamp(40px, 6vw, 72px);
+  font-size: clamp(32px, 4vw, 48px);
   font-style: normal;
   font-variant-numeric: tabular-nums;
   font-weight: 500;
@@ -215,14 +204,8 @@
   font-weight: 500;
   letter-spacing: 0.04em;
   line-height: 1.35;
-  margin-top: 8px;
+  margin-top: 4px;
   text-transform: uppercase;
-}
-
-.migrationPanel,
-.process {
-  margin-inline: auto;
-  width: min(calc(100% - 48px), 1120px);
 }
 
 .migrationPanel {
@@ -230,7 +213,9 @@
   border: 1px solid var(--webde-line);
   border-radius: 16px;
   box-shadow: 0 32px 80px rgb(0 0 0 / 0.32);
+  margin-inline: auto;
   overflow: hidden;
+  width: min(calc(100% - 48px), 1180px);
 }
 
 .closedNotice {
@@ -255,50 +240,22 @@
   line-height: 1.5;
 }
 
-.summary {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.summary > div {
-  align-items: flex-start;
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  padding: 24px;
-}
-
-.summary > div + div {
-  border-inline-start: 1px solid var(--webde-line);
-}
-
-.summary span,
 .walletRow span,
-.balanceRow span,
-.transferReview span {
+.balanceRow span {
   color: var(--webde-dim);
   font-size: 13px;
   line-height: 1.4;
 }
 
-.summary strong {
-  color: #fff;
-  font-size: 16px;
-  font-weight: 560;
-  line-height: 1.45;
-  margin-top: 6px;
-}
-
 .panelGrid {
-  border-top: 1px solid var(--webde-line);
   display: grid;
-  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+  grid-template-columns: minmax(0, 1.08fr) minmax(320px, 0.92fr);
 }
 
 .transferColumn,
 .destinationColumn {
   min-width: 0;
-  padding: 48px;
+  padding: 24px;
 }
 
 .destinationColumn {
@@ -306,10 +263,9 @@
   border-inline-start: 1px solid var(--webde-line);
 }
 
-.panelHeader h2,
-.process h2 {
+.panelHeader h2 {
   color: #fff;
-  font-size: 30px;
+  font-size: 24px;
   font-weight: 560;
   letter-spacing: -0.025em;
   line-height: 1.2;
@@ -322,7 +278,7 @@
   color: var(--webde-muted);
   font-size: 16px;
   line-height: 1.55;
-  margin: 32px 0 0;
+  margin: 16px 0 0;
   text-wrap: pretty;
 }
 
@@ -331,7 +287,7 @@
   align-items: center;
   display: flex;
   justify-content: space-between;
-  margin-top: 32px;
+  margin-top: 16px;
   min-height: 24px;
 }
 
@@ -397,7 +353,7 @@
 }
 
 .amountGroup {
-  margin-top: 32px;
+  margin-top: 16px;
 }
 
 .amountGroup > label {
@@ -466,8 +422,7 @@
 
 .amountControl button:active,
 .addressBlock button:active,
-.primaryAction:active,
-.backLink:active {
+.primaryAction:active {
   transform: scale(0.98);
 }
 
@@ -499,7 +454,7 @@
   gap: 12px;
   grid-template-columns: 20px minmax(0, 1fr);
   line-height: 1.5;
-  margin-top: 32px;
+  margin-top: 16px;
   min-height: 44px;
   padding-block: 4px;
 }
@@ -546,69 +501,6 @@
   opacity: 0.55;
 }
 
-.transferReview {
-  background: #131313;
-  border-radius: 8px;
-  display: grid;
-  gap: 12px;
-  margin-top: 32px;
-  padding: 16px;
-}
-
-.transferReview > div {
-  align-items: center;
-  display: flex;
-  gap: 16px;
-  justify-content: space-between;
-}
-
-.transferReview strong {
-  color: #fff;
-  font-size: 14px;
-  font-weight: 560;
-  line-height: 1.4;
-  overflow-wrap: anywhere;
-  text-align: end;
-}
-
-.addressReviewRow {
-  align-items: flex-start !important;
-  flex-direction: column;
-}
-
-.addressReviewRow code {
-  color: #fff;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 12px;
-  line-height: 1.55;
-  overflow-wrap: anywhere;
-  text-align: start;
-}
-
-.destinationUnavailable {
-  background: #101010;
-  border: 1px dashed #343434;
-  border-radius: 8px;
-  display: grid;
-  gap: 6px;
-  margin-top: 32px;
-  padding: 16px;
-}
-
-.destinationUnavailable strong {
-  color: #fff;
-  font-size: 14px;
-  font-weight: 600;
-  line-height: 1.4;
-}
-
-.destinationUnavailable span {
-  color: var(--webde-muted);
-  font-size: 13px;
-  line-height: 1.5;
-  text-wrap: pretty;
-}
-
 .primaryAction {
   background: #fff;
   border: 1px solid #fff;
@@ -617,7 +509,7 @@
   cursor: pointer;
   font-size: 16px;
   font-weight: 650;
-  margin-top: 24px;
+  margin-top: 16px;
   min-height: 52px;
   padding: 12px 16px;
   transition:
@@ -696,8 +588,7 @@
   color: #ffd3d3;
 }
 
-.transactionStatus a,
-.backLink {
+.transactionStatus a {
   color: #fff;
   display: inline-flex;
   font-size: 14px;
@@ -751,8 +642,7 @@
   padding: 16px;
 }
 
-.addressBlock code,
-.contractFacts code {
+.addressBlock code {
   color: #fff;
   display: block;
   font-family: var(--font-plex-mono), monospace;
@@ -782,35 +672,6 @@
   text-align: center;
 }
 
-.contractFacts {
-  margin: 32px 0 0;
-}
-
-.contractFacts > div + div {
-  margin-top: 20px;
-}
-
-.contractFacts dt {
-  color: var(--webde-dim);
-  font-size: 13px;
-  line-height: 1.4;
-}
-
-.contractFacts dd {
-  color: #fff;
-  font-size: 14px;
-  line-height: 1.5;
-  margin: 6px 0 0;
-}
-
-.warning {
-  background: #241c13;
-  border: 1px solid #49351f;
-  border-radius: 8px;
-  margin-top: 32px;
-  padding: 16px;
-}
-
 .closedAddressNote {
   color: var(--webde-muted);
   font-size: 13px;
@@ -818,84 +679,12 @@
   margin: 16px 0 0;
 }
 
-.warning strong {
-  color: #ffe3bb;
-  font-size: 15px;
-}
-
-.warning p {
-  color: #d2b994;
+.manualWarning {
+  color: var(--webde-muted);
   font-size: 13px;
   line-height: 1.5;
-  margin: 10px 0 0;
+  margin: 16px 0 0;
   text-wrap: pretty;
-}
-
-.process {
-  padding-block: 96px 0;
-}
-
-.process header {
-  text-align: center;
-}
-
-.process ol {
-  display: grid;
-  gap: 48px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  list-style: none;
-  margin: 64px 0 0;
-  padding: 0;
-}
-
-.process li {
-  counter-increment: migration-step;
-}
-
-.process ol {
-  counter-reset: migration-step;
-}
-
-.process li::before {
-  color: var(--webde-dim);
-  content: "0" counter(migration-step);
-  display: block;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 13px;
-  line-height: 1.4;
-  margin-bottom: 16px;
-}
-
-.process li strong,
-.process li span {
-  display: block;
-}
-
-.process li strong {
-  color: #fff;
-  font-size: 18px;
-  font-weight: 560;
-  line-height: 1.45;
-}
-
-.process li span,
-.finalNote {
-  color: var(--webde-muted);
-  font-size: 15px;
-  line-height: 1.6;
-  margin-top: 8px;
-  text-wrap: pretty;
-}
-
-.finalNote {
-  margin: 64px auto 0;
-  max-width: 680px;
-  text-align: center;
-}
-
-.backLink {
-  margin: 24px auto 0;
-  width: max-content;
 }
 
 .page :is(button, a, input):focus-visible {
@@ -904,8 +693,12 @@
 }
 
 @keyframes balance-pulse {
-  from { opacity: 0.42; }
-  to { opacity: 0.9; }
+  from {
+    opacity: 0.42;
+  }
+  to {
+    opacity: 0.9;
+  }
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -918,8 +711,7 @@
     background: #e9e9e9;
   }
 
-  .transactionStatus a:hover,
-  .backLink:hover {
+  .transactionStatus a:hover {
     color: var(--webde-muted);
   }
 
@@ -943,19 +735,6 @@
 }
 
 @media (max-width: 56rem) {
-  .summary {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .summary > div:nth-child(3) {
-    border-inline-start: 0;
-    border-top: 1px solid var(--webde-line);
-  }
-
-  .summary > div:nth-child(4) {
-    border-top: 1px solid var(--webde-line);
-  }
-
   .panelGrid {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -963,11 +742,6 @@
   .destinationColumn {
     border-inline-start: 0;
     border-top: 1px solid var(--webde-line);
-  }
-
-  .process ol {
-    gap: 40px;
-    grid-template-columns: minmax(0, 1fr);
   }
 }
 
@@ -978,16 +752,16 @@
 
   .hero {
     min-height: auto;
-    padding: 64px 20px 80px;
+    padding: 12px 16px 8px;
   }
 
   .hero h1 {
-    font-size: clamp(36px, 11vw, 48px);
+    font-size: clamp(36px, 11vw, 44px);
   }
 
   .chainFlow {
     gap: 14px;
-    margin-top: 18px;
+    margin-top: 8px;
   }
 
   .chainName {
@@ -1005,12 +779,12 @@
   }
 
   .heroCopy {
-    font-size: 18px;
-    margin-top: 24px;
+    font-size: 16px;
+    margin-top: 12px;
   }
 
   .countdown {
-    margin-top: 32px;
+    margin-top: 16px;
     width: 100%;
   }
 
@@ -1028,13 +802,8 @@
     font-size: 36px;
   }
 
-  .migrationPanel,
-  .process {
-    width: min(calc(100% - 32px), 1120px);
-  }
-
-  .summary > div {
-    padding: 16px;
+  .migrationPanel {
+    width: min(calc(100% - 24px), 1180px);
   }
 
   .closedNotice {
@@ -1046,7 +815,7 @@
 
   .transferColumn,
   .destinationColumn {
-    padding: 32px 20px;
+    padding: 24px 16px;
   }
 
   .walletRow,
@@ -1067,20 +836,6 @@
   .amountControl > span {
     margin-inline: 8px;
   }
-
-  .transferReview > div {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 4px;
-  }
-
-  .transferReview strong {
-    text-align: start;
-  }
-
-  .process {
-    padding-top: 80px;
-  }
 }
 
 @media (max-width: 22rem) {
@@ -1088,18 +843,7 @@
     padding-inline: 16px;
   }
 
-  .migrationPanel,
-  .process {
+  .migrationPanel {
     width: calc(100% - 24px);
-  }
-
-  .summary {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .summary > div + div,
-  .summary > div:nth-child(3) {
-    border-inline-start: 0;
-    border-top: 1px solid var(--webde-line);
   }
 }

--- a/components/main-token-migration.tsx
+++ b/components/main-token-migration.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Image from "next/image";
-import Link from "next/link";
 import {
   useCallback,
   useEffect,
@@ -36,12 +35,7 @@ const decimalIntegerPattern = /^(?:0|[1-9][0-9]*)$/u;
 const positiveIntegerPattern = /^[1-9][0-9]*$/u;
 const bytes32Pattern = /^0x[0-9a-fA-F]{64}$/u;
 
-type MigrationPhase =
-  | "checking"
-  | "preview"
-  | "upcoming"
-  | "active"
-  | "closed";
+type MigrationPhase = "checking" | "preview" | "upcoming" | "active" | "closed";
 
 type MigrationWindow = Readonly<{
   enabled: boolean;
@@ -87,8 +81,7 @@ const migrationTransferGasReserve = 100_000n;
 const trustedClockMaximumAgeMs = 90_000;
 const trustedClockRequestTimeoutMs = 8_000;
 const migrationTransferSafetyMs = 5 * 60 * 1_000;
-const trustedClockEndpoint =
-  "/api/main-token-migration/window-time" as const;
+const trustedClockEndpoint = "/api/main-token-migration/window-time" as const;
 
 export function hasEnoughMigrationGas(
   nativeBalanceWei: bigint,
@@ -99,11 +92,7 @@ export function hasEnoughMigrationGas(
 }
 
 export type MainTokenGasSponsorshipStatus =
-  | "eligible"
-  | "submitted"
-  | "pending"
-  | "confirmed"
-  | "not_needed";
+  "eligible" | "submitted" | "pending" | "confirmed" | "not_needed";
 
 export type MainTokenGasSponsorshipRequest = Readonly<{
   walletAddress: string;
@@ -155,14 +144,16 @@ export type GasSponsorshipFailure = Readonly<{
 }>;
 
 class GasSponsorshipEndpointError extends Error {
-  constructor(message: string, readonly retryable: boolean) {
+  constructor(
+    message: string,
+    readonly retryable: boolean,
+  ) {
     super(message);
     this.name = "GasSponsorshipEndpointError";
   }
 }
 
-const migrationTransferStorageKey =
-  `programmable:main-token-migration:${MAIN_TOKEN_MIGRATION_WALLET.toLowerCase()}`;
+const migrationTransferStorageKey = `programmable:main-token-migration:${MAIN_TOKEN_MIGRATION_WALLET.toLowerCase()}`;
 const transactionHashPattern = /^0x[0-9a-fA-F]{64}$/u;
 const sponsorshipIntegerPattern = /^(?:0|[1-9][0-9]*)$/u;
 
@@ -211,11 +202,14 @@ export function parseGasSponsorshipResponse(
   const transactionHashIsValid =
     typeof value.transactionHash === "string" &&
     transactionHashPattern.test(value.transactionHash);
-  const statusFieldsAreValid = status === "not_needed"
-    ? value.topUpWei === "0" && value.transactionHash === null
-    : status === "eligible"
-      ? topUpIsInteger && value.topUpWei !== "0" && value.transactionHash === null
-      : topUpIsInteger && value.topUpWei !== "0" && transactionHashIsValid;
+  const statusFieldsAreValid =
+    status === "not_needed"
+      ? value.topUpWei === "0" && value.transactionHash === null
+      : status === "eligible"
+        ? topUpIsInteger &&
+          value.topUpWei !== "0" &&
+          value.transactionHash === null
+        : topUpIsInteger && value.topUpWei !== "0" && transactionHashIsValid;
   if (
     Object.keys(value).sort().join("\0") !== exactKeys.sort().join("\0") ||
     value.schema !== gasSponsorshipSchema ||
@@ -238,7 +232,7 @@ export function parseGasSponsorshipResponse(
     transactionHash:
       value.transactionHash === null
         ? null
-        : (value.transactionHash as string).toLowerCase() as Hex,
+        : ((value.transactionHash as string).toLowerCase() as Hex),
     estimatedTransferGas: value.estimatedTransferGas as string,
   });
 }
@@ -250,18 +244,18 @@ export async function gasSponsorshipFailure(
   let message = "";
   let requestId = "";
   try {
-    const body = await response.json() as {
+    const body = (await response.json()) as {
       error?: unknown;
       message?: unknown;
       requestId?: unknown;
     };
     const nestedError =
       body.error && typeof body.error === "object" && !Array.isArray(body.error)
-        ? body.error as {
+        ? (body.error as {
             code?: unknown;
             message?: unknown;
             requestId?: unknown;
-          }
+          })
         : null;
     const responseMessage =
       typeof body.error === "string"
@@ -270,14 +264,15 @@ export async function gasSponsorshipFailure(
           ? body.message
           : typeof nestedError?.message === "string"
             ? nestedError.message
-          : "";
+            : "";
     code = typeof nestedError?.code === "string" ? nestedError.code : "";
     message = responseMessage.length <= 240 ? responseMessage : "";
     const responseRequestId = nestedError?.requestId ?? body.requestId;
     requestId =
       typeof responseRequestId === "string" &&
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu
-        .test(responseRequestId)
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu.test(
+        responseRequestId,
+      )
         ? responseRequestId
         : "";
   } catch {
@@ -289,17 +284,18 @@ export async function gasSponsorshipFailure(
     "sponsorship_closed",
     "sponsorship_failed",
   ].includes(code);
-  const fallback = response.status === 401 || response.status === 403
-    ? "Reconnect this wallet before requesting sponsored gas."
-    : response.status === 429
-      ? "Gas sponsorship is temporarily rate limited. Wait a moment and try again."
-      : code === "submission_unknown"
-        ? "The gas top-up needs a status review. No second top-up was sent."
-        : code === "sponsorship_closed"
-          ? "Gas sponsorship is closed for this migration window."
-          : code === "sponsorship_failed"
-            ? "The gas top-up could not be confirmed. Contact migration support before trying again."
-            : "Unable to request sponsored gas. Check your connection and try again.";
+  const fallback =
+    response.status === 401 || response.status === 403
+      ? "Reconnect this wallet before requesting sponsored gas."
+      : response.status === 429
+        ? "Gas sponsorship is temporarily rate limited. Wait a moment and try again."
+        : code === "submission_unknown"
+          ? "The gas top-up needs a status review. No second top-up was sent."
+          : code === "sponsorship_closed"
+            ? "Gas sponsorship is closed for this migration window."
+            : code === "sponsorship_failed"
+              ? "The gas top-up could not be confirmed. Contact migration support before trying again."
+              : "Unable to request sponsored gas. Check your connection and try again.";
   const publicMessage = message || fallback;
   return {
     message: requestId
@@ -313,7 +309,10 @@ export async function gasSponsorshipErrorMessage(response: Response) {
   return (await gasSponsorshipFailure(response)).message;
 }
 
-function gasSponsorshipError(error: unknown, account: string): GasSponsorshipState {
+function gasSponsorshipError(
+  error: unknown,
+  account: string,
+): GasSponsorshipState {
   return {
     kind: "error",
     account,
@@ -367,8 +366,7 @@ export function gasSponsorshipDisplayKind(
 
 function gasSponsorshipIdempotencyKey(account: string) {
   const normalizedAccount = getAddress(account).toLowerCase();
-  const storageKey =
-    `programmable:main-token-migration:gas-sponsor:${MAIN_TOKEN_MIGRATION_RELEASE_ID}:${normalizedAccount}`;
+  const storageKey = `programmable:main-token-migration:gas-sponsor:${MAIN_TOKEN_MIGRATION_RELEASE_ID}:${normalizedAccount}`;
   try {
     const stored = window.localStorage.getItem(storageKey);
     if (stored && /^[a-zA-Z0-9:_-]{16,200}$/u.test(stored)) return stored;
@@ -507,20 +505,23 @@ function parseMigrationWindow(): MigrationWindow {
     manifest.startBlockNumber !== null &&
     positiveIntegerPattern.test(manifest.startBlockNumber)
       ? BigInt(manifest.startBlockNumber)
-    : null;
+      : null;
   const startBlockHash =
-    manifest.startBlockHash !== null && bytes32Pattern.test(manifest.startBlockHash)
-      ? manifest.startBlockHash.toLowerCase() as Hex
+    manifest.startBlockHash !== null &&
+    bytes32Pattern.test(manifest.startBlockHash)
+      ? (manifest.startBlockHash.toLowerCase() as Hex)
       : null;
   const exactPolicy =
     manifest.schema === "programmable-main-token-migration-activation/v1" &&
     manifest.releaseId === MAIN_TOKEN_MIGRATION_RELEASE_ID &&
     manifest.sourceChainId === String(MAIN_TOKEN_MIGRATION_CHAIN_ID) &&
-    manifest.sourceTokenAddress.toLowerCase() === MAIN_TOKEN_ADDRESS.toLowerCase() &&
+    manifest.sourceTokenAddress.toLowerCase() ===
+      MAIN_TOKEN_ADDRESS.toLowerCase() &&
     manifest.sourceTokenRuntimeCodeKeccak256.toLowerCase() ===
       MAIN_TOKEN_RUNTIME_CODE_KECCAK256 &&
     manifest.sourceTokenDecimals === String(MAIN_TOKEN_DECIMALS) &&
-    manifest.sourceTokenTotalSupplyRaw === MAIN_TOKEN_TOTAL_SUPPLY_RAW.toString() &&
+    manifest.sourceTokenTotalSupplyRaw ===
+      MAIN_TOKEN_TOTAL_SUPPLY_RAW.toString() &&
     manifest.migrationWallet.toLowerCase() ===
       MAIN_TOKEN_MIGRATION_WALLET.toLowerCase() &&
     manifest.windowDurationSeconds ===
@@ -579,20 +580,18 @@ function transferWindowOpenAt(now: number, uncertaintyMs = 0) {
     migrationWindow.deadlineAt === null ||
     !Number.isFinite(uncertaintyMs) ||
     uncertaintyMs < 0
-  ) return false;
+  )
+    return false;
   return (
     now - uncertaintyMs >= migrationWindow.startAt &&
-    now + uncertaintyMs <
-      migrationWindow.deadlineAt - migrationTransferSafetyMs
+    now + uncertaintyMs < migrationWindow.deadlineAt - migrationTransferSafetyMs
   );
 }
 
 function remainingAt(now: number, phase: MigrationPhase) {
   if (phase === "preview") return MAIN_TOKEN_MIGRATION_WINDOW_SECONDS;
   const target =
-    phase === "upcoming"
-      ? migrationWindow.startAt
-      : migrationWindow.deadlineAt;
+    phase === "upcoming" ? migrationWindow.startAt : migrationWindow.deadlineAt;
   if (target === null) return 0;
   return Math.max(0, Math.ceil((target - now) / 1_000));
 }
@@ -610,11 +609,13 @@ function clockParts(totalSeconds: number) {
 
 function formatUtc(value: number | null) {
   if (value === null) return "Set before activation";
-  return new Intl.DateTimeFormat("en", {
-    dateStyle: "medium",
-    timeStyle: "short",
-    timeZone: "UTC",
-  }).format(value) + " UTC";
+  return (
+    new Intl.DateTimeFormat("en", {
+      dateStyle: "medium",
+      timeStyle: "short",
+      timeZone: "UTC",
+    }).format(value) + " UTC"
+  );
 }
 
 function shortenAddress(address: string) {
@@ -637,10 +638,16 @@ function migrationErrorMessage(error: unknown) {
   if (/rejected|denied|cancelled|canceled/u.test(message.toLowerCase())) {
     return "Wallet request rejected. No tokens were sent.";
   }
-  return message || "Unable to prepare the transfer. Check your wallet and try again.";
+  return (
+    message ||
+    "Unable to prepare the transfer. Check your wallet and try again."
+  );
 }
 
-function Countdown({ phase, remaining }: Readonly<{
+function Countdown({
+  phase,
+  remaining,
+}: Readonly<{
   phase: MigrationPhase;
   remaining: number | null;
 }>) {
@@ -649,12 +656,12 @@ function Countdown({ phase, remaining }: Readonly<{
     phase === "checking"
       ? "Checking migration window"
       : phase === "closed"
-      ? "Migration closed"
-      : phase === "upcoming"
-        ? "Migration opens in"
-        : phase === "preview"
-          ? "Planned migration window"
-          : "Migration closes in";
+        ? "Migration closed"
+        : phase === "upcoming"
+          ? "Migration opens in"
+          : phase === "preview"
+            ? "Planned migration window"
+            : "Migration closes in";
 
   return (
     <div
@@ -667,22 +674,31 @@ function Countdown({ phase, remaining }: Readonly<{
     >
       <span className={styles.countdownLabel}>{label}</span>
       <div className={styles.clock} aria-hidden="true">
-        <span><strong>{parts?.hours ?? "––"}</strong><small>Hours</small></span>
+        <span>
+          <strong>{parts?.hours ?? "––"}</strong>
+          <small>Hours</small>
+        </span>
         <i>:</i>
-        <span><strong>{parts?.minutes ?? "––"}</strong><small>Minutes</small></span>
+        <span>
+          <strong>{parts?.minutes ?? "––"}</strong>
+          <small>Minutes</small>
+        </span>
         <i>:</i>
-        <span><strong>{parts?.seconds ?? "––"}</strong><small>Seconds</small></span>
+        <span>
+          <strong>{parts?.seconds ?? "––"}</strong>
+          <small>Seconds</small>
+        </span>
       </div>
       <span className={styles.absoluteDeadline}>
         {phase === "checking"
           ? "Verifying the published UTC window"
           : phase === "preview"
-          ? "96-hour transfer window"
-          : `${phase === "upcoming" ? "Opens" : "Closes"} ${formatUtc(
-              phase === "upcoming"
-                ? migrationWindow.startAt
-                : migrationWindow.deadlineAt,
-            )}`}
+            ? "96-hour transfer window"
+            : `${phase === "upcoming" ? "Opens" : "Closes"} ${formatUtc(
+                phase === "upcoming"
+                  ? migrationWindow.startAt
+                  : migrationWindow.deadlineAt,
+              )}`}
       </span>
     </div>
   );
@@ -715,9 +731,12 @@ export function MainTokenMigration() {
   const [copyStatus, setCopyStatus] = useState("");
   const [clockIssue, setClockIssue] = useState("");
   const [confirmationIssue, setConfirmationIssue] = useState("");
-  const [submission, setSubmission] = useState<SubmissionState>({ kind: "idle" });
-  const [gasSponsorship, setGasSponsorship] =
-    useState<GasSponsorshipState>({ kind: "idle" });
+  const [submission, setSubmission] = useState<SubmissionState>({
+    kind: "idle",
+  });
+  const [gasSponsorship, setGasSponsorship] = useState<GasSponsorshipState>({
+    kind: "idle",
+  });
   const [accountCodeObservation, setAccountCodeObservation] =
     useState<AccountCodeObservation | null>(null);
   const amountInputRef = useRef<HTMLInputElement>(null);
@@ -749,16 +768,16 @@ export function MainTokenMigration() {
   }, []);
 
   const phase = now === null ? "checking" : phaseAt(now);
-  const remaining = now === null
-    ? null
-    : remainingAt(now, phase);
-  const onMainnet = wallet !== null &&
+  const remaining = now === null ? null : remainingAt(now, phase);
+  const onMainnet =
+    wallet !== null &&
     normalizeChainId(wallet.chainId) === MAIN_TOKEN_MIGRATION_CHAIN_ID;
-  const accountCodeStatus = !wallet || !onMainnet
-    ? "idle"
-    : accountCodeObservation?.account === wallet.account.toLowerCase()
-      ? accountCodeObservation.status
-      : "checking";
+  const accountCodeStatus =
+    !wallet || !onMainnet
+      ? "idle"
+      : accountCodeObservation?.account === wallet.account.toLowerCase()
+        ? accountCodeObservation.status
+        : "checking";
   const hasTrackedTransfer =
     submission.kind === "submitted" || submission.kind === "confirmed";
   const transferWindowOpen =
@@ -767,10 +786,6 @@ export function MainTokenMigration() {
     transferWindowOpenAt(now, clockUncertaintyMs);
   const canRevealDestination = transferWindowOpen || hasTrackedTransfer;
   const canCopyDestination = transferWindowOpen;
-  const transferSender =
-    submission.kind === "submitted" || submission.kind === "confirmed"
-    ? submission.account
-    : wallet?.account ?? null;
   const connectedAccount = wallet?.account.toLowerCase() ?? null;
   const hasEnoughObservedGas =
     nativeBalance !== null &&
@@ -847,7 +862,7 @@ export function MainTokenMigration() {
           headers: { accept: "application/json" },
           signal: controller.signal,
         });
-        const body = await response.json() as Record<string, unknown>;
+        const body = (await response.json()) as Record<string, unknown>;
         const requestFinishedAt = performance.now();
         if (
           !response.ok ||
@@ -967,38 +982,43 @@ export function MainTokenMigration() {
     return () => window.clearTimeout(pendingRefresh);
   }, [refreshBalance]);
 
-  const readGasSponsorship = useCallback(async (
-    account: string,
-    signal: AbortSignal,
-  ): Promise<GasSponsorshipEndpointResult> => {
-    const accessToken = await getAccessToken();
-    if (!accessToken) {
-      throw new GasSponsorshipEndpointError(
-        "Reconnect this wallet before requesting sponsored gas.",
-        true,
-      );
-    }
-    const search = new URLSearchParams({ walletAddress: getAddress(account) });
-    const response = await fetch(`${gasSponsorshipEndpoint}?${search}`, {
-      cache: "no-store",
-      headers: {
-        Accept: "application/json",
-        Authorization: `Bearer ${accessToken}`,
-      },
-      signal,
-    });
-    if (!response.ok) {
-      const failure = await gasSponsorshipFailure(response);
-      throw new GasSponsorshipEndpointError(
-        failure.message,
-        failure.retryable,
-      );
-    }
-    return {
-      body: parseGasSponsorshipResponse(await response.json(), account),
-      retryAfterMs: sponsorshipRetryAfterMs(response),
-    };
-  }, [getAccessToken]);
+  const readGasSponsorship = useCallback(
+    async (
+      account: string,
+      signal: AbortSignal,
+    ): Promise<GasSponsorshipEndpointResult> => {
+      const accessToken = await getAccessToken();
+      if (!accessToken) {
+        throw new GasSponsorshipEndpointError(
+          "Reconnect this wallet before requesting sponsored gas.",
+          true,
+        );
+      }
+      const search = new URLSearchParams({
+        walletAddress: getAddress(account),
+      });
+      const response = await fetch(`${gasSponsorshipEndpoint}?${search}`, {
+        cache: "no-store",
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+        signal,
+      });
+      if (!response.ok) {
+        const failure = await gasSponsorshipFailure(response);
+        throw new GasSponsorshipEndpointError(
+          failure.message,
+          failure.retryable,
+        );
+      }
+      return {
+        body: parseGasSponsorshipResponse(await response.json(), account),
+        retryAfterMs: sponsorshipRetryAfterMs(response),
+      };
+    },
+    [getAccessToken],
+  );
 
   useEffect(() => {
     if (
@@ -1093,7 +1113,10 @@ export function MainTokenMigration() {
           result.body.status === "submitted" ||
           result.body.status === "pending"
         ) {
-          retryTimer = window.setTimeout(() => void poll(), result.retryAfterMs);
+          retryTimer = window.setTimeout(
+            () => void poll(),
+            result.retryAfterMs,
+          );
         }
       } catch (error) {
         if (controller.signal.aborted) return;
@@ -1347,7 +1370,10 @@ export function MainTokenMigration() {
           failure.retryable,
         );
       }
-      const result = parseGasSponsorshipResponse(await response.json(), account);
+      const result = parseGasSponsorshipResponse(
+        await response.json(),
+        account,
+      );
       setGasSponsorship(gasSponsorshipState(result));
       if (result.status === "confirmed" || result.status === "not_needed") {
         void refreshBalance();
@@ -1363,7 +1389,8 @@ export function MainTokenMigration() {
     if (!wallet || !onMainnet) {
       setSubmission({
         kind: "error",
-        message: "Connect this wallet on Ethereum before checking sponsored gas.",
+        message:
+          "Connect this wallet on Ethereum before checking sponsored gas.",
       });
       return;
     }
@@ -1537,57 +1564,60 @@ export function MainTokenMigration() {
     }
   }
 
-  const primaryLabel = phase === "checking"
-    ? "Checking migration window"
-    : phase === "preview"
-      ? "Migration not open"
-      : phase === "upcoming"
-        ? "Migration opens soon"
-        : phase === "closed"
-    ? "Migration closed"
-    : !transferWindowOpen
-      ? "New transfers closed"
-    : submission.kind === "submitted"
-      ? "Waiting for Ethereum confirmation"
-      : submission.kind === "confirmed"
-        ? "Transfer confirmed"
-    : !wallet
-    ? connecting
-      ? "Opening wallet"
-      : "Connect wallet"
-    : !onMainnet
-      ? switchingNetwork
-        ? "Switching network"
-        : "Switch to Ethereum"
-      : submission.kind === "submitting"
-        ? "Confirm in your wallet"
-        : accountCodeStatus === "checking"
-          ? "Checking wallet type"
-          : accountCodeStatus === "contract"
-            ? "Manual review required"
-            : !amount.trim()
-              ? "Enter amount"
-              : amountError
-                ? "Check amount"
-                : balance === null
-                  ? "Balance unavailable"
-                  : !acknowledged
-                    ? "Confirm address control"
-                    : !sponsoredGasReady
-                      ? sponsorshipKind === "eligible"
-                        ? "Request sponsored gas first"
-                        : sponsorshipKind === "requesting"
-                          ? "Requesting sponsored gas"
-                          : sponsorshipKind === "requested" ||
-                              sponsorshipKind === "funding-confirming" ||
-                              sponsorshipKind === "balance-confirming"
-                            ? "Waiting for sponsored gas"
-                            : sponsorshipKind === "error"
-                              ? terminalSponsorshipFailure
-                                ? "Check ETH and continue"
-                                : "Check gas sponsorship"
-                              : "Checking gas balance"
-                    : "Review transfer in wallet";
+  const primaryLabel =
+    phase === "checking"
+      ? "Checking migration window"
+      : phase === "preview"
+        ? "Migration not open"
+        : phase === "upcoming"
+          ? "Migration opens soon"
+          : phase === "closed"
+            ? "Migration closed"
+            : !transferWindowOpen
+              ? "New transfers closed"
+              : submission.kind === "submitted"
+                ? "Waiting for Ethereum confirmation"
+                : submission.kind === "confirmed"
+                  ? "Transfer confirmed"
+                  : !wallet
+                    ? connecting
+                      ? "Opening wallet"
+                      : "Connect wallet"
+                    : !onMainnet
+                      ? switchingNetwork
+                        ? "Switching network"
+                        : "Switch to Ethereum"
+                      : submission.kind === "submitting"
+                        ? "Confirm in your wallet"
+                        : accountCodeStatus === "checking"
+                          ? "Checking wallet type"
+                          : accountCodeStatus === "contract"
+                            ? "Use manual transfer"
+                            : !amount.trim()
+                              ? "Enter amount"
+                              : amountError
+                                ? "Check amount"
+                                : balance === null
+                                  ? "Balance unavailable"
+                                  : !acknowledged
+                                    ? "Confirm address control"
+                                    : !sponsoredGasReady
+                                      ? sponsorshipKind === "eligible"
+                                        ? "Request sponsored gas first"
+                                        : sponsorshipKind === "requesting"
+                                          ? "Requesting sponsored gas"
+                                          : sponsorshipKind === "requested" ||
+                                              sponsorshipKind ===
+                                                "funding-confirming" ||
+                                              sponsorshipKind ===
+                                                "balance-confirming"
+                                            ? "Waiting for sponsored gas"
+                                            : sponsorshipKind === "error"
+                                              ? terminalSponsorshipFailure
+                                                ? "Check ETH and continue"
+                                                : "Check gas sponsorship"
+                                              : "Checking gas balance"
+                                      : "Review transfer in wallet";
 
   return (
     <article className={styles.page}>
@@ -1617,20 +1647,20 @@ export function MainTokenMigration() {
             </svg>
             Ethereum
           </span>
-          <span className={styles.chainArrow} aria-hidden="true">→</span>
+          <span className={styles.chainArrow} aria-hidden="true">
+            →
+          </span>
           <span className={styles.chainName}>Robinhood</span>
         </div>
         <Countdown phase={phase} remaining={remaining} />
         {clockIssue ? (
-          <p className={styles.clockIssue} role="status">{clockIssue}</p>
+          <p className={styles.clockIssue} role="status">
+            {clockIssue}
+          </p>
         ) : null}
         <p className={styles.heroCopy}>
-          Send your V4 during the 96-hour window. You get the same number of V4
-          tokens sent to the same wallet when V4 launches on Robinhood.
-        </p>
-        <p className={styles.criticalCopy}>
-          V4 launched with a total supply of 1 billion on Ethereum. V4 on
-          Robinhood will also have a total supply of 1 billion.
+          Send V4 during the active window. The same token amount will be sent
+          to the same wallet on Robinhood.
         </p>
         <p className={styles.officialNotice}>
           Use only <strong>programmable.market/migration</strong>. Programmable
@@ -1638,7 +1668,10 @@ export function MainTokenMigration() {
         </p>
       </section>
 
-      <section className={styles.migrationPanel} aria-labelledby="send-v4-title">
+      <section
+        className={styles.migrationPanel}
+        aria-labelledby="send-v4-title"
+      >
         {phase === "closed" ? (
           <div className={styles.closedNotice} role="alert">
             <strong>Migration closed</strong>
@@ -1648,18 +1681,11 @@ export function MainTokenMigration() {
             </span>
           </div>
         ) : null}
-        <div className={styles.summary} aria-label="Migration terms">
-          <div><span>Window</span><strong>96 hours</strong></div>
-          <div><span>You receive</span><strong>The same V4 amount</strong></div>
-          <div><span>Robinhood wallet</span><strong>The same address</strong></div>
-          <div><span>Total supply</span><strong>1 billion V4</strong></div>
-        </div>
-
         <div className={styles.panelGrid}>
           <div className={styles.transferColumn}>
             <header className={styles.panelHeader}>
-              <p>Send with your wallet</p>
-              <h2 id="send-v4-title">Send V4 for migration</h2>
+              <p>Wallet transfer</p>
+              <h2 id="send-v4-title">Connect wallet and send V4</h2>
             </header>
 
             {wallet ? (
@@ -1669,40 +1695,26 @@ export function MainTokenMigration() {
               </div>
             ) : (
               <p className={styles.connectPrompt}>
-                Connect the wallet that holds your V4.
+                Connect the Ethereum wallet that holds your V4.
               </p>
             )}
 
-            {wallet && onMainnet ? (
-              <div
-                className={styles.walletTypeStatus}
-                data-status={accountCodeStatus}
-                role="status"
+            {!wallet ? (
+              <button
+                className={styles.primaryAction}
+                type="button"
+                onClick={() => void reviewTransfer()}
+                disabled={!transferWindowOpen || connecting}
               >
-                <strong>
-                  {accountCodeStatus === "eoa"
-                    ? "Wallet ready"
-                    : accountCodeStatus === "contract"
-                      ? "Smart-contract wallet detected"
-                      : accountCodeStatus === "unavailable"
-                        ? "Wallet type unavailable"
-                        : "Checking wallet type"}
-                </strong>
-                <span>
-                  {accountCodeStatus === "eoa"
-                    ? "This address can use the automatic migration path. It is checked again before sending."
-                    : accountCodeStatus === "contract"
-                      ? "Do not send. Multisigs and smart-contract wallets require manual review and are not guaranteed an automatic allocation."
-                      : accountCodeStatus === "unavailable"
-                        ? "The automatic path remains blocked until the wallet type can be checked."
-                        : "Checking whether this address can use the automatic migration path."}
-                </span>
-              </div>
+                {primaryLabel}
+              </button>
             ) : null}
 
             <div className={styles.balanceRow} aria-live="polite">
               <span>Available balance</span>
-              <strong className={balanceLoading ? styles.balanceLoading : undefined}>
+              <strong
+                className={balanceLoading ? styles.balanceLoading : undefined}
+              >
                 {balanceLoading
                   ? "Reading balance"
                   : balance === null
@@ -1710,7 +1722,9 @@ export function MainTokenMigration() {
                     : `${formatTokenAmount(balance)} ${MAIN_TOKEN_SYMBOL}`}
               </strong>
             </div>
-            {balanceError ? <p className={styles.inlineError}>{balanceError}</p> : null}
+            {balanceError ? (
+              <p className={styles.inlineError}>{balanceError}</p>
+            ) : null}
 
             <div className={styles.amountGroup}>
               <label htmlFor="migration-amount">Amount to send</label>
@@ -1726,6 +1740,7 @@ export function MainTokenMigration() {
                   value={amount}
                   onChange={onAmountChange}
                   disabled={
+                    !wallet ||
                     !transferWindowOpen ||
                     hasTrackedTransfer ||
                     submission.kind === "submitting"
@@ -1754,8 +1769,7 @@ export function MainTokenMigration() {
                 </button>
               </div>
               <p id="migration-amount-help">
-                Max selects your full V4 balance. If this wallet needs ETH for
-                gas, a one-time sponsorship option appears below.
+                Max selects the full V4 balance in your connected wallet.
               </p>
               {amountError ? (
                 <p className={styles.inlineError} id="migration-amount-error">
@@ -1808,8 +1822,8 @@ export function MainTokenMigration() {
                     <strong>Sponsored gas available</strong>
                     <span>
                       This wallet needs ETH for gas. Request a one-time top-up,
-                      wait for confirmation, then sign the normal V4 transfer
-                      in your wallet.
+                      wait for confirmation, then sign the normal V4 transfer in
+                      your wallet.
                     </span>
                     <button
                       ref={sponsorButtonRef}
@@ -1838,8 +1852,8 @@ export function MainTokenMigration() {
                   >
                     <strong>Gas top-up requested</strong>
                     <p>
-                      The sponsor transaction was submitted. Your V4 remains
-                      in this wallet while Ethereum confirms the top-up.
+                      The sponsor transaction was submitted. Your V4 remains in
+                      this wallet while Ethereum confirms the top-up.
                     </p>
                     {sponsorshipTransactionHash ? (
                       <a
@@ -1935,87 +1949,62 @@ export function MainTokenMigration() {
               </div>
             ) : null}
 
-            <label className={styles.acknowledgement}>
-              <input
-                ref={acknowledgementRef}
-                type="checkbox"
-                checked={acknowledged}
-                onChange={(event) => setAcknowledged(event.target.checked)}
+            {wallet ? (
+              <label className={styles.acknowledgement}>
+                <input
+                  ref={acknowledgementRef}
+                  type="checkbox"
+                  checked={acknowledged}
+                  onChange={(event) => setAcknowledged(event.target.checked)}
+                  disabled={
+                    !transferWindowOpen ||
+                    hasTrackedTransfer ||
+                    submission.kind === "submitting"
+                  }
+                />
+                <span>
+                  I control this wallet on Ethereum and will use the same
+                  address on Robinhood. I understand the allocation cannot be
+                  redirected.
+                </span>
+              </label>
+            ) : null}
+
+            {wallet ? (
+              <button
+                className={styles.primaryAction}
+                type="button"
+                onClick={() => void reviewTransfer()}
                 disabled={
                   !transferWindowOpen ||
+                  connecting ||
+                  switchingNetwork ||
+                  submission.kind === "submitting" ||
                   hasTrackedTransfer ||
-                  submission.kind === "submitting"
+                  accountCodeStatus === "checking" ||
+                  accountCodeStatus === "contract"
                 }
-              />
-              <span>
-                I control this wallet on Ethereum and will use the same address
-                on Robinhood. I understand the allocation cannot be redirected.
-              </span>
-            </label>
-
-            {canRevealDestination ? (
-              <div className={styles.transferReview}>
-                <div>
-                  <span>From</span>
-                  <strong>
-                    {transferSender
-                      ? shortenAddress(transferSender)
-                      : "Connected sender"}
-                  </strong>
-                </div>
-                <div className={styles.addressReviewRow}>
-                  <span>Ethereum recipient</span>
-                  <code>{MAIN_TOKEN_MIGRATION_WALLET}</code>
-                </div>
-                <div>
-                  <span>You send</span>
-                  <strong>{parsedAmount === null ? "Enter amount" : `${formatUnits(parsedAmount, MAIN_TOKEN_DECIMALS)} ${MAIN_TOKEN_SYMBOL}`}</strong>
-                </div>
-                <div>
-                  <span>Robinhood allocation</span>
-                  <strong>{parsedAmount === null ? "1:1 V4 amount" : `${formatUnits(parsedAmount, MAIN_TOKEN_DECIMALS)} ${MAIN_TOKEN_SYMBOL}`}</strong>
-                </div>
-              </div>
-            ) : (
-              <div className={styles.destinationUnavailable}>
-                <strong>Transfer destination is not available yet</strong>
-                <span>
-                  The full migration wallet appears here only while the
-                  published window is active. Do not use an address from a DM.
-                </span>
-              </div>
-            )}
-
-            <button
-              className={styles.primaryAction}
-              type="button"
-              onClick={() => void reviewTransfer()}
-              disabled={
-                !transferWindowOpen ||
-                connecting ||
-                switchingNetwork ||
-                submission.kind === "submitting" ||
-                hasTrackedTransfer ||
-                accountCodeStatus === "checking" ||
-                accountCodeStatus === "contract"
-              }
-            >
-              {primaryLabel}
-            </button>
+              >
+                {primaryLabel}
+              </button>
+            ) : null}
             <p className={styles.walletBoundary}>
-              This is an irreversible ERC-20 transfer on Ethereum, not a
-              bridge. Nothing is sent until you confirm the transfer in your wallet.
-              The optional gas sponsor only sends ETH to this wallet and never
-              initiates the V4 transfer. Verify the network, V4 token contract,
-              full recipient and amount.
+              Nothing is sent until you approve the V4 transfer in your wallet.
             </p>
 
-            <div className={styles.status} role="status" aria-live="polite" aria-atomic="true">
+            <div
+              className={styles.status}
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            >
               {submission.kind === "error" ? (
                 <p className={styles.inlineError}>{submission.message}</p>
               ) : null}
               {submission.kind === "submitted" ? (
-                <div className={`${styles.transactionStatus} ${styles.pendingStatus}`}>
+                <div
+                  className={`${styles.transactionStatus} ${styles.pendingStatus}`}
+                >
                   <strong>Transaction submitted — not confirmed</strong>
                   <p>
                     Waiting for Ethereum confirmation. Do not send again. The
@@ -2032,13 +2021,15 @@ export function MainTokenMigration() {
                 </div>
               ) : null}
               {submission.kind === "confirmed" ? (
-                <div className={`${styles.transactionStatus} ${styles.confirmedStatus}`}>
+                <div
+                  className={`${styles.transactionStatus} ${styles.confirmedStatus}`}
+                >
                   <strong>Wallet transaction confirmed on Ethereum</strong>
                   <p>
-                    The transaction was confirmed in block {submission.blockNumber}.
-                    After the window closes, we will verify the transfer,
-                    amount, sender, recipient and block timestamp before the
-                    Robinhood allocation is sent.
+                    The transaction was confirmed in block{" "}
+                    {submission.blockNumber}. After the window closes, we will
+                    verify the transfer, amount, sender, recipient and block
+                    timestamp before the Robinhood allocation is sent.
                   </p>
                   <a
                     href={`https://etherscan.io/tx/${submission.hash}`}
@@ -2059,7 +2050,9 @@ export function MainTokenMigration() {
                 </div>
               ) : null}
               {submission.kind === "reverted" ? (
-                <div className={`${styles.transactionStatus} ${styles.revertedStatus}`}>
+                <div
+                  className={`${styles.transactionStatus} ${styles.revertedStatus}`}
+                >
                   <strong>Transaction reverted</strong>
                   <p>
                     No V4 was transferred. Review the transaction before trying
@@ -2080,18 +2073,17 @@ export function MainTokenMigration() {
             </div>
           </div>
 
-          <aside className={styles.destinationColumn} aria-labelledby="migration-wallet-title">
+          <aside
+            className={styles.destinationColumn}
+            aria-labelledby="migration-wallet-title"
+          >
             <header className={styles.panelHeader}>
-              <p>Fixed destination</p>
-              <h2 id="migration-wallet-title">Migration wallet</h2>
+              <p>Manual transfer</p>
+              <h2 id="migration-wallet-title">Send V4 directly</h2>
             </header>
-            <>
-              <p>
-                Send only V4 from the wallet that should receive the Robinhood
-                allocation. This address is fixed for the migration.
-              </p>
-              {canRevealDestination ? (
-                <>
+            <p>Prefer not to connect? Send V4 directly to this address.</p>
+            {canRevealDestination ? (
+              <>
                 <div className={styles.addressBlock}>
                   <code>{MAIN_TOKEN_MIGRATION_WALLET}</code>
                   <button
@@ -2105,69 +2097,19 @@ export function MainTokenMigration() {
                     {copyStatus}
                   </p>
                 </div>
-                <dl className={styles.contractFacts}>
-                  <div>
-                    <dt>Eligible token contract</dt>
-                    <dd><code>{MAIN_TOKEN_ADDRESS}</code></dd>
-                  </div>
-                  <div>
-                    <dt>Network</dt>
-                    <dd>Ethereum Mainnet</dd>
-                  </div>
-                  <div>
-                    <dt>Allocation identity</dt>
-                    <dd>Ethereum Transfer event sender</dd>
-                  </div>
-                  <div>
-                    <dt>Eligibility cutoff</dt>
-                    <dd>
-                      Ethereum block timestamp at or after opening and before
-                      the deadline
-                    </dd>
-                  </div>
-                </dl>
-                <div className={styles.warning}>
-                  <strong>Before you send</strong>
-                  <p>Do not send ETH or another token.</p>
-                  <p>
-                    Do not send from an exchange, custodian or router. The
-                    Transfer event sender would receive the record, not your
-                    wallet.
-                  </p>
-                  <p>
-                    Multisigs and smart-contract wallets require manual review
-                    and have no automatic allocation guarantee.
-                  </p>
-                </div>
-                </>
-              ) : (
-                <p className={styles.closedAddressNote}>
-                  The address and copy action unlock only during the published
-                  96-hour window. Do not send before it opens or after it closes.
+                <p className={styles.manualWarning}>
+                  Send only V4 from the wallet that should receive the Robinhood
+                  allocation. Do not send ETH or use an exchange or router.
                 </p>
-              )}
-            </>
+              </>
+            ) : (
+              <p className={styles.closedAddressNote}>
+                The migration address is available only while the window is
+                active.
+              </p>
+            )}
           </aside>
         </div>
-      </section>
-
-      <section className={styles.process} aria-labelledby="migration-process-title">
-        <header>
-          <p>One address. One allocation.</p>
-          <h2 id="migration-process-title">How it works</h2>
-        </header>
-        <ol>
-          <li><strong>Send while active</strong><span>If needed, request sponsored gas first. Then transfer V4 directly from your wallet during the published window.</span></li>
-          <li><strong>Confirm on Ethereum</strong><span>Only confirmed transfers inside the window can enter the migration list.</span></li>
-          <li><strong>We verify the list</strong><span>After 96 hours, confirmed amounts are totaled by exact sender address before the Robinhood allocation is sent.</span></li>
-        </ol>
-        <p className={styles.finalNote}>
-          Your Robinhood allocation matches the exact V4 token amount recorded
-          from your Ethereum wallet.
-        </p>
-        <Link className={styles.backLink} href="/">
-          Back to Programmable
-        </Link>
       </section>
     </article>
   );

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -22,14 +22,14 @@ import {
   NavigationMenuIcon,
 } from "@/components/navigation-icons";
 import { useViewChain, type ViewChainId } from "@/components/view-chain";
-import { isRobinhoodUnavailableRoute } from
-  "@/components/view-chain-unavailable";
+import { isRobinhoodUnavailableRoute } from "@/components/view-chain-unavailable";
 import { useWallet } from "@/components/wallet-provider";
 import styles from "@/components/site-navigation.module.css";
 
 const desktopNavItems = [
   { href: "/explore", label: "Explore" },
   { href: "/launch", label: "Create" },
+  { href: "/migration", label: "Migrate" },
   { href: "/docs", label: "Docs" },
   { href: "/developers/api-keys", label: "API keys" },
   { href: "/profile", label: "Profile" },
@@ -51,9 +51,7 @@ function HeaderSocialLinks({ mobile = false }: { mobile?: boolean }) {
   return (
     <div
       className={
-        mobile
-          ? styles.mobileSocials
-          : `header-socials ${styles.headerSocials}`
+        mobile ? styles.mobileSocials : `header-socials ${styles.headerSocials}`
       }
       role="group"
       aria-label="Programmable social links"
@@ -242,10 +240,7 @@ function isCurrent(pathname: string, item: (typeof desktopNavItems)[number]) {
   const activePath = "activePath" in item ? item.activePath : item.href;
 
   if (activePath === "/explore") {
-    return (
-      pathname === "/explore" ||
-      pathname.startsWith("/explore/")
-    );
+    return pathname === "/explore" || pathname.startsWith("/explore/");
   }
   if (activePath === "/docs") {
     return pathname === "/docs" || pathname.startsWith("/docs/");
@@ -302,7 +297,11 @@ function ViewChainMark({ viewChainId }: { viewChainId: ViewChainId }) {
         fill="currentColor"
         opacity="0.72"
       />
-      <path d="m12 9.25-6.5 2.95L12 15.9l6.5-3.7L12 9.25Z" fill="currentColor" opacity="0.9" />
+      <path
+        d="m12 9.25-6.5 2.95L12 15.9l6.5-3.7L12 9.25Z"
+        fill="currentColor"
+        opacity="0.9"
+      />
     </svg>
   );
 }
@@ -366,7 +365,9 @@ function HeaderChainSelector({
         aria-expanded={open}
         aria-busy={!hydrated || undefined}
         aria-label={
-          hydrated ? `Viewing ${currentLabel}. Change network` : "Loading network"
+          hydrated
+            ? `Viewing ${currentLabel}. Change network`
+            : "Loading network"
         }
         disabled={!hydrated}
         title={hydrated ? currentLabel : undefined}
@@ -574,10 +575,7 @@ export function SiteHeader() {
         aria-hidden={!menuOpen}
         inert={menuOpen ? undefined : true}
       >
-        <div
-          className={styles.mobileSheetSurface}
-          id={menuId}
-        >
+        <div className={styles.mobileSheetSurface} id={menuId}>
           <HeaderAccountAction
             menuOpen={menuOpen}
             onConnect={() => setMenuPath(null)}

--- a/tests/interaction-accessibility.test.ts
+++ b/tests/interaction-accessibility.test.ts
@@ -25,7 +25,7 @@ describe("interaction accessibility", () => {
     expect(chartSource).toContain("onKeyDown={inspectKeyboard}");
     expect(chartSource).toContain('role="group"');
     expect(chartSource).toContain("tabIndex={0}");
-    expect(chartSource).not.toContain("role=\"slider\"");
+    expect(chartSource).not.toContain('role="slider"');
   });
 
   it("keeps primary token interactions at a reliable touch size", () => {
@@ -44,9 +44,7 @@ describe("interaction accessibility", () => {
 
     expect(tokenCss).toMatch(/\.back\s*\{[^}]*min-height:\s*44px;/s);
     expect(tokenCss).toMatch(/\.address\s*\{[^}]*min-height:\s*44px;/s);
-    expect(tokenCss).toMatch(
-      /\.slippageControl\s*\{[^}]*min-height:\s*44px;/s,
-    );
+    expect(tokenCss).toMatch(/\.slippageControl\s*\{[^}]*min-height:\s*44px;/s);
     expect(tokenCss).toMatch(
       /\.slippageControl input\s*\{[^}]*min-height:\s*44px;/s,
     );
@@ -54,14 +52,14 @@ describe("interaction accessibility", () => {
       /\.rangeButton\s*\{[^}]*height:\s*44px;[^}]*min-width:\s*44px;/s,
     );
     expect(tokenSource).toContain(
-      '<section\n      className={styles.tradeForm}',
+      "<section\n      className={styles.tradeForm}",
     );
     expect(tokenSource).toContain(
-      'className={`${styles.links} ${styles.addressLinks}`}',
+      "className={`${styles.links} ${styles.addressLinks}`}",
     );
-    expect(tokenSource).toContain('aria-label={`${token.name} links`}');
+    expect(tokenSource).toContain("aria-label={`${token.name} links`}");
     expect(tokenSource).toContain(
-      '<nav className={styles.links} aria-label={`${project.name} links`}>',
+      "<nav className={styles.links} aria-label={`${project.name} links`}>",
     );
   });
 
@@ -193,7 +191,9 @@ describe("interaction accessibility", () => {
     );
 
     expect(source).toContain("onBlur={closeOnFocusLeave}");
-    expect(source).toContain("event.currentTarget.contains(event.relatedTarget)");
+    expect(source).toContain(
+      "event.currentTarget.contains(event.relatedTarget)",
+    );
     expect(source).toContain("header.contains(document.activeElement)");
     expect(source).not.toContain(
       '.querySelector<HTMLElement>("a, button:not(:disabled)")',
@@ -258,15 +258,14 @@ describe("interaction accessibility", () => {
       return segments;
     });
 
-    expect(source).toContain('const mobileNavItems = desktopNavItems;');
+    expect(source).toContain("const mobileNavItems = desktopNavItems;");
     expect(source).toContain('{ href: "/profile", label: "Profile" },');
-    expect(source).not.toContain('/hookathon');
+    expect(source).toContain('{ href: "/migration", label: "Migrate" },');
+    expect(source).not.toContain("/hookathon");
     expect(source).toContain(
       '<nav className="mobile-nav" aria-label="Primary navigation">',
     );
-    expect(source).toContain(
-      'aria-current={current ? "page" : undefined}',
-    );
+    expect(source).toContain('aria-current={current ? "page" : undefined}');
     expect(source).not.toContain('<Icon aria-hidden="true"');
     expect(source).toContain("<span>{item.label}</span>");
     expect(mobileMediaSegments).toEqual(

--- a/tests/main-token-migration.test.ts
+++ b/tests/main-token-migration.test.ts
@@ -88,16 +88,10 @@ describe("main token migration transfer", () => {
       ),
     ).toThrow("Ethereum Mainnet");
     expect(() =>
-      assertMainTokenMigrationTransaction(
-        { ...prepared, to: other },
-        sender,
-      ),
+      assertMainTokenMigrationTransaction({ ...prepared, to: other }, sender),
     ).toThrow("binding");
     expect(() =>
-      assertMainTokenMigrationTransaction(
-        { ...prepared, value: "1" },
-        sender,
-      ),
+      assertMainTokenMigrationTransaction({ ...prepared, value: "1" }, sender),
     ).toThrow("binding");
 
     const redirected = buildMainTokenMigrationTransaction({
@@ -156,7 +150,8 @@ describe("main token migration transfer", () => {
 });
 
 describe("main token migration page contract", () => {
-  const read = (path: string) => readFileSync(join(process.cwd(), path), "utf8");
+  const read = (path: string) =>
+    readFileSync(join(process.cwd(), path), "utf8");
   const page = read("components/main-token-migration.tsx");
 
   it("derives the countdown from one absolute window across reloads", () => {
@@ -171,16 +166,16 @@ describe("main token migration page contract", () => {
     expect(page).toContain("trustedClockEndpoint");
     expect(page).toContain("performance.now()");
     expect(page).toContain("setNow(readTrustedNow())");
-    expect(page).toContain("phase === \"upcoming\"");
+    expect(page).toContain('phase === "upcoming"');
     expect(page).toContain("migrationWindow.startAt");
     expect(page).toContain("migrationWindow.deadlineAt");
     expect(page).not.toMatch(
       /Date\.now\(\)\s*\+\s*MAIN_TOKEN_MIGRATION_WINDOW_SECONDS/u,
     );
     expect(page).toContain("const hours = Math.floor(totalSeconds / 3_600)");
-    expect(page).toContain('<small>Hours</small>');
-    expect(page).toContain('<small>Minutes</small>');
-    expect(page).toContain('<small>Seconds</small>');
+    expect(page).toContain("<small>Hours</small>");
+    expect(page).toContain("<small>Minutes</small>");
+    expect(page).toContain("<small>Seconds</small>");
     expect(page).not.toContain("<small>Days</small>");
   });
 
@@ -218,18 +213,24 @@ describe("main token migration page contract", () => {
     expect(transferWindowOpenAt(startAt + 250, 250, false)).toBe(false);
     expect(page).toContain("const migrationTransferSafetyMs = 5 * 60 * 1_000;");
     expect(page).toContain("!migrationWindow.enabled ||");
-    expect(page).toContain("transferWindowOpenAt(trustedNow, clock.uncertaintyMs)");
-    const firstFinalWindowCheck = page.indexOf("const finalCheckTime = readTrustedNow()");
-    const finalWindowCheck = page.indexOf("const walletReviewTime = readTrustedNow()");
+    expect(page).toContain(
+      "transferWindowOpenAt(trustedNow, clock.uncertaintyMs)",
+    );
+    const firstFinalWindowCheck = page.indexOf(
+      "const finalCheckTime = readTrustedNow()",
+    );
+    const finalWindowCheck = page.indexOf(
+      "const walletReviewTime = readTrustedNow()",
+    );
     const finalTransactionBinding = page.indexOf(
       "const checked = assertMainTokenMigrationTransaction",
     );
     const walletPrompt = page.indexOf("const hash = await sendTransaction");
     expect(firstFinalWindowCheck).toBeGreaterThan(0);
     expect(finalWindowCheck).toBeGreaterThan(firstFinalWindowCheck);
-    expect(page.slice(firstFinalWindowCheck, finalTransactionBinding)).toContain(
-      "!trustedTransferWindowOpen()",
-    );
+    expect(
+      page.slice(firstFinalWindowCheck, finalTransactionBinding),
+    ).toContain("!trustedTransferWindowOpen()");
     expect(page.slice(finalWindowCheck, walletPrompt)).toContain(
       "!trustedTransferWindowOpen()",
     );
@@ -248,9 +249,7 @@ describe("main token migration page contract", () => {
   });
 
   it("reveals the fixed destination only during the active window or for a tracked transfer", () => {
-    expect(page).toContain(
-      "transferWindowOpenAt(now, clockUncertaintyMs)",
-    );
+    expect(page).toContain("transferWindowOpenAt(now, clockUncertaintyMs)");
     expect(page).toContain(
       "const canRevealDestination = transferWindowOpen || hasTrackedTransfer;",
     );
@@ -259,7 +258,7 @@ describe("main token migration page contract", () => {
     expect(page).toContain("Copy address");
     expect(page).toContain("disabled={!canCopyDestination}");
     expect(page).toContain(
-      "The address and copy action unlock only during the published",
+      "The migration address is available only while the window is",
     );
   });
 
@@ -368,21 +367,21 @@ describe("main token migration page contract", () => {
     expect(page).toContain("deadlineAt - startAt ===");
     expect(page).toContain("startBlock !== null");
     expect(page).toContain("Local preview · transfers disabled");
-    expect(page).toContain("96-hour");
-    expect(page).toContain("<strong>96 hours</strong>");
     expect(page).toContain(
-      "Nothing is sent until you confirm the transfer in your wallet.",
+      "Nothing is sent until you approve the V4 transfer in your wallet.",
     );
-    expect(page).toContain("1:1 V4 amount");
-    expect(page).toContain("Do not send from an exchange, custodian or router");
+    expect(page).toContain("Connect wallet and send V4");
+    expect(page).toContain("Prefer not to connect?");
+    expect(page).toContain("Do not send ETH or use an exchange or router.");
+    expect(page).not.toContain("Smart-contract wallet detected");
+    expect(page).not.toContain("How it works");
+    expect(read("components/main-token-migration.module.css")).not.toContain(
+      "min-height: calc(100svh - 88px)",
+    );
     expect(route).toContain("index: false");
     expect(route).toContain("follow: false");
-    expect(route).toContain(
-      "PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_ENABLED",
-    );
-    expect(route).toContain(
-      "PROGRAMMABLE_MAIN_TOKEN_MIGRATION_LOCAL_PREVIEW",
-    );
+    expect(route).toContain("PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_ENABLED");
+    expect(route).toContain("PROGRAMMABLE_MAIN_TOKEN_MIGRATION_LOCAL_PREVIEW");
     expect(route).toContain("migrationActivationManifest.enabled");
     expect(route).toContain("notFound()");
     expect(landing).toContain('href="/migration"');

--- a/tests/topbar-hero-polish.test.ts
+++ b/tests/topbar-hero-polish.test.ts
@@ -63,12 +63,14 @@ describe("topbar and Explore hero polish", () => {
     expect(navigation).toContain(
       "https://dune.com/0xprogrammable6098/programmable-analytics",
     );
-    expect(navigation.indexOf('aria-label="Programmable on DEX Screener"')).toBeLessThan(
+    expect(
+      navigation.indexOf('aria-label="Programmable on DEX Screener"'),
+    ).toBeLessThan(
       navigation.indexOf('aria-label="Programmable analytics on Dune"'),
     );
-    expect(navigation.indexOf('aria-label="Programmable analytics on Dune"')).toBeLessThan(
-      navigation.indexOf('aria-label="Programmable on Discord"'),
-    );
+    expect(
+      navigation.indexOf('aria-label="Programmable analytics on Dune"'),
+    ).toBeLessThan(navigation.indexOf('aria-label="Programmable on Discord"'));
     expect(landing).toContain('href="/docs"');
     expect(landing).toContain("Read the Programmable overview");
     expect(navigation).not.toContain("ThemeToggle");
@@ -85,16 +87,16 @@ describe("topbar and Explore hero polish", () => {
     for (const label of [
       "Explore",
       "Create",
+      "Migrate",
       "Docs",
       "API keys",
       "Profile",
     ]) {
       expect(navigation).toContain(`label: "${label}"`);
     }
+    expect(navigation).toContain('{ href: "/migration", label: "Migrate" }');
     expect(navigationCss).toContain("@media (max-width: 60rem)");
-    expect(navigationCss).toContain(
-      "grid-template-columns: 1fr",
-    );
+    expect(navigationCss).toContain("grid-template-columns: 1fr");
     expect(navigation).toContain("<HeaderSocialLinks mobile />");
     expect(navigationCss).toMatch(
       /\.siteHeader\.siteHeader :global\(\.desktop-nav\)\s*\{[^}]*display:\s*flex;[\s\S]*?\.menuButton\s*\{[^}]*display:\s*inline-flex;/s,
@@ -116,19 +118,19 @@ describe("topbar and Explore hero polish", () => {
     expect(navigationCss).toMatch(
       /@media \(max-width: 26rem\)[\s\S]*?\.mobileSheet\s*\{[^}]*width:\s*calc\(100vw - 24px\);/s,
     );
-    expect(landingCss).toMatch(
-      /\.docsLink\s*\{[^}]*font-size:\s*18px;/s,
-    );
+    expect(landingCss).toMatch(/\.docsLink\s*\{[^}]*font-size:\s*18px;/s);
   });
 
   it("keeps the wallet menu mounted for a smooth accessible exit", () => {
     const wallet = read("components/wallet-provider.tsx");
     const css = read("app/webde-final-ui.css");
 
-    expect(wallet).toContain('menuOpen ? "wallet-menu-open" : "wallet-menu-closed"');
+    expect(wallet).toContain(
+      'menuOpen ? "wallet-menu-open" : "wallet-menu-closed"',
+    );
     expect(wallet).toContain("aria-hidden={!menuOpen}");
     expect(wallet).toContain("tabIndex={menuOpen ? undefined : -1}");
-    expect(wallet).toContain('prefetch={false}');
+    expect(wallet).toContain("prefetch={false}");
     expect(css).toMatch(
       /\.header-actions \.wallet-button-compact\s*\{[^}]*width:\s*154px;/s,
     );


### PR DESCRIPTION
## Outcome
- puts the active migration countdown and both transfer paths in the first desktop viewport
- makes Connect wallet and the manual copyable destination immediately obvious
- removes redundant migration summary and process blocks
- adds Migrate to desktop and mobile navigation
- preserves trusted-window, exact transaction, wallet-type, and sponsored-gas checks

## Verification
- `npm run migration:main-token:test` (32 passed)
- focused navigation/accessibility tests (22 passed)
- `npm run typecheck`
- focused ESLint
- `git diff --check`
- local browser QA at 1440x900 and 390x844, no horizontal overflow or console errors
- independent read-only diff audit: no P0/P1/P2 findings