### PR TITLE
fix(ui): prevent hidden status overflow

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -486,6 +486,7 @@ textarea {
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
   height: 1px;
+  margin: -1px;
   overflow: hidden;
   position: absolute;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- keep visually hidden live regions out of page overflow
- remove the remaining 1px browser scroll artifact without changing migration activation, wallet, sponsor, or onchain behavior

## Verification
- `git diff --check`
- remote 1440x900 and 390x844 layout measurements remain exact with no horizontal or vertical overflow