### PR TITLE
fix: canonicalize Safe getter address arrays

### DIFF
--- a/contracts/scripts/capture-robinhood-custom-launch-postdeployment.mjs
+++ b/contracts/scripts/capture-robinhood-custom-launch-postdeployment.mjs
@@ -168,6 +168,13 @@ export function validateRobinhoodCaptureEndpoint(endpoint, layer, providerId) {
   return true;
 }
 
+export function canonicalizeRobinhoodAddressList(values) {
+  if (!Array.isArray(values)) {
+    throw new TypeError("address list must be an array");
+  }
+  return values.map((value) => getAddress(value));
+}
+
 async function rpcEntry(endpoint, key, method, params, id, responseBudget) {
   const request = Buffer.from(JSON.stringify({ jsonrpc: "2.0", id, method, params }), "utf8");
   const response = await fetch(endpoint, {
@@ -392,8 +399,10 @@ async function collectL2(endpoint, providerPin, transactionHash, observedAt, res
         runtimeCodeHash: codeHash(codes.get("safeSingletonCode")), version: safeVersion },
       fallbackHandler: SAFE_FALLBACK,
       fallbackHandlerRuntimeCodeHash: codeHash(codes.get("safeFallbackHandlerCode")),
-      owners: owners.map(getAddress), threshold: Number(threshold), nonce: nonce.toString(10),
-      modules: modules.map(getAddress), modulesNext: getAddress(modulesNext), guard: null,
+      owners: canonicalizeRobinhoodAddressList(owners),
+      threshold: Number(threshold), nonce: nonce.toString(10),
+      modules: canonicalizeRobinhoodAddressList(modules),
+      modulesNext: getAddress(modulesNext), guard: null,
       singletonSlot, fallbackHandlerSlot, guardSlot,
     },
     permit2Genesis: {

--- a/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
@@ -100,7 +100,10 @@ import {
   SIGSTORE_BUNDLE_V03_MEDIA_TYPE,
 } from "../robinhood-backend-promotion-v1.mjs";
 import { runRobinhoodPostdeploymentCli } from "../finalize-robinhood-custom-launch-deployment.mjs";
-import { validateRobinhoodCaptureEndpoint } from
+import {
+  canonicalizeRobinhoodAddressList,
+  validateRobinhoodCaptureEndpoint,
+} from
   "../capture-robinhood-custom-launch-postdeployment.mjs";
 
 const repositoryRoot = path.resolve(fileURLToPath(new URL("../../../", import.meta.url)));
@@ -520,6 +523,14 @@ test("public v3 RPC evidence drops provider bytes and credential-like endpoint c
   } finally {
     await rm(fixture.root, { recursive: true, force: true });
   }
+});
+
+test("canonicalizes Safe address arrays without treating map indices as chain IDs", () => {
+  const lowercaseOwners = SAFE_OWNERS.map((owner) => owner.toLowerCase());
+  assert.deepEqual(canonicalizeRobinhoodAddressList(lowercaseOwners), SAFE_OWNERS);
+  assert.notDeepEqual(lowercaseOwners.map(getAddress), SAFE_OWNERS);
+  assert.deepEqual(canonicalizeRobinhoodAddressList([]), []);
+  assert.throws(() => canonicalizeRobinhoodAddressList(null), /must be an array/u);
 });
 
 test("accepts alternate self-consistent no-CBOR provider context without granting source authority", async () => {


### PR DESCRIPTION
## Summary

- canonicalize decoded Safe owner and module arrays through unary callbacks
- prevent Array.map indices from being interpreted as viem chain IDs and changing EIP-1191 checksum casing
- cover the two-owner and empty-module regression

## Evidence

- capture run 33357385668 failed closed before artifact creation at the raw Safe getter equality check
- the second reviewed owner differs only when the Array.map index is passed as a chain ID; unary normalization returns the canonical address
- node --test contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs (21/21)
- node --test contracts/scripts/test/robinhood-custom-launch-release-docs.test.mjs (3/3)
- git diff --check
- independent exact-diff audit requested

No wallet, chain, backend, database, secret, or production activation mutation is performed by this PR.