### PR TITLE
Activate 72-hour V4 migration window

### DIFF
--- a/config/main-token-migration-activation.v1.json
+++ b/config/main-token-migration-activation.v1.json
@@ -1,7 +1,7 @@
 {
   "schema": "programmable-main-token-migration-activation/v1",
   "releaseId": "v4-ethereum-to-robinhood-72h-2026-v2",
-  "enabled": false,
+  "enabled": true,
   "sourceChainId": "1",
   "sourceTokenAddress": "0x7987f03462200b3D8A072E02C89A8A41dCB124EE",
   "sourceTokenRuntimeCodeKeccak256": "0x4fe466386aeebe507f6bcfc58e046a0632e4687699fa5bd28c4b7ec6333141ad",
@@ -9,8 +9,8 @@
   "sourceTokenTotalSupplyRaw": "1000000000000000000000000000",
   "migrationWallet": "0x228Be90653fDDAa408fB6cf9ca0AEC311dbE9A0D",
   "windowDurationSeconds": "259200",
-  "windowStartTimestamp": null,
-  "deadlineTimestampExclusive": null,
-  "startBlockNumber": null,
-  "startBlockHash": null
+  "windowStartTimestamp": "1788159300",
+  "deadlineTimestampExclusive": "1788418500",
+  "startBlockNumber": "25873498",
+  "startBlockHash": "0xa46ee16545a66fb139b9d21780ea7566d6748fa88d55340ebfb0ed640fd8d7e8"
 }

--- a/tests/main-token-migration-gas-sponsor-contract.test.ts
+++ b/tests/main-token-migration-gas-sponsor-contract.test.ts
@@ -55,20 +55,24 @@ describe("main token migration gas sponsor activation contract", () => {
     "docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-READINESS-V1.md",
   );
 
-  it("pins the checked-in release window while keeping operational sponsor values blank", () => {
+  it("pins the exact checked-in release window while keeping operational sponsor values blank", () => {
     expect(contract.releaseId).toBe(
       "v4-ethereum-to-robinhood-72h-2026-v2",
     );
     expect(manifest).toMatchObject({
       schema: "programmable-main-token-migration-activation/v1",
       releaseId: contract.releaseId,
-      enabled: false,
+      enabled: true,
       windowDurationSeconds: "259200",
-      windowStartTimestamp: null,
-      deadlineTimestampExclusive: null,
-      startBlockNumber: null,
-      startBlockHash: null,
     });
+    expect(manifest.windowStartTimestamp).toMatch(/^[1-9][0-9]*$/u);
+    expect(manifest.deadlineTimestampExclusive).toMatch(/^[1-9][0-9]*$/u);
+    expect(
+      Number(manifest.deadlineTimestampExclusive) -
+        Number(manifest.windowStartTimestamp),
+    ).toBe(259_200);
+    expect(manifest.startBlockNumber).toMatch(/^[1-9][0-9]*$/u);
+    expect(manifest.startBlockHash).toMatch(/^0x[0-9a-f]{64}$/u);
 
     expect(environment).toContain(
       `${contract.environment.enabled.name}=${contract.environment.enabled.disabledValue}`,

--- a/tests/main-token-migration.test.ts
+++ b/tests/main-token-migration.test.ts
@@ -366,7 +366,7 @@ describe("main token migration page contract", () => {
     expect(page).toContain("startBlockHash !== null");
   });
 
-  it("publishes a fail-closed 72-hour preparation page until an exact Ethereum anchor is set", () => {
+  it("publishes a fail-closed 72-hour page with an exact activation manifest", () => {
     const route = read("app/migration/page.tsx");
     const landing = read("components/landing-page.tsx");
     const activationManifest = JSON.parse(
@@ -412,14 +412,20 @@ describe("main token migration page contract", () => {
       "programmable-main-token-migration-window-time/v1",
     );
     expect(activationManifest).toMatchObject({
-      enabled: false,
+      enabled: true,
       releaseId: MAIN_TOKEN_MIGRATION_RELEASE_ID,
       windowDurationSeconds: String(MAIN_TOKEN_MIGRATION_WINDOW_SECONDS),
-      windowStartTimestamp: null,
-      deadlineTimestampExclusive: null,
-      startBlockNumber: null,
-      startBlockHash: null,
     });
+    expect(activationManifest.windowStartTimestamp).toMatch(/^[1-9][0-9]*$/u);
+    expect(activationManifest.deadlineTimestampExclusive).toMatch(
+      /^[1-9][0-9]*$/u,
+    );
+    expect(
+      Number(activationManifest.deadlineTimestampExclusive) -
+        Number(activationManifest.windowStartTimestamp),
+    ).toBe(MAIN_TOKEN_MIGRATION_WINDOW_SECONDS);
+    expect(activationManifest.startBlockNumber).toMatch(/^[1-9][0-9]*$/u);
+    expect(activationManifest.startBlockHash).toMatch(/^0x[0-9a-f]{64}$/u);
     expect(page).toContain("return false");
     expect(page).toContain("const canCopyDestination = transferWindowOpen;");
   });


### PR DESCRIPTION
Activates the reviewed V4 Ethereum-to-Robinhood migration window.

- Start: 2026-08-31 06:55:00 UTC
- Exclusive deadline: 2026-09-03 06:55:00 UTC
- Duration: 259,200 seconds
- Ethereum anchor: finalized block 25873498, dual-confirmed by the committed dRPC and QuickNode providers
- Sponsor production switch: enabled separately; operational values remain server-only

Focused migration tests: 42/42 passed. Typecheck and diff check passed. No wallet signature or token transaction.