### PR TITLE
Prepare fail-closed 72-hour V4 migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,13 +52,14 @@ PROGRAMMABLE_PREDICTION_V2_SETTLEMENT_RPC_ENDPOINT_COMMITMENT=
 PRIVY_APP_SECRET=
 
 # V4 migration page release controls. The public route and landing-page entry
-# must be enabled together only after the checked-in 96-hour activation window
-# is finalized. Local preview never enables production transfers.
+# may show the inactive 72-hour preview before an exact window is finalized.
+# The checked-in activation manifest remains the authority for the timer,
+# official address, wallet actions and production transfers.
 PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_ENABLED=false
 NEXT_PUBLIC_PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_VISIBLE=false
 PROGRAMMABLE_MAIN_TOKEN_MIGRATION_LOCAL_PREVIEW=false
 
-# Optional, server-only V4 migration gas sponsor for the reviewed 96-hour
+# Optional, server-only V4 migration gas sponsor for the reviewed 72-hour
 # release. This remains fail-closed until
 # the signed migration activation manifest is enabled and every value below is
 # configured. Use a dedicated, policy-limited Privy EOA with a deliberately

--- a/app/migration/page.tsx
+++ b/app/migration/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { MainTokenMigration } from "@/components/main-token-migration";
-import migrationActivationManifest from "@/config/main-token-migration-activation.v1.json";
 
 export const metadata: Metadata = {
   title: "V4 migration | Programmable",
@@ -18,10 +17,9 @@ export default function MigrationPage() {
   const localPreview =
     process.env.NODE_ENV !== "production" &&
     process.env.PROGRAMMABLE_MAIN_TOKEN_MIGRATION_LOCAL_PREVIEW === "true";
-  const publicReleaseEnabled =
-    process.env.PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_ENABLED === "true" &&
-    migrationActivationManifest.enabled === true;
-  if (!localPreview && !publicReleaseEnabled) {
+  const publicPageEnabled =
+    process.env.PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_ENABLED === "true";
+  if (!localPreview && !publicPageEnabled) {
     notFound();
   }
   return <MainTokenMigration />;

--- a/components/landing-page.module.css
+++ b/components/landing-page.module.css
@@ -153,10 +153,10 @@
   color: #fff;
   display: flex;
   flex-direction: column;
-  margin-top: 40px;
-  min-height: 72px;
-  min-width: min(320px, calc(100vw - 40px));
-  padding: 12px 24px;
+  margin-top: 36px;
+  min-height: 92px;
+  min-width: min(460px, calc(100vw - 40px));
+  padding: 17px 30px;
   transition:
     background 700ms var(--webde-ease),
     border-color 700ms var(--webde-ease),
@@ -164,17 +164,17 @@
 }
 
 .migrationCta span {
-  font-size: 20px;
-  font-weight: 600;
+  font-size: clamp(21px, 2vw, 27px);
+  font-weight: 650;
   line-height: 1.35;
 }
 
 .migrationCta small {
   color: #c9c9c6;
   font-family: var(--font-plex-mono), monospace;
-  font-size: 12px;
+  font-size: 13px;
   line-height: 1.4;
-  margin-top: 2px;
+  margin-top: 4px;
 }
 
 .scrollCue {

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -11,9 +11,9 @@ import migrationActivationManifest from "@/config/main-token-migration-activatio
 const loopMark = "/brand/loop/programmable-loop-mark-header-white-v1-1536.png";
 const HERO_TWINKLE_COUNT = 120;
 const migrationAnnouncementVisible =
-  migrationActivationManifest.enabled === true &&
   process.env.NEXT_PUBLIC_PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_VISIBLE ===
   "true";
+const migrationWindowActive = migrationActivationManifest.enabled === true;
 
 type HeroStarStyle = CSSProperties & {
   "--hero-star-delay": string;
@@ -161,9 +161,16 @@ export function LandingPage() {
           <h1 id="landing-title">Programmable</h1>
           <p>Build and launch custom Uniswap v4 hooks</p>
           {migrationAnnouncementVisible ? (
-            <Link className={styles.migrationCta} href="/migration">
-              <span>We are migrating</span>
-              <small>Ethereum → Robinhood Chain</small>
+            <Link
+              className={styles.migrationCta}
+              href="/migration"
+            >
+              <span>V4 is moving to Robinhood</span>
+              <small>
+                {migrationWindowActive
+                  ? "Migration window open · View details"
+                  : "Migration opens soon · View details"}
+              </small>
             </Link>
           ) : null}
         </div>

--- a/components/main-token-migration.module.css
+++ b/components/main-token-migration.module.css
@@ -13,9 +13,17 @@
   overflow-y: visible;
 }
 
+:global(body .app-frame):has(.page) > :global(main) {
+  padding-bottom: 0;
+}
+
+:global(body .app-frame):has(.page) [data-site-footer] {
+  display: none;
+}
+
 .page {
   color: var(--webde-ink);
-  min-height: 100svh;
+  min-height: calc(100svh - var(--header-height));
   min-width: 0;
   overflow-x: clip;
   padding-bottom: 48px;
@@ -42,7 +50,7 @@
   font-size: 12px;
   letter-spacing: 0.04em;
   line-height: 1.35;
-  margin-bottom: 32px;
+  margin-bottom: 12px;
   padding: 8px 12px;
   text-transform: uppercase;
 }
@@ -167,6 +175,15 @@
   line-height: 1.45;
 }
 
+.previewCountdown {
+  color: #fff;
+  font-size: clamp(20px, 2.4vw, 28px);
+  font-weight: 560;
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+  margin-top: 8px;
+}
+
 .clock {
   align-items: start;
   display: grid;
@@ -216,6 +233,71 @@
   margin-inline: auto;
   overflow: hidden;
   width: min(calc(100% - 48px), 1180px);
+}
+
+.previewPanel {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.8fr) minmax(0, 1.2fr);
+  padding: 28px;
+}
+
+.previewPanelHeader {
+  align-content: center;
+  border-inline-end: 1px solid var(--webde-line);
+  display: grid;
+  padding-inline-end: 28px;
+}
+
+.previewPanelHeader > p {
+  color: var(--webde-dim);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.previewPanelHeader h2 {
+  color: #fff;
+  font-size: clamp(22px, 2.4vw, 30px);
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  margin: 8px 0 0;
+}
+
+.previewPanelHeader span,
+.previewOptions span {
+  color: var(--webde-muted);
+  font-size: 14px;
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+
+.previewPanelHeader span {
+  margin-top: 10px;
+}
+
+.previewOptions {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  padding-inline-start: 28px;
+}
+
+.previewOptions > div {
+  align-content: start;
+  background: #111;
+  border: 1px solid var(--webde-line);
+  border-radius: 10px;
+  display: grid;
+  gap: 8px;
+  padding: 18px;
+}
+
+.previewOptions strong {
+  color: #fff;
+  font-size: 16px;
+  line-height: 1.35;
 }
 
 .closedNotice {
@@ -735,6 +817,20 @@
 }
 
 @media (max-width: 56rem) {
+  .previewPanel {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .previewPanelHeader {
+    border-bottom: 1px solid var(--webde-line);
+    border-inline-end: 0;
+    padding: 0 0 20px;
+  }
+
+  .previewOptions {
+    padding: 20px 0 0;
+  }
+
   .panelGrid {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -747,16 +843,23 @@
 
 @media (max-width: 40rem) {
   .page {
-    padding-bottom: 64px;
+    min-height: calc(100svh - 72px);
+    padding-bottom: 36px;
   }
 
   .hero {
     min-height: auto;
-    padding: 12px 16px 8px;
+    padding: 8px 14px 6px;
+  }
+
+  .previewFlag {
+    font-size: 10px;
+    margin-bottom: 8px;
+    padding: 6px 10px;
   }
 
   .hero h1 {
-    font-size: clamp(36px, 11vw, 44px);
+    font-size: clamp(34px, 10vw, 40px);
   }
 
   .chainFlow {
@@ -765,7 +868,7 @@
   }
 
   .chainName {
-    font-size: 17px;
+    font-size: 15px;
     gap: 8px;
   }
 
@@ -775,16 +878,24 @@
   }
 
   .chainArrow {
-    font-size: 34px;
+    font-size: 30px;
   }
 
   .heroCopy {
-    font-size: 16px;
-    margin-top: 12px;
+    font-size: 14px;
+    line-height: 1.4;
+    margin-top: 8px;
+  }
+
+  .officialNotice {
+    font-size: 10.5px;
+    line-height: 1.4;
+    margin-top: 6px;
+    padding: 6px 8px;
   }
 
   .countdown {
-    margin-top: 16px;
+    margin-top: 10px;
     width: 100%;
   }
 
@@ -804,6 +915,43 @@
 
   .migrationPanel {
     width: min(calc(100% - 24px), 1180px);
+  }
+
+  .previewPanel {
+    padding: 16px 14px;
+  }
+
+  .previewPanelHeader {
+    padding-bottom: 12px;
+  }
+
+  .previewPanelHeader h2 {
+    font-size: 21px;
+    margin-top: 5px;
+  }
+
+  .previewPanelHeader span {
+    display: none;
+  }
+
+  .previewOptions {
+    gap: 10px;
+    grid-template-columns: minmax(0, 1fr);
+    padding-top: 12px;
+  }
+
+  .previewOptions > div {
+    gap: 5px;
+    padding: 12px 14px;
+  }
+
+  .previewOptions strong {
+    font-size: 14px;
+  }
+
+  .previewOptions span {
+    font-size: 12.5px;
+    line-height: 1.4;
   }
 
   .closedNotice {

--- a/components/main-token-migration.tsx
+++ b/components/main-token-migration.tsx
@@ -603,7 +603,7 @@ function transferWindowOpenAt(now: number, uncertaintyMs = 0) {
 }
 
 function remainingAt(now: number, phase: MigrationPhase) {
-  if (phase === "preview") return MAIN_TOKEN_MIGRATION_WINDOW_SECONDS;
+  if (phase === "preview") return null;
   const target =
     phase === "upcoming" ? migrationWindow.startAt : migrationWindow.deadlineAt;
   if (target === null) return 0;
@@ -674,7 +674,7 @@ function Countdown({
         : phase === "upcoming"
           ? "Migration opens in"
           : phase === "preview"
-            ? "Planned migration window"
+            ? "72-hour migration window"
             : "Migration closes in";
 
   return (
@@ -687,33 +687,39 @@ function Countdown({
       }
     >
       <span className={styles.countdownLabel}>{label}</span>
-      <div className={styles.clock} aria-hidden="true">
-        <span>
-          <strong>{parts?.hours ?? "––"}</strong>
-          <small>Hours</small>
-        </span>
-        <i>:</i>
-        <span>
-          <strong>{parts?.minutes ?? "––"}</strong>
-          <small>Minutes</small>
-        </span>
-        <i>:</i>
-        <span>
-          <strong>{parts?.seconds ?? "––"}</strong>
-          <small>Seconds</small>
-        </span>
-      </div>
-      <span className={styles.absoluteDeadline}>
-        {phase === "checking"
-          ? "Verifying the published UTC window"
-          : phase === "preview"
-            ? "96-hour transfer window"
-            : `${phase === "upcoming" ? "Opens" : "Closes"} ${formatUtc(
-                phase === "upcoming"
-                  ? migrationWindow.startAt
-                  : migrationWindow.deadlineAt,
-              )}`}
-      </span>
+      {phase === "preview" ? (
+        <strong className={styles.previewCountdown}>
+          The countdown has not started
+        </strong>
+      ) : (
+        <>
+          <div className={styles.clock} aria-hidden="true">
+            <span>
+              <strong>{parts?.hours ?? "––"}</strong>
+              <small>Hours</small>
+            </span>
+            <i>:</i>
+            <span>
+              <strong>{parts?.minutes ?? "––"}</strong>
+              <small>Minutes</small>
+            </span>
+            <i>:</i>
+            <span>
+              <strong>{parts?.seconds ?? "––"}</strong>
+              <small>Seconds</small>
+            </span>
+          </div>
+          <span className={styles.absoluteDeadline}>
+            {phase === "checking"
+              ? "Verifying the published UTC window"
+              : `${phase === "upcoming" ? "Opens" : "Closes"} ${formatUtc(
+                  phase === "upcoming"
+                    ? migrationWindow.startAt
+                    : migrationWindow.deadlineAt,
+                )}`}
+          </span>
+        </>
+      )}
     </div>
   );
 }
@@ -782,7 +788,11 @@ export function MainTokenMigration() {
     });
   }, []);
 
-  const phase = now === null ? "checking" : phaseAt(now);
+  const phase = !migrationWindow.enabled
+    ? "preview"
+    : now === null
+      ? "checking"
+      : phaseAt(now);
   const remaining = now === null ? null : remainingAt(now, phase);
   const onMainnet =
     wallet !== null &&
@@ -863,6 +873,7 @@ export function MainTokenMigration() {
   }, [amount, balance]);
 
   useEffect(() => {
+    if (!migrationWindow.enabled) return;
     let cancelled = false;
     const synchronize = async () => {
       const requestStartedAt = performance.now();
@@ -1646,7 +1657,7 @@ export function MainTokenMigration() {
     <article className={styles.page}>
       <section className={styles.hero} aria-labelledby="migration-title">
         <div className={styles.previewFlag} hidden={phase !== "preview"}>
-          Local preview · transfers disabled
+          No action required right now
         </div>
         <Image
           className={styles.loopMark}
@@ -1676,14 +1687,14 @@ export function MainTokenMigration() {
           <span className={styles.chainName}>Robinhood</span>
         </div>
         <Countdown phase={phase} remaining={remaining} />
-        {clockIssue ? (
+        {phase !== "preview" && clockIssue ? (
           <p className={styles.clockIssue} role="status">
             {clockIssue}
           </p>
         ) : null}
         <p className={styles.heroCopy}>
-          Send V4 during the active window. The same token amount will be sent
-          to the same wallet on Robinhood.
+          When the window opens, send V4 from Ethereum. The same number of V4
+          tokens will go to that wallet on Robinhood.
         </p>
         <p className={styles.officialNotice}>
           Use only <strong>programmable.market/migration</strong>. Programmable
@@ -1691,10 +1702,42 @@ export function MainTokenMigration() {
         </p>
       </section>
 
-      <section
-        className={styles.migrationPanel}
-        aria-labelledby="send-v4-title"
-      >
+      {phase === "preview" ? (
+        <section
+          className={`${styles.migrationPanel} ${styles.previewPanel}`}
+          aria-labelledby="migration-preview-title"
+        >
+          <header className={styles.previewPanelHeader}>
+            <p>Migration opens soon</p>
+            <h2 id="migration-preview-title">Two simple ways to send V4</h2>
+            <span>
+              The timer, official address and transfer buttons will appear here
+              when the window starts.
+            </span>
+          </header>
+          <div className={styles.previewOptions}>
+            <div>
+              <strong>Connect your wallet</strong>
+              <span>
+                Choose an amount or select Max. If you have no ETH,
+                Programmable can sponsor the gas. You still approve the V4
+                transfer in your wallet.
+              </span>
+            </div>
+            <div>
+              <strong>Send V4 manually</strong>
+              <span>
+                Prefer not to connect? Copy the official address here and send
+                V4 from the wallet that should receive the Robinhood tokens.
+              </span>
+            </div>
+          </div>
+        </section>
+      ) : (
+        <section
+          className={styles.migrationPanel}
+          aria-labelledby="send-v4-title"
+        >
         {phase === "closed" ? (
           <div className={styles.closedNotice} role="alert">
             <strong>Migration closed</strong>
@@ -2139,7 +2182,8 @@ export function MainTokenMigration() {
             )}
           </aside>
         </div>
-      </section>
+        </section>
+      )}
     </article>
   );
 }

--- a/config/main-token-migration-activation.v1.json
+++ b/config/main-token-migration-activation.v1.json
@@ -1,16 +1,16 @@
 {
   "schema": "programmable-main-token-migration-activation/v1",
-  "releaseId": "v4-ethereum-to-robinhood-96h-2026-v1",
-  "enabled": true,
+  "releaseId": "v4-ethereum-to-robinhood-72h-2026-v2",
+  "enabled": false,
   "sourceChainId": "1",
   "sourceTokenAddress": "0x7987f03462200b3D8A072E02C89A8A41dCB124EE",
   "sourceTokenRuntimeCodeKeccak256": "0x4fe466386aeebe507f6bcfc58e046a0632e4687699fa5bd28c4b7ec6333141ad",
   "sourceTokenDecimals": "18",
   "sourceTokenTotalSupplyRaw": "1000000000000000000000000000",
   "migrationWallet": "0x228Be90653fDDAa408fB6cf9ca0AEC311dbE9A0D",
-  "windowDurationSeconds": "345600",
-  "windowStartTimestamp": "1788125400",
-  "deadlineTimestampExclusive": "1788471000",
-  "startBlockNumber": "25870405",
-  "startBlockHash": "0xe4f50afeba1884b8354b3c962f99a258f2901f9768ec8da8ad05391761ff57de"
+  "windowDurationSeconds": "259200",
+  "windowStartTimestamp": null,
+  "deadlineTimestampExclusive": null,
+  "startBlockNumber": null,
+  "startBlockHash": null
 }

--- a/config/main-token-migration-gas-sponsor-contract.v1.json
+++ b/config/main-token-migration-gas-sponsor-contract.v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "programmable-main-token-migration-gas-sponsor-activation-contract/v1",
-  "releaseId": "v4-ethereum-to-robinhood-96h-2026-v1",
+  "releaseId": "v4-ethereum-to-robinhood-72h-2026-v2",
   "activationManifestPath": "config/main-token-migration-activation.v1.json",
   "route": "/api/main-token-migration/gas-sponsorship",
   "serverOnly": true,

--- a/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-READINESS-V1.md
+++ b/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-READINESS-V1.md
@@ -7,7 +7,7 @@ and private release evidence.
 ## Candidate identity
 
 - [ ] The candidate is an immutable build from the exact reviewed `production` commit.
-- [ ] `config/main-token-migration-activation.v1.json` binds the reviewed release and has a 345,600-second window,
+- [ ] `config/main-token-migration-activation.v1.json` binds the reviewed release and has a 259,200-second window,
       exact finalized pre-window eligibility block number and hash.
 - [ ] The sponsor contract matches
       `config/main-token-migration-gas-sponsor-contract.v1.json` byte-for-byte in the candidate.
@@ -50,7 +50,8 @@ and private release evidence.
 - [ ] Privy wallet/policy readback is captured privately without credentials.
 - [ ] Candidate route readback, sponsor balance, durable-store readiness and independent RPC identity are captured at
       the activation time.
-- [ ] Public page visibility is enabled only after the activation manifest, server-time readback and sponsor readiness
+- [ ] The inactive public preview exposes no timer, address or transfer action. The timer, official address, wallet
+      actions and sponsor become visible only after the activation manifest, server-time readback and sponsor readiness
       gates pass.
 - [ ] Post-window disablement and Privy policy revocation have named owners.
 

--- a/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-V1.md
+++ b/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-V1.md
@@ -1,12 +1,13 @@
 # Main Token Migration Gas Sponsor V1
 
-Status: release-live. The checked-in activation manifest binds the exact migration window. No committed file contains
-the operational Privy wallet ID, policy ID, sponsor address or release budget.
+Status: preparation-ready, activation-blocked. The checked-in activation manifest binds the 72-hour release policy,
+but it intentionally contains no start time, deadline or eligibility-block anchor yet. No committed file contains the
+operational Privy wallet ID, policy ID, sponsor address or release budget.
 
 ## Purpose
 
 This runbook defines the server-only activation contract for one bounded Ethereum Mainnet gas top-up per eligible
-V4 holder during the exact 96-hour migration window. The sponsor sends native ETH only to the authenticated holder
+V4 holder during the exact 72-hour migration window. The sponsor sends native ETH only to the authenticated holder
 wallet so that the holder can separately approve the exact V4 token transfer in their own wallet. It never sends V4,
 never submits the holder's token transfer, and never uses the migration recipient wallet as the sponsor.
 
@@ -46,7 +47,7 @@ Activation additionally requires the normal runtime dependencies:
 | `PROGRAMMABLE_WEBSITE_MAINNET_RPC_SECONDARY_ENDPOINT_COMMITMENT` | Commitment to the secondary endpoint |
 
 The root migration manifest must independently bind the exact release, token, runtime-code hash, migration wallet,
-96-hour timestamps, finalized pre-window eligibility block number and block hash. Sponsor configuration is accepted only while that
+72-hour timestamps, finalized pre-window eligibility block number and block hash. Sponsor configuration is accepted only while that
 manifest has `enabled: true`, the current time is inside the window, and at least five minutes remain.
 
 ## Privy wallet and policy
@@ -128,7 +129,7 @@ value, fee fields, gas limit, empty calldata and successful receipt on the same 
 5. Configure the Privy secret, projection database bindings and exact independent RPC commitments on the immutable
    deployment candidate.
 6. Before the migration opens, record one exact block number/hash already finalized by both providers and calculate
-   timestamps whose exclusive deadline is exactly 345,600 seconds after the start.
+   timestamps whose exclusive deadline is exactly 259,200 seconds after the start.
 7. Only the integration owner may change the reviewed activation manifest to `enabled: true`, inject all six sponsor
    values with `MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ENABLED=true`, and deploy the exact reviewed `production` commit.
 8. Run the separate readiness checklist before exposing the migration entry point.

--- a/lib/main-token-migration.ts
+++ b/lib/main-token-migration.ts
@@ -14,9 +14,9 @@ import {
 } from "./prepared-transaction";
 
 export const MAIN_TOKEN_MIGRATION_CHAIN_ID = 1 as const;
-export const MAIN_TOKEN_MIGRATION_WINDOW_SECONDS = 96 * 60 * 60;
+export const MAIN_TOKEN_MIGRATION_WINDOW_SECONDS = 72 * 60 * 60;
 export const MAIN_TOKEN_MIGRATION_RELEASE_ID =
-  "v4-ethereum-to-robinhood-96h-2026-v1" as const;
+  "v4-ethereum-to-robinhood-72h-2026-v2" as const;
 export const MAIN_TOKEN_DECIMALS = 18;
 export const MAIN_TOKEN_SYMBOL = "V4";
 export const MAIN_TOKEN_TOTAL_SUPPLY_RAW =

--- a/tests/main-token-migration-gas-sponsor-contract.test.ts
+++ b/tests/main-token-migration-gas-sponsor-contract.test.ts
@@ -57,18 +57,17 @@ describe("main token migration gas sponsor activation contract", () => {
 
   it("pins the checked-in release window while keeping operational sponsor values blank", () => {
     expect(contract.releaseId).toBe(
-      "v4-ethereum-to-robinhood-96h-2026-v1",
+      "v4-ethereum-to-robinhood-72h-2026-v2",
     );
     expect(manifest).toMatchObject({
       schema: "programmable-main-token-migration-activation/v1",
       releaseId: contract.releaseId,
-      enabled: true,
-      windowDurationSeconds: "345600",
-      windowStartTimestamp: "1788125400",
-      deadlineTimestampExclusive: "1788471000",
-      startBlockNumber: "25870405",
-      startBlockHash:
-        "0xe4f50afeba1884b8354b3c962f99a258f2901f9768ec8da8ad05391761ff57de",
+      enabled: false,
+      windowDurationSeconds: "259200",
+      windowStartTimestamp: null,
+      deadlineTimestampExclusive: null,
+      startBlockNumber: null,
+      startBlockHash: null,
     });
 
     expect(environment).toContain(
@@ -108,9 +107,9 @@ describe("main token migration gas sponsor activation contract", () => {
       expect(runbook).toContain(`\`${name}\``);
     }
     expect(readiness).toContain("If any item is false or unknown");
-    expect(runbook).toContain("exact 96-hour migration window");
-    expect(runbook).toContain("exactly 345,600 seconds after the start");
-    expect(readiness).toContain("has a 345,600-second window");
+    expect(runbook).toContain("exact 72-hour migration window");
+    expect(runbook).toContain("exactly 259,200 seconds after the start");
+    expect(readiness).toContain("has a 259,200-second window");
   });
 
   it("binds the documented wallet, fee, budget and deadline limits to code", () => {

--- a/tests/main-token-migration-gas-sponsor-v1.test.ts
+++ b/tests/main-token-migration-gas-sponsor-v1.test.ts
@@ -53,7 +53,7 @@ const TEST_ERC20_ABI = parseAbi([
   "function transferFrom(address from,address to,uint256 amount) returns (bool)",
 ]);
 const CONFIGURATION: MainTokenMigrationGasSponsorConfigurationV1 = {
-  releaseId: "v4-ethereum-to-robinhood-96h-2026-v1",
+  releaseId: "v4-ethereum-to-robinhood-72h-2026-v2",
   windowStartTimestamp: 1_899_654_400,
   startBlockNumber: 100n,
   startBlockHash: `0x${"12".repeat(32)}`,
@@ -528,7 +528,7 @@ describe("main token migration gas sponsor", () => {
     }
   });
 
-  it("accepts only the exact 96-hour release identity and window", () => {
+  it("accepts only the exact 72-hour release identity and window", () => {
     const start = Math.floor(NOW.getTime() / 1_000) - 60;
     const manifest = {
       schema: "programmable-main-token-migration-activation/v1",
@@ -565,8 +565,8 @@ describe("main token migration gas sponsor", () => {
       manifest,
       nowMs: NOW.getTime(),
     })).toMatchObject({
-      releaseId: "v4-ethereum-to-robinhood-96h-2026-v1",
-      deadlineTimestampExclusive: start + 96 * 60 * 60,
+      releaseId: "v4-ethereum-to-robinhood-72h-2026-v2",
+      deadlineTimestampExclusive: start + 72 * 60 * 60,
     });
     expect(readMainTokenMigrationGasSponsorConfigurationV1({
       environment,

--- a/tests/main-token-migration.test.ts
+++ b/tests/main-token-migration.test.ts
@@ -28,7 +28,7 @@ const transferAbi = parseAbi([
   "function transfer(address to,uint256 amount) returns (bool)",
 ]);
 const migrationWallet = "0x228Be90653fDDAa408fB6cf9ca0AEC311dbE9A0D";
-const migrationWindowSeconds = 96 * 60 * 60;
+const migrationWindowSeconds = 72 * 60 * 60;
 
 describe("main token migration transfer", () => {
   it("accepts empty or exact EIP-7702 delegated EOA code only", () => {
@@ -48,7 +48,7 @@ describe("main token migration transfer", () => {
     }
   });
 
-  it("freezes the 96-hour Ethereum migration identities", () => {
+  it("freezes the 72-hour Ethereum migration identities", () => {
     expect(MAIN_TOKEN_MIGRATION_CHAIN_ID).toBe(1);
     expect(MAIN_TOKEN_ADDRESS).toBe(
       "0x7987f03462200b3D8A072E02C89A8A41dCB124EE",
@@ -58,7 +58,7 @@ describe("main token migration transfer", () => {
     expect(MAIN_TOKEN_MIGRATION_WINDOW_SECONDS).toBe(migrationWindowSeconds);
 
     expect(MAIN_TOKEN_MIGRATION_RELEASE_ID).toBe(
-      "v4-ethereum-to-robinhood-96h-2026-v1",
+      "v4-ethereum-to-robinhood-72h-2026-v2",
     );
   });
 
@@ -179,8 +179,8 @@ describe("main token migration page contract", () => {
       Math.max(0, Math.ceil((deadlineAt - now) / 1_000));
 
     expect(remainingAt(startAt)).toBe(migrationWindowSeconds);
-    expect(remainingAt(startAt + 12 * 60 * 60 * 1_000)).toBe(84 * 60 * 60);
-    expect(remainingAt(startAt + 85 * 60 * 60 * 1_000)).toBe(11 * 60 * 60);
+    expect(remainingAt(startAt + 12 * 60 * 60 * 1_000)).toBe(60 * 60 * 60);
+    expect(remainingAt(startAt + 61 * 60 * 60 * 1_000)).toBe(11 * 60 * 60);
     expect(page).toContain("trustedClockEndpoint");
     expect(page).toContain("performance.now()");
     expect(page).toContain("setNow(readTrustedNow())");
@@ -280,7 +280,7 @@ describe("main token migration page contract", () => {
     );
   });
 
-  it("activates only with the exact 96-hour window, start block and release", () => {
+  it("activates only with the exact 72-hour window, start block and release", () => {
     const startAt = Date.parse("2026-08-30T12:00:00.000Z");
     const activation = (
       requested: boolean,
@@ -366,7 +366,7 @@ describe("main token migration page contract", () => {
     expect(page).toContain("startBlockHash !== null");
   });
 
-  it("binds the public page to the exact 96-hour window and finalized Ethereum anchor", () => {
+  it("publishes a fail-closed 72-hour preparation page until an exact Ethereum anchor is set", () => {
     const route = read("app/migration/page.tsx");
     const landing = read("components/landing-page.tsx");
     const activationManifest = JSON.parse(
@@ -384,7 +384,8 @@ describe("main token migration page contract", () => {
     expect(page).toContain("main-token-migration-activation.v1.json");
     expect(page).toContain("deadlineAt - startAt ===");
     expect(page).toContain("startBlock !== null");
-    expect(page).toContain("Local preview · transfers disabled");
+    expect(page).toContain("No action required right now");
+    expect(page).toContain("const phase = !migrationWindow.enabled");
     expect(page).toContain(
       "Nothing is sent until you approve the V4 transfer in your wallet.",
     );
@@ -400,30 +401,26 @@ describe("main token migration page contract", () => {
     expect(route).toContain("follow: false");
     expect(route).toContain("PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_ENABLED");
     expect(route).toContain("PROGRAMMABLE_MAIN_TOKEN_MIGRATION_LOCAL_PREVIEW");
-    expect(route).toContain("migrationActivationManifest.enabled");
     expect(route).toContain("notFound()");
     expect(landing).toContain('href="/migration"');
-    expect(landing).toContain("We are migrating");
+    expect(landing).toContain("V4 is moving to Robinhood");
     expect(landing).toContain(
       "NEXT_PUBLIC_PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_VISIBLE",
     );
-    expect(landing).toContain("migrationActivationManifest.enabled");
+    expect(landing).toContain("migrationWindowActive");
     expect(read("app/api/main-token-migration/window-time/route.ts")).toContain(
       "programmable-main-token-migration-window-time/v1",
     );
     expect(activationManifest).toMatchObject({
-      enabled: true,
+      enabled: false,
       releaseId: MAIN_TOKEN_MIGRATION_RELEASE_ID,
       windowDurationSeconds: String(MAIN_TOKEN_MIGRATION_WINDOW_SECONDS),
-      windowStartTimestamp: "1788125400",
-      deadlineTimestampExclusive: "1788471000",
-      startBlockNumber: "25870405",
-      startBlockHash:
-        "0xe4f50afeba1884b8354b3c962f99a258f2901f9768ec8da8ad05391761ff57de",
+      windowStartTimestamp: null,
+      deadlineTimestampExclusive: null,
+      startBlockNumber: null,
+      startBlockHash: null,
     });
-    expect(
-      Number(activationManifest.deadlineTimestampExclusive) -
-        Number(activationManifest.windowStartTimestamp),
-    ).toBe(MAIN_TOKEN_MIGRATION_WINDOW_SECONDS);
+    expect(page).toContain("return false");
+    expect(page).toContain("const canCopyDestination = transferWindowOpen;");
   });
 });


### PR DESCRIPTION
## Outcome
- replaces the old live 96-hour release with a prepared, disabled 72-hour release
- keeps the public migration information page and prominent homepage notice visible while all transfers, address copy, and gas sponsorship remain fail-closed
- simplifies the pre-open page for non-technical holders and hides the full transfer form until the exact window is activated
- preserves the superseded release and its confirmed direct-transfer receipts in immutable git/onchain history for later reconciliation

## Verification
- `npm run migration:main-token:test` (42/42)
- `npm run typecheck`
- focused ESLint on changed TypeScript files
- `git diff --check`

No timer was started, no wallet was signed, and no onchain transaction was submitted.