### PR TITLE
fix: separate Sourcify evidence from source authority

### DIFF
--- a/contracts/scripts/robinhood-custom-launch-capture-v2.mjs
+++ b/contracts/scripts/robinhood-custom-launch-capture-v2.mjs
@@ -76,14 +76,20 @@ const SAFE_OWNERS = Object.freeze([
   "0x032b1c7b96793717F0BD2f11eb86cd10CdefC4a3",
   "0x2Bb333d48DFAF1596D9036671d2E43168994249E",
 ]);
+const ROBINHOOD_PHASE_A_TRANSACTION_HASH =
+  "0x30617f11ef467997bace3ab8b8d6048a19e42675fc101c73b1b216b5f8b0d08d";
+const ROBINHOOD_PHASE_A_BLOCK_NUMBER = "50469365";
+const ROBINHOOD_PHASE_A_TRANSACTION_INDEX = "9";
+const ROBINHOOD_PHASE_A_DEPLOYER =
+  "0x2Bb333d48DFAF1596D9036671d2E43168994249E";
 const MAX_RPC_BYTES = 8 * 1024 * 1024;
 const MAX_SOURCIFY_BYTES = 32 * 1024 * 1024;
 const MAX_FRESH_CAPTURE_BYTES = 96 * 1024 * 1024;
 const MAX_PUBLIC_CAPTURE_BYTES = 128 * 1024 * 1024;
 const SOURCIFY_NORMALIZED_RESPONSE_DOMAIN =
-  "programmable.robinhood-custom-launch.sourcify-normalized-response.v2";
+  "programmable.robinhood-custom-launch.sourcify-normalized-response.v3";
 const SOURCIFY_RESPONSE_CLOSURE_DOMAIN =
-  "programmable.robinhood-custom-launch.sourcify-response-closure.v5";
+  "programmable.robinhood-custom-launch.sourcify-response-closure.v6";
 const SOURCIFY_PROVIDER_CLASSIFICATION = "PARTIAL_NO_CBOR_EXACT_BYTES";
 const CAPTURE_INVENTORY_DOMAIN =
   "programmable.robinhood-custom-launch.capture-inventory.v4";
@@ -1678,7 +1684,7 @@ function normalizeL1Provider(value, index, batchNumber) {
   });
 }
 
-function normalizeRawSourcify(value, index, repositoryRoot, expected, readFile, observedAt) {
+function normalizeRawSourcify(value, index, expected, observedAt) {
   const label = `capture.sourcifyResponses[${index}]`;
   assertExactKeys(value, [
     "contract", "urlPath", "httpStatus", "contentType", "responseBase64",
@@ -1705,34 +1711,59 @@ function normalizeRawSourcify(value, index, repositoryRoot, expected, readFile, 
     );
   }
   providerRfc3339(response.verifiedAt, `${label}.verifiedAt`);
+  if (!/^[1-9][0-9]*$/u.test(response.matchId)) {
+    throw new TypeError(`${label}.matchId must be a canonical positive decimal identifier`);
+  }
+  const deployment = plainObject(response.deployment, `${label}.deployment`);
+  assertExactKeys(deployment, [
+    "transactionHash", "blockNumber", "transactionIndex", "deployer",
+  ], `${label}.deployment`);
+  if (deployment.transactionHash !== ROBINHOOD_PHASE_A_TRANSACTION_HASH
+    || deployment.blockNumber !== ROBINHOOD_PHASE_A_BLOCK_NUMBER
+    || deployment.transactionIndex !== ROBINHOOD_PHASE_A_TRANSACTION_INDEX
+    || deployment.deployer !== ROBINHOOD_PHASE_A_DEPLOYER) {
+    throw new TypeError(`${label}.deployment differs from the finalized Phase A transaction`);
+  }
   const compilation = plainObject(response.compilation, `${label}.compilation`);
   if (compilation.language !== "Solidity" || compilation.compiler !== "solc"
     || compilation.compilerVersion !== "0.8.26+commit.8a97fa7a"
     || compilation.name !== expected.name
-    || compilation.fullyQualifiedName !== expected.fullyQualifiedName
-    || typeof compilation.compilerSettings !== "object" || compilation.compilerSettings === null) {
+    || typeof compilation.fullyQualifiedName !== "string"
+    || compilation.fullyQualifiedName.length <= expected.name.length + 1
+    || compilation.fullyQualifiedName.length > 4_096
+    || !compilation.fullyQualifiedName.endsWith(`:${expected.name}`)) {
     throw new TypeError(`${label} compiler/contract identity differs`);
   }
+  const compilerSettings = plainObject(
+    compilation.compilerSettings,
+    `${label}.compilation.compilerSettings`,
+  );
   const stdJsonInput = plainObject(response.stdJsonInput, `${label}.stdJsonInput`);
-  const localBytes = readFile(repositoryRoot, expected.standardJsonInputPath);
-  const localInput = parseStrictJson(decodeExactUtf8(localBytes, expected.standardJsonInputPath), {
-    maximumBytes: localBytes.byteLength,
-  });
-  if (canonicalizeJson(stdJsonInput) !== canonicalizeJson(localInput)) {
-    throw new TypeError(`${label} Standard JSON input differs from the exact repository input`);
-  }
-  if (canonicalizeJson(compilation.compilerSettings)
-      !== canonicalizeJson(localInput.settings)) {
-    throw new TypeError(`${label} compiler settings differ from the exact repository input`);
+  const stdJsonSettings = plainObject(stdJsonInput.settings, `${label}.stdJsonInput.settings`);
+  const stdJsonSources = plainObject(stdJsonInput.sources, `${label}.stdJsonInput.sources`);
+  const providerSourcePath = compilation.fullyQualifiedName.slice(
+    0,
+    compilation.fullyQualifiedName.length - expected.name.length - 1,
+  );
+  if (stdJsonInput.language !== "Solidity"
+    || stdJsonSettings.metadata?.appendCBOR !== false
+    || !Object.hasOwn(stdJsonSources, providerSourcePath)
+    || canonicalizeJson(compilerSettings) !== canonicalizeJson(stdJsonSettings)) {
+    throw new TypeError(`${label} provider compiler settings and Standard JSON differ`);
   }
   const sources = plainObject(response.sources, `${label}.sources`);
-  const sourceNames = Object.keys(stdJsonInput.sources ?? {}).sort();
+  const sourceNames = Object.keys(stdJsonSources).sort();
   if (sourceNames.length === 0 || Object.keys(sources).sort().join("\0") !== sourceNames.join("\0")) {
-    throw new TypeError(`${label} source-file closure differs from Standard JSON`);
+    throw new TypeError(`${label} provider source-file closure differs from Standard JSON`);
   }
   for (const sourceName of sourceNames) {
-    if (sources[sourceName]?.content !== stdJsonInput.sources[sourceName]?.content) {
-      throw new TypeError(`${label} source ${sourceName} differs from Standard JSON`);
+    const source = plainObject(sources[sourceName], `${label}.sources[${sourceName}]`);
+    const inputSource = plainObject(
+      stdJsonSources[sourceName],
+      `${label}.stdJsonInput.sources[${sourceName}]`,
+    );
+    if (typeof source.content !== "string" || source.content !== inputSource.content) {
+      throw new TypeError(`${label} provider source ${sourceName} differs from Standard JSON`);
     }
   }
   const normalized = {
@@ -1746,7 +1777,9 @@ function normalizeRawSourcify(value, index, repositoryRoot, expected, readFile, 
     providerClassification: SOURCIFY_PROVIDER_CLASSIFICATION,
     providerReleaseAuthority: false,
     observedAt: iso(observedAt, `${label}.observedAt`),
-    compiler: Object.freeze({
+    providerMatchId: response.matchId,
+    providerVerifiedAt: response.verifiedAt,
+    providerCompiler: Object.freeze({
       language: "Solidity",
       compiler: "solc",
       compilerVersion: compilation.compilerVersion,
@@ -1754,15 +1787,23 @@ function normalizeRawSourcify(value, index, repositoryRoot, expected, readFile, 
       fullyQualifiedName: compilation.fullyQualifiedName,
       compilerSettingsDigest: framedSha256(
         "programmable.robinhood-custom-launch.sourcify-compiler-settings.v1",
-        compilation.compilerSettings,
+        compilerSettings,
       ),
     }),
-    sourceFilesDigest: framedSha256(
+    providerSourceFilesDigest: framedSha256(
       "programmable.robinhood-custom-launch.sourcify-source-files.v1",
       sources,
     ),
-    standardJsonInputPath: expected.standardJsonInputPath,
-    standardJsonInputSha256: sha256(localBytes),
+    providerStandardJsonInputDigest: framedSha256(
+      "programmable.robinhood-custom-launch.sourcify-standard-json-input.v1",
+      stdJsonInput,
+    ),
+    providerDeployment: Object.freeze({
+      transactionHash: deployment.transactionHash,
+      blockNumber: deployment.blockNumber,
+      transactionIndex: deployment.transactionIndex,
+      deployer: deployment.deployer,
+    }),
     urlPath: value.urlPath,
     httpStatus: 200,
     contentType: "application/json",
@@ -1778,33 +1819,37 @@ function normalizeRawSourcify(value, index, repositoryRoot, expected, readFile, 
 function validateNormalizedSourcify(
   value,
   index,
-  repositoryRoot,
   expected,
-  readFile,
   observedAt,
 ) {
   const label = `capture.sourcifyResponses[${index}]`;
   assertExactKeys(value, [
     "contract", "provider", "chainId", "address", "match", "creationMatch",
     "runtimeMatch", "providerClassification", "providerReleaseAuthority",
-    "observedAt", "compiler", "sourceFilesDigest",
-    "standardJsonInputPath", "standardJsonInputSha256", "urlPath", "httpStatus",
+    "observedAt", "providerMatchId", "providerVerifiedAt", "providerCompiler",
+    "providerSourceFilesDigest", "providerStandardJsonInputDigest",
+    "providerDeployment", "urlPath", "httpStatus",
     "contentType", "normalizedVerificationDigest",
   ], label);
-  assertExactKeys(value.compiler, [
+  assertExactKeys(value.providerCompiler, [
     "language", "compiler", "compilerVersion", "name", "fullyQualifiedName",
     "compilerSettingsDigest",
-  ], `${label}.compiler`);
-  const localBytes = readFile(repositoryRoot, expected.standardJsonInputPath);
-  const localInput = parseStrictJson(decodeExactUtf8(localBytes, expected.standardJsonInputPath), {
-    maximumBytes: localBytes.byteLength,
-  });
-  const expectedSources = plainObject(localInput.sources, `${label} local sources`);
+  ], `${label}.providerCompiler`);
+  assertExactKeys(value.providerDeployment, [
+    "transactionHash", "blockNumber", "transactionIndex", "deployer",
+  ], `${label}.providerDeployment`);
   if (value.match !== "match" || value.creationMatch !== "match"
     || value.runtimeMatch !== "match" || value.address !== expected.address) {
     throw new TypeError(
       `${label} is not the required provider match/match/match for appendCBOR=false`,
     );
+  }
+  providerRfc3339(value.providerVerifiedAt, `${label}.providerVerifiedAt`);
+  if (value.providerDeployment.transactionHash !== ROBINHOOD_PHASE_A_TRANSACTION_HASH
+    || value.providerDeployment.blockNumber !== ROBINHOOD_PHASE_A_BLOCK_NUMBER
+    || value.providerDeployment.transactionIndex !== ROBINHOOD_PHASE_A_TRANSACTION_INDEX
+    || value.providerDeployment.deployer !== ROBINHOOD_PHASE_A_DEPLOYER) {
+    throw new TypeError(`${label}.providerDeployment differs from the finalized Phase A transaction`);
   }
   if (value.contract !== expected.contract || value.provider !== "sourcify-v2"
     || value.chainId !== "4663" || value.address !== expected.address
@@ -1812,20 +1857,20 @@ function validateNormalizedSourcify(
     || value.runtimeMatch !== "match"
     || value.providerClassification !== SOURCIFY_PROVIDER_CLASSIFICATION
     || value.providerReleaseAuthority !== false || value.observedAt !== observedAt
-    || value.compiler.language !== "Solidity" || value.compiler.compiler !== "solc"
-    || value.compiler.compilerVersion !== "0.8.26+commit.8a97fa7a"
-    || value.compiler.name !== expected.name
-    || value.compiler.fullyQualifiedName !== expected.fullyQualifiedName
-    || value.compiler.compilerSettingsDigest !== framedSha256(
-      "programmable.robinhood-custom-launch.sourcify-compiler-settings.v1",
-      localInput.settings,
+    || !/^[1-9][0-9]*$/u.test(value.providerMatchId)
+    || value.providerCompiler.language !== "Solidity"
+    || value.providerCompiler.compiler !== "solc"
+    || value.providerCompiler.compilerVersion !== "0.8.26+commit.8a97fa7a"
+    || value.providerCompiler.name !== expected.name
+    || typeof value.providerCompiler.fullyQualifiedName !== "string"
+    || value.providerCompiler.fullyQualifiedName.length <= expected.name.length + 1
+    || value.providerCompiler.fullyQualifiedName.length > 4_096
+    || !value.providerCompiler.fullyQualifiedName.endsWith(`:${expected.name}`)
+    || !/^sha256:[0-9a-f]{64}$/u.test(
+      value.providerCompiler.compilerSettingsDigest,
     )
-    || value.sourceFilesDigest !== framedSha256(
-      "programmable.robinhood-custom-launch.sourcify-source-files.v1",
-      expectedSources,
-    )
-    || value.standardJsonInputPath !== expected.standardJsonInputPath
-    || value.standardJsonInputSha256 !== sha256(localBytes)
+    || !/^sha256:[0-9a-f]{64}$/u.test(value.providerSourceFilesDigest)
+    || !/^sha256:[0-9a-f]{64}$/u.test(value.providerStandardJsonInputDigest)
     || value.urlPath !== `/server/v2/contract/4663/${expected.address}?fields=all`
     || value.httpStatus !== 200 || value.contentType !== "application/json"
     || value.normalizedVerificationDigest !== framedSha256(
@@ -2033,9 +2078,7 @@ export async function validateRobinhoodProductionCapture({
     validateNormalizedSourcify(
       response,
       index,
-      repositoryRoot,
       sourceTargets[index],
-      readFile,
       observedAt,
     ));
   if (l2Providers[0].transactionHash !== l2Providers[1].transactionHash
@@ -2124,9 +2167,7 @@ export async function validateRobinhoodProductionCapture({
 }
 
 export async function freshVerifyRobinhoodSourcify({
-  repositoryRoot,
   captureClosure,
-  readFile,
   fetch: request = fetch,
   now = () => new Date(),
 }) {
@@ -2173,16 +2214,29 @@ export async function freshVerifyRobinhoodSourcify({
       contentType: response.headers.get("content-type") ?? "",
       responseBase64: bytes.toString("base64"),
       responseSha256: sha256(bytes),
-    }, index, repositoryRoot, target, readFile, freshObservedAt));
+    }, index, target, freshObservedAt));
   }
-  const semantic = (entry) => {
-    const {
-      observedAt: _observedAt,
-      normalizedVerificationDigest: _normalizedVerificationDigest,
-      ...stable
-    } = entry;
-    return stable;
-  };
+  const semantic = (entry) => ({
+    contract: entry.contract,
+    provider: entry.provider,
+    chainId: entry.chainId,
+    address: entry.address,
+    match: entry.match,
+    creationMatch: entry.creationMatch,
+    runtimeMatch: entry.runtimeMatch,
+    providerClassification: entry.providerClassification,
+    providerReleaseAuthority: entry.providerReleaseAuthority,
+    providerCompiler: {
+      language: entry.providerCompiler.language,
+      compiler: entry.providerCompiler.compiler,
+      compilerVersion: entry.providerCompiler.compilerVersion,
+      name: entry.providerCompiler.name,
+    },
+    providerDeployment: structuredClone(entry.providerDeployment),
+    urlPath: entry.urlPath,
+    httpStatus: entry.httpStatus,
+    contentType: entry.contentType,
+  });
   if (canonicalizeJson(fresh.map(semantic))
       !== canonicalizeJson(captureClosure.sourcify.map(semantic))) {
     throw new TypeError("fresh Sourcify V2 closure differs from the attested capture");
@@ -2542,9 +2596,7 @@ export async function buildRobinhoodPostdeploymentInput({
     normalizeRawSourcify(
       response,
       index,
-      repositoryRoot,
       sourceTargets[index],
-      readFile,
       observedAt,
     ));
   if (testOnlyDependencies !== undefined && testOnlyDependencies?.allowTestOnly !== true) {

--- a/contracts/scripts/robinhood-custom-launch-postdeploy-core.mjs
+++ b/contracts/scripts/robinhood-custom-launch-postdeploy-core.mjs
@@ -80,6 +80,8 @@ const PREDEPLOYMENT_SHA256 =
 const CHAIN_DEPLOYMENT_ID = "robinhood-mainnet-custom-launch-v1";
 const CHAIN_ID = "4663";
 const CAIP2 = "eip155:4663";
+const ROBINHOOD_BACKEND_PROVIDER_PROFILE_DIGEST =
+  "sha256:c03afd37c077e78bea30f69d1ce139d026cb4fad86fa74122257bba8f5e9a910";
 const FOUNDATION_SOURCE_COMMITMENT =
   "0xe87f5edc2dc839bd87a26a80cb53f14b021e603a1753d27aae3a02862058d730";
 const EMPTY_RUNTIME_CODE_HASH =
@@ -177,21 +179,41 @@ const ROOTS = Object.freeze({
 const EXACT_SOURCE_BUILD_TARGETS = Object.freeze([
   Object.freeze({
     contract: "programmableLaunchStampRouter",
+    name: "ProgrammableLaunchStampRouterV1",
+    fullyQualifiedName:
+      "src/robinhood-custom-launch/ProgrammableLaunchStampRouterV1.sol:ProgrammableLaunchStampRouterV1",
+    standardJsonInputPath:
+      "contracts/spec/robinhood-custom-launch/standard-json/ProgrammableLaunchStampRouterV1.standard-input.json",
+    sourcePath: "contracts/src/robinhood-custom-launch/ProgrammableLaunchStampRouterV1.sol",
+    sourceSha256:
+      "sha256:ef87aa9338c364634bffda64423bd3fb096c1630a45cc58ecf854d24959ff163",
     address: ROOTS.programmableLaunchStampRouter.address,
     standardJsonInputSha256:
       "sha256:6abca24d06b013599f4ff63e049976419c3f17455fa9bc343b15ec0d6e6a078a",
     creationCodeHash:
       "0xf4176bf15de19a93b76cd138d6525a30d68efdad356e831f6d8449659959eb39",
     runtimeCodeHash: ROOTS.programmableLaunchStampRouter.runtimeCodeHash,
+    compilerSettingsDigest:
+      "sha256:0ae76a7ec92d6bb3c4612261fb06ccffe41fa34dfdd2fb1c3362f7a0b7d7b3ac",
   }),
   Object.freeze({
     contract: "graphFactory",
+    name: "ProgrammableCreate2GraphDeployerV1",
+    fullyQualifiedName:
+      "src/ProgrammableCreate2GraphDeployerV1.sol:ProgrammableCreate2GraphDeployerV1",
+    standardJsonInputPath:
+      "contracts/spec/robinhood-custom-launch/standard-json/ProgrammableCreate2GraphDeployerV1.standard-input.json",
+    sourcePath: "contracts/src/ProgrammableCreate2GraphDeployerV1.sol",
+    sourceSha256:
+      "sha256:06a3acaf9beeb68647af231f5524c5a34dc013d99611a1b2d0a6c80895f595e9",
     address: ROOTS.graphFactory.address,
     standardJsonInputSha256:
       "sha256:8ab811a215d70b1d5aef0c71a47153173953ee78d7632725413833888369ec4d",
     creationCodeHash:
       "0x84f7cb8e9e445d3322249dbc2b9efc65bb9c7a8ba26902aafef9b0552f4bc208",
     runtimeCodeHash: ROOTS.graphFactory.runtimeCodeHash,
+    compilerSettingsDigest:
+      "sha256:0ae76a7ec92d6bb3c4612261fb06ccffe41fa34dfdd2fb1c3362f7a0b7d7b3ac",
   }),
 ]);
 const HOSTED_REPRODUCTION_COMPILER_SHA256 =
@@ -253,9 +275,9 @@ const DOMAINS = Object.freeze({
   permit2: "programmable.custom-launch-genesis-provenance.v1",
   externalReadback: "programmable.custom-launch-deployment-provider-readback.v2",
   sourceVerification:
-    "programmable.robinhood-custom-launch.source-verification-closure.v5",
+    "programmable.robinhood-custom-launch.source-verification-closure.v6",
   exactSourceBinding:
-    "programmable.robinhood-custom-launch.exact-byte-source-build-transaction-binding.v1",
+    "programmable.robinhood-custom-launch.exact-byte-source-build-transaction-binding.v2",
   backendReleaseAssets:
     "programmable.robinhood-custom-launch.backend-release-assets.v1",
   stageBundle: ROBINHOOD_STAGE_BUNDLE_SCHEMA,
@@ -834,18 +856,13 @@ function normalizeFinalityInput(value, profile, blockNumber, blockHash) {
 
 function exactSourceBindingFromCapture(captureClosure) {
   const provider = captureClosure.l2ProviderReadbacks[0];
-  const compilerSettingsByContract = new Map(
-    captureClosure.sourcify.map((entry) => [
-      entry.contract,
-      entry.compiler.compilerSettingsDigest,
-    ]),
-  );
   const normalized = {
     schemaVersion: DOMAINS.exactSourceBinding,
     authority: "protected-hosted-build-finalized-transaction-bytecode",
     coveredContracts: EXACT_SOURCE_BUILD_TARGETS.map(({ contract }) => contract),
     sourceRevision: captureClosure.sourceOrigin.revision,
     sourceTree: captureClosure.sourceOrigin.tree,
+    sourceClosureDigest: captureClosure.sourceOrigin.sourceClosureDigest,
     captureAuthorizationDigest: captureClosure.authorization.verificationDigest,
     productionVerifyProofSha256:
       captureClosure.authorization.productionVerifyProofSha256,
@@ -857,16 +874,9 @@ function exactSourceBindingFromCapture(captureClosure) {
     deploymentBlockNumber: provider.deploymentBlock.blockNumber,
     deploymentBlockHash: provider.deploymentBlock.blockHash,
     ownerTransactionDataHash: OWNER_CALLDATA_HASH,
-    contracts: EXACT_SOURCE_BUILD_TARGETS.map((target) => ({
-      ...target,
-      compilerSettingsDigest: compilerSettingsByContract.get(target.contract),
-    })),
+    contracts: EXACT_SOURCE_BUILD_TARGETS.map((target) => ({ ...target })),
     bindingDigest: null,
   };
-  if (normalized.contracts.some(({ compilerSettingsDigest }) =>
-    typeof compilerSettingsDigest !== "string")) {
-    throw new TypeError("exact source binding is missing compiler settings evidence");
-  }
   normalized.bindingDigest = framedSha256(
     DOMAINS.exactSourceBinding,
     { ...normalized, bindingDigest: null },
@@ -890,17 +900,11 @@ function normalizeSourceVerification(value, captureClosure) {
   const sourceRoots = {
     graphFactory: {
       ...ROOTS.graphFactory,
-      standardJsonInputPath:
-        "contracts/spec/robinhood-custom-launch/standard-json/ProgrammableCreate2GraphDeployerV1.standard-input.json",
-      standardJsonInputSha256:
-        "sha256:8ab811a215d70b1d5aef0c71a47153173953ee78d7632725413833888369ec4d",
+      name: "ProgrammableCreate2GraphDeployerV1",
     },
     programmableLaunchStampRouter: {
       ...ROOTS.programmableLaunchStampRouter,
-      standardJsonInputPath:
-        "contracts/spec/robinhood-custom-launch/standard-json/ProgrammableLaunchStampRouterV1.standard-input.json",
-      standardJsonInputSha256:
-        "sha256:6abca24d06b013599f4ff63e049976419c3f17455fa9bc343b15ec0d6e6a078a",
+      name: "ProgrammableLaunchStampRouterV1",
     },
   };
   const normalizedRoots = Object.fromEntries(Object.entries(sourceRoots).map(([name, expected]) => {
@@ -909,20 +913,51 @@ function normalizeSourceVerification(value, captureClosure) {
     assertExactKeys(entry, [
       "chainId", "address", "match", "creationMatch", "runtimeMatch", "observedAt",
       "providerClassification", "providerReleaseAuthority",
-      "compiler", "sourceFilesDigest", "urlPath", "httpStatus",
-      "contentType", "standardJsonInputPath",
-      "standardJsonInputSha256", "normalizedVerificationDigest",
+      "providerMatchId", "providerVerifiedAt", "providerCompiler",
+      "providerSourceFilesDigest", "providerStandardJsonInputDigest",
+      "providerDeployment", "urlPath", "httpStatus", "contentType",
+      "normalizedVerificationDigest",
     ], entryLabel);
-    assertExactKeys(entry.compiler, [
+    assertExactKeys(entry.providerCompiler, [
       "language", "compiler", "compilerVersion", "name", "fullyQualifiedName",
       "compilerSettingsDigest",
-    ], `${entryLabel}.compiler`);
+    ], `${entryLabel}.providerCompiler`);
+    assertExactKeys(entry.providerDeployment, [
+      "transactionHash", "blockNumber", "transactionIndex", "deployer",
+    ], `${entryLabel}.providerDeployment`);
+    const captured = captureClosure.sourcify.find(({ contract }) => contract === name);
+    const capturedEntry = captured === undefined ? null : {
+      chainId: captured.chainId,
+      address: captured.address,
+      match: captured.match,
+      creationMatch: captured.creationMatch,
+      runtimeMatch: captured.runtimeMatch,
+      providerClassification: captured.providerClassification,
+      providerReleaseAuthority: captured.providerReleaseAuthority,
+      observedAt: captured.observedAt,
+      providerMatchId: captured.providerMatchId,
+      providerVerifiedAt: captured.providerVerifiedAt,
+      providerCompiler: structuredClone(captured.providerCompiler),
+      providerSourceFilesDigest: captured.providerSourceFilesDigest,
+      providerStandardJsonInputDigest: captured.providerStandardJsonInputDigest,
+      providerDeployment: structuredClone(captured.providerDeployment),
+      urlPath: captured.urlPath,
+      httpStatus: captured.httpStatus,
+      contentType: captured.contentType,
+      normalizedVerificationDigest: captured.normalizedVerificationDigest,
+    };
     if (entry.chainId !== CHAIN_ID || entry.match !== "match"
       || entry.creationMatch !== "match" || entry.runtimeMatch !== "match"
       || entry.providerClassification !== "PARTIAL_NO_CBOR_EXACT_BYTES"
       || entry.providerReleaseAuthority !== false
       || entry.httpStatus !== 200 || entry.contentType !== "application/json"
-      || entry.standardJsonInputPath !== expected.standardJsonInputPath) {
+      || entry.providerCompiler.language !== "Solidity"
+      || entry.providerCompiler.compiler !== "solc"
+      || entry.providerCompiler.compilerVersion !== "0.8.26+commit.8a97fa7a"
+      || entry.providerCompiler.name !== expected.name
+      || typeof entry.providerCompiler.fullyQualifiedName !== "string"
+      || !entry.providerCompiler.fullyQualifiedName.endsWith(`:${expected.name}`)
+      || canonicalizeJson(entry) !== canonicalizeJson(capturedEntry)) {
       throw new TypeError(`${entryLabel} is not the no-CBOR provider source match`);
     }
     return [name, {
@@ -934,27 +969,49 @@ function normalizeSourceVerification(value, captureClosure) {
       providerClassification: "PARTIAL_NO_CBOR_EXACT_BYTES",
       providerReleaseAuthority: false,
       observedAt: isoDate(entry.observedAt, `${entryLabel}.observedAt`),
-      compiler: {
-        language: entry.compiler.language,
-        compiler: entry.compiler.compiler,
-        compilerVersion: entry.compiler.compilerVersion,
-        name: entry.compiler.name,
-        fullyQualifiedName: entry.compiler.fullyQualifiedName,
+      providerMatchId: entry.providerMatchId,
+      providerVerifiedAt: entry.providerVerifiedAt,
+      providerCompiler: {
+        language: entry.providerCompiler.language,
+        compiler: entry.providerCompiler.compiler,
+        compilerVersion: entry.providerCompiler.compilerVersion,
+        name: entry.providerCompiler.name,
+        fullyQualifiedName: entry.providerCompiler.fullyQualifiedName,
         compilerSettingsDigest: exactSha256(
-          entry.compiler.compilerSettingsDigest,
-          `${entryLabel}.compiler.compilerSettingsDigest`,
+          entry.providerCompiler.compilerSettingsDigest,
+          `${entryLabel}.providerCompiler.compilerSettingsDigest`,
         ),
       },
-      sourceFilesDigest: exactSha256(entry.sourceFilesDigest, `${entryLabel}.sourceFilesDigest`),
+      providerSourceFilesDigest: exactSha256(
+        entry.providerSourceFilesDigest,
+        `${entryLabel}.providerSourceFilesDigest`,
+      ),
+      providerStandardJsonInputDigest: exactSha256(
+        entry.providerStandardJsonInputDigest,
+        `${entryLabel}.providerStandardJsonInputDigest`,
+      ),
+      providerDeployment: {
+        transactionHash: exactHex32(
+          entry.providerDeployment.transactionHash,
+          `${entryLabel}.providerDeployment.transactionHash`,
+        ),
+        blockNumber: decimal(
+          entry.providerDeployment.blockNumber,
+          `${entryLabel}.providerDeployment.blockNumber`,
+          { positive: true },
+        ),
+        transactionIndex: decimal(
+          entry.providerDeployment.transactionIndex,
+          `${entryLabel}.providerDeployment.transactionIndex`,
+        ),
+        deployer: exactAddress(
+          entry.providerDeployment.deployer,
+          `${entryLabel}.providerDeployment.deployer`,
+        ),
+      },
       urlPath: entry.urlPath,
       httpStatus: 200,
       contentType: "application/json",
-      standardJsonInputPath: expected.standardJsonInputPath,
-      standardJsonInputSha256: exactSha256(
-        entry.standardJsonInputSha256,
-        `${entryLabel}.standardJsonInputSha256`,
-        expected.standardJsonInputSha256,
-      ),
       normalizedVerificationDigest: exactSha256(
         entry.normalizedVerificationDigest,
         `${entryLabel}.normalizedVerificationDigest`,
@@ -1295,13 +1352,15 @@ function sourceVerificationFromCapture(captureClosure) {
     providerClassification: entry.providerClassification,
     providerReleaseAuthority: entry.providerReleaseAuthority,
     observedAt: entry.observedAt,
-    compiler: structuredClone(entry.compiler),
-    sourceFilesDigest: entry.sourceFilesDigest,
+    providerMatchId: entry.providerMatchId,
+    providerVerifiedAt: entry.providerVerifiedAt,
+    providerCompiler: structuredClone(entry.providerCompiler),
+    providerSourceFilesDigest: entry.providerSourceFilesDigest,
+    providerStandardJsonInputDigest: entry.providerStandardJsonInputDigest,
+    providerDeployment: structuredClone(entry.providerDeployment),
     urlPath: entry.urlPath,
     httpStatus: entry.httpStatus,
     contentType: entry.contentType,
-    standardJsonInputPath: entry.standardJsonInputPath,
-    standardJsonInputSha256: entry.standardJsonInputSha256,
     normalizedVerificationDigest: entry.normalizedVerificationDigest,
   }]));
   return {
@@ -1503,38 +1562,39 @@ function buildSourceClosure(
 }
 
 function bindSourceVerificationToClosure(repositoryRoot, sourceVerification, sourceClosure) {
-  const bindings = [
-    {
-      contract: "graphFactory",
-      standardJsonPath:
-        "contracts/spec/robinhood-custom-launch/standard-json/ProgrammableCreate2GraphDeployerV1.standard-input.json",
-      sourcePath: "contracts/src/ProgrammableCreate2GraphDeployerV1.sol",
-      compilerSourcePath: "src/ProgrammableCreate2GraphDeployerV1.sol",
-    },
-    {
-      contract: "programmableLaunchStampRouter",
-      standardJsonPath:
-        "contracts/spec/robinhood-custom-launch/standard-json/ProgrammableLaunchStampRouterV1.standard-input.json",
-      sourcePath: "contracts/src/robinhood-custom-launch/ProgrammableLaunchStampRouterV1.sol",
-      compilerSourcePath: "src/robinhood-custom-launch/ProgrammableLaunchStampRouterV1.sol",
-    },
-  ];
+  if (sourceVerification.exactSourceBinding.sourceClosureDigest
+      !== sourceClosure.sourceClosureDigest) {
+    throw new TypeError("exact source binding differs from the production source closure");
+  }
+  const bindings = EXACT_SOURCE_BUILD_TARGETS.map((target) => ({
+    ...target,
+    compilerSourcePath: target.fullyQualifiedName.split(":", 1)[0],
+  }));
+  const exactBindings = new Map(
+    sourceVerification.exactSourceBinding.contracts.map((entry) => [entry.contract, entry]),
+  );
   const entries = new Map(sourceClosure.entries.map((entry) => [entry.path, entry]));
   for (const binding of bindings) {
-    const standardJsonEntry = entries.get(binding.standardJsonPath);
+    const exactBinding = exactBindings.get(binding.contract);
+    const standardJsonEntry = entries.get(binding.standardJsonInputPath);
     const sourceEntry = entries.get(binding.sourcePath);
     if (standardJsonEntry?.sha256
-        !== sourceVerification[binding.contract].standardJsonInputSha256) {
+        !== exactBinding?.standardJsonInputSha256) {
       throw new TypeError(
         `${binding.contract} source verification does not bind the production Standard JSON bytes`,
       );
     }
     const standardJson = JSON.parse(
-      readFileSync(resolveInside(repositoryRoot, binding.standardJsonPath), "utf8"),
+      readFileSync(resolveInside(repositoryRoot, binding.standardJsonInputPath), "utf8"),
     );
     const sourceContent = standardJson?.sources?.[binding.compilerSourcePath]?.content;
     if (typeof sourceContent !== "string"
-      || sourceEntry?.sha256 !== sha256Digest(Buffer.from(sourceContent, "utf8"))) {
+      || sourceEntry?.sha256 !== exactBinding?.sourceSha256
+      || sourceEntry.sha256 !== sha256Digest(Buffer.from(sourceContent, "utf8"))
+      || exactBinding?.compilerSettingsDigest !== framedSha256(
+        "programmable.robinhood-custom-launch.sourcify-compiler-settings.v1",
+        standardJson.settings,
+      )) {
       throw new TypeError(
         `${binding.contract} production source differs from its verified Standard JSON closure`,
       );
@@ -1604,8 +1664,9 @@ function buildBackendReleaseAssets({
   descriptorDigest,
   captureClosure,
 }) {
-  const sourceByContract = Object.fromEntries(
-    captureClosure.sourcify.map((entry) => [entry.contract, entry]),
+  const exactSourceBinding = exactSourceBindingFromCapture(captureClosure);
+  const exactByContract = new Map(
+    exactSourceBinding.contracts.map((entry) => [entry.contract, entry]),
   );
   const transactionHash = descriptor.deploymentEvidence.transactionHash;
   const finalizedBlockNumber = descriptor.deploymentEvidence.blockNumber;
@@ -1631,43 +1692,43 @@ function buildBackendReleaseAssets({
     },
   ];
   const standardJsonInputs = targets.map((target) => {
-    const source = sourceByContract[target.captureKey];
-    if (source === undefined) {
+    const exact = exactByContract.get(target.captureKey);
+    if (exact === undefined) {
       throw new TypeError(`backend source asset is missing ${target.captureKey}`);
     }
-    const bytes = readFileSync(resolveInside(repositoryRoot, source.standardJsonInputPath));
-    if (sha256Digest(bytes) !== source.standardJsonInputSha256) {
+    const bytes = readFileSync(resolveInside(repositoryRoot, exact.standardJsonInputPath));
+    if (sha256Digest(bytes) !== exact.standardJsonInputSha256) {
       throw new TypeError(`backend source asset changed for ${target.captureKey}`);
     }
     return {
       target,
-      source,
+      exact,
       artifact: binaryArtifact(target.backendPath, bytes),
     };
   });
-  const jobs = standardJsonInputs.map(({ target, source }) => ({
+  const jobs = standardJsonInputs.map(({ target, exact }) => ({
     contract: target.contract,
     verificationJobId:
       `robinhood-v4-${target.contract}-${captureClosure.captureId.slice(0, 16)}`,
     requestId: captureClosure.captureId,
     attemptNumber: 1,
     targetId: target.targetId,
-    address: source.address,
+    address: exact.address,
     expectedRuntimeCodeHash: descriptor.contracts[target.captureKey].runtimeCodeHash,
-    compilerVersion: source.compiler.compilerVersion,
+    compilerVersion: exactSourceBinding.compilerVersion,
     standardJsonInputPath: target.backendPath.slice("release/".length),
-    standardJsonInputSha256: source.standardJsonInputSha256,
-    sourcePath: source.compiler.fullyQualifiedName.split(":", 1)[0],
-    contractName: source.compiler.name,
+    standardJsonInputSha256: exact.standardJsonInputSha256,
+    sourcePath: exact.fullyQualifiedName.split(":", 1)[0],
+    contractName: exact.name,
     constructorArguments: target.constructorArguments,
     artifactHash: framedSha256(
       "programmable.robinhood-custom-launch.backend-source-job-artifact.v1",
       {
         chainDeploymentDescriptorDigest: descriptorDigest,
         contract: target.contract,
-        address: source.address,
+        address: exact.address,
         runtimeCodeHash: descriptor.contracts[target.captureKey].runtimeCodeHash,
-        standardJsonInputSha256: source.standardJsonInputSha256,
+        standardJsonInputSha256: exact.standardJsonInputSha256,
       },
     ),
     verificationBundleHash: captureClosure.sourceVerificationClosureDigest,
@@ -1676,7 +1737,7 @@ function buildBackendReleaseAssets({
   }));
   const sourceManifest = artifact(ROBINHOOD_BACKEND_SOURCE_MANIFEST_PATH, {
     schemaVersion: "programmable.robinhood-prepared-root-source-manifest.v1",
-    providerProfileDigest: captureClosure.profileDigest,
+    providerProfileDigest: ROBINHOOD_BACKEND_PROVIDER_PROFILE_DIGEST,
     jobs,
   });
   const normalized = {

--- a/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
@@ -168,6 +168,11 @@ const SAFE_OWNERS = [
   OWNER,
   "0x2Bb333d48DFAF1596D9036671d2E43168994249E",
 ];
+const PHASE_A_TRANSACTION_HASH =
+  "0x30617f11ef467997bace3ab8b8d6048a19e42675fc101c73b1b216b5f8b0d08d";
+const PHASE_A_BLOCK_NUMBER = "50469365";
+const PHASE_A_TRANSACTION_INDEX = "9";
+const PHASE_A_DEPLOYER = "0x2Bb333d48DFAF1596D9036671d2E43168994249E";
 const OWNER_CALLDATA_HASH =
   "0x3ba04469085b17e12843a94c154a335c9c384837f8f6531f179cb4915fd237d9";
 const ROUTER_READ_ABI = [
@@ -517,6 +522,100 @@ test("public v3 RPC evidence drops provider bytes and credential-like endpoint c
   }
 });
 
+test("accepts alternate self-consistent no-CBOR provider context without granting source authority", async () => {
+  const fixture = await fixtureRepository();
+  try {
+    const canonicalRaw = await buildWithProductionInputBuilder(fixture);
+    const alternateRaw = await buildWithProductionInputBuilder(fixture, {
+      alternateSourcifyContext: true,
+    });
+    const canonicalProvider = canonicalRaw.capture.sourcifyResponses[0];
+    const alternateProvider = alternateRaw.capture.sourcifyResponses[0];
+    assert.notEqual(
+      alternateProvider.providerCompiler.fullyQualifiedName,
+      canonicalProvider.providerCompiler.fullyQualifiedName,
+    );
+    assert.notEqual(
+      alternateProvider.providerCompiler.compilerSettingsDigest,
+      canonicalProvider.providerCompiler.compilerSettingsDigest,
+    );
+    assert.notEqual(
+      alternateProvider.providerSourceFilesDigest,
+      canonicalProvider.providerSourceFilesDigest,
+    );
+    assert.notEqual(
+      alternateProvider.providerStandardJsonInputDigest,
+      canonicalProvider.providerStandardJsonInputDigest,
+      "alternate provider build context must remain explicitly provider-scoped",
+    );
+
+    const canonicalBuilt = await buildInput(fixture);
+    const alternateBuilt = await buildInput(fixture, { alternateSourcifyContext: true });
+    const canonicalBundle = await materialize(fixture, canonicalBuilt);
+    const alternateBundle = await materialize(fixture, alternateBuilt);
+    assert.deepEqual(
+      alternateBundle.sourceVerification.exactSourceBinding.contracts,
+      canonicalBundle.sourceVerification.exactSourceBinding.contracts,
+      "provider context must not supply any exact-source contract commitment",
+    );
+    const canonicalJobs = canonicalBundle.artifacts.backendRelease
+      .preparedRootSourceManifest.value.jobs;
+    const alternateJobs = alternateBundle.artifacts.backendRelease
+      .preparedRootSourceManifest.value.jobs;
+    const sourceProjection = (jobs) => jobs.map((job) => ({
+      contract: job.contract,
+      compilerVersion: job.compilerVersion,
+      standardJsonInputPath: job.standardJsonInputPath,
+      standardJsonInputSha256: job.standardJsonInputSha256,
+      sourcePath: job.sourcePath,
+      contractName: job.contractName,
+    }));
+    assert.deepEqual(
+      sourceProjection(alternateJobs),
+      sourceProjection(canonicalJobs),
+      "provider context must not change any prepared backend source job",
+    );
+    for (const contract of alternateBundle.sourceVerification.exactSourceBinding.contracts) {
+      assert.equal(
+        contract.compilerSettingsDigest,
+        "sha256:0ae76a7ec92d6bb3c4612261fb06ccffe41fa34dfdd2fb1c3362f7a0b7d7b3ac",
+      );
+    }
+    assert.notEqual(
+      alternateBundle.captureClosure.sourceVerificationClosureDigest,
+      canonicalBundle.captureClosure.sourceVerificationClosureDigest,
+      "distinct provider observations must remain separately committed",
+    );
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("rejects internally inconsistent alternate Sourcify build contexts", async () => {
+  const fixture = await fixtureRepository();
+  try {
+    const cases = [
+      [
+        { alternateSourcifyContext: true, sourcifyCompilerSettingsMismatch: true },
+        /provider compiler settings and Standard JSON differ/u,
+      ],
+      [
+        { alternateSourcifyContext: true, sourcifySourceContentMismatch: true },
+        /provider source .* differs from Standard JSON/u,
+      ],
+      [
+        { alternateSourcifyContext: true, wrongSourcifyContractIdentifier: true },
+        /compiler\/contract identity differs/u,
+      ],
+    ];
+    for (const [options, expected] of cases) {
+      await assert.rejects(buildWithProductionInputBuilder(fixture, options), expected);
+    }
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("authenticated raw capture deterministically materializes a closed test-only bundle", async () => {
   const fixture = await fixtureRepository();
   try {
@@ -569,6 +668,29 @@ test("authenticated raw capture deterministically materializes a closed test-onl
       "release/assets/robinhood-v4/ProgrammableLaunchStampRouterV1.standard-input.json",
       "release/assets/robinhood-v4/ProgrammableCreate2GraphDeployerV1.standard-input.json",
     ]);
+    assert.equal(
+      bundle.artifacts.backendRelease.preparedRootSourceManifest.value.providerProfileDigest,
+      "sha256:c03afd37c077e78bea30f69d1ce139d026cb4fad86fa74122257bba8f5e9a910",
+      "prepared-root jobs must bind the backend runtime provider profile",
+    );
+    const standardJsonAssets = new Map(
+      bundle.artifacts.backendRelease.standardJsonInputs.map((asset) => [asset.path, asset]),
+    );
+    for (const job of bundle.artifacts.backendRelease.preparedRootSourceManifest.value.jobs) {
+      const asset = standardJsonAssets.get(`release/${job.standardJsonInputPath}`);
+      assert.ok(asset, `${job.contract} Standard JSON asset is retained`);
+      const standardJson = JSON.parse(Buffer.from(asset.bytesBase64, "base64").toString("utf8"));
+      assert.equal(
+        typeof standardJson.sources[job.sourcePath]?.content,
+        "string",
+        `${job.contract} sourcePath must exist in its copied Standard JSON closure`,
+      );
+      assert.equal(
+        job.contractName,
+        job.sourcePath.endsWith("ProgrammableLaunchStampRouterV1.sol")
+          ? "ProgrammableLaunchStampRouterV1" : "ProgrammableCreate2GraphDeployerV1",
+      );
+    }
     await assert.rejects(
       readFile(path.join(fixture.root, ROBINHOOD_LIVE_DEPLOYMENT_PATH)),
       /ENOENT/u,
@@ -583,27 +705,48 @@ test("rejects a fully redigested substitution of the exact source/build/transact
   try {
     const built = await buildInput(fixture);
     const bundle = await materialize(fixture, built);
-    const tampered = structuredClone(bundle);
-    const binding = tampered.sourceVerification.exactSourceBinding;
-    binding.deploymentTransactionHash = hash32("substituted-source-binding-transaction");
-    binding.bindingDigest = framed(
-      "programmable.robinhood-custom-launch.exact-byte-source-build-transaction-binding.v1",
-      { ...binding, bindingDigest: null },
-    );
-    const { evidenceDigest: _sourceDigest, ...sourcePreimage } = tampered.sourceVerification;
-    tampered.sourceVerification.evidenceDigest = framed(
-      "programmable.robinhood-custom-launch.source-verification-closure.v5",
-      sourcePreimage,
-    );
-    const { stageBundleDigest: _stageDigest, ...stagePreimage } = tampered;
-    tampered.stageBundleDigest = framed(
-      "programmable.robinhood-custom-launch.stage-bundle.v1",
-      stagePreimage,
-    );
-    await assert.rejects(
-      verify(fixture, built, tampered),
-      /stage bundle and authenticated capture sidecar/u,
-    );
+    const substitutions = [
+      ["deployment transaction", (binding) => {
+        binding.deploymentTransactionHash = hash32("substituted-source-binding-transaction");
+      }],
+      ["fully-qualified name", (binding) => {
+        binding.contracts[0].fullyQualifiedName =
+          "provider/substitution.sol:ProgrammableLaunchStampRouterV1";
+      }],
+      ["Standard JSON path", (binding) => {
+        binding.contracts[0].standardJsonInputPath = sourcePaths[0];
+      }],
+      ["source digest", (binding) => {
+        binding.contracts[0].sourceSha256 = `sha256:${"7".repeat(64)}`;
+      }],
+      ["source closure", (binding) => {
+        binding.sourceClosureDigest = `sha256:${"8".repeat(64)}`;
+      }],
+    ];
+    for (const [label, mutate] of substitutions) {
+      const tampered = structuredClone(bundle);
+      const binding = tampered.sourceVerification.exactSourceBinding;
+      mutate(binding);
+      binding.bindingDigest = framed(
+        "programmable.robinhood-custom-launch.exact-byte-source-build-transaction-binding.v2",
+        { ...binding, bindingDigest: null },
+      );
+      const { evidenceDigest: _sourceDigest, ...sourcePreimage } = tampered.sourceVerification;
+      tampered.sourceVerification.evidenceDigest = framed(
+        "programmable.robinhood-custom-launch.source-verification-closure.v6",
+        sourcePreimage,
+      );
+      const { stageBundleDigest: _stageDigest, ...stagePreimage } = tampered;
+      tampered.stageBundleDigest = framed(
+        "programmable.robinhood-custom-launch.stage-bundle.v1",
+        stagePreimage,
+      );
+      await assert.rejects(
+        verify(fixture, built, tampered),
+        /stage bundle and authenticated capture sidecar/u,
+        label,
+      );
+    }
   } finally {
     await rm(fixture.root, { recursive: true, force: true });
   }
@@ -1230,6 +1373,9 @@ test("rejects recomputed adversarial raw capture variants", async () => {
     ["impossible no-CBOR exact Sourcify", { sourcifyMatch: "exact_match" }, /appendCBOR=false/u],
     ["missing Sourcify match", { sourcifyMatch: null }, /appendCBOR=false/u],
     ["wrong Sourcify address", { wrongSourcifyAddress: true }, /appendCBOR=false/u],
+    ["wrong Sourcify deployment transaction", {
+      wrongSourcifyDeploymentTransaction: true,
+    }, /finalized Phase A transaction/u],
     ["reordered inventory", { reorderL2Inventory: true }, /missing or reorders/u],
     ["late external code", { lateExternalCode: true }, /runtime code hash|transition/u],
     ["preexisting external code", { preexistingExternalCode: true }, /runtime code hash|transition/u],
@@ -1793,16 +1939,18 @@ test("fresh Sourcify normalization ignores provider-only canaries and binds its 
   try {
     const built = await buildInput(fixture);
     const bundle = await materialize(fixture, built);
-    const verifyAt = async (observedAt, providerOnlyCanary = false) =>
+    const verifyAt = async (observedAt, options = {}) =>
       freshVerifyRobinhoodSourcify({
         repositoryRoot: fixture.root,
         captureClosure: bundle.captureClosure,
         readFile: (root, relativePath) => readFileSync(path.join(root, relativePath)),
-        fetch: await freshSourcifyFetch(fixture, { providerOnlyCanary }),
+        fetch: await freshSourcifyFetch(fixture, options),
         now: () => new Date(observedAt),
       });
     const baseline = await verifyAt("2026-08-29T18:05:00.000Z");
-    const canary = await verifyAt("2026-08-29T18:05:00.000Z", true);
+    const canary = await verifyAt("2026-08-29T18:05:00.000Z", {
+      providerOnlyCanary: true,
+    });
     assert.equal(baseline.observedAt, "2026-08-29T18:05:00.000Z");
     assert.deepEqual(
       Buffer.from(`${JSON.stringify(canary.responses)}\n`, "utf8"),
@@ -1820,6 +1968,29 @@ test("fresh Sourcify normalization ignores provider-only canaries and binds its 
       baseline.sourceVerificationClosureDigest,
       "an older Sourcify freshness digest must not replay at a later observation instant",
     );
+    const alternate = await verifyAt("2026-08-29T18:07:00.000Z", {
+      alternateSourcifyContext: true,
+    });
+    assert.notEqual(
+      alternate.responses[0].providerCompiler.fullyQualifiedName,
+      baseline.responses[0].providerCompiler.fullyQualifiedName,
+      "a later self-consistent provider build context may differ without gaining authority",
+    );
+    assert.deepEqual(
+      alternate.responses.map(({ providerDeployment }) => providerDeployment),
+      baseline.responses.map(({ providerDeployment }) => providerDeployment),
+      "fresh corroboration remains bound to the same finalized deployment transaction",
+    );
+    for (const [options, expected] of [
+      [{ wrongSourcifyAddress: true }, /appendCBOR=false/u],
+      [{ sourcifyMatch: null }, /appendCBOR=false/u],
+      [{ wrongSourcifyDeploymentTransaction: true }, /finalized Phase A transaction/u],
+    ]) {
+      await assert.rejects(
+        verifyAt("2026-08-29T18:08:00.000Z", options),
+        expected,
+      );
+    }
   } finally {
     await rm(fixture.root, { recursive: true, force: true });
   }
@@ -1992,7 +2163,7 @@ async function buildInput(fixture, options = {}) {
   ]);
   const sourcifyNormalized = sourcifyResponses.map(({ normalized }) => normalized);
   const sourceVerificationClosureDigest = framed(
-    "programmable.robinhood-custom-launch.sourcify-response-closure.v5",
+    "programmable.robinhood-custom-launch.sourcify-response-closure.v6",
     sourcifyNormalized,
   );
   const sourceEntries = await Promise.all([...sourcePaths].sort(bufferCompare).map(async (relativePath) => {
@@ -2437,6 +2608,18 @@ function l1Capture(index, options) {
 async function sourcifyResponse(fixture, target, options, index) {
   const localBytes = await readFile(path.join(fixture.root, target.standardJsonInputPath));
   const stdJsonInput = JSON.parse(localBytes.toString("utf8"));
+  let providerFullyQualifiedName = target.fullyQualifiedName;
+  if (options.alternateSourcifyContext) {
+    const sourcePrefix = index === 0 ? "deployment/router-v4/" : "provider-build/";
+    stdJsonInput.sources = Object.fromEntries(Object.entries(stdJsonInput.sources).map(
+      ([name, value]) => [`${sourcePrefix}${name}`, value],
+    ));
+    stdJsonInput.settings.metadata = {
+      appendCBOR: false,
+      bytecodeHash: "none",
+    };
+    providerFullyQualifiedName = `${sourcePrefix}${target.fullyQualifiedName}`;
+  }
   const sources = Object.fromEntries(Object.entries(stdJsonInput.sources).map(([name, value]) => [
     name, { content: value.content },
   ]));
@@ -2450,18 +2633,40 @@ async function sourcifyResponse(fixture, target, options, index) {
     address,
     verifiedAt: options.sourcifyVerifiedAt ?? "2026-08-29T17:55:00Z",
     matchId: String(index + 100),
+    deployment: {
+      transactionHash: options.wrongSourcifyDeploymentTransaction
+        ? hash32("wrong Sourcify deployment transaction") : PHASE_A_TRANSACTION_HASH,
+      blockNumber: options.wrongSourcifyDeploymentBlock
+        ? "50469366" : PHASE_A_BLOCK_NUMBER,
+      transactionIndex: PHASE_A_TRANSACTION_INDEX,
+      deployer: PHASE_A_DEPLOYER,
+    },
     compilation: {
       language: "Solidity",
       compiler: "solc",
       compilerVersion: "0.8.26+commit.8a97fa7a",
       compilerSettings: stdJsonInput.settings,
       name: target.name,
-      fullyQualifiedName: target.fullyQualifiedName,
+      fullyQualifiedName: options.wrongSourcifyContractIdentifier
+        ? `${providerFullyQualifiedName.split(":")[0]}:WrongContract`
+        : providerFullyQualifiedName,
     },
     sources,
     stdJsonInput,
     metadata: { compiler: { version: "0.8.26+commit.8a97fa7a" }, language: "Solidity" },
   };
+  if (options.sourcifyCompilerSettingsMismatch) {
+    response.compilation.compilerSettings = {
+      ...response.compilation.compilerSettings,
+      optimizer: { enabled: true, runs: 999 },
+    };
+  }
+  if (options.sourcifySourceContentMismatch) {
+    const firstSource = Object.keys(response.sources)[0];
+    response.sources[firstSource] = {
+      content: `${response.sources[firstSource].content}\n// provider mismatch`,
+    };
+  }
   const responseBytes = Buffer.from(JSON.stringify(response), "utf8");
   const responseSha256 = sha256Digest(responseBytes);
   const raw = {
@@ -2483,36 +2688,41 @@ async function sourcifyResponse(fixture, target, options, index) {
     providerClassification: "PARTIAL_NO_CBOR_EXACT_BYTES",
     providerReleaseAuthority: false,
     observedAt: OBSERVED_AT,
-    compiler: {
+    providerMatchId: response.matchId,
+    providerVerifiedAt: response.verifiedAt,
+    providerCompiler: {
       language: "Solidity",
       compiler: "solc",
       compilerVersion: "0.8.26+commit.8a97fa7a",
       name: target.name,
-      fullyQualifiedName: target.fullyQualifiedName,
+      fullyQualifiedName: response.compilation.fullyQualifiedName,
       compilerSettingsDigest: framed(
         "programmable.robinhood-custom-launch.sourcify-compiler-settings.v1",
-        stdJsonInput.settings,
+        response.compilation.compilerSettings,
       ),
     },
-    sourceFilesDigest: framed(
+    providerSourceFilesDigest: framed(
       "programmable.robinhood-custom-launch.sourcify-source-files.v1",
-      sources,
+      response.sources,
     ),
-    standardJsonInputPath: target.standardJsonInputPath,
-    standardJsonInputSha256: sha256Digest(localBytes),
+    providerStandardJsonInputDigest: framed(
+      "programmable.robinhood-custom-launch.sourcify-standard-json-input.v1",
+      response.stdJsonInput,
+    ),
+    providerDeployment: response.deployment,
     urlPath: raw.urlPath,
     httpStatus: 200,
     contentType: "application/json",
     normalizedVerificationDigest: null,
   };
   normalized.normalizedVerificationDigest = framed(
-    "programmable.robinhood-custom-launch.sourcify-normalized-response.v2",
+    "programmable.robinhood-custom-launch.sourcify-normalized-response.v3",
     { ...normalized, normalizedVerificationDigest: null },
   );
   return { raw, normalized };
 }
 
-async function freshSourcifyFetch(fixture, { providerOnlyCanary = false } = {}) {
+async function freshSourcifyFetch(fixture, options = {}) {
   const targets = [
     {
       contract: "graphFactory",
@@ -2533,9 +2743,9 @@ async function freshSourcifyFetch(fixture, { providerOnlyCanary = false } = {}) 
   ];
   const byUrl = new Map();
   for (const [index, target] of targets.entries()) {
-    const { raw } = await sourcifyResponse(fixture, target, {}, index);
+    const { raw } = await sourcifyResponse(fixture, target, options, index);
     const value = JSON.parse(Buffer.from(raw.responseBase64, "base64").toString("utf8"));
-    if (providerOnlyCanary) {
+    if (options.providerOnlyCanary) {
       value.providerOnlyCanary = `must-not-publish-${index}`;
       value.metadata = {
         ...value.metadata,
@@ -2754,20 +2964,41 @@ async function materialize(fixture, built) {
   });
 }
 
-async function rebuildWithProductionInputBuilder(fixture, input) {
+async function buildWithProductionInputBuilder(fixture, options = {}) {
+  const built = await buildInput(fixture);
+  const targets = [
+    {
+      contract: "graphFactory",
+      address: ROOTS.graphFactory.address,
+      name: "ProgrammableCreate2GraphDeployerV1",
+      fullyQualifiedName:
+        "src/ProgrammableCreate2GraphDeployerV1.sol:ProgrammableCreate2GraphDeployerV1",
+      standardJsonInputPath: sourcePaths[0],
+    },
+    {
+      contract: "programmableLaunchStampRouter",
+      address: ROOTS.programmableLaunchStampRouter.address,
+      name: "ProgrammableLaunchStampRouterV1",
+      fullyQualifiedName:
+        "src/robinhood-custom-launch/ProgrammableLaunchStampRouterV1.sol:ProgrammableLaunchStampRouterV1",
+      standardJsonInputPath: sourcePaths[1],
+    },
+  ];
+  const sourcifyResponses = await Promise.all(targets.map(async (target, index) =>
+    (await sourcifyResponse(fixture, target, options, index)).raw));
   return buildRobinhoodPostdeploymentInput({
     repositoryRoot: fixture.root,
     revision: fixture.revision,
     tree: fixture.tree,
     observedAt: OBSERVED_AT,
     expiresAt: EXPIRES_AT,
-    providers: input.providers,
+    providers: built.input.providers,
     l2ProviderEndpointCommitments:
-      input.capture.l2ProviderEndpointCommitments,
-    l2ProviderReadbacks: input.capture.l2ProviderReadbacks,
-    ethereumProviderReadbacks: input.capture.ethereumProviderReadbacks,
-    sourcifyResponses: input.capture.sourcifyResponses,
-    readFile: (root, relativePath) => readFile(path.join(root, relativePath)),
+      built.input.capture.l2ProviderEndpointCommitments,
+    l2ProviderReadbacks: built.input.capture.l2ProviderReadbacks,
+    ethereumProviderReadbacks: built.input.capture.ethereumProviderReadbacks,
+    sourcifyResponses,
+    readFile: (root, relativePath) => readFileSync(path.join(root, relativePath)),
     testOnlyDependencies: testCaptureDependencies,
   });
 }

--- a/docs/operations/releases/custom-launch-v4/POSTDEPLOYMENT.md
+++ b/docs/operations/releases/custom-launch-v4/POSTDEPLOYMENT.md
@@ -451,11 +451,16 @@ GET /server/v2/contract/4663/{EIP55Address}?fields=all
 `providerClassification=PARTIAL_NO_CBOR_EXACT_BYTES` and
 `providerReleaseAuthority=false`. `exact_match` is rejected: the pinned Standard JSON inputs set
 `metadata.appendCBOR=false`, so Sourcify cannot produce its metadata-backed exact classification.
-The provider validator still binds compiler settings, metadata, sources and the repository Standard
-JSON input into the source-verification closure.
+The provider validator binds a self-consistent provider-reported compiler, Standard JSON and source
+closure plus the exact finalized deployment transaction tuple. Provider-only fields are explicitly
+prefixed and contain no protected-repository path or digest. Because no-CBOR bytecode does not commit
+to source paths or an equivalent build context, that provider-reported context is deliberately not
+required to equal the protected repository context and never becomes release authority. Fresh
+corroboration compares only stable chain, address, match, compiler/contract identity and deployment
+facts; a later self-consistent provider build layout may differ.
 
 The release-authoritative exact claim is a separate
-`programmable.robinhood-custom-launch.exact-byte-source-build-transaction-binding.v1` record. It
+`programmable.robinhood-custom-launch.exact-byte-source-build-transaction-binding.v2` record. It
 binds the protected revision/tree and capture authorization, the attested hosted Verify proof and
 pinned Linux solc binary, both Standard JSON/compiler-settings digests, exact creation-code hashes,
 the owner transaction hash/data hash and finalized block, and exact deployed runtime hashes observed
@@ -665,10 +670,10 @@ The relevant domains are:
 ```text
 programmable.robinhood-custom-launch.capture-authorization.v2
 programmable.robinhood-custom-launch.capture-closure.v3
-programmable.robinhood-custom-launch.sourcify-normalized-response.v2
-programmable.robinhood-custom-launch.sourcify-response-closure.v5
-programmable.robinhood-custom-launch.source-verification-closure.v5
-programmable.robinhood-custom-launch.exact-byte-source-build-transaction-binding.v1
+programmable.robinhood-custom-launch.sourcify-normalized-response.v3
+programmable.robinhood-custom-launch.sourcify-response-closure.v6
+programmable.robinhood-custom-launch.source-verification-closure.v6
+programmable.robinhood-custom-launch.exact-byte-source-build-transaction-binding.v2
 programmable.robinhood-custom-launch.backend-promotion-input.v1
 programmable.robinhood-custom-launch.backend-promotion-public-input.v2
 programmable.robinhood-custom-launch.backend-promotion-semantic-input.v1

--- a/docs/operations/releases/custom-launch-v4/README.md
+++ b/docs/operations/releases/custom-launch-v4/README.md
@@ -72,6 +72,9 @@ profile.
 - `ProgrammableLaunchStampRouter` and `GraphFactory` require Sourcify V2
   `match`/`match`/`match` and classification `PARTIAL_NO_CBOR_EXACT_BYTES` because their pinned
   Standard JSON inputs set `metadata.appendCBOR=false`. Sourcify is not the exact-source authority.
+  An alternate self-consistent Sourcify build context that produces the same no-CBOR creation and
+  runtime bytes remains provider evidence only; it cannot supply compiler settings to the exact
+  source binding.
   Their exact claim is a separate composite binding across the protected source revision/tree,
   authenticated hosted reproduction build, pinned compiler settings and Standard JSON bytes,
   creation bytes in the finalized atomic transaction, and runtime bytes independently read by

--- a/docs/operations/releases/custom-launch-v4/stage-bundle.schema.json
+++ b/docs/operations/releases/custom-launch-v4/stage-bundle.schema.json
@@ -109,6 +109,10 @@
       "type": "string",
       "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$"
     },
+    "providerInstant": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?Z$"
+    },
     "pathDigestLength": {
       "type": "object",
       "additionalProperties": false,
@@ -451,6 +455,19 @@
         "compilerSettingsDigest": { "$ref": "#/$defs/sha256" }
       }
     },
+    "providerDeployment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["transactionHash", "blockNumber", "transactionIndex", "deployer"],
+      "properties": {
+        "transactionHash": {
+          "const": "0x30617f11ef467997bace3ab8b8d6048a19e42675fc101c73b1b216b5f8b0d08d"
+        },
+        "blockNumber": { "const": "50469365" },
+        "transactionIndex": { "const": "9" },
+        "deployer": { "const": "0x2Bb333d48DFAF1596D9036671d2E43168994249E" }
+      }
+    },
     "sourcifyClosure": {
       "type": "object",
       "additionalProperties": false,
@@ -465,10 +482,12 @@
         "providerClassification",
         "providerReleaseAuthority",
         "observedAt",
-        "compiler",
-        "sourceFilesDigest",
-        "standardJsonInputPath",
-        "standardJsonInputSha256",
+        "providerMatchId",
+        "providerVerifiedAt",
+        "providerCompiler",
+        "providerSourceFilesDigest",
+        "providerStandardJsonInputDigest",
+        "providerDeployment",
         "urlPath",
         "httpStatus",
         "contentType",
@@ -487,10 +506,12 @@
         "providerClassification": { "const": "PARTIAL_NO_CBOR_EXACT_BYTES" },
         "providerReleaseAuthority": { "const": false },
         "observedAt": { "$ref": "#/$defs/isoInstant" },
-        "compiler": { "$ref": "#/$defs/compilerIdentity" },
-        "sourceFilesDigest": { "$ref": "#/$defs/sha256" },
-        "standardJsonInputPath": { "type": "string", "minLength": 1 },
-        "standardJsonInputSha256": { "$ref": "#/$defs/sha256" },
+        "providerMatchId": { "$ref": "#/$defs/positiveDecimal" },
+        "providerVerifiedAt": { "$ref": "#/$defs/providerInstant" },
+        "providerCompiler": { "$ref": "#/$defs/compilerIdentity" },
+        "providerSourceFilesDigest": { "$ref": "#/$defs/sha256" },
+        "providerStandardJsonInputDigest": { "$ref": "#/$defs/sha256" },
+        "providerDeployment": { "$ref": "#/$defs/providerDeployment" },
         "urlPath": {
           "type": "string",
           "pattern": "^/server/v2/contract/4663/0x[0-9A-Fa-f]{40}\\?fields=all$"
@@ -598,13 +619,15 @@
         "providerClassification",
         "providerReleaseAuthority",
         "observedAt",
-        "compiler",
-        "sourceFilesDigest",
+        "providerMatchId",
+        "providerVerifiedAt",
+        "providerCompiler",
+        "providerSourceFilesDigest",
+        "providerStandardJsonInputDigest",
+        "providerDeployment",
         "urlPath",
         "httpStatus",
         "contentType",
-        "standardJsonInputPath",
-        "standardJsonInputSha256",
         "normalizedVerificationDigest"
       ],
       "properties": {
@@ -616,13 +639,15 @@
         "providerClassification": { "const": "PARTIAL_NO_CBOR_EXACT_BYTES" },
         "providerReleaseAuthority": { "const": false },
         "observedAt": { "$ref": "#/$defs/isoInstant" },
-        "compiler": { "$ref": "#/$defs/compilerIdentity" },
-        "sourceFilesDigest": { "$ref": "#/$defs/sha256" },
+        "providerMatchId": { "$ref": "#/$defs/positiveDecimal" },
+        "providerVerifiedAt": { "$ref": "#/$defs/providerInstant" },
+        "providerCompiler": { "$ref": "#/$defs/compilerIdentity" },
+        "providerSourceFilesDigest": { "$ref": "#/$defs/sha256" },
+        "providerStandardJsonInputDigest": { "$ref": "#/$defs/sha256" },
+        "providerDeployment": { "$ref": "#/$defs/providerDeployment" },
         "urlPath": { "type": "string", "minLength": 1 },
         "httpStatus": { "const": 200 },
         "contentType": { "type": "string", "minLength": 1 },
-        "standardJsonInputPath": { "type": "string", "minLength": 1 },
-        "standardJsonInputSha256": { "$ref": "#/$defs/sha256" },
         "normalizedVerificationDigest": { "$ref": "#/$defs/sha256" }
       }
     },
@@ -631,8 +656,13 @@
       "additionalProperties": false,
       "required": [
         "contract",
+        "name",
+        "fullyQualifiedName",
+        "standardJsonInputPath",
         "address",
         "standardJsonInputSha256",
+        "sourcePath",
+        "sourceSha256",
         "creationCodeHash",
         "runtimeCodeHash",
         "compilerSettingsDigest"
@@ -641,8 +671,13 @@
         "contract": {
           "enum": ["programmableLaunchStampRouter", "graphFactory"]
         },
+        "name": { "type": "string", "minLength": 1 },
+        "fullyQualifiedName": { "type": "string", "minLength": 3 },
+        "standardJsonInputPath": { "type": "string", "minLength": 1 },
         "address": { "$ref": "#/$defs/address" },
         "standardJsonInputSha256": { "$ref": "#/$defs/sha256" },
+        "sourcePath": { "type": "string", "minLength": 1 },
+        "sourceSha256": { "$ref": "#/$defs/sha256" },
         "creationCodeHash": { "$ref": "#/$defs/hex32" },
         "runtimeCodeHash": { "$ref": "#/$defs/hex32" },
         "compilerSettingsDigest": { "$ref": "#/$defs/sha256" }
@@ -657,6 +692,7 @@
         "coveredContracts",
         "sourceRevision",
         "sourceTree",
+        "sourceClosureDigest",
         "captureAuthorizationDigest",
         "productionVerifyProofSha256",
         "productionVerifyArtifactDigest",
@@ -671,7 +707,7 @@
       ],
       "properties": {
         "schemaVersion": {
-          "const": "programmable.robinhood-custom-launch.exact-byte-source-build-transaction-binding.v1"
+          "const": "programmable.robinhood-custom-launch.exact-byte-source-build-transaction-binding.v2"
         },
         "authority": {
           "const": "protected-hosted-build-finalized-transaction-bytecode"
@@ -681,6 +717,7 @@
         },
         "sourceRevision": { "$ref": "#/$defs/gitHash" },
         "sourceTree": { "$ref": "#/$defs/gitHash" },
+        "sourceClosureDigest": { "$ref": "#/$defs/sha256" },
         "captureAuthorizationDigest": { "$ref": "#/$defs/sha256" },
         "productionVerifyProofSha256": { "$ref": "#/$defs/sha256" },
         "productionVerifyArtifactDigest": { "$ref": "#/$defs/sha256" },
@@ -720,7 +757,7 @@
       ],
       "properties": {
         "schemaVersion": {
-          "const": "programmable.robinhood-custom-launch.source-verification-closure.v5"
+          "const": "programmable.robinhood-custom-launch.source-verification-closure.v6"
         },
         "provider": { "const": "sourcify-v2" },
         "providerReleaseAuthority": { "const": false },


### PR DESCRIPTION
## Summary

- keep Sourcify match/match/match as explicitly non-authoritative no-CBOR provider corroboration
- bind fresh provider checks to the stable finalized Phase A deployment tuple while permitting a later self-consistent provider build context
- derive exact source and backend jobs only from the protected hosted-build/finalized-byte binding
- bind the prepared-root source manifest to the production backend provider profile

## Verification

- npm run contracts:robinhood:postdeploy:test (20/20)
- npm run contracts:robinhood:sourcify:test (26/26)
- node --test contracts/scripts/test/robinhood-custom-launch-release-docs.test.mjs (3/3)
- independent exact-diff audit: P0/P1/P2 none

No wallet, chain, backend, database, or production activation mutation is performed by this PR.