### PR TITLE
Allow delegated migration sponsor wallet

### DIFF
--- a/lib/main-token-migration.ts
+++ b/lib/main-token-migration.ts
@@ -44,8 +44,10 @@ export type MainTokenMigrationTransaction = Extract<
 export function isMainTokenMigrationWalletCodeEligible(
   code: Hex | undefined,
 ) {
-  return code === "0x" ||
-    (code !== undefined && EIP_7702_DELEGATION_INDICATOR.test(code));
+  // viem normalizes the canonical `eth_getCode` result `0x` to `undefined`.
+  // Both representations therefore mean a normal EOA with no runtime code.
+  return code === undefined || code === "0x" ||
+    EIP_7702_DELEGATION_INDICATOR.test(code);
 }
 
 export function parseMainTokenMigrationAmount(value: string): bigint {

--- a/lib/server/main-token-migration-gas-sponsor-v1.ts
+++ b/lib/server/main-token-migration-gas-sponsor-v1.ts
@@ -1417,7 +1417,8 @@ export function createMainTokenMigrationGasSponsorChainV1(
           || !isMainTokenMigrationWalletCodeEligible(right.holderCode)
           || !isMainTokenMigrationWalletCodeEligible(left.startHolderCode)
           || !isMainTokenMigrationWalletCodeEligible(right.startHolderCode)
-          || left.sponsorCode !== "0x" || right.sponsorCode !== "0x"
+          || !isMainTokenMigrationWalletCodeEligible(left.sponsorCode)
+          || !isMainTokenMigrationWalletCodeEligible(right.sponsorCode)
           || left.currentBalance < request.amountRaw
           || right.currentBalance < request.amountRaw) {
           throw new MainTokenMigrationGasSponsorErrorV1(422, "wallet_not_eligible");
@@ -1484,7 +1485,8 @@ export function createMainTokenMigrationGasSponsorChainV1(
         if (!left || !right || left.chainId !== 1 || right.chainId !== 1
           || left.block.hash !== right.block.hash
           || left.walletCode !== right.walletCode
-          || left.sponsorCode !== "0x" || right.sponsorCode !== "0x"
+          || !isMainTokenMigrationWalletCodeEligible(left.sponsorCode)
+          || !isMainTokenMigrationWalletCodeEligible(right.sponsorCode)
           || !isMainTokenMigrationWalletCodeEligible(left.walletCode)) {
           throw new MainTokenMigrationGasSponsorErrorV1(
             503,

--- a/tests/main-token-migration.test.ts
+++ b/tests/main-token-migration.test.ts
@@ -31,14 +31,14 @@ const migrationWallet = "0x228Be90653fDDAa408fB6cf9ca0AEC311dbE9A0D";
 const migrationWindowSeconds = 72 * 60 * 60;
 
 describe("main token migration transfer", () => {
-  it("accepts empty or exact EIP-7702 delegated EOA code only", () => {
+  it("accepts viem-empty or exact EIP-7702 delegated EOA code only", () => {
+    expect(isMainTokenMigrationWalletCodeEligible(undefined)).toBe(true);
     expect(isMainTokenMigrationWalletCodeEligible("0x")).toBe(true);
     expect(isMainTokenMigrationWalletCodeEligible(
       "0xef010063c0c19a282a1b52b07dd5a65b58948a07dae32b",
     )).toBe(true);
 
     for (const code of [
-      undefined,
       "0x60006000",
       "0xef0100",
       "0xef010063c0c19a282a1b52b07dd5a65b58948a07dae32b00",


### PR DESCRIPTION
## Outcome

- treats viem’s `undefined` result for canonical empty `eth_getCode` as the normal EOA representation
- accepts the same narrowly pinned EOA or exact EIP-7702 delegated-EOA shape for the configured Privy sponsor
- preserves dual-RPC equality, exact wallet/policy attestation, holder provenance, budget, idempotency and transfer checks

## Root cause and live reproduction

The authenticated production GET returned `wallet_not_eligible` for a wallet holding 10,951.180471410974470390 V4 both currently and at activation block 25873498, with zero ETH. Raw JSON-RPC returned `0x` code for holder and sponsor, while viem correctly normalized that empty runtime code to `undefined`. The shared eligibility helper incorrectly rejected `undefined`.

Running the exact patched production observer against the two bound production RPCs now returns eligible for that same wallet and observes the funded 0.020 ETH sponsor balance. No wallet signature or transaction was performed.

## Verification

- `npm run migration:main-token:test` (42 passed)
- `npm run typecheck`
- `git diff --check`
- exact dual-provider production observer: eligible for the reported holder; sponsor balance 0.020 ETH