### PR TITLE
Fix Robinhood Phase A capture source closure digest

### DIFF
--- a/contracts/scripts/robinhood-custom-launch-capture-v2.mjs
+++ b/contracts/scripts/robinhood-custom-launch-capture-v2.mjs
@@ -14,6 +14,8 @@ import {
 
 import { canonicalizeJson, parseStrictJson } from "../../packages/launch/src/canonical-json.mjs";
 import { assertExactKeys, decodeExactUtf8, sha256Digest } from "../../packages/launch/src/io.mjs";
+import { computeV4SourceClosureDigest } from
+  "../../scripts/programmable-launch-v4-release-binding.mjs";
 import { assertRobinhoodFoundationRpcProviders } from
   "./robinhood-custom-launch-owner-envelope-core.mjs";
 
@@ -2657,10 +2659,7 @@ export async function buildRobinhoodPostdeploymentInput({
     sourceVerificationClosureDigest,
     sourceClosureDigest: null,
   };
-  sourceClosure.sourceClosureDigest = framedSha256(
-    sourceClosure.schemaVersion,
-    { ...sourceClosure, sourceClosureDigest: null },
-  );
+  sourceClosure.sourceClosureDigest = computeV4SourceClosureDigest(sourceClosure);
   const inventories = [
     ...l2ProviderReadbacks.map((provider, index) => {
       const identity = verifyProviderIdentity(

--- a/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
@@ -576,6 +576,34 @@ test("canonical verifier timestamps remain valid through Phase A stage assembly"
   }
 });
 
+test("production capture builder binds the exact protected Git source closure", async () => {
+  const fixture = await fixtureRepository();
+  try {
+    const base = await buildInput(fixture);
+    const input = await buildWithProductionInputBuilder(fixture);
+    const bytes = Buffer.from(`${JSON.stringify(input, null, 2)}\n`, "utf8");
+    const authorization = buildRobinhoodCaptureAuthorization({
+      ...structuredClone(base.authorization),
+      subjectSha256: sha256CaptureBytes(bytes),
+      sourceClosureDigest: input.capture.sourceOrigin.sourceClosureDigest,
+      verificationDigest: null,
+    });
+    const bundle = await materializeRobinhoodStageBundle({
+      repositoryRoot: fixture.root,
+      input,
+      inputBytes: bytes,
+      captureAuthorization: authorization,
+      captureDependencies: testCaptureDependencies,
+    });
+    assert.equal(
+      bundle.sourceClosure.sourceClosureDigest,
+      input.capture.sourceOrigin.sourceClosureDigest,
+    );
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("accepts alternate self-consistent no-CBOR provider context without granting source authority", async () => {
   const fixture = await fixtureRepository();
   try {


### PR DESCRIPTION
Closes the exact fail-closed mismatch observed in protected capture run 33361690271.

The production capture builder previously hashed the source-closure preimage with sourceClosureDigest:null, while the protected stage builder uses the shared release-binding function that omits the digest field. This change makes the capture producer reuse that canonical function.

Evidence:
- protected raw L2/L1/Sourcify capture and capture attestation succeeded before the stage guard rejected the mismatched digest
- focused production-builder-to-stage regression: green
- full Robinhood postdeploy suite: 23/23 green
- git diff --check: clean
- independent audit: P0/P1/P2 = 0

No wallet, chain, deployment, backend, or public-write behavior is changed.