### PR TITLE
Restore migration send flow for delegated EOAs

### DIFF
--- a/components/main-token-migration.tsx
+++ b/components/main-token-migration.tsx
@@ -27,6 +27,7 @@ import {
   MAIN_TOKEN_RUNTIME_CODE_KECCAK256,
   MAIN_TOKEN_SYMBOL,
   MAIN_TOKEN_TOTAL_SUPPLY_RAW,
+  isMainTokenMigrationWalletCodeEligible,
   parseMainTokenMigrationAmount,
 } from "@/lib/main-token-migration";
 
@@ -920,7 +921,9 @@ export function MainTokenMigration() {
         if (!cancelled) {
           setAccountCodeObservation({
             account,
-            status: code === "0x" ? "eoa" : "contract",
+            status: isMainTokenMigrationWalletCodeEligible(code)
+              ? "eoa"
+              : "contract",
           });
         }
       })
@@ -1484,7 +1487,7 @@ export function MainTokenMigration() {
           "Unable to verify this wallet for the automatic path. Nothing was sent. Try again before the window closes.",
         );
       }
-      if (code !== "0x") {
+      if (!isMainTokenMigrationWalletCodeEligible(code)) {
         setAccountCodeObservation({
           account: wallet.account.toLowerCase(),
           status: "contract",

--- a/lib/main-token-migration.ts
+++ b/lib/main-token-migration.ts
@@ -5,6 +5,7 @@ import {
   parseAbi,
   parseUnits,
   type Address,
+  type Hex,
 } from "viem";
 
 import {
@@ -30,6 +31,7 @@ export const MAIN_TOKEN_MIGRATION_WALLET = getAddress(
 );
 
 const UINT256_MAX = (1n << 256n) - 1n;
+const EIP_7702_DELEGATION_INDICATOR = /^0xef0100[0-9a-f]{40}$/iu;
 const erc20TransferAbi = parseAbi([
   "function transfer(address to,uint256 amount) returns (bool)",
 ]);
@@ -38,6 +40,13 @@ export type MainTokenMigrationTransaction = Extract<
   PreparedTransaction,
   { kind: "main-token-migration" }
 >;
+
+export function isMainTokenMigrationWalletCodeEligible(
+  code: Hex | undefined,
+) {
+  return code === "0x" ||
+    (code !== undefined && EIP_7702_DELEGATION_INDICATOR.test(code));
+}
 
 export function parseMainTokenMigrationAmount(value: string): bigint {
   const normalized = value.trim();

--- a/lib/server/main-token-migration-gas-sponsor-v1.ts
+++ b/lib/server/main-token-migration-gas-sponsor-v1.ts
@@ -26,6 +26,7 @@ import {
   MAIN_TOKEN_MIGRATION_WINDOW_SECONDS,
   MAIN_TOKEN_RUNTIME_CODE_KECCAK256,
   MAIN_TOKEN_TOTAL_SUPPLY_RAW,
+  isMainTokenMigrationWalletCodeEligible,
 } from "@/lib/main-token-migration";
 import {
   createPrivyWalletPrincipalAuthenticatorV1,
@@ -887,8 +888,10 @@ export function createMainTokenMigrationGasSponsorChainV1(
             "rpc_quorum_unavailable",
           );
         }
-        if (left.holderCode !== "0x" || right.holderCode !== "0x"
-          || left.startHolderCode !== "0x" || right.startHolderCode !== "0x"
+        if (!isMainTokenMigrationWalletCodeEligible(left.holderCode)
+          || !isMainTokenMigrationWalletCodeEligible(right.holderCode)
+          || !isMainTokenMigrationWalletCodeEligible(left.startHolderCode)
+          || !isMainTokenMigrationWalletCodeEligible(right.startHolderCode)
           || left.sponsorCode !== "0x" || right.sponsorCode !== "0x"
           || left.currentBalance < request.amountRaw || right.currentBalance < request.amountRaw
           || left.openingBalance < request.amountRaw || right.openingBalance < request.amountRaw) {

--- a/tests/main-token-migration.test.ts
+++ b/tests/main-token-migration.test.ts
@@ -14,6 +14,7 @@ import {
   MAIN_TOKEN_MIGRATION_RELEASE_ID,
   MAIN_TOKEN_MIGRATION_WALLET,
   MAIN_TOKEN_MIGRATION_WINDOW_SECONDS,
+  isMainTokenMigrationWalletCodeEligible,
   parseMainTokenMigrationAmount,
 } from "../lib/main-token-migration";
 import {
@@ -30,6 +31,23 @@ const migrationWallet = "0x228Be90653fDDAa408fB6cf9ca0AEC311dbE9A0D";
 const migrationWindowSeconds = 96 * 60 * 60;
 
 describe("main token migration transfer", () => {
+  it("accepts empty or exact EIP-7702 delegated EOA code only", () => {
+    expect(isMainTokenMigrationWalletCodeEligible("0x")).toBe(true);
+    expect(isMainTokenMigrationWalletCodeEligible(
+      "0xef010063c0c19a282a1b52b07dd5a65b58948a07dae32b",
+    )).toBe(true);
+
+    for (const code of [
+      undefined,
+      "0x60006000",
+      "0xef0100",
+      "0xef010063c0c19a282a1b52b07dd5a65b58948a07dae32b00",
+      "0xef020063c0c19a282a1b52b07dd5a65b58948a07dae32b",
+    ] as const) {
+      expect(isMainTokenMigrationWalletCodeEligible(code)).toBe(false);
+    }
+  });
+
   it("freezes the 96-hour Ethereum migration identities", () => {
     expect(MAIN_TOKEN_MIGRATION_CHAIN_ID).toBe(1);
     expect(MAIN_TOKEN_ADDRESS).toBe(


### PR DESCRIPTION
## Outcome\n\nRestores the connected-wallet migration path for EIP-7702 delegated EOAs while continuing to reject ordinary contract wallets.\n\n## Changes\n\n- recognizes only empty runtime code or the exact 23-byte EIP-7702 delegation indicator\n- applies the same eligibility rule in the browser and gas-sponsorship quorum\n- keeps arbitrary contract runtime code fail-closed\n- adds regression coverage using the affected wallet public delegation-code shape\n\n## Verification\n\n- npm run migration:main-token:test (33/33)\n- npm run typecheck\n- targeted ESLint on the four changed files\n- git diff --check