### PR TITLE
docs: add planned Robinhood V4 indexing contract

### DIFF
--- a/docs/operations/releases/custom-launch-v4/cli-release-binding.json
+++ b/docs/operations/releases/custom-launch-v4/cli-release-binding.json
@@ -65,7 +65,7 @@
       "name": "openapi",
       "path": "public/openapi/custom-launch-v4.json",
       "url": "https://programmable.market/openapi/custom-launch-v4.json",
-      "sha256": "sha256:dd551dbe2d4d60a1b4e7ec20dece7f0ee91e36642ce9f1e4186e341f13b60728"
+      "sha256": "sha256:581eb94ad6b8500646ec8b60aa56023c1badee44daf8814ffcd821a85e1ed1ef"
     },
     {
       "name": "packConfig",

--- a/docs/public/developers/indexing.md
+++ b/docs/public/developers/indexing.md
@@ -4,7 +4,7 @@ description: Index Programmable launches with finality, cursor completeness and 
 
 # Index Programmable launches
 
-An indexer can use the normalized v2 feed or reproduce Router records directly. In both cases, finality, cursor traversal and unknown data need explicit handling.
+An Ethereum indexer can use the normalized v2 feed or reproduce Router records directly. Robinhood Chain V4 uses the separate planned feed described below. In every case, finality, cursor traversal and unknown data need explicit handling.
 
 The normalized launch feed returns versioned records for Classic and Registry-verified Custom launches. Consumers should follow every cursor until completion, remove duplicate launch ids and retain records when optional price, chart or liquidity data is unavailable. A missing chart or quote is not permission to discard a valid launch record.
 
@@ -12,7 +12,54 @@ Direct Router indexing starts at the manifest's current start block. Process the
 
 Price and liquidity data should carry its own source, timestamp, status and quality. When a current value cannot be established, expose that state directly rather than converting the last launch transaction into a current valuation.
 
-The public status endpoint reports feed freshness, chain head, scan coverage and current counts. Production consumers should alert on lag and incomplete traversal instead of treating service availability as freshness.
+The Ethereum public status endpoint reports feed freshness, chain head, scan coverage and current counts. Production consumers should alert on lag and incomplete traversal instead of treating service availability as freshness.
+
+## Prepare Robinhood V4 indexing before activation
+
+Robinhood Chain Mainnet (`chainId: 4663`, `eip155:4663`) has a stable planned
+[V4 OpenAPI contract](https://programmable.market/openapi/custom-launch-v4.json). You can generate types, validate
+feed fixtures, map ABI topics and build cursor, quality and reorg handling now. This is integration preparation only.
+While discovery says `planned` and `planned-not-deployed`, live V4 ingestion is unavailable. A downloadable schema,
+an onchain foundation deployment or an HTTP `200` for the schema does not activate the API. Start network polling only
+after [Programmable discovery](https://programmable.market/.well-known/programmable.json),
+`GET /v4/chains/4663/capabilities` and `/readyz` bind the live chain deployment and finalized feed. The planned V4
+capabilities and finalized-feed routes currently return `404`, and the public Developer API v2 does not support chain
+`4663`; it remains an Ethereum integration surface. The deployed foundation has no Router-stamped launch event yet.
+
+After activation, read the public, keyless
+`GET /v4/chains/4663/finalized-custom-launches` feed. Validate every response and item against both chain identifiers,
+then apply these rules:
+
+- Publish only items with `onchain.terminal: true` and `onchain.checkpointType: ethereum_finalized`. Store the chain
+  deployment ID and descriptor digest, Router, Router runtime hash, Router launch ID, transaction hash, block number and
+  hash, log index, finality-policy binding, evidence digest and observation time. A sequencer soft confirmation or
+  Ethereum posting is not finality.
+- Store `projectMetadata.token` with `projectMetadata.tokenMetadataBinding.tokenTargetId`. Resolve the token address by
+  matching that target ID to `sourceVerification.components[*].targetId` and its address; never identify a token by
+  name or symbol alone.
+- Keep each source-verification component keyed by both `targetId` and address and preserve its server-authored status.
+  Finalized means the launch reached Robinhood-to-Ethereum finality; it does not mean every component is an
+  `exact_match`.
+- Read top-level `quality.status` as `ready`, `partial`, `stale` or `unavailable`, together with the source, published
+  and quarantined row counts. A successful response is not a complete inventory when quality is not `ready`.
+
+The request accepts an optional `limit` from 1 to 25 and defaults to 10. The response returns an opaque `nextCursor`;
+pass each non-null value back unchanged as `cursor` and never decode or construct one. Declare traversal complete only
+after `nextCursor` is null and quality remains `ready`.
+
+Direct Robinhood Router indexing starts only after activated discovery or its canonical manifest publishes the exact
+live Router address, runtime hash, ABI and event bindings, start block and finality policy, and provider readback agrees
+with that binding. Do not backfill from a source candidate, an address embedded in a schema or one deployment
+transaction. Advance the public checkpoint only through the published Robinhood-to-Ethereum finality proof.
+Enable a terminal's Robinhood launch label only after those manifest roots are active, a finalized canary is present in
+the feed and the complete traversal reports `quality.status: ready`.
+
+Indexability proves neither trading compatibility nor current price, liquidity, fee behavior, source verification or
+safety. The optional post-finality Universal Router trading-descriptor path is deliberately disabled, and V4 finalized
+items publish no such descriptor. A V4 Quoter call does not prove that an arbitrary hook can execute through Universal
+Router. Unless a later public schema and capabilities contract enables a server-authored descriptor backed by an exact
+Universal Router execution proof, terminals should display launch identity only and must not infer a route from a
+Router address, PoolKey or project metadata.
 
 ## Index protocol fee claims separately
 

--- a/packages/launch/scripts/sync-v4-machine-contracts.mjs
+++ b/packages/launch/scripts/sync-v4-machine-contracts.mjs
@@ -56,6 +56,12 @@ const uuid = {
   type: "string",
   pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
 };
+const opaqueListCursor = {
+  type: "string",
+  minLength: 16,
+  maxLength: 512,
+  pattern: "^[A-Za-z0-9_-]+$",
+};
 
 const finalityPolicy = closed(
   ["schemaVersion", "policyId", "policyRevision", "policyDigest"],
@@ -1843,7 +1849,7 @@ const listEnvelope = closed(
     caip2: { const: "eip155:4663" },
     generatedAt: dateTime,
     launches: array(resource),
-    nextCursor: nullable({ type: "string", minLength: 1, maxLength: 4096 }),
+    nextCursor: nullable(clone(opaqueListCursor)),
   },
 );
 const finalizedListEnvelope = closed(
@@ -1861,9 +1867,25 @@ const finalizedListEnvelope = closed(
       quarantinedRowCount: { type: "integer", minimum: 0 },
     }),
     launches: array(finalizedMetadata),
-    nextCursor: nullable({ type: "string", minLength: 1, maxLength: 4096 }),
+    nextCursor: nullable(clone(opaqueListCursor)),
   },
 );
+const listPaginationParameters = [
+  {
+    name: "limit",
+    in: "query",
+    required: false,
+    description: "Page size. Defaults to 10 and never exceeds 25.",
+    schema: { type: "integer", minimum: 1, maximum: 25, default: 10 },
+  },
+  {
+    name: "cursor",
+    in: "query",
+    required: false,
+    description: "Opaque continuation cursor returned by nextCursor. Pass it back unchanged.",
+    schema: clone(opaqueListCursor),
+  },
+];
 
 const standalone = new Map([
   ["custom-launch-create-request.json", annotate("Custom Launch V4 create request", "custom-launch-create-request.json", createRequest)],
@@ -1906,6 +1928,19 @@ listResponse.schema = { $ref: "#/components/schemas/CustomLaunchListV4" };
 const finalizedResponse = openapi.paths["/v4/chains/{chainId}/finalized-custom-launches"].get
   .responses["200"].content["application/json"];
 finalizedResponse.schema = { $ref: "#/components/schemas/CustomLaunchFinalizedListV4" };
+for (const pathName of [
+  "/v4/chains/{chainId}/custom-launches",
+  "/v4/chains/{chainId}/finalized-custom-launches",
+]) {
+  const operation = openapi.paths[pathName].get;
+  operation.parameters = [
+    ...(operation.parameters ?? []).filter((parameter) => !(
+      parameter.in === "query"
+      && (parameter.name === "limit" || parameter.name === "cursor")
+    )),
+    ...clone(listPaginationParameters),
+  ];
+}
 
 await writeFile(openApiPath, `${JSON.stringify(openapi, null, 2)}\n`);
 

--- a/packages/launch/test/v4-machine-contracts.test.mjs
+++ b/packages/launch/test/v4-machine-contracts.test.mjs
@@ -692,6 +692,57 @@ test("V4 list and finalized routes publish closed launches/nextCursor envelopes"
   assert.equal(finalizedValidator(finalizedGolden), false, "finalized envelope must be closed");
 });
 
+test("V4 collection routes publish the exact runtime pagination contract", () => {
+  const expectedPaginationParameters = [
+    {
+      name: "limit",
+      in: "query",
+      required: false,
+      description: "Page size. Defaults to 10 and never exceeds 25.",
+      schema: { type: "integer", minimum: 1, maximum: 25, default: 10 },
+    },
+    {
+      name: "cursor",
+      in: "query",
+      required: false,
+      description: "Opaque continuation cursor returned by nextCursor. Pass it back unchanged.",
+      schema: {
+        type: "string",
+        minLength: 16,
+        maxLength: 512,
+        pattern: "^[A-Za-z0-9_-]+$",
+      },
+    },
+  ];
+  const expectedNextCursor = {
+    oneOf: [
+      structuredClone(expectedPaginationParameters[1].schema),
+      { type: "null" },
+    ],
+  };
+  for (const [pathName, componentName] of [
+    ["/v4/chains/{chainId}/custom-launches", "CustomLaunchListV4"],
+    ["/v4/chains/{chainId}/finalized-custom-launches", "CustomLaunchFinalizedListV4"],
+  ]) {
+    const parameters = openapi.paths[pathName].get.parameters;
+    assert.deepEqual(
+      parameters.map(({ name, in: location }) => ({ name, in: location })),
+      [
+        { name: "chainId", in: "path" },
+        { name: "limit", in: "query" },
+        { name: "cursor", in: "query" },
+      ],
+      `${pathName} parameter order and uniqueness`,
+    );
+    assert.deepEqual(parameters.slice(1), expectedPaginationParameters, pathName);
+    assert.deepEqual(
+      openapi.components.schemas[componentName].properties.nextCursor,
+      expectedNextCursor,
+      `${componentName} nextCursor must be accepted unchanged by the request cursor`,
+    );
+  }
+});
+
 test("V4 source-verification schemas bind aggregate truth, exact evidence, and finalized readback", () => {
   const standalone = publicSchemas.get("source-verification-status.json");
   const {

--- a/public/openapi/custom-launch-v4.json
+++ b/public/openapi/custom-launch-v4.json
@@ -374,6 +374,30 @@
               "const": "4663",
               "type": "string"
             }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Page size. Defaults to 10 and never exceeds 25.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 25,
+              "default": 10
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "description": "Opaque continuation cursor returned by nextCursor. Pass it back unchanged.",
+            "schema": {
+              "type": "string",
+              "minLength": 16,
+              "maxLength": 512,
+              "pattern": "^[A-Za-z0-9_-]+$"
+            }
           }
         ],
         "responses": {
@@ -593,6 +617,30 @@
             "schema": {
               "const": "4663",
               "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Page size. Defaults to 10 and never exceeds 25.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 25,
+              "default": 10
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "description": "Opaque continuation cursor returned by nextCursor. Pass it back unchanged.",
+            "schema": {
+              "type": "string",
+              "minLength": 16,
+              "maxLength": 512,
+              "pattern": "^[A-Za-z0-9_-]+$"
             }
           }
         ],
@@ -57262,8 +57310,9 @@
             "oneOf": [
               {
                 "type": "string",
-                "minLength": 1,
-                "maxLength": 4096
+                "minLength": 16,
+                "maxLength": 512,
+                "pattern": "^[A-Za-z0-9_-]+$"
               },
               {
                 "type": "null"
@@ -64554,8 +64603,9 @@
             "oneOf": [
               {
                 "type": "string",
-                "minLength": 1,
-                "maxLength": 4096
+                "minLength": 16,
+                "maxLength": 512,
+                "pattern": "^[A-Za-z0-9_-]+$"
               },
               {
                 "type": "null"


### PR DESCRIPTION
## Summary

- Document planned-safe Robinhood Chain V4 indexing for terminal integrations without changing activation state.
- Add runtime-aligned limit and opaque cursor parameters to both V4 collection routes through the canonical generator.
- Keep nextCursor byte-compatible with the request cursor and add focused machine-contract coverage.

## Verification

- V4 generator rerun is idempotent.
- Focused list-envelope and pagination tests: 2/2 passed.
- Public machine-contract verification: verified.
- Root TypeScript check and git diff check passed.

## Activation boundary

Discovery remains planned and planned-not-deployed. This PR does not deploy, activate, promote, or enable V4 routes or Universal Router trading descriptors.
