### PR TITLE
fix: canonicalize capture verifier timestamps

### DIFF
--- a/contracts/scripts/finalize-robinhood-custom-launch-deployment.mjs
+++ b/contracts/scripts/finalize-robinhood-custom-launch-deployment.mjs
@@ -93,6 +93,15 @@ const execFileAsync = promisify(execFile);
 
 const DEFAULT_STAGE_BUNDLE_PATH = ROBINHOOD_STAGE_BUNDLE_PATH;
 const DEFAULT_PROMOTION_BUNDLE_PATH = ROBINHOOD_PROMOTION_BUNDLE_PATH;
+
+export function canonicalRobinhoodVerifierInstant(now = () => new Date(), label = "verifier clock") {
+  const instant = now();
+  if (!(instant instanceof Date) || !Number.isFinite(instant.getTime())) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return new Date(Math.floor(instant.getTime() / 1_000) * 1_000).toISOString();
+}
+
 function usage() {
   return [
     "Usage:",
@@ -610,12 +619,7 @@ async function verifyGithubCaptureAttestation({
       portable,
       trustedRootPath,
     });
-    const verified = now();
-    if (!(verified instanceof Date) || !Number.isFinite(verified.getTime())) {
-      throw new TypeError("capture verifier clock is invalid");
-    }
-    const verifiedAt = new Date(Math.floor(verified.getTime() / 1000) * 1000)
-      .toISOString().replace(".000Z", "Z");
+    const verifiedAt = canonicalRobinhoodVerifierInstant(now, "capture verifier clock");
     return buildRobinhoodCaptureAuthorization({
       schemaVersion: ROBINHOOD_CAPTURE_AUTHORIZATION_SCHEMA,
       trustClass: "github-artifact-attestation",
@@ -759,12 +763,7 @@ async function verifySigstoreBackendCaptureAttestation({
       || Buffer.byteLength(result.stderr) > 16 * 1024 * 1024) {
       throw new TypeError("Cosign backend verification diagnostics exceeded their bound");
     }
-    const verifiedDate = now();
-    const verifiedAt = verifiedDate instanceof Date && Number.isFinite(verifiedDate.getTime())
-      ? new Date(Math.floor(verifiedDate.getTime() / 1000) * 1000)
-        .toISOString().replace(".000Z", "Z")
-      : null;
-    if (verifiedAt === null) throw new TypeError("backend verifier clock is invalid");
+    const verifiedAt = canonicalRobinhoodVerifierInstant(now, "backend verifier clock");
     return {
       authorization: buildRobinhoodBackendCaptureAuthorization({
         schemaVersion: ROBINHOOD_BACKEND_CAPTURE_AUTHORIZATION_SCHEMA,

--- a/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
@@ -99,7 +99,10 @@ import {
   validateSigstoreMessageBundleV03,
   SIGSTORE_BUNDLE_V03_MEDIA_TYPE,
 } from "../robinhood-backend-promotion-v1.mjs";
-import { runRobinhoodPostdeploymentCli } from "../finalize-robinhood-custom-launch-deployment.mjs";
+import {
+  canonicalRobinhoodVerifierInstant,
+  runRobinhoodPostdeploymentCli,
+} from "../finalize-robinhood-custom-launch-deployment.mjs";
 import {
   canonicalizeRobinhoodAddressList,
   validateRobinhoodCaptureEndpoint,
@@ -531,6 +534,46 @@ test("canonicalizes Safe address arrays without treating map indices as chain ID
   assert.notDeepEqual(lowercaseOwners.map(getAddress), SAFE_OWNERS);
   assert.deepEqual(canonicalizeRobinhoodAddressList([]), []);
   assert.throws(() => canonicalizeRobinhoodAddressList(null), /must be an array/u);
+});
+
+test("canonical verifier timestamps remain valid through Phase A stage assembly", async () => {
+  const fixture = await fixtureRepository();
+  try {
+    const built = await buildInput(fixture);
+    const verifiedAt = canonicalRobinhoodVerifierInstant(
+      () => new Date("2026-08-29T18:00:00.987Z"),
+      "capture verifier clock",
+    );
+    assert.equal(verifiedAt, OBSERVED_AT);
+    const authorization = buildRobinhoodCaptureAuthorization({
+      ...structuredClone(built.authorization),
+      verifiedAt,
+      verificationDigest: null,
+    });
+    const bundle = await materializeRobinhoodStageBundle({
+      repositoryRoot: fixture.root,
+      input: built.input,
+      inputBytes: built.bytes,
+      captureAuthorization: authorization,
+      captureDependencies: testCaptureDependencies,
+    });
+    assert.equal(bundle.captureAuthorization.verifiedAt, OBSERVED_AT);
+
+    const secondsOnly = buildRobinhoodCaptureAuthorization({
+      ...structuredClone(authorization),
+      verifiedAt: "2026-08-29T18:00:00Z",
+      verificationDigest: null,
+    });
+    await assert.rejects(() => materializeRobinhoodStageBundle({
+      repositoryRoot: fixture.root,
+      input: built.input,
+      inputBytes: built.bytes,
+      captureAuthorization: secondsOnly,
+      captureDependencies: testCaptureDependencies,
+    }), /verifiedAt must be a canonical ISO-8601 instant/u);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
 });
 
 test("accepts alternate self-consistent no-CBOR provider context without granting source authority", async () => {


### PR DESCRIPTION
## Summary
- emit canonical millisecond ISO-8601 verifier instants for Phase A capture authorization
- close the same latent backend capture authorization seam
- add full stage-assembly regression coverage for canonical and seconds-only spellings

## Evidence
- postdeployment tests: 22/22
- release docs tests: 3/3
- git diff --check: clean
- independent audit: P0=0, P1=0, P2=0

This is the minimal follow-up to capture run 33359320725. It does not repeat or mutate any onchain state.