### PR TITLE
Fix migration progress rate limits and retry handling

### DIFF
--- a/components/main-token-migration.tsx
+++ b/components/main-token-migration.tsx
@@ -342,11 +342,94 @@ export function sponsorshipRetryAfterMs(response: Response) {
   if (!value) return 3_000;
   const seconds = Number(value);
   if (Number.isFinite(seconds) && seconds >= 0) {
-    return Math.min(Math.max(Math.ceil(seconds * 1_000), 1_000), 15_000);
+    return Math.max(
+      Math.min(Math.ceil(seconds * 1_000), Number.MAX_SAFE_INTEGER),
+      1_000,
+    );
   }
   const date = Date.parse(value);
   if (!Number.isFinite(date)) return 3_000;
-  return Math.min(Math.max(date - Date.now(), 1_000), 15_000);
+  return Math.max(date - Date.now(), 1_000);
+}
+
+export async function waitForMigrationRetry(
+  delayMs: number,
+  signal?: AbortSignal,
+) {
+  const startedAt = performance.now();
+  let remaining = delayMs;
+  while (remaining > 0) {
+    if (signal?.aborted) throw new DOMException("Request aborted", "AbortError");
+    await new Promise<void>((resolve, reject) => {
+      const abort = () => {
+        globalThis.clearTimeout(timer);
+        reject(new DOMException("Request aborted", "AbortError"));
+      };
+      // Larger browser timeouts wrap to a near-immediate retry. Split long waits.
+      const timer = globalThis.setTimeout(() => {
+        signal?.removeEventListener("abort", abort);
+        resolve();
+      }, Math.min(remaining, 2_147_483_647));
+      signal?.addEventListener("abort", abort, { once: true });
+    });
+    remaining = delayMs - (performance.now() - startedAt);
+  }
+  if (signal?.aborted) throw new DOMException("Request aborted", "AbortError");
+}
+
+export function createMigrationRequestGate() {
+  const accounts = new Map<string, {
+    inFlight: Promise<void> | null;
+    nextAllowedAt: number;
+  }>();
+  const entryFor = (account: string) => {
+    const key = account.toLowerCase();
+    let entry = accounts.get(key);
+    if (!entry) {
+      entry = { inFlight: null, nextAllowedAt: 0 };
+      accounts.set(key, entry);
+    }
+    return entry;
+  };
+  return {
+    defer(account: string, delayMs: number) {
+      const entry = entryFor(account);
+      entry.nextAllowedAt = Math.max(
+        entry.nextAllowedAt,
+        performance.now() + delayMs,
+      );
+    },
+    async run<T>(
+      account: string,
+      request: () => Promise<T>,
+      signal?: AbortSignal,
+    ): Promise<T> {
+      const entry = entryFor(account);
+      while (true) {
+        if (signal?.aborted) {
+          throw new DOMException("Request aborted", "AbortError");
+        }
+        if (entry.inFlight) {
+          await entry.inFlight;
+          continue;
+        }
+        const remaining = entry.nextAllowedAt - performance.now();
+        if (remaining > 0) {
+          await waitForMigrationRetry(remaining, signal);
+          continue;
+        }
+        break;
+      }
+      let release!: () => void;
+      entry.inFlight = new Promise<void>((resolve) => { release = resolve; });
+      try {
+        return await request();
+      } finally {
+        entry.inFlight = null;
+        release();
+      }
+    },
+  };
 }
 
 export function parseGasSponsorshipResponse(
@@ -1001,14 +1084,18 @@ function Countdown({
 
 export function MainTokenMigration() {
   const { wallet } = useWallet();
+  const [sponsorshipRequestGate] = useState(createMigrationRequestGate);
   return (
     <MainTokenMigrationSession
       key={wallet?.account.toLowerCase() ?? "disconnected"}
+      sponsorshipRequestGate={sponsorshipRequestGate}
     />
   );
 }
 
-function MainTokenMigrationSession() {
+function MainTokenMigrationSession({ sponsorshipRequestGate }: {
+  sponsorshipRequestGate: ReturnType<typeof createMigrationRequestGate>;
+}) {
   const {
     wallet,
     connecting,
@@ -1055,6 +1142,7 @@ function MainTokenMigrationSession() {
   const sponsorshipIdempotencyKeysRef = useRef(new Map<string, string>());
   const gaslessIdempotencyKeysRef = useRef(new Map<string, string>());
   const sessionActiveRef = useRef(true);
+  const transferInFlightRef = useRef(false);
 
   useEffect(() => {
     sessionActiveRef.current = true;
@@ -1124,6 +1212,12 @@ function MainTokenMigrationSession() {
     connectedAccount !== null &&
     "account" in gasSponsorship &&
     gasSponsorship.account === connectedAccount;
+  const sponsorshipPollingAccount =
+    sponsorshipForConnectedAccount &&
+    (gasSponsorship.kind === "requested" ||
+      gasSponsorship.kind === "funding-confirming")
+      ? connectedAccount
+      : null;
   const sponsorshipInProgressOrReady =
     sponsorshipForConnectedAccount &&
     (gasSponsorship.kind === "requesting" ||
@@ -1384,37 +1478,42 @@ function MainTokenMigrationSession() {
       account: string,
       signal: AbortSignal,
     ): Promise<GasSponsorshipEndpointResult> => {
-      const accessToken = await getAccessToken();
-      if (!accessToken) {
-        throw new GasSponsorshipEndpointError(
-          "Reconnect this wallet before requesting sponsored gas.",
-          true,
-        );
-      }
-      const search = new URLSearchParams({
-        walletAddress: getAddress(account),
-      });
-      const response = await fetch(`${gasSponsorshipEndpoint}?${search}`, {
-        cache: "no-store",
-        headers: {
-          Accept: "application/json",
-          Authorization: `Bearer ${accessToken}`,
-        },
-        signal,
-      });
-      if (!response.ok) {
-        const failure = await gasSponsorshipFailure(response);
-        throw new GasSponsorshipEndpointError(
-          failure.message,
-          failure.retryable,
-        );
-      }
-      return {
-        body: parseGasSponsorshipResponse(await response.json(), account),
-        retryAfterMs: sponsorshipRetryAfterMs(response),
-      };
+      return sponsorshipRequestGate.run(account, async () => {
+        const accessToken = await getAccessToken();
+        if (!accessToken) {
+          throw new GasSponsorshipEndpointError(
+            "Reconnect this wallet before requesting sponsored gas.",
+            true,
+          );
+        }
+        const search = new URLSearchParams({
+          walletAddress: getAddress(account),
+        });
+        const response = await fetch(`${gasSponsorshipEndpoint}?${search}`, {
+          cache: "no-store",
+          headers: {
+            Accept: "application/json",
+            Authorization: `Bearer ${accessToken}`,
+          },
+          signal,
+        });
+        if (response.headers.has("retry-after") || !response.ok) {
+          sponsorshipRequestGate.defer(account, sponsorshipRetryAfterMs(response));
+        }
+        if (!response.ok) {
+          const failure = await gasSponsorshipFailure(response);
+          throw new GasSponsorshipEndpointError(
+            failure.message,
+            failure.retryable,
+          );
+        }
+        return {
+          body: parseGasSponsorshipResponse(await response.json(), account),
+          retryAfterMs: sponsorshipRetryAfterMs(response),
+        };
+      }, signal);
     },
-    [getAccessToken],
+    [getAccessToken, sponsorshipRequestGate],
   );
 
   useEffect(() => {
@@ -1427,6 +1526,7 @@ function MainTokenMigrationSession() {
       gasPrice === null ||
       hasEnoughObservedGas ||
       hasTrackedTransfer ||
+      sponsorshipForConnectedAccount ||
       submission.kind === "submitting"
     ) {
       return;
@@ -1457,80 +1557,74 @@ function MainTokenMigrationSession() {
     transferWindowOpen,
     readGasSponsorship,
     refreshBalance,
+    sponsorshipForConnectedAccount,
     submission.kind,
     wallet,
   ]);
 
   useEffect(() => {
-    if (
-      !sponsorshipForConnectedAccount ||
-      (gasSponsorship.kind !== "requested" &&
-        gasSponsorship.kind !== "funding-confirming")
-    ) {
-      return;
-    }
+    if (!sponsorshipPollingAccount) return;
 
-    const account = gasSponsorship.account;
+    const account = sponsorshipPollingAccount;
     const controller = new AbortController();
-    let retryTimer: number | undefined;
 
     const poll = async () => {
-      try {
-        const result = await readGasSponsorship(account, controller.signal);
-        if (controller.signal.aborted) return;
-        const next = gasSponsorshipState(result.body);
-        setGasSponsorship((previous) => {
+      let retryDelay = 10_000;
+      while (!controller.signal.aborted) {
+        try {
+          await waitForMigrationRetry(retryDelay, controller.signal);
+          const result = await readGasSponsorship(account, controller.signal);
+          if (controller.signal.aborted) return;
+          const next = gasSponsorshipState(result.body);
+          setGasSponsorship((previous) => {
+            if (
+              previous.kind === next.kind &&
+              "account" in previous &&
+              "account" in next &&
+              previous.account === next.account &&
+              (previous.kind !== "requested" &&
+              previous.kind !== "funding-confirming" &&
+              previous.kind !== "ready"
+                ? true
+                : next.kind === "requested" ||
+                    next.kind === "funding-confirming" ||
+                    next.kind === "ready"
+                  ? previous.transactionHash === next.transactionHash
+                  : false)
+            ) {
+              return previous;
+            }
+            return next;
+          });
           if (
-            previous.kind === next.kind &&
-            "account" in previous &&
-            "account" in next &&
-            previous.account === next.account &&
-            (previous.kind !== "requested" &&
-            previous.kind !== "funding-confirming" &&
-            previous.kind !== "ready"
-              ? true
-              : next.kind === "requested" ||
-                  next.kind === "funding-confirming" ||
-                  next.kind === "ready"
-                ? previous.transactionHash === next.transactionHash
-                : false)
+            result.body.status === "confirmed" ||
+            result.body.status === "not_needed"
           ) {
-            return previous;
+            void refreshBalance();
+            return;
           }
-          return next;
-        });
-        if (
-          result.body.status === "confirmed" ||
-          result.body.status === "not_needed"
-        ) {
-          void refreshBalance();
+          if (
+            result.body.status === "submitted" ||
+            result.body.status === "pending"
+          ) {
+            retryDelay = Math.max(10_000, result.retryAfterMs);
+          } else {
+            return;
+          }
+        } catch (error) {
+          if (controller.signal.aborted) return;
+          setGasSponsorship(gasSponsorshipError(error, account));
           return;
         }
-        if (
-          result.body.status === "submitted" ||
-          result.body.status === "pending"
-        ) {
-          retryTimer = window.setTimeout(
-            () => void poll(),
-            result.retryAfterMs,
-          );
-        }
-      } catch (error) {
-        if (controller.signal.aborted) return;
-        setGasSponsorship(gasSponsorshipError(error, account));
       }
     };
 
-    retryTimer = window.setTimeout(() => void poll(), 2_000);
-    return () => {
-      controller.abort();
-      if (retryTimer !== undefined) window.clearTimeout(retryTimer);
-    };
+    void poll();
+    return () => controller.abort();
   }, [
-    gasSponsorship,
     readGasSponsorship,
     refreshBalance,
-    sponsorshipForConnectedAccount,
+    sponsorshipPollingAccount,
   ]);
 
   useEffect(() => {
@@ -1749,41 +1843,49 @@ function MainTokenMigrationSession() {
     });
     focusSponsorshipActionOrStatus();
     try {
-      const accessToken = await getAccessToken();
-      if (!accessToken) {
-        throw new Error(
-          "Reconnect this wallet before requesting sponsored gas.",
+      const result = await sponsorshipRequestGate.run(account, async () => {
+        const accessToken = await getAccessToken();
+        if (!sessionActiveRef.current) {
+          throw new DOMException("Request aborted", "AbortError");
+        }
+        if (!accessToken) {
+          throw new Error(
+            "Reconnect this wallet before requesting sponsored gas.",
+          );
+        }
+        const body: MainTokenGasSponsorshipRequest = {
+          walletAddress: account,
+          amountRaw: parsedAmount.toString(),
+        };
+        const response = await fetch(gasSponsorshipEndpoint, {
+          method: "POST",
+          cache: "no-store",
+          headers: {
+            Accept: "application/json",
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+            "Idempotency-Key": gasSponsorshipIdempotencyKey(
+              account,
+              sponsorshipIdempotencyKeysRef.current,
+            ),
+          },
+          body: JSON.stringify(body),
+        });
+        if (response.headers.has("retry-after") || !response.ok) {
+          sponsorshipRequestGate.defer(account, sponsorshipRetryAfterMs(response));
+        }
+        if (!response.ok) {
+          const failure = await gasSponsorshipFailure(response);
+          throw new GasSponsorshipEndpointError(
+            failure.message,
+            failure.retryable,
+          );
+        }
+        return parseGasSponsorshipResponse(
+          await response.json(),
+          account,
         );
-      }
-      const body: MainTokenGasSponsorshipRequest = {
-        walletAddress: account,
-        amountRaw: parsedAmount.toString(),
-      };
-      const response = await fetch(gasSponsorshipEndpoint, {
-        method: "POST",
-        cache: "no-store",
-        headers: {
-          Accept: "application/json",
-          Authorization: `Bearer ${accessToken}`,
-          "Content-Type": "application/json",
-          "Idempotency-Key": gasSponsorshipIdempotencyKey(
-            account,
-            sponsorshipIdempotencyKeysRef.current,
-          ),
-        },
-        body: JSON.stringify(body),
       });
-      if (!response.ok) {
-        const failure = await gasSponsorshipFailure(response);
-        throw new GasSponsorshipEndpointError(
-          failure.message,
-          failure.retryable,
-        );
-      }
-      const result = parseGasSponsorshipResponse(
-        await response.json(),
-        account,
-      );
       setGasSponsorship(gasSponsorshipState(result));
       if (result.status === "confirmed" || result.status === "not_needed") {
         void refreshBalance();
@@ -1872,9 +1974,7 @@ function MainTokenMigrationSession() {
       if ((response.status !== 429 && response.status !== 503) || attempt === 4) {
         throw new Error(prepareFailure);
       }
-      await new Promise<void>((resolve) => {
-        window.setTimeout(resolve, sponsorshipRetryAfterMs(response));
-      });
+      await waitForMigrationRetry(sponsorshipRetryAfterMs(response));
     }
     if (!prepared) throw new Error(prepareFailure);
     if (prepared.status !== "signature_required") {
@@ -1917,9 +2017,7 @@ function MainTokenMigrationSession() {
       if (!response.ok) {
         const failure = await gaslessTransferFailure(response);
         if ((response.status === 429 || response.status === 503) && attempt < 59) {
-          await new Promise<void>((resolve) => {
-            window.setTimeout(resolve, sponsorshipRetryAfterMs(response));
-          });
+          await waitForMigrationRetry(sponsorshipRetryAfterMs(response));
           continue;
         }
         throw new Error(failure);
@@ -1947,9 +2045,7 @@ function MainTokenMigrationSession() {
         void refreshBalance();
         return;
       }
-      await new Promise<void>((resolve) => {
-        window.setTimeout(resolve, sponsorshipRetryAfterMs(response));
-      });
+      await waitForMigrationRetry(sponsorshipRetryAfterMs(response));
     }
     throw new Error(
       "The gasless transfer is still being reconciled. Resume it here; do not send V4 separately.",
@@ -1957,6 +2053,22 @@ function MainTokenMigrationSession() {
   }
 
   async function reviewTransfer() {
+    if (transferInFlightRef.current || hasTrackedTransfer) return;
+    transferInFlightRef.current = true;
+    setSubmission({ kind: "submitting" });
+    setGaslessStage("preparing");
+    try {
+      await reviewTransferOnce();
+    } finally {
+      transferInFlightRef.current = false;
+      setGaslessStage("idle");
+      setSubmission((current) => current.kind === "submitting"
+        ? { kind: "idle" }
+        : current);
+    }
+  }
+
+  async function reviewTransferOnce() {
     if (!trustedTransferWindowOpen()) {
       setSubmission({
         kind: "error",
@@ -2094,6 +2206,7 @@ function MainTokenMigrationSession() {
       }
       if (!sessionActiveRef.current) return;
       setSubmission({ kind: "submitting" });
+      setGaslessStage("signing");
       const hash = await sendTransaction(checked);
       const submitted: Extract<SubmissionState, { kind: "submitted" }> = {
         kind: "submitted",
@@ -2135,7 +2248,7 @@ function MainTokenMigrationSession() {
                         : "Switch to Ethereum"
                       : visibleSubmission.kind === "submitting"
                         ? gaslessStage === "preparing"
-                          ? "Preparing gasless transfer"
+                          ? "Preparing transfer"
                           : gaslessStage === "relaying"
                             ? "Relaying gasless transfer"
                             : "Confirm exact amount in wallet"

--- a/lib/server/main-token-migration-gas-sponsor-store-v1.ts
+++ b/lib/server/main-token-migration-gas-sponsor-store-v1.ts
@@ -31,6 +31,9 @@ const ADMISSION_WINDOW_SECONDS = 60;
 const ADMISSION_LIMITS = Object.freeze({
   read: Object.freeze({ holder: 8, principal: 12 }),
   submit: Object.freeze({ holder: 2, principal: 3 }),
+  // A signed relay request is also its progress poll. Keep those bounded
+  // separately from creating a new sponsorship reservation.
+  progress: Object.freeze({ holder: 24, principal: 36 }),
 });
 const ROOT_GUARD_TOP_UP_WEI = 1n;
 const ROOT_GUARD_FEE_PER_GAS_WEI = 1n;
@@ -94,7 +97,7 @@ type EligibilityAliasV1 = Readonly<{
   transferLogIndex: string | null;
 }>;
 
-type AdmissionOperation = "read" | "submit";
+type AdmissionOperation = "read" | "submit" | "progress";
 type AdmissionInput = Readonly<{
   releaseId: string;
   principalBindingHash: `sha256:${string}`;
@@ -845,7 +848,8 @@ function validateAdmission(input: AdmissionInput) {
     walletAddress: input.walletAddress,
   });
   if (!DIGEST.test(input.principalBindingHash)
-    || (input.operation !== "read" && input.operation !== "submit")) {
+    || (input.operation !== "read" && input.operation !== "submit"
+      && input.operation !== "progress")) {
     throw new TypeError("Gas sponsor admission is invalid");
   }
 }

--- a/lib/server/main-token-migration-gasless-transfer-v1.ts
+++ b/lib/server/main-token-migration-gasless-transfer-v1.ts
@@ -165,14 +165,17 @@ export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
           amountRaw: parsed.amountRaw,
           idempotencyKey,
         });
-        await input.admissionStore.admit({
+        const admission = {
           releaseId: input.configuration.releaseId,
           principalBindingHash:
             deriveMainTokenMigrationSponsorPrincipalBindingV1(
               principal.privyUserId,
             ),
           walletAddress: parsed.walletAddress,
-          operation: parsed.action === "prepare" ? "read" : "submit",
+        };
+        await input.admissionStore.admit({
+          ...admission,
+          operation: parsed.action === "prepare" ? "read" : "progress",
         });
         const lookup = {
           releaseId: input.configuration.releaseId,
@@ -252,6 +255,13 @@ export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
 
         let record = existing;
         if (!record) {
+          // Only a new durable reservation consumes the new-transfer budget.
+          // Identical signed retries still pass the bounded progress admission,
+          // signature verification and immutable binding checks above/below.
+          await input.admissionStore.admit({
+            ...admission,
+            operation: "submit",
+          });
           const nowSeconds = Math.floor(now().getTime() / 1_000);
           if (parsed.permitDeadline <= BigInt(nowSeconds + 30) ||
             parsed.permitDeadline > BigInt(
@@ -376,11 +386,15 @@ async function progressTransfer(input: Readonly<{
   if (permitStatus === "pending") {
     return transferResponse("permit_pending", record, 10);
   }
-  await input.chain.assertPermitEffect(record);
   if (!record.transferTransactionHash) {
     const reconciled = await input.sender.lookup("transfer", record.intent);
     const recoveredHash = providerHashOrNull(reconciled);
-    if (!recoveredHash) assertProviderRetryWindow(record.intent, input.now);
+    if (!recoveredHash) {
+      assertProviderRetryWindow(record.intent, input.now);
+      // transferFrom consumes the exact allowance. A known transaction must
+      // be reconciled by its receipt, not rejected for already using it.
+      await input.chain.assertPermitEffect(record);
+    }
     const hash = recoveredHash ?? await input.sender.send("transfer", record.intent);
     record = await input.store.complete({
       lookup: {
@@ -831,6 +845,12 @@ function errorResponse(error: unknown) {
       code: failure.code,
       requestId,
     });
+  } else if (failure.status === 429) {
+    console.warn("Main token migration gasless transfer rate limited", {
+      code: failure.code,
+      requestId,
+      retryAfterSeconds: failure.retryAfterSeconds ?? 60,
+    });
   }
   const message = failure.status === 401 || failure.status === 403
     ? "Reconnect this wallet and try again."
@@ -842,7 +862,7 @@ function errorResponse(error: unknown) {
       : failure.status === 422
         ? "This wallet cannot use the gasless transfer path."
         : failure.status === 429
-          ? "Too many migration requests. Wait briefly and try again."
+          ? "Migration checks are briefly paused. Wait before resuming this same request."
           : failure.code === "sponsorship_closed"
             ? "The migration window is closed."
             : "The gasless transfer is temporarily unavailable.";

--- a/tests/main-token-migration-gas-sponsor-v1.test.ts
+++ b/tests/main-token-migration-gas-sponsor-v1.test.ts
@@ -823,12 +823,30 @@ describe("main token migration gas sponsor", () => {
         code: "rate_limited",
       });
 
+      // Polling cannot consume or bypass the stricter new-transfer budget.
+      for (const [operation, limit] of [["submit", 2], ["progress", 24]] as const) {
+        for (let index = 0; index < limit; index += 1) {
+          await store.admit({
+            releaseId: CONFIGURATION.releaseId,
+            principalBindingHash,
+            walletAddress: WALLET,
+            operation,
+          });
+        }
+        await expect(store.admit({
+          releaseId: CONFIGURATION.releaseId,
+          principalBindingHash,
+          walletAddress: WALLET,
+          operation,
+        })).rejects.toMatchObject({ code: "rate_limited" });
+      }
+
       const rows = await database.query<{ count: string }>(`
         SELECT count(*)::text AS count
           FROM programmable_website_projection_v1.credential_uses
          WHERE credential_id LIKE '%:admission:%'
       `);
-      expect(rows.rows[0]?.count).toBe("16");
+      expect(rows.rows[0]?.count).toBe("68");
 
       const firstBindings = deriveMainTokenMigrationSponsorBindingsV1({
         releaseId: CONFIGURATION.releaseId,

--- a/tests/main-token-migration-gas-sponsorship-ui.test.ts
+++ b/tests/main-token-migration-gas-sponsorship-ui.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  createMigrationRequestGate,
   gasSponsorshipDisplayKind,
   gasSponsorshipErrorMessage,
   gasSponsorshipFailure,
@@ -8,6 +9,7 @@ import {
   hasEnoughMigrationGas,
   parseGasSponsorshipResponse,
   sponsorshipRetryAfterMs,
+  waitForMigrationRetry,
   type MainTokenGasSponsorshipResponse,
   type MainTokenGasSponsorshipStatus,
 } from "../components/main-token-migration";
@@ -34,7 +36,10 @@ function response(
 }
 
 describe("main token migration gas sponsorship UI contract", () => {
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
 
   it("accepts only the exact schema and connected wallet", () => {
     expect(parseGasSponsorshipResponse(response("confirmed"), WALLET)).toEqual({
@@ -107,7 +112,7 @@ describe("main token migration gas sponsorship UI contract", () => {
     expect(hasEnoughMigrationGas(-1n, gasPriceWei)).toBe(false);
   });
 
-  it("bounds Retry-After polling and falls back safely", () => {
+  it("honors the full Retry-After minimum and falls back safely", () => {
     expect(sponsorshipRetryAfterMs(new Response())).toBe(3_000);
     expect(sponsorshipRetryAfterMs(new Response(null, {
       headers: { "retry-after": "0" },
@@ -117,9 +122,15 @@ describe("main token migration gas sponsorship UI contract", () => {
     }))).toBe(2_200);
     expect(sponsorshipRetryAfterMs(new Response(null, {
       headers: { "retry-after": "999" },
-    }))).toBe(15_000);
+    }))).toBe(999_000);
+    expect(sponsorshipRetryAfterMs(new Response(null, {
+      headers: { "retry-after": "60" },
+    }))).toBe(60_000);
     expect(sponsorshipRetryAfterMs(new Response(null, {
       headers: { "retry-after": "not-a-date" },
+    }))).toBe(3_000);
+    expect(sponsorshipRetryAfterMs(new Response(null, {
+      headers: { "retry-after": "Infinity" },
     }))).toBe(3_000);
 
     vi.spyOn(Date, "now").mockReturnValue(
@@ -128,6 +139,65 @@ describe("main token migration gas sponsorship UI contract", () => {
     expect(sponsorshipRetryAfterMs(new Response(null, {
       headers: { "retry-after": "Sun, 30 Aug 2026 12:00:07 GMT" },
     }))).toBe(7_000);
+    expect(sponsorshipRetryAfterMs(new Response(null, {
+      headers: { "retry-after": "Sun, 30 Aug 2026 12:05:00 GMT" },
+    }))).toBe(300_000);
+  });
+
+  it("splits waits beyond the browser timer range without retrying early", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
+    const complete = vi.fn();
+    const waiting = waitForMigrationRetry(2_147_484_647).then(complete);
+    await vi.advanceTimersByTimeAsync(2_147_483_647);
+    expect(complete).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(999);
+    expect(complete).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    await waiting;
+    expect(complete).toHaveBeenCalledOnce();
+  });
+
+  it("serializes one wallet's reads and submits while preserving its cooldown", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
+    const gate = createMigrationRequestGate();
+    let releaseRead!: () => void;
+    const readPending = new Promise<void>((resolve) => { releaseRead = resolve; });
+    const read = gate.run(WALLET, async () => {
+      await readPending;
+      gate.defer(WALLET, 60_000);
+      return "read";
+    });
+    const submit = vi.fn(async () => "submitted");
+    const submitted = gate.run(WALLET.toUpperCase(), submit);
+    await gate.run(OTHER_WALLET, async () => "independent");
+    expect(submit).not.toHaveBeenCalled();
+    releaseRead();
+    await read;
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(submit).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(submitted).resolves.toBe("submitted");
+    expect(submit).toHaveBeenCalledOnce();
+  });
+
+  it("does not issue an aborted queued read and releases a failed request", async () => {
+    const gate = createMigrationRequestGate();
+    let releaseFirst!: () => void;
+    const firstPending = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    const first = gate.run(WALLET, async () => { await firstPending; });
+    const controller = new AbortController();
+    const queuedRead = vi.fn(async () => "should not run");
+    const queued = gate.run(WALLET, queuedRead, controller.signal);
+    const aborted = expect(queued).rejects.toMatchObject({ name: "AbortError" });
+    controller.abort();
+    releaseFirst();
+    await first;
+    await aborted;
+    expect(queuedRead).not.toHaveBeenCalled();
+    await expect(gate.run(WALLET, async () => {
+      throw new Error("Temporary failure");
+    })).rejects.toThrow("Temporary failure");
+    await expect(gate.run(WALLET, async () => "recovered")).resolves.toBe("recovered");
   });
 
   it("preserves the safe server message and request ID", async () => {

--- a/tests/main-token-migration-gasless-transfer-v1.test.ts
+++ b/tests/main-token-migration-gasless-transfer-v1.test.ts
@@ -23,6 +23,9 @@ import {
 import {
   deriveMainTokenMigrationSponsorBindingsV1,
 } from "../lib/server/main-token-migration-gas-sponsor-v1";
+import {
+  createMainTokenMigrationGasSponsorPostgresStoreV1,
+} from "../lib/server/main-token-migration-gas-sponsor-store-v1";
 import type {
   ProjectionTargetPostgresClientV1,
   ProjectionTargetPostgresQueryResultV1,
@@ -65,143 +68,205 @@ function request(body: unknown) {
 }
 
 describe("main token migration gasless permit transfer", () => {
-  it("binds the signature and relays only the exact fixed-destination transfer", async () => {
-    let record: MainTokenMigrationGaslessRecordV1 | null = null;
-    const store = {
-      async get() {
-        return record;
-      },
-      async reserve(input: { intent: MainTokenMigrationGaslessRecordV1["intent"] }) {
-        record = {
-          intent: input.intent,
-          permitTransactionHash: null,
-          transferTransactionHash: null,
-        };
-        return { kind: "created" as const, record };
-      },
-      async complete(input: {
-        kind: "permit" | "transfer";
-        transactionHash: typeof permitHash | typeof transferHash;
-      }) {
-        if (!record) throw new Error("missing intent");
-        record = {
-          ...record,
-          permitTransactionHash: input.kind === "permit"
-            ? input.transactionHash
-            : record.permitTransactionHash,
-          transferTransactionHash: input.kind === "transfer"
-            ? input.transactionHash
-            : record.transferTransactionHash,
-        };
-        return record;
-      },
-    };
-    const sender = {
-      async assertReady() {},
-      async lookup() {
-        return null;
-      },
-      async send(kind: "permit" | "transfer") {
-        return kind === "permit" ? permitHash : transferHash;
-      },
-    };
-    const handler = createMainTokenMigrationGaslessTransferV1({
-      configuration,
-      authenticator: {
-        async authenticate() {
-          return {
-            privyUserId: "did:privy:test",
-            privySessionId: "session-test",
-            wallets: [account.address],
+  it("finishes the exact relay without counting progress as new transfer requests", async () => {
+    const database = new PGlite();
+    try {
+      await database.exec(`
+        CREATE SCHEMA programmable_website_projection_v1;
+        CREATE TABLE programmable_website_projection_v1.credential_uses (
+          credential_id text PRIMARY KEY,
+          request_binding_hash text NOT NULL,
+          canonical_use text NOT NULL,
+          created_at timestamptz NOT NULL DEFAULT clock_timestamp()
+        );
+      `);
+      const admissionStore = createMainTokenMigrationGasSponsorPostgresStoreV1(
+        new GaslessTestPool(database),
+      );
+      let record: MainTokenMigrationGaslessRecordV1 | null = null;
+      let permitConfirmed = false;
+      let allowanceConsumed = false;
+      let recoverTransferFromProvider = false;
+      const store = {
+        async get() {
+          return record;
+        },
+        async reserve(input: { intent: MainTokenMigrationGaslessRecordV1["intent"] }) {
+          record = {
+            intent: input.intent,
+            permitTransactionHash: null,
+            transferTransactionHash: null,
           };
+          return { kind: "created" as const, record };
         },
-      },
-      admissionStore: { async admit() {} } as never,
-      store: store as never,
-      chain: {
-        async prepare() {
-          return {
-            nonce: 0n,
-            feePerGasWei: 1_000_000_000n,
-            maxPriorityFeePerGasWei: 100_000_000n,
-            sponsorBalanceWei: 1_000_000_000_000_000_000n,
-            rootWalletAddress: account.address,
+        async complete(input: {
+          kind: "permit" | "transfer";
+          transactionHash: typeof permitHash | typeof transferHash;
+        }) {
+          if (!record) throw new Error("missing intent");
+          record = {
+            ...record,
+            permitTransactionHash: input.kind === "permit"
+              ? input.transactionHash
+              : record.permitTransactionHash,
+            transferTransactionHash: input.kind === "transfer"
+              ? input.transactionHash
+              : record.transferTransactionHash,
           };
+          return record;
         },
-        async assertPermitEffect() {},
-        async transactionStatus(kind: "permit" | "transfer") {
-          return kind === "permit"
-            ? ({ status: "confirmed", blockNumber: 25_900_001n } as const)
-            : ({ status: "confirmed", blockNumber: 25_900_002n } as const);
+      };
+      const sender = {
+        async assertReady() {},
+        async lookup(kind: "permit" | "transfer") {
+          if (kind === "transfer" && recoverTransferFromProvider) {
+            return { status: "confirmed", transactionHash: transferHash };
+          }
+          return null;
         },
-      } as never,
-      sender: sender as never,
-      now: () => now,
-    });
+        send: vi.fn(async (kind: "permit" | "transfer") => {
+          if (kind === "transfer") allowanceConsumed = true;
+          return kind === "permit" ? permitHash : transferHash;
+        }),
+      };
+      const handler = createMainTokenMigrationGaslessTransferV1({
+        configuration,
+        authenticator: {
+          async authenticate() {
+            return {
+              privyUserId: "did:privy:test",
+              privySessionId: "session-test",
+              wallets: [account.address],
+            };
+          },
+        },
+        admissionStore,
+        store: store as never,
+        chain: {
+          async prepare() {
+            return {
+              nonce: 0n,
+              feePerGasWei: 1_000_000_000n,
+              maxPriorityFeePerGasWei: 100_000_000n,
+              sponsorBalanceWei: 1_000_000_000_000_000_000n,
+              rootWalletAddress: account.address,
+            };
+          },
+          async assertPermitEffect() {
+            if (allowanceConsumed) {
+              throw new Error("the exact permit allowance was already consumed");
+            }
+          },
+          async transactionStatus(kind: "permit" | "transfer") {
+            if (kind === "permit" && !permitConfirmed) return "pending";
+            return kind === "permit"
+              ? ({ status: "confirmed", blockNumber: 25_900_001n } as const)
+              : ({ status: "confirmed", blockNumber: 25_900_002n } as const);
+          },
+        } as never,
+        sender: sender as never,
+        now: () => now,
+      });
 
-    const preparedResponse = await handler.post(request({
-      action: "prepare",
-      amountRaw: "100",
-      walletAddress: account.address,
-    }));
-    expect(preparedResponse.status).toBe(200);
-    const prepared = await preparedResponse.json() as {
-      nonce: string;
-      permitDeadline: string;
-      requestBindingHash: `sha256:${string}`;
-      sponsorAddress: `0x${string}`;
-      status: string;
-      transferBlockNumber: string | null;
-    };
-    expect(prepared).toMatchObject({
-      status: "signature_required",
-      nonce: "0",
-      sponsorAddress,
-      transferBlockNumber: null,
-    });
-    const signature = await account.signTypedData(
-      buildMainTokenMigrationPermitTypedData({
-        owner: account.address,
-        spender: sponsorAddress,
-        value: 100n,
-        nonce: BigInt(prepared.nonce),
-        deadline: BigInt(prepared.permitDeadline),
-      }),
-    );
-    const submitBody = {
-      action: "submit",
-      amountRaw: "100",
-      nonce: prepared.nonce,
-      permitDeadline: prepared.permitDeadline,
-      permitSignature: signature,
-      requestBindingHash: prepared.requestBindingHash,
-      walletAddress: account.address,
-    };
-    const permitResponse = await handler.post(request(submitBody));
-    expect(await permitResponse.json()).toMatchObject({
-      status: "permit_submitted",
-      permitTransactionHash: permitHash,
-      transferTransactionHash: null,
-    });
-    const transferResponse = await handler.post(request(submitBody));
-    expect(await transferResponse.json()).toMatchObject({
-      status: "transfer_submitted",
-      permitTransactionHash: permitHash,
-      transferTransactionHash: transferHash,
-      transferBlockNumber: null,
-    });
-    const confirmedResponse = await handler.post(request(submitBody));
-    expect(await confirmedResponse.json()).toMatchObject({
-      status: "confirmed",
-      permitTransactionHash: permitHash,
-      transferTransactionHash: transferHash,
-      transferBlockNumber: "25900002",
-    });
-    const finalRecord = record as MainTokenMigrationGaslessRecordV1 | null;
-    expect(finalRecord?.intent.walletAddress).toBe(account.address);
-    expect(finalRecord?.intent.amountRaw).toBe("100");
-    expect(MAIN_TOKEN_MIGRATION_WALLET).not.toBe(account.address);
-  });
+      const preparedResponse = await handler.post(request({
+        action: "prepare",
+        amountRaw: "100",
+        walletAddress: account.address,
+      }));
+      expect(preparedResponse.status).toBe(200);
+      const prepared = await preparedResponse.json() as {
+        nonce: string;
+        permitDeadline: string;
+        requestBindingHash: `sha256:${string}`;
+        sponsorAddress: `0x${string}`;
+        status: string;
+        transferBlockNumber: string | null;
+      };
+      expect(prepared).toMatchObject({
+        status: "signature_required",
+        nonce: "0",
+        sponsorAddress,
+        transferBlockNumber: null,
+      });
+      const signature = await account.signTypedData(
+        buildMainTokenMigrationPermitTypedData({
+          owner: account.address,
+          spender: sponsorAddress,
+          value: 100n,
+          nonce: BigInt(prepared.nonce),
+          deadline: BigInt(prepared.permitDeadline),
+        }),
+      );
+      const submitBody = {
+        action: "submit",
+        amountRaw: "100",
+        nonce: prepared.nonce,
+        permitDeadline: prepared.permitDeadline,
+        permitSignature: signature,
+        requestBindingHash: prepared.requestBindingHash,
+        walletAddress: account.address,
+      };
+      const permitResponse = await handler.post(request(submitBody));
+      expect(await permitResponse.json()).toMatchObject({
+        status: "permit_submitted",
+        permitTransactionHash: permitHash,
+        transferTransactionHash: null,
+      });
+      for (let index = 0; index < 3; index += 1) {
+        const pendingResponse = await handler.post(request(submitBody));
+        expect(pendingResponse.status).toBe(200);
+        expect(await pendingResponse.json()).toMatchObject({
+          status: "permit_pending",
+          permitTransactionHash: permitHash,
+          transferTransactionHash: null,
+        });
+      }
+      permitConfirmed = true;
+      const transferResponse = await handler.post(request(submitBody));
+      expect(await transferResponse.json()).toMatchObject({
+        status: "transfer_submitted",
+        permitTransactionHash: permitHash,
+        transferTransactionHash: transferHash,
+        transferBlockNumber: null,
+      });
+      const confirmedResponse = await handler.post(request(submitBody));
+      expect(await confirmedResponse.json()).toMatchObject({
+        status: "confirmed",
+        permitTransactionHash: permitHash,
+        transferTransactionHash: transferHash,
+        transferBlockNumber: "25900002",
+      });
+      const finalRecord = record as MainTokenMigrationGaslessRecordV1 | null;
+      expect(finalRecord?.intent.walletAddress).toBe(account.address);
+      expect(finalRecord?.intent.amountRaw).toBe("100");
+      expect(MAIN_TOKEN_MIGRATION_WALLET).not.toBe(account.address);
+      expect(sender.send).toHaveBeenCalledTimes(2);
+      // The provider may have sent the transfer before the completion row was
+      // persisted. Its known hash must recover even though allowance is now zero.
+      if (!finalRecord) throw new Error("missing confirmed intent");
+      record = { ...finalRecord, transferTransactionHash: null };
+      recoverTransferFromProvider = true;
+      const recoveredResponse = await handler.post(request(submitBody));
+      expect(recoveredResponse.status).toBe(200);
+      expect(await recoveredResponse.json()).toMatchObject({
+        status: "transfer_submitted",
+        transferTransactionHash: transferHash,
+      });
+      expect(await (await handler.post(request(submitBody))).json()).toMatchObject({
+        status: "confirmed",
+        transferTransactionHash: transferHash,
+      });
+      expect(sender.send).toHaveBeenCalledTimes(2);
+      const admissionRows = await database.query<{ count: string }>(`
+        SELECT count(*)::text AS count
+          FROM programmable_website_projection_v1.credential_uses
+         WHERE credential_id LIKE '%:admission:%:submit:%'
+      `);
+      expect(admissionRows.rows[0]?.count).toBe("2");
+    } finally {
+      await database.close();
+    }
+  }, 10_000);
 
   it("rejects a permit signed by a different wallet", async () => {
     const other = privateKeyToAccount(

--- a/tests/main-token-migration.test.ts
+++ b/tests/main-token-migration.test.ts
@@ -177,6 +177,22 @@ describe("main token migration page contract", () => {
     readFileSync(join(process.cwd(), path), "utf8");
   const page = read("components/main-token-migration.tsx");
 
+  it("locks wallet review before the first asynchronous preparation", () => {
+    const review = page.slice(
+      page.indexOf("async function reviewTransfer()"),
+      page.indexOf("async function reviewTransferOnce()"),
+    );
+    expect(review).toContain("if (transferInFlightRef.current || hasTrackedTransfer) return;");
+    expect(review.indexOf("transferInFlightRef.current = true;")).toBeLessThan(
+      review.indexOf("await reviewTransferOnce();"),
+    );
+    expect(review.indexOf('setSubmission({ kind: "submitting" });')).toBeLessThan(
+      review.indexOf("await reviewTransferOnce();"),
+    );
+    expect(review).toContain("finally {");
+    expect(review).toContain("transferInFlightRef.current = false;");
+  });
+
   it("scopes persisted transfer receipts to the connected wallet", () => {
     const hash = `0x${"ab".repeat(32)}`;
     const receipt = JSON.stringify({


### PR DESCRIPTION
## Summary
- Separate bounded relay progress checks from new transfer submission limits without weakening holder, signature, recipient or budget checks.
- Honor the complete Retry-After delay, serialize per-wallet sponsor requests and prevent concurrent transfer actions.
- Confirm and recover known transfers after the exact permit allowance has been consumed.
- Log rate-limit request IDs safely without wallet signatures or credentials.

## Verification
- 49 focused migration tests passed.
- TypeScript, scoped ESLint and git diff --check passed.
- Independent server and client review: no P0/P1 findings.
- No wallet signing, broadcast, recipient change, migration-window change or activation change.

Production deployment and public readback remain separate release steps.