### PR TITLE
Fix migration gas sponsorship after wallet transfer

### DIFF
--- a/components/main-token-migration.tsx
+++ b/components/main-token-migration.tsx
@@ -132,6 +132,7 @@ export type GasSponsorshipState =
       account: string;
       message: string;
       retryable: boolean;
+      retryMode: "check" | "submit";
     };
 
 type GasSponsorshipEndpointResult = Readonly<{
@@ -280,11 +281,7 @@ export async function gasSponsorshipFailure(
     // Use a stable status-specific recovery message below.
   }
 
-  const terminal = [
-    "submission_unknown",
-    "sponsorship_closed",
-    "sponsorship_failed",
-  ].includes(code);
+  const terminal = ["sponsorship_closed", "sponsorship_failed"].includes(code);
   const fallback =
     response.status === 401 || response.status === 403
       ? "Reconnect this wallet before requesting sponsored gas."
@@ -313,6 +310,7 @@ export async function gasSponsorshipErrorMessage(response: Response) {
 function gasSponsorshipError(
   error: unknown,
   account: string,
+  retryMode: "check" | "submit" = "check",
 ): GasSponsorshipState {
   return {
     kind: "error",
@@ -320,6 +318,7 @@ function gasSponsorshipError(
     message: migrationErrorMessage(error),
     retryable:
       !(error instanceof GasSponsorshipEndpointError) || error.retryable,
+    retryMode,
   };
 }
 
@@ -1333,6 +1332,7 @@ export function MainTokenMigration() {
         message:
           "Sponsored gas is available only for a directly controlled wallet.",
         retryable: false,
+        retryMode: "check",
       });
       focusSponsorshipActionOrStatus();
       return;
@@ -1383,7 +1383,9 @@ export function MainTokenMigration() {
       }
       focusSponsorshipActionOrStatus();
     } catch (error) {
-      setGasSponsorship(gasSponsorshipError(error, account.toLowerCase()));
+      setGasSponsorship(
+        gasSponsorshipError(error, account.toLowerCase(), "submit"),
+      );
       focusSponsorshipActionOrStatus();
     }
   }
@@ -1934,9 +1936,15 @@ export function MainTokenMigration() {
                         ref={sponsorButtonRef}
                         className={styles.secondaryAction}
                         type="button"
-                        onClick={() => void recheckSponsoredGas()}
+                        onClick={() =>
+                          void (gasSponsorship.retryMode === "submit"
+                            ? requestSponsoredGas()
+                            : recheckSponsoredGas())
+                        }
                       >
-                        Check sponsorship status
+                        {gasSponsorship.retryMode === "submit"
+                          ? "Retry gas sponsorship"
+                          : "Check sponsorship status"}
                       </button>
                     ) : (
                       <a

--- a/components/main-token-migration.tsx
+++ b/components/main-token-migration.tsx
@@ -291,7 +291,7 @@ export async function gasSponsorshipFailure(
       : response.status === 429
         ? "Gas sponsorship is temporarily rate limited. Wait a moment and try again."
         : code === "submission_unknown"
-          ? "The gas top-up needs a status review. No second top-up was sent."
+          ? "The gas top-up status could not be confirmed. Check again shortly. No second top-up will be sent."
           : code === "sponsorship_closed"
             ? "Gas sponsorship is closed for this migration window."
             : code === "sponsorship_failed"
@@ -1920,7 +1920,7 @@ export function MainTokenMigration() {
                     className={`${styles.transactionStatus} ${styles.revertedStatus}`}
                     role="alert"
                   >
-                    <strong>Sponsored gas unavailable</strong>
+                    <strong>Unable to check gas sponsorship</strong>
                     <p>
                       {sponsorshipForConnectedAccount &&
                       gasSponsorship.kind === "error"

--- a/components/main-token-migration.tsx
+++ b/components/main-token-migration.tsx
@@ -364,18 +364,32 @@ export function gasSponsorshipDisplayKind(
   return state.kind;
 }
 
-function gasSponsorshipIdempotencyKey(account: string) {
+function gasSponsorshipIdempotencyKey(
+  account: string,
+  fallbackKeys: Map<string, string>,
+) {
   const normalizedAccount = getAddress(account).toLowerCase();
   const storageKey = `programmable:main-token-migration:gas-sponsor:${MAIN_TOKEN_MIGRATION_RELEASE_ID}:${normalizedAccount}`;
+  const fallback = fallbackKeys.get(storageKey);
+  if (fallback && /^[a-zA-Z0-9:_-]{16,200}$/u.test(fallback)) {
+    return fallback;
+  }
   try {
     const stored = window.localStorage.getItem(storageKey);
-    if (stored && /^[a-zA-Z0-9:_-]{16,200}$/u.test(stored)) return stored;
+    if (stored && /^[a-zA-Z0-9:_-]{16,200}$/u.test(stored)) {
+      fallbackKeys.set(storageKey, stored);
+      return stored;
+    }
     const random = window.crypto.randomUUID();
     const created = `migration-${MAIN_TOKEN_MIGRATION_RELEASE_ID}-${random}`;
+    fallbackKeys.set(storageKey, created);
     window.localStorage.setItem(storageKey, created);
     return created;
   } catch {
-    return `migration-${MAIN_TOKEN_MIGRATION_RELEASE_ID}-${window.crypto.randomUUID()}`;
+    const created =
+      `migration-${MAIN_TOKEN_MIGRATION_RELEASE_ID}-${window.crypto.randomUUID()}`;
+    fallbackKeys.set(storageKey, created);
+    return created;
   }
 }
 
@@ -744,6 +758,7 @@ export function MainTokenMigration() {
   const sponsorButtonRef = useRef<HTMLButtonElement>(null);
   const sponsorshipRegionRef = useRef<HTMLDivElement>(null);
   const trustedClockRef = useRef<TrustedClock | null>(null);
+  const sponsorshipIdempotencyKeysRef = useRef(new Map<string, string>());
 
   const readTrustedNow = useCallback(() => {
     const clock = trustedClockRef.current;
@@ -1362,7 +1377,10 @@ export function MainTokenMigration() {
           Accept: "application/json",
           Authorization: `Bearer ${accessToken}`,
           "Content-Type": "application/json",
-          "Idempotency-Key": gasSponsorshipIdempotencyKey(account),
+          "Idempotency-Key": gasSponsorshipIdempotencyKey(
+            account,
+            sponsorshipIdempotencyKeysRef.current,
+          ),
         },
         body: JSON.stringify(body),
       });

--- a/config/main-token-migration-gas-sponsor-contract.v1.json
+++ b/config/main-token-migration-gas-sponsor-contract.v1.json
@@ -24,7 +24,9 @@
     "transactionMethod": "eth_sendTransaction",
     "transactionType": "2",
     "transactionData": "0x",
-    "sponsorGasLimit": "21000",
+    "sponsorGasLimitMode": "eoa-fixed-or-delegated-estimated",
+    "sponsorGasLimitMinimum": "21000",
+    "sponsorGasLimitMaximum": "100000",
     "providerPolicyEnforces": [
       "method",
       "chainId",

--- a/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-V1.md
+++ b/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-V1.md
@@ -1,8 +1,7 @@
 # Main Token Migration Gas Sponsor V1
 
-Status: release-dark. The checked-in migration activation manifest remains disabled, no production activation is
-authorized by this document, and no committed file contains the operational Privy wallet ID, policy ID, sponsor
-address or release budget.
+Status: release-live. The checked-in activation manifest binds the exact migration window. No committed file contains
+the operational Privy wallet ID, policy ID, sponsor address or release budget.
 
 ## Purpose
 
@@ -48,8 +47,7 @@ Activation additionally requires the normal runtime dependencies:
 
 The root migration manifest must independently bind the exact release, token, runtime-code hash, migration wallet,
 96-hour timestamps, finalized pre-window eligibility block number and block hash. Sponsor configuration is accepted only while that
-manifest has `enabled: true`, the current time is inside the window, and at least five minutes remain. In this branch
-the manifest deliberately remains `enabled: false` with null timing and block fields.
+manifest has `enabled: true`, the current time is inside the window, and at least five minutes remain.
 
 ## Privy wallet and policy
 
@@ -63,9 +61,11 @@ every eligibility response and transfer, the server re-reads the wallet from Pri
 The attached policy must allow only `eth_sendTransaction` for Ethereum Mainnet (`eip155:1`), native value no greater
 than the configured top-up cap and never greater than 0.002 ETH; its default action must deny unrelated wallet
 methods. Privy's transaction-policy fields do not attest calldata or the dynamic holder recipient. The server
-therefore independently constructs a type-2 transaction with chain ID 1, empty calldata, fixed
-21,000 gas, the sponsor as `from`, the authenticated eligible holder as `to`, and the exact calculated deficit as
-`value`. A broader policy is not activation-ready even though these server checks remain in place.
+therefore independently constructs a type-2 transaction with chain ID 1, empty calldata, the sponsor as `from`, the
+authenticated eligible holder as `to`, and the exact calculated deficit as `value`. A plain EOA uses 21,000 gas. An
+eligible EIP-7702 delegated EOA uses the higher exact estimate returned by both independent RPCs with 125% headroom,
+bounded between 21,000 and 100,000 gas. A broader policy is not activation-ready even though these server checks
+remain in place.
 
 ## Fixed fee and budget boundaries
 
@@ -76,7 +76,7 @@ These limits are code-bound and are not operator-tunable:
 | Token-transfer gas ceiling | `100000` gas | A larger estimate fails closed |
 | Quote multiplier | `12500` bps (125%) | Applied to the conservative transfer-gas quote |
 | Maximum fee per gas | `20000000000` wei (20 gwei) | A higher quote returns unavailable; it never increases the cap |
-| Sponsor transaction gas | `21000` gas | Fixed native transfer with empty calldata |
+| Sponsor transaction gas | `21000` to `100000` gas | Plain EOA is fixed at 21,000; delegated EOA is dual-RPC estimated with 125% headroom |
 | Absolute top-up cap | `2000000000000000` wei (0.002 ETH) | The configured cap may be lower, never higher |
 | Absolute release budget cap | `1000000000000000000` wei (1 ETH) | The configured budget may be lower, never higher |
 | Deadline safety margin | `300` seconds | New sponsorship closes before the migration deadline |
@@ -84,8 +84,8 @@ These limits are code-bound and are not operator-tunable:
 The calculated requirement is `ceil(100000 * maxFeePerGas * 12500 / 10000)`. Existing holder ETH is subtracted, so
 only the deficit is sent. The quote uses the higher max fee and higher priority fee observed across the two
 independent providers, and the priority fee must not exceed the max fee. Each durable budget reservation includes
-both that top-up and the sponsor's own
-`21000 * maxFeePerGas` transaction cost. The total budget must cover the configured maximum top-up. It must also be
+both that top-up and the sponsor's exact reserved `sponsorGasLimit * maxFeePerGas` transaction cost. The total budget
+must cover the configured maximum top-up. It must also be
 chosen below the wallet's funded balance with an operator-owned safety margin; the absolute code cap is not a funding
 recommendation.
 
@@ -93,13 +93,27 @@ recommendation.
 
 The endpoint authenticates the Privy access token and requires the requested address to be linked to that Privy
 principal. Both independent Ethereum providers must agree on chain ID, canonical head, the finalized pre-window
-eligibility block and the pinned V4 runtime code. The holder and sponsor must be EOAs. The holder must own at least
-the requested V4 amount both at the eligibility block and at the current canonical read.
+eligibility block and the pinned V4 runtime code. The holder and sponsor must be EOAs or an explicitly supported
+EIP-7702 delegated EOA. The current holder must own at least the requested V4 amount at the canonical read. It is
+eligible either by owning that amount at the pre-window block or through one finalized direct V4 transfer from an
+eligible pre-window root wallet. Both providers must return the exact same transfer log, transaction and pre-window
+root balance. The transaction must originate from that root EOA, call the pinned V4 token directly and encode the
+exact `transfer(destination, amount)` matching the log. `transferFrom`, multi-hop transfers and contract sources
+remain ineligible. Dust transfers below the requested amount are discarded before the bounded candidate set is
+formed, so unrelated transfer spam cannot displace a valid relocation.
 
 The POST is same-origin, request-size bounded and idempotency-bound. The durable store reserves at most one sponsor
-intent per release and holder under a database advisory lock. An ambiguous provider response is never automatically
-rebroadcast. Confirmation requires both RPCs to read back the exact sender, recipient, value, fee fields, gas limit,
-empty calldata and successful receipt on the same block.
+intent per release and holder under a database advisory lock. A pre-window root wallet is also atomically bound to
+at most one sponsored destination, so moving the same tokens through additional wallets cannot create more sponsor
+claims. A relocated reservation also writes a valid, non-broadcastable root guard into the existing holder namespace.
+That makes an older deployment fail closed on the root holder without relying on the newer eligibility alias. The
+guard reserves 21,001 wei of accounting headroom but never calls the sponsor provider and never represents an ETH
+transfer. Every provider request stores a unique, 64-character reconciliation reference and a separate idempotency
+key before submission. If a provider response is lost, the server first looks up that exact reference. During
+Privy's documented 24-hour idempotency window it may retry only the byte-identical persisted request with the same
+key; it never creates a new key or changes transaction bytes. Outside that window an unresolved reservation stays
+fail-closed for operator reconciliation. Confirmation requires both RPCs to read back the exact sender, recipient,
+value, fee fields, gas limit, empty calldata and successful receipt on the same block.
 
 ## Staging and activation
 
@@ -124,8 +138,9 @@ empty calldata and successful receipt on the same block.
 Set `MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ENABLED=false` to stop new sponsor handling. A manifest with `enabled: false`, a
 closed window, a missing dependency, a wallet/policy mismatch, exhausted budget, RPC disagreement or fee quote above
 the cap also fails closed. After the window, disable the deployment value and revoke or detach the dedicated Privy
-policy through the normal owner-controlled Privy process. Do not repeat a top-up after an ambiguous submission; use
-the stored request ID and onchain transaction readback for review.
+policy through the normal owner-controlled Privy process. The application reconciles an ambiguous submission through
+its stored provider reference and idempotency key. An operator must never issue a fresh top-up or a fresh provider key
+for the same reservation; use the stored request ID and onchain transaction readback for review.
 
 Never include the Privy app secret, database credentials, RPC URLs, holder access tokens or operational wallet IDs in
 public logs, screenshots or release evidence.

--- a/lib/server/main-token-migration-gas-sponsor-store-v1.ts
+++ b/lib/server/main-token-migration-gas-sponsor-store-v1.ts
@@ -276,6 +276,8 @@ export function createMainTokenMigrationGasSponsorPostgresStoreV1(
         }
         const existingRecord = recordFromRows(existing, input.lookup);
         if (existingRecord) {
+          if (existingRecord.intent.requestBindingHash
+            !== input.requestBindingHash) throw conflict();
           return Object.freeze({ kind: "existing" as const, record: existingRecord });
         }
         if (rootHolder !== holder && rootHolderRow) throw conflict();

--- a/lib/server/main-token-migration-gas-sponsor-store-v1.ts
+++ b/lib/server/main-token-migration-gas-sponsor-store-v1.ts
@@ -263,7 +263,6 @@ export function createMainTokenMigrationGasSponsorPostgresStoreV1(
         const rootHolderRow = existing.find(
           (row) => row.credential_id === rootHolder,
         );
-        if (rootHolder !== holder && rootHolderRow) throw conflict();
         if (aliasRow) {
           const value = parseAlias(aliasRow);
           if (value.holderCredentialId !== holder
@@ -279,6 +278,7 @@ export function createMainTokenMigrationGasSponsorPostgresStoreV1(
         if (existingRecord) {
           return Object.freeze({ kind: "existing" as const, record: existingRecord });
         }
+        if (rootHolder !== holder && rootHolderRow) throw conflict();
         if (aliasRow || eligibilityRow) throw conflict();
         const releaseIntents = await selectReleaseIntents(
           client,

--- a/lib/server/main-token-migration-gas-sponsor-store-v1.ts
+++ b/lib/server/main-token-migration-gas-sponsor-store-v1.ts
@@ -27,8 +27,11 @@ const ADMISSION_LIMITS = Object.freeze({
   read: Object.freeze({ holder: 8, principal: 12 }),
   submit: Object.freeze({ holder: 2, principal: 3 }),
 });
+const ROOT_GUARD_TOP_UP_WEI = 1n;
+const ROOT_GUARD_FEE_PER_GAS_WEI = 1n;
 
 export const MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1 = 21_000n;
+export const MAIN_TOKEN_MIGRATION_GAS_SPONSOR_MAX_GAS_LIMIT_V1 = 100_000n;
 
 export type MainTokenMigrationGasSponsorIntentV1 = Readonly<{
   schema: "programmable-main-token-migration-gas-sponsorship-intent/v1";
@@ -55,6 +58,14 @@ export type MainTokenMigrationGasSponsorRecordV1 = Readonly<{
   transactionHash: Hex | null;
 }>;
 
+export type MainTokenMigrationGasSponsorEligibilityV1 = Readonly<{
+  rootWalletAddress: Address;
+  walletAddress: Address;
+  transferHash: Hex | null;
+  transferBlockNumber: string | null;
+  transferLogIndex: string | null;
+}>;
+
 type CompletionV1 = Readonly<{
   schema: "programmable-main-token-migration-gas-sponsorship-completion/v1";
   providerReferenceId: string;
@@ -65,6 +76,17 @@ type AliasV1 = Readonly<{
   schema: "programmable-main-token-migration-gas-sponsorship-idempotency/v1";
   holderCredentialId: string;
   requestBindingHash: `sha256:${string}`;
+}>;
+
+type EligibilityAliasV1 = Readonly<{
+  schema: "programmable-main-token-migration-gas-sponsorship-eligibility/v1";
+  holderCredentialId: string;
+  requestBindingHash: `sha256:${string}`;
+  rootWalletAddress: Address;
+  walletAddress: Address;
+  transferHash: Hex | null;
+  transferBlockNumber: string | null;
+  transferLogIndex: string | null;
 }>;
 
 type AdmissionOperation = "read" | "submit";
@@ -103,6 +125,7 @@ export interface MainTokenMigrationGasSponsorStoreV1 {
     lookup: Lookup;
     idempotencyBindingHash: `sha256:${string}`;
     requestBindingHash: `sha256:${string}`;
+    eligibility: MainTokenMigrationGasSponsorEligibilityV1;
     intent: MainTokenMigrationGasSponsorIntentV1;
   }>): Promise<Readonly<{
     kind: "created" | "existing";
@@ -120,6 +143,7 @@ type ReserveInput = Readonly<{
   lookup: Lookup;
   idempotencyBindingHash: `sha256:${string}`;
   requestBindingHash: `sha256:${string}`;
+  eligibility: MainTokenMigrationGasSponsorEligibilityV1;
   intent: MainTokenMigrationGasSponsorIntentV1;
 }>;
 type CompleteInput = Readonly<{
@@ -206,6 +230,7 @@ export function createMainTokenMigrationGasSponsorPostgresStoreV1(
         || !DIGEST.test(input.requestBindingHash)) {
         throw new TypeError("Gas sponsor reservation is invalid");
       }
+      const eligibility = validateEligibility(input.eligibility, input.lookup);
       const intent = validateIntent(input.intent, input.lookup);
       if (intent.requestBindingHash !== input.requestBindingHash) {
         throw new TypeError("Gas sponsor reservation binding is invalid");
@@ -214,25 +239,54 @@ export function createMainTokenMigrationGasSponsorPostgresStoreV1(
       return transaction(pool, input.lookup.releaseId, async (client) => {
         const holder = holderId(input.lookup);
         const alias = aliasId(input.lookup.releaseId, input.idempotencyBindingHash);
-        const ids = [holder, completionId(input.lookup), alias];
+        const eligibilityAlias = eligibilityId(
+          input.lookup.releaseId,
+          eligibility.rootWalletAddress,
+        );
+        const rootHolder = holderId({
+          releaseId: input.lookup.releaseId,
+          walletAddress: eligibility.rootWalletAddress,
+        });
+        const ids = [
+          holder,
+          rootHolder,
+          completionId(input.lookup),
+          alias,
+          eligibilityAlias,
+        ];
         const existing = await selectRows(client, ids);
         const aliasRow = existing.find((row) => row.credential_id === alias);
+        const eligibilityRow = existing.find(
+          (row) => row.credential_id === eligibilityAlias,
+        );
         const holderRow = existing.find((row) => row.credential_id === holder);
+        const rootHolderRow = existing.find(
+          (row) => row.credential_id === rootHolder,
+        );
+        if (rootHolder !== holder && rootHolderRow) throw conflict();
         if (aliasRow) {
           const value = parseAlias(aliasRow);
           if (value.holderCredentialId !== holder
             || value.requestBindingHash !== input.requestBindingHash
             || !holderRow) throw conflict();
         }
+        if (eligibilityRow) {
+          const value = parseEligibilityAlias(eligibilityRow);
+          if (value.holderCredentialId !== holder
+            || !holderRow) throw conflict();
+        }
         const existingRecord = recordFromRows(existing, input.lookup);
         if (existingRecord) {
           return Object.freeze({ kind: "existing" as const, record: existingRecord });
         }
-        if (aliasRow) throw conflict();
+        if (aliasRow || eligibilityRow) throw conflict();
         const releaseIntents = await selectReleaseIntents(
           client,
           input.lookup.releaseId,
         );
+        const rootGuard = rootHolder === holder
+          ? null
+          : createRootGuardIntent(intent, eligibility);
         const reservedWei = releaseIntents.reduce((total, row) => {
           const existingIntent = parseIntent(row);
           if (existingIntent.releaseId !== input.lookup.releaseId
@@ -241,12 +295,29 @@ export function createMainTokenMigrationGasSponsorPostgresStoreV1(
           }
           return total + BigInt(existingIntent.reservedTotalWei);
         }, 0n);
-        if (reservedWei + BigInt(intent.reservedTotalWei)
+        const requestedReservationWei = BigInt(intent.reservedTotalWei)
+          + (rootGuard ? BigInt(rootGuard.reservedTotalWei) : 0n);
+        if (reservedWei + requestedReservationWei
           > BigInt(intent.totalBudgetWei)) {
           throw budgetExhausted();
         }
         await insertRow(client, holder, input.requestBindingHash, intent);
         await insertAlias(client, alias, holder, input.requestBindingHash);
+        await insertEligibilityAlias(
+          client,
+          eligibilityAlias,
+          holder,
+          input.requestBindingHash,
+          eligibility,
+        );
+        if (rootGuard) {
+          await insertRow(
+            client,
+            rootHolder,
+            rootGuard.requestBindingHash,
+            rootGuard,
+          );
+        }
         return Object.freeze({
           kind: "created" as const,
           record: Object.freeze({ intent, transactionHash: null }),
@@ -468,6 +539,22 @@ async function insertAlias(
   await insertRow(client, credentialId, requestBindingHash, alias);
 }
 
+async function insertEligibilityAlias(
+  client: ProjectionTargetPostgresClientV1,
+  credentialId: string,
+  holderCredentialId: string,
+  requestBindingHash: `sha256:${string}`,
+  eligibility: MainTokenMigrationGasSponsorEligibilityV1,
+) {
+  const alias: EligibilityAliasV1 = Object.freeze({
+    schema: "programmable-main-token-migration-gas-sponsorship-eligibility/v1",
+    holderCredentialId,
+    requestBindingHash,
+    ...eligibility,
+  });
+  await insertRow(client, credentialId, requestBindingHash, alias);
+}
+
 function recordFromRows(rows: readonly Row[], lookup: Lookup) {
   const holder = rows.find((row) => row.credential_id === holderId(lookup));
   if (!holder) return null;
@@ -496,6 +583,83 @@ function validateIntent(value: MainTokenMigrationGasSponsorIntentV1, lookup: Loo
     throw new TypeError("Gas sponsor intent lookup is invalid");
   }
   return parsed;
+}
+
+function validateEligibility(
+  input: MainTokenMigrationGasSponsorEligibilityV1,
+  lookup: Lookup,
+) {
+  if (!input || typeof input !== "object"
+    || !isAddress(input.rootWalletAddress, { strict: true })
+    || !isAddress(input.walletAddress, { strict: true })
+    || input.walletAddress.toLowerCase() !== lookup.walletAddress.toLowerCase()) {
+    throw new TypeError("Gas sponsor eligibility is invalid");
+  }
+  const rootWalletAddress = getAddress(input.rootWalletAddress);
+  const walletAddress = getAddress(input.walletAddress);
+  const direct = rootWalletAddress.toLowerCase() === walletAddress.toLowerCase();
+  if (direct) {
+    if (input.transferHash !== null
+      || input.transferBlockNumber !== null
+      || input.transferLogIndex !== null) {
+      throw new TypeError("Gas sponsor eligibility is invalid");
+    }
+  } else if (input.transferHash === null || !HASH.test(input.transferHash)
+    || input.transferBlockNumber === null
+    || !positiveDecimal(input.transferBlockNumber)
+    || input.transferLogIndex === null
+    || !decimal(input.transferLogIndex)) {
+    throw new TypeError("Gas sponsor eligibility is invalid");
+  }
+  return Object.freeze({
+    rootWalletAddress,
+    walletAddress,
+    transferHash: input.transferHash,
+    transferBlockNumber: input.transferBlockNumber,
+    transferLogIndex: input.transferLogIndex,
+  });
+}
+
+function createRootGuardIntent(
+  intent: MainTokenMigrationGasSponsorIntentV1,
+  eligibility: MainTokenMigrationGasSponsorEligibilityV1,
+) {
+  const rootWalletAddress = getAddress(eligibility.rootWalletAddress);
+  const requestBindingHash = canonicalSha256(
+    "programmable.main-token-migration.gas-sponsor.root-guard.v1",
+    {
+      releaseId: intent.releaseId,
+      rootWalletAddress,
+      walletAddress: eligibility.walletAddress,
+    },
+  );
+  const identity = rootWalletAddress.toLowerCase().slice(2);
+  const reservedTotalWei = ROOT_GUARD_TOP_UP_WEI
+    + MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1
+      * ROOT_GUARD_FEE_PER_GAS_WEI;
+  return validateIntent({
+    schema: "programmable-main-token-migration-gas-sponsorship-intent/v1",
+    releaseId: intent.releaseId,
+    walletAddress: rootWalletAddress,
+    sponsorAddress: intent.sponsorAddress,
+    amountRaw: "1",
+    topUpWei: ROOT_GUARD_TOP_UP_WEI.toString(),
+    totalBudgetWei: intent.totalBudgetWei,
+    sponsorGasLimit:
+      MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1.toString(),
+    sponsorMaxFeePerGasWei: ROOT_GUARD_FEE_PER_GAS_WEI.toString(),
+    sponsorMaxPriorityFeePerGasWei: "0",
+    reservedTotalWei: reservedTotalWei.toString(),
+    estimatedTransferGas: "1",
+    feePerGasWei: ROOT_GUARD_FEE_PER_GAS_WEI.toString(),
+    requestBindingHash,
+    providerIdempotencyKey: `mtmgs-root-guard-${identity}`,
+    providerReferenceId: `mtmgs-root-guard-${identity}`,
+    reservedAt: intent.reservedAt,
+  }, {
+    releaseId: intent.releaseId,
+    walletAddress: rootWalletAddress,
+  });
 }
 
 function parseIntent(row: Row) {
@@ -530,7 +694,8 @@ function parseIntentValue(input: JsonValue): MainTokenMigrationGasSponsorIntentV
   const sponsorGasLimit = BigInt(value.sponsorGasLimit);
   const sponsorMaxFeePerGasWei = BigInt(value.sponsorMaxFeePerGasWei);
   const sponsorMaxPriorityFeePerGasWei = BigInt(value.sponsorMaxPriorityFeePerGasWei);
-  if (sponsorGasLimit !== MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1
+  if (sponsorGasLimit < MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1
+    || sponsorGasLimit > MAIN_TOKEN_MIGRATION_GAS_SPONSOR_MAX_GAS_LIMIT_V1
     || sponsorMaxPriorityFeePerGasWei > sponsorMaxFeePerGasWei
     || BigInt(value.reservedTotalWei)
       !== BigInt(value.topUpWei) + sponsorGasLimit * sponsorMaxFeePerGasWei
@@ -586,6 +751,40 @@ function parseAlias(row: Row): AliasV1 {
   });
 }
 
+function parseEligibilityAlias(row: Row): EligibilityAliasV1 {
+  const value = object(parseCanonical(row.canonical_use));
+  exactKeys(value, [
+    "holderCredentialId", "requestBindingHash", "rootWalletAddress", "schema",
+    "transferBlockNumber", "transferHash", "transferLogIndex", "walletAddress",
+  ]);
+  if (value.schema
+      !== "programmable-main-token-migration-gas-sponsorship-eligibility/v1"
+    || typeof value.holderCredentialId !== "string"
+    || typeof value.requestBindingHash !== "string"
+    || !DIGEST.test(value.requestBindingHash)
+    || row.request_binding_hash !== value.requestBindingHash
+    || typeof value.rootWalletAddress !== "string"
+    || !isAddress(value.rootWalletAddress, { strict: true })
+    || typeof value.walletAddress !== "string"
+    || !isAddress(value.walletAddress, { strict: true })) throw unavailable();
+  const eligibility = validateEligibility({
+    rootWalletAddress: getAddress(value.rootWalletAddress),
+    walletAddress: getAddress(value.walletAddress),
+    transferHash: value.transferHash as Hex | null,
+    transferBlockNumber: value.transferBlockNumber as string | null,
+    transferLogIndex: value.transferLogIndex as string | null,
+  }, {
+    releaseId: "validation-only",
+    walletAddress: getAddress(value.walletAddress),
+  });
+  return Object.freeze({
+    schema: value.schema,
+    holderCredentialId: value.holderCredentialId,
+    requestBindingHash: value.requestBindingHash as `sha256:${string}`,
+    ...eligibility,
+  });
+}
+
 function parseCanonical(source: string) {
   const value = parseStrictJson(source, { maximumBytes: 16_384, maximumDepth: 8 });
   if (canonicalizeJson(value) !== source) throw unavailable();
@@ -637,6 +836,10 @@ function completionId(input: Lookup) {
 
 function aliasId(releaseId: string, binding: string) {
   return `${PREFIX}:idempotency:${releaseId}:${binding.slice("sha256:".length)}`;
+}
+
+function eligibilityId(releaseId: string, rootWalletAddress: Address) {
+  return `${PREFIX}:eligibility:${releaseId}:${rootWalletAddress.toLowerCase()}`;
 }
 
 function conflict() {

--- a/lib/server/main-token-migration-gas-sponsor-v1.ts
+++ b/lib/server/main-token-migration-gas-sponsor-v1.ts
@@ -5,11 +5,13 @@ import { randomUUID } from "node:crypto";
 import { PrivyClient } from "@privy-io/node";
 import {
   createPublicClient,
+  decodeFunctionData,
   getAddress,
   http,
   isAddress,
   keccak256,
   parseAbi,
+  parseAbiItem,
   toHex,
   type Address,
   type Hex,
@@ -40,7 +42,9 @@ import { canonicalSha256 } from "./projection-target/hashing";
 import {
   getProductionMainTokenMigrationGasSponsorStoreV1,
   MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1,
+  MAIN_TOKEN_MIGRATION_GAS_SPONSOR_MAX_GAS_LIMIT_V1,
   MainTokenMigrationGasSponsorStoreErrorV1,
+  type MainTokenMigrationGasSponsorEligibilityV1,
   type MainTokenMigrationGasSponsorIntentV1,
   type MainTokenMigrationGasSponsorRecordV1,
   type MainTokenMigrationGasSponsorStoreV1,
@@ -50,6 +54,9 @@ const ERC20_ABI = parseAbi([
   "function balanceOf(address account) view returns (uint256)",
   "function transfer(address to,uint256 amount) returns (bool)",
 ]);
+const ERC20_TRANSFER_EVENT = parseAbiItem(
+  "event Transfer(address indexed from,address indexed to,uint256 value)",
+);
 const IDEMPOTENCY_KEY = /^[A-Za-z0-9][A-Za-z0-9._~-]{15,127}$/u;
 const DECIMAL = /^[1-9][0-9]{0,77}$/u;
 const HASH = /^0x[0-9a-f]{64}$/u;
@@ -61,6 +68,31 @@ const MAXIMUM_FEE_PER_GAS_WEI = 20_000_000_000n;
 const ABSOLUTE_TOP_UP_CAP_WEI = 2_000_000_000_000_000n;
 const ABSOLUTE_TOTAL_BUDGET_CAP_WEI = 1_000_000_000_000_000_000n;
 const DEADLINE_SAFETY_SECONDS = 5 * 60;
+const MAXIMUM_RELOCATION_LOGS = 64;
+const MAXIMUM_RELOCATION_SOURCES = 8;
+const RELOCATION_LOG_BLOCK_RANGE = 5_000n;
+const PROVIDER_IDEMPOTENCY_WINDOW_MS = 24 * 60 * 60 * 1_000;
+const PROVIDER_IDEMPOTENCY_SAFETY_MS = 5 * 60 * 1_000;
+const MAXIMUM_PROVIDER_RESPONSE_BYTES = 32_768;
+
+const PROVIDER_TRANSACTION_STATUSES = Object.freeze([
+  "broadcasted",
+  "confirmed",
+  "execution_reverted",
+  "failed",
+  "replaced",
+  "finalized",
+  "provider_error",
+  "pending",
+] as const);
+
+type MainTokenMigrationGasSponsorProviderStatusV1 =
+  typeof PROVIDER_TRANSACTION_STATUSES[number];
+
+type MainTokenMigrationGasSponsorProviderRecordV1 = Readonly<{
+  status: MainTokenMigrationGasSponsorProviderStatusV1;
+  transactionHash: Hex | null;
+}>;
 
 type Environment = Readonly<Record<string, string | undefined>>;
 
@@ -90,6 +122,7 @@ export type MainTokenMigrationGasSponsorObservationV1 = Readonly<{
   maxPriorityFeePerGasWei: bigint;
   nativeBalanceWei: bigint;
   sponsorBalanceWei: bigint;
+  eligibility: MainTokenMigrationGasSponsorEligibilityV1;
 }>;
 
 export interface MainTokenMigrationGasSponsorChainV1 {
@@ -97,6 +130,11 @@ export interface MainTokenMigrationGasSponsorChainV1 {
     configuration: MainTokenMigrationGasSponsorConfigurationV1;
     request: MainTokenMigrationGasSponsorRequestV1;
   }>): Promise<MainTokenMigrationGasSponsorObservationV1>;
+  sponsorGasLimit(input: Readonly<{
+    configuration: MainTokenMigrationGasSponsorConfigurationV1;
+    walletAddress: Address;
+    topUpWei: bigint;
+  }>): Promise<bigint>;
   status(
     record: MainTokenMigrationGasSponsorRecordV1,
   ): Promise<"pending" | "confirmed" | "failed">;
@@ -104,6 +142,9 @@ export interface MainTokenMigrationGasSponsorChainV1 {
 
 export interface MainTokenMigrationGasSponsorSenderV1 {
   assertReady(): Promise<void>;
+  lookup(
+    intent: MainTokenMigrationGasSponsorIntentV1,
+  ): Promise<MainTokenMigrationGasSponsorProviderRecordV1 | null>;
   send(intent: MainTokenMigrationGasSponsorIntentV1): Promise<Hex>;
 }
 
@@ -216,7 +257,9 @@ export function deriveMainTokenMigrationSponsorBindingsV1(input: Readonly<{
     idempotencyBindingHash,
     requestBindingHash,
     providerIdempotencyKey: `mtmgs-${providerBinding}`,
-    providerReferenceId: `mtmgs-${providerBinding}`,
+    // Privy caps reference IDs at 64 characters. This preserves 232 bits of
+    // the independently bound release + wallet digest.
+    providerReferenceId: `mtmgs-${providerBinding.slice(0, 58)}`,
   });
 }
 
@@ -442,7 +485,20 @@ export function createMainTokenMigrationGasSponsorV1(input: Readonly<{
           walletAddress: sponsorRequest.walletAddress,
           operation: "submit",
         });
-        if (existing) return await existingResponse(existing, input.chain);
+        if (existing) {
+          if (existing.transactionHash !== null) {
+            return await existingResponse(existing, input.chain);
+          }
+          assertBroadcastableSponsorIntent(existing.intent);
+          await input.sender.assertReady();
+          return await resumeReservedSponsorIntent({
+            chain: input.chain,
+            now: now(),
+            record: existing,
+            sender: input.sender,
+            store: input.store,
+          });
+        }
         await input.sender.assertReady();
         const observation = await input.chain.observe({
           configuration: input.configuration,
@@ -470,9 +526,13 @@ export function createMainTokenMigrationGasSponsorV1(input: Readonly<{
             "gas_quote_unavailable",
           );
         }
+        const sponsorGasLimit = await input.chain.sponsorGasLimit({
+          configuration: input.configuration,
+          walletAddress: sponsorRequest.walletAddress,
+          topUpWei: quote.topUpWei,
+        });
         const reservedTotalWei = quote.topUpWei
-          + MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1
-            * observation.feePerGasWei;
+          + sponsorGasLimit * observation.feePerGasWei;
         if (observation.sponsorBalanceWei < reservedTotalWei) {
           throw new MainTokenMigrationGasSponsorErrorV1(503, "sponsor_balance_low");
         }
@@ -484,8 +544,7 @@ export function createMainTokenMigrationGasSponsorV1(input: Readonly<{
           amountRaw: sponsorRequest.amountRaw.toString(),
           topUpWei: quote.topUpWei.toString(),
           totalBudgetWei: input.configuration.totalBudgetWei.toString(),
-          sponsorGasLimit:
-            MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1.toString(),
+          sponsorGasLimit: sponsorGasLimit.toString(),
           sponsorMaxFeePerGasWei: observation.feePerGasWei.toString(),
           sponsorMaxPriorityFeePerGasWei:
             observation.maxPriorityFeePerGasWei.toString(),
@@ -504,37 +563,27 @@ export function createMainTokenMigrationGasSponsorV1(input: Readonly<{
           },
           idempotencyBindingHash: bindings.idempotencyBindingHash,
           requestBindingHash: bindings.requestBindingHash,
+          eligibility: observation.eligibility,
           intent,
         });
         if (reservation.record.transactionHash !== null) {
           return await existingResponse(reservation.record, input.chain);
         }
-        if (reservation.kind !== "created") {
-          throw new MainTokenMigrationGasSponsorErrorV1(
-            503,
-            "submission_unknown",
-          );
+        assertBroadcastableSponsorIntent(reservation.record.intent);
+        if (reservation.kind === "existing") {
+          return await resumeReservedSponsorIntent({
+            chain: input.chain,
+            now: now(),
+            record: reservation.record,
+            sender: input.sender,
+            store: input.store,
+          });
         }
-        let hash: Hex;
-        try {
-          hash = await input.sender.send(reservation.record.intent);
-        } catch {
-          throw new MainTokenMigrationGasSponsorErrorV1(503, "submission_unknown");
-        }
-        const completed = await input.store.complete({
-          lookup: {
-            releaseId: input.configuration.releaseId,
-            walletAddress: sponsorRequest.walletAddress,
-          },
-          providerReferenceId: reservation.record.intent.providerReferenceId,
-          transactionHash: hash,
-        });
-        return response({
-          status: "submitted",
-          walletAddress: completed.intent.walletAddress,
-          topUpWei: completed.intent.topUpWei,
-          transactionHash: completed.transactionHash,
-          estimatedTransferGas: completed.intent.estimatedTransferGas,
+        return await submitReservedSponsorIntent({
+          chain: input.chain,
+          record: reservation.record,
+          sender: input.sender,
+          store: input.store,
         });
       } catch (error) {
         return errorResponse(error);
@@ -579,6 +628,124 @@ async function existingResponse(
     transactionHash: record.transactionHash,
     estimatedTransferGas: record.intent.estimatedTransferGas,
   });
+}
+
+async function resumeReservedSponsorIntent(input: Readonly<{
+  chain: MainTokenMigrationGasSponsorChainV1;
+  now: Date;
+  record: MainTokenMigrationGasSponsorRecordV1;
+  sender: MainTokenMigrationGasSponsorSenderV1;
+  store: MainTokenMigrationGasSponsorStoreV1;
+}>) {
+  assertBroadcastableSponsorIntent(input.record.intent);
+  const providerRecord = await input.sender.lookup(input.record.intent);
+  if (providerRecord?.transactionHash) {
+    const completed = await completeSponsorIntent(
+      input.store,
+      input.record.intent,
+      providerRecord.transactionHash,
+    );
+    return existingResponse(completed, input.chain);
+  }
+  if (providerRecord !== null) {
+    if (providerRecord.status === "failed"
+      || providerRecord.status === "provider_error"
+      || providerRecord.status === "execution_reverted") {
+      throw new MainTokenMigrationGasSponsorErrorV1(
+        503,
+        "sponsorship_failed",
+      );
+    }
+    throw new MainTokenMigrationGasSponsorErrorV1(503, "submission_unknown");
+  }
+  const reservedAtMs = new Date(input.record.intent.reservedAt).getTime();
+  const ageMs = input.now.getTime() - reservedAtMs;
+  if (!Number.isFinite(ageMs) || ageMs < 0
+    || ageMs >= PROVIDER_IDEMPOTENCY_WINDOW_MS
+      - PROVIDER_IDEMPOTENCY_SAFETY_MS) {
+    throw new MainTokenMigrationGasSponsorErrorV1(503, "submission_unknown");
+  }
+  return submitReservedSponsorIntent(input);
+}
+
+async function submitReservedSponsorIntent(input: Readonly<{
+  chain: MainTokenMigrationGasSponsorChainV1;
+  record: MainTokenMigrationGasSponsorRecordV1;
+  sender: MainTokenMigrationGasSponsorSenderV1;
+  store: MainTokenMigrationGasSponsorStoreV1;
+}>) {
+  assertBroadcastableSponsorIntent(input.record.intent);
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const hash = await input.sender.send(input.record.intent);
+      const completed = await completeSponsorIntent(
+        input.store,
+        input.record.intent,
+        hash,
+      );
+      return response({
+        status: "submitted",
+        walletAddress: completed.intent.walletAddress,
+        topUpWei: completed.intent.topUpWei,
+        transactionHash: completed.transactionHash,
+        estimatedTransferGas: completed.intent.estimatedTransferGas,
+      });
+    } catch {
+      try {
+        const providerRecord = await input.sender.lookup(input.record.intent);
+        if (providerRecord?.transactionHash) {
+          const completed = await completeSponsorIntent(
+            input.store,
+            input.record.intent,
+            providerRecord.transactionHash,
+          );
+          return existingResponse(completed, input.chain);
+        }
+        if (providerRecord !== null) break;
+      } catch {
+        // A second send uses the identical persisted body and idempotency key.
+        // Privy guarantees it cannot execute twice inside its 24-hour window.
+      }
+    }
+  }
+  throw new MainTokenMigrationGasSponsorErrorV1(503, "submission_unknown");
+}
+
+async function completeSponsorIntent(
+  store: MainTokenMigrationGasSponsorStoreV1,
+  intent: MainTokenMigrationGasSponsorIntentV1,
+  transactionHash: Hex,
+) {
+  return store.complete({
+    lookup: {
+      releaseId: intent.releaseId,
+      walletAddress: intent.walletAddress,
+    },
+    providerReferenceId: intent.providerReferenceId,
+    transactionHash,
+  });
+}
+
+function assertBroadcastableSponsorIntent(
+  intent: MainTokenMigrationGasSponsorIntentV1,
+) {
+  const rootGuardPrefix = "mtmgs-root-guard-";
+  if (intent.providerIdempotencyKey.startsWith(rootGuardPrefix)
+    || intent.providerReferenceId.startsWith(rootGuardPrefix)) {
+    const identity = intent.walletAddress.toLowerCase().slice(2);
+    const expected = `${rootGuardPrefix}${identity}`;
+    const exactRootGuard = intent.providerIdempotencyKey === expected
+      && intent.providerReferenceId === expected
+      && intent.topUpWei === "1"
+      && intent.sponsorGasLimit === "21000"
+      && intent.sponsorMaxFeePerGasWei === "1"
+      && intent.sponsorMaxPriorityFeePerGasWei === "0"
+      && intent.reservedTotalWei === "21001";
+    throw new MainTokenMigrationGasSponsorErrorV1(
+      exactRootGuard ? 409 : 503,
+      exactRootGuard ? "idempotency_conflict" : "sponsor_intent_mismatch",
+    );
+  }
 }
 
 function response(input: Readonly<{
@@ -654,7 +821,7 @@ function publicGasSponsorshipFailureMessage(
     return "This wallet is not eligible for automatic gas sponsorship.";
   }
   if (failure.code === "submission_unknown") {
-    return "The gas top-up needs a status review. No second top-up was sent.";
+    return "The gas top-up status could not be confirmed. Check again shortly. No second top-up will be sent.";
   }
   if (failure.code === "sponsorship_closed") {
     return "Gas sponsorship is closed for this migration window.";
@@ -757,13 +924,66 @@ function createProductionSender(
       const wallet = await privy.wallets().get(configuration.sponsorWalletId);
       assertMainTokenMigrationPrivySponsorWalletV1(wallet, configuration);
     },
+    async lookup(intent: MainTokenMigrationGasSponsorIntentV1) {
+      assertBroadcastableSponsorIntent(intent);
+      const url = new URL("https://api.privy.io/v1/transactions");
+      url.searchParams.set("reference_id", intent.providerReferenceId);
+      const authorization = Buffer.from(
+        `${appId}:${appSecret}`,
+        "utf8",
+      ).toString("base64");
+      const result = await fetch(url, {
+        method: "GET",
+        cache: "no-store",
+        headers: {
+          accept: "application/json",
+          authorization: `Basic ${authorization}`,
+          "privy-app-id": appId,
+        },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!result.ok) {
+        throw new MainTokenMigrationGasSponsorErrorV1(
+          503,
+          "provider_reconciliation_unavailable",
+        );
+      }
+      const contentLength = result.headers.get("content-length");
+      if (contentLength && (!/^[0-9]+$/u.test(contentLength)
+        || Number(contentLength) > MAXIMUM_PROVIDER_RESPONSE_BYTES)) {
+        throw new MainTokenMigrationGasSponsorErrorV1(
+          503,
+          "provider_response_invalid",
+        );
+      }
+      const source = await result.text();
+      if (Buffer.byteLength(source, "utf8") > MAXIMUM_PROVIDER_RESPONSE_BYTES) {
+        throw new MainTokenMigrationGasSponsorErrorV1(
+          503,
+          "provider_response_invalid",
+        );
+      }
+      return parsePrivySponsorTransactionLookupV1(
+        parseStrictJson(source, {
+          maximumBytes: MAXIMUM_PROVIDER_RESPONSE_BYTES,
+          maximumDepth: 8,
+        }),
+        {
+          referenceId: intent.providerReferenceId,
+          sponsorWalletId: configuration.sponsorWalletId,
+        },
+      );
+    },
     async send(intent: MainTokenMigrationGasSponsorIntentV1) {
+      assertBroadcastableSponsorIntent(intent);
       if (intent.sponsorAddress !== configuration.sponsorAddress
         || intent.releaseId !== configuration.releaseId
         || BigInt(intent.topUpWei) > configuration.maximumTopUpWei
         || BigInt(intent.totalBudgetWei) !== configuration.totalBudgetWei
         || BigInt(intent.sponsorGasLimit)
-          !== MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1
+          < MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1
+        || BigInt(intent.sponsorGasLimit)
+          > MAIN_TOKEN_MIGRATION_GAS_SPONSOR_MAX_GAS_LIMIT_V1
         || BigInt(intent.sponsorMaxFeePerGasWei)
           > MAXIMUM_FEE_PER_GAS_WEI
         || BigInt(intent.sponsorMaxPriorityFeePerGasWei)
@@ -793,7 +1013,6 @@ function createProductionSender(
           },
           idempotency_key: intent.providerIdempotencyKey,
           reference_id: intent.providerReferenceId,
-          request_expiry: Date.now() + 30_000,
         },
       );
       if (result.caip2 !== "eip155:1" || !HASH.test(result.hash)
@@ -803,6 +1022,282 @@ function createProductionSender(
       return result.hash as Hex;
     },
   });
+}
+
+export function parsePrivySponsorTransactionLookupV1(
+  input: unknown,
+  expected: Readonly<{
+    referenceId: string;
+    sponsorWalletId: string;
+  }>,
+): MainTokenMigrationGasSponsorProviderRecordV1 | null {
+  if (!input || Array.isArray(input) || typeof input !== "object") {
+    throw new MainTokenMigrationGasSponsorErrorV1(
+      503,
+      "provider_response_invalid",
+    );
+  }
+  const transactions = (input as Record<string, unknown>).transactions;
+  if (!Array.isArray(transactions) || transactions.length > 1) {
+    throw new MainTokenMigrationGasSponsorErrorV1(
+      503,
+      "provider_response_invalid",
+    );
+  }
+  if (transactions.length === 0) return null;
+  const transaction = transactions[0];
+  if (!transaction || Array.isArray(transaction)
+    || typeof transaction !== "object") {
+    throw new MainTokenMigrationGasSponsorErrorV1(
+      503,
+      "provider_response_invalid",
+    );
+  }
+  const value = transaction as Record<string, unknown>;
+  if (value.wallet_id !== expected.sponsorWalletId
+    || value.caip2 !== "eip155:1"
+    || value.reference_id !== expected.referenceId
+    || typeof value.status !== "string"
+    || !PROVIDER_TRANSACTION_STATUSES.some(
+      (status) => status === value.status,
+    )
+    || (value.transaction_hash !== null
+      && (typeof value.transaction_hash !== "string"
+        || !HASH.test(value.transaction_hash)))) {
+    throw new MainTokenMigrationGasSponsorErrorV1(
+      503,
+      "provider_response_invalid",
+    );
+  }
+  return Object.freeze({
+    status: value.status as MainTokenMigrationGasSponsorProviderStatusV1,
+    transactionHash: value.transaction_hash as Hex | null,
+  });
+}
+
+type RelocationTransferV1 = Readonly<{
+  blockHash: Hex;
+  blockNumber: bigint;
+  from: Address;
+  logIndex: number;
+  to: Address;
+  transactionHash: Hex;
+  value: bigint;
+}>;
+
+async function readRelocationTransfersV1(
+  client: PublicClient,
+  input: Readonly<{
+    fromBlock: bigint;
+    minimumValue: bigint;
+    toBlock: bigint;
+    walletAddress: Address;
+  }>,
+) {
+  if (input.fromBlock > input.toBlock) return [] as RelocationTransferV1[];
+  const transfers: RelocationTransferV1[] = [];
+  let cursor = input.fromBlock;
+  while (cursor <= input.toBlock) {
+    const rangeEnd = cursor + RELOCATION_LOG_BLOCK_RANGE - 1n < input.toBlock
+      ? cursor + RELOCATION_LOG_BLOCK_RANGE - 1n
+      : input.toBlock;
+    const logs = await client.getLogs({
+      address: MAIN_TOKEN_ADDRESS,
+      event: ERC20_TRANSFER_EVENT,
+      args: { to: input.walletAddress },
+      fromBlock: cursor,
+      toBlock: rangeEnd,
+      strict: true,
+    });
+    for (const log of logs) {
+      const { from, to, value } = log.args;
+      if (log.removed || log.blockHash === null || log.blockNumber === null
+        || log.transactionHash === null || log.logIndex === null
+        || !isAddress(from, { strict: true })
+        || !isAddress(to, { strict: true })
+        || getAddress(to) !== input.walletAddress
+        || typeof value !== "bigint" || value <= 0n) {
+        throw new MainTokenMigrationGasSponsorErrorV1(
+          503,
+          "eligibility_history_unavailable",
+        );
+      }
+      if (value < input.minimumValue) continue;
+      transfers.push(Object.freeze({
+        blockHash: log.blockHash.toLowerCase() as Hex,
+        blockNumber: log.blockNumber,
+        from: getAddress(from),
+        logIndex: log.logIndex,
+        to: getAddress(to),
+        transactionHash: log.transactionHash.toLowerCase() as Hex,
+        value,
+      }));
+      transfers.sort((left, right) => {
+        if (left.value !== right.value) return left.value > right.value ? -1 : 1;
+        if (left.blockNumber !== right.blockNumber) {
+          return left.blockNumber > right.blockNumber ? -1 : 1;
+        }
+        return right.logIndex - left.logIndex;
+      });
+      if (transfers.length > MAXIMUM_RELOCATION_LOGS) transfers.pop();
+    }
+    cursor = rangeEnd + 1n;
+  }
+  transfers.sort((left, right) => {
+    if (left.blockNumber !== right.blockNumber) {
+      return left.blockNumber < right.blockNumber ? -1 : 1;
+    }
+    return left.logIndex - right.logIndex;
+  });
+  return transfers;
+}
+
+function relocationTransferFingerprintV1(transfer: RelocationTransferV1) {
+  return [
+    transfer.blockHash,
+    transfer.blockNumber.toString(),
+    transfer.from.toLowerCase(),
+    String(transfer.logIndex),
+    transfer.to.toLowerCase(),
+    transfer.transactionHash,
+    transfer.value.toString(),
+  ].join(":");
+}
+
+async function isExactDirectRelocationTransferV1(
+  clients: readonly [PublicClient, PublicClient],
+  transfer: RelocationTransferV1,
+) {
+  const transactions = await Promise.all(clients.map((client) =>
+    client.getTransaction({ hash: transfer.transactionHash })));
+  const [left, right] = transactions;
+  if (!left || !right || left.hash !== right.hash
+    || left.blockHash !== right.blockHash
+    || left.blockNumber !== right.blockNumber
+    || left.from.toLowerCase() !== right.from.toLowerCase()
+    || left.to?.toLowerCase() !== right.to?.toLowerCase()
+    || left.input !== right.input || left.value !== right.value
+    || left.hash !== transfer.transactionHash
+    || left.blockHash !== transfer.blockHash
+    || left.blockNumber !== transfer.blockNumber) {
+    throw new MainTokenMigrationGasSponsorErrorV1(
+      503,
+      "rpc_quorum_unavailable",
+    );
+  }
+  if (left.from.toLowerCase() !== transfer.from.toLowerCase()
+    || left.to?.toLowerCase() !== MAIN_TOKEN_ADDRESS.toLowerCase()
+    || left.value !== 0n) return false;
+  try {
+    const decoded = decodeFunctionData({ abi: ERC20_ABI, data: left.input });
+    if (decoded.functionName !== "transfer" || decoded.args.length !== 2) {
+      return false;
+    }
+    const [recipient, amount] = decoded.args;
+    return typeof recipient === "string"
+      && getAddress(recipient).toLowerCase() === transfer.to.toLowerCase()
+      && typeof amount === "bigint"
+      && amount === transfer.value;
+  } catch {
+    return false;
+  }
+}
+
+export async function resolveMainTokenMigrationSponsorEligibilityV1(input: Readonly<{
+  clients: readonly [PublicClient, PublicClient];
+  configuration: MainTokenMigrationGasSponsorConfigurationV1;
+  request: MainTokenMigrationGasSponsorRequestV1;
+  blockNumber: bigint;
+  provenanceBlockNumber: bigint;
+  directOpeningBalances: readonly [bigint, bigint];
+}>) : Promise<MainTokenMigrationGasSponsorEligibilityV1 | null> {
+  if (input.directOpeningBalances[0] >= input.request.amountRaw
+    && input.directOpeningBalances[1] >= input.request.amountRaw) {
+    return Object.freeze({
+      rootWalletAddress: input.request.walletAddress,
+      walletAddress: input.request.walletAddress,
+      transferHash: null,
+      transferBlockNumber: null,
+      transferLogIndex: null,
+    });
+  }
+  const logs = await Promise.all(input.clients.map((client) =>
+    readRelocationTransfersV1(client, {
+      fromBlock: input.configuration.startBlockNumber + 1n,
+      minimumValue: input.request.amountRaw,
+      toBlock: input.provenanceBlockNumber,
+      walletAddress: input.request.walletAddress,
+    })));
+  const leftFingerprint = logs[0].map(relocationTransferFingerprintV1);
+  const rightFingerprint = logs[1].map(relocationTransferFingerprintV1);
+  if (leftFingerprint.length !== rightFingerprint.length
+    || leftFingerprint.some((value, index) => value !== rightFingerprint[index])) {
+    throw new MainTokenMigrationGasSponsorErrorV1(
+      503,
+      "rpc_quorum_unavailable",
+    );
+  }
+  const candidates: RelocationTransferV1[] = [];
+  const sources = new Set<string>();
+  const prioritized = [...logs[0]].sort((left, right) => {
+    if (left.value !== right.value) return left.value > right.value ? -1 : 1;
+    if (left.blockNumber !== right.blockNumber) {
+      return left.blockNumber > right.blockNumber ? -1 : 1;
+    }
+    return right.logIndex - left.logIndex;
+  });
+  for (const transfer of prioritized) {
+    const source = transfer.from.toLowerCase();
+    if (sources.has(source)) continue;
+    sources.add(source);
+    candidates.push(transfer);
+    if (candidates.length >= MAXIMUM_RELOCATION_SOURCES) break;
+  }
+  for (const transfer of candidates) {
+    if (!await isExactDirectRelocationTransferV1(input.clients, transfer)) {
+      continue;
+    }
+    const sourceStates = await Promise.all(input.clients.map(async (client) => {
+      const [currentCode, openingCode, openingBalance] = await Promise.all([
+        client.getCode({
+          address: transfer.from,
+          blockNumber: input.blockNumber,
+        }),
+        client.getCode({
+          address: transfer.from,
+          blockNumber: input.configuration.startBlockNumber,
+        }),
+        client.readContract({
+          address: MAIN_TOKEN_ADDRESS,
+          abi: ERC20_ABI,
+          functionName: "balanceOf",
+          args: [transfer.from],
+          blockNumber: input.configuration.startBlockNumber,
+        }),
+      ]);
+      return { currentCode, openingCode, openingBalance };
+    }));
+    const [left, right] = sourceStates;
+    if (!left || !right || left.currentCode !== right.currentCode
+      || left.openingCode !== right.openingCode
+      || left.openingBalance !== right.openingBalance) {
+      throw new MainTokenMigrationGasSponsorErrorV1(
+        503,
+        "rpc_quorum_unavailable",
+      );
+    }
+    if (!isMainTokenMigrationWalletCodeEligible(left.currentCode)
+      || !isMainTokenMigrationWalletCodeEligible(left.openingCode)
+      || left.openingBalance < transfer.value) continue;
+    return Object.freeze({
+      rootWalletAddress: transfer.from,
+      walletAddress: input.request.walletAddress,
+      transferHash: transfer.transactionHash,
+      transferBlockNumber: transfer.blockNumber.toString(),
+      transferLogIndex: String(transfer.logIndex),
+    });
+  }
+  return null;
 }
 
 export function createMainTokenMigrationGasSponsorChainV1(
@@ -825,16 +1320,31 @@ export function createMainTokenMigrationGasSponsorChainV1(
       request: MainTokenMigrationGasSponsorRequestV1;
     }>) {
       try {
-        const heads = await Promise.all(clients.map((client) => client.getBlockNumber()));
+        const [heads, finalizedHeads] = await Promise.all([
+          Promise.all(clients.map((client) => client.getBlockNumber())),
+          Promise.all(clients.map((client) =>
+            client.getBlock({ blockTag: "finalized" }))),
+        ]);
         const blockNumber = heads[0] < heads[1] ? heads[0] : heads[1];
+        const finalizedNumbers = finalizedHeads.map((block) => block.number);
+        if (finalizedNumbers[0] === null || finalizedNumbers[1] === null) {
+          throw new MainTokenMigrationGasSponsorErrorV1(
+            503,
+            "rpc_quorum_unavailable",
+          );
+        }
+        const provenanceBlockNumber = finalizedNumbers[0]
+          < finalizedNumbers[1]
+          ? finalizedNumbers[0]
+          : finalizedNumbers[1];
         const observations = await Promise.all(clients.map(async (client) => {
-          const [chainId, block, finalizedBlock, startBlock,
+          const [chainId, block, provenanceBlock, startBlock,
             tokenCode, holderCode, startHolderCode,
             sponsorCode, currentBalance, openingBalance, nativeBalance, sponsorBalance,
             fees] = await Promise.all([
             client.getChainId(),
             client.getBlock({ blockNumber }),
-            client.getBlock({ blockTag: "finalized" }),
+            client.getBlock({ blockNumber: provenanceBlockNumber }),
             client.getBlock({ blockNumber: configuration.startBlockNumber }),
             client.getCode({ address: MAIN_TOKEN_ADDRESS, blockNumber }),
             client.getCode({ address: request.walletAddress, blockNumber }),
@@ -849,7 +1359,7 @@ export function createMainTokenMigrationGasSponsorChainV1(
             client.getBalance({ address: configuration.sponsorAddress, blockNumber }),
             client.estimateFeesPerGas(),
           ]);
-          return { chainId, block, finalizedBlock, startBlock,
+          return { chainId, block, provenanceBlock, startBlock,
             tokenCode, holderCode, startHolderCode,
             sponsorCode,
             currentBalance, openingBalance, nativeBalance, sponsorBalance,
@@ -865,22 +1375,32 @@ export function createMainTokenMigrationGasSponsorChainV1(
                 number: left.startBlock.number,
                 hash: left.startBlock.hash,
                 timestamp: left.startBlock.timestamp,
-                finalizedBlockNumber: left.finalizedBlock.number,
+                finalizedBlockNumber: left.provenanceBlock.number,
               },
               {
                 number: right.startBlock.number,
                 hash: right.startBlock.hash,
                 timestamp: right.startBlock.timestamp,
-                finalizedBlockNumber: right.finalizedBlock.number,
+                finalizedBlockNumber: right.provenanceBlock.number,
               },
             ],
           );
         }
         if (!left || !right || left.chainId !== 1 || right.chainId !== 1
           || left.block.hash !== right.block.hash
+          || left.provenanceBlock.number !== provenanceBlockNumber
+          || right.provenanceBlock.number !== provenanceBlockNumber
+          || left.provenanceBlock.hash !== right.provenanceBlock.hash
           || !left.tokenCode || !right.tokenCode
           || keccak256(left.tokenCode) !== MAIN_TOKEN_RUNTIME_CODE_KECCAK256
           || keccak256(right.tokenCode) !== MAIN_TOKEN_RUNTIME_CODE_KECCAK256
+          || left.holderCode !== right.holderCode
+          || left.startHolderCode !== right.startHolderCode
+          || left.sponsorCode !== right.sponsorCode
+          || left.currentBalance !== right.currentBalance
+          || left.openingBalance !== right.openingBalance
+          || left.nativeBalance !== right.nativeBalance
+          || left.sponsorBalance !== right.sponsorBalance
           || !left.fee || !right.fee
           || left.priorityFee === undefined || right.priorityFee === undefined) {
           throw new MainTokenMigrationGasSponsorErrorV1(
@@ -893,8 +1413,19 @@ export function createMainTokenMigrationGasSponsorChainV1(
           || !isMainTokenMigrationWalletCodeEligible(left.startHolderCode)
           || !isMainTokenMigrationWalletCodeEligible(right.startHolderCode)
           || left.sponsorCode !== "0x" || right.sponsorCode !== "0x"
-          || left.currentBalance < request.amountRaw || right.currentBalance < request.amountRaw
-          || left.openingBalance < request.amountRaw || right.openingBalance < request.amountRaw) {
+          || left.currentBalance < request.amountRaw
+          || right.currentBalance < request.amountRaw) {
+          throw new MainTokenMigrationGasSponsorErrorV1(422, "wallet_not_eligible");
+        }
+        const eligibility = await resolveMainTokenMigrationSponsorEligibilityV1({
+          clients,
+          configuration,
+          request,
+          blockNumber,
+          provenanceBlockNumber,
+          directOpeningBalances: [left.openingBalance, right.openingBalance],
+        });
+        if (!eligibility) {
           throw new MainTokenMigrationGasSponsorErrorV1(422, "wallet_not_eligible");
         }
         return Object.freeze({
@@ -907,14 +1438,83 @@ export function createMainTokenMigrationGasSponsorChainV1(
           feePerGasWei: left.fee > right.fee ? left.fee : right.fee,
           maxPriorityFeePerGasWei: left.priorityFee > right.priorityFee
             ? left.priorityFee : right.priorityFee,
-          nativeBalanceWei: left.nativeBalance > right.nativeBalance
-            ? left.nativeBalance : right.nativeBalance,
-          sponsorBalanceWei: left.sponsorBalance < right.sponsorBalance
-            ? left.sponsorBalance : right.sponsorBalance,
+          nativeBalanceWei: left.nativeBalance,
+          sponsorBalanceWei: left.sponsorBalance,
+          eligibility,
         });
       } catch (error) {
         if (error instanceof MainTokenMigrationGasSponsorErrorV1) throw error;
         throw new MainTokenMigrationGasSponsorErrorV1(503, "rpc_quorum_unavailable");
+      }
+    },
+    async sponsorGasLimit({ configuration, walletAddress, topUpWei }: Readonly<{
+      configuration: MainTokenMigrationGasSponsorConfigurationV1;
+      walletAddress: Address;
+      topUpWei: bigint;
+    }>) {
+      try {
+        if (topUpWei <= 0n || topUpWei > configuration.maximumTopUpWei) {
+          throw new MainTokenMigrationGasSponsorErrorV1(
+            503,
+            "gas_quote_unavailable",
+          );
+        }
+        const heads = await Promise.all(clients.map(
+          (client) => client.getBlockNumber(),
+        ));
+        const blockNumber = heads[0] < heads[1] ? heads[0] : heads[1];
+        const states = await Promise.all(clients.map(async (client) => {
+          const [chainId, block, walletCode, sponsorCode] = await Promise.all([
+            client.getChainId(),
+            client.getBlock({ blockNumber }),
+            client.getCode({ address: walletAddress, blockNumber }),
+            client.getCode({
+              address: configuration.sponsorAddress,
+              blockNumber,
+            }),
+          ]);
+          return { chainId, block, walletCode, sponsorCode };
+        }));
+        const [left, right] = states;
+        if (!left || !right || left.chainId !== 1 || right.chainId !== 1
+          || left.block.hash !== right.block.hash
+          || left.walletCode !== right.walletCode
+          || left.sponsorCode !== "0x" || right.sponsorCode !== "0x"
+          || !isMainTokenMigrationWalletCodeEligible(left.walletCode)) {
+          throw new MainTokenMigrationGasSponsorErrorV1(
+            503,
+            "rpc_quorum_unavailable",
+          );
+        }
+        if (left.walletCode === "0x") {
+          return MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1;
+        }
+        const estimates = await Promise.all(clients.map((client) =>
+          client.estimateGas({
+            account: configuration.sponsorAddress,
+            to: walletAddress,
+            value: topUpWei,
+            data: "0x",
+            blockNumber,
+          })));
+        const estimate = estimates[0] > estimates[1]
+          ? estimates[0]
+          : estimates[1];
+        const gasLimit = divCeil(estimate * GAS_MULTIPLIER_BPS, BPS);
+        if (estimate < MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1
+          || gasLimit > MAIN_TOKEN_MIGRATION_GAS_SPONSOR_MAX_GAS_LIMIT_V1) {
+          throw new MainTokenMigrationGasSponsorErrorV1(
+            422,
+            "wallet_not_eligible",
+          );
+        }
+        return gasLimit;
+      } catch (error) {
+        if (error instanceof MainTokenMigrationGasSponsorErrorV1) throw error;
+        throw new MainTokenMigrationGasSponsorErrorV1(
+          503,
+          "gas_quote_unavailable",
+        );
       }
     },
     async status(record: MainTokenMigrationGasSponsorRecordV1) {

--- a/lib/server/main-token-migration-gas-sponsor-v1.ts
+++ b/lib/server/main-token-migration-gas-sponsor-v1.ts
@@ -6,6 +6,7 @@ import { PrivyClient } from "@privy-io/node";
 import {
   createPublicClient,
   decodeFunctionData,
+  encodeFunctionData,
   getAddress,
   http,
   isAddress,
@@ -69,7 +70,6 @@ const ABSOLUTE_TOP_UP_CAP_WEI = 2_000_000_000_000_000n;
 const ABSOLUTE_TOTAL_BUDGET_CAP_WEI = 1_000_000_000_000_000_000n;
 const DEADLINE_SAFETY_SECONDS = 5 * 60;
 const MAXIMUM_RELOCATION_LOGS = 64;
-const MAXIMUM_RELOCATION_SOURCES = 8;
 const RELOCATION_LOG_BLOCK_RANGE = 5_000n;
 const PROVIDER_IDEMPOTENCY_WINDOW_MS = 24 * 60 * 60 * 1_000;
 const PROVIDER_IDEMPOTENCY_SAFETY_MS = 5 * 60 * 1_000;
@@ -486,6 +486,12 @@ export function createMainTokenMigrationGasSponsorV1(input: Readonly<{
           operation: "submit",
         });
         if (existing) {
+          if (existing.intent.requestBindingHash !== bindings.requestBindingHash) {
+            throw new MainTokenMigrationGasSponsorErrorV1(
+              409,
+              "idempotency_conflict",
+            );
+          }
           if (existing.transactionHash !== null) {
             return await existingResponse(existing, input.chain);
           }
@@ -1194,10 +1200,18 @@ async function isExactDirectRelocationTransferV1(
       return false;
     }
     const [recipient, amount] = decoded.args;
-    return typeof recipient === "string"
-      && getAddress(recipient).toLowerCase() === transfer.to.toLowerCase()
-      && typeof amount === "bigint"
-      && amount === transfer.value;
+    if (typeof recipient !== "string" || typeof amount !== "bigint") {
+      return false;
+    }
+    const normalizedRecipient = getAddress(recipient);
+    const canonicalInput = encodeFunctionData({
+      abi: ERC20_ABI,
+      functionName: "transfer",
+      args: [normalizedRecipient, amount],
+    });
+    return normalizedRecipient.toLowerCase() === transfer.to.toLowerCase()
+      && amount === transfer.value
+      && canonicalInput.toLowerCase() === left.input.toLowerCase();
   } catch {
     return false;
   }
@@ -1237,8 +1251,6 @@ export async function resolveMainTokenMigrationSponsorEligibilityV1(input: Reado
       "rpc_quorum_unavailable",
     );
   }
-  const candidates: RelocationTransferV1[] = [];
-  const sources = new Set<string>();
   const prioritized = [...logs[0]].sort((left, right) => {
     if (left.value !== right.value) return left.value > right.value ? -1 : 1;
     if (left.blockNumber !== right.blockNumber) {
@@ -1247,13 +1259,6 @@ export async function resolveMainTokenMigrationSponsorEligibilityV1(input: Reado
     return right.logIndex - left.logIndex;
   });
   for (const transfer of prioritized) {
-    const source = transfer.from.toLowerCase();
-    if (sources.has(source)) continue;
-    sources.add(source);
-    candidates.push(transfer);
-    if (candidates.length >= MAXIMUM_RELOCATION_SOURCES) break;
-  }
-  for (const transfer of candidates) {
     if (!await isExactDirectRelocationTransferV1(input.clients, transfer)) {
       continue;
     }

--- a/tests/main-token-migration-gas-sponsor-contract.test.ts
+++ b/tests/main-token-migration-gas-sponsor-contract.test.ts
@@ -120,7 +120,9 @@ describe("main token migration gas sponsor activation contract", () => {
       transactionMethod: "eth_sendTransaction",
       transactionType: "2",
       transactionData: "0x",
-      sponsorGasLimit: "21000",
+      sponsorGasLimitMode: "eoa-fixed-or-delegated-estimated",
+      sponsorGasLimitMinimum: "21000",
+      sponsorGasLimitMaximum: "100000",
       providerPolicyEnforces: ["method", "chainId", "maximumValue"],
       serverEnforces: [
         "holderRecipient",

--- a/tests/main-token-migration-gas-sponsor-v1.test.ts
+++ b/tests/main-token-migration-gas-sponsor-v1.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
+import { encodeFunctionData, parseAbi } from "viem";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
@@ -11,8 +12,10 @@ import {
   createMainTokenMigrationGasSponsorV1,
   deriveMainTokenMigrationSponsorBindingsV1,
   deriveMainTokenMigrationSponsorPrincipalBindingV1,
+  parsePrivySponsorTransactionLookupV1,
   parseMainTokenMigrationSponsorRequestV1,
   readMainTokenMigrationGasSponsorConfigurationV1,
+  resolveMainTokenMigrationSponsorEligibilityV1,
   type MainTokenMigrationGasSponsorChainV1,
   type MainTokenMigrationGasSponsorConfigurationV1,
   type MainTokenMigrationGasSponsorSenderV1,
@@ -22,6 +25,7 @@ import {
   MainTokenMigrationGasSponsorStoreErrorV1,
   createMainTokenMigrationGasSponsorPostgresStoreV1,
   type MainTokenMigrationGasSponsorIntentV1,
+  type MainTokenMigrationGasSponsorEligibilityV1,
   type MainTokenMigrationGasSponsorRecordV1,
   type MainTokenMigrationGasSponsorStoreV1,
 } from "../lib/server/main-token-migration-gas-sponsor-store-v1";
@@ -44,6 +48,10 @@ const SPONSOR = "0x2222222222222222222222222222222222222222" as const;
 const TX_HASH = `0x${"ab".repeat(32)}` as const;
 const NOW = new Date("2026-08-30T12:00:00.000Z");
 const IDEMPOTENCY_KEY = "migration-request-00000001";
+const TEST_ERC20_ABI = parseAbi([
+  "function transfer(address to,uint256 amount) returns (bool)",
+  "function transferFrom(address from,address to,uint256 amount) returns (bool)",
+]);
 const CONFIGURATION: MainTokenMigrationGasSponsorConfigurationV1 = {
   releaseId: "v4-ethereum-to-robinhood-96h-2026-v1",
   windowStartTimestamp: 1_899_654_400,
@@ -64,6 +72,7 @@ function key(releaseId: string, walletAddress: string) {
 class MemoryStore implements MainTokenMigrationGasSponsorStoreV1 {
   readonly records = new Map<string, MainTokenMigrationGasSponsorRecordV1>();
   readonly aliases = new Map<string, string>();
+  readonly eligibilityAliases = new Map<string, string>();
   readonly admissions:
     Parameters<MainTokenMigrationGasSponsorStoreV1["admit"]>[0][] = [];
   rateLimited = false;
@@ -90,7 +99,15 @@ class MemoryStore implements MainTokenMigrationGasSponsorStoreV1 {
     try {
       const recordKey = key(input.lookup.releaseId, input.lookup.walletAddress);
       const alias = this.aliases.get(input.idempotencyBindingHash);
+      const eligibilityKey = key(
+        input.lookup.releaseId,
+        input.eligibility.rootWalletAddress,
+      );
+      const eligibilityHolder = this.eligibilityAliases.get(eligibilityKey);
       if (alias !== undefined && alias !== input.requestBindingHash) {
+        throw new MainTokenMigrationGasSponsorStoreErrorV1("conflict");
+      }
+      if (eligibilityHolder !== undefined && eligibilityHolder !== recordKey) {
         throw new MainTokenMigrationGasSponsorStoreErrorV1("conflict");
       }
       const existing = this.records.get(recordKey);
@@ -111,6 +128,7 @@ class MemoryStore implements MainTokenMigrationGasSponsorStoreV1 {
         input.idempotencyBindingHash,
         input.requestBindingHash,
       );
+      this.eligibilityAliases.set(eligibilityKey, recordKey);
       const record = Object.freeze({
         intent: input.intent,
         transactionHash: null,
@@ -146,12 +164,25 @@ class IdempotentSender implements MainTokenMigrationGasSponsorSenderV1 {
   readonly hashes = new Map<string, typeof TX_HASH>();
   actualTransfers = 0;
   throwAfterFirstBroadcast = false;
+  throwBeforeFirstBroadcast = false;
   private threwAmbiguous = false;
+  private threwBeforeBroadcast = false;
 
   async assertReady() {}
 
+  async lookup(intent: MainTokenMigrationGasSponsorIntentV1) {
+    const hash = this.hashes.get(intent.providerIdempotencyKey);
+    return hash
+      ? { status: "broadcasted" as const, transactionHash: hash }
+      : null;
+  }
+
   async send(intent: MainTokenMigrationGasSponsorIntentV1) {
     this.calls.push(intent);
+    if (this.throwBeforeFirstBroadcast && !this.threwBeforeBroadcast) {
+      this.threwBeforeBroadcast = true;
+      throw new Error("provider request failed before broadcast");
+    }
     let hash = this.hashes.get(intent.providerIdempotencyKey);
     if (!hash) {
       hash = TX_HASH;
@@ -178,12 +209,28 @@ function chain(): MainTokenMigrationGasSponsorChainV1 {
         maxPriorityFeePerGasWei: 1_000_000_000n,
         nativeBalanceWei: 0n,
         sponsorBalanceWei: 1_000_000_000_000_000_000n,
+        eligibility: directEligibility(request.walletAddress),
       };
     },
     async status() {
       return "confirmed";
     },
+    async sponsorGasLimit() {
+      return MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1;
+    },
   };
+}
+
+function directEligibility(
+  walletAddress: `0x${string}`,
+): MainTokenMigrationGasSponsorEligibilityV1 {
+  return Object.freeze({
+    rootWalletAddress: walletAddress,
+    walletAddress,
+    transferHash: null,
+    transferBlockNumber: null,
+    transferLogIndex: null,
+  });
 }
 
 function request(
@@ -230,6 +277,144 @@ function sponsor(
 }
 
 describe("main token migration gas sponsor", () => {
+  it("accepts one confirmed direct transfer from the eligible root wallet", async () => {
+    const blockHash = `0x${"45".repeat(32)}` as const;
+    const transferHash = `0x${"67".repeat(32)}` as const;
+    const transferData = encodeFunctionData({
+      abi: TEST_ERC20_ABI,
+      functionName: "transfer",
+      args: [SECOND_WALLET, 100n],
+    });
+    const client = () => ({
+      async getLogs() {
+        return [{
+          args: { from: WALLET, to: SECOND_WALLET, value: 100n },
+          blockHash,
+          blockNumber: 103n,
+          logIndex: 0,
+          removed: false,
+          transactionHash: transferHash,
+        }];
+      },
+      async getCode() {
+        return "0x";
+      },
+      async getTransaction() {
+        return {
+          blockHash,
+          blockNumber: 103n,
+          from: WALLET,
+          hash: transferHash,
+          input: transferData,
+          to: MAIN_TOKEN_ADDRESS,
+          value: 0n,
+        };
+      },
+      async readContract() {
+        return 100n;
+      },
+    });
+
+    await expect(resolveMainTokenMigrationSponsorEligibilityV1({
+      clients: [client(), client()] as never,
+      configuration: CONFIGURATION,
+      request: { walletAddress: SECOND_WALLET, amountRaw: 100n },
+      blockNumber: 105n,
+      provenanceBlockNumber: 105n,
+      directOpeningBalances: [0n, 0n],
+    })).resolves.toEqual({
+      rootWalletAddress: WALLET,
+      walletAddress: SECOND_WALLET,
+      transferHash,
+      transferBlockNumber: "103",
+      transferLogIndex: "0",
+    });
+  });
+
+  it("rejects transferFrom provenance even when its Transfer log matches", async () => {
+    const blockHash = `0x${"45".repeat(32)}` as const;
+    const transferHash = `0x${"67".repeat(32)}` as const;
+    const transferData = encodeFunctionData({
+      abi: TEST_ERC20_ABI,
+      functionName: "transferFrom",
+      args: [WALLET, SECOND_WALLET, 100n],
+    });
+    const client = () => ({
+      async getLogs() {
+        return [{
+          args: { from: WALLET, to: SECOND_WALLET, value: 100n },
+          blockHash,
+          blockNumber: 103n,
+          logIndex: 0,
+          removed: false,
+          transactionHash: transferHash,
+        }];
+      },
+      async getCode() {
+        return "0x";
+      },
+      async getTransaction() {
+        return {
+          blockHash,
+          blockNumber: 103n,
+          from: WALLET,
+          hash: transferHash,
+          input: transferData,
+          to: MAIN_TOKEN_ADDRESS,
+          value: 0n,
+        };
+      },
+      async readContract() {
+        return 100n;
+      },
+    });
+
+    await expect(resolveMainTokenMigrationSponsorEligibilityV1({
+      clients: [client(), client()] as never,
+      configuration: CONFIGURATION,
+      request: { walletAddress: SECOND_WALLET, amountRaw: 100n },
+      blockNumber: 105n,
+      provenanceBlockNumber: 105n,
+      directOpeningBalances: [0n, 0n],
+    })).resolves.toBeNull();
+  });
+
+  it("fails closed when independent providers disagree on transfer provenance", async () => {
+    const client = (transactionHash: `0x${string}`) => ({
+      async getLogs() {
+        return [{
+          args: { from: WALLET, to: SECOND_WALLET, value: 100n },
+          blockHash: `0x${"45".repeat(32)}`,
+          blockNumber: 103n,
+          logIndex: 0,
+          removed: false,
+          transactionHash,
+        }];
+      },
+      async getCode() {
+        return "0x";
+      },
+      async readContract() {
+        return 100n;
+      },
+    });
+
+    await expect(resolveMainTokenMigrationSponsorEligibilityV1({
+      clients: [
+        client(`0x${"67".repeat(32)}`),
+        client(`0x${"68".repeat(32)}`),
+      ] as never,
+      configuration: CONFIGURATION,
+      request: { walletAddress: SECOND_WALLET, amountRaw: 100n },
+      blockNumber: 105n,
+      provenanceBlockNumber: 105n,
+      directOpeningBalances: [0n, 0n],
+    })).rejects.toMatchObject({
+      status: 503,
+      code: "rpc_quorum_unavailable",
+    });
+  });
+
   it("accepts only the exact finalized eligibility block before the window", () => {
     const exact = {
       number: CONFIGURATION.startBlockNumber,
@@ -365,6 +550,8 @@ describe("main token migration gas sponsor", () => {
     expect(first.providerReferenceId).toBe(
       replayWithDifferentClientKey.providerReferenceId,
     );
+    expect(first.providerReferenceId).toHaveLength(64);
+    expect(first.providerIdempotencyKey).toHaveLength(70);
     expect(deriveMainTokenMigrationSponsorPrincipalBindingV1(
       "did:privy:test-user",
     )).toMatch(/^sha256:[0-9a-f]{64}$/u);
@@ -404,6 +591,43 @@ describe("main token migration gas sponsor", () => {
     }
   });
 
+  it("accepts only one exact Privy reconciliation record", () => {
+    const referenceId = "mtmgs-test-provider-reference";
+    const record = {
+      caip2: "eip155:1",
+      reference_id: referenceId,
+      status: "broadcasted",
+      transaction_hash: TX_HASH,
+      wallet_id: CONFIGURATION.sponsorWalletId,
+    };
+    expect(parsePrivySponsorTransactionLookupV1({
+      transactions: [record],
+    }, {
+      referenceId,
+      sponsorWalletId: CONFIGURATION.sponsorWalletId,
+    })).toEqual({
+      status: "broadcasted",
+      transactionHash: TX_HASH,
+    });
+    expect(parsePrivySponsorTransactionLookupV1({
+      transactions: [],
+    }, {
+      referenceId,
+      sponsorWalletId: CONFIGURATION.sponsorWalletId,
+    })).toBeNull();
+    for (const transactions of [
+      [record, record],
+      [{ ...record, caip2: "eip155:10" }],
+      [{ ...record, reference_id: "another-reference" }],
+      [{ ...record, wallet_id: "another-wallet" }],
+    ]) {
+      expect(() => parsePrivySponsorTransactionLookupV1({ transactions }, {
+        referenceId,
+        sponsorWalletId: CONFIGURATION.sponsorWalletId,
+      })).toThrowError(MainTokenMigrationGasSponsorErrorV1);
+    }
+  });
+
   it("durably admits the authenticated principal before sender or RPC work", async () => {
     const store = new MemoryStore();
     store.rateLimited = true;
@@ -429,6 +653,9 @@ describe("main token migration gas sponsor", () => {
         },
         async status() {
           return "confirmed";
+        },
+        async sponsorGasLimit() {
+          return MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1;
         },
       },
       sender,
@@ -506,6 +733,7 @@ describe("main token migration gas sponsor", () => {
         },
         idempotencyBindingHash: firstBindings.idempotencyBindingHash,
         requestBindingHash: firstBindings.requestBindingHash,
+        eligibility: directEligibility(WALLET),
         intent: firstIntent,
       })).kind).toBe("created");
 
@@ -522,6 +750,7 @@ describe("main token migration gas sponsor", () => {
         },
         idempotencyBindingHash: replayBindings.idempotencyBindingHash,
         requestBindingHash: replayBindings.requestBindingHash,
+        eligibility: directEligibility(WALLET),
         intent: testIntent(replayBindings.requestBindingHash),
       })).kind).toBe("existing");
       const aliases = await database.query<{ count: string }>(`
@@ -530,6 +759,145 @@ describe("main token migration gas sponsor", () => {
          WHERE credential_id LIKE '%:idempotency:%'
       `);
       expect(aliases.rows[0]?.count).toBe("1");
+
+      const relocatedBindings = deriveMainTokenMigrationSponsorBindingsV1({
+        releaseId: CONFIGURATION.releaseId,
+        walletAddress: SECOND_WALLET,
+        amountRaw: 100n,
+        idempotencyKey: "migration-request-00000013",
+      });
+      await expect(store.reserve({
+        lookup: {
+          releaseId: CONFIGURATION.releaseId,
+          walletAddress: SECOND_WALLET,
+        },
+        idempotencyBindingHash: relocatedBindings.idempotencyBindingHash,
+        requestBindingHash: relocatedBindings.requestBindingHash,
+        eligibility: {
+          rootWalletAddress: WALLET,
+          walletAddress: SECOND_WALLET,
+          transferHash: TX_HASH,
+          transferBlockNumber: "101",
+          transferLogIndex: "0",
+        },
+        intent: testIntent(relocatedBindings.requestBindingHash, SECOND_WALLET),
+      })).rejects.toMatchObject({ code: "conflict" });
+      const eligibilityAliases = await database.query<{ count: string }>(`
+        SELECT count(*)::text AS count
+          FROM programmable_website_projection_v1.credential_uses
+         WHERE credential_id LIKE '%:eligibility:%'
+      `);
+      expect(eligibilityAliases.rows[0]?.count).toBe("1");
+    } finally {
+      await database.close();
+    }
+  }, 10_000);
+
+  it("blocks legacy root-wallet writers with a durable holder guard", async () => {
+    const database = new PGlite();
+    try {
+      await database.exec(`
+        CREATE SCHEMA programmable_website_projection_v1;
+        CREATE TABLE programmable_website_projection_v1.credential_uses (
+          credential_id text PRIMARY KEY,
+          request_binding_hash text NOT NULL,
+          canonical_use text NOT NULL,
+          created_at timestamptz NOT NULL DEFAULT clock_timestamp()
+        );
+      `);
+      const store = createMainTokenMigrationGasSponsorPostgresStoreV1(
+        new SponsorTestPool(database),
+      );
+      const totalBudgetWei = "1000000000000000";
+      const relocatedBindings = deriveMainTokenMigrationSponsorBindingsV1({
+        releaseId: CONFIGURATION.releaseId,
+        walletAddress: SECOND_WALLET,
+        amountRaw: 100n,
+        idempotencyKey: "migration-request-00000014",
+      });
+      expect((await store.reserve({
+        lookup: {
+          releaseId: CONFIGURATION.releaseId,
+          walletAddress: SECOND_WALLET,
+        },
+        idempotencyBindingHash: relocatedBindings.idempotencyBindingHash,
+        requestBindingHash: relocatedBindings.requestBindingHash,
+        eligibility: {
+          rootWalletAddress: WALLET,
+          walletAddress: SECOND_WALLET,
+          transferHash: TX_HASH,
+          transferBlockNumber: "103",
+          transferLogIndex: "0",
+        },
+        intent: testIntent(
+          relocatedBindings.requestBindingHash,
+          SECOND_WALLET,
+          totalBudgetWei,
+        ),
+      })).kind).toBe("created");
+
+      const rootGuard = await store.get({
+        releaseId: CONFIGURATION.releaseId,
+        walletAddress: WALLET,
+      });
+      expect(rootGuard).toMatchObject({
+        transactionHash: null,
+        intent: {
+          walletAddress: WALLET,
+          topUpWei: "1",
+          reservedTotalWei: "21001",
+        },
+      });
+      const sender = new IdempotentSender();
+      const handler = createMainTokenMigrationGasSponsorV1({
+        configuration: CONFIGURATION,
+        authenticator: {
+          async authenticate() {
+            return {
+              privyUserId: "did:privy:test-user",
+              privySessionId: "session-1",
+              wallets: [WALLET],
+            };
+          },
+        },
+        store,
+        chain: chain(),
+        sender,
+        now: () => NOW,
+      });
+      const blockedGuard = await handler.post(request(
+        WALLET,
+        "migration-request-00000016",
+      ));
+      expect(blockedGuard.status).toBe(409);
+      expect(sender.calls).toHaveLength(0);
+      const rootBindings = deriveMainTokenMigrationSponsorBindingsV1({
+        releaseId: CONFIGURATION.releaseId,
+        walletAddress: WALLET,
+        amountRaw: 100n,
+        idempotencyKey: "migration-request-00000015",
+      });
+      await expect(store.reserve({
+        lookup: {
+          releaseId: CONFIGURATION.releaseId,
+          walletAddress: WALLET,
+        },
+        idempotencyBindingHash: rootBindings.idempotencyBindingHash,
+        requestBindingHash: rootBindings.requestBindingHash,
+        eligibility: directEligibility(WALLET),
+        intent: testIntent(
+          rootBindings.requestBindingHash,
+          WALLET,
+          totalBudgetWei,
+        ),
+      })).rejects.toMatchObject({ code: "conflict" });
+      const holders = await database.query<{ count: string }>(`
+        SELECT count(*)::text AS count
+          FROM programmable_website_projection_v1.credential_uses
+         WHERE credential_id LIKE
+           'main-token-migration-gas-sponsor:v1:holder:%'
+      `);
+      expect(holders.rows[0]?.count).toBe("2");
     } finally {
       await database.close();
     }
@@ -545,16 +913,11 @@ describe("main token migration gas sponsor", () => {
       handler.post(request()),
     ]);
 
-    expect([left.status, right.status].sort()).toEqual([200, 503]);
+    expect([left.status, right.status].sort()).toEqual([200, 200]);
     const bodies = await Promise.all([left.json(), right.json()]);
-    expect(bodies.some((body) => body.transactionHash === TX_HASH)).toBe(true);
-    expect(bodies.some(
-      (body) => body.error?.code === "submission_unknown",
-    )).toBe(true);
-    expect([left, right].find((response) => response.status === 200)
-      ?.headers.get("retry-after")).toBe("10");
+    expect(bodies.every((body) => body.transactionHash === TX_HASH)).toBe(true);
     expect(sender.actualTransfers).toBe(1);
-    expect(sender.calls).toHaveLength(1);
+    expect(sender.calls.length).toBeGreaterThanOrEqual(1);
     expect([...store.records.values()][0]?.transactionHash).toBe(TX_HASH);
   });
 
@@ -572,6 +935,43 @@ describe("main token migration gas sponsor", () => {
     expect(store.aliases.size).toBe(1);
     expect(sender.calls).toHaveLength(1);
     expect(sender.actualTransfers).toBe(1);
+  });
+
+  it("reserves the exact bounded gas estimate for a delegated recipient", async () => {
+    const store = new MemoryStore();
+    const sender = new IdempotentSender();
+    const delegatedSponsorGas = 30_000n;
+    const handler = createMainTokenMigrationGasSponsorV1({
+      configuration: {
+        ...CONFIGURATION,
+        totalBudgetWei: 250_000_000_000_000n,
+      },
+      authenticator: {
+        async authenticate() {
+          return {
+            privyUserId: "did:privy:test-user",
+            privySessionId: "session-1",
+            wallets: [WALLET],
+          };
+        },
+      },
+      store,
+      chain: {
+        ...chain(),
+        async sponsorGasLimit() {
+          return delegatedSponsorGas;
+        },
+      },
+      sender,
+      now: () => NOW,
+    });
+
+    const submitted = await handler.post(request());
+    expect(submitted.status).toBe(200);
+    expect(sender.calls[0]).toMatchObject({
+      sponsorGasLimit: "30000",
+      reservedTotalWei: "190000000000000",
+    });
   });
 
   it("atomically refuses a second holder once the release budget is reserved", async () => {
@@ -605,24 +1005,67 @@ describe("main token migration gas sponsor", () => {
     });
   });
 
-  it("never resends after an ambiguous provider outcome", async () => {
+  it("reconciles an ambiguous provider outcome without a second transfer", async () => {
     const store = new MemoryStore();
     const sender = new IdempotentSender();
     sender.throwAfterFirstBroadcast = true;
     const handler = sponsor(store, sender);
 
-    const unknown = await handler.post(request());
-    expect(unknown.status).toBe(503);
-    expect((await unknown.json()).error.code).toBe("submission_unknown");
+    const recovered = await handler.post(request());
+    expect(recovered.status).toBe(200);
+    expect((await recovered.json()).transactionHash).toBe(TX_HASH);
     expect(sender.actualTransfers).toBe(1);
-    expect([...store.records.values()][0]?.transactionHash).toBeNull();
+    expect([...store.records.values()][0]?.transactionHash).toBe(TX_HASH);
 
     const duplicate = await handler.post(request());
-    expect(duplicate.status).toBe(503);
-    expect((await duplicate.json()).error.code).toBe("submission_unknown");
+    expect(duplicate.status).toBe(200);
+    expect((await duplicate.json()).transactionHash).toBe(TX_HASH);
     expect(sender.actualTransfers).toBe(1);
     expect(sender.calls).toHaveLength(1);
-    expect([...store.records.values()][0]?.transactionHash).toBeNull();
+    expect([...store.records.values()][0]?.transactionHash).toBe(TX_HASH);
+  });
+
+  it("retries the identical provider request after a pre-broadcast failure", async () => {
+    const store = new MemoryStore();
+    const sender = new IdempotentSender();
+    sender.throwBeforeFirstBroadcast = true;
+    const handler = sponsor(store, sender);
+
+    const recovered = await handler.post(request());
+    expect(recovered.status).toBe(200);
+    expect((await recovered.json()).transactionHash).toBe(TX_HASH);
+    expect(sender.calls).toHaveLength(2);
+    expect(sender.calls[0]).toBe(sender.calls[1]);
+    expect(sender.actualTransfers).toBe(1);
+    expect([...store.records.values()][0]?.transactionHash).toBe(TX_HASH);
+  });
+
+  it("never resends an unresolved reservation outside the provider window", async () => {
+    const store = new MemoryStore();
+    const sender = new IdempotentSender();
+    const bindings = deriveMainTokenMigrationSponsorBindingsV1({
+      releaseId: CONFIGURATION.releaseId,
+      walletAddress: WALLET,
+      amountRaw: 100n,
+      idempotencyKey: IDEMPOTENCY_KEY,
+    });
+    const intent = Object.freeze({
+      ...testIntent(bindings.requestBindingHash),
+      providerIdempotencyKey: bindings.providerIdempotencyKey,
+      providerReferenceId: bindings.providerReferenceId,
+      reservedAt: new Date(NOW.getTime() - 24 * 60 * 60 * 1_000).toISOString(),
+    });
+    store.records.set(key(CONFIGURATION.releaseId, WALLET), {
+      intent,
+      transactionHash: null,
+    });
+    const handler = sponsor(store, sender);
+
+    const blocked = await handler.post(request());
+    expect(blocked.status).toBe(503);
+    expect((await blocked.json()).error.code).toBe("submission_unknown");
+    expect(sender.calls).toHaveLength(0);
+    expect(sender.actualTransfers).toBe(0);
   });
 
   it("rechecks the deadline on every request from a cached handler", async () => {
@@ -642,15 +1085,17 @@ describe("main token migration gas sponsor", () => {
 
 function testIntent(
   requestBindingHash: `sha256:${string}`,
+  walletAddress: typeof WALLET | typeof SECOND_WALLET = WALLET,
+  totalBudgetWei = CONFIGURATION.totalBudgetWei.toString(),
 ): MainTokenMigrationGasSponsorIntentV1 {
   return Object.freeze({
     schema: "programmable-main-token-migration-gas-sponsorship-intent/v1",
     releaseId: CONFIGURATION.releaseId,
-    walletAddress: WALLET,
+    walletAddress,
     sponsorAddress: SPONSOR,
     amountRaw: "100",
     topUpWei: "130000000000000",
-    totalBudgetWei: CONFIGURATION.totalBudgetWei.toString(),
+    totalBudgetWei,
     sponsorGasLimit:
       MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1.toString(),
     sponsorMaxFeePerGasWei: "2000000000",

--- a/tests/main-token-migration-gas-sponsor-v1.test.ts
+++ b/tests/main-token-migration-gas-sponsor-v1.test.ts
@@ -379,6 +379,76 @@ describe("main token migration gas sponsor", () => {
     })).resolves.toBeNull();
   });
 
+  it("keeps checking a valid direct transfer after transferFrom noise", async () => {
+    const blockHash = `0x${"46".repeat(32)}` as const;
+    const directHash = `0x${"68".repeat(32)}` as const;
+    const transferFromHash = `0x${"69".repeat(32)}` as const;
+    const directData = encodeFunctionData({
+      abi: TEST_ERC20_ABI,
+      functionName: "transfer",
+      args: [SECOND_WALLET, 100n],
+    });
+    const transferFromData = encodeFunctionData({
+      abi: TEST_ERC20_ABI,
+      functionName: "transferFrom",
+      args: [WALLET, SECOND_WALLET, 101n],
+    });
+    const client = () => ({
+      async getLogs() {
+        return [
+          {
+            args: { from: WALLET, to: SECOND_WALLET, value: 100n },
+            blockHash,
+            blockNumber: 103n,
+            logIndex: 0,
+            removed: false,
+            transactionHash: directHash,
+          },
+          {
+            args: { from: WALLET, to: SECOND_WALLET, value: 101n },
+            blockHash,
+            blockNumber: 104n,
+            logIndex: 0,
+            removed: false,
+            transactionHash: transferFromHash,
+          },
+        ];
+      },
+      async getCode() {
+        return "0x";
+      },
+      async getTransaction({ hash }: { hash: string }) {
+        return {
+          blockHash,
+          blockNumber: hash === directHash ? 103n : 104n,
+          from: WALLET,
+          hash,
+          input: hash === directHash ? directData : transferFromData,
+          to: MAIN_TOKEN_ADDRESS,
+          value: 0n,
+        };
+      },
+      async readContract() {
+        return 101n;
+      },
+    });
+
+    await expect(resolveMainTokenMigrationSponsorEligibilityV1({
+      clients: [client(), client()] as never,
+      configuration: CONFIGURATION,
+      request: { walletAddress: SECOND_WALLET, amountRaw: 100n },
+      blockNumber: 105n,
+      provenanceBlockNumber: 105n,
+      directOpeningBalances: [0n, 0n],
+    })).resolves.toEqual({
+      rootWalletAddress: WALLET,
+      walletAddress: SECOND_WALLET,
+      transferHash: directHash,
+      transferBlockNumber: "103",
+      transferLogIndex: "0",
+    });
+  });
+
   it("fails closed when independent providers disagree on transfer provenance", async () => {
     const client = (transactionHash: `0x${string}`) => ({
       async getLogs() {
@@ -921,16 +991,18 @@ describe("main token migration gas sponsor", () => {
     expect([...store.records.values()][0]?.transactionHash).toBe(TX_HASH);
   });
 
-  it("returns the holder record without growing aliases for fresh client keys", async () => {
+  it("rejects a fresh client key after the holder request is bound", async () => {
     const store = new MemoryStore();
     const sender = new IdempotentSender();
     const handler = sponsor(store, sender);
 
     expect((await handler.post(request())).status).toBe(200);
-    expect((await handler.post(request(
+    const conflict = await handler.post(request(
       WALLET,
       "migration-request-00000002",
-    ))).status).toBe(200);
+    ));
+    expect(conflict.status).toBe(409);
+    expect((await conflict.json()).error.code).toBe("idempotency_conflict");
 
     expect(store.aliases.size).toBe(1);
     expect(sender.calls).toHaveLength(1);

--- a/tests/main-token-migration-gas-sponsor-v1.test.ts
+++ b/tests/main-token-migration-gas-sponsor-v1.test.ts
@@ -112,6 +112,9 @@ class MemoryStore implements MainTokenMigrationGasSponsorStoreV1 {
       }
       const existing = this.records.get(recordKey);
       if (existing) {
+        if (existing.intent.requestBindingHash !== input.requestBindingHash) {
+          throw new MainTokenMigrationGasSponsorStoreErrorV1("conflict");
+        }
         return { kind: "existing" as const, record: existing };
       }
       const reservedWei = [...this.records.values()]
@@ -813,7 +816,7 @@ describe("main token migration gas sponsor", () => {
         amountRaw: 100n,
         idempotencyKey: "migration-request-00000012",
       });
-      expect((await store.reserve({
+      await expect(store.reserve({
         lookup: {
           releaseId: CONFIGURATION.releaseId,
           walletAddress: WALLET,
@@ -822,7 +825,7 @@ describe("main token migration gas sponsor", () => {
         requestBindingHash: replayBindings.requestBindingHash,
         eligibility: directEligibility(WALLET),
         intent: testIntent(replayBindings.requestBindingHash),
-      })).kind).toBe("existing");
+      })).rejects.toMatchObject({ code: "conflict" });
       const aliases = await database.query<{ count: string }>(`
         SELECT count(*)::text AS count
           FROM programmable_website_projection_v1.credential_uses

--- a/tests/main-token-migration-gas-sponsorship-ui.test.ts
+++ b/tests/main-token-migration-gas-sponsorship-ui.test.ts
@@ -159,7 +159,7 @@ describe("main token migration gas sponsorship UI contract", () => {
     for (const [code, expected] of [
       [
         "submission_unknown",
-        "The gas top-up needs a status review. No second top-up was sent.",
+        "The gas top-up status could not be confirmed. Check again shortly. No second top-up will be sent.",
       ],
       [
         "sponsorship_closed",

--- a/tests/main-token-migration-gas-sponsorship-ui.test.ts
+++ b/tests/main-token-migration-gas-sponsorship-ui.test.ts
@@ -150,24 +150,27 @@ describe("main token migration gas sponsorship UI contract", () => {
       message:
         "The gas top-up needs a status review. No second top-up was sent. " +
         "Request ID: 123e4567-e89b-12d3-a456-426614174000",
-      retryable: false,
+      retryable: true,
     });
   });
 
-  it("keeps terminal failures terminal even without usable server copy", async () => {
+  it("keeps only closed or failed sponsorship terminal", async () => {
     const requestId = "123e4567-e89b-12d3-a456-426614174000";
-    for (const [code, expected] of [
+    for (const [code, expected, retryable] of [
       [
         "submission_unknown",
         "The gas top-up status could not be confirmed. Check again shortly. No second top-up will be sent.",
+        true,
       ],
       [
         "sponsorship_closed",
         "Gas sponsorship is closed for this migration window.",
+        false,
       ],
       [
         "sponsorship_failed",
         "The gas top-up could not be confirmed. Contact migration support before trying again.",
+        false,
       ],
     ] as const) {
       const failure = await gasSponsorshipFailure(new Response(JSON.stringify({
@@ -178,7 +181,7 @@ describe("main token migration gas sponsorship UI contract", () => {
       }));
       expect(failure).toEqual({
         message: `${expected} Request ID: ${requestId}`,
-        retryable: false,
+        retryable,
       });
     }
   });


### PR DESCRIPTION
## Outcome
- recognizes one finalized direct V4 wallet relocation without special-casing an address
- binds relocation to exact ERC20 `transfer` provenance across two RPCs and blocks replay through the original holder
- estimates sponsor gas safely for EOAs and EIP-7702 delegated EOAs
- reconciles lost Privy responses by 64-character reference ID and byte-identical idempotent retry
- replaces false permanent-error wording with a recoverable status message

## Focused verification
- `npm run typecheck`
- `npm run migration:main-token:test` (41 passed)
- targeted ESLint
- `git diff --check`
- live read-only provenance check of the reported wallet transfer

The isolated worktree uses an out-of-root `node_modules` symlink, so the standard Turbopack production build is left to the clean hosted Verify runner.