### PR TITLE
Pace Robinhood owner RPC preflight

### DIFF
--- a/contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs
+++ b/contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
 
 import {
   decodeAbiParameters,
@@ -290,6 +291,8 @@ const OWNER_ENVELOPE_RPC_METHOD_INVENTORY = Object.freeze(
   ),
 );
 const RPC_AGGREGATE_RESPONSE_LIMIT_BYTES = 4 * 1024 * 1024;
+const QUICKNODE_RPC_MINIMUM_REQUEST_INTERVAL_MS = 100;
+const quicknodeRpcPacing = new Map();
 
 function fail(message) {
   throw new Error(message);
@@ -1057,6 +1060,52 @@ export function assertRobinhoodFoundationRpcProviders({
   );
 }
 
+async function pacedRobinhoodFoundationRpcFetch({
+  providerId,
+  rpcUrl,
+  operationSignal,
+  fetchResponse,
+}) {
+  if (providerId !== "quicknode") return fetchResponse();
+  const key = sha256(
+    Buffer.concat([
+      Buffer.from(
+        "programmable.robinhood-custom-launch.quicknode-pacing.v1",
+        "utf8",
+      ),
+      Buffer.from([0]),
+      Buffer.from(rpcUrl, "utf8"),
+    ]),
+  );
+  let pacing = quicknodeRpcPacing.get(key);
+  if (!pacing) {
+    pacing = {
+      nextRequestNotBefore: 0,
+      tail: Promise.resolve(),
+    };
+    quicknodeRpcPacing.set(key, pacing);
+  }
+  const scheduled = pacing.tail.then(async () => {
+    const waitMilliseconds = Math.max(
+      0,
+      pacing.nextRequestNotBefore - Date.now(),
+    );
+    if (waitMilliseconds > 0) {
+      await delay(waitMilliseconds, undefined, {
+        signal: operationSignal,
+      });
+    }
+    pacing.nextRequestNotBefore =
+      Date.now() + QUICKNODE_RPC_MINIMUM_REQUEST_INTERVAL_MS;
+    return fetchResponse();
+  });
+  pacing.tail = scheduled.then(
+    () => undefined,
+    () => undefined,
+  );
+  return scheduled;
+}
+
 export async function robinhoodFoundationRpc({
   providerId,
   rpcUrl,
@@ -1088,18 +1137,25 @@ export async function robinhoodFoundationRpc({
   }
   let response;
   try {
-    const requestSignal = AbortSignal.timeout(requestTimeoutMs);
-    response = await fetchImpl(rpcUrl, {
-      method: "POST",
-      headers: {
-        accept: "application/json",
-        "content-type": "application/json",
+    response = await pacedRobinhoodFoundationRpcFetch({
+      providerId,
+      rpcUrl,
+      operationSignal,
+      fetchResponse: () => {
+        const requestSignal = AbortSignal.timeout(requestTimeoutMs);
+        return fetchImpl(rpcUrl, {
+          method: "POST",
+          headers: {
+            accept: "application/json",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+          redirect: "error",
+          signal: operationSignal
+            ? AbortSignal.any([requestSignal, operationSignal])
+            : requestSignal,
+        });
       },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-      redirect: "error",
-      signal: operationSignal
-        ? AbortSignal.any([requestSignal, operationSignal])
-        : requestSignal,
     });
   } catch {
     fail(`${providerId} RPC ${method} request failed`);

--- a/contracts/scripts/test/robinhood-custom-launch-owner-envelope.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-owner-envelope.test.mjs
@@ -947,6 +947,51 @@ test("RPC transport is strict, bounded, and redacts endpoint/error content", asy
       return true;
     },
   );
+  const requestStarts = [];
+  await Promise.all(
+    Array.from({ length: 3 }, () =>
+      robinhoodFoundationRpc({
+        providerId: "quicknode",
+        rpcUrl:
+          "https://pacing-test.robinhood-mainnet.quiknode.pro/0123456789abcdef/",
+        method: "eth_chainId",
+        responseBudget: { consumed: 0, limit: 4 * 1024 * 1024 },
+        fetchImpl: async () => {
+          requestStarts.push(Date.now());
+          return new Response(
+            JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x1237" }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        },
+      }),
+    ),
+  );
+  assert.equal(requestStarts.length, 3);
+  assert.ok(requestStarts[1] - requestStarts[0] >= 80);
+  assert.ok(requestStarts[2] - requestStarts[1] >= 80);
+  await assert.rejects(
+    () =>
+      robinhoodFoundationRpc({
+        providerId: "quicknode",
+        rpcUrl: `https://rate-limit.robinhood-mainnet.quiknode.pro/${secret}/`,
+        method: "eth_getCode",
+        responseBudget: { consumed: 0, limit: 4 * 1024 * 1024 },
+        fetchImpl: async () =>
+          new Response(`rate-limited-${secret}`, {
+            status: 429,
+            headers: { "content-type": "text/plain" },
+          }),
+      }),
+    (error) => {
+      assert.match(error.message, /invalid HTTP envelope/u);
+      assert.ok(!error.message.includes(secret));
+      assert.ok(!error.message.includes("rate-limited"));
+      return true;
+    },
+  );
 });
 
 test("CLI parser accepts only the five non-signing review inputs", () => {

--- a/docs/operations/releases/custom-launch-v4/OWNER-WALLET-HANDOFF.md
+++ b/docs/operations/releases/custom-launch-v4/OWNER-WALLET-HANDOFF.md
@@ -127,6 +127,11 @@ pending observations. The final action-time guard additionally requires a
 provider-agreed owner balance that remains unchanged through its closing read.
 Fee fields use the highest base fee, gas price and priority fee reported by
 either provider and remain bounded by the owner's explicit ceilings.
+The transport paces QuickNode requests at a bounded provider-specific rate so
+the complete opening and closing inventories do not become an unreviewed burst.
+An HTTP throttle response still fails the entire fresh attempt closed; it is
+never treated as agreement, retried as a partial snapshot or replaced by a
+different endpoint.
 
 ## Fresh envelope
 


### PR DESCRIPTION
Summary

- pace QuickNode request starts at a bounded 100 ms interval during the Robinhood owner-envelope and action-time inventories
- preserve Alchemy parallelism, exact reviewed endpoint commitments, dual-provider equality, freshness, response budgets, and fail-closed handling
- keep HTTP 429 and every noncanonical HTTP envelope as a full-attempt failure; no partial retry, provider substitution, signing, or broadcast
- document the provider-specific pacing boundary

Reproduction and validation

- before fix: the protected QuickNode accepted the first burst, then returned 9 HTTP 429 responses across the immediate 18-address inventory; the canonical envelope refresh failed closed three times before wallet preparation
- after fix live canary: exact protected QuickNode and Alchemy commitments matched; 19 requests per provider completed on chain 4663; QuickNode elapsed 1992 ms and Alchemy 262 ms; no endpoint value was printed
- focused owner-envelope test file: 37/37 passed
- full Robinhood owner-envelope release test command: 82/82 passed
- focused ESLint: passed
- canonical contract build: completed and regenerated the two pinned Robinhood artifacts

No wallet was opened. No transaction was signed or broadcast. No funds or chain state were changed.