### PR TITLE
Pass Phase A Verify proof output binding

### DIFF
--- a/.github/workflows/capture-robinhood-custom-launch-postdeployment.yml
+++ b/.github/workflows/capture-robinhood-custom-launch-postdeployment.yml
@@ -177,7 +177,8 @@ jobs:
             --run-id "$VERIFY_RUN_ID" \
             --run-attempt "$VERIFY_RUN_ATTEMPT" \
             --artifact-digest "$ARTIFACT_DIGEST" \
-            --verification-mode change
+            --verification-mode change \
+            --github-output "$GITHUB_OUTPUT"
           jq --null-input \
             --arg runId "$VERIFY_RUN_ID" \
             --arg runAttempt "$VERIFY_RUN_ATTEMPT" \

--- a/scripts/test/programmable-launch-release-workflow.test.mjs
+++ b/scripts/test/programmable-launch-release-workflow.test.mjs
@@ -444,6 +444,9 @@ function robinhoodCaptureFailures(value) {
   if (value.split(cleanCheckoutAssertion).length - 1 !== 2) {
     missing.push("exactly two initial/final clean-checkout assertions");
   }
+  if (value.split('--github-output "$GITHUB_OUTPUT"').length - 1 !== 2) {
+    missing.push("resolve and verify GitHub output bindings");
+  }
   return missing;
 }
 
@@ -474,6 +477,11 @@ test("Robinhood Phase A workflow contract mutations fail closed", () => {
     robinhoodCaptureSource.replace("node-version: 24.14.0", "node-version: latest"),
     robinhoodCaptureSource.replace("gh attestation download \"$proof\"", "echo skipped"),
     robinhoodCaptureSource.replace("test \"${#bundle_files[@]}\" = \"1\"", "true"),
+    replaceLast(
+      robinhoodCaptureSource,
+      '--github-output "$GITHUB_OUTPUT"',
+      "--github-output missing",
+    ),
     robinhoodCaptureSource.replaceAll("--header \"X-GitHub-Api-Version: 2026-03-10\"", ""),
     robinhoodCaptureSource.replace(
       "ROBINHOOD_MAINNET_RPC_URL_SECONDARY: ${{ secrets.ROBINHOOD_MAINNET_RPC_URL_SECONDARY }}",


### PR DESCRIPTION
## Summary
- pass the required `--github-output` path to the closed production Verify-proof verifier in the Robinhood Phase-A workflow
- bind the workflow contract test to both resolve and verify output arguments

## Evidence
- Phase-A run `33349081404` reached the exact proof verifier and failed before capture with `Production Verify proof arguments do not match the closed command contract`
- `node --test scripts/test/programmable-launch-release-workflow.test.mjs` (7/7)
- `node --test scripts/test/production-verify-proof.test.mjs` (18/18)
- `git diff --check`

No wallet, chain, provider, database, deployment, or secret mutation.