### PR TITLE
Use conservative Robinhood provider gas estimate

### DIFF
--- a/contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs
+++ b/contracts/scripts/robinhood-custom-launch-owner-envelope-core.mjs
@@ -23,6 +23,8 @@ export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_MAX_HEAD_GAP = 4n;
 export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_GAS_HEADROOM_BPS = 500n;
 export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_FIXED_GAS_HEADROOM = 25_000n;
 export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_MAX_GAS_LIMIT = 10_000_000n;
+export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_MAX_ESTIMATE_DRIFT_GAS = 1_000n;
+export const ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_MAX_ESTIMATE_DRIFT_BPS = 1n;
 
 const CHAIN_ID = 4_663n;
 const CHAIN_ID_HEX = "0x1237";
@@ -585,7 +587,21 @@ export function assertFreshRobinhoodFoundationOwnerEnvelope(
     const gasEstimateArrays = [
       simulation.gasEstimates,
       simulation.closingGasEstimates,
-    ];
+    ].map((values, arrayIndex) => {
+      if (!Array.isArray(values) || values.length !== providerIds.length) {
+        fail("receipt gas estimate provider count is invalid");
+      }
+      return values.map((value, providerIndex) => {
+        const parsed = parseDecimalWei(
+          value,
+          `receipt ${arrayIndex === 0 ? "opening" : "closing"} ${providerIds[providerIndex]} gas estimate`,
+        );
+        if (value !== parsed.toString()) {
+          fail("receipt gas estimate is not canonical decimal text");
+        }
+        return parsed;
+      });
+    });
     const expectedReturnedAddresses = Object.values(EXPECTED_PREPARED_ADDRESSES);
     const pendingBaseFeeMaximum = [
       ...openingPendingBlocks,
@@ -682,9 +698,11 @@ export function assertFreshRobinhoodFoundationOwnerEnvelope(
       ) &&
       gasEstimateArrays.every(
         (values) =>
-          Array.isArray(values) &&
-          values.length === providerIds.length &&
-          values.every((value) => value === agreedGasEstimate.toString()),
+          conservativeRobinhoodFoundationGasEstimate(values) ===
+          agreedGasEstimate,
+      ) &&
+      gasEstimateArrays[0].every(
+        (value, index) => value === gasEstimateArrays[1][index],
       ) &&
       reviewedRobinhoodFoundationGasLimit(agreedGasEstimate) ===
         reviewedGasLimit &&
@@ -932,6 +950,30 @@ export function reviewedRobinhoodFoundationGasLimit(estimatedGas) {
     fail("foundation gas limit exceeds the reviewed 10,000,000 gas cap");
   }
   return reviewed;
+}
+
+export function conservativeRobinhoodFoundationGasEstimate(values) {
+  if (
+    !Array.isArray(values) ||
+    values.length !== 2 ||
+    values.some(
+      (value) =>
+        typeof value !== "bigint" || value <= 0n || value > UINT64_MAXIMUM,
+    )
+  ) {
+    fail("foundation provider gas estimates are invalid");
+  }
+  const minimum = values[0] < values[1] ? values[0] : values[1];
+  const maximum = values[0] > values[1] ? values[0] : values[1];
+  const drift = maximum - minimum;
+  if (
+    drift > ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_MAX_ESTIMATE_DRIFT_GAS ||
+    drift * BASIS_POINTS >
+      minimum * ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_MAX_ESTIMATE_DRIFT_BPS
+  ) {
+    fail("foundation provider gas estimates exceed the reviewed drift bound");
+  }
+  return maximum;
 }
 
 function authenticatedProviderBinding(pin, rpcUrl) {
@@ -1562,6 +1604,20 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
     receipt.simulation.agreedGasEstimate,
     "owner-envelope gas estimate",
   );
+  const expectedProviderGasEstimates = receipt.simulation.gasEstimates.map(
+    (value, index) =>
+      parseDecimalWei(
+        value,
+        `${providers[index].providerId} owner-envelope gas estimate`,
+      ),
+  );
+  if (
+    conservativeRobinhoodFoundationGasEstimate(
+      expectedProviderGasEstimates,
+    ) !== expectedGasEstimate
+  ) {
+    fail("owner-envelope conservative gas estimate is invalid");
+  }
   const reviewedGasLimit = parseQuantity(
     receipt.transaction.gasQuantity,
     "owner-envelope gas limit",
@@ -1752,7 +1808,7 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
       snapshot.callResult !== snapshots[0].callResult ||
       JSON.stringify(returnedAddresses) !==
         JSON.stringify(receipt.simulation.returnedAddresses) ||
-      snapshot.estimatedGas !== expectedGasEstimate ||
+      snapshot.estimatedGas !== expectedProviderGasEstimates[index] ||
       snapshot.estimatedGas > reviewedGasLimit
     ) {
       fail(
@@ -1769,10 +1825,16 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
       JSON.stringify(snapshots[1].codes) ||
     JSON.stringify(snapshots[0].vacancyNonces) !==
       JSON.stringify(snapshots[1].vacancyNonces) ||
-    snapshots[0].callResult !== snapshots[1].callResult ||
-    snapshots[0].estimatedGas !== snapshots[1].estimatedGas
+    snapshots[0].callResult !== snapshots[1].callResult
   ) {
     fail("Robinhood RPCs disagree on action-time owner-wallet state");
+  }
+  if (
+    conservativeRobinhoodFoundationGasEstimate(
+      snapshots.map(({ estimatedGas }) => estimatedGas),
+    ) !== expectedGasEstimate
+  ) {
+    fail("action-time conservative gas estimate differs from the envelope");
   }
 
   const closings = await Promise.all(
@@ -1915,7 +1977,6 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
       closing.callResult !== snapshots[index].callResult ||
       closing.callResult !== snapshots[0].callResult ||
       closing.estimatedGas !== snapshots[index].estimatedGas ||
-      closing.estimatedGas !== expectedGasEstimate ||
       closing.estimatedGas > reviewedGasLimit
     ) {
       fail(`${providerId} action-time state changed during wallet verification`);
@@ -1941,10 +2002,18 @@ export async function verifyRobinhoodFoundationOwnerWalletActionTimeState({
     JSON.stringify(closings[0].codes) !== JSON.stringify(closings[1].codes) ||
     JSON.stringify(closings[0].vacancyNonces) !==
       JSON.stringify(closings[1].vacancyNonces) ||
-    closings[0].callResult !== closings[1].callResult ||
-    closings[0].estimatedGas !== closings[1].estimatedGas
+    closings[0].callResult !== closings[1].callResult
   ) {
     fail("Robinhood RPCs disagree on action-time closing owner-wallet state");
+  }
+  if (
+    conservativeRobinhoodFoundationGasEstimate(
+      closings.map(({ estimatedGas }) => estimatedGas),
+    ) !== expectedGasEstimate
+  ) {
+    fail(
+      "action-time closing conservative gas estimate differs from the envelope",
+    );
   }
   const feeObservations = [...snapshots, ...closings];
   const observedPendingBaseFeePerGas = feeObservations.reduce(
@@ -2350,15 +2419,16 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
       JSON.stringify(pendingSnapshots[1].codes) ||
     JSON.stringify(pendingSnapshots[0].vacancyNonces) !==
       JSON.stringify(pendingSnapshots[1].vacancyNonces) ||
-    pendingSnapshots[0].callResult !== pendingSnapshots[1].callResult ||
-    pendingSnapshots[0].estimatedGas !== pendingSnapshots[1].estimatedGas
+    pendingSnapshots[0].callResult !== pendingSnapshots[1].callResult
   ) {
-    fail("Robinhood RPCs disagree on pending state, simulation, or gas");
+    fail("Robinhood RPCs disagree on pending state or simulation");
   }
   const returnedAddresses = decodeSimulationReturn(
     pendingSnapshots[0].callResult,
   );
-  const estimatedGas = pendingSnapshots[0].estimatedGas;
+  const estimatedGas = conservativeRobinhoodFoundationGasEstimate(
+    pendingSnapshots.map(({ estimatedGas: value }) => value),
+  );
   const gasLimit = reviewedRobinhoodFoundationGasLimit(estimatedGas);
   if (
     commonBlocks.some((block) => gasLimit > block.gasLimit) ||
@@ -2508,7 +2578,6 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
         JSON.stringify(pendingSnapshots[index].vacancyNonces) ||
       closing.callResult !== pendingSnapshots[index].callResult ||
       closing.estimatedGas !== pendingSnapshots[index].estimatedGas ||
-      closing.estimatedGas !== estimatedGas ||
       gasLimit > closing.pendingBlock.gasLimit
     ) {
       fail(`${providers[index].providerId} state changed during preflight`);
@@ -2532,12 +2601,18 @@ export async function prepareRobinhoodFoundationOwnerEnvelope({
     JSON.stringify(closings[0].codes) !== JSON.stringify(closings[1].codes) ||
     JSON.stringify(closings[0].vacancyNonces) !==
       JSON.stringify(closings[1].vacancyNonces) ||
-    closings[0].callResult !== closings[1].callResult ||
-    closings[0].estimatedGas !== closings[1].estimatedGas
+    closings[0].callResult !== closings[1].callResult
   ) {
     fail(
-      "Robinhood RPCs disagree on closing nonce, code, vacancy, simulation, or gas",
+      "Robinhood RPCs disagree on closing nonce, code, vacancy, or simulation",
     );
+  }
+  if (
+    conservativeRobinhoodFoundationGasEstimate(
+      closings.map(({ estimatedGas: value }) => value),
+    ) !== estimatedGas
+  ) {
+    fail("conservative gas estimate changed during preflight");
   }
   const feeObservations = [...pendingSnapshots, ...closings];
   const maxPriorityFeePerGas = feeObservations.reduce(

--- a/contracts/scripts/test/robinhood-custom-launch-owner-envelope.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-owner-envelope.test.mjs
@@ -15,10 +15,12 @@ import {
   ROBINHOOD_FOUNDATION_OWNER_ENVELOPE_SCHEMA,
   assertRobinhoodFoundationRpcProviders,
   assertFreshRobinhoodFoundationOwnerEnvelope,
+  conservativeRobinhoodFoundationGasEstimate,
   prepareRobinhoodFoundationOwnerEnvelope,
   reviewedRobinhoodFoundationGasLimit,
   robinhoodFoundationRpcEndpointCommitment,
   robinhoodFoundationRpc,
+  verifyRobinhoodFoundationOwnerWalletActionTimeState,
 } from "../robinhood-custom-launch-owner-envelope-core.mjs";
 import {
   parseRobinhoodFoundationEnvelopeCli,
@@ -402,6 +404,118 @@ test("reviewed gas headroom is exact and fails instead of clamping", () => {
   assert.throws(
     () => reviewedRobinhoodFoundationGasLimit(1n << 64n),
     /exceeds uint64/u,
+  );
+});
+
+test("provider estimator variance records both values and uses the conservative maximum", async () => {
+  const quicknodeEstimate = 7_178_588n;
+  const alchemyEstimate = 7_178_540n;
+  const options = {
+    providers: {
+      quicknode: { estimate: `0x${quicknodeEstimate.toString(16)}` },
+      alchemy: { estimate: `0x${alchemyEstimate.toString(16)}` },
+    },
+  };
+  assert.equal(
+    conservativeRobinhoodFoundationGasEstimate([
+      alchemyEstimate,
+      quicknodeEstimate,
+    ]),
+    quicknodeEstimate,
+  );
+  assert.equal(
+    conservativeRobinhoodFoundationGasEstimate([
+      alchemyEstimate,
+      alchemyEstimate + 717n,
+    ]),
+    alchemyEstimate + 717n,
+  );
+  assert.throws(
+    () =>
+      conservativeRobinhoodFoundationGasEstimate([
+        alchemyEstimate,
+        alchemyEstimate + 718n,
+      ]),
+    /gas estimates exceed the reviewed drift bound/u,
+  );
+  assert.throws(
+    () =>
+      conservativeRobinhoodFoundationGasEstimate([
+        20_000_000n,
+        20_001_001n,
+      ]),
+    /gas estimates exceed the reviewed drift bound/u,
+  );
+  assert.equal(
+    conservativeRobinhoodFoundationGasEstimate([
+      10_000_000n,
+      10_001_000n,
+    ]),
+    10_001_000n,
+  );
+  const { receipt } = await prepareEnvelope({ options });
+  assert.deepEqual(receipt.simulation.gasEstimates, [
+    quicknodeEstimate.toString(),
+    alchemyEstimate.toString(),
+  ]);
+  assert.deepEqual(
+    receipt.simulation.closingGasEstimates,
+    receipt.simulation.gasEstimates,
+  );
+  assert.equal(
+    receipt.simulation.agreedGasEstimate,
+    quicknodeEstimate.toString(),
+  );
+  assert.equal(
+    receipt.transaction.gasLimit,
+    reviewedRobinhoodFoundationGasLimit(quicknodeEstimate).toString(),
+  );
+  assert.equal(receipt.transaction.gasLimit, "7562518");
+
+  const actionTimeMock = mockRpc(options);
+  const actionTime = await verifyRobinhoodFoundationOwnerWalletActionTimeState({
+    receipt,
+    rpcUrls: RPC_URLS,
+    rpcEndpointCommitments: RPC_COMMITMENTS,
+    rpcClient: actionTimeMock.rpcClient,
+    runtimeCodeHash: actionTimeMock.runtimeCodeHash,
+    clock: () => FIXED_TIMESTAMP * 1_000,
+  });
+  assert.equal(actionTime.pendingGasEstimate, quicknodeEstimate.toString());
+  assert.equal(actionTime.closingGasEstimate, quicknodeEstimate.toString());
+
+  const swappedActionTimeMock = mockRpc({
+    providers: {
+      quicknode: { estimate: `0x${alchemyEstimate.toString(16)}` },
+      alchemy: { estimate: `0x${quicknodeEstimate.toString(16)}` },
+    },
+  });
+  await assert.rejects(
+    () =>
+      verifyRobinhoodFoundationOwnerWalletActionTimeState({
+        receipt,
+        rpcUrls: RPC_URLS,
+        rpcEndpointCommitments: RPC_COMMITMENTS,
+        rpcClient: swappedActionTimeMock.rpcClient,
+        runtimeCodeHash: swappedActionTimeMock.runtimeCodeHash,
+        clock: () => FIXED_TIMESTAMP * 1_000,
+      }),
+    /simulation or gas differs from the envelope/u,
+  );
+
+  await assert.rejects(
+    () =>
+      prepareEnvelope({
+        options: {
+          providers: {
+            quicknode: { estimate: "0x6d66aa" },
+            alchemy: {
+              estimate: `0x${(0x6d66aan + 718n).toString(16)}`,
+            },
+          },
+        },
+      }),
+    /gas estimates exceed the reviewed drift bound/u,
   );
 });
 
@@ -826,12 +940,16 @@ test("preflight fails closed on provider, pin, vacancy, nonce, simulation, and g
     [
       "simulation",
       { providers: { alchemy: { callResult: "0x" } } },
-      /pending state, simulation, or gas/u,
+      /pending state or simulation/u,
     ],
     [
-      "estimate",
-      { providers: { alchemy: { estimate: "0x6d66ab" } } },
-      /pending state, simulation, or gas/u,
+      "estimate drift bound",
+      {
+        providers: {
+          alchemy: { estimate: `0x${(0x6d66aan + 718n).toString(16)}` },
+        },
+      },
+      /gas estimates exceed the reviewed drift bound/u,
     ],
     [
       "closing nonce",
@@ -1563,7 +1681,14 @@ test("action-time closing chain, target, simulation, and gas drift fail closed",
 });
 
 test("freshness validation and protected output reject tampering, expiry, and overwrite", async () => {
-  const { receipt } = await prepareEnvelope();
+  const { receipt } = await prepareEnvelope({
+    options: {
+      providers: {
+        quicknode: { estimate: `0x${7_178_588n.toString(16)}` },
+        alchemy: { estimate: `0x${7_178_540n.toString(16)}` },
+      },
+    },
+  });
   assert.equal(
     assertFreshRobinhoodFoundationOwnerEnvelope(
       receipt,
@@ -1611,6 +1736,17 @@ test("freshness validation and protected output reject tampering, expiry, and ov
     ["simulation gas agreement", (candidate) => {
       candidate.simulation.gasEstimates[0] = (
         BigInt(candidate.simulation.agreedGasEstimate) + 1n
+      ).toString();
+    }],
+    ["simulation conservative maximum", (candidate) => {
+      candidate.simulation.agreedGasEstimate =
+        candidate.simulation.gasEstimates[1];
+    }],
+    ["simulation estimate average", (candidate) => {
+      candidate.simulation.agreedGasEstimate = (
+        (BigInt(candidate.simulation.gasEstimates[0]) +
+          BigInt(candidate.simulation.gasEstimates[1])) /
+        2n
       ).toString();
     }],
     ["boolean check", (candidate) => {

--- a/docs/operations/releases/custom-launch-v4/OWNER-WALLET-HANDOFF.md
+++ b/docs/operations/releases/custom-launch-v4/OWNER-WALLET-HANDOFF.md
@@ -122,15 +122,17 @@ pending-state, simulation and closing-state inventory. Robinhood produces blocks
 fast enough that authenticated providers can legitimately observe different
 pending parents or fees during one bounded preflight. The preparation guard
 therefore requires two identical state-relevant snapshots (runtime code, target
-vacancy, owner nonce, simulation return and gas estimate) while recording both
-pending observations. The final action-time guard additionally requires a
+vacancy, owner nonce and simulation return) while recording both providers'
+gas estimates. The final action-time guard additionally requires a
 provider-agreed owner balance that remains unchanged through its closing read.
 Fee fields use the highest base fee, gas price and priority fee reported by
 either provider and remain bounded by the owner's explicit ceilings.
-The wallet gas limit is the exact provider-agreed estimate plus 5% and a fixed
-25,000 gas reserve. Both providers must return that same estimate in the
-opening and closing snapshots; the helper never shrinks the reserve from a
-balance observation or clamps a result above the reviewed 10,000,000 gas cap.
+The wallet gas limit uses the higher of the two provider estimates plus 5% and a
+fixed 25,000 gas reserve. Provider estimates may differ by no more than both
+1,000 gas and one basis point of the lower estimate, and each provider must
+reproduce its own exact estimate in the closing snapshot. The helper never
+averages the estimates, shrinks the reserve from a balance observation or
+clamps a result above the reviewed 10,000,000 gas cap.
 The transport paces QuickNode requests at a bounded provider-specific rate so
 the complete opening and closing inventories do not become an unreviewed burst.
 An HTTP throttle response still fails the entire fresh attempt closed; it is
@@ -204,7 +206,9 @@ balance; pending base fee, gas price and maximum priority fee; pending code and
 nonce vacancy for all three targets; and the exact pending simulation and gas
 estimate. The action-time `eth_call` carries the exact proposed gas limit, so a
 provider rejection at that boundary fails before the wallet opens; the separate
-uncapped `eth_estimateGas` must still reproduce the envelope estimate. It
+uncapped `eth_estimateGas` must still reproduce that provider's recorded
+estimate, remain inside the reviewed cross-provider drift bound and preserve the
+same conservative maximum. It
 repeats a second closing
 nonce/balance/fee/code/vacancy/simulation/gas snapshot immediately before wallet
 delivery. Both providers must agree on the owner balance, and the opening and


### PR DESCRIPTION
## Summary

- record both authenticated Robinhood provider gas estimates and derive the wallet gas limit from the higher value
- accept estimator-only variance only when it is at most both 1,000 gas and 1 basis point of the lower estimate
- preserve exact per-provider opening-to-closing and action-time reproduction, plus every existing source, CI, code, vacancy, nonce, simulation, fee, balance, maximum-debit and no-sign/no-broadcast guard

## Live blocker reproduced

On the same pending block and owner nonce, QuickNode returned `7,178,588` and Alchemy returned `7,178,540`: a 48-gas / 0.0669-bp heuristic difference. All nine code hashes, all three target vacancy nonces and the exact simulation return hash agreed. The conservative reviewed gas limit is `7,562,518` (`max + 5% + 25,000`).

## Validation

- focused owner-envelope tests: 38/38
- focused release-doc tests: 3/3
- focused ESLint: passed
- `git diff --check`: passed
- 717-gas relative boundary passes; 718 fails
- 1,000-gas absolute boundary passes; 1,001 fails
- lower/average receipt selection, provider reordering at action time and temporal estimate drift fail closed

No wallet was opened. No transaction was signed or broadcast. No chain state, credentials, funds or provider configuration were changed.
