### PR TITLE
Fix gasless migration for delegated wallets

### DIFF
--- a/app/api/main-token-migration/gasless-transfer/route.ts
+++ b/app/api/main-token-migration/gasless-transfer/route.ts
@@ -1,0 +1,11 @@
+import {
+  handleProductionMainTokenMigrationGaslessTransferPostV1,
+} from "@/lib/server/main-token-migration-gasless-transfer-v1";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+export const runtime = "nodejs";
+
+export function POST(request: Request): Promise<Response> {
+  return handleProductionMainTokenMigrationGaslessTransferPostV1(request);
+}

--- a/components/main-token-migration.tsx
+++ b/components/main-token-migration.tsx
@@ -27,6 +27,7 @@ import {
   MAIN_TOKEN_RUNTIME_CODE_KECCAK256,
   MAIN_TOKEN_SYMBOL,
   MAIN_TOKEN_TOTAL_SUPPLY_RAW,
+  isMainTokenMigrationDelegatedWalletCode,
   isMainTokenMigrationWalletCodeEligible,
   parseMainTokenMigrationAmount,
 } from "@/lib/main-token-migration";
@@ -68,13 +69,17 @@ type SubmissionState =
 
 type AccountCodeObservation = Readonly<{
   account: string;
-  status: "eoa" | "contract" | "unavailable";
+  status: "eoa" | "delegated" | "contract" | "unavailable";
 }>;
 
 const gasSponsorshipEndpoint =
   "/api/main-token-migration/gas-sponsorship" as const;
 const gasSponsorshipSchema =
   "programmable-main-token-migration-gas-sponsorship/v1" as const;
+const gaslessTransferEndpoint =
+  "/api/main-token-migration/gasless-transfer" as const;
+const gaslessTransferSchema =
+  "programmable-main-token-migration-gasless-transfer/v1" as const;
 // A V4 transfer currently uses roughly 52k gas. This conservative client-side
 // reserve only decides whether the UI can skip the sponsor endpoint entirely;
 // the server independently estimates and caps every sponsored top-up.
@@ -135,6 +140,36 @@ export type GasSponsorshipState =
       retryMode: "check" | "submit";
     };
 
+type GaslessTransferStatus =
+  | "signature_required"
+  | "permit_submitted"
+  | "permit_pending"
+  | "transfer_submitted"
+  | "transfer_pending"
+  | "confirmed";
+
+type GaslessTransferResponse = Readonly<{
+  schema: typeof gaslessTransferSchema;
+  status: GaslessTransferStatus;
+  walletAddress: string;
+  amountRaw: string;
+  sponsorAddress: string;
+  nonce: string;
+  permitDeadline: string;
+  requestBindingHash: `sha256:${string}`;
+  permitTransactionHash: Hex | null;
+  transferTransactionHash: Hex | null;
+  transferBlockNumber: string | null;
+}>;
+
+type GaslessStage = "idle" | "preparing" | "signing" | "relaying";
+
+type StoredGaslessTransferProgress = Readonly<{
+  schema: "programmable-main-token-migration-gasless-ui/v1";
+  account: string;
+  amountRaw: string;
+}>;
+
 type GasSponsorshipEndpointResult = Readonly<{
   body: MainTokenGasSponsorshipResponse;
   retryAfterMs: number;
@@ -158,6 +193,143 @@ class GasSponsorshipEndpointError extends Error {
 const migrationTransferStorageKey = `programmable:main-token-migration:${MAIN_TOKEN_MIGRATION_WALLET.toLowerCase()}`;
 const transactionHashPattern = /^0x[0-9a-fA-F]{64}$/u;
 const sponsorshipIntegerPattern = /^(?:0|[1-9][0-9]*)$/u;
+const digestPattern = /^sha256:[0-9a-f]{64}$/u;
+
+const gaslessTransferProgressStorageKey =
+  `programmable:main-token-migration:gasless-progress:${MAIN_TOKEN_MIGRATION_RELEASE_ID}`;
+
+function persistGaslessTransferProgress(
+  account: string,
+  amountRaw: bigint,
+) {
+  const value: StoredGaslessTransferProgress = {
+    schema: "programmable-main-token-migration-gasless-ui/v1",
+    account: getAddress(account).toLowerCase(),
+    amountRaw: amountRaw.toString(),
+  };
+  const source = JSON.stringify(value);
+  try {
+    window.localStorage.setItem(gaslessTransferProgressStorageKey, source);
+    if (window.localStorage.getItem(gaslessTransferProgressStorageKey) !== source) {
+      throw new Error("Gasless transfer recovery state was not persisted");
+    }
+  } catch {
+    throw new Error(
+      "Gasless transfer recovery is unavailable in this browser. No signature was requested.",
+    );
+  }
+  return value;
+}
+
+function clearGaslessTransferProgress() {
+  try {
+    window.localStorage.removeItem(gaslessTransferProgressStorageKey);
+  } catch {
+    // The confirmed transfer remains tracked by the normal transaction state.
+  }
+}
+
+function storedGaslessTransferProgress(): StoredGaslessTransferProgress | null {
+  try {
+    const source = window.localStorage.getItem(gaslessTransferProgressStorageKey);
+    if (!source) return null;
+    const value = JSON.parse(source) as Record<string, unknown>;
+    if (Object.keys(value).sort().join("\0") !==
+        ["account", "amountRaw", "schema"].sort().join("\0") ||
+      value.schema !== "programmable-main-token-migration-gasless-ui/v1" ||
+      typeof value.account !== "string" ||
+      !isAddress(value.account, { strict: true }) ||
+      value.account !== getAddress(value.account).toLowerCase() ||
+      typeof value.amountRaw !== "string" ||
+      !positiveIntegerPattern.test(value.amountRaw)) return null;
+    return Object.freeze({
+      schema: value.schema,
+      account: value.account,
+      amountRaw: value.amountRaw,
+    });
+  } catch {
+    return null;
+  }
+}
+
+export function parseGaslessTransferResponse(
+  input: unknown,
+  expectedAccount: string,
+  expectedAmountRaw: bigint,
+): GaslessTransferResponse {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("The gasless transfer response is invalid.");
+  }
+  const value = input as Record<string, unknown>;
+  const exactKeys = [
+    "amountRaw", "nonce", "permitDeadline", "permitTransactionHash",
+    "requestBindingHash", "schema", "sponsorAddress", "status",
+    "transferBlockNumber", "transferTransactionHash", "walletAddress",
+  ];
+  const statuses: readonly GaslessTransferStatus[] = [
+    "signature_required", "permit_submitted", "permit_pending",
+    "transfer_submitted", "transfer_pending", "confirmed",
+  ];
+  const status = value.status as GaslessTransferStatus;
+  const permitHashValid = value.permitTransactionHash === null ||
+    (typeof value.permitTransactionHash === "string" &&
+      transactionHashPattern.test(value.permitTransactionHash));
+  const transferHashValid = value.transferTransactionHash === null ||
+    (typeof value.transferTransactionHash === "string" &&
+      transactionHashPattern.test(value.transferTransactionHash));
+  const transferBlockValid = value.transferBlockNumber === null ||
+    (typeof value.transferBlockNumber === "string" &&
+      positiveIntegerPattern.test(value.transferBlockNumber));
+  const statusHashesValid = status === "signature_required"
+    ? value.permitTransactionHash === null &&
+      value.transferTransactionHash === null
+    : status === "permit_submitted" || status === "permit_pending"
+      ? typeof value.permitTransactionHash === "string" &&
+        value.transferTransactionHash === null
+      : typeof value.permitTransactionHash === "string" &&
+        typeof value.transferTransactionHash === "string" &&
+        (status !== "confirmed" ||
+          typeof value.transferBlockNumber === "string");
+  if (Object.keys(value).sort().join("\0") !== exactKeys.sort().join("\0") ||
+    value.schema !== gaslessTransferSchema || !statuses.includes(status) ||
+    typeof value.walletAddress !== "string" ||
+    !isAddress(value.walletAddress, { strict: true }) ||
+    getAddress(value.walletAddress).toLowerCase() !==
+      getAddress(expectedAccount).toLowerCase() ||
+    typeof value.sponsorAddress !== "string" ||
+    !isAddress(value.sponsorAddress, { strict: true }) ||
+    typeof value.amountRaw !== "string" ||
+    !positiveIntegerPattern.test(value.amountRaw) ||
+    BigInt(value.amountRaw) !== expectedAmountRaw ||
+    typeof value.nonce !== "string" ||
+    !sponsorshipIntegerPattern.test(value.nonce) ||
+    typeof value.permitDeadline !== "string" ||
+    !positiveIntegerPattern.test(value.permitDeadline) ||
+    typeof value.requestBindingHash !== "string" ||
+    !digestPattern.test(value.requestBindingHash) ||
+    !permitHashValid || !transferHashValid || !transferBlockValid ||
+    (status !== "confirmed" && value.transferBlockNumber !== null) ||
+    !statusHashesValid) {
+    throw new Error("The gasless transfer response is invalid.");
+  }
+  return Object.freeze({
+    schema: gaslessTransferSchema,
+    status,
+    walletAddress: getAddress(value.walletAddress),
+    amountRaw: value.amountRaw,
+    sponsorAddress: getAddress(value.sponsorAddress),
+    nonce: value.nonce,
+    permitDeadline: value.permitDeadline,
+    requestBindingHash: value.requestBindingHash as `sha256:${string}`,
+    permitTransactionHash: value.permitTransactionHash === null
+      ? null
+      : (value.permitTransactionHash as string).toLowerCase() as Hex,
+    transferTransactionHash: value.transferTransactionHash === null
+      ? null
+      : (value.transferTransactionHash as string).toLowerCase() as Hex,
+    transferBlockNumber: value.transferBlockNumber as string | null,
+  });
+}
 
 export function sponsorshipRetryAfterMs(response: Response) {
   const value = response.headers.get("retry-after");
@@ -307,6 +479,25 @@ export async function gasSponsorshipErrorMessage(response: Response) {
   return (await gasSponsorshipFailure(response)).message;
 }
 
+async function gaslessTransferFailure(response: Response) {
+  let message = "The gasless transfer is temporarily unavailable.";
+  let requestId = "";
+  try {
+    const body = await response.json() as {
+      error?: { message?: unknown; requestId?: unknown };
+    };
+    if (typeof body.error?.message === "string" &&
+      body.error.message.length <= 240) message = body.error.message;
+    if (typeof body.error?.requestId === "string" &&
+      /^[0-9a-f-]{36}$/iu.test(body.error.requestId)) {
+      requestId = body.error.requestId;
+    }
+  } catch {
+    // Keep the stable recovery message.
+  }
+  return requestId ? `${message} Request ID: ${requestId}` : message;
+}
+
 function gasSponsorshipError(
   error: unknown,
   account: string,
@@ -388,6 +579,33 @@ function gasSponsorshipIdempotencyKey(
   } catch {
     const created =
       `migration-${MAIN_TOKEN_MIGRATION_RELEASE_ID}-${window.crypto.randomUUID()}`;
+    fallbackKeys.set(storageKey, created);
+    return created;
+  }
+}
+
+function gaslessTransferIdempotencyKey(
+  account: string,
+  fallbackKeys: Map<string, string>,
+) {
+  const normalizedAccount = getAddress(account).toLowerCase();
+  const storageKey = `programmable:main-token-migration:gasless:${MAIN_TOKEN_MIGRATION_RELEASE_ID}:${normalizedAccount}`;
+  const fallback = fallbackKeys.get(storageKey);
+  if (fallback && /^[a-zA-Z0-9:_-]{16,200}$/u.test(fallback)) return fallback;
+  try {
+    const stored = window.localStorage.getItem(storageKey);
+    if (stored && /^[a-zA-Z0-9:_-]{16,200}$/u.test(stored)) {
+      fallbackKeys.set(storageKey, stored);
+      return stored;
+    }
+    const created =
+      `gasless-${MAIN_TOKEN_MIGRATION_RELEASE_ID}-${window.crypto.randomUUID()}`;
+    fallbackKeys.set(storageKey, created);
+    window.localStorage.setItem(storageKey, created);
+    return created;
+  } catch {
+    const created =
+      `gasless-${MAIN_TOKEN_MIGRATION_RELEASE_ID}-${window.crypto.randomUUID()}`;
     fallbackKeys.set(storageKey, created);
     return created;
   }
@@ -735,6 +953,7 @@ export function MainTokenMigration() {
     readConnectedAccountCode,
     readTradeBalances,
     sendTransaction,
+    signMainTokenMigrationPermit,
   } = useWallet();
   const [now, setNow] = useState<number | null>(null);
   const [clockUncertaintyMs, setClockUncertaintyMs] = useState<number | null>(
@@ -757,6 +976,9 @@ export function MainTokenMigration() {
   const [gasSponsorship, setGasSponsorship] = useState<GasSponsorshipState>({
     kind: "idle",
   });
+  const [gaslessStage, setGaslessStage] = useState<GaslessStage>("idle");
+  const [gaslessProgress, setGaslessProgress] =
+    useState<StoredGaslessTransferProgress | null>(null);
   const [accountCodeObservation, setAccountCodeObservation] =
     useState<AccountCodeObservation | null>(null);
   const amountInputRef = useRef<HTMLInputElement>(null);
@@ -765,6 +987,7 @@ export function MainTokenMigration() {
   const sponsorshipRegionRef = useRef<HTMLDivElement>(null);
   const trustedClockRef = useRef<TrustedClock | null>(null);
   const sponsorshipIdempotencyKeysRef = useRef(new Map<string, string>());
+  const gaslessIdempotencyKeysRef = useRef(new Map<string, string>());
 
   const readTrustedNow = useCallback(() => {
     const clock = trustedClockRef.current;
@@ -851,6 +1074,10 @@ export function MainTokenMigration() {
       ? gasSponsorship.transactionHash
       : null;
   const sponsoredGasReady = hasEnoughObservedGas;
+  const delegatedWallet = accountCodeStatus === "delegated";
+  const unresolvedGaslessTransfer = gaslessProgress !== null;
+  const gaslessProgressForConnectedAccount =
+    connectedAccount !== null && gaslessProgress?.account === connectedAccount;
   const parsedAmount = useMemo(() => {
     if (!amount.trim()) return null;
     try {
@@ -946,9 +1173,11 @@ export function MainTokenMigration() {
         if (!cancelled) {
           setAccountCodeObservation({
             account,
-            status: isMainTokenMigrationWalletCodeEligible(code)
-              ? "eoa"
-              : "contract",
+            status: isMainTokenMigrationDelegatedWalletCode(code)
+              ? "delegated"
+              : isMainTokenMigrationWalletCodeEligible(code)
+                ? "eoa"
+                : "contract",
           });
         }
       })
@@ -961,6 +1190,33 @@ export function MainTokenMigration() {
       cancelled = true;
     };
   }, [onMainnet, readConnectedAccountCode, wallet]);
+
+  useEffect(() => {
+    const restore = () => {
+      const restored = storedGaslessTransferProgress();
+      setGaslessProgress(restored);
+      if (restored && !hasTrackedTransfer) {
+        if (wallet?.account.toLowerCase() === restored.account) {
+          setAmount(formatUnits(BigInt(restored.amountRaw), MAIN_TOKEN_DECIMALS));
+          setAcknowledged(true);
+        }
+        setSubmission({
+          kind: "error",
+          message:
+            "This gasless transfer still needs reconciliation. Resume it here and do not send V4 separately.",
+        });
+      }
+    };
+    const timeout = window.setTimeout(restore, 0);
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === gaslessTransferProgressStorageKey) restore();
+    };
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.clearTimeout(timeout);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, [hasTrackedTransfer, wallet]);
 
   useEffect(() => {
     const restore = window.setTimeout(() => {
@@ -1451,6 +1707,132 @@ export function MainTokenMigration() {
     }
   }
 
+  async function reviewGaslessTransfer(account: `0x${string}`, amountRaw: bigint) {
+    const accessToken = await getAccessToken();
+    if (!accessToken) {
+      throw new Error("Reconnect this wallet before using the gasless transfer.");
+    }
+    const idempotencyKey = gaslessTransferIdempotencyKey(
+      account,
+      gaslessIdempotencyKeysRef.current,
+    );
+    const headers = {
+      Accept: "application/json",
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+      "Idempotency-Key": idempotencyKey,
+    };
+    setSubmission({ kind: "submitting" });
+    setGaslessStage("preparing");
+    const prepareBody = JSON.stringify({
+      action: "prepare",
+      walletAddress: account,
+      amountRaw: amountRaw.toString(),
+    });
+    let prepared: GaslessTransferResponse | null = null;
+    let prepareFailure = "The gasless transfer is temporarily unavailable.";
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const response = await fetch(gaslessTransferEndpoint, {
+        method: "POST",
+        cache: "no-store",
+        headers,
+        body: prepareBody,
+      });
+      if (response.ok) {
+        prepared = parseGaslessTransferResponse(
+          await response.json(),
+          account,
+          amountRaw,
+        );
+        break;
+      }
+      prepareFailure = await gaslessTransferFailure(response);
+      if ((response.status !== 429 && response.status !== 503) || attempt === 4) {
+        throw new Error(prepareFailure);
+      }
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, sponsorshipRetryAfterMs(response));
+      });
+    }
+    if (!prepared) throw new Error(prepareFailure);
+    if (prepared.status !== "signature_required") {
+      throw new Error("The gasless transfer request is not ready for review.");
+    }
+    const progress = persistGaslessTransferProgress(account, amountRaw);
+    setGaslessProgress(progress);
+    setGaslessStage("signing");
+    let permit;
+    try {
+      permit = await signMainTokenMigrationPermit({
+        deadline: BigInt(prepared.permitDeadline),
+        nonce: BigInt(prepared.nonce),
+        spender: getAddress(prepared.sponsorAddress),
+        value: amountRaw,
+      });
+    } catch (error) {
+      clearGaslessTransferProgress();
+      setGaslessProgress(null);
+      throw error;
+    }
+    setGaslessStage("relaying");
+    const submitBody = JSON.stringify({
+      action: "submit",
+      walletAddress: account,
+      amountRaw: amountRaw.toString(),
+      nonce: prepared.nonce,
+      permitDeadline: prepared.permitDeadline,
+      permitSignature: permit.signature,
+      requestBindingHash: prepared.requestBindingHash,
+    });
+    for (let attempt = 0; attempt < 60; attempt += 1) {
+      const response = await fetch(gaslessTransferEndpoint, {
+        method: "POST",
+        cache: "no-store",
+        headers,
+        body: submitBody,
+      });
+      if (!response.ok) {
+        const failure = await gaslessTransferFailure(response);
+        if ((response.status === 429 || response.status === 503) && attempt < 59) {
+          await new Promise<void>((resolve) => {
+            window.setTimeout(resolve, sponsorshipRetryAfterMs(response));
+          });
+          continue;
+        }
+        throw new Error(failure);
+      }
+      const result = parseGaslessTransferResponse(
+        await response.json(),
+        account,
+        amountRaw,
+      );
+      if (result.status === "confirmed" && result.transferTransactionHash &&
+        result.transferBlockNumber) {
+        const confirmed: Extract<SubmissionState, { kind: "confirmed" }> = {
+          kind: "confirmed",
+          account,
+          hash: result.transferTransactionHash,
+          amount: formatUnits(amountRaw, MAIN_TOKEN_DECIMALS),
+          blockNumber: result.transferBlockNumber,
+        };
+        persistMigrationTransfer(confirmed);
+        clearGaslessTransferProgress();
+        setGaslessProgress(null);
+        setConfirmationIssue("");
+        setSubmission(confirmed);
+        setGaslessStage("idle");
+        void refreshBalance();
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, sponsorshipRetryAfterMs(response));
+      });
+    }
+    throw new Error(
+      "The gasless transfer is still being reconciled. Resume it here; do not send V4 separately.",
+    );
+  }
+
   async function reviewTransfer() {
     if (!trustedTransferWindowOpen()) {
       setSubmission({
@@ -1527,9 +1909,10 @@ export function MainTokenMigration() {
           "Smart-contract wallets are not eligible for the automatic allocation path. Contact support for manual review before sending.",
         );
       }
+      const delegated = isMainTokenMigrationDelegatedWalletCode(code);
       setAccountCodeObservation({
         account: wallet.account.toLowerCase(),
-        status: "eoa",
+        status: delegated ? "delegated" : "eoa",
       });
       const amountRaw = parsedAmount;
       const freshBalances = await readTradeBalances(MAIN_TOKEN_ADDRESS);
@@ -1537,6 +1920,11 @@ export function MainTokenMigration() {
       setNativeBalance(freshBalances.nativeBalanceWei);
       setGasPrice(freshBalances.gasPriceWei);
       assertMainTokenMigrationBalance(amountRaw, freshBalances.tokenBalanceRaw);
+      const account = getAddress(wallet.account);
+      if (delegated) {
+        await reviewGaslessTransfer(account, amountRaw);
+        return;
+      }
       if (
         !hasEnoughMigrationGas(
           freshBalances.nativeBalanceWei,
@@ -1567,7 +1955,6 @@ export function MainTokenMigration() {
         });
         return;
       }
-      const account = getAddress(wallet.account);
       const prepared = buildMainTokenMigrationTransaction({
         from: account,
         amountRaw,
@@ -1594,6 +1981,7 @@ export function MainTokenMigration() {
       setConfirmationIssue("");
       setSubmission(submitted);
     } catch (error) {
+      setGaslessStage("idle");
       setSubmission({ kind: "error", message: migrationErrorMessage(error) });
     }
   }
@@ -1622,7 +2010,11 @@ export function MainTokenMigration() {
                         ? "Switching network"
                         : "Switch to Ethereum"
                       : submission.kind === "submitting"
-                        ? "Confirm in your wallet"
+                        ? gaslessStage === "preparing"
+                          ? "Preparing gasless transfer"
+                          : gaslessStage === "relaying"
+                            ? "Relaying gasless transfer"
+                            : "Confirm exact amount in wallet"
                         : accountCodeStatus === "checking"
                           ? "Checking wallet type"
                           : accountCodeStatus === "contract"
@@ -1635,6 +2027,13 @@ export function MainTokenMigration() {
                                   ? "Balance unavailable"
                                   : !acknowledged
                                     ? "Confirm address control"
+                                    : gaslessProgress &&
+                                        gaslessProgress.account !== connectedAccount
+                                      ? "Reconnect pending wallet"
+                                    : delegatedWallet
+                                      ? gaslessProgressForConnectedAccount
+                                        ? "Resume gasless transfer"
+                                        : "Review gasless transfer"
                                     : !sponsoredGasReady
                                       ? sponsorshipKind === "eligible"
                                         ? "Request sponsored gas first"
@@ -1846,7 +2245,8 @@ export function MainTokenMigration() {
 
             {wallet &&
             onMainnet &&
-            accountCodeStatus === "eoa" &&
+            (accountCodeStatus === "eoa" ||
+              accountCodeStatus === "delegated") &&
             parsedAmount !== null &&
             !amountError &&
             balance !== null ? (
@@ -1855,7 +2255,21 @@ export function MainTokenMigration() {
                 tabIndex={-1}
                 aria-label="Gas sponsorship status"
               >
-                {sponsorshipKind === "not-needed" ? (
+                {delegatedWallet ? (
+                  <div
+                    className={styles.walletTypeStatus}
+                    data-status="eoa"
+                    role="status"
+                  >
+                    <strong>Gasless transfer available</strong>
+                    <span>
+                      Review the exact V4 amount in your wallet. Programmable
+                      pays the Ethereum gas and sends only that amount to the
+                      fixed migration address. Use Max to move your full balance
+                      in one gasless transfer.
+                    </span>
+                  </div>
+                ) : sponsorshipKind === "not-needed" ? (
                   <div
                     className={styles.walletTypeStatus}
                     data-status="eoa"
@@ -2054,7 +2468,9 @@ export function MainTokenMigration() {
                   submission.kind === "submitting" ||
                   hasTrackedTransfer ||
                   accountCodeStatus === "checking" ||
-                  accountCodeStatus === "contract"
+                  accountCodeStatus === "contract" ||
+                  (gaslessProgress !== null &&
+                    gaslessProgress.account !== connectedAccount)
                 }
               >
                 {primaryLabel}
@@ -2062,6 +2478,8 @@ export function MainTokenMigration() {
             ) : null}
             <p className={styles.walletBoundary}>
               Nothing is sent until you approve the V4 transfer in your wallet.
+              For gasless wallets, Programmable then relays that amount to the
+              fixed migration address.
             </p>
 
             <div
@@ -2110,7 +2528,7 @@ export function MainTokenMigration() {
                   >
                     View on Etherscan
                   </a>
-                  {transferWindowOpen ? (
+                  {transferWindowOpen && !delegatedWallet ? (
                     <button
                       className={styles.secondaryAction}
                       type="button"
@@ -2153,8 +2571,17 @@ export function MainTokenMigration() {
               <p>Manual transfer</p>
               <h2 id="migration-wallet-title">Send V4 directly</h2>
             </header>
-            <p>Prefer not to connect? Send V4 directly to this address.</p>
-            {canRevealDestination ? (
+            <p>
+              {unresolvedGaslessTransfer
+                ? "Finish the pending gasless transfer before using the manual path."
+                : "Prefer not to connect? Send V4 directly to this address."}
+            </p>
+            {unresolvedGaslessTransfer ? (
+              <p className={styles.closedAddressNote} role="status">
+                Select Resume gasless transfer. Do not send another transfer while
+                its outcome is being reconciled.
+              </p>
+            ) : canRevealDestination ? (
               <>
                 <div className={styles.addressBlock}>
                   <code>{MAIN_TOKEN_MIGRATION_WALLET}</code>

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -56,7 +56,13 @@ import {
 } from "@/lib/custom-launch/wallet-handoff-v4";
 import { parseLocalProfile } from "@/lib/profile/local-profile";
 import { robinhoodChain } from "@/lib/chains";
-import { assertMainTokenMigrationTransaction } from "@/lib/main-token-migration";
+import {
+  assertMainTokenMigrationTransaction,
+  buildMainTokenMigrationPermitTypedData,
+  parseMainTokenMigrationPermitSignature,
+  serializeMainTokenMigrationPermitTypedData,
+  type MainTokenMigrationPermitSignature,
+} from "@/lib/main-token-migration";
 import {
   buildPredictionPermitTypedData,
   buildUsdgPermitTypedData,
@@ -179,6 +185,12 @@ type WalletContextValue = {
     tokenName: string;
     value: bigint;
   }>) => Promise<PredictionPermitSignature>;
+  signMainTokenMigrationPermit: (input: Readonly<{
+    deadline: bigint;
+    nonce: bigint;
+    spender: Address;
+    value: bigint;
+  }>) => Promise<MainTokenMigrationPermitSignature>;
   sendBrowserWalletAction: (input: Readonly<{
     chainId: string;
     from: `0x${string}`;
@@ -1025,6 +1037,9 @@ function DeferredWalletProvider({
         throw new Error("Wallet sign-in is still loading");
       },
       signPredictionTokenPermit: async () => {
+        throw new Error("Wallet sign-in is still loading");
+      },
+      signMainTokenMigrationPermit: async () => {
         throw new Error("Wallet sign-in is still loading");
       },
       sendBrowserWalletAction: async () => {
@@ -2085,6 +2100,75 @@ function PrivyWalletBridge({
     }
   }, [connectedWallet, user?.id, wallet]);
 
+  const signMainTokenMigrationPermit = useCallback(async (input: Readonly<{
+    deadline: bigint;
+    nonce: bigint;
+    spender: Address;
+    value: bigint;
+  }>) => {
+    if (!connectedWallet || !wallet) {
+      throw new Error("Connect an Ethereum wallet before continuing");
+    }
+    const sessionSubject = user?.id ?? null;
+    if (sessionSubject === null) {
+      throw new Error("Your wallet session expired. Reconnect and try again");
+    }
+    const expectedAccount = wallet.account.toLowerCase();
+    const assertCurrentSession = () => {
+      const current = walletRequestSessionRef.current;
+      if (!current.authenticated || current.privyUserId !== sessionSubject ||
+        current.account?.toLowerCase() !== expectedAccount) {
+        throw new Error("The wallet session changed. Reconnect and try again");
+      }
+    };
+    const typedData = buildMainTokenMigrationPermitTypedData({
+      ...input,
+      owner: wallet.account,
+    });
+    const mainnetChainHex = `0x${mainnet.id.toString(16)}`;
+
+    try {
+      if (normalizeChainId(wallet.chainId) !== mainnetChainHex) {
+        await connectedWallet.switchChain(mainnet.id);
+        assertCurrentSession();
+      }
+      const provider = await connectedWallet.getEthereumProvider();
+      await assertExternalWalletAuthorityCurrent({
+        expectedAccount: wallet.account,
+        expectedChainId: mainnetChainHex,
+        networkName: mainnet.name,
+        request: (method) => provider.request({ method }),
+      });
+      const signature = await runWithBrowserWalletRequestLock({
+        sessionSubject,
+        account: wallet.account,
+        chainId: String(mainnet.id),
+        requestSubject: JSON.stringify([
+          "main-token-migration-permit-v1",
+          input.spender.toLowerCase(),
+          input.value.toString(),
+          input.nonce.toString(),
+          input.deadline.toString(),
+        ]),
+        assertCurrentSession,
+        execute: () => provider.request({
+          method: "eth_signTypedData_v4",
+          params: [
+            wallet.account,
+            serializeMainTokenMigrationPermitTypedData(typedData),
+          ],
+        }),
+      });
+      assertCurrentSession();
+      if (typeof signature !== "string") {
+        throw new Error("The wallet returned an invalid migration permit signature");
+      }
+      return parseMainTokenMigrationPermitSignature(signature as Hex);
+    } catch (caught) {
+      throw new Error(getWalletTransactionErrorMessage(caught));
+    }
+  }, [connectedWallet, user?.id, wallet]);
+
   const signLaunchMessage = useCallback(async (
     signingMessageBase64Url: string,
   ) => {
@@ -2525,6 +2609,7 @@ function PrivyWalletBridge({
       signLaunchMessage,
       signPredictionPermit,
       signPredictionTokenPermit,
+      signMainTokenMigrationPermit,
       sendBrowserWalletAction,
       sendCustomLaunchWalletAction,
       sendCustomLaunchWalletActionV4,
@@ -2567,6 +2652,7 @@ function PrivyWalletBridge({
       signLaunchMessage,
       signPredictionPermit,
       signPredictionTokenPermit,
+      signMainTokenMigrationPermit,
       switchingNetwork,
       switchWalletNetwork,
       providerSettled,
@@ -2660,6 +2746,9 @@ function UnconfiguredWalletProvider({ children }: { children: ReactNode }) {
         throw new Error("Wallet sign-in is unavailable");
       },
       signPredictionTokenPermit: async () => {
+        throw new Error("Wallet sign-in is unavailable");
+      },
+      signMainTokenMigrationPermit: async () => {
         throw new Error("Wallet sign-in is unavailable");
       },
       sendBrowserWalletAction: async () => {

--- a/config/main-token-migration-gas-sponsor-contract.v1.json
+++ b/config/main-token-migration-gas-sponsor-contract.v1.json
@@ -24,13 +24,16 @@
     "transactionMethod": "eth_sendTransaction",
     "transactionType": "2",
     "transactionData": "0x",
-    "sponsorGasLimitMode": "eoa-fixed-or-delegated-estimated",
+    "sponsorGasLimitMode": "plain-eoa-fixed",
     "sponsorGasLimitMinimum": "21000",
     "sponsorGasLimitMaximum": "100000",
     "providerPolicyEnforces": [
       "method",
       "chainId",
-      "maximumValue"
+      "positiveMaximumNativeValue",
+      "pinnedToken",
+      "permitSpenderAmountDeadline",
+      "fixedTransferFromDestinationAndAmount"
     ],
     "serverEnforces": [
       "holderRecipient",

--- a/config/main-token-migration-gas-sponsor-privy-policy.v2.json
+++ b/config/main-token-migration-gas-sponsor-privy-policy.v2.json
@@ -1,0 +1,232 @@
+{
+  "schema": "programmable-main-token-migration-gas-sponsor-privy-policy/v2",
+  "name": "Main token migration gas sponsor v2",
+  "chainType": "ethereum",
+  "version": "1.0",
+  "rules": [
+    {
+      "name": "Positive bounded Ethereum native top-ups",
+      "action": "ALLOW",
+      "method": "eth_sendTransaction",
+      "conditions": [
+        {
+          "field_source": "ethereum_transaction",
+          "field": "chain_id",
+          "operator": "eq",
+          "value": "1"
+        },
+        {
+          "field_source": "ethereum_transaction",
+          "field": "value",
+          "operator": "gt",
+          "value": "0x0"
+        },
+        {
+          "field_source": "ethereum_transaction",
+          "field": "value",
+          "operator": "lte",
+          "value": "0x71afd498d0000"
+        }
+      ]
+    },
+    {
+      "name": "Exact V4 migration permits",
+      "action": "ALLOW",
+      "method": "eth_sendTransaction",
+      "conditions": [
+        {
+          "field_source": "ethereum_transaction",
+          "field": "chain_id",
+          "operator": "eq",
+          "value": "1"
+        },
+        {
+          "field_source": "ethereum_transaction",
+          "field": "to",
+          "operator": "eq",
+          "value": "0x7987f03462200b3D8A072E02C89A8A41dCB124EE"
+        },
+        {
+          "field_source": "ethereum_transaction",
+          "field": "value",
+          "operator": "eq",
+          "value": "0x0"
+        },
+        {
+          "field_source": "ethereum_calldata",
+          "field": "function_name",
+          "operator": "eq",
+          "value": "permit",
+          "abi": [
+            {
+              "type": "function",
+              "name": "permit",
+              "stateMutability": "nonpayable",
+              "inputs": [
+                { "name": "owner", "type": "address" },
+                { "name": "spender", "type": "address" },
+                { "name": "value", "type": "uint256" },
+                { "name": "deadline", "type": "uint256" },
+                { "name": "v", "type": "uint8" },
+                { "name": "r", "type": "bytes32" },
+                { "name": "s", "type": "bytes32" }
+              ],
+              "outputs": []
+            }
+          ]
+        },
+        {
+          "field_source": "ethereum_calldata",
+          "field": "permit.spender",
+          "operator": "eq",
+          "value": "0x0060f9E57FCcc0611ef44809B257919e78Aa99Ac",
+          "abi": [
+            {
+              "type": "function",
+              "name": "permit",
+              "stateMutability": "nonpayable",
+              "inputs": [
+                { "name": "owner", "type": "address" },
+                { "name": "spender", "type": "address" },
+                { "name": "value", "type": "uint256" },
+                { "name": "deadline", "type": "uint256" },
+                { "name": "v", "type": "uint8" },
+                { "name": "r", "type": "bytes32" },
+                { "name": "s", "type": "bytes32" }
+              ],
+              "outputs": []
+            }
+          ]
+        },
+        {
+          "field_source": "ethereum_calldata",
+          "field": "permit.value",
+          "operator": "lte",
+          "value": "0x33b2e3c9fd0803ce8000000",
+          "abi": [
+            {
+              "type": "function",
+              "name": "permit",
+              "stateMutability": "nonpayable",
+              "inputs": [
+                { "name": "owner", "type": "address" },
+                { "name": "spender", "type": "address" },
+                { "name": "value", "type": "uint256" },
+                { "name": "deadline", "type": "uint256" },
+                { "name": "v", "type": "uint8" },
+                { "name": "r", "type": "bytes32" },
+                { "name": "s", "type": "bytes32" }
+              ],
+              "outputs": []
+            }
+          ]
+        },
+        {
+          "field_source": "ethereum_calldata",
+          "field": "permit.deadline",
+          "operator": "lte",
+          "value": "0x6a9919c4",
+          "abi": [
+            {
+              "type": "function",
+              "name": "permit",
+              "stateMutability": "nonpayable",
+              "inputs": [
+                { "name": "owner", "type": "address" },
+                { "name": "spender", "type": "address" },
+                { "name": "value", "type": "uint256" },
+                { "name": "deadline", "type": "uint256" },
+                { "name": "v", "type": "uint8" },
+                { "name": "r", "type": "bytes32" },
+                { "name": "s", "type": "bytes32" }
+              ],
+              "outputs": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Exact V4 migration transfers",
+      "action": "ALLOW",
+      "method": "eth_sendTransaction",
+      "conditions": [
+        {
+          "field_source": "ethereum_transaction",
+          "field": "chain_id",
+          "operator": "eq",
+          "value": "1"
+        },
+        {
+          "field_source": "ethereum_transaction",
+          "field": "to",
+          "operator": "eq",
+          "value": "0x7987f03462200b3D8A072E02C89A8A41dCB124EE"
+        },
+        {
+          "field_source": "ethereum_transaction",
+          "field": "value",
+          "operator": "eq",
+          "value": "0x0"
+        },
+        {
+          "field_source": "ethereum_calldata",
+          "field": "function_name",
+          "operator": "eq",
+          "value": "transferFrom",
+          "abi": [
+            {
+              "type": "function",
+              "name": "transferFrom",
+              "stateMutability": "nonpayable",
+              "inputs": [
+                { "name": "from", "type": "address" },
+                { "name": "to", "type": "address" },
+                { "name": "amount", "type": "uint256" }
+              ],
+              "outputs": [{ "name": "", "type": "bool" }]
+            }
+          ]
+        },
+        {
+          "field_source": "ethereum_calldata",
+          "field": "transferFrom.to",
+          "operator": "eq",
+          "value": "0x228Be90653fDDAa408fB6cf9ca0AEC311dbE9A0D",
+          "abi": [
+            {
+              "type": "function",
+              "name": "transferFrom",
+              "stateMutability": "nonpayable",
+              "inputs": [
+                { "name": "from", "type": "address" },
+                { "name": "to", "type": "address" },
+                { "name": "amount", "type": "uint256" }
+              ],
+              "outputs": [{ "name": "", "type": "bool" }]
+            }
+          ]
+        },
+        {
+          "field_source": "ethereum_calldata",
+          "field": "transferFrom.amount",
+          "operator": "lte",
+          "value": "0x33b2e3c9fd0803ce8000000",
+          "abi": [
+            {
+              "type": "function",
+              "name": "transferFrom",
+              "stateMutability": "nonpayable",
+              "inputs": [
+                { "name": "from", "type": "address" },
+                { "name": "to", "type": "address" },
+                { "name": "amount", "type": "uint256" }
+              ],
+              "outputs": [{ "name": "", "type": "bool" }]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/config/main-token-migration-gasless-transfer-contract.v1.json
+++ b/config/main-token-migration-gasless-transfer-contract.v1.json
@@ -1,0 +1,47 @@
+{
+  "schema": "programmable-main-token-migration-gasless-transfer-contract/v1",
+  "releaseId": "v4-ethereum-to-robinhood-72h-2026-v2",
+  "activationManifestPath": "config/main-token-migration-activation.v1.json",
+  "route": "/api/main-token-migration/gasless-transfer",
+  "serverOnly": true,
+  "chainId": "1",
+  "sourceAssetContract": "0x7987f03462200b3D8A072E02C89A8A41dCB124EE",
+  "tokenName": "Programmable",
+  "permitVersion": "1",
+  "permitDomainSeparator": "0xe2ac19a052ba41dccaaa930f489a94353d986c7769e416830273d9362ad26a47",
+  "migrationWallet": "0x228Be90653fDDAa408fB6cf9ca0AEC311dbE9A0D",
+  "eligibleWalletCode": "eip-7702-delegation-indicator",
+  "walletReview": {
+    "standard": "EIP-2612 Permit",
+    "binds": [
+      "owner",
+      "sponsorSpender",
+      "exactAmountRaw",
+      "currentNonce",
+      "shortDeadline",
+      "EthereumChainId",
+      "pinnedToken"
+    ]
+  },
+  "relayer": {
+    "permitGasLimit": "100000",
+    "transferFromGasLimit": "100000",
+    "maximumFeePerGasWei": "20000000000",
+    "destination": "fixedMigrationWallet",
+    "providerTransactions": "separate-idempotent-permit-and-transferFrom"
+  },
+  "serverEnforces": [
+    "authenticatedLinkedOwner",
+    "sameOrigin",
+    "openingAndCurrentBalance",
+    "dualRpcQuorum",
+    "eip7702WalletCode",
+    "exactPermitSigner",
+    "exactPermitTypedData",
+    "fixedToken",
+    "fixedMigrationDestination",
+    "sharedBudget",
+    "rootWalletReplayGuard",
+    "exactTransactionReadback"
+  ]
+}

--- a/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-READINESS-V1.md
+++ b/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-READINESS-V1.md
@@ -1,8 +1,7 @@
 # Main Token Migration Gas Sponsor V1 Readiness
 
-This checklist is an activation gate, not an activation record. The committed migration manifest is currently
-disabled. Replace no placeholders in the repository; operational values belong only in the deployment secret manager
-and private release evidence.
+This checklist remains the release and incident-response gate for the active migration window. Operational values
+belong only in the deployment secret manager and private release evidence.
 
 ## Candidate identity
 
@@ -11,6 +10,10 @@ and private release evidence.
       exact finalized pre-window eligibility block number and hash.
 - [ ] The sponsor contract matches
       `config/main-token-migration-gas-sponsor-contract.v1.json` byte-for-byte in the candidate.
+- [ ] The delegated-wallet path matches
+      `config/main-token-migration-gasless-transfer-contract.v1.json` byte-for-byte in the candidate.
+- [ ] The normalized provider readback exactly matches
+      `config/main-token-migration-gas-sponsor-privy-policy.v2.json`.
 
 ## Server configuration
 
@@ -27,10 +30,11 @@ and private release evidence.
 
 - [ ] The wallet readback reports `chain_type=ethereum`, the configured address and exactly one attached policy.
 - [ ] The attached policy ID exactly matches the configured policy ID.
-- [ ] The policy permits only Ethereum Mainnet `eth_sendTransaction` native transfers, caps value at or below the
-      configured maximum top-up, and defaults to deny for unrelated wallet methods.
-- [ ] Server tests and the reviewed candidate independently bind the exact linked holder recipient, empty calldata,
-      sender, type-2 fee/gas limits and exact calculated value; these fields are not attributed to the Privy policy.
+- [ ] The policy allows only strictly positive bounded Mainnet top-ups plus exact V4 `permit` and `transferFrom`
+      calls; the permit spender and fixed migration destination are provider-enforced and unrelated calls default to
+      deny.
+- [ ] Server tests independently bind the exact linked holder, signed amount, token calldata, native recipient,
+      sender, type-2 fee/gas limits and exact calculated value.
 - [ ] The sponsor address differs from both the V4 token and migration recipient addresses and has empty runtime code.
 
 ## Focused behavior
@@ -43,6 +47,12 @@ and private release evidence.
 - [ ] Concurrent duplicate requests reserve and broadcast no more than one transfer.
 - [ ] An ambiguous Privy response is recorded as unknown and is not rebroadcast.
 - [ ] Dual-RPC readback confirms the exact transaction fields and successful receipt before status becomes confirmed.
+- [ ] A delegated EIP-7702 wallet signs the exact EIP-2612 domain/message, receives no ETH top-up, and the sponsor can
+      relay only the signed amount through the pinned token to the fixed migration wallet.
+- [ ] The normal top-up endpoint rejects delegated wallets; both paths share one total budget and a gasless root guard
+      blocks a later native reservation.
+- [ ] Wrong signer, token, spender, amount, nonce, deadline, destination, calldata, root eligibility or provider
+      reference fails closed without a token transfer.
 
 ## Release evidence
 

--- a/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-V1.md
+++ b/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-V1.md
@@ -1,18 +1,23 @@
 # Main Token Migration Gas Sponsor V1
 
-Status: preparation-ready, activation-blocked. The checked-in activation manifest binds the 72-hour release policy,
-but it intentionally contains no start time, deadline or eligibility-block anchor yet. No committed file contains the
-operational Privy wallet ID, policy ID, sponsor address or release budget.
+Status: active for the checked-in 72-hour migration window. The activation manifest binds the exact start, exclusive
+deadline and finalized eligibility block. No committed file contains the operational Privy wallet ID, policy ID or
+release budget.
 
 ## Purpose
 
-This runbook defines the server-only activation contract for one bounded Ethereum Mainnet gas top-up per eligible
-V4 holder during the exact 72-hour migration window. The sponsor sends native ETH only to the authenticated holder
-wallet so that the holder can separately approve the exact V4 token transfer in their own wallet. It never sends V4,
-never submits the holder's token transfer, and never uses the migration recipient wallet as the sponsor.
+This runbook defines two server-only gas paths during the exact 72-hour migration window. A normal EOA can receive
+one bounded Ethereum Mainnet gas top-up and then separately approve the V4 transfer. An eligible EIP-7702 delegated
+wallet, including wallets that automatically wrap incoming ETH, instead signs an exact EIP-2612 permit. The same
+dedicated sponsor pays gas for the permit and an exact `transferFrom` to the fixed migration wallet. No private key is
+requested or exported, and neither path uses the migration recipient wallet as the sponsor.
 
 The machine-readable companion is
 [`config/main-token-migration-gas-sponsor-contract.v1.json`](../../config/main-token-migration-gas-sponsor-contract.v1.json).
+The gasless delegated-wallet companion is
+[`config/main-token-migration-gasless-transfer-contract.v1.json`](../../config/main-token-migration-gasless-transfer-contract.v1.json).
+The exact provider-enforced policy is
+[`config/main-token-migration-gas-sponsor-privy-policy.v2.json`](../../config/main-token-migration-gas-sponsor-privy-policy.v2.json).
 The release activation source is
 [`config/main-token-migration-activation.v1.json`](../../config/main-token-migration-activation.v1.json).
 
@@ -53,20 +58,36 @@ manifest has `enabled: true`, the current time is inside the window, and at leas
 ## Privy wallet and policy
 
 Use a dedicated Privy Ethereum EOA. It must not be the V4 token contract or the migration recipient wallet. Before
-every eligibility response and transfer, the server re-reads the wallet from Privy and requires all of the following:
+every eligibility response and transfer, the server re-reads the wallet and policy from Privy and requires all of the
+following:
 
 - the returned wallet ID equals `MAIN_TOKEN_MIGRATION_GAS_SPONSOR_PRIVY_WALLET_ID`;
 - `chain_type` is `ethereum` and the returned address equals the configured checksummed address; and
 - exactly one policy is attached and its ID equals `MAIN_TOKEN_MIGRATION_GAS_SPONSOR_PRIVY_POLICY_ID`.
+- the policy has no owner, is Ethereum policy version 1.0, and its normalized rules exactly match the checked-in V2
+  policy contract; an extra, missing or broader rule fails closed.
 
-The attached policy must allow only `eth_sendTransaction` for Ethereum Mainnet (`eip155:1`), native value no greater
-than the configured top-up cap and never greater than 0.002 ETH; its default action must deny unrelated wallet
-methods. Privy's transaction-policy fields do not attest calldata or the dynamic holder recipient. The server
-therefore independently constructs a type-2 transaction with chain ID 1, empty calldata, the sponsor as `from`, the
-authenticated eligible holder as `to`, and the exact calculated deficit as `value`. A plain EOA uses 21,000 gas. An
-eligible EIP-7702 delegated EOA uses the higher exact estimate returned by both independent RPCs with 125% headroom,
-bounded between 21,000 and 100,000 gas. A broader policy is not activation-ready even though these server checks
-remain in place.
+The policy has three non-overlapping allow rules and defaults to deny everything else. The native rule requires a
+strictly positive Mainnet value no greater than 0.002 ETH, so it cannot authorize zero-value contract calls. The
+permit rule pins the V4 token, sponsor spender, total-supply ceiling and release deadline. The `transferFrom` rule pins
+the V4 token, total-supply ceiling and fixed migration destination. The server independently binds the dynamic holder,
+exact signed amount, empty native calldata or byte-exact token calldata, sender, type-2 gas/fee fields and calculated
+value. Every submitted transaction is independently read back through two RPCs.
+
+## Delegated-wallet gasless path
+
+The gasless route is used only when the connected address has the canonical EIP-7702 delegation indicator. Both RPCs
+must agree on that code, the pinned token runtime, token name `Programmable`, permit domain separator, current nonce,
+current balance and pre-window eligibility. The wallet reviews an EIP-2612 permit binding chain ID 1, the pinned V4
+token, the dedicated sponsor as spender, exact raw amount, current nonce and a deadline of at most 20 minutes. The
+server recovers the exact connected owner before reserving anything.
+
+The private ledger stores one request binding plus separate deterministic provider references for `permit` and
+`transferFrom`. The sponsor first submits the byte-exact permit. Only after two providers confirm its successful
+receipt and the allowance is visible may the sponsor call `transferFrom(owner, fixedMigrationWallet, exactAmount)`.
+Both calls have zero native value, 100,000-gas ceilings and share the existing release budget and root-wallet replay
+guard. The ordinary ETH endpoint rejects delegated wallets, preventing a new wallet from claiming both paths. The UI
+never signs automatically and never treats a provider response as a confirmed token transfer.
 
 ## Fixed fee and budget boundaries
 
@@ -77,7 +98,7 @@ These limits are code-bound and are not operator-tunable:
 | Token-transfer gas ceiling | `100000` gas | A larger estimate fails closed |
 | Quote multiplier | `12500` bps (125%) | Applied to the conservative transfer-gas quote |
 | Maximum fee per gas | `20000000000` wei (20 gwei) | A higher quote returns unavailable; it never increases the cap |
-| Sponsor transaction gas | `21000` to `100000` gas | Plain EOA is fixed at 21,000; delegated EOA is dual-RPC estimated with 125% headroom |
+| Sponsor transaction gas | `21000` gas | Only a plain EOA can receive a native top-up; delegated wallets use the gasless token path |
 | Absolute top-up cap | `2000000000000000` wei (0.002 ETH) | The configured cap may be lower, never higher |
 | Absolute release budget cap | `1000000000000000000` wei (1 ETH) | The configured budget may be lower, never higher |
 | Deadline safety margin | `300` seconds | New sponsorship closes before the migration deadline |
@@ -85,7 +106,8 @@ These limits are code-bound and are not operator-tunable:
 The calculated requirement is `ceil(100000 * maxFeePerGas * 12500 / 10000)`. Existing holder ETH is subtracted, so
 only the deficit is sent. The quote uses the higher max fee and higher priority fee observed across the two
 independent providers, and the priority fee must not exceed the max fee. Each durable budget reservation includes
-both that top-up and the sponsor's exact reserved `sponsorGasLimit * maxFeePerGas` transaction cost. The total budget
+both that top-up and the sponsor's exact reserved `sponsorGasLimit * maxFeePerGas` transaction cost. Native and
+gasless holder rows are summed under the same advisory lock. The total budget
 must cover the configured maximum top-up. It must also be
 chosen below the wallet's funded balance with an operator-owned safety margin; the absolute code cap is not a funding
 recommendation.
@@ -95,7 +117,8 @@ recommendation.
 The endpoint authenticates the Privy access token and requires the requested address to be linked to that Privy
 principal. Both independent Ethereum providers must agree on chain ID, canonical head, the finalized pre-window
 eligibility block and the pinned V4 runtime code. The holder and sponsor must be EOAs or an explicitly supported
-EIP-7702 delegated EOA. The current holder must own at least the requested V4 amount at the canonical read. It is
+EIP-7702 delegated EOA. The native top-up path accepts only a plain EOA; a supported delegated holder is routed
+exclusively to the gasless transfer. The current holder must own at least the requested V4 amount at the canonical read. It is
 eligible either by owning that amount at the pre-window block or through one finalized direct V4 transfer from an
 eligible pre-window root wallet. Both providers must return the exact same transfer log, transaction and pre-window
 root balance. The transaction must originate from that root EOA, call the pinned V4 token directly and encode the

--- a/lib/main-token-migration.ts
+++ b/lib/main-token-migration.ts
@@ -2,8 +2,11 @@ import {
   decodeFunctionData,
   encodeFunctionData,
   getAddress,
+  isHex,
   parseAbi,
+  parseSignature,
   parseUnits,
+  serializeTypedData,
   type Address,
   type Hex,
 } from "viem";
@@ -19,6 +22,10 @@ export const MAIN_TOKEN_MIGRATION_RELEASE_ID =
   "v4-ethereum-to-robinhood-72h-2026-v2" as const;
 export const MAIN_TOKEN_DECIMALS = 18;
 export const MAIN_TOKEN_SYMBOL = "V4";
+export const MAIN_TOKEN_NAME = "Programmable";
+export const MAIN_TOKEN_PERMIT_VERSION = "1";
+export const MAIN_TOKEN_PERMIT_DOMAIN_SEPARATOR =
+  "0xe2ac19a052ba41dccaaa930f489a94353d986c7769e416830273d9362ad26a47" as const;
 export const MAIN_TOKEN_TOTAL_SUPPLY_RAW =
   1_000_000_000_000_000_000_000_000_000n;
 export const MAIN_TOKEN_RUNTIME_CODE_KECCAK256 =
@@ -32,6 +39,23 @@ export const MAIN_TOKEN_MIGRATION_WALLET = getAddress(
 
 const UINT256_MAX = (1n << 256n) - 1n;
 const EIP_7702_DELEGATION_INDICATOR = /^0xef0100[0-9a-f]{40}$/iu;
+const permitTypes = {
+  Permit: [
+    { name: "owner", type: "address" },
+    { name: "spender", type: "address" },
+    { name: "value", type: "uint256" },
+    { name: "nonce", type: "uint256" },
+    { name: "deadline", type: "uint256" },
+  ],
+} as const;
+const permitDomainTypes = {
+  EIP712Domain: [
+    { name: "name", type: "string" },
+    { name: "version", type: "string" },
+    { name: "chainId", type: "uint256" },
+    { name: "verifyingContract", type: "address" },
+  ],
+} as const;
 const erc20TransferAbi = parseAbi([
   "function transfer(address to,uint256 amount) returns (bool)",
 ]);
@@ -48,6 +72,86 @@ export function isMainTokenMigrationWalletCodeEligible(
   // Both representations therefore mean a normal EOA with no runtime code.
   return code === undefined || code === "0x" ||
     EIP_7702_DELEGATION_INDICATOR.test(code);
+}
+
+export function isMainTokenMigrationDelegatedWalletCode(
+  code: Hex | undefined,
+) {
+  return typeof code === "string" &&
+    EIP_7702_DELEGATION_INDICATOR.test(code);
+}
+
+export type MainTokenMigrationPermitSignature = Readonly<{
+  signature: Hex;
+  v: number;
+  r: Hex;
+  s: Hex;
+}>;
+
+export function buildMainTokenMigrationPermitTypedData(input: Readonly<{
+  owner: Address;
+  spender: Address;
+  value: bigint;
+  nonce: bigint;
+  deadline: bigint;
+}>) {
+  if (input.value <= 0n || input.value > UINT256_MAX || input.nonce < 0n ||
+    input.nonce > UINT256_MAX || input.deadline <= 0n ||
+    input.deadline > UINT256_MAX) {
+    throw new Error("The migration permit is outside uint256 bounds");
+  }
+  return {
+    domain: {
+      chainId: MAIN_TOKEN_MIGRATION_CHAIN_ID,
+      name: MAIN_TOKEN_NAME,
+      verifyingContract: MAIN_TOKEN_ADDRESS,
+      version: MAIN_TOKEN_PERMIT_VERSION,
+    },
+    message: {
+      deadline: input.deadline,
+      nonce: input.nonce,
+      owner: getAddress(input.owner),
+      spender: getAddress(input.spender),
+      value: input.value,
+    },
+    primaryType: "Permit" as const,
+    types: permitTypes,
+  };
+}
+
+export function serializeMainTokenMigrationPermitTypedData(
+  typedData: ReturnType<typeof buildMainTokenMigrationPermitTypedData>,
+) {
+  const serialized = serializeTypedData({
+    ...typedData,
+    domain: {
+      ...typedData.domain,
+      chainId: BigInt(typedData.domain.chainId),
+    },
+    types: { ...permitDomainTypes, ...typedData.types },
+  });
+  const payload = JSON.parse(serialized) as {
+    domain: { chainId: number | string };
+  };
+  payload.domain.chainId = MAIN_TOKEN_MIGRATION_CHAIN_ID;
+  return JSON.stringify(payload);
+}
+
+export function parseMainTokenMigrationPermitSignature(
+  signature: Hex,
+): MainTokenMigrationPermitSignature {
+  if (!isHex(signature, { strict: true }) || signature.length !== 132) {
+    throw new Error("The wallet returned an invalid migration permit signature");
+  }
+  const parsed = parseSignature(signature);
+  const v = parsed.v === undefined
+    ? (parsed.yParity ?? -1) + 27
+    : Number(parsed.v);
+  if ((v !== 27 && v !== 28) || parsed.r.length !== 66 ||
+    parsed.s.length !== 66) {
+    throw new Error("The wallet returned an invalid migration permit signature");
+  }
+  return Object.freeze({ signature, v, r: parsed.r, s: parsed.s });
 }
 
 export function parseMainTokenMigrationAmount(value: string): bigint {

--- a/lib/server/main-token-migration-gas-sponsor-store-v1.ts
+++ b/lib/server/main-token-migration-gas-sponsor-store-v1.ts
@@ -15,6 +15,11 @@ import {
   createProductionProjectionTargetPostgresPoolV1,
 } from "./projection-target/website-target";
 import { canonicalSha256 } from "./projection-target/hashing";
+import {
+  MAIN_TOKEN_MIGRATION_GASLESS_PREFIX_V1,
+  mainTokenMigrationGaslessRootGuardIdV1,
+  parseMainTokenMigrationGaslessBudgetReservationV1,
+} from "./main-token-migration-gasless-transfer-store-v1";
 
 const DIGEST = /^sha256:[0-9a-f]{64}$/u;
 const HASH = /^0x[0-9a-f]{64}$/u;
@@ -243,6 +248,10 @@ export function createMainTokenMigrationGasSponsorPostgresStoreV1(
           input.lookup.releaseId,
           eligibility.rootWalletAddress,
         );
+        const gaslessRoot = mainTokenMigrationGaslessRootGuardIdV1(
+          input.lookup.releaseId,
+          eligibility.rootWalletAddress,
+        );
         const rootHolder = holderId({
           releaseId: input.lookup.releaseId,
           walletAddress: eligibility.rootWalletAddress,
@@ -253,6 +262,7 @@ export function createMainTokenMigrationGasSponsorPostgresStoreV1(
           completionId(input.lookup),
           alias,
           eligibilityAlias,
+          gaslessRoot,
         ];
         const existing = await selectRows(client, ids);
         const aliasRow = existing.find((row) => row.credential_id === alias);
@@ -262,6 +272,9 @@ export function createMainTokenMigrationGasSponsorPostgresStoreV1(
         const holderRow = existing.find((row) => row.credential_id === holder);
         const rootHolderRow = existing.find(
           (row) => row.credential_id === rootHolder,
+        );
+        const gaslessRootRow = existing.find(
+          (row) => row.credential_id === gaslessRoot,
         );
         if (aliasRow) {
           const value = parseAlias(aliasRow);
@@ -281,7 +294,7 @@ export function createMainTokenMigrationGasSponsorPostgresStoreV1(
           return Object.freeze({ kind: "existing" as const, record: existingRecord });
         }
         if (rootHolder !== holder && rootHolderRow) throw conflict();
-        if (aliasRow || eligibilityRow) throw conflict();
+        if (aliasRow || eligibilityRow || gaslessRootRow) throw conflict();
         const releaseIntents = await selectReleaseIntents(
           client,
           input.lookup.releaseId,
@@ -290,7 +303,13 @@ export function createMainTokenMigrationGasSponsorPostgresStoreV1(
           ? null
           : createRootGuardIntent(intent, eligibility);
         const reservedWei = releaseIntents.reduce((total, row) => {
-          const existingIntent = parseIntent(row);
+          const existingIntent = row.credential_id.startsWith(
+            `${MAIN_TOKEN_MIGRATION_GASLESS_PREFIX_V1}:holder:`,
+          )
+            ? parseMainTokenMigrationGaslessBudgetReservationV1(
+                row.canonical_use,
+              )
+            : parseIntent(row);
           if (existingIntent.releaseId !== input.lookup.releaseId
             || existingIntent.totalBudgetWei !== intent.totalBudgetWei) {
             throw unavailable();
@@ -505,9 +524,12 @@ async function selectReleaseIntents(
   const result = await client.query<Row>(`
     SELECT credential_id, request_binding_hash, canonical_use
       FROM programmable_website_projection_v1.credential_uses
-     WHERE credential_id LIKE $1
+     WHERE credential_id LIKE $1 OR credential_id LIKE $2
      ORDER BY credential_id
-  `, [`${PREFIX}:holder:${releaseId}:%`]);
+  `, [
+    `${PREFIX}:holder:${releaseId}:%`,
+    `${MAIN_TOKEN_MIGRATION_GASLESS_PREFIX_V1}:holder:${releaseId}:%`,
+  ]);
   return result.rows;
 }
 

--- a/lib/server/main-token-migration-gas-sponsor-v1.ts
+++ b/lib/server/main-token-migration-gas-sponsor-v1.ts
@@ -21,6 +21,8 @@ import {
 import { mainnet } from "viem/chains";
 
 import activationManifest from "@/config/main-token-migration-activation.v1.json";
+import sponsorPolicyContract from
+  "@/config/main-token-migration-gas-sponsor-privy-policy.v2.json";
 import {
   MAIN_TOKEN_ADDRESS,
   MAIN_TOKEN_MIGRATION_CHAIN_ID,
@@ -29,6 +31,7 @@ import {
   MAIN_TOKEN_MIGRATION_WINDOW_SECONDS,
   MAIN_TOKEN_RUNTIME_CODE_KECCAK256,
   MAIN_TOKEN_TOTAL_SUPPLY_RAW,
+  isMainTokenMigrationDelegatedWalletCode,
   isMainTokenMigrationWalletCodeEligible,
 } from "@/lib/main-token-migration";
 import {
@@ -153,6 +156,14 @@ type PrivySponsorWalletAttestationV1 = Readonly<{
   chain_type?: unknown;
   id?: unknown;
   policy_ids?: unknown;
+}>;
+
+type PrivySponsorPolicyAttestationV2 = Readonly<{
+  chain_type?: unknown;
+  name?: unknown;
+  owner_id?: unknown;
+  rules?: unknown;
+  version?: unknown;
 }>;
 
 export class MainTokenMigrationGasSponsorErrorV1 extends Error {
@@ -294,6 +305,78 @@ export function assertMainTokenMigrationPrivySponsorWalletV1(
     throw new MainTokenMigrationGasSponsorErrorV1(
       503,
       "sponsor_wallet_mismatch",
+    );
+  }
+}
+
+export function assertMainTokenMigrationPrivySponsorPolicyV2(
+  policy: PrivySponsorPolicyAttestationV2,
+  configuration: MainTokenMigrationGasSponsorConfigurationV1,
+) {
+  const contract = sponsorPolicyContract as Readonly<{
+    schema: string;
+    name: string;
+    chainType: string;
+    version: string;
+    rules: unknown;
+  }>;
+  if (contract.schema !==
+      "programmable-main-token-migration-gas-sponsor-privy-policy/v2" ||
+    contract.chainType !== "ethereum" || contract.version !== "1.0" ||
+    configuration.sponsorAddress.toLowerCase() !==
+      "0x0060f9e57fccc0611ef44809b257919e78aa99ac" ||
+    canonicalizeJson(contract.rules as never).includes(
+      "0x0060f9e57fccc0611ef44809b257919e78aa99ac",
+    ) ||
+    !canonicalizeJson(contract.rules as never).includes(
+      configuration.sponsorAddress,
+    ) ||
+    !canonicalizeJson(contract.rules as never).includes(MAIN_TOKEN_ADDRESS) ||
+    !canonicalizeJson(contract.rules as never).includes(
+      MAIN_TOKEN_MIGRATION_WALLET,
+    ) ||
+    !canonicalizeJson(contract.rules as never).includes(
+      toHex(MAIN_TOKEN_TOTAL_SUPPLY_RAW),
+    ) ||
+    !canonicalizeJson(contract.rules as never).includes(
+      toHex(configuration.deadlineTimestampExclusive),
+    ) ||
+    !canonicalizeJson(contract.rules as never).includes(
+      toHex(ABSOLUTE_TOP_UP_CAP_WEI),
+    )) {
+    throw new MainTokenMigrationGasSponsorErrorV1(
+      503,
+      "sponsor_policy_contract_invalid",
+    );
+  }
+  if (policy.owner_id !== null || policy.chain_type !== contract.chainType ||
+    policy.name !== contract.name || policy.version !== contract.version ||
+    !Array.isArray(policy.rules)) {
+    throw new MainTokenMigrationGasSponsorErrorV1(
+      503,
+      "sponsor_policy_mismatch",
+    );
+  }
+  const rules = policy.rules.map((candidate) => {
+    if (!candidate || Array.isArray(candidate) || typeof candidate !== "object") {
+      throw new MainTokenMigrationGasSponsorErrorV1(
+        503,
+        "sponsor_policy_mismatch",
+      );
+    }
+    const rule = candidate as Record<string, unknown>;
+    return {
+      name: rule.name,
+      action: rule.action,
+      method: rule.method,
+      conditions: rule.conditions,
+    };
+  });
+  if (canonicalizeJson(rules as never) !==
+    canonicalizeJson(contract.rules as never)) {
+    throw new MainTokenMigrationGasSponsorErrorV1(
+      503,
+      "sponsor_policy_mismatch",
     );
   }
 }
@@ -929,6 +1012,8 @@ function createProductionSender(
     async assertReady() {
       const wallet = await privy.wallets().get(configuration.sponsorWalletId);
       assertMainTokenMigrationPrivySponsorWalletV1(wallet, configuration);
+      const policy = await privy.policies().get(configuration.sponsorPolicyId);
+      assertMainTokenMigrationPrivySponsorPolicyV2(policy, configuration);
     },
     async lookup(intent: MainTokenMigrationGasSponsorIntentV1) {
       assertBroadcastableSponsorIntent(intent);
@@ -1493,7 +1578,13 @@ export function createMainTokenMigrationGasSponsorChainV1(
             "rpc_quorum_unavailable",
           );
         }
-        if (left.walletCode === "0x") {
+        if (isMainTokenMigrationDelegatedWalletCode(left.walletCode)) {
+          throw new MainTokenMigrationGasSponsorErrorV1(
+            422,
+            "gasless_transfer_required",
+          );
+        }
+        if (left.walletCode === undefined || left.walletCode === "0x") {
           return MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1;
         }
         const estimates = await Promise.all(clients.map((client) =>

--- a/lib/server/main-token-migration-gasless-transfer-store-v1.ts
+++ b/lib/server/main-token-migration-gasless-transfer-store-v1.ts
@@ -1,0 +1,613 @@
+import "server-only";
+
+import { getAddress, isAddress, type Address, type Hex } from "viem";
+
+import { MAIN_TOKEN_TOTAL_SUPPLY_RAW } from "@/lib/main-token-migration";
+import {
+  canonicalizeJson,
+  parseStrictJson,
+  type JsonValue,
+} from "./projection-target/canonical-json";
+import type {
+  ProjectionTargetPostgresClientV1,
+  ProjectionTargetPostgresPoolV1,
+} from "./projection-target/postgres-store";
+import {
+  createProductionProjectionTargetPostgresPoolV1,
+} from "./projection-target/website-target";
+
+export const MAIN_TOKEN_MIGRATION_GASLESS_PREFIX_V1 =
+  "main-token-migration-gasless-transfer:v1";
+const PREFIX = MAIN_TOKEN_MIGRATION_GASLESS_PREFIX_V1;
+const SHARED_BUDGET_PREFIX = "main-token-migration-gas-sponsor:v1";
+const DIGEST = /^sha256:[0-9a-f]{64}$/u;
+const HASH = /^0x[0-9a-f]{64}$/u;
+const SIGNATURE = /^0x[0-9a-f]{130}$/u;
+const DECIMAL = /^(?:0|[1-9][0-9]*)$/u;
+const POSITIVE_DECIMAL = /^[1-9][0-9]*$/u;
+const SAFE_RELEASE_ID = /^[a-z0-9][a-z0-9.-]{0,127}$/u;
+const SAFE_REFERENCE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u;
+
+type Row = Readonly<{
+  credential_id: string;
+  request_binding_hash: string;
+  canonical_use: string;
+}> & Record<string, unknown>;
+
+type AttestedPool = ProjectionTargetPostgresPoolV1 & Readonly<{
+  assertProductionReadiness(): Promise<void>;
+}>;
+
+export type MainTokenMigrationGaslessIntentV1 = Readonly<{
+  schema: "programmable-main-token-migration-gasless-intent/v1";
+  releaseId: string;
+  walletAddress: Address;
+  rootWalletAddress: Address;
+  sponsorAddress: Address;
+  amountRaw: string;
+  nonce: string;
+  permitDeadline: string;
+  permitSignature: Hex;
+  permitGasLimit: string;
+  transferGasLimit: string;
+  maxFeePerGasWei: string;
+  maxPriorityFeePerGasWei: string;
+  reservedTotalWei: string;
+  totalBudgetWei: string;
+  requestBindingHash: `sha256:${string}`;
+  providerPermitIdempotencyKey: string;
+  providerPermitReferenceId: string;
+  providerTransferIdempotencyKey: string;
+  providerTransferReferenceId: string;
+  reservedAt: string;
+}>;
+
+export type MainTokenMigrationGaslessRecordV1 = Readonly<{
+  intent: MainTokenMigrationGaslessIntentV1;
+  permitTransactionHash: Hex | null;
+  transferTransactionHash: Hex | null;
+}>;
+
+type CompletionKind = "permit" | "transfer";
+type CompletionV1 = Readonly<{
+  schema: "programmable-main-token-migration-gasless-completion/v1";
+  kind: CompletionKind;
+  providerReferenceId: string;
+  transactionHash: Hex;
+}>;
+
+type AliasV1 = Readonly<{
+  schema: "programmable-main-token-migration-gasless-idempotency/v1";
+  holderCredentialId: string;
+  requestBindingHash: `sha256:${string}`;
+}>;
+
+type RootGuardV1 = Readonly<{
+  schema: "programmable-main-token-migration-gasless-root-guard/v1";
+  holderCredentialId: string;
+  rootWalletAddress: Address;
+  walletAddress: Address;
+  requestBindingHash: `sha256:${string}`;
+}>;
+
+type Lookup = Readonly<{ releaseId: string; walletAddress: Address }>;
+type ReserveInput = Readonly<{
+  lookup: Lookup;
+  idempotencyBindingHash: `sha256:${string}`;
+  intent: MainTokenMigrationGaslessIntentV1;
+}>;
+type CompleteInput = Readonly<{
+  lookup: Lookup;
+  kind: CompletionKind;
+  providerReferenceId: string;
+  transactionHash: Hex;
+}>;
+
+export interface MainTokenMigrationGaslessStoreV1 {
+  get(input: Lookup): Promise<MainTokenMigrationGaslessRecordV1 | null>;
+  reserve(input: Readonly<{
+    lookup: Lookup;
+    idempotencyBindingHash: `sha256:${string}`;
+    intent: MainTokenMigrationGaslessIntentV1;
+  }>): Promise<Readonly<{
+    kind: "created" | "existing";
+    record: MainTokenMigrationGaslessRecordV1;
+  }>>;
+  complete(input: Readonly<{
+    lookup: Lookup;
+    kind: CompletionKind;
+    providerReferenceId: string;
+    transactionHash: Hex;
+  }>): Promise<MainTokenMigrationGaslessRecordV1>;
+}
+
+export class MainTokenMigrationGaslessStoreErrorV1 extends Error {
+  constructor(readonly code: "budget_exhausted" | "conflict" | "unavailable") {
+    super("Main token migration gasless transfer store failed closed");
+    this.name = "MainTokenMigrationGaslessStoreErrorV1";
+  }
+}
+
+export function parseMainTokenMigrationGaslessBudgetReservationV1(
+  source: string,
+) {
+  const intent = parseIntentValue(parseCanonical(source));
+  return Object.freeze({
+    releaseId: intent.releaseId,
+    reservedTotalWei: intent.reservedTotalWei,
+    totalBudgetWei: intent.totalBudgetWei,
+  });
+}
+
+export function mainTokenMigrationGaslessRootGuardIdV1(
+  releaseId: string,
+  rootWalletAddress: Address,
+) {
+  if (!SAFE_RELEASE_ID.test(releaseId) ||
+    !isAddress(rootWalletAddress, { strict: true })) {
+    throw new TypeError("Gasless migration root guard is invalid");
+  }
+  return rootId(releaseId, getAddress(rootWalletAddress));
+}
+
+export function createMainTokenMigrationGaslessPostgresStoreV1(
+  pool: AttestedPool,
+): MainTokenMigrationGaslessStoreV1 {
+  if (!pool || typeof pool.connect !== "function" ||
+    typeof pool.assertProductionReadiness !== "function") {
+    throw new TypeError("Gasless migration PostgreSQL pool is invalid");
+  }
+  return Object.freeze({
+    async get(input: Lookup) {
+      validateLookup(input);
+      await pool.assertProductionReadiness();
+      const result = await pool.query<Row>(`
+        SELECT credential_id, request_binding_hash, canonical_use
+          FROM programmable_website_projection_v1.credential_uses
+         WHERE credential_id = ANY($1::text[])
+         ORDER BY credential_id
+      `, [[holderId(input), completionId(input, "permit"),
+        completionId(input, "transfer")]]);
+      return recordFromRows(result.rows, input);
+    },
+
+    async reserve(input: ReserveInput) {
+      validateLookup(input.lookup);
+      if (!DIGEST.test(input.idempotencyBindingHash)) {
+        throw new TypeError("Gasless migration idempotency binding is invalid");
+      }
+      const intent = validateIntent(input.intent, input.lookup);
+      await pool.assertProductionReadiness();
+      return transaction(pool, input.lookup.releaseId, async (client) => {
+        const holder = holderId(input.lookup);
+        const alias = aliasId(input.lookup.releaseId, input.idempotencyBindingHash);
+        const root = rootId(input.lookup.releaseId, intent.rootWalletAddress);
+        const existing = await selectRows(client, [
+          holder,
+          alias,
+          root,
+          completionId(input.lookup, "permit"),
+          completionId(input.lookup, "transfer"),
+        ]);
+        const existingRecord = recordFromRows(existing, input.lookup);
+        const aliasRow = existing.find((row) => row.credential_id === alias);
+        const rootRow = existing.find((row) => row.credential_id === root);
+        if (existingRecord) {
+          if (existingRecord.intent.requestBindingHash !==
+            intent.requestBindingHash || !aliasRow || !rootRow) throw conflict();
+          const parsedAlias = parseAlias(aliasRow);
+          const parsedRoot = parseRootGuard(rootRow);
+          if (parsedAlias.holderCredentialId !== holder ||
+            parsedRoot.holderCredentialId !== holder) throw conflict();
+          return Object.freeze({
+            kind: "existing" as const,
+            record: existingRecord,
+          });
+        }
+        if (aliasRow || rootRow) throw conflict();
+        const reserved = await readSharedReservedBudget(client, input.lookup.releaseId);
+        if (reserved + BigInt(intent.reservedTotalWei) >
+          BigInt(intent.totalBudgetWei)) throw budgetExhausted();
+        await insertRow(client, holder, intent.requestBindingHash, intent);
+        await insertRow(client, alias, intent.requestBindingHash, {
+          schema: "programmable-main-token-migration-gasless-idempotency/v1",
+          holderCredentialId: holder,
+          requestBindingHash: intent.requestBindingHash,
+        } satisfies AliasV1);
+        await insertRow(client, root, intent.requestBindingHash, {
+          schema: "programmable-main-token-migration-gasless-root-guard/v1",
+          holderCredentialId: holder,
+          rootWalletAddress: intent.rootWalletAddress,
+          walletAddress: intent.walletAddress,
+          requestBindingHash: intent.requestBindingHash,
+        } satisfies RootGuardV1);
+        return Object.freeze({
+          kind: "created" as const,
+          record: Object.freeze({
+            intent,
+            permitTransactionHash: null,
+            transferTransactionHash: null,
+          }),
+        });
+      });
+    },
+
+    async complete(input: CompleteInput) {
+      validateLookup(input.lookup);
+      if ((input.kind !== "permit" && input.kind !== "transfer") ||
+        !SAFE_REFERENCE_ID.test(input.providerReferenceId) ||
+        !HASH.test(input.transactionHash)) {
+        throw new TypeError("Gasless migration completion is invalid");
+      }
+      await pool.assertProductionReadiness();
+      return transaction(pool, input.lookup.releaseId, async (client) => {
+        const rows = await selectRows(client, [
+          holderId(input.lookup),
+          completionId(input.lookup, "permit"),
+          completionId(input.lookup, "transfer"),
+        ]);
+        const record = recordFromRows(rows, input.lookup);
+        if (!record) throw unavailable();
+        const expectedReference = input.kind === "permit"
+          ? record.intent.providerPermitReferenceId
+          : record.intent.providerTransferReferenceId;
+        if (expectedReference !== input.providerReferenceId ||
+          (input.kind === "transfer" && !record.permitTransactionHash)) {
+          throw unavailable();
+        }
+        const currentHash = input.kind === "permit"
+          ? record.permitTransactionHash
+          : record.transferTransactionHash;
+        if (currentHash) {
+          if (currentHash !== input.transactionHash) throw conflict();
+          return record;
+        }
+        const completion: CompletionV1 = {
+          schema: "programmable-main-token-migration-gasless-completion/v1",
+          kind: input.kind,
+          providerReferenceId: input.providerReferenceId,
+          transactionHash: input.transactionHash,
+        };
+        await insertRow(
+          client,
+          completionId(input.lookup, input.kind),
+          record.intent.requestBindingHash,
+          completion,
+        );
+        return Object.freeze({
+          intent: record.intent,
+          permitTransactionHash: input.kind === "permit"
+            ? input.transactionHash
+            : record.permitTransactionHash,
+          transferTransactionHash: input.kind === "transfer"
+            ? input.transactionHash
+            : record.transferTransactionHash,
+        });
+      });
+    },
+  });
+}
+
+async function transaction<T>(
+  pool: AttestedPool,
+  releaseId: string,
+  work: (client: ProjectionTargetPostgresClientV1) => Promise<T>,
+) {
+  const client = await pool.connect();
+  let open = false;
+  try {
+    await client.query("BEGIN");
+    open = true;
+    await client.query(
+      "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+      [`${SHARED_BUDGET_PREFIX}:lock:${releaseId}`],
+    );
+    const result = await work(client);
+    await client.query("COMMIT");
+    open = false;
+    return result;
+  } catch (error) {
+    if (open) await client.query("ROLLBACK").catch(() => undefined);
+    if (error instanceof MainTokenMigrationGaslessStoreErrorV1) throw error;
+    throw unavailable();
+  } finally {
+    client.release();
+  }
+}
+
+async function readSharedReservedBudget(
+  client: ProjectionTargetPostgresClientV1,
+  releaseId: string,
+) {
+  const result = await client.query<{ reserved_wei: string }>(`
+    SELECT coalesce(sum(
+      (canonical_use::jsonb ->> 'reservedTotalWei')::numeric
+    ), 0)::text AS reserved_wei
+      FROM programmable_website_projection_v1.credential_uses
+     WHERE credential_id LIKE $1 OR credential_id LIKE $2
+  `, [
+    `${SHARED_BUDGET_PREFIX}:holder:${releaseId}:%`,
+    `${PREFIX}:holder:${releaseId}:%`,
+  ]);
+  const row = result.rows[0];
+  if (result.rows.length !== 1 || !row || !DECIMAL.test(row.reserved_wei)) {
+    throw unavailable();
+  }
+  return BigInt(row.reserved_wei);
+}
+
+async function selectRows(
+  client: ProjectionTargetPostgresClientV1,
+  ids: string[],
+) {
+  const result = await client.query<Row>(`
+    SELECT credential_id, request_binding_hash, canonical_use
+      FROM programmable_website_projection_v1.credential_uses
+     WHERE credential_id = ANY($1::text[])
+     ORDER BY credential_id
+  `, [ids]);
+  return result.rows;
+}
+
+async function insertRow(
+  client: ProjectionTargetPostgresClientV1,
+  credentialId: string,
+  requestBindingHash: string,
+  value: JsonValue,
+) {
+  const result = await client.query<Row>(`
+    INSERT INTO programmable_website_projection_v1.credential_uses
+      (credential_id, request_binding_hash, canonical_use)
+    VALUES ($1, $2, $3)
+    ON CONFLICT DO NOTHING
+    RETURNING credential_id, request_binding_hash, canonical_use
+  `, [credentialId, requestBindingHash, canonicalizeJson(value)]);
+  if (result.rowCount !== 1) throw conflict();
+}
+
+function recordFromRows(rows: readonly Row[], lookup: Lookup) {
+  const holder = rows.find((row) => row.credential_id === holderId(lookup));
+  if (!holder) return null;
+  const intent = parseIntent(holder);
+  if (intent.releaseId !== lookup.releaseId ||
+    intent.walletAddress.toLowerCase() !== lookup.walletAddress.toLowerCase() ||
+    holder.request_binding_hash !== intent.requestBindingHash) throw unavailable();
+  const permit = completionFromRows(rows, lookup, "permit", intent);
+  const transfer = completionFromRows(rows, lookup, "transfer", intent);
+  if (transfer && !permit) throw unavailable();
+  return Object.freeze({
+    intent,
+    permitTransactionHash: permit?.transactionHash ?? null,
+    transferTransactionHash: transfer?.transactionHash ?? null,
+  });
+}
+
+function completionFromRows(
+  rows: readonly Row[],
+  lookup: Lookup,
+  kind: CompletionKind,
+  intent: MainTokenMigrationGaslessIntentV1,
+) {
+  const row = rows.find((candidate) =>
+    candidate.credential_id === completionId(lookup, kind));
+  if (!row) return null;
+  const completion = parseCompletion(row);
+  const reference = kind === "permit"
+    ? intent.providerPermitReferenceId
+    : intent.providerTransferReferenceId;
+  if (completion.kind !== kind || completion.providerReferenceId !== reference ||
+    row.request_binding_hash !== intent.requestBindingHash) throw unavailable();
+  return completion;
+}
+
+function validateIntent(value: MainTokenMigrationGaslessIntentV1, lookup: Lookup) {
+  const parsed = parseIntentValue(parseCanonical(canonicalizeJson(value)));
+  if (parsed.releaseId !== lookup.releaseId ||
+    parsed.walletAddress.toLowerCase() !== lookup.walletAddress.toLowerCase()) {
+    throw new TypeError("Gasless migration intent lookup is invalid");
+  }
+  return parsed;
+}
+
+function parseIntent(row: Row) {
+  return parseIntentValue(parseCanonical(row.canonical_use));
+}
+
+function parseIntentValue(input: JsonValue): MainTokenMigrationGaslessIntentV1 {
+  const value = object(input);
+  exactKeys(value, [
+    "amountRaw", "maxFeePerGasWei", "maxPriorityFeePerGasWei", "nonce",
+    "permitDeadline", "permitGasLimit", "permitSignature",
+    "providerPermitIdempotencyKey", "providerPermitReferenceId",
+    "providerTransferIdempotencyKey", "providerTransferReferenceId",
+    "releaseId", "requestBindingHash", "reservedAt", "reservedTotalWei",
+    "rootWalletAddress", "schema", "sponsorAddress", "totalBudgetWei",
+    "transferGasLimit", "walletAddress",
+  ]);
+  if (value.schema !== "programmable-main-token-migration-gasless-intent/v1" ||
+    typeof value.releaseId !== "string" || !SAFE_RELEASE_ID.test(value.releaseId) ||
+    typeof value.walletAddress !== "string" ||
+    !isAddress(value.walletAddress, { strict: true }) ||
+    typeof value.rootWalletAddress !== "string" ||
+    !isAddress(value.rootWalletAddress, { strict: true }) ||
+    typeof value.sponsorAddress !== "string" ||
+    !isAddress(value.sponsorAddress, { strict: true }) ||
+    typeof value.permitSignature !== "string" || !SIGNATURE.test(value.permitSignature) ||
+    !positiveDecimal(value.amountRaw) || !decimal(value.nonce) ||
+    !positiveDecimal(value.permitDeadline) || !positiveDecimal(value.permitGasLimit) ||
+    !positiveDecimal(value.transferGasLimit) || !positiveDecimal(value.maxFeePerGasWei) ||
+    !decimal(value.maxPriorityFeePerGasWei) || !positiveDecimal(value.reservedTotalWei) ||
+    !positiveDecimal(value.totalBudgetWei) ||
+    typeof value.requestBindingHash !== "string" || !DIGEST.test(value.requestBindingHash) ||
+    !reference(value.providerPermitIdempotencyKey) ||
+    !reference(value.providerPermitReferenceId) ||
+    !reference(value.providerTransferIdempotencyKey) ||
+    !reference(value.providerTransferReferenceId) ||
+    typeof value.reservedAt !== "string" ||
+    new Date(value.reservedAt).toISOString() !== value.reservedAt) throw unavailable();
+  const amountRaw = BigInt(value.amountRaw);
+  const maxFee = BigInt(value.maxFeePerGasWei);
+  const priority = BigInt(value.maxPriorityFeePerGasWei);
+  const expectedReservation = (BigInt(value.permitGasLimit) +
+    BigInt(value.transferGasLimit)) * maxFee;
+  if (amountRaw > MAIN_TOKEN_TOTAL_SUPPLY_RAW || priority > maxFee ||
+    expectedReservation !== BigInt(value.reservedTotalWei) ||
+    expectedReservation > BigInt(value.totalBudgetWei)) throw unavailable();
+  return Object.freeze({
+    schema: value.schema,
+    releaseId: value.releaseId,
+    walletAddress: getAddress(value.walletAddress),
+    rootWalletAddress: getAddress(value.rootWalletAddress),
+    sponsorAddress: getAddress(value.sponsorAddress),
+    amountRaw: value.amountRaw,
+    nonce: value.nonce,
+    permitDeadline: value.permitDeadline,
+    permitSignature: value.permitSignature as Hex,
+    permitGasLimit: value.permitGasLimit,
+    transferGasLimit: value.transferGasLimit,
+    maxFeePerGasWei: value.maxFeePerGasWei,
+    maxPriorityFeePerGasWei: value.maxPriorityFeePerGasWei,
+    reservedTotalWei: value.reservedTotalWei,
+    totalBudgetWei: value.totalBudgetWei,
+    requestBindingHash: value.requestBindingHash as `sha256:${string}`,
+    providerPermitIdempotencyKey: value.providerPermitIdempotencyKey,
+    providerPermitReferenceId: value.providerPermitReferenceId,
+    providerTransferIdempotencyKey: value.providerTransferIdempotencyKey,
+    providerTransferReferenceId: value.providerTransferReferenceId,
+    reservedAt: value.reservedAt,
+  });
+}
+
+function parseCompletion(row: Row): CompletionV1 {
+  const value = object(parseCanonical(row.canonical_use));
+  exactKeys(value, ["kind", "providerReferenceId", "schema", "transactionHash"]);
+  if (value.schema !== "programmable-main-token-migration-gasless-completion/v1" ||
+    (value.kind !== "permit" && value.kind !== "transfer") ||
+    !reference(value.providerReferenceId) ||
+    typeof value.transactionHash !== "string" || !HASH.test(value.transactionHash)) {
+    throw unavailable();
+  }
+  return Object.freeze({
+    schema: value.schema,
+    kind: value.kind,
+    providerReferenceId: value.providerReferenceId,
+    transactionHash: value.transactionHash as Hex,
+  });
+}
+
+function parseAlias(row: Row): AliasV1 {
+  const value = object(parseCanonical(row.canonical_use));
+  exactKeys(value, ["holderCredentialId", "requestBindingHash", "schema"]);
+  if (value.schema !== "programmable-main-token-migration-gasless-idempotency/v1" ||
+    typeof value.holderCredentialId !== "string" ||
+    typeof value.requestBindingHash !== "string" ||
+    !DIGEST.test(value.requestBindingHash) ||
+    row.request_binding_hash !== value.requestBindingHash) throw unavailable();
+  return value as AliasV1;
+}
+
+function parseRootGuard(row: Row): RootGuardV1 {
+  const value = object(parseCanonical(row.canonical_use));
+  exactKeys(value, ["holderCredentialId", "requestBindingHash",
+    "rootWalletAddress", "schema", "walletAddress"]);
+  if (value.schema !== "programmable-main-token-migration-gasless-root-guard/v1" ||
+    typeof value.holderCredentialId !== "string" ||
+    typeof value.requestBindingHash !== "string" ||
+    !DIGEST.test(value.requestBindingHash) ||
+    typeof value.rootWalletAddress !== "string" ||
+    !isAddress(value.rootWalletAddress, { strict: true }) ||
+    typeof value.walletAddress !== "string" ||
+    !isAddress(value.walletAddress, { strict: true }) ||
+    row.request_binding_hash !== value.requestBindingHash) throw unavailable();
+  return Object.freeze({
+    schema: value.schema,
+    holderCredentialId: value.holderCredentialId,
+    requestBindingHash: value.requestBindingHash as `sha256:${string}`,
+    rootWalletAddress: getAddress(value.rootWalletAddress),
+    walletAddress: getAddress(value.walletAddress),
+  });
+}
+
+function parseCanonical(source: string) {
+  const value = parseStrictJson(source, { maximumBytes: 24_576, maximumDepth: 8 });
+  if (canonicalizeJson(value) !== source) throw unavailable();
+  return value;
+}
+
+function object(value: JsonValue): Readonly<Record<string, JsonValue>> {
+  if (!value || Array.isArray(value) || typeof value !== "object") throw unavailable();
+  return value;
+}
+
+function exactKeys(value: Readonly<Record<string, JsonValue>>, keys: string[]) {
+  if (Object.keys(value).sort().join("\0") !== [...keys].sort().join("\0")) {
+    throw unavailable();
+  }
+}
+
+function positiveDecimal(value: JsonValue): value is string {
+  return typeof value === "string" && POSITIVE_DECIMAL.test(value);
+}
+
+function decimal(value: JsonValue): value is string {
+  return typeof value === "string" && DECIMAL.test(value);
+}
+
+function reference(value: JsonValue): value is string {
+  return typeof value === "string" && SAFE_REFERENCE_ID.test(value);
+}
+
+function validateLookup(input: Lookup) {
+  if (!SAFE_RELEASE_ID.test(input.releaseId) ||
+    !isAddress(input.walletAddress, { strict: true })) {
+    throw new TypeError("Gasless migration lookup is invalid");
+  }
+}
+
+function holderId(input: Lookup) {
+  return `${PREFIX}:holder:${input.releaseId}:${input.walletAddress.toLowerCase()}`;
+}
+
+function completionId(input: Lookup, kind: CompletionKind) {
+  return `${PREFIX}:${kind}:${input.releaseId}:${input.walletAddress.toLowerCase()}`;
+}
+
+function aliasId(releaseId: string, binding: string) {
+  return `${PREFIX}:idempotency:${releaseId}:${binding.slice("sha256:".length)}`;
+}
+
+function rootId(releaseId: string, rootWalletAddress: Address) {
+  return `${PREFIX}:root:${releaseId}:${rootWalletAddress.toLowerCase()}`;
+}
+
+function conflict() {
+  return new MainTokenMigrationGaslessStoreErrorV1("conflict");
+}
+
+function budgetExhausted() {
+  return new MainTokenMigrationGaslessStoreErrorV1("budget_exhausted");
+}
+
+function unavailable() {
+  return new MainTokenMigrationGaslessStoreErrorV1("unavailable");
+}
+
+let productionStore: MainTokenMigrationGaslessStoreV1 | null = null;
+
+export function getProductionMainTokenMigrationGaslessStoreV1() {
+  if (productionStore) return productionStore;
+  const pool = createProductionProjectionTargetPostgresPoolV1(
+    requiredEnv("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL"),
+    requiredEnv("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM")
+      .replaceAll("\\n", "\n"),
+    requiredEnv("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE"),
+  );
+  productionStore = createMainTokenMigrationGaslessPostgresStoreV1(pool);
+  return productionStore;
+}
+
+function requiredEnv(name: string) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new TypeError(`${name} is not configured`);
+  return value;
+}

--- a/lib/server/main-token-migration-gasless-transfer-v1.ts
+++ b/lib/server/main-token-migration-gasless-transfer-v1.ts
@@ -1,0 +1,981 @@
+import "server-only";
+
+import { randomUUID } from "node:crypto";
+
+import { PrivyClient } from "@privy-io/node";
+import {
+  createPublicClient,
+  encodeFunctionData,
+  getAddress,
+  http,
+  isAddress,
+  parseAbi,
+  recoverTypedDataAddress,
+  toHex,
+  type Address,
+  type Hex,
+  type PublicClient,
+} from "viem";
+import { mainnet } from "viem/chains";
+
+import activationManifest from "@/config/main-token-migration-activation.v1.json";
+import {
+  buildMainTokenMigrationPermitTypedData,
+  isMainTokenMigrationDelegatedWalletCode,
+  MAIN_TOKEN_ADDRESS,
+  MAIN_TOKEN_MIGRATION_CHAIN_ID,
+  MAIN_TOKEN_MIGRATION_WALLET,
+  MAIN_TOKEN_PERMIT_DOMAIN_SEPARATOR,
+  MAIN_TOKEN_TOTAL_SUPPLY_RAW,
+  parseMainTokenMigrationPermitSignature,
+} from "@/lib/main-token-migration";
+import { tradeActionRpcProviders } from "./action-rpc-quorum.server";
+import {
+  createPrivyWalletPrincipalAuthenticatorV1,
+  WalletPrincipalAuthenticationErrorV1,
+  type WalletPrincipalAuthenticatorV1,
+} from "./creator-article/wallet-principal.server";
+import {
+  assertMainTokenMigrationPrivySponsorWalletV1,
+  assertMainTokenMigrationPrivySponsorPolicyV2,
+  createMainTokenMigrationGasSponsorChainV1,
+  deriveMainTokenMigrationSponsorBindingsV1,
+  deriveMainTokenMigrationSponsorPrincipalBindingV1,
+  parsePrivySponsorTransactionLookupV1,
+  readMainTokenMigrationGasSponsorConfigurationV1,
+  type MainTokenMigrationGasSponsorConfigurationV1,
+} from "./main-token-migration-gas-sponsor-v1";
+import {
+  getProductionMainTokenMigrationGasSponsorStoreV1,
+  MainTokenMigrationGasSponsorStoreErrorV1,
+  type MainTokenMigrationGasSponsorStoreV1,
+} from "./main-token-migration-gas-sponsor-store-v1";
+import {
+  getProductionMainTokenMigrationGaslessStoreV1,
+  MainTokenMigrationGaslessStoreErrorV1,
+  type MainTokenMigrationGaslessIntentV1,
+  type MainTokenMigrationGaslessRecordV1,
+  type MainTokenMigrationGaslessStoreV1,
+} from "./main-token-migration-gasless-transfer-store-v1";
+import {
+  canonicalizeJson,
+  parseStrictJson,
+} from "./projection-target/canonical-json";
+import { canonicalSha256 } from "./projection-target/hashing";
+
+const TOKEN_ABI = parseAbi([
+  "function name() view returns (string)",
+  "function DOMAIN_SEPARATOR() view returns (bytes32)",
+  "function nonces(address owner) view returns (uint256)",
+  "function allowance(address owner,address spender) view returns (uint256)",
+  "function permit(address owner,address spender,uint256 value,uint256 deadline,uint8 v,bytes32 r,bytes32 s)",
+  "function transferFrom(address from,address to,uint256 amount) returns (bool)",
+]);
+const IDEMPOTENCY_KEY = /^[A-Za-z0-9][A-Za-z0-9._~-]{15,127}$/u;
+const DECIMAL = /^[1-9][0-9]{0,77}$/u;
+const ZERO_DECIMAL = /^(?:0|[1-9][0-9]{0,77})$/u;
+const HASH = /^0x[0-9a-f]{64}$/u;
+const SIGNATURE = /^0x[0-9a-fA-F]{130}$/u;
+const DIGEST = /^sha256:[0-9a-f]{64}$/u;
+const MAXIMUM_BODY_BYTES = 8_192;
+const MAXIMUM_PROVIDER_RESPONSE_BYTES = 32_768;
+const PROVIDER_IDEMPOTENCY_WINDOW_MS = 24 * 60 * 60 * 1_000;
+const PROVIDER_IDEMPOTENCY_SAFETY_MS = 5 * 60 * 1_000;
+const PERMIT_VALIDITY_SECONDS = 20 * 60;
+const DEADLINE_SAFETY_SECONDS = 5 * 60;
+const GAS_MULTIPLIER_BPS = 12_500n;
+const BPS = 10_000n;
+const PERMIT_GAS_LIMIT = 100_000n;
+const TRANSFER_GAS_LIMIT = 100_000n;
+const MAXIMUM_FEE_PER_GAS_WEI = 20_000_000_000n;
+
+type Environment = Readonly<Record<string, string | undefined>>;
+type ProviderStatus = Readonly<{
+  status: string;
+  transactionHash: Hex | null;
+}>;
+type TransactionKind = "permit" | "transfer";
+
+type PrepareRequest = Readonly<{
+  action: "prepare";
+  walletAddress: Address;
+  amountRaw: bigint;
+}>;
+type SubmitRequest = Readonly<{
+  action: "submit";
+  walletAddress: Address;
+  amountRaw: bigint;
+  nonce: bigint;
+  permitDeadline: bigint;
+  permitSignature: Hex;
+  requestBindingHash: `sha256:${string}`;
+}>;
+
+export class MainTokenMigrationGaslessErrorV1 extends Error {
+  constructor(
+    readonly status: 400 | 401 | 403 | 409 | 413 | 422 | 429 | 503,
+    readonly code: string,
+    readonly retryAfterSeconds?: number,
+  ) {
+    super("Main token migration gasless transfer failed closed");
+    this.name = "MainTokenMigrationGaslessErrorV1";
+  }
+}
+
+export function deriveMainTokenMigrationGaslessBindingV1(input: Readonly<{
+  baseRequestBindingHash: `sha256:${string}`;
+  nonce: bigint;
+  permitDeadline: bigint;
+}>) {
+  return canonicalSha256("programmable.main-token-migration.gasless.v1", {
+    baseRequestBindingHash: input.baseRequestBindingHash,
+    nonce: input.nonce.toString(),
+    permitDeadline: input.permitDeadline.toString(),
+  });
+}
+
+export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
+  configuration: MainTokenMigrationGasSponsorConfigurationV1;
+  authenticator: WalletPrincipalAuthenticatorV1;
+  admissionStore: MainTokenMigrationGasSponsorStoreV1;
+  store: MainTokenMigrationGaslessStoreV1;
+  chain: ReturnType<typeof createMainTokenMigrationGaslessChainV1>;
+  sender: ReturnType<typeof createMainTokenMigrationGaslessSenderV1>;
+  now?: () => Date;
+}>) {
+  const now = input.now ?? (() => new Date());
+  return Object.freeze({
+    async post(request: Request) {
+      try {
+        assertWindowOpen(input.configuration, now());
+        requireSameOrigin(request);
+        const principal = await input.authenticator.authenticate(request);
+        const parsed = parseRequest(await boundedJson(request));
+        assertLinkedWallet(principal.wallets, parsed.walletAddress);
+        const idempotencyKey = request.headers.get("idempotency-key") ?? "";
+        if (!IDEMPOTENCY_KEY.test(idempotencyKey)) {
+          throw new MainTokenMigrationGaslessErrorV1(
+            400,
+            "idempotency_key_invalid",
+          );
+        }
+        const baseBindings = deriveMainTokenMigrationSponsorBindingsV1({
+          releaseId: input.configuration.releaseId,
+          walletAddress: parsed.walletAddress,
+          amountRaw: parsed.amountRaw,
+          idempotencyKey,
+        });
+        await input.admissionStore.admit({
+          releaseId: input.configuration.releaseId,
+          principalBindingHash:
+            deriveMainTokenMigrationSponsorPrincipalBindingV1(
+              principal.privyUserId,
+            ),
+          walletAddress: parsed.walletAddress,
+          operation: parsed.action === "prepare" ? "read" : "submit",
+        });
+        const lookup = {
+          releaseId: input.configuration.releaseId,
+          walletAddress: parsed.walletAddress,
+        };
+        const existing = await input.store.get(lookup);
+        if (parsed.action === "prepare") {
+          if (existing) {
+            const binding = deriveMainTokenMigrationGaslessBindingV1({
+              baseRequestBindingHash: baseBindings.requestBindingHash,
+              nonce: BigInt(existing.intent.nonce),
+              permitDeadline: BigInt(existing.intent.permitDeadline),
+            });
+            if (binding !== existing.intent.requestBindingHash ||
+              existing.intent.amountRaw !== parsed.amountRaw.toString()) {
+              throw new MainTokenMigrationGaslessErrorV1(
+                409,
+                "idempotency_conflict",
+              );
+            }
+            return prepareResponse(existing.intent);
+          }
+          const observation = await input.chain.prepare({
+            configuration: input.configuration,
+            walletAddress: parsed.walletAddress,
+            amountRaw: parsed.amountRaw,
+          });
+          const permitDeadline = BigInt(Math.min(
+            Math.floor(now().getTime() / 1_000) + PERMIT_VALIDITY_SECONDS,
+            input.configuration.deadlineTimestampExclusive -
+              DEADLINE_SAFETY_SECONDS,
+          ));
+          const binding = deriveMainTokenMigrationGaslessBindingV1({
+            baseRequestBindingHash: baseBindings.requestBindingHash,
+            nonce: observation.nonce,
+            permitDeadline,
+          });
+          return json({
+            schema: "programmable-main-token-migration-gasless-transfer/v1",
+            status: "signature_required",
+            walletAddress: parsed.walletAddress,
+            amountRaw: parsed.amountRaw.toString(),
+            sponsorAddress: input.configuration.sponsorAddress,
+            nonce: observation.nonce.toString(),
+            permitDeadline: permitDeadline.toString(),
+            requestBindingHash: binding,
+            permitTransactionHash: null,
+            transferTransactionHash: null,
+            transferBlockNumber: null,
+          }, 200);
+        }
+
+        const expectedBinding = deriveMainTokenMigrationGaslessBindingV1({
+          baseRequestBindingHash: baseBindings.requestBindingHash,
+          nonce: parsed.nonce,
+          permitDeadline: parsed.permitDeadline,
+        });
+        if (parsed.requestBindingHash !== expectedBinding) {
+          throw new MainTokenMigrationGaslessErrorV1(409, "idempotency_conflict");
+        }
+        const permit = parseMainTokenMigrationPermitSignature(
+          parsed.permitSignature,
+        );
+        const recovered = await recoverTypedDataAddress({
+          ...buildMainTokenMigrationPermitTypedData({
+            owner: parsed.walletAddress,
+            spender: input.configuration.sponsorAddress,
+            value: parsed.amountRaw,
+            nonce: parsed.nonce,
+            deadline: parsed.permitDeadline,
+          }),
+          signature: permit.signature,
+        });
+        if (recovered.toLowerCase() !== parsed.walletAddress.toLowerCase()) {
+          throw new MainTokenMigrationGaslessErrorV1(422, "signature_invalid");
+        }
+
+        let record = existing;
+        if (!record) {
+          const nowSeconds = Math.floor(now().getTime() / 1_000);
+          if (parsed.permitDeadline <= BigInt(nowSeconds + 30) ||
+            parsed.permitDeadline > BigInt(
+              Math.min(
+                nowSeconds + PERMIT_VALIDITY_SECONDS,
+                input.configuration.deadlineTimestampExclusive -
+                  DEADLINE_SAFETY_SECONDS,
+              ),
+            )) {
+            throw new MainTokenMigrationGaslessErrorV1(422, "permit_expired");
+          }
+          const observation = await input.chain.prepare({
+            configuration: input.configuration,
+            walletAddress: parsed.walletAddress,
+            amountRaw: parsed.amountRaw,
+          });
+          if (observation.nonce !== parsed.nonce) {
+            throw new MainTokenMigrationGaslessErrorV1(409, "permit_nonce_changed");
+          }
+          const maxFeePerGasWei = divCeil(
+            observation.feePerGasWei * GAS_MULTIPLIER_BPS,
+            BPS,
+          );
+          if (maxFeePerGasWei <= 0n ||
+            maxFeePerGasWei > MAXIMUM_FEE_PER_GAS_WEI ||
+            observation.maxPriorityFeePerGasWei > maxFeePerGasWei) {
+            throw new MainTokenMigrationGaslessErrorV1(503, "gas_quote_unavailable");
+          }
+          const reservedTotalWei =
+            (PERMIT_GAS_LIMIT + TRANSFER_GAS_LIMIT) * maxFeePerGasWei;
+          if (observation.sponsorBalanceWei < reservedTotalWei) {
+            throw new MainTokenMigrationGaslessErrorV1(503, "sponsor_balance_low");
+          }
+          const providerBinding = expectedBinding.slice("sha256:".length);
+          const intent: MainTokenMigrationGaslessIntentV1 = Object.freeze({
+            schema: "programmable-main-token-migration-gasless-intent/v1",
+            releaseId: input.configuration.releaseId,
+            walletAddress: parsed.walletAddress,
+            rootWalletAddress: observation.rootWalletAddress,
+            sponsorAddress: input.configuration.sponsorAddress,
+            amountRaw: parsed.amountRaw.toString(),
+            nonce: parsed.nonce.toString(),
+            permitDeadline: parsed.permitDeadline.toString(),
+            permitSignature: permit.signature.toLowerCase() as Hex,
+            permitGasLimit: PERMIT_GAS_LIMIT.toString(),
+            transferGasLimit: TRANSFER_GAS_LIMIT.toString(),
+            maxFeePerGasWei: maxFeePerGasWei.toString(),
+            maxPriorityFeePerGasWei:
+              observation.maxPriorityFeePerGasWei.toString(),
+            reservedTotalWei: reservedTotalWei.toString(),
+            totalBudgetWei: input.configuration.totalBudgetWei.toString(),
+            requestBindingHash: expectedBinding,
+            providerPermitIdempotencyKey:
+              `mtmgp-${providerBinding.slice(0, 58)}`,
+            providerPermitReferenceId:
+              `mtmgp-${providerBinding.slice(0, 58)}`,
+            providerTransferIdempotencyKey:
+              `mtmgt-${providerBinding.slice(0, 58)}`,
+            providerTransferReferenceId:
+              `mtmgt-${providerBinding.slice(0, 58)}`,
+            reservedAt: now().toISOString(),
+          });
+          record = (await input.store.reserve({
+            lookup,
+            idempotencyBindingHash: baseBindings.idempotencyBindingHash,
+            intent,
+          })).record;
+        } else if (record.intent.requestBindingHash !== expectedBinding ||
+          record.intent.amountRaw !== parsed.amountRaw.toString() ||
+          record.intent.nonce !== parsed.nonce.toString() ||
+          record.intent.permitDeadline !== parsed.permitDeadline.toString()) {
+          throw new MainTokenMigrationGaslessErrorV1(409, "idempotency_conflict");
+        }
+        await input.sender.assertReady();
+        return await progressTransfer({
+          chain: input.chain,
+          configuration: input.configuration,
+          now: now(),
+          record,
+          sender: input.sender,
+          store: input.store,
+        });
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  });
+}
+
+async function progressTransfer(input: Readonly<{
+  chain: ReturnType<typeof createMainTokenMigrationGaslessChainV1>;
+  configuration: MainTokenMigrationGasSponsorConfigurationV1;
+  now: Date;
+  record: MainTokenMigrationGaslessRecordV1;
+  sender: ReturnType<typeof createMainTokenMigrationGaslessSenderV1>;
+  store: MainTokenMigrationGaslessStoreV1;
+}>) {
+  let record = input.record;
+  if (!record.permitTransactionHash) {
+    const reconciled = await input.sender.lookup("permit", record.intent);
+    const recoveredHash = providerHashOrNull(reconciled);
+    if (!recoveredHash) assertProviderRetryWindow(record.intent, input.now);
+    const hash = recoveredHash ?? await input.sender.send("permit", record.intent);
+    record = await input.store.complete({
+      lookup: {
+        releaseId: record.intent.releaseId,
+        walletAddress: record.intent.walletAddress,
+      },
+      kind: "permit",
+      providerReferenceId: record.intent.providerPermitReferenceId,
+      transactionHash: hash,
+    });
+    return transferResponse("permit_submitted", record, 10);
+  }
+  const permitStatus = await input.chain.transactionStatus(
+    "permit",
+    record,
+  );
+  if (permitStatus === "failed") {
+    throw new MainTokenMigrationGaslessErrorV1(409, "permit_reverted");
+  }
+  if (permitStatus === "pending") {
+    return transferResponse("permit_pending", record, 10);
+  }
+  await input.chain.assertPermitEffect(record);
+  if (!record.transferTransactionHash) {
+    const reconciled = await input.sender.lookup("transfer", record.intent);
+    const recoveredHash = providerHashOrNull(reconciled);
+    if (!recoveredHash) assertProviderRetryWindow(record.intent, input.now);
+    const hash = recoveredHash ?? await input.sender.send("transfer", record.intent);
+    record = await input.store.complete({
+      lookup: {
+        releaseId: record.intent.releaseId,
+        walletAddress: record.intent.walletAddress,
+      },
+      kind: "transfer",
+      providerReferenceId: record.intent.providerTransferReferenceId,
+      transactionHash: hash,
+    });
+    return transferResponse("transfer_submitted", record, 5);
+  }
+  const transferStatus = await input.chain.transactionStatus(
+    "transfer",
+    record,
+  );
+  if (transferStatus === "failed") {
+    throw new MainTokenMigrationGaslessErrorV1(409, "transfer_reverted");
+  }
+  return typeof transferStatus === "object"
+    ? transferResponse(
+        "confirmed",
+        record,
+        undefined,
+        transferStatus.blockNumber.toString(),
+      )
+    : transferResponse("transfer_pending", record, 5);
+}
+
+function providerHashOrNull(record: ProviderStatus | null) {
+  if (record === null) return null;
+  if (["failed", "provider_error", "execution_reverted"].includes(
+    record.status,
+  )) {
+    throw new MainTokenMigrationGaslessErrorV1(503, "provider_failed");
+  }
+  if (record.transactionHash) return record.transactionHash;
+  throw new MainTokenMigrationGaslessErrorV1(503, "submission_unknown");
+}
+
+function assertProviderRetryWindow(
+  intent: MainTokenMigrationGaslessIntentV1,
+  now: Date,
+) {
+  const reservedAtMs = new Date(intent.reservedAt).getTime();
+  const ageMs = now.getTime() - reservedAtMs;
+  if (!Number.isFinite(ageMs) || ageMs < 0 ||
+    ageMs >= PROVIDER_IDEMPOTENCY_WINDOW_MS -
+      PROVIDER_IDEMPOTENCY_SAFETY_MS) {
+    throw new MainTokenMigrationGaslessErrorV1(503, "submission_unknown");
+  }
+}
+
+export function createMainTokenMigrationGaslessChainV1(
+  providers = tradeActionRpcProviders(1),
+) {
+  if (providers.length !== 2) {
+    throw new TypeError("Gasless migration RPC quorum is invalid");
+  }
+  const clients: [PublicClient, PublicClient] = [
+    createPublicClient({
+      chain: mainnet,
+      transport: http(providers[0]!.endpoint, { retryCount: 1, timeout: 12_000 }),
+    }),
+    createPublicClient({
+      chain: mainnet,
+      transport: http(providers[1]!.endpoint, { retryCount: 1, timeout: 12_000 }),
+    }),
+  ];
+  const eligibilityChain = createMainTokenMigrationGasSponsorChainV1(providers);
+  return Object.freeze({
+    async prepare(input: Readonly<{
+      configuration: MainTokenMigrationGasSponsorConfigurationV1;
+      walletAddress: Address;
+      amountRaw: bigint;
+    }>) {
+      const eligibility = await eligibilityChain.observe({
+        configuration: input.configuration,
+        request: {
+          walletAddress: input.walletAddress,
+          amountRaw: input.amountRaw,
+        },
+      });
+      const heads = await Promise.all(clients.map((client) =>
+        client.getBlockNumber()));
+      const blockNumber = heads[0] < heads[1] ? heads[0] : heads[1];
+      const states = await Promise.all(clients.map(async (client) => {
+        const [chainId, block, code, tokenCode, name, domainSeparator, nonce] =
+          await Promise.all([
+            client.getChainId(),
+            client.getBlock({ blockNumber }),
+            client.getCode({ address: input.walletAddress, blockNumber }),
+            client.getCode({ address: MAIN_TOKEN_ADDRESS, blockNumber }),
+            client.readContract({
+              address: MAIN_TOKEN_ADDRESS,
+              abi: TOKEN_ABI,
+              functionName: "name",
+              blockNumber,
+            }),
+            client.readContract({
+              address: MAIN_TOKEN_ADDRESS,
+              abi: TOKEN_ABI,
+              functionName: "DOMAIN_SEPARATOR",
+              blockNumber,
+            }),
+            client.readContract({
+              address: MAIN_TOKEN_ADDRESS,
+              abi: TOKEN_ABI,
+              functionName: "nonces",
+              args: [input.walletAddress],
+              blockNumber,
+            }),
+          ]);
+        return { chainId, block, code, tokenCode, name, domainSeparator, nonce };
+      }));
+      const [left, right] = states;
+      if (!left || !right || left.chainId !== MAIN_TOKEN_MIGRATION_CHAIN_ID ||
+        right.chainId !== MAIN_TOKEN_MIGRATION_CHAIN_ID ||
+        left.block.hash !== right.block.hash || left.code !== right.code ||
+        left.tokenCode !== right.tokenCode || left.name !== right.name ||
+        left.domainSeparator !== right.domainSeparator || left.nonce !== right.nonce ||
+        !left.tokenCode || !right.tokenCode ||
+        !isMainTokenMigrationDelegatedWalletCode(left.code) ||
+        !isMainTokenMigrationDelegatedWalletCode(right.code) ||
+        left.name !== "Programmable" ||
+        left.domainSeparator.toLowerCase() !==
+          MAIN_TOKEN_PERMIT_DOMAIN_SEPARATOR.toLowerCase()) {
+        throw new MainTokenMigrationGaslessErrorV1(422, "gasless_wallet_unsupported");
+      }
+      return Object.freeze({
+        nonce: left.nonce,
+        feePerGasWei: eligibility.feePerGasWei,
+        maxPriorityFeePerGasWei: eligibility.maxPriorityFeePerGasWei,
+        sponsorBalanceWei: eligibility.sponsorBalanceWei,
+        rootWalletAddress: eligibility.eligibility.rootWalletAddress,
+      });
+    },
+
+    async assertPermitEffect(record: MainTokenMigrationGaslessRecordV1) {
+      const values = await Promise.all(clients.map((client) =>
+        client.readContract({
+          address: MAIN_TOKEN_ADDRESS,
+          abi: TOKEN_ABI,
+          functionName: "allowance",
+          args: [record.intent.walletAddress, record.intent.sponsorAddress],
+        })));
+      if (values[0] !== values[1] || values[0] < BigInt(record.intent.amountRaw)) {
+        throw new MainTokenMigrationGaslessErrorV1(503, "permit_effect_unavailable");
+      }
+    },
+
+    async transactionStatus(
+      kind: TransactionKind,
+      record: MainTokenMigrationGaslessRecordV1,
+    ) {
+      const hash = kind === "permit"
+        ? record.permitTransactionHash
+        : record.transferTransactionHash;
+      if (!hash) return "pending" as const;
+      const expectedData = transactionData(kind, record.intent);
+      const states = await Promise.all(clients.map(async (client) => {
+        try {
+          const [transaction, receipt] = await Promise.all([
+            client.getTransaction({ hash }),
+            client.getTransactionReceipt({ hash }),
+          ]);
+          const exact = transaction.hash === hash &&
+            transaction.from.toLowerCase() ===
+              record.intent.sponsorAddress.toLowerCase() &&
+            transaction.to?.toLowerCase() === MAIN_TOKEN_ADDRESS.toLowerCase() &&
+            transaction.value === 0n &&
+            transaction.gas === BigInt(kind === "permit"
+              ? record.intent.permitGasLimit
+              : record.intent.transferGasLimit) &&
+            transaction.maxFeePerGas ===
+              BigInt(record.intent.maxFeePerGasWei) &&
+            transaction.maxPriorityFeePerGas ===
+              BigInt(record.intent.maxPriorityFeePerGasWei) &&
+            transaction.input.toLowerCase() === expectedData.toLowerCase() &&
+            receipt.transactionHash === hash;
+          if (!exact || receipt.status !== "success") return "failed" as const;
+          return {
+            status: "confirmed" as const,
+            blockHash: receipt.blockHash,
+            blockNumber: receipt.blockNumber,
+          };
+        } catch {
+          return "pending" as const;
+        }
+      }));
+      if (states.some((state) => state === "failed")) return "failed" as const;
+      const [left, right] = states;
+      if (typeof left === "object" && typeof right === "object" &&
+        left.blockHash === right.blockHash && left.blockNumber === right.blockNumber) {
+        return {
+          status: "confirmed" as const,
+          blockNumber: left.blockNumber,
+        };
+      }
+      return "pending" as const;
+    },
+  });
+}
+
+export function createMainTokenMigrationGaslessSenderV1(
+  configuration: MainTokenMigrationGasSponsorConfigurationV1,
+  environment: Environment,
+) {
+  const appId = requiredEnv(environment, "NEXT_PUBLIC_PRIVY_APP_ID");
+  const appSecret = requiredEnv(environment, "PRIVY_APP_SECRET");
+  const privy = new PrivyClient({ appId, appSecret });
+  return Object.freeze({
+    async assertReady() {
+      const wallet = await privy.wallets().get(configuration.sponsorWalletId);
+      assertMainTokenMigrationPrivySponsorWalletV1(wallet, configuration);
+      const policy = await privy.policies().get(configuration.sponsorPolicyId);
+      assertMainTokenMigrationPrivySponsorPolicyV2(policy, configuration);
+    },
+    async lookup(kind: TransactionKind, intent: MainTokenMigrationGaslessIntentV1) {
+      const referenceId = kind === "permit"
+        ? intent.providerPermitReferenceId
+        : intent.providerTransferReferenceId;
+      const url = new URL("https://api.privy.io/v1/transactions");
+      url.searchParams.set("reference_id", referenceId);
+      const authorization = Buffer.from(`${appId}:${appSecret}`, "utf8")
+        .toString("base64");
+      const response = await fetch(url, {
+        method: "GET",
+        cache: "no-store",
+        headers: {
+          accept: "application/json",
+          authorization: `Basic ${authorization}`,
+          "privy-app-id": appId,
+        },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok) {
+        throw new MainTokenMigrationGaslessErrorV1(503, "provider_unavailable");
+      }
+      const source = await response.text();
+      if (Buffer.byteLength(source, "utf8") > MAXIMUM_PROVIDER_RESPONSE_BYTES) {
+        throw new MainTokenMigrationGaslessErrorV1(503, "provider_response_invalid");
+      }
+      return parsePrivySponsorTransactionLookupV1(
+        parseStrictJson(source, {
+          maximumBytes: MAXIMUM_PROVIDER_RESPONSE_BYTES,
+          maximumDepth: 8,
+        }),
+        { referenceId, sponsorWalletId: configuration.sponsorWalletId },
+      ) as ProviderStatus | null;
+    },
+    async send(kind: TransactionKind, intent: MainTokenMigrationGaslessIntentV1) {
+      assertSenderIntent(configuration, intent);
+      const gasLimit = kind === "permit"
+        ? BigInt(intent.permitGasLimit)
+        : BigInt(intent.transferGasLimit);
+      const idempotencyKey = kind === "permit"
+        ? intent.providerPermitIdempotencyKey
+        : intent.providerTransferIdempotencyKey;
+      const referenceId = kind === "permit"
+        ? intent.providerPermitReferenceId
+        : intent.providerTransferReferenceId;
+      const result = await privy.wallets().ethereum().sendTransaction(
+        configuration.sponsorWalletId,
+        {
+          caip2: "eip155:1",
+          params: {
+            transaction: {
+              chain_id: MAIN_TOKEN_MIGRATION_CHAIN_ID,
+              data: transactionData(kind, intent),
+              from: configuration.sponsorAddress,
+              gas_limit: toHex(gasLimit),
+              max_fee_per_gas: toHex(BigInt(intent.maxFeePerGasWei)),
+              max_priority_fee_per_gas:
+                toHex(BigInt(intent.maxPriorityFeePerGasWei)),
+              to: MAIN_TOKEN_ADDRESS,
+              type: 2,
+              value: "0x0",
+            },
+          },
+          idempotency_key: idempotencyKey,
+          reference_id: referenceId,
+        },
+      );
+      if (result.caip2 !== "eip155:1" || !HASH.test(result.hash) ||
+        result.reference_id !== referenceId) {
+        throw new MainTokenMigrationGaslessErrorV1(503, "provider_response_invalid");
+      }
+      return result.hash as Hex;
+    },
+  });
+}
+
+function transactionData(
+  kind: TransactionKind,
+  intent: MainTokenMigrationGaslessIntentV1,
+) {
+  if (kind === "transfer") {
+    return encodeFunctionData({
+      abi: TOKEN_ABI,
+      functionName: "transferFrom",
+      args: [
+        intent.walletAddress,
+        MAIN_TOKEN_MIGRATION_WALLET,
+        BigInt(intent.amountRaw),
+      ],
+    });
+  }
+  const signature = parseMainTokenMigrationPermitSignature(
+    intent.permitSignature,
+  );
+  return encodeFunctionData({
+    abi: TOKEN_ABI,
+    functionName: "permit",
+    args: [
+      intent.walletAddress,
+      intent.sponsorAddress,
+      BigInt(intent.amountRaw),
+      BigInt(intent.permitDeadline),
+      signature.v,
+      signature.r,
+      signature.s,
+    ],
+  });
+}
+
+function assertSenderIntent(
+  configuration: MainTokenMigrationGasSponsorConfigurationV1,
+  intent: MainTokenMigrationGaslessIntentV1,
+) {
+  if (intent.releaseId !== configuration.releaseId ||
+    intent.sponsorAddress !== configuration.sponsorAddress ||
+    BigInt(intent.permitGasLimit) !== PERMIT_GAS_LIMIT ||
+    BigInt(intent.transferGasLimit) !== TRANSFER_GAS_LIMIT ||
+    BigInt(intent.maxFeePerGasWei) > MAXIMUM_FEE_PER_GAS_WEI ||
+    BigInt(intent.maxPriorityFeePerGasWei) > BigInt(intent.maxFeePerGasWei) ||
+    BigInt(intent.reservedTotalWei) !==
+      (PERMIT_GAS_LIMIT + TRANSFER_GAS_LIMIT) *
+        BigInt(intent.maxFeePerGasWei)) {
+    throw new MainTokenMigrationGaslessErrorV1(503, "intent_mismatch");
+  }
+}
+
+function parseRequest(input: unknown): PrepareRequest | SubmitRequest {
+  if (!input || Array.isArray(input) || typeof input !== "object") {
+    throw new MainTokenMigrationGaslessErrorV1(400, "request_invalid");
+  }
+  const value = input as Record<string, unknown>;
+  const common = value.action === "prepare"
+    ? ["action", "amountRaw", "walletAddress"]
+    : ["action", "amountRaw", "nonce", "permitDeadline", "permitSignature",
+      "requestBindingHash", "walletAddress"];
+  if (Object.keys(value).sort().join("\0") !== common.sort().join("\0") ||
+    (value.action !== "prepare" && value.action !== "submit") ||
+    typeof value.walletAddress !== "string" ||
+    !isAddress(value.walletAddress, { strict: true }) ||
+    typeof value.amountRaw !== "string" || !DECIMAL.test(value.amountRaw)) {
+    throw new MainTokenMigrationGaslessErrorV1(400, "request_invalid");
+  }
+  const amountRaw = BigInt(value.amountRaw);
+  if (amountRaw <= 0n || amountRaw > MAIN_TOKEN_TOTAL_SUPPLY_RAW) {
+    throw new MainTokenMigrationGaslessErrorV1(400, "request_invalid");
+  }
+  const walletAddress = getAddress(value.walletAddress);
+  if (value.action === "prepare") {
+    return Object.freeze({ action: "prepare", walletAddress, amountRaw });
+  }
+  if (typeof value.nonce !== "string" || !ZERO_DECIMAL.test(value.nonce) ||
+    typeof value.permitDeadline !== "string" || !DECIMAL.test(value.permitDeadline) ||
+    typeof value.permitSignature !== "string" ||
+    !SIGNATURE.test(value.permitSignature) ||
+    typeof value.requestBindingHash !== "string" ||
+    !DIGEST.test(value.requestBindingHash)) {
+    throw new MainTokenMigrationGaslessErrorV1(400, "request_invalid");
+  }
+  return Object.freeze({
+    action: "submit",
+    walletAddress,
+    amountRaw,
+    nonce: BigInt(value.nonce),
+    permitDeadline: BigInt(value.permitDeadline),
+    permitSignature: value.permitSignature.toLowerCase() as Hex,
+    requestBindingHash: value.requestBindingHash as `sha256:${string}`,
+  });
+}
+
+function prepareResponse(intent: MainTokenMigrationGaslessIntentV1) {
+  return json({
+    schema: "programmable-main-token-migration-gasless-transfer/v1",
+    status: "signature_required",
+    walletAddress: intent.walletAddress,
+    amountRaw: intent.amountRaw,
+    sponsorAddress: intent.sponsorAddress,
+    nonce: intent.nonce,
+    permitDeadline: intent.permitDeadline,
+    requestBindingHash: intent.requestBindingHash,
+    permitTransactionHash: null,
+    transferTransactionHash: null,
+    transferBlockNumber: null,
+  }, 200);
+}
+
+function transferResponse(
+  status: "permit_submitted" | "permit_pending" | "transfer_submitted" |
+    "transfer_pending" | "confirmed",
+  record: MainTokenMigrationGaslessRecordV1,
+  retryAfterSeconds?: number,
+  transferBlockNumber: string | null = null,
+) {
+  return json({
+    schema: "programmable-main-token-migration-gasless-transfer/v1",
+    status,
+    walletAddress: record.intent.walletAddress,
+    amountRaw: record.intent.amountRaw,
+    sponsorAddress: record.intent.sponsorAddress,
+    nonce: record.intent.nonce,
+    permitDeadline: record.intent.permitDeadline,
+    requestBindingHash: record.intent.requestBindingHash,
+    permitTransactionHash: record.permitTransactionHash,
+    transferTransactionHash: record.transferTransactionHash,
+    transferBlockNumber,
+  }, 200, retryAfterSeconds === undefined
+    ? {}
+    : { "retry-after": String(retryAfterSeconds) });
+}
+
+function errorResponse(error: unknown) {
+  const requestId = randomUUID();
+  const failure = error instanceof WalletPrincipalAuthenticationErrorV1
+    ? new MainTokenMigrationGaslessErrorV1(error.status, error.code)
+    : error instanceof MainTokenMigrationGasSponsorStoreErrorV1
+      ? new MainTokenMigrationGaslessErrorV1(
+          error.code === "conflict" ? 409 :
+            error.code === "rate_limited" ? 429 : 503,
+          error.code === "conflict" ? "idempotency_conflict" : error.code,
+          error.retryAfterSeconds,
+        )
+      : error instanceof MainTokenMigrationGaslessStoreErrorV1
+        ? new MainTokenMigrationGaslessErrorV1(
+            error.code === "conflict" ? 409 : 503,
+            error.code,
+          )
+        : error instanceof MainTokenMigrationGaslessErrorV1
+          ? error
+          : new MainTokenMigrationGaslessErrorV1(503, "gasless_unavailable");
+  if (failure.status >= 500) {
+    console.error("Main token migration gasless transfer unavailable", {
+      code: failure.code,
+      requestId,
+    });
+  }
+  const message = failure.status === 401 || failure.status === 403
+    ? "Reconnect this wallet and try again."
+    : failure.code === "permit_reverted" ||
+        failure.code === "transfer_reverted"
+      ? "The gasless relay reverted and cannot be retried automatically. Do not send again; contact migration support with this request ID."
+    : failure.status === 409
+      ? "This wallet already has a different migration request."
+      : failure.status === 422
+        ? "This wallet cannot use the gasless transfer path."
+        : failure.status === 429
+          ? "Too many migration requests. Wait briefly and try again."
+          : failure.code === "sponsorship_closed"
+            ? "The migration window is closed."
+            : "The gasless transfer is temporarily unavailable.";
+  return json({ error: { code: failure.code, message, requestId } },
+    failure.status, failure.status === 429
+      ? { "retry-after": String(failure.retryAfterSeconds ?? 60) }
+      : failure.status === 503
+        ? { "retry-after": "5" }
+        : {});
+}
+
+function json(
+  value: unknown,
+  status: number,
+  headers: Record<string, string> = {},
+) {
+  return new Response(canonicalizeJson(value), {
+    status,
+    headers: {
+      "cache-control": "no-store",
+      "content-type": "application/json; charset=utf-8",
+      "x-content-type-options": "nosniff",
+      ...headers,
+    },
+  });
+}
+
+function assertLinkedWallet(wallets: readonly `0x${string}`[], wallet: Address) {
+  if (!wallets.some((candidate) =>
+    candidate.toLowerCase() === wallet.toLowerCase())) {
+    throw new MainTokenMigrationGaslessErrorV1(403, "wallet_not_linked");
+  }
+}
+
+function requireSameOrigin(request: Request) {
+  const origin = request.headers.get("origin");
+  let expected: string;
+  try {
+    expected = new URL(request.url).origin;
+  } catch {
+    throw new MainTokenMigrationGaslessErrorV1(403, "origin_forbidden");
+  }
+  if (origin !== expected || request.headers.get("sec-fetch-site") !== "same-origin") {
+    throw new MainTokenMigrationGaslessErrorV1(403, "origin_forbidden");
+  }
+}
+
+async function boundedJson(request: Request) {
+  const length = request.headers.get("content-length");
+  if (length && (!/^[0-9]+$/u.test(length) ||
+    Number(length) > MAXIMUM_BODY_BYTES)) {
+    throw new MainTokenMigrationGaslessErrorV1(413, "request_too_large");
+  }
+  const reader = request.body?.getReader();
+  if (!reader) throw new MainTokenMigrationGaslessErrorV1(400, "request_invalid");
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+  while (true) {
+    const part = await reader.read();
+    if (part.done) break;
+    bytes += part.value.byteLength;
+    if (bytes > MAXIMUM_BODY_BYTES) {
+      await reader.cancel().catch(() => undefined);
+      throw new MainTokenMigrationGaslessErrorV1(413, "request_too_large");
+    }
+    chunks.push(part.value);
+  }
+  let source: string;
+  try {
+    source = new TextDecoder("utf-8", { fatal: true })
+      .decode(Buffer.concat(chunks, bytes));
+  } catch {
+    throw new MainTokenMigrationGaslessErrorV1(400, "request_invalid");
+  }
+  return parseStrictJson(source, {
+    maximumBytes: MAXIMUM_BODY_BYTES,
+    maximumDepth: 4,
+  });
+}
+
+function assertWindowOpen(
+  configuration: MainTokenMigrationGasSponsorConfigurationV1,
+  now: Date,
+) {
+  const nowSeconds = Math.floor(now.getTime() / 1_000);
+  if (!Number.isFinite(nowSeconds) ||
+    nowSeconds >= configuration.deadlineTimestampExclusive -
+      DEADLINE_SAFETY_SECONDS) {
+    throw new MainTokenMigrationGaslessErrorV1(503, "sponsorship_closed");
+  }
+}
+
+function divCeil(value: bigint, denominator: bigint) {
+  return (value + denominator - 1n) / denominator;
+}
+
+function requiredEnv(environment: Environment, name: string) {
+  const value = environment[name]?.trim();
+  if (!value) throw new MainTokenMigrationGaslessErrorV1(503, "configuration_invalid");
+  return value;
+}
+
+let productionHandler: ReturnType<
+  typeof createMainTokenMigrationGaslessTransferV1
+> | null = null;
+
+export function getProductionMainTokenMigrationGaslessTransferV1() {
+  if (productionHandler) return productionHandler;
+  const configuration = readMainTokenMigrationGasSponsorConfigurationV1({
+    environment: process.env,
+    manifest: activationManifest,
+    nowMs: Date.now(),
+  });
+  if (!configuration) {
+    throw new MainTokenMigrationGaslessErrorV1(503, "sponsorship_disabled");
+  }
+  productionHandler = createMainTokenMigrationGaslessTransferV1({
+    configuration,
+    authenticator: createPrivyWalletPrincipalAuthenticatorV1(),
+    admissionStore: getProductionMainTokenMigrationGasSponsorStoreV1(),
+    store: getProductionMainTokenMigrationGaslessStoreV1(),
+    chain: createMainTokenMigrationGaslessChainV1(),
+    sender: createMainTokenMigrationGaslessSenderV1(configuration, process.env),
+  });
+  return productionHandler;
+}
+
+export async function handleProductionMainTokenMigrationGaslessTransferPostV1(
+  request: Request,
+) {
+  try {
+    return await getProductionMainTokenMigrationGaslessTransferV1().post(request);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "verify:uniswap-launcher-sdk": "node scripts/verify-uniswap-liquidity-launcher-sdk.mjs",
     "brand:favicons": "node scripts/generate-programmable-favicons.mjs",
     "creator-article:programmable:seed": "node scripts/seed-programmable-creator-article.mjs",
-    "migration:main-token:test": "vitest run tests/main-token-migration.test.ts tests/main-token-migration-gas-sponsor-contract.test.ts tests/main-token-migration-gas-sponsor-v1.test.ts tests/main-token-migration-gas-sponsorship-ui.test.ts",
+    "migration:main-token:test": "vitest run tests/main-token-migration.test.ts tests/main-token-migration-gas-sponsor-contract.test.ts tests/main-token-migration-gas-sponsor-v1.test.ts tests/main-token-migration-gas-sponsorship-ui.test.ts tests/main-token-migration-gasless-transfer-v1.test.ts",
     "audit:prod": "npm audit --omit=dev --audit-level=moderate",
     "release:custom-launch:record:verify": "node scripts/verify-custom-launch-release-record.mjs",
     "release:custom-launch:v2:record:verify": "node scripts/verify-custom-launch-release-record-v2.mjs",

--- a/tests/main-token-migration-gas-sponsor-contract.test.ts
+++ b/tests/main-token-migration-gas-sponsor-contract.test.ts
@@ -30,6 +30,44 @@ type SponsorContract = Readonly<{
   runtimeDependencies: readonly string[];
 }>;
 
+type GaslessTransferContract = Readonly<{
+  schema: string;
+  releaseId: string;
+  activationManifestPath: string;
+  route: string;
+  serverOnly: boolean;
+  chainId: string;
+  sourceAssetContract: string;
+  tokenName: string;
+  permitVersion: string;
+  permitDomainSeparator: string;
+  migrationWallet: string;
+  walletReview: Readonly<{
+    standard: string;
+    binds: readonly string[];
+  }>;
+  relayer: Readonly<Record<string, string>>;
+  serverEnforces: readonly string[];
+}>;
+
+type PrivyPolicyContract = Readonly<{
+  schema: string;
+  name: string;
+  chainType: string;
+  version: string;
+  rules: readonly Readonly<{
+    name: string;
+    action: string;
+    method: string;
+    conditions: readonly Readonly<{
+      field_source: string;
+      field: string;
+      operator: string;
+      value: string;
+    }>[];
+  }>[];
+}>;
+
 const read = (path: string) =>
   readFileSync(join(process.cwd(), path), "utf8");
 const parse = <T>(path: string) => JSON.parse(read(path)) as T;
@@ -37,6 +75,12 @@ const parse = <T>(path: string) => JSON.parse(read(path)) as T;
 describe("main token migration gas sponsor activation contract", () => {
   const contract = parse<SponsorContract>(
     "config/main-token-migration-gas-sponsor-contract.v1.json",
+  );
+  const gaslessContract = parse<GaslessTransferContract>(
+    "config/main-token-migration-gasless-transfer-contract.v1.json",
+  );
+  const privyPolicy = parse<PrivyPolicyContract>(
+    "config/main-token-migration-gas-sponsor-privy-policy.v2.json",
   );
   const manifest = parse<Record<string, unknown>>(
     "config/main-token-migration-activation.v1.json",
@@ -47,6 +91,9 @@ describe("main token migration gas sponsor activation contract", () => {
   );
   const store = read(
     "lib/server/main-token-migration-gas-sponsor-store-v1.ts",
+  );
+  const gaslessImplementation = read(
+    "lib/server/main-token-migration-gasless-transfer-v1.ts",
   );
   const runbook = read(
     "docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-V1.md",
@@ -123,10 +170,17 @@ describe("main token migration gas sponsor activation contract", () => {
       transactionMethod: "eth_sendTransaction",
       transactionType: "2",
       transactionData: "0x",
-      sponsorGasLimitMode: "eoa-fixed-or-delegated-estimated",
+      sponsorGasLimitMode: "plain-eoa-fixed",
       sponsorGasLimitMinimum: "21000",
       sponsorGasLimitMaximum: "100000",
-      providerPolicyEnforces: ["method", "chainId", "maximumValue"],
+      providerPolicyEnforces: [
+        "method",
+        "chainId",
+        "positiveMaximumNativeValue",
+        "pinnedToken",
+        "permitSpenderAmountDeadline",
+        "fixedTransferFromDestinationAndAmount",
+      ],
       serverEnforces: [
         "holderRecipient",
         "emptyCalldata",
@@ -171,6 +225,121 @@ describe("main token migration gas sponsor activation contract", () => {
     );
     expect(store).toContain(
       "MAIN_TOKEN_MIGRATION_GAS_SPONSOR_GAS_LIMIT_V1 = 21_000n",
+    );
+  });
+
+  it("pins the delegated-wallet permit and fixed transfer destination", () => {
+    expect(gaslessContract).toMatchObject({
+      schema: "programmable-main-token-migration-gasless-transfer-contract/v1",
+      releaseId: contract.releaseId,
+      activationManifestPath: contract.activationManifestPath,
+      route: "/api/main-token-migration/gasless-transfer",
+      serverOnly: true,
+      chainId: "1",
+      sourceAssetContract: manifest.sourceTokenAddress,
+      tokenName: "Programmable",
+      permitVersion: "1",
+      migrationWallet: manifest.migrationWallet,
+      walletReview: {
+        standard: "EIP-2612 Permit",
+        binds: [
+          "owner",
+          "sponsorSpender",
+          "exactAmountRaw",
+          "currentNonce",
+          "shortDeadline",
+          "EthereumChainId",
+          "pinnedToken",
+        ],
+      },
+      relayer: {
+        permitGasLimit: "100000",
+        transferFromGasLimit: "100000",
+        maximumFeePerGasWei: "20000000000",
+        destination: "fixedMigrationWallet",
+        providerTransactions: "separate-idempotent-permit-and-transferFrom",
+      },
+    });
+    expect(gaslessContract.permitDomainSeparator).toMatch(
+      /^0x[0-9a-f]{64}$/u,
+    );
+    for (const boundary of [
+      "authenticatedLinkedOwner",
+      "sameOrigin",
+      "openingAndCurrentBalance",
+      "dualRpcQuorum",
+      "eip7702WalletCode",
+      "exactPermitSigner",
+      "exactPermitTypedData",
+      "fixedToken",
+      "fixedMigrationDestination",
+      "sharedBudget",
+      "rootWalletReplayGuard",
+      "exactTransactionReadback",
+    ]) {
+      expect(gaslessContract.serverEnforces).toContain(boundary);
+    }
+    expect(gaslessImplementation).toContain(
+      "const PERMIT_GAS_LIMIT = 100_000n;",
+    );
+    expect(gaslessImplementation).toContain(
+      "const TRANSFER_GAS_LIMIT = 100_000n;",
+    );
+    expect(gaslessImplementation).toContain(
+      "const MAXIMUM_FEE_PER_GAS_WEI = 20_000_000_000n;",
+    );
+    expect(gaslessImplementation).toContain(
+      "MAIN_TOKEN_MIGRATION_WALLET,",
+    );
+  });
+
+  it("pins a provider policy that cannot turn the permit into a broad allowance", () => {
+    expect(privyPolicy).toMatchObject({
+      schema: "programmable-main-token-migration-gas-sponsor-privy-policy/v2",
+      name: "Main token migration gas sponsor v2",
+      chainType: "ethereum",
+      version: "1.0",
+    });
+    expect(privyPolicy.rules).toHaveLength(3);
+    expect(privyPolicy.rules.every((rule) =>
+      rule.action === "ALLOW" && rule.method === "eth_sendTransaction",
+    )).toBe(true);
+    expect(privyPolicy.rules.some((rule) => rule.method === "*")).toBe(false);
+    const [native, permit, transfer] = privyPolicy.rules;
+    expect(native?.conditions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ field: "value", operator: "gt", value: "0x0" }),
+      expect.objectContaining({
+        field: "value",
+        operator: "lte",
+        value: "0x71afd498d0000",
+      }),
+    ]));
+    expect(permit?.conditions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        field: "to",
+        value: "0x7987f03462200b3D8A072E02C89A8A41dCB124EE",
+      }),
+      expect.objectContaining({
+        field: "permit.spender",
+        value: "0x0060f9E57FCcc0611ef44809B257919e78Aa99Ac",
+      }),
+      expect.objectContaining({ field: "permit.deadline", value: "0x6a9919c4" }),
+    ]));
+    expect(transfer?.conditions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        field: "transferFrom.to",
+        value: "0x228Be90653fDDAa408fB6cf9ca0AEC311dbE9A0D",
+      }),
+      expect.objectContaining({
+        field: "transferFrom.amount",
+        value: "0x33b2e3c9fd0803ce8000000",
+      }),
+    ]));
+    expect(implementation).toContain(
+      "assertMainTokenMigrationPrivySponsorPolicyV2",
+    );
+    expect(runbook).toContain(
+      "main-token-migration-gas-sponsor-privy-policy.v2.json",
     );
   });
 });

--- a/tests/main-token-migration-gas-sponsor-v1.test.ts
+++ b/tests/main-token-migration-gas-sponsor-v1.test.ts
@@ -6,6 +6,7 @@ vi.mock("server-only", () => ({}));
 
 import {
   MainTokenMigrationGasSponsorErrorV1,
+  assertMainTokenMigrationPrivySponsorPolicyV2,
   assertMainTokenMigrationSponsorEligibilityAnchorV1,
   assertMainTokenMigrationPrivySponsorWalletV1,
   calculateMainTokenMigrationTopUpWeiV1,
@@ -29,6 +30,8 @@ import {
   type MainTokenMigrationGasSponsorRecordV1,
   type MainTokenMigrationGasSponsorStoreV1,
 } from "../lib/server/main-token-migration-gas-sponsor-store-v1";
+import sponsorPolicyContract from
+  "../config/main-token-migration-gas-sponsor-privy-policy.v2.json";
 import {
   MAIN_TOKEN_ADDRESS,
   MAIN_TOKEN_MIGRATION_CHAIN_ID,
@@ -63,6 +66,12 @@ const CONFIGURATION: MainTokenMigrationGasSponsorConfigurationV1 = {
   sponsorAddress: SPONSOR,
   maximumTopUpWei: 2_000_000_000_000_000n,
   totalBudgetWei: 172_000_000_000_000n,
+};
+
+const PRODUCTION_POLICY_CONFIGURATION: MainTokenMigrationGasSponsorConfigurationV1 = {
+  ...CONFIGURATION,
+  deadlineTimestampExclusive: 1_788_418_500,
+  sponsorAddress: "0x0060f9E57FCcc0611ef44809B257919e78Aa99Ac",
 };
 
 function key(releaseId: string, walletAddress: string) {
@@ -280,6 +289,35 @@ function sponsor(
 }
 
 describe("main token migration gas sponsor", () => {
+  it("requires the exact provider policy and rejects a broader allow rule", () => {
+    const policy = {
+      chain_type: sponsorPolicyContract.chainType,
+      name: sponsorPolicyContract.name,
+      owner_id: null,
+      version: sponsorPolicyContract.version,
+      rules: sponsorPolicyContract.rules.map((rule, index) => ({
+        ...rule,
+        id: `rule-${index}`,
+      })),
+    };
+    expect(() => assertMainTokenMigrationPrivySponsorPolicyV2(
+      policy,
+      PRODUCTION_POLICY_CONFIGURATION,
+    )).not.toThrow();
+    expect(() => assertMainTokenMigrationPrivySponsorPolicyV2({
+      ...policy,
+      rules: [...policy.rules, {
+        id: "broad-rule",
+        name: "Broad allow",
+        action: "ALLOW",
+        method: "eth_sendTransaction",
+        conditions: [],
+      }],
+    }, PRODUCTION_POLICY_CONFIGURATION)).toThrow(
+      MainTokenMigrationGasSponsorErrorV1,
+    );
+  });
+
   it("accepts one confirmed direct transfer from the eligible root wallet", async () => {
     const blockHash = `0x${"45".repeat(32)}` as const;
     const transferHash = `0x${"67".repeat(32)}` as const;

--- a/tests/main-token-migration-gasless-transfer-v1.test.ts
+++ b/tests/main-token-migration-gasless-transfer-v1.test.ts
@@ -1,0 +1,401 @@
+import { PGlite } from "@electric-sql/pglite";
+import { keccak256, stringToHex } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  buildMainTokenMigrationPermitTypedData,
+  MAIN_TOKEN_MIGRATION_RELEASE_ID,
+  MAIN_TOKEN_MIGRATION_WALLET,
+} from "../lib/main-token-migration";
+import {
+  createMainTokenMigrationGaslessTransferV1,
+  deriveMainTokenMigrationGaslessBindingV1,
+} from "../lib/server/main-token-migration-gasless-transfer-v1";
+import type {
+  MainTokenMigrationGaslessRecordV1,
+} from "../lib/server/main-token-migration-gasless-transfer-store-v1";
+import {
+  createMainTokenMigrationGaslessPostgresStoreV1,
+} from "../lib/server/main-token-migration-gasless-transfer-store-v1";
+import {
+  deriveMainTokenMigrationSponsorBindingsV1,
+} from "../lib/server/main-token-migration-gas-sponsor-v1";
+import type {
+  ProjectionTargetPostgresClientV1,
+  ProjectionTargetPostgresQueryResultV1,
+} from "../lib/server/projection-target/postgres-store";
+
+const account = privateKeyToAccount(
+  keccak256(stringToHex("programmable gasless migration test account")),
+);
+const sponsorAddress = "0x0060f9E57FCcc0611ef44809B257919e78Aa99Ac";
+const permitHash = `0x${"11".repeat(32)}` as const;
+const transferHash = `0x${"22".repeat(32)}` as const;
+const now = new Date("2026-08-31T10:00:00.000Z");
+const idempotencyKey = "gasless-test-request-0001";
+
+const configuration = {
+  releaseId: MAIN_TOKEN_MIGRATION_RELEASE_ID,
+  windowStartTimestamp: 1_788_159_300,
+  startBlockNumber: 25_873_498n,
+  startBlockHash: `0x${"33".repeat(32)}` as const,
+  deadlineTimestampExclusive: 1_788_418_500,
+  sponsorWalletId: "wallet-test-0001",
+  sponsorPolicyId: "policy-test-0001",
+  sponsorAddress,
+  maximumTopUpWei: 2_000_000_000_000_000n,
+  totalBudgetWei: 1_000_000_000_000_000_000n,
+} as const;
+
+function request(body: unknown) {
+  return new Request("https://programmable.market/api/main-token-migration/gasless-transfer", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer test",
+      "content-type": "application/json",
+      "idempotency-key": idempotencyKey,
+      origin: "https://programmable.market",
+      "sec-fetch-site": "same-origin",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("main token migration gasless permit transfer", () => {
+  it("binds the signature and relays only the exact fixed-destination transfer", async () => {
+    let record: MainTokenMigrationGaslessRecordV1 | null = null;
+    const store = {
+      async get() {
+        return record;
+      },
+      async reserve(input: { intent: MainTokenMigrationGaslessRecordV1["intent"] }) {
+        record = {
+          intent: input.intent,
+          permitTransactionHash: null,
+          transferTransactionHash: null,
+        };
+        return { kind: "created" as const, record };
+      },
+      async complete(input: {
+        kind: "permit" | "transfer";
+        transactionHash: typeof permitHash | typeof transferHash;
+      }) {
+        if (!record) throw new Error("missing intent");
+        record = {
+          ...record,
+          permitTransactionHash: input.kind === "permit"
+            ? input.transactionHash
+            : record.permitTransactionHash,
+          transferTransactionHash: input.kind === "transfer"
+            ? input.transactionHash
+            : record.transferTransactionHash,
+        };
+        return record;
+      },
+    };
+    const sender = {
+      async assertReady() {},
+      async lookup() {
+        return null;
+      },
+      async send(kind: "permit" | "transfer") {
+        return kind === "permit" ? permitHash : transferHash;
+      },
+    };
+    const handler = createMainTokenMigrationGaslessTransferV1({
+      configuration,
+      authenticator: {
+        async authenticate() {
+          return {
+            privyUserId: "did:privy:test",
+            privySessionId: "session-test",
+            wallets: [account.address],
+          };
+        },
+      },
+      admissionStore: { async admit() {} } as never,
+      store: store as never,
+      chain: {
+        async prepare() {
+          return {
+            nonce: 0n,
+            feePerGasWei: 1_000_000_000n,
+            maxPriorityFeePerGasWei: 100_000_000n,
+            sponsorBalanceWei: 1_000_000_000_000_000_000n,
+            rootWalletAddress: account.address,
+          };
+        },
+        async assertPermitEffect() {},
+        async transactionStatus(kind: "permit" | "transfer") {
+          return kind === "permit"
+            ? ({ status: "confirmed", blockNumber: 25_900_001n } as const)
+            : ({ status: "confirmed", blockNumber: 25_900_002n } as const);
+        },
+      } as never,
+      sender: sender as never,
+      now: () => now,
+    });
+
+    const preparedResponse = await handler.post(request({
+      action: "prepare",
+      amountRaw: "100",
+      walletAddress: account.address,
+    }));
+    expect(preparedResponse.status).toBe(200);
+    const prepared = await preparedResponse.json() as {
+      nonce: string;
+      permitDeadline: string;
+      requestBindingHash: `sha256:${string}`;
+      sponsorAddress: `0x${string}`;
+      status: string;
+      transferBlockNumber: string | null;
+    };
+    expect(prepared).toMatchObject({
+      status: "signature_required",
+      nonce: "0",
+      sponsorAddress,
+      transferBlockNumber: null,
+    });
+    const signature = await account.signTypedData(
+      buildMainTokenMigrationPermitTypedData({
+        owner: account.address,
+        spender: sponsorAddress,
+        value: 100n,
+        nonce: BigInt(prepared.nonce),
+        deadline: BigInt(prepared.permitDeadline),
+      }),
+    );
+    const submitBody = {
+      action: "submit",
+      amountRaw: "100",
+      nonce: prepared.nonce,
+      permitDeadline: prepared.permitDeadline,
+      permitSignature: signature,
+      requestBindingHash: prepared.requestBindingHash,
+      walletAddress: account.address,
+    };
+    const permitResponse = await handler.post(request(submitBody));
+    expect(await permitResponse.json()).toMatchObject({
+      status: "permit_submitted",
+      permitTransactionHash: permitHash,
+      transferTransactionHash: null,
+    });
+    const transferResponse = await handler.post(request(submitBody));
+    expect(await transferResponse.json()).toMatchObject({
+      status: "transfer_submitted",
+      permitTransactionHash: permitHash,
+      transferTransactionHash: transferHash,
+      transferBlockNumber: null,
+    });
+    const confirmedResponse = await handler.post(request(submitBody));
+    expect(await confirmedResponse.json()).toMatchObject({
+      status: "confirmed",
+      permitTransactionHash: permitHash,
+      transferTransactionHash: transferHash,
+      transferBlockNumber: "25900002",
+    });
+    const finalRecord = record as MainTokenMigrationGaslessRecordV1 | null;
+    expect(finalRecord?.intent.walletAddress).toBe(account.address);
+    expect(finalRecord?.intent.amountRaw).toBe("100");
+    expect(MAIN_TOKEN_MIGRATION_WALLET).not.toBe(account.address);
+  });
+
+  it("rejects a permit signed by a different wallet", async () => {
+    const other = privateKeyToAccount(
+      keccak256(stringToHex("programmable gasless migration other account")),
+    );
+    const handler = createMainTokenMigrationGaslessTransferV1({
+      configuration,
+      authenticator: {
+        async authenticate() {
+          return {
+            privyUserId: "did:privy:test",
+            privySessionId: "session-test",
+            wallets: [account.address],
+          };
+        },
+      },
+      admissionStore: { async admit() {} } as never,
+      store: { async get() { return null; } } as never,
+      chain: {
+        async prepare() {
+          return {
+            nonce: 0n,
+            feePerGasWei: 1n,
+            maxPriorityFeePerGasWei: 0n,
+            sponsorBalanceWei: 1_000_000n,
+            rootWalletAddress: account.address,
+          };
+        },
+      } as never,
+      sender: {} as never,
+      now: () => now,
+    });
+    const preparedResponse = await handler.post(request({
+      action: "prepare",
+      amountRaw: "100",
+      walletAddress: account.address,
+    }));
+    const prepared = await preparedResponse.json() as {
+      nonce: string;
+      permitDeadline: string;
+      requestBindingHash: `sha256:${string}`;
+    };
+    const signature = await other.signTypedData(
+      buildMainTokenMigrationPermitTypedData({
+        owner: account.address,
+        spender: sponsorAddress,
+        value: 100n,
+        nonce: 0n,
+        deadline: BigInt(prepared.permitDeadline),
+      }),
+    );
+    const response = await handler.post(request({
+      action: "submit",
+      amountRaw: "100",
+      nonce: "0",
+      permitDeadline: prepared.permitDeadline,
+      permitSignature: signature,
+      requestBindingHash: prepared.requestBindingHash,
+      walletAddress: account.address,
+    }));
+    expect(response.status).toBe(422);
+    expect(await response.json()).toMatchObject({
+      error: { code: "signature_invalid" },
+    });
+  });
+
+  it("durably binds one root wallet and both exact relayer transactions", async () => {
+    const database = new PGlite();
+    try {
+      await database.exec(`
+        CREATE SCHEMA programmable_website_projection_v1;
+        CREATE TABLE programmable_website_projection_v1.credential_uses (
+          credential_id text PRIMARY KEY,
+          request_binding_hash text NOT NULL,
+          canonical_use text NOT NULL,
+          created_at timestamptz NOT NULL DEFAULT clock_timestamp()
+        );
+      `);
+      const store = createMainTokenMigrationGaslessPostgresStoreV1(
+        new GaslessTestPool(database) as never,
+      );
+      const base = deriveMainTokenMigrationSponsorBindingsV1({
+        releaseId: MAIN_TOKEN_MIGRATION_RELEASE_ID,
+        walletAddress: account.address,
+        amountRaw: 100n,
+        idempotencyKey,
+      });
+      const binding = deriveMainTokenMigrationGaslessBindingV1({
+        baseRequestBindingHash: base.requestBindingHash,
+        nonce: 0n,
+        permitDeadline: 1_788_169_000n,
+      });
+      const signature = await account.signTypedData(
+        buildMainTokenMigrationPermitTypedData({
+          owner: account.address,
+          spender: sponsorAddress,
+          value: 100n,
+          nonce: 0n,
+          deadline: 1_788_169_000n,
+        }),
+      );
+      const lookup = {
+        releaseId: MAIN_TOKEN_MIGRATION_RELEASE_ID,
+        walletAddress: account.address,
+      };
+      const reserved = await store.reserve({
+        lookup,
+        idempotencyBindingHash: base.idempotencyBindingHash,
+        intent: {
+          schema: "programmable-main-token-migration-gasless-intent/v1",
+          releaseId: MAIN_TOKEN_MIGRATION_RELEASE_ID,
+          walletAddress: account.address,
+          rootWalletAddress: account.address,
+          sponsorAddress,
+          amountRaw: "100",
+          nonce: "0",
+          permitDeadline: "1788169000",
+          permitSignature: signature,
+          permitGasLimit: "100000",
+          transferGasLimit: "100000",
+          maxFeePerGasWei: "1000000000",
+          maxPriorityFeePerGasWei: "100000000",
+          reservedTotalWei: "200000000000000",
+          totalBudgetWei: "1000000000000000000",
+          requestBindingHash: binding,
+          providerPermitIdempotencyKey: "mtmgp-store-test-0001",
+          providerPermitReferenceId: "mtmgp-store-test-0001",
+          providerTransferIdempotencyKey: "mtmgt-store-test-0001",
+          providerTransferReferenceId: "mtmgt-store-test-0001",
+          reservedAt: now.toISOString(),
+        },
+      });
+      expect(reserved.kind).toBe("created");
+      await store.complete({
+        lookup,
+        kind: "permit",
+        providerReferenceId: "mtmgp-store-test-0001",
+        transactionHash: permitHash,
+      });
+      const completed = await store.complete({
+        lookup,
+        kind: "transfer",
+        providerReferenceId: "mtmgt-store-test-0001",
+        transactionHash: transferHash,
+      });
+      expect(completed).toMatchObject({
+        permitTransactionHash: permitHash,
+        transferTransactionHash: transferHash,
+        intent: {
+          walletAddress: account.address,
+          rootWalletAddress: account.address,
+          amountRaw: "100",
+        },
+      });
+      await expect(store.reserve({
+        lookup: {
+          releaseId: MAIN_TOKEN_MIGRATION_RELEASE_ID,
+          walletAddress: "0x1111111111111111111111111111111111111111",
+        },
+        idempotencyBindingHash: base.idempotencyBindingHash,
+        intent: {
+          ...reserved.record.intent,
+          walletAddress: "0x1111111111111111111111111111111111111111",
+        },
+      })).rejects.toMatchObject({ code: "conflict" });
+    } finally {
+      await database.close();
+    }
+  }, 10_000);
+});
+
+class GaslessTestPool {
+  constructor(private readonly database: PGlite) {}
+
+  async assertProductionReadiness() {}
+
+  async connect(): Promise<ProjectionTargetPostgresClientV1> {
+    return Object.freeze({
+      query: <Row extends Record<string, unknown>>(
+        text: string,
+        values: readonly unknown[] = [],
+      ) => this.query<Row>(text, values),
+      release() {},
+    });
+  }
+
+  async query<Row extends Record<string, unknown> = Record<string, unknown>>(
+    text: string,
+    values: readonly unknown[] = [],
+  ): Promise<ProjectionTargetPostgresQueryResultV1<Row>> {
+    const result = await this.database.query<Row>(text, [...values]);
+    return Object.freeze({
+      rows: result.rows,
+      rowCount: result.affectedRows ?? result.rows.length,
+    });
+  }
+}

--- a/tests/main-token-migration.test.ts
+++ b/tests/main-token-migration.test.ts
@@ -272,7 +272,7 @@ describe("main token migration page contract", () => {
       "const canRevealDestination = transferWindowOpen || hasTrackedTransfer;",
     );
     expect(page).toContain("const canCopyDestination = transferWindowOpen;");
-    expect(page).toContain("{canRevealDestination ? (");
+    expect(page).toContain(": canRevealDestination ? (");
     expect(page).toContain("Copy address");
     expect(page).toContain("disabled={!canCopyDestination}");
     expect(page).toContain(


### PR DESCRIPTION
## Outcome

Adds an EIP-2612 based gasless migration path for EIP-7702 delegated wallets that automatically wrap native ETH. The browser requests only the exact permit signature; the server authenticates the linked wallet and relays only the pinned token amount to the fixed migration destination. Normal EOAs retain the bounded native gas top-up path.

## Safety

- exact chain, token, owner, spender, nonce, amount and short deadline
- dual-RPC wallet/code/balance and transaction readback
- provider policy pins permit and transferFrom semantics
- durable idempotency, shared budget and root guard
- fail-closed cross-tab recovery before the wallet signature
- no wallet signature or migration transfer was performed by this change

## Verification

- `npm run migration:main-token:test` (48/48)
- `npm run typecheck -- --pretty false`
- scoped ESLint
- `npm run build`
- `git diff --check`