### PR TITLE
Right-size Robinhood owner gas headroom

### DIFF
--- a/contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs
+++ b/contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs
@@ -20,8 +20,8 @@ export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_MINIMUM_REMAINING_TTL_SECONDS =
 export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_REQUEST_TIMEOUT_MS = 15_000;
 export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_MAX_OPERATION_MS = 45_000;
 export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_MAX_HEAD_GAP = 4n;
-export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_GAS_HEADROOM_BPS = 2_000n;
-export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_FIXED_GAS_HEADROOM = 50_000n;
+export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_GAS_HEADROOM_BPS = 500n;
+export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_FIXED_GAS_HEADROOM = 25_000n;
 export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_MAX_GAS_LIMIT = 10_000_000n;
 
 const CHAIN_ID = 4_663n;
@@ -1594,6 +1594,10 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
     value: "0x0",
     data: receipt.transaction.input,
   };
+  const gasCappedSimulationRequest = {
+    ...simulationRequest,
+    gas: receipt.transaction.gasQuantity,
+  };
 
   const snapshots = await Promise.all(
     providers.map(async (provider) => {
@@ -1664,7 +1668,7 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
         rpc(
           provider,
           "eth_call",
-          [simulationRequest, "pending"],
+          [gasCappedSimulationRequest, "pending"],
           rpcClient,
           requestTimeoutMs,
         ),
@@ -1840,7 +1844,7 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
           rpc(
             provider,
             "eth_call",
-            [simulationRequest, "pending"],
+            [gasCappedSimulationRequest, "pending"],
             rpcClient,
             requestTimeoutMs,
           ),

--- a/contracts/scripts/test/robinhood-custom-launch-owner-envelope.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-owner-envelope.test.mjs
@@ -312,6 +312,9 @@ function mockRpc(options = {}) {
       return entry.code;
     }
     if (method === "eth_call") {
+      if (provider.rejectGasCappedCall && params[0].gas !== undefined) {
+        throw new Error("gas-capped simulation rejected");
+      }
       const count = (callReads.get(providerId) ?? 0) + 1;
       callReads.set(providerId, count);
       return count > 1 && provider.closingCallResult !== undefined
@@ -390,9 +393,10 @@ async function prepareEnvelope({
 }
 
 test("reviewed gas headroom is exact and fails instead of clamping", () => {
-  assert.equal(reviewedRobinhoodFoundationGasLimit(7_169_706n), 8_653_648n);
+  assert.equal(reviewedRobinhoodFoundationGasLimit(7_169_706n), 7_553_192n);
+  assert.equal(reviewedRobinhoodFoundationGasLimit(9_500_000n), 10_000_000n);
   assert.throws(
-    () => reviewedRobinhoodFoundationGasLimit(9_000_000n),
+    () => reviewedRobinhoodFoundationGasLimit(9_500_001n),
     /10,000,000 gas cap/u,
   );
   assert.throws(
@@ -416,7 +420,7 @@ test("both reviewed owners produce a protected, digest-bound envelope", async ()
       receipt.transaction.inputKeccak256,
       deployment.atomicOwnerTransaction.dataHash,
     );
-    assert.equal(receipt.transaction.gasLimit, "8653648");
+    assert.equal(receipt.transaction.gasLimit, "7553192");
     assert.equal(receipt.observation.ttlSeconds, 300);
     assert.equal(receipt.gasPolicy.balanceReadPerformed, false);
     assert.equal(receipt.gasPolicy.fundingVerified, false);
@@ -1166,6 +1170,25 @@ test("read-only action-time verifier rebinds source, CI, endpoints, funding, fee
     assert.equal(requestsByProvider.quicknode.length, 42);
     assert.deepEqual(requestsByProvider.quicknode, requestsByProvider.alchemy);
     assert.ok(
+      actionTimeMock.requestInventory
+        .filter(({ method }) => method === "eth_call")
+        .every(
+          ({ params }) =>
+            params[0].gas === receipt.transaction.gasQuantity &&
+            params[1] === "pending",
+        ),
+      "every action-time simulation must execute under the exact proposed gas limit",
+    );
+    assert.ok(
+      actionTimeMock.requestInventory
+        .filter(({ method }) => method === "eth_estimateGas")
+        .every(
+          ({ params }) =>
+            params[0].gas === undefined && params[1] === "pending",
+        ),
+      "every action-time estimate must independently reproduce the uncapped envelope estimate",
+    );
+    assert.ok(
       actionTimeMock.requestInventory.every(
         ({ method }) =>
           !/eth_send|wallet_|personal_|sign/iu.test(method),
@@ -1249,6 +1272,11 @@ test("read-only action-time verifier rebinds source, CI, endpoints, funding, fee
         "simulation",
         { providers: { alchemy: { callResult: "0x" } } },
         /simulation return commitment/u,
+      ],
+      [
+        "gas-capped simulation rejection",
+        { providers: { alchemy: { rejectGasCappedCall: true } } },
+        /gas-capped simulation rejected/u,
       ],
       [
         "gas estimate",

--- a/docs/operations/releases/custom-launch-v4/OWNER-WALLET-HANDOFF.md
+++ b/docs/operations/releases/custom-launch-v4/OWNER-WALLET-HANDOFF.md
@@ -127,6 +127,10 @@ pending observations. The final action-time guard additionally requires a
 provider-agreed owner balance that remains unchanged through its closing read.
 Fee fields use the highest base fee, gas price and priority fee reported by
 either provider and remain bounded by the owner's explicit ceilings.
+The wallet gas limit is the exact provider-agreed estimate plus 5% and a fixed
+25,000 gas reserve. Both providers must return that same estimate in the
+opening and closing snapshots; the helper never shrinks the reserve from a
+balance observation or clamps a result above the reviewed 10,000,000 gas cap.
 The transport paces QuickNode requests at a bounded provider-specific rate so
 the complete opening and closing inventories do not become an unreviewed burst.
 An HTTP throttle response still fails the entire fresh attempt closed; it is
@@ -198,7 +202,10 @@ including exact `accessList: []`. It then uses both frozen credentialed
 providers to re-read chain ID; owner `latest` and `pending` nonce; owner pending
 balance; pending base fee, gas price and maximum priority fee; pending code and
 nonce vacancy for all three targets; and the exact pending simulation and gas
-estimate. It repeats a second closing
+estimate. The action-time `eth_call` carries the exact proposed gas limit, so a
+provider rejection at that boundary fails before the wallet opens; the separate
+uncapped `eth_estimateGas` must still reproduce the envelope estimate. It
+repeats a second closing
 nonce/balance/fee/code/vacancy/simulation/gas snapshot immediately before wallet
 delivery. Both providers must agree on the owner balance, and the opening and
 closing balance must remain identical. The balance must cover the maximum debit


### PR DESCRIPTION
## Summary

- replace the over-conservative 20% + 50,000 owner gas reserve with exact 5% + 25,000 headroom while preserving the 10,000,000 fail-closed cap
- run every action-time `eth_call` under the exact proposed wallet gas limit while keeping `eth_estimateGas` uncapped and independently reproducible
- document the reviewed formula and gas-boundary behavior

## Evidence

- focused owner-envelope suite: 37/37
- release-doc contract tests: 3/3
- exact dual-provider live boundary: QuickNode and Alchemy both reproduce estimate 7,169,706, accept proposed limit 7,553,192 with the exact return commitment, and reject 7,000,000
- provider balances agree and the proposed maximum debit fits
- independent review: P0/P1/P2 none
- no signing, broadcast, deployment, wallet mutation, or chain mutation performed
