### PR TITLE
Fix gasless migration for current V4 holders and safe resume

### DIFF
--- a/components/main-token-migration.tsx
+++ b/components/main-token-migration.tsx
@@ -73,6 +73,36 @@ type AccountCodeObservation = Readonly<{
   status: "eoa" | "delegated" | "contract" | "unavailable";
 }>;
 
+export function migrationGaslessResumeAmount(
+  progress: Readonly<{ account: string; amountRaw: string }> | null,
+  connectedAccount: string | null,
+): bigint | null {
+  if (!progress || !connectedAccount ||
+    progress.account.toLowerCase() !== connectedAccount.toLowerCase() ||
+    !/^[1-9][0-9]*$/u.test(progress.amountRaw) || progress.amountRaw.length > 28) {
+    return null;
+  }
+  const amountRaw = BigInt(progress.amountRaw);
+  return amountRaw <= MAIN_TOKEN_TOTAL_SUPPLY_RAW ? amountRaw : null;
+}
+
+export function migrationTransferRoute(input: Readonly<{
+  accountCodeStatus: AccountCodeObservation["status"] | "idle" | "checking";
+  nativeBalanceWei: bigint | null;
+  gasPriceWei: bigint | null;
+  resumingGasless: boolean;
+}>): "gasless" | "wallet" | "checking" | "unsupported" {
+  if (input.accountCodeStatus === "contract") return "unsupported";
+  if (input.resumingGasless) return "gasless";
+  if (input.accountCodeStatus === "delegated") return "gasless";
+  if (input.accountCodeStatus !== "eoa" || input.nativeBalanceWei === null ||
+    input.gasPriceWei === null || input.nativeBalanceWei < 0n ||
+    input.gasPriceWei <= 0n) return "checking";
+  return hasEnoughMigrationGas(input.nativeBalanceWei, input.gasPriceWei)
+    ? "wallet"
+    : "gasless";
+}
+
 const gasSponsorshipEndpoint =
   "/api/main-token-migration/gas-sponsorship" as const;
 const gasSponsorshipSchema =
@@ -163,7 +193,7 @@ type GaslessTransferResponse = Readonly<{
   transferBlockNumber: string | null;
 }>;
 
-type GaslessStage = "idle" | "preparing" | "signing" | "relaying";
+type GaslessStage = "idle" | "preparing" | "signing" | "relaying" | "reconciling";
 
 type StoredGaslessTransferProgress = Readonly<{
   schema: "programmable-main-token-migration-gasless-ui/v1";
@@ -220,7 +250,7 @@ function persistGaslessTransferProgress(
     }
   } catch {
     throw new Error(
-      "Gasless transfer recovery is unavailable in this browser. No signature was requested.",
+      "This browser could not save transfer recovery. This attempt was not submitted. Contact migration support before trying again.",
     );
   }
   window.dispatchEvent(new Event(migrationRecoveryEvent));
@@ -569,13 +599,16 @@ export async function gasSponsorshipErrorMessage(response: Response) {
   return (await gasSponsorshipFailure(response)).message;
 }
 
-async function gaslessTransferFailure(response: Response) {
+export async function gaslessTransferFailure(response: Response) {
+  let code = "";
   let message = "The gasless transfer is temporarily unavailable.";
   let requestId = "";
   try {
     const body = await response.json() as {
-      error?: { message?: unknown; requestId?: unknown };
+      error?: { code?: unknown; message?: unknown; requestId?: unknown };
     };
+    if (typeof body.error?.code === "string" &&
+      /^[a-z_]{1,80}$/u.test(body.error.code)) code = body.error.code;
     if (typeof body.error?.message === "string" &&
       body.error.message.length <= 240) message = body.error.message;
     if (typeof body.error?.requestId === "string" &&
@@ -585,7 +618,10 @@ async function gaslessTransferFailure(response: Response) {
   } catch {
     // Keep the stable recovery message.
   }
-  return requestId ? `${message} Request ID: ${requestId}` : message;
+  return {
+    code,
+    message: requestId ? `${message} Request ID: ${requestId}` : message,
+  };
 }
 
 function gasSponsorshipError(
@@ -674,9 +710,10 @@ function gasSponsorshipIdempotencyKey(
   }
 }
 
-function gaslessTransferIdempotencyKey(
+export function gaslessTransferIdempotencyKey(
   account: string,
   fallbackKeys: Map<string, string>,
+  requireExisting = false,
 ) {
   const normalizedAccount = getAddress(account).toLowerCase();
   const storageKey = `programmable:main-token-migration:gasless:${MAIN_TOKEN_MIGRATION_RELEASE_ID}:${normalizedAccount}`;
@@ -688,12 +725,18 @@ function gaslessTransferIdempotencyKey(
       fallbackKeys.set(storageKey, stored);
       return stored;
     }
+    if (requireExisting) {
+      throw new Error("The saved migration request key is unavailable. Contact migration support before sending again.");
+    }
     const created =
       `gasless-${MAIN_TOKEN_MIGRATION_RELEASE_ID}-${window.crypto.randomUUID()}`;
     fallbackKeys.set(storageKey, created);
     window.localStorage.setItem(storageKey, created);
     return created;
   } catch {
+    if (requireExisting) {
+      throw new Error("The saved migration request key is unavailable. Contact migration support before sending again.");
+    }
     const created =
       `gasless-${MAIN_TOKEN_MIGRATION_RELEASE_ID}-${window.crypto.randomUUID()}`;
     fallbackKeys.set(storageKey, created);
@@ -1253,10 +1296,6 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
       : sponsorshipForConnectedAccount
         ? gasSponsorship.kind
         : "idle";
-  const terminalSponsorshipFailure =
-    sponsorshipForConnectedAccount &&
-    gasSponsorship.kind === "error" &&
-    !gasSponsorship.retryable;
   const sponsorReceiptConfirmed =
     sponsorshipForConnectedAccount &&
     (gasSponsorship.kind === "balance-confirming" ||
@@ -1269,11 +1308,19 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
       gasSponsorship.kind === "ready")
       ? gasSponsorship.transactionHash
       : null;
-  const sponsoredGasReady = hasEnoughObservedGas;
-  const delegatedWallet = accountCodeStatus === "delegated";
   const unresolvedGaslessTransfer = gaslessProgress !== null;
   const gaslessProgressForConnectedAccount =
     connectedAccount !== null && gaslessProgress?.account === connectedAccount;
+  const resumeAmountRaw = migrationGaslessResumeAmount(gaslessProgress, connectedAccount);
+  const canResumeGaslessTransfer = resumeAmountRaw !== null &&
+    accountCodeStatus !== "contract";
+  const transferRoute = migrationTransferRoute({
+    accountCodeStatus,
+    nativeBalanceWei: nativeBalance,
+    gasPriceWei: gasPrice,
+    resumingGasless: canResumeGaslessTransfer,
+  });
+  const gaslessTransferPath = transferRoute === "gasless";
   const parsedAmount = useMemo(() => {
     if (!amount.trim()) return null;
     try {
@@ -1283,17 +1330,18 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
     }
   }, [amount]);
   const amountError = useMemo(() => {
+    if (hasTrackedTransfer) return "";
     if (!amount.trim()) return "";
     try {
       const amountRaw = parseMainTokenMigrationAmount(amount);
-      if (balance !== null) {
+      if (balance !== null && amountRaw !== resumeAmountRaw) {
         assertMainTokenMigrationBalance(amountRaw, balance);
       }
       return "";
     } catch (error) {
       return migrationErrorMessage(error);
     }
-  }, [amount, balance]);
+  }, [amount, balance, hasTrackedTransfer, resumeAmountRaw]);
 
   useEffect(() => {
     if (!migrationWindow.enabled) return;
@@ -1537,52 +1585,8 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
     [getAccessToken, sponsorshipRequestGate],
   );
 
-  useEffect(() => {
-    if (
-      !transferWindowOpen ||
-      !wallet ||
-      !onMainnet ||
-      accountCodeStatus !== "eoa" ||
-      nativeBalance === null ||
-      gasPrice === null ||
-      hasEnoughObservedGas ||
-      hasTrackedTransfer ||
-      sponsorshipForConnectedAccount ||
-      submission.kind === "submitting"
-    ) {
-      return;
-    }
-
-    const account = wallet.account.toLowerCase();
-    const controller = new AbortController();
-    void readGasSponsorship(account, controller.signal)
-      .then(({ body }) => {
-        if (controller.signal.aborted) return;
-        setGasSponsorship(gasSponsorshipState(body));
-        if (body.status === "confirmed" || body.status === "not_needed") {
-          void refreshBalance();
-        }
-      })
-      .catch((error: unknown) => {
-        if (controller.signal.aborted) return;
-        setGasSponsorship(gasSponsorshipError(error, account));
-      });
-    return () => controller.abort();
-  }, [
-    accountCodeStatus,
-    gasPrice,
-    hasEnoughObservedGas,
-    hasTrackedTransfer,
-    nativeBalance,
-    onMainnet,
-    transferWindowOpen,
-    readGasSponsorship,
-    refreshBalance,
-    sponsorshipForConnectedAccount,
-    submission.kind,
-    wallet,
-  ]);
-
+  // New gasless transfers use the token-bound endpoint, never ETH-faucet eligibility.
+  // Retain reconciliation for an ETH top-up already started in this page session.
   useEffect(() => {
     if (!sponsorshipPollingAccount) return;
 
@@ -1952,7 +1956,12 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
     }
   }
 
-  async function reviewGaslessTransfer(account: `0x${string}`, amountRaw: bigint) {
+  async function reviewGaslessTransfer(
+    account: `0x${string}`,
+    amountRaw: bigint,
+    resumeExisting = false,
+    preservePendingRequest = false,
+  ) {
     const accessToken = await getAccessToken();
     if (!accessToken) {
       throw new Error("Reconnect this wallet before using the gasless transfer.");
@@ -1960,6 +1969,7 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
     const idempotencyKey = gaslessTransferIdempotencyKey(
       account,
       gaslessIdempotencyKeysRef.current,
+      resumeExisting || preservePendingRequest,
     );
     const headers = {
       Accept: "application/json",
@@ -1968,66 +1978,74 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
       "Idempotency-Key": idempotencyKey,
     };
     setSubmission({ kind: "submitting" });
-    setGaslessStage("preparing");
-    const prepareBody = JSON.stringify({
-      action: "prepare",
-      walletAddress: account,
-      amountRaw: amountRaw.toString(),
-    });
-    let prepared: GaslessTransferResponse | null = null;
-    let prepareFailure = "The gasless transfer is temporarily unavailable.";
-    for (let attempt = 0; attempt < 5; attempt += 1) {
-      const response = await fetch(gaslessTransferEndpoint, {
-        method: "POST",
-        cache: "no-store",
-        headers,
-        body: prepareBody,
+    let submitBody: string;
+    if (resumeExisting) {
+      setGaslessStage("reconciling");
+      submitBody = JSON.stringify({
+        action: "resume",
+        walletAddress: account,
+        amountRaw: amountRaw.toString(),
       });
-      if (response.ok) {
-        prepared = parseGaslessTransferResponse(
-          await response.json(),
-          account,
-          amountRaw,
-        );
-        break;
+    } else {
+      if (!trustedTransferWindowOpen()) {
+        throw new Error("New transfers are closed. Contact migration support about this saved request.");
       }
-      prepareFailure = await gaslessTransferFailure(response);
-      if ((response.status !== 429 && response.status !== 503) || attempt === 4) {
-        throw new Error(prepareFailure);
+      setGaslessStage("preparing");
+      const prepareBody = JSON.stringify({
+        action: "prepare",
+        walletAddress: account,
+        amountRaw: amountRaw.toString(),
+      });
+      let prepared: GaslessTransferResponse | null = null;
+      let prepareFailure = "The gasless transfer is temporarily unavailable.";
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        const response = await fetch(gaslessTransferEndpoint, {
+          method: "POST",
+          cache: "no-store",
+          headers,
+          body: prepareBody,
+        });
+        if (response.ok) {
+          prepared = parseGaslessTransferResponse(
+            await response.json(),
+            account,
+            amountRaw,
+          );
+          break;
+        }
+        prepareFailure = (await gaslessTransferFailure(response)).message;
+        if ((response.status !== 429 && response.status !== 503) || attempt === 4) {
+          throw new Error(prepareFailure);
+        }
+        await waitForMigrationRetry(sponsorshipRetryAfterMs(response));
       }
-      await waitForMigrationRetry(sponsorshipRetryAfterMs(response));
-    }
-    if (!prepared) throw new Error(prepareFailure);
-    if (prepared.status !== "signature_required") {
-      throw new Error("The gasless transfer request is not ready for review.");
-    }
-    if (!sessionActiveRef.current) return;
-    const progress = persistGaslessTransferProgress(account, amountRaw);
-    setGaslessProgress(progress);
-    setGaslessStage("signing");
-    let permit;
-    try {
-      permit = await signMainTokenMigrationPermit({
+      if (!prepared) throw new Error(prepareFailure);
+      if (prepared.status !== "signature_required") {
+        throw new Error("The gasless transfer request is not ready for review.");
+      }
+      if (!sessionActiveRef.current) return;
+      setGaslessStage("signing");
+      const permit = await signMainTokenMigrationPermit({
         deadline: BigInt(prepared.permitDeadline),
         nonce: BigInt(prepared.nonce),
         spender: getAddress(prepared.sponsorAddress),
         value: amountRaw,
       });
-    } catch (error) {
-      clearGaslessTransferProgress();
-      setGaslessProgress(null);
-      throw error;
+      // An unsigned request cannot transfer V4 and must not leave a stuck marker.
+      // Persist before submit so a lost response always resumes this exact intent.
+      const progress = persistGaslessTransferProgress(account, amountRaw);
+      setGaslessProgress(progress);
+      setGaslessStage("relaying");
+      submitBody = JSON.stringify({
+        action: "submit",
+        walletAddress: account,
+        amountRaw: amountRaw.toString(),
+        nonce: prepared.nonce,
+        permitDeadline: prepared.permitDeadline,
+        permitSignature: permit.signature,
+        requestBindingHash: prepared.requestBindingHash,
+      });
     }
-    setGaslessStage("relaying");
-    const submitBody = JSON.stringify({
-      action: "submit",
-      walletAddress: account,
-      amountRaw: amountRaw.toString(),
-      nonce: prepared.nonce,
-      permitDeadline: prepared.permitDeadline,
-      permitSignature: permit.signature,
-      requestBindingHash: prepared.requestBindingHash,
-    });
     for (let attempt = 0; attempt < 60; attempt += 1) {
       const response = await fetch(gaslessTransferEndpoint, {
         method: "POST",
@@ -2037,17 +2055,27 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
       });
       if (!response.ok) {
         const failure = await gaslessTransferFailure(response);
+        if (resumeExisting && response.status === 409 &&
+          failure.code === "gasless_request_not_found" && trustedTransferWindowOpen()) {
+          // A crash before the first submit can leave only the local marker.
+          // Retry once with its same binding; never clear it or start a second key.
+          await reviewGaslessTransfer(account, amountRaw, false, true);
+          return;
+        }
         if ((response.status === 429 || response.status === 503) && attempt < 59) {
           await waitForMigrationRetry(sponsorshipRetryAfterMs(response));
           continue;
         }
-        throw new Error(failure);
+        throw new Error(failure.message);
       }
       const result = parseGaslessTransferResponse(
         await response.json(),
         account,
         amountRaw,
       );
+      if (result.status === "signature_required") {
+        throw new Error("The existing transfer could not be reconciled. Contact migration support before sending again.");
+      }
       if (result.status === "confirmed" && result.transferTransactionHash &&
         result.transferBlockNumber) {
         const confirmed: Extract<SubmissionState, { kind: "confirmed" }> = {
@@ -2090,6 +2118,31 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
   }
 
   async function reviewTransferOnce() {
+    if (canResumeGaslessTransfer && wallet && resumeAmountRaw !== null) {
+      try {
+        if (!onMainnet) {
+          await switchNetwork(String(MAIN_TOKEN_MIGRATION_CHAIN_ID));
+          return;
+        }
+        // Resume uses only the stored signed intent. It may read receipts after
+        // the window closes and must not depend on V4 already spent by that intent.
+        await reviewGaslessTransfer(getAddress(wallet.account), resumeAmountRaw, true);
+      } catch (error) {
+        setSubmission({ kind: "error", message: migrationErrorMessage(error) });
+      }
+      return;
+    }
+    if (unresolvedGaslessTransfer) {
+      if (!wallet) {
+        openWallet();
+        return;
+      }
+      setSubmission({
+        kind: "error",
+        message: "Reconnect the wallet used for the pending transfer. Do not send V4 separately.",
+      });
+      return;
+    }
     if (!trustedTransferWindowOpen()) {
       setSubmission({
         kind: "error",
@@ -2177,29 +2230,11 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
       setGasPrice(freshBalances.gasPriceWei);
       assertMainTokenMigrationBalance(amountRaw, freshBalances.tokenBalanceRaw);
       const account = getAddress(wallet.account);
-      if (delegated) {
+      if (delegated || !hasEnoughMigrationGas(
+        freshBalances.nativeBalanceWei,
+        freshBalances.gasPriceWei,
+      )) {
         await reviewGaslessTransfer(account, amountRaw);
-        return;
-      }
-      if (
-        !hasEnoughMigrationGas(
-          freshBalances.nativeBalanceWei,
-          freshBalances.gasPriceWei,
-        )
-      ) {
-        setSubmission({
-          kind: "error",
-          message:
-            sponsorshipKind === "requesting" ||
-            sponsorshipKind === "requested" ||
-            sponsorshipKind === "funding-confirming" ||
-            sponsorshipKind === "balance-confirming"
-              ? "The sponsored ETH is not available yet. Wait for confirmation and try again."
-              : sponsorshipKind === "ready"
-                ? "This wallet no longer has enough ETH for the transfer. Add ETH and try again."
-                : "This wallet needs ETH for gas. Request sponsored gas before sending V4.",
-        });
-        focusSponsorshipActionOrStatus();
         return;
       }
       const finalCheckTime = readTrustedNow();
@@ -2245,7 +2280,15 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
   }
 
   const primaryLabel =
-    phase === "checking"
+    unresolvedGaslessTransfer && !wallet
+      ? connecting ? "Opening wallet" : "Connect wallet"
+      : canResumeGaslessTransfer
+        ? !onMainnet
+          ? switchingNetwork ? "Switching network" : "Switch to Ethereum"
+          : visibleSubmission.kind === "submitting"
+            ? "Checking previous transfer"
+            : "Resume gasless transfer"
+      : phase === "checking"
       ? "Checking migration window"
       : phase === "preview"
         ? "Migration not open"
@@ -2288,26 +2331,10 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
                                     : gaslessProgress &&
                                         gaslessProgress.account !== connectedAccount
                                       ? "Reconnect pending wallet"
-                                    : delegatedWallet
-                                      ? gaslessProgressForConnectedAccount
-                                        ? "Resume gasless transfer"
-                                        : "Review gasless transfer"
-                                    : !sponsoredGasReady
-                                      ? sponsorshipKind === "eligible"
-                                        ? "Request sponsored gas first"
-                                        : sponsorshipKind === "requesting"
-                                          ? "Requesting sponsored gas"
-                                          : sponsorshipKind === "requested" ||
-                                              sponsorshipKind ===
-                                                "funding-confirming" ||
-                                              sponsorshipKind ===
-                                                "balance-confirming"
-                                            ? "Waiting for sponsored gas"
-                                            : sponsorshipKind === "error"
-                                              ? terminalSponsorshipFailure
-                                                ? "Check ETH and continue"
-                                                : "Check gas sponsorship"
-                                              : "Checking gas balance"
+                                    : gaslessTransferPath
+                                      ? "Check gasless transfer"
+                                    : transferRoute === "checking"
+                                      ? "Check gas balance"
                                       : "Review transfer in wallet";
 
   return (
@@ -2426,7 +2453,7 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
                 className={styles.primaryAction}
                 type="button"
                 onClick={() => void reviewTransfer()}
-                disabled={!transferWindowOpen || connecting}
+                disabled={(!transferWindowOpen && !unresolvedGaslessTransfer) || connecting}
               >
                 {primaryLabel}
               </button>
@@ -2465,6 +2492,7 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
                     !wallet ||
                     !transferWindowOpen ||
                     hasTrackedTransfer ||
+                    unresolvedGaslessTransfer ||
                     submission.kind === "submitting"
                   }
                   aria-describedby={
@@ -2484,6 +2512,7 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
                     balanceLoading ||
                     !transferWindowOpen ||
                     hasTrackedTransfer ||
+                    unresolvedGaslessTransfer ||
                     submission.kind === "submitting"
                   }
                 >
@@ -2506,24 +2535,29 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
               accountCodeStatus === "delegated") &&
             parsedAmount !== null &&
             !amountError &&
-            balance !== null ? (
+            (balance !== null || canResumeGaslessTransfer) ? (
               <div
                 ref={sponsorshipRegionRef}
                 tabIndex={-1}
                 aria-label="Gas sponsorship status"
               >
-                {delegatedWallet ? (
+                {gaslessTransferPath ? (
                   <div
                     className={styles.walletTypeStatus}
                     data-status="eoa"
                     role="status"
                   >
-                    <strong>Gasless transfer available</strong>
+                    <strong>{canResumeGaslessTransfer
+                      ? "Previous transfer"
+                      : gaslessStage === "signing"
+                        ? "Ready for wallet review"
+                        : gaslessStage === "relaying"
+                          ? "Transfer in progress"
+                          : "Gasless transfer checks"}</strong>
                     <span>
-                      Review the exact V4 amount in your wallet. Programmable
-                      pays the Ethereum gas and sends only that amount to the
-                      fixed migration address. Use Max to move your full balance
-                      in one gasless transfer.
+                      {canResumeGaslessTransfer
+                        ? "Check the saved request. Submitted transfers need no new signature. After the deadline, only existing transactions can be checked."
+                        : "Select Check gasless transfer. Your current V4 balance and sponsorship are checked before wallet review. No ETH top-up is needed."}
                     </span>
                   </div>
                 ) : sponsorshipKind === "not-needed" ? (
@@ -2728,12 +2762,12 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
                 type="button"
                 onClick={() => void reviewTransfer()}
                 disabled={
-                  !transferWindowOpen ||
+                  (!transferWindowOpen && !canResumeGaslessTransfer) ||
                   connecting ||
                   switchingNetwork ||
                   submission.kind === "submitting" ||
                   hasTrackedTransfer ||
-                  accountCodeStatus === "checking" ||
+                  (accountCodeStatus === "checking" && !canResumeGaslessTransfer) ||
                   (gaslessProgress !== null &&
                     gaslessProgress.account !== connectedAccount)
                 }
@@ -2793,7 +2827,7 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
                   >
                     View on Etherscan
                   </a>
-                  {transferWindowOpen && !delegatedWallet ? (
+                  {transferWindowOpen && transferRoute === "wallet" ? (
                     <button
                       className={styles.secondaryAction}
                       type="button"

--- a/config/main-token-migration-gasless-transfer-contract.v1.json
+++ b/config/main-token-migration-gasless-transfer-contract.v1.json
@@ -10,7 +10,9 @@
   "permitVersion": "1",
   "permitDomainSeparator": "0xe2ac19a052ba41dccaaa930f489a94353d986c7769e416830273d9362ad26a47",
   "migrationWallet": "0x228Be90653fDDAa408fB6cf9ca0AEC311dbE9A0D",
-  "eligibleWalletCode": "eip-7702-delegation-indicator",
+  "eligibleWalletCode": "plain-eoa-or-eip-7702-delegation-indicator",
+  "holderEligibility": "current-token-balance-including-post-start-acquisitions",
+  "actions": ["prepare", "submit", "resume"],
   "walletReview": {
     "standard": "EIP-2612 Permit",
     "binds": [
@@ -33,15 +35,16 @@
   "serverEnforces": [
     "authenticatedLinkedOwner",
     "sameOrigin",
-    "openingAndCurrentBalance",
+    "currentBalance",
     "dualRpcQuorum",
-    "eip7702WalletCode",
+    "plainEoaOrEip7702WalletCode",
     "exactPermitSigner",
     "exactPermitTypedData",
     "fixedToken",
     "fixedMigrationDestination",
     "sharedBudget",
-    "rootWalletReplayGuard",
+    "durableHolderReplayGuard",
+    "authenticatedExistingIntentResume",
     "exactTransactionReadback"
   ]
 }

--- a/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-READINESS-V1.md
+++ b/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-READINESS-V1.md
@@ -10,7 +10,7 @@ belong only in the deployment secret manager and private release evidence.
       exact finalized pre-window eligibility block number and hash.
 - [ ] The sponsor contract matches
       `config/main-token-migration-gas-sponsor-contract.v1.json` byte-for-byte in the candidate.
-- [ ] The delegated-wallet path matches
+- [ ] The current-holder gasless path matches
       `config/main-token-migration-gasless-transfer-contract.v1.json` byte-for-byte in the candidate.
 - [ ] The normalized provider readback exactly matches
       `config/main-token-migration-gas-sponsor-privy-policy.v2.json`.
@@ -42,17 +42,20 @@ belong only in the deployment secret manager and private release evidence.
 - [ ] Disabled manifest or disabled environment switch returns a fail-closed unavailable response and spends nothing.
 - [ ] An authenticated linked EOA that held the requested V4 amount at the eligibility block can receive only its bounded
       current gas deficit.
-- [ ] Unlinked wallets, smart-contract wallets, insufficient eligibility/current token balances, wrong eligibility block,
+- [ ] Unlinked wallets, unsupported smart-contract wallets, insufficient current token balances, wrong eligibility block for native top-ups,
       RPC disagreement, quotes above 20 gwei, exhausted budget and the final five minutes all fail closed.
 - [ ] Concurrent duplicate requests reserve and broadcast no more than one transfer.
 - [ ] An ambiguous Privy response is recorded as unknown and is not rebroadcast.
 - [ ] Dual-RPC readback confirms the exact transaction fields and successful receipt before status becomes confirmed.
-- [ ] A delegated EIP-7702 wallet signs the exact EIP-2612 domain/message, receives no ETH top-up, and the sponsor can
+- [ ] A plain EOA without gas or delegated EIP-7702 wallet, including a post-start buyer, signs the exact EIP-2612 domain/message, receives no ETH top-up, and the sponsor can
       relay only the signed amount through the pinned token to the fixed migration wallet.
 - [ ] The normal top-up endpoint rejects delegated wallets; both paths share one total budget and a gasless root guard
       blocks a later native reservation.
-- [ ] Wrong signer, token, spender, amount, nonce, deadline, destination, calldata, root eligibility or provider
+- [ ] Wrong signer, token, spender, amount, nonce, deadline, destination, calldata, native top-up root eligibility or provider
       reference fails closed without a token transfer.
+- [ ] Resume uses only the existing signed intent and exact account/amount/idempotency binding, even if its token balance is now lower.
+- [ ] Resume after the window is receipt-only; expired unsent permits and replaced provider hashes never cause blind resubmission.
+- [ ] Shared budget exhaustion fails closed. Current-holder eligibility is not an unlimited or Sybil-resistant gas guarantee.
 
 ## Release evidence
 

--- a/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-V1.md
+++ b/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-V1.md
@@ -6,15 +6,16 @@ release budget.
 
 ## Purpose
 
-This runbook defines two server-only gas paths during the exact 72-hour migration window. A normal EOA can receive
-one bounded Ethereum Mainnet gas top-up and then separately approve the V4 transfer. An eligible EIP-7702 delegated
-wallet, including wallets that automatically wrap incoming ETH, instead signs an exact EIP-2612 permit. The same
+This runbook defines two server-only gas paths during the exact 72-hour migration window. Current V4 holders using a
+normal EOA without enough ETH or an EIP-7702 delegated EOA sign an exact EIP-2612 permit. This includes tokens bought
+or received after the window opened. Funded normal EOAs can still use the direct wallet transfer. The same
 dedicated sponsor pays gas for the permit and an exact `transferFrom` to the fixed migration wallet. No private key is
-requested or exported, and neither path uses the migration recipient wallet as the sponsor.
+requested or exported, and neither path uses the migration recipient wallet as the sponsor. The legacy native ETH
+top-up endpoint retains its narrower pre-window ownership rules; widening the token-bound relay does not open an ETH faucet.
 
 The machine-readable companion is
 [`config/main-token-migration-gas-sponsor-contract.v1.json`](../../config/main-token-migration-gas-sponsor-contract.v1.json).
-The gasless delegated-wallet companion is
+The gasless current-holder companion is
 [`config/main-token-migration-gasless-transfer-contract.v1.json`](../../config/main-token-migration-gasless-transfer-contract.v1.json).
 The exact provider-enforced policy is
 [`config/main-token-migration-gas-sponsor-privy-policy.v2.json`](../../config/main-token-migration-gas-sponsor-privy-policy.v2.json).
@@ -74,20 +75,31 @@ the V4 token, total-supply ceiling and fixed migration destination. The server i
 exact signed amount, empty native calldata or byte-exact token calldata, sender, type-2 gas/fee fields and calculated
 value. Every submitted transaction is independently read back through two RPCs.
 
-## Delegated-wallet gasless path
+## Current-holder gasless path
 
-The gasless route is used only when the connected address has the canonical EIP-7702 delegation indicator. Both RPCs
-must agree on that code, the pinned token runtime, token name `Programmable`, permit domain separator, current nonce,
-current balance and pre-window eligibility. The wallet reviews an EIP-2612 permit binding chain ID 1, the pinned V4
+The gasless route accepts plain EOAs and addresses with the canonical EIP-7702 delegation indicator. Both RPCs
+must agree on that code, the pinned token runtime, token name `Programmable`, permit domain separator, current nonce
+and current balance. No historical balance or acquisition route is required. General smart-contract wallets are not
+supported by this token's EIP-2612 owner-signature path. The wallet reviews a permit binding chain ID 1, the pinned V4
 token, the dedicated sponsor as spender, exact raw amount, current nonce and a deadline of at most 20 minutes. The
 server recovers the exact connected owner before reserving anything.
 
 The private ledger stores one request binding plus separate deterministic provider references for `permit` and
 `transferFrom`. The sponsor first submits the byte-exact permit. Only after two providers confirm its successful
 receipt and the allowance is visible may the sponsor call `transferFrom(owner, fixedMigrationWallet, exactAmount)`.
-Both calls have zero native value, 100,000-gas ceilings and share the existing release budget and root-wallet replay
-guard. The ordinary ETH endpoint rejects delegated wallets, preventing a new wallet from claiming both paths. The UI
+Both calls have zero native value, 100,000-gas ceilings and share the existing release budget and durable holder replay
+guard. The ordinary ETH endpoint still rejects delegated wallets. The UI
 never signs automatically and never treats a provider response as a confirmed token transfer.
+
+An authenticated `resume` request binds the same linked holder, amount and idempotency key to an already signed private
+ledger intent. It cannot create a reservation or change the amount. It resumes without another signature or a fresh
+balance requirement, so a completed transfer remains recoverable after the wallet balance decreases. After the
+window closes, recovery only reads existing receipts and does not send transactions. Expired permits with no known
+submission and replaced or failed provider transactions require explicit support reconciliation, not blind resubmission.
+
+The release budget and per-holder/principal admission limits bound spending, but do not make arbitrary current-holder
+eligibility Sybil-resistant. Splitting tokens among many wallets can consume the finite budget. Keep funding bounded,
+monitor reservations and never present gas sponsorship as unlimited or guaranteed during provider outages.
 
 ## Fixed fee and budget boundaries
 
@@ -112,7 +124,7 @@ must cover the configured maximum top-up. It must also be
 chosen below the wallet's funded balance with an operator-owned safety margin; the absolute code cap is not a funding
 recommendation.
 
-## Eligibility and replay boundary
+## Native ETH top-up eligibility and replay boundary
 
 The endpoint authenticates the Privy access token and requires the requested address to be linked to that Privy
 principal. Both independent Ethereum providers must agree on chain ID, canonical head, the finalized pre-window

--- a/lib/server/main-token-migration-gas-sponsor-v1.ts
+++ b/lib/server/main-token-migration-gas-sponsor-v1.ts
@@ -385,6 +385,9 @@ export function readMainTokenMigrationGasSponsorConfigurationV1(input: Readonly<
   environment: Environment;
   manifest: unknown;
   nowMs: number;
+  // Only constructs the gasless handler for receipt-only recovery. Send paths
+  // still enforce their own window; native top-ups never opt in.
+  allowClosedWindowReadback?: boolean;
 }>): MainTokenMigrationGasSponsorConfigurationV1 | null {
   if (input.environment.MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ENABLED !== "true") {
     return null;
@@ -414,8 +417,10 @@ export function readMainTokenMigrationGasSponsorConfigurationV1(input: Readonly<
   const deadline = Number(manifest.deadlineTimestampExclusive);
   const now = Math.floor(input.nowMs / 1_000);
   if (!Number.isSafeInteger(start) || !Number.isSafeInteger(deadline)
+    || !Number.isSafeInteger(now)
     || deadline - start !== MAIN_TOKEN_MIGRATION_WINDOW_SECONDS
-    || now < start || now >= deadline - DEADLINE_SAFETY_SECONDS) return null;
+    || now < start || (!input.allowClosedWindowReadback &&
+      now >= deadline - DEADLINE_SAFETY_SECONDS)) return null;
   const walletId = input.environment.MAIN_TOKEN_MIGRATION_GAS_SPONSOR_PRIVY_WALLET_ID?.trim() ?? "";
   const policyId = input.environment.MAIN_TOKEN_MIGRATION_GAS_SPONSOR_PRIVY_POLICY_ID?.trim() ?? "";
   const sponsorAddressValue = input.environment.MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ADDRESS?.trim() ?? "";

--- a/lib/server/main-token-migration-gasless-transfer-v1.ts
+++ b/lib/server/main-token-migration-gasless-transfer-v1.ts
@@ -9,6 +9,7 @@ import {
   getAddress,
   http,
   isAddress,
+  keccak256,
   parseAbi,
   recoverTypedDataAddress,
   toHex,
@@ -21,11 +22,13 @@ import { mainnet } from "viem/chains";
 import activationManifest from "@/config/main-token-migration-activation.v1.json";
 import {
   buildMainTokenMigrationPermitTypedData,
-  isMainTokenMigrationDelegatedWalletCode,
+  isMainTokenMigrationWalletCodeEligible,
   MAIN_TOKEN_ADDRESS,
   MAIN_TOKEN_MIGRATION_CHAIN_ID,
   MAIN_TOKEN_MIGRATION_WALLET,
+  MAIN_TOKEN_NAME,
   MAIN_TOKEN_PERMIT_DOMAIN_SEPARATOR,
+  MAIN_TOKEN_RUNTIME_CODE_KECCAK256,
   MAIN_TOKEN_TOTAL_SUPPLY_RAW,
   parseMainTokenMigrationPermitSignature,
 } from "@/lib/main-token-migration";
@@ -38,7 +41,6 @@ import {
 import {
   assertMainTokenMigrationPrivySponsorWalletV1,
   assertMainTokenMigrationPrivySponsorPolicyV2,
-  createMainTokenMigrationGasSponsorChainV1,
   deriveMainTokenMigrationSponsorBindingsV1,
   deriveMainTokenMigrationSponsorPrincipalBindingV1,
   MainTokenMigrationGasSponsorErrorV1,
@@ -66,6 +68,7 @@ import { canonicalSha256 } from "./projection-target/hashing";
 
 const TOKEN_ABI = parseAbi([
   "function name() view returns (string)",
+  "function balanceOf(address owner) view returns (uint256)",
   "function DOMAIN_SEPARATOR() view returns (bytes32)",
   "function nonces(address owner) view returns (uint256)",
   "function allowance(address owner,address spender) view returns (uint256)",
@@ -98,7 +101,7 @@ type ProviderStatus = Readonly<{
 type TransactionKind = "permit" | "transfer";
 
 type PrepareRequest = Readonly<{
-  action: "prepare";
+  action: "prepare" | "resume";
   walletAddress: Address;
   amountRaw: bigint;
 }>;
@@ -148,10 +151,10 @@ export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
   return Object.freeze({
     async post(request: Request) {
       try {
-        assertWindowOpen(input.configuration, now());
         requireSameOrigin(request);
         const principal = await input.authenticator.authenticate(request);
         const parsed = parseRequest(await boundedJson(request));
+        if (parsed.action !== "resume") assertWindowOpen(input.configuration, now());
         assertLinkedWallet(principal.wallets, parsed.walletAddress);
         const idempotencyKey = request.headers.get("idempotency-key") ?? "";
         if (!IDEMPOTENCY_KEY.test(idempotencyKey)) {
@@ -183,7 +186,7 @@ export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
           walletAddress: parsed.walletAddress,
         };
         const existing = await input.store.get(lookup);
-        if (parsed.action === "prepare") {
+        if (parsed.action === "prepare" || parsed.action === "resume") {
           if (existing) {
             const binding = deriveMainTokenMigrationGaslessBindingV1({
               baseRequestBindingHash: baseBindings.requestBindingHash,
@@ -197,7 +200,25 @@ export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
                 "idempotency_conflict",
               );
             }
+            if (parsed.action === "resume") {
+              const allowSend = windowOpen(input.configuration, now());
+              if (allowSend) await input.sender.assertReady();
+              return await progressTransfer({
+                chain: input.chain,
+                configuration: input.configuration,
+                now: now(),
+                record: existing,
+                sender: input.sender,
+                store: input.store,
+                allowSend,
+              });
+            }
             return prepareResponse(existing.intent);
+          }
+          if (parsed.action === "resume") {
+            throw new MainTokenMigrationGaslessErrorV1(
+              409, "gasless_request_not_found",
+            );
           }
           const observation = await input.chain.prepare({
             configuration: input.configuration,
@@ -325,6 +346,8 @@ export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
               `mtmgt-${providerBinding.slice(0, 58)}`,
             reservedAt: now().toISOString(),
           });
+          // An unavailable sponsor must not consume the wallet's durable slot.
+          await input.sender.assertReady();
           record = (await input.store.reserve({
             lookup,
             idempotencyBindingHash: baseBindings.idempotencyBindingHash,
@@ -335,8 +358,9 @@ export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
           record.intent.nonce !== parsed.nonce.toString() ||
           record.intent.permitDeadline !== parsed.permitDeadline.toString()) {
           throw new MainTokenMigrationGaslessErrorV1(409, "idempotency_conflict");
+        } else {
+          await input.sender.assertReady();
         }
-        await input.sender.assertReady();
         return await progressTransfer({
           chain: input.chain,
           configuration: input.configuration,
@@ -359,12 +383,22 @@ async function progressTransfer(input: Readonly<{
   record: MainTokenMigrationGaslessRecordV1;
   sender: ReturnType<typeof createMainTokenMigrationGaslessSenderV1>;
   store: MainTokenMigrationGaslessStoreV1;
+  allowSend?: boolean;
 }>) {
   let record = input.record;
   if (!record.permitTransactionHash) {
     const reconciled = await input.sender.lookup("permit", record.intent);
     const recoveredHash = providerHashOrNull(reconciled);
-    if (!recoveredHash) assertProviderRetryWindow(record.intent, input.now);
+    if (!recoveredHash) {
+      if (input.allowSend === false) {
+        throw new MainTokenMigrationGaslessErrorV1(409, "relay_needs_attention");
+      }
+      if (BigInt(record.intent.permitDeadline) <=
+        BigInt(Math.floor(input.now.getTime() / 1_000))) {
+        throw new MainTokenMigrationGaslessErrorV1(422, "permit_expired");
+      }
+      assertProviderRetryWindow(record.intent, input.now);
+    }
     const hash = recoveredHash ?? await input.sender.send("permit", record.intent);
     record = await input.store.complete({
       lookup: {
@@ -385,12 +419,16 @@ async function progressTransfer(input: Readonly<{
     throw new MainTokenMigrationGaslessErrorV1(409, "permit_reverted");
   }
   if (permitStatus === "pending") {
+    assertProviderNotTerminal(await input.sender.lookup("permit", record.intent));
     return transferResponse("permit_pending", record, 10);
   }
   if (!record.transferTransactionHash) {
     const reconciled = await input.sender.lookup("transfer", record.intent);
     const recoveredHash = providerHashOrNull(reconciled);
     if (!recoveredHash) {
+      if (input.allowSend === false) {
+        throw new MainTokenMigrationGaslessErrorV1(409, "relay_needs_attention");
+      }
       assertProviderRetryWindow(record.intent, input.now);
       // transferFrom consumes the exact allowance. A known transaction must
       // be reconciled by its receipt, not rejected for already using it.
@@ -415,6 +453,9 @@ async function progressTransfer(input: Readonly<{
   if (transferStatus === "failed") {
     throw new MainTokenMigrationGaslessErrorV1(409, "transfer_reverted");
   }
+  if (transferStatus === "pending") {
+    assertProviderNotTerminal(await input.sender.lookup("transfer", record.intent));
+  }
   return typeof transferStatus === "object"
     ? transferResponse(
         "confirmed",
@@ -425,13 +466,16 @@ async function progressTransfer(input: Readonly<{
     : transferResponse("transfer_pending", record, 5);
 }
 
+function assertProviderNotTerminal(record: ProviderStatus | null) {
+  if (record && ["replaced", "failed", "provider_error", "execution_reverted"]
+    .includes(record.status)) {
+    throw new MainTokenMigrationGaslessErrorV1(409, "relay_needs_attention");
+  }
+}
+
 function providerHashOrNull(record: ProviderStatus | null) {
   if (record === null) return null;
-  if (["failed", "provider_error", "execution_reverted"].includes(
-    record.status,
-  )) {
-    throw new MainTokenMigrationGaslessErrorV1(503, "provider_failed");
-  }
+  assertProviderNotTerminal(record);
   if (record.transactionHash) return record.transactionHash;
   throw new MainTokenMigrationGaslessErrorV1(503, "submission_unknown");
 }
@@ -465,73 +509,112 @@ export function createMainTokenMigrationGaslessChainV1(
       transport: http(providers[1]!.endpoint, { retryCount: 1, timeout: 12_000 }),
     }),
   ];
-  const eligibilityChain = createMainTokenMigrationGasSponsorChainV1(providers);
   return Object.freeze({
     async prepare(input: Readonly<{
       configuration: MainTokenMigrationGasSponsorConfigurationV1;
       walletAddress: Address;
       amountRaw: bigint;
     }>) {
-      const eligibility = await eligibilityChain.observe({
-        configuration: input.configuration,
-        request: {
-          walletAddress: input.walletAddress,
-          amountRaw: input.amountRaw,
-        },
-      });
-      const heads = await Promise.all(clients.map((client) =>
-        client.getBlockNumber()));
-      const blockNumber = heads[0] < heads[1] ? heads[0] : heads[1];
-      const states = await Promise.all(clients.map(async (client) => {
-        const [chainId, block, code, tokenCode, name, domainSeparator, nonce] =
-          await Promise.all([
-            client.getChainId(),
-            client.getBlock({ blockNumber }),
-            client.getCode({ address: input.walletAddress, blockNumber }),
-            client.getCode({ address: MAIN_TOKEN_ADDRESS, blockNumber }),
-            client.readContract({
-              address: MAIN_TOKEN_ADDRESS,
-              abi: TOKEN_ABI,
-              functionName: "name",
-              blockNumber,
-            }),
-            client.readContract({
-              address: MAIN_TOKEN_ADDRESS,
-              abi: TOKEN_ABI,
-              functionName: "DOMAIN_SEPARATOR",
-              blockNumber,
-            }),
-            client.readContract({
-              address: MAIN_TOKEN_ADDRESS,
-              abi: TOKEN_ABI,
-              functionName: "nonces",
-              args: [input.walletAddress],
-              blockNumber,
-            }),
-          ]);
-        return { chainId, block, code, tokenCode, name, domainSeparator, nonce };
-      }));
-      const [left, right] = states;
-      if (!left || !right || left.chainId !== MAIN_TOKEN_MIGRATION_CHAIN_ID ||
-        right.chainId !== MAIN_TOKEN_MIGRATION_CHAIN_ID ||
-        left.block.hash !== right.block.hash || left.code !== right.code ||
-        left.tokenCode !== right.tokenCode || left.name !== right.name ||
-        left.domainSeparator !== right.domainSeparator || left.nonce !== right.nonce ||
-        !left.tokenCode || !right.tokenCode ||
-        !isMainTokenMigrationDelegatedWalletCode(left.code) ||
-        !isMainTokenMigrationDelegatedWalletCode(right.code) ||
-        left.name !== "Programmable" ||
-        left.domainSeparator.toLowerCase() !==
-          MAIN_TOKEN_PERMIT_DOMAIN_SEPARATOR.toLowerCase()) {
-        throw new MainTokenMigrationGaslessErrorV1(422, "gasless_wallet_unsupported");
+      if (input.amountRaw <= 0n || input.amountRaw > MAIN_TOKEN_TOTAL_SUPPLY_RAW) {
+        throw new MainTokenMigrationGaslessErrorV1(400, "request_invalid");
       }
-      return Object.freeze({
-        nonce: left.nonce,
-        feePerGasWei: eligibility.feePerGasWei,
-        maxPriorityFeePerGasWei: eligibility.maxPriorityFeePerGasWei,
-        sponsorBalanceWei: eligibility.sponsorBalanceWei,
-        rootWalletAddress: eligibility.eligibility.rootWalletAddress,
-      });
+      try {
+        const heads = await Promise.all(clients.map((client) =>
+          client.getBlockNumber()));
+        const blockNumber = heads[0] < heads[1] ? heads[0] : heads[1];
+        const states = await Promise.all(clients.map(async (client) => {
+          const [chainId, block, code, tokenCode, sponsorCode, name,
+            domainSeparator, nonce, balance, sponsorBalance, fees] =
+            await Promise.all([
+              client.getChainId(),
+              client.getBlock({ blockNumber }),
+              client.getCode({ address: input.walletAddress, blockNumber }),
+              client.getCode({ address: MAIN_TOKEN_ADDRESS, blockNumber }),
+              client.getCode({ address: input.configuration.sponsorAddress, blockNumber }),
+              client.readContract({
+                address: MAIN_TOKEN_ADDRESS,
+                abi: TOKEN_ABI,
+                functionName: "name",
+                blockNumber,
+              }),
+              client.readContract({
+                address: MAIN_TOKEN_ADDRESS,
+                abi: TOKEN_ABI,
+                functionName: "DOMAIN_SEPARATOR",
+                blockNumber,
+              }),
+              client.readContract({
+                address: MAIN_TOKEN_ADDRESS,
+                abi: TOKEN_ABI,
+                functionName: "nonces",
+                args: [input.walletAddress],
+                blockNumber,
+              }),
+              client.readContract({
+                address: MAIN_TOKEN_ADDRESS,
+                abi: TOKEN_ABI,
+                functionName: "balanceOf",
+                args: [input.walletAddress],
+                blockNumber,
+              }),
+              client.getBalance({ address: input.configuration.sponsorAddress, blockNumber }),
+              client.estimateFeesPerGas(),
+            ]);
+          return {
+            chainId, block, code: code ?? "0x", tokenCode,
+            sponsorCode: sponsorCode ?? "0x", name, domainSeparator,
+            nonce, balance, sponsorBalance,
+            fee: fees.maxFeePerGas,
+            priorityFee: fees.maxPriorityFeePerGas,
+          };
+        }));
+        const [left, right] = states;
+        if (!left || !right || left.chainId !== MAIN_TOKEN_MIGRATION_CHAIN_ID ||
+          right.chainId !== MAIN_TOKEN_MIGRATION_CHAIN_ID ||
+          left.block.number !== blockNumber || right.block.number !== blockNumber ||
+          !left.block.hash || left.block.hash !== right.block.hash ||
+          left.block.timestamp !== right.block.timestamp || left.code !== right.code ||
+          left.sponsorCode !== right.sponsorCode ||
+          left.tokenCode !== right.tokenCode || left.name !== right.name ||
+          left.domainSeparator !== right.domainSeparator || left.nonce !== right.nonce ||
+          left.balance !== right.balance || left.sponsorBalance !== right.sponsorBalance ||
+          !left.tokenCode || !right.tokenCode) {
+          throw new MainTokenMigrationGaslessErrorV1(503, "rpc_quorum_unavailable");
+        }
+        if (keccak256(left.tokenCode) !== MAIN_TOKEN_RUNTIME_CODE_KECCAK256 ||
+          left.name !== MAIN_TOKEN_NAME ||
+          left.domainSeparator.toLowerCase() !==
+            MAIN_TOKEN_PERMIT_DOMAIN_SEPARATOR.toLowerCase()) {
+          throw new MainTokenMigrationGaslessErrorV1(503, "token_binding_mismatch");
+        }
+        if (left.sponsorCode !== "0x") {
+          throw new MainTokenMigrationGaslessErrorV1(503, "sponsor_wallet_mismatch");
+        }
+        if (!isMainTokenMigrationWalletCodeEligible(left.code)) {
+          throw new MainTokenMigrationGaslessErrorV1(422, "gasless_wallet_unsupported");
+        }
+        if (left.balance < input.amountRaw) {
+          throw new MainTokenMigrationGaslessErrorV1(422, "insufficient_balance");
+        }
+        if (!left.fee || !right.fee || left.fee < 0n || right.fee < 0n ||
+          left.priorityFee === undefined || right.priorityFee === undefined ||
+          left.priorityFee < 0n || right.priorityFee < 0n) {
+          throw new MainTokenMigrationGaslessErrorV1(503, "gas_quote_unavailable");
+        }
+        return Object.freeze({
+          nonce: left.nonce,
+          feePerGasWei: left.fee > right.fee ? left.fee : right.fee,
+          maxPriorityFeePerGasWei: left.priorityFee > right.priorityFee
+            ? left.priorityFee : right.priorityFee,
+          sponsorBalanceWei: left.sponsorBalance,
+          // Gasless support binds the current holder; the separate ETH faucet
+          // retains its historical eligibility and relocation guards.
+          rootWalletAddress: getAddress(input.walletAddress),
+        });
+      } catch (error) {
+        if (error instanceof MainTokenMigrationGaslessErrorV1) throw error;
+        throw new MainTokenMigrationGaslessErrorV1(503, "rpc_quorum_unavailable");
+      }
     },
 
     async assertPermitEffect(record: MainTokenMigrationGaslessRecordV1) {
@@ -744,12 +827,13 @@ function parseRequest(input: unknown): PrepareRequest | SubmitRequest {
     throw new MainTokenMigrationGaslessErrorV1(400, "request_invalid");
   }
   const value = input as Record<string, unknown>;
-  const common = value.action === "prepare"
+  const common = value.action === "prepare" || value.action === "resume"
     ? ["action", "amountRaw", "walletAddress"]
     : ["action", "amountRaw", "nonce", "permitDeadline", "permitSignature",
       "requestBindingHash", "walletAddress"];
   if (Object.keys(value).sort().join("\0") !== common.sort().join("\0") ||
-    (value.action !== "prepare" && value.action !== "submit") ||
+    (value.action !== "prepare" && value.action !== "resume" &&
+      value.action !== "submit") ||
     typeof value.walletAddress !== "string" ||
     !isAddress(value.walletAddress, { strict: true }) ||
     typeof value.amountRaw !== "string" || !DECIMAL.test(value.amountRaw)) {
@@ -760,8 +844,8 @@ function parseRequest(input: unknown): PrepareRequest | SubmitRequest {
     throw new MainTokenMigrationGaslessErrorV1(400, "request_invalid");
   }
   const walletAddress = getAddress(value.walletAddress);
-  if (value.action === "prepare") {
-    return Object.freeze({ action: "prepare", walletAddress, amountRaw });
+  if (value.action === "prepare" || value.action === "resume") {
+    return Object.freeze({ action: value.action, walletAddress, amountRaw });
   }
   if (typeof value.nonce !== "string" || !ZERO_DECIMAL.test(value.nonce) ||
     typeof value.permitDeadline !== "string" || !DECIMAL.test(value.permitDeadline) ||
@@ -856,6 +940,16 @@ function errorResponse(error: unknown) {
   }
   const message = failure.status === 401 || failure.status === 403
     ? "Reconnect this wallet and try again."
+    : failure.code === "relay_needs_attention" || failure.code === "permit_expired"
+      ? "This gasless request needs migration support. Do not send V4 again; contact support with this request ID."
+    : failure.code === "gasless_request_not_found"
+      ? "No stored signed gasless request was found. Contact migration support before starting again."
+    : failure.code === "insufficient_balance"
+      ? "This wallet does not hold the requested V4 amount. Refresh your balance before starting a new transfer."
+    : failure.code === "budget_exhausted"
+      ? "The gas sponsorship budget is exhausted. No new gasless transfer can start."
+    : failure.code === "sponsor_balance_low"
+      ? "Gas sponsorship needs more ETH before a new transfer can start. Contact migration support."
     : failure.code === "permit_reverted" ||
         failure.code === "transfer_reverted"
       ? "The gasless relay reverted and cannot be retried automatically. Do not send again; contact migration support with this request ID."
@@ -949,12 +1043,19 @@ function assertWindowOpen(
   configuration: MainTokenMigrationGasSponsorConfigurationV1,
   now: Date,
 ) {
-  const nowSeconds = Math.floor(now.getTime() / 1_000);
-  if (!Number.isFinite(nowSeconds) ||
-    nowSeconds >= configuration.deadlineTimestampExclusive -
-      DEADLINE_SAFETY_SECONDS) {
+  if (!windowOpen(configuration, now)) {
     throw new MainTokenMigrationGaslessErrorV1(503, "sponsorship_closed");
   }
+}
+
+function windowOpen(
+  configuration: MainTokenMigrationGasSponsorConfigurationV1,
+  now: Date,
+) {
+  const nowSeconds = Math.floor(now.getTime() / 1_000);
+  return Number.isFinite(nowSeconds) &&
+    nowSeconds >= configuration.windowStartTimestamp &&
+    nowSeconds < configuration.deadlineTimestampExclusive - DEADLINE_SAFETY_SECONDS;
 }
 
 function divCeil(value: bigint, denominator: bigint) {
@@ -977,6 +1078,7 @@ export function getProductionMainTokenMigrationGaslessTransferV1() {
     environment: process.env,
     manifest: activationManifest,
     nowMs: Date.now(),
+    allowClosedWindowReadback: true,
   });
   if (!configuration) {
     throw new MainTokenMigrationGaslessErrorV1(503, "sponsorship_disabled");

--- a/lib/server/main-token-migration-gasless-transfer-v1.ts
+++ b/lib/server/main-token-migration-gasless-transfer-v1.ts
@@ -186,7 +186,7 @@ export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
           walletAddress: parsed.walletAddress,
         };
         const existing = await input.store.get(lookup);
-        if (parsed.action === "prepare" || parsed.action === "resume") {
+        if (parsed.action !== "submit") {
           if (existing) {
             const binding = deriveMainTokenMigrationGaslessBindingV1({
               baseRequestBindingHash: baseBindings.requestBindingHash,

--- a/tests/main-token-migration-current-holder-chain-v1.test.ts
+++ b/tests/main-token-migration-current-holder-chain-v1.test.ts
@@ -1,0 +1,174 @@
+import type { Address, Hex } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ createPublicClient: vi.fn() }));
+vi.mock("server-only", () => ({}));
+vi.mock("viem", async (importOriginal) => ({
+  ...await importOriginal<typeof import("viem")>(),
+  createPublicClient: mocks.createPublicClient,
+}));
+vi.mock("../lib/main-token-migration", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/main-token-migration")>();
+  const { keccak256 } = await import("viem");
+  return {
+    ...actual,
+    // Unit-only runtime fixture: derive its pin from its actual bytes. This
+    // does not replace the production token's runtime pin or claim live proof.
+    MAIN_TOKEN_RUNTIME_CODE_KECCAK256: keccak256("0x6001600055"),
+  };
+});
+
+import {
+  MAIN_TOKEN_ADDRESS,
+  MAIN_TOKEN_MIGRATION_RELEASE_ID,
+  MAIN_TOKEN_NAME,
+  MAIN_TOKEN_PERMIT_DOMAIN_SEPARATOR,
+} from "../lib/main-token-migration";
+import {
+  createMainTokenMigrationGaslessChainV1,
+} from "../lib/server/main-token-migration-gasless-transfer-v1";
+
+const walletAddress = "0x0000000000000000000000000000000000000011" as Address;
+const sponsorAddress = "0x0000000000000000000000000000000000000022" as Address;
+const tokenCode = "0x6001600055" as Hex;
+const blockHash = `0x${"12".repeat(32)}` as Hex;
+const commonBlock = 25_900_100n;
+const configuration = {
+  releaseId: MAIN_TOKEN_MIGRATION_RELEASE_ID,
+  windowStartTimestamp: 1_788_159_300,
+  startBlockNumber: 25_873_498n,
+  startBlockHash: `0x${"33".repeat(32)}` as Hex,
+  deadlineTimestampExclusive: 1_788_418_500,
+  sponsorWalletId: "wallet-current-holder-test",
+  sponsorPolicyId: "policy-current-holder-test",
+  sponsorAddress,
+  maximumTopUpWei: 2_000_000_000_000_000n,
+  totalBudgetWei: 1_000_000_000_000_000_000n,
+};
+type State = {
+  code?: Hex;
+  tokenCode: Hex;
+  sponsorCode?: Hex;
+  chainId: number;
+  blockHash: Hex;
+  name: string;
+  domainSeparator: Hex;
+  nonce: bigint;
+  balance: bigint;
+  sponsorBalance: bigint;
+  fee: bigint;
+  priorityFee: bigint;
+};
+
+function client(state: State, head: bigint) {
+  return {
+    getBlockNumber: vi.fn(async () => head),
+    getChainId: vi.fn(async () => state.chainId),
+    getBlock: vi.fn(async ({ blockNumber }: { blockNumber: bigint }) => ({
+      number: blockNumber, hash: state.blockHash, timestamp: 1_788_170_000n,
+    })),
+    getCode: vi.fn(async ({ address }: { address: Address; blockNumber: bigint }) =>
+      address.toLowerCase() === MAIN_TOKEN_ADDRESS.toLowerCase() ? state.tokenCode
+        : address === sponsorAddress ? state.sponsorCode : state.code),
+    readContract: vi.fn(async (input: {
+      functionName: string; blockNumber: bigint; args?: readonly unknown[];
+    }) => {
+      if (input.blockNumber !== commonBlock) throw new Error("unexpected historical read");
+      if (input.functionName === "name") return state.name;
+      if (input.functionName === "DOMAIN_SEPARATOR") return state.domainSeparator;
+      if (input.functionName === "nonces") return state.nonce;
+      if (input.functionName === "balanceOf") return state.balance;
+      throw new Error("unexpected contract read");
+    }),
+    getBalance: vi.fn(async () => state.sponsorBalance),
+    estimateFeesPerGas: vi.fn(async () => ({
+      maxFeePerGas: state.fee, maxPriorityFeePerGas: state.priorityFee,
+    })),
+    getLogs: vi.fn(async () => { throw new Error("historical eligibility must not run"); }),
+  };
+}
+
+function fixture(overrides: Partial<State> = {}) {
+  const initial: State = {
+    code: "0x", tokenCode, sponsorCode: "0x", chainId: 1, blockHash,
+    name: MAIN_TOKEN_NAME, domainSeparator: MAIN_TOKEN_PERMIT_DOMAIN_SEPARATOR,
+    nonce: 3n, balance: 150n, sponsorBalance: 20_000_000_000_000_000n,
+    fee: 1_000_000_000n, priorityFee: 100_000_000n, ...overrides,
+  };
+  const left = { ...initial };
+  const right = { ...initial };
+  const clients = [client(left, commonBlock + 1n), client(right, commonBlock)];
+  mocks.createPublicClient.mockReturnValueOnce(clients[0]).mockReturnValueOnce(clients[1]);
+  const chain = createMainTokenMigrationGaslessChainV1([
+    { endpoint: "https://primary.invalid" },
+    { endpoint: "https://secondary.invalid" },
+  ] as never);
+  return { left, right, clients, prepare: () => chain.prepare({
+    configuration, walletAddress, amountRaw: 100n,
+  }) };
+}
+
+beforeEach(() => { mocks.createPublicClient.mockReset(); });
+
+describe("gasless current-holder eligibility", () => {
+  it.each([
+    undefined,
+    "0x" as Hex,
+    `0xef0100${"55".repeat(20)}` as Hex,
+  ])("accepts a current EOA holder without historical eligibility (code=%s)", async (code) => {
+    const { prepare, clients } = fixture({ code });
+    await expect(prepare()).resolves.toMatchObject({
+      nonce: 3n, rootWalletAddress: walletAddress,
+      sponsorBalanceWei: 20_000_000_000_000_000n,
+    });
+    for (const rpc of clients) {
+      expect(rpc.getLogs).not.toHaveBeenCalled();
+      expect(rpc.getBlock).toHaveBeenCalledExactlyOnceWith({ blockNumber: commonBlock });
+      expect(rpc.readContract).toHaveBeenCalledWith(expect.objectContaining({
+        functionName: "balanceOf", args: [walletAddress], blockNumber: commonBlock,
+      }));
+      expect(rpc.getCode.mock.calls.every(([input]) => input.blockNumber === commonBlock)).toBe(true);
+    }
+  });
+
+  it("uses conservative current fee quotes without requiring identical estimates", async () => {
+    const { right, prepare } = fixture();
+    right.fee = 2_000_000_000n;
+    right.priorityFee = 200_000_000n;
+    await expect(prepare()).resolves.toMatchObject({
+      feePerGasWei: right.fee, maxPriorityFeePerGasWei: right.priorityFee,
+    });
+  });
+
+  it.each([
+    [{ balance: 99n }, 422, "insufficient_balance"],
+    [{ code: "0x6002" }, 422, "gasless_wallet_unsupported"],
+    [{ code: "0xef010055" }, 422, "gasless_wallet_unsupported"],
+    [{ tokenCode: "0x6002" }, 503, "token_binding_mismatch"],
+    [{ name: "Other token" }, 503, "token_binding_mismatch"],
+    [{ domainSeparator: `0x${"44".repeat(32)}` }, 503, "token_binding_mismatch"],
+    [{ sponsorCode: `0xef0100${"55".repeat(20)}` }, 503, "sponsor_wallet_mismatch"],
+    [{ fee: 0n }, 503, "gas_quote_unavailable"],
+  ] as const)("rejects unsupported or unbound state (case %#)", async (override, status, code) => {
+    const { prepare } = fixture(override);
+    await expect(prepare()).rejects.toMatchObject({ status, code });
+  });
+
+  it.each([
+    { chainId: 4663 },
+    { blockHash: `0x${"66".repeat(32)}` as Hex },
+    { nonce: 4n },
+    { balance: 151n },
+    { sponsorBalance: 1n },
+  ])("fails closed on provider disagreement (case %#)", async (override) => {
+    const { right, prepare } = fixture();
+    Object.assign(right, override);
+    await expect(prepare()).rejects.toMatchObject({ status: 503, code: "rpc_quorum_unavailable" });
+  });
+
+  it("normalizes RPC failures without leaking provider details", async () => {
+    const { clients, prepare } = fixture();
+    clients[0]!.getBlockNumber.mockRejectedValueOnce(new Error("private-provider-credential"));
+    await expect(prepare()).rejects.toMatchObject({ status: 503, code: "rpc_quorum_unavailable" });
+  });
+});

--- a/tests/main-token-migration-gas-sponsor-contract.test.ts
+++ b/tests/main-token-migration-gas-sponsor-contract.test.ts
@@ -228,7 +228,7 @@ describe("main token migration gas sponsor activation contract", () => {
     );
   });
 
-  it("pins the delegated-wallet permit and fixed transfer destination", () => {
+  it("pins current-holder permits and the fixed transfer destination", () => {
     expect(gaslessContract).toMatchObject({
       schema: "programmable-main-token-migration-gasless-transfer-contract/v1",
       releaseId: contract.releaseId,
@@ -240,6 +240,9 @@ describe("main token migration gas sponsor activation contract", () => {
       tokenName: "Programmable",
       permitVersion: "1",
       migrationWallet: manifest.migrationWallet,
+      eligibleWalletCode: "plain-eoa-or-eip-7702-delegation-indicator",
+      holderEligibility: "current-token-balance-including-post-start-acquisitions",
+      actions: ["prepare", "submit", "resume"],
       walletReview: {
         standard: "EIP-2612 Permit",
         binds: [
@@ -266,15 +269,16 @@ describe("main token migration gas sponsor activation contract", () => {
     for (const boundary of [
       "authenticatedLinkedOwner",
       "sameOrigin",
-      "openingAndCurrentBalance",
+      "currentBalance",
       "dualRpcQuorum",
-      "eip7702WalletCode",
+      "plainEoaOrEip7702WalletCode",
       "exactPermitSigner",
       "exactPermitTypedData",
       "fixedToken",
       "fixedMigrationDestination",
       "sharedBudget",
-      "rootWalletReplayGuard",
+      "durableHolderReplayGuard",
+      "authenticatedExistingIntentResume",
       "exactTransactionReadback",
     ]) {
       expect(gaslessContract.serverEnforces).toContain(boundary);

--- a/tests/main-token-migration-gas-sponsor-v1.test.ts
+++ b/tests/main-token-migration-gas-sponsor-v1.test.ts
@@ -606,6 +606,23 @@ describe("main token migration gas sponsor", () => {
       releaseId: "v4-ethereum-to-robinhood-72h-2026-v2",
       deadlineTimestampExclusive: start + 72 * 60 * 60,
     });
+    const afterDeadline = (start + MAIN_TOKEN_MIGRATION_WINDOW_SECONDS) * 1_000;
+    expect(readMainTokenMigrationGasSponsorConfigurationV1({
+      environment, manifest, nowMs: afterDeadline,
+    })).toBeNull();
+    expect(readMainTokenMigrationGasSponsorConfigurationV1({
+      environment, manifest, nowMs: afterDeadline,
+      allowClosedWindowReadback: true,
+    })).toMatchObject({ deadlineTimestampExclusive: afterDeadline / 1_000 });
+    for (const nowMs of [(start - 1) * 1_000, NaN, Infinity]) {
+      expect(readMainTokenMigrationGasSponsorConfigurationV1({
+        environment, manifest, nowMs, allowClosedWindowReadback: true,
+      })).toBeNull();
+    }
+    expect(readMainTokenMigrationGasSponsorConfigurationV1({
+      environment: { ...environment, MAIN_TOKEN_MIGRATION_GAS_SPONSOR_ENABLED: "false" },
+      manifest, nowMs: afterDeadline, allowClosedWindowReadback: true,
+    })).toBeNull();
     expect(readMainTokenMigrationGasSponsorConfigurationV1({
       environment,
       manifest: {

--- a/tests/main-token-migration-gas-sponsorship-ui.test.ts
+++ b/tests/main-token-migration-gas-sponsorship-ui.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -6,13 +7,21 @@ import {
   gasSponsorshipErrorMessage,
   gasSponsorshipFailure,
   gasSponsorshipState,
+  gaslessTransferFailure,
+  gaslessTransferIdempotencyKey,
   hasEnoughMigrationGas,
+  migrationGaslessResumeAmount,
+  migrationTransferRoute,
   parseGasSponsorshipResponse,
   sponsorshipRetryAfterMs,
   waitForMigrationRetry,
   type MainTokenGasSponsorshipResponse,
   type MainTokenGasSponsorshipStatus,
 } from "../components/main-token-migration";
+import {
+  MAIN_TOKEN_MIGRATION_RELEASE_ID,
+  MAIN_TOKEN_TOTAL_SUPPLY_RAW,
+} from "../lib/main-token-migration";
 
 const SCHEMA =
   "programmable-main-token-migration-gas-sponsorship/v1" as const;
@@ -39,6 +48,7 @@ describe("main token migration gas sponsorship UI contract", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("accepts only the exact schema and connected wallet", () => {
@@ -110,6 +120,140 @@ describe("main token migration gas sponsorship UI contract", () => {
     expect(hasEnoughMigrationGas(0n, gasPriceWei)).toBe(false);
     expect(hasEnoughMigrationGas(exactReserveWei, 0n)).toBe(false);
     expect(hasEnoughMigrationGas(-1n, gasPriceWei)).toBe(false);
+  });
+
+  it("routes current EOAs without ETH to token-bound gasless checks", () => {
+    const input = {
+      accountCodeStatus: "eoa" as const,
+      nativeBalanceWei: 0n,
+      gasPriceWei: 2_000_000_000n,
+      resumingGasless: false,
+    };
+    expect(migrationTransferRoute(input)).toBe("gasless");
+    expect(migrationTransferRoute({
+      ...input,
+      nativeBalanceWei: 100_000n * input.gasPriceWei,
+    })).toBe("wallet");
+    expect(migrationTransferRoute({
+      ...input,
+      accountCodeStatus: "delegated",
+      nativeBalanceWei: 100_000n * input.gasPriceWei,
+    })).toBe("gasless");
+    expect(migrationTransferRoute({
+      ...input,
+      accountCodeStatus: "contract",
+    })).toBe("unsupported");
+  });
+
+  it("does not infer readiness from an unknown gas balance or wallet code", () => {
+    const input = {
+      accountCodeStatus: "eoa" as const,
+      nativeBalanceWei: 0n,
+      gasPriceWei: 2_000_000_000n,
+      resumingGasless: false,
+    };
+    for (const change of [
+      { nativeBalanceWei: null },
+      { nativeBalanceWei: -1n },
+      { gasPriceWei: null },
+      { gasPriceWei: 0n },
+      { accountCodeStatus: "unavailable" as const },
+      { accountCodeStatus: "checking" as const },
+    ]) {
+      expect(migrationTransferRoute({ ...input, ...change })).toBe("checking");
+    }
+    expect(migrationTransferRoute({
+      ...input,
+      accountCodeStatus: "checking",
+      nativeBalanceWei: null,
+      gasPriceWei: null,
+      resumingGasless: true,
+    })).toBe("gasless");
+    expect(migrationTransferRoute({
+      ...input,
+      accountCodeStatus: "contract",
+      resumingGasless: true,
+    })).toBe("unsupported");
+  });
+
+  it("resumes only the same wallet's exact saved amount even after its balance is spent", () => {
+    const saved = { account: WALLET, amountRaw: "2000000000000000000" };
+    expect(migrationGaslessResumeAmount(saved, WALLET)).toBe(2_000_000_000_000_000_000n);
+    expect(migrationGaslessResumeAmount(saved, OTHER_WALLET)).toBeNull();
+    expect(migrationGaslessResumeAmount(saved, null)).toBeNull();
+    expect(migrationGaslessResumeAmount(null, WALLET)).toBeNull();
+    const account = `0x${"ab".repeat(20)}`;
+    expect(migrationGaslessResumeAmount({ ...saved, account },
+      `0x${"AB".repeat(20)}`)).toBe(2_000_000_000_000_000_000n);
+    for (const amountRaw of ["0", "01", "-1", "1e18", " 1", "9".repeat(29),
+      (MAIN_TOKEN_TOTAL_SUPPLY_RAW + 1n).toString()]) {
+      expect(migrationGaslessResumeAmount({ ...saved, amountRaw }, WALLET)).toBeNull();
+    }
+  });
+
+  it("never replaces a missing saved gasless request key while resuming", () => {
+    const localStorage = { getItem: vi.fn(() => null), setItem: vi.fn() };
+    const randomUUID = vi.fn(() => "new-key-must-not-be-used");
+    vi.stubGlobal("window", { localStorage, crypto: { randomUUID } });
+    const keys = new Map<string, string>();
+    expect(() => gaslessTransferIdempotencyKey(WALLET, keys, true)).toThrow(
+      "saved migration request key is unavailable",
+    );
+    expect(randomUUID).not.toHaveBeenCalled();
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+    expect(keys.size).toBe(0);
+    localStorage.getItem.mockImplementation(() => { throw new Error("Storage unavailable"); });
+    expect(() => gaslessTransferIdempotencyKey(WALLET, keys, true)).toThrow(
+      "saved migration request key is unavailable",
+    );
+    expect(randomUUID).not.toHaveBeenCalled();
+  });
+
+  it("reuses the saved gasless request key for every reconciliation", () => {
+    const key = "gasless-existing-request-123456789";
+    const localStorage = { getItem: vi.fn(() => key), setItem: vi.fn() };
+    vi.stubGlobal("window", { localStorage });
+    const keys = new Map<string, string>();
+    expect(gaslessTransferIdempotencyKey(WALLET, keys, true)).toBe(key);
+    expect(localStorage.getItem).toHaveBeenCalledWith(
+      `programmable:main-token-migration:gasless:${MAIN_TOKEN_MIGRATION_RELEASE_ID}:${WALLET}`,
+    );
+    expect(gaslessTransferIdempotencyKey(WALLET, keys, true)).toBe(key);
+    expect(localStorage.getItem).toHaveBeenCalledOnce();
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it("recognizes only the exact server missing-request code for bounded pre-submit recovery", async () => {
+    const requestId = "123e4567-e89b-12d3-a456-426614174000";
+    await expect(gaslessTransferFailure(new Response(JSON.stringify({
+      error: { code: "gasless_request_not_found", message: "Saved request not found.", requestId },
+    }), { status: 409 }))).resolves.toEqual({
+      code: "gasless_request_not_found",
+      message: `Saved request not found. Request ID: ${requestId}`,
+    });
+    await expect(gaslessTransferFailure(new Response(JSON.stringify({
+      error: { code: "gasless_request_not_found\n", message: "x".repeat(241) },
+    }), { status: 409 }))).resolves.toEqual({
+      code: "",
+      message: "The gasless transfer is temporarily unavailable.",
+    });
+  });
+
+  it("persists only signed requests and never drops a pending marker on cancellation", () => {
+    const source = readFileSync(new URL("../components/main-token-migration.tsx", import.meta.url), "utf8");
+    const review = source.slice(source.indexOf("  async function reviewGaslessTransfer("),
+      source.indexOf("  async function reviewTransfer()"));
+    expect(review.indexOf("const permit = await signMainTokenMigrationPermit")).toBeLessThan(
+      review.indexOf("const progress = persistGaslessTransferProgress"),
+    );
+    const beforeConfirmation = review.slice(0, review.indexOf('result.status === "confirmed"'));
+    expect(beforeConfirmation).not.toContain("clearGaslessTransferProgress()");
+    expect(review).toContain('action: "resume"');
+    expect(review).toContain("resumeExisting || preservePendingRequest");
+    expect(review).toContain('resumeExisting && response.status === 409 &&');
+    expect(review).toContain('failure.code === "gasless_request_not_found" && trustedTransferWindowOpen()');
+    expect(review).toContain("reviewGaslessTransfer(account, amountRaw, false, true)");
+    expect(source).not.toContain('Gasless transfer available');
   });
 
   it("honors the full Retry-After minimum and falls back safely", () => {

--- a/tests/main-token-migration-gasless-transfer-v1.test.ts
+++ b/tests/main-token-migration-gasless-transfer-v1.test.ts
@@ -68,6 +68,117 @@ function request(body: unknown) {
   });
 }
 
+async function recoveryFixture() {
+  const permitDeadline = BigInt(Math.floor(now.getTime() / 1_000) + 600);
+  const baseBindings = deriveMainTokenMigrationSponsorBindingsV1({
+    releaseId: configuration.releaseId,
+    walletAddress: account.address,
+    amountRaw: 100n,
+    idempotencyKey,
+  });
+  const requestBindingHash = deriveMainTokenMigrationGaslessBindingV1({
+    baseRequestBindingHash: baseBindings.requestBindingHash,
+    nonce: 0n,
+    permitDeadline,
+  });
+  const permitSignature = await account.signTypedData(
+    buildMainTokenMigrationPermitTypedData({
+      owner: account.address, spender: sponsorAddress, value: 100n,
+      nonce: 0n, deadline: permitDeadline,
+    }),
+  );
+  type ReceiptStatus = "pending" | "failed" |
+    { status: "confirmed"; blockNumber: bigint };
+  type ProviderStatus = { status: string; transactionHash: `0x${string}` | null };
+  const state: {
+    now: Date;
+    record: MainTokenMigrationGaslessRecordV1 | null;
+    permitStatus: ReceiptStatus;
+    transferStatus: ReceiptStatus;
+    permitProvider: ProviderStatus | null;
+    transferProvider: ProviderStatus | null;
+  } = {
+    now,
+    record: {
+      intent: {
+        schema: "programmable-main-token-migration-gasless-intent/v1",
+        releaseId: configuration.releaseId,
+        walletAddress: account.address,
+        rootWalletAddress: account.address,
+        sponsorAddress,
+        amountRaw: "100",
+        nonce: "0",
+        permitDeadline: permitDeadline.toString(),
+        permitSignature,
+        permitGasLimit: "100000",
+        transferGasLimit: "100000",
+        maxFeePerGasWei: "1000000000",
+        maxPriorityFeePerGasWei: "100000000",
+        reservedTotalWei: "200000000000000",
+        totalBudgetWei: configuration.totalBudgetWei.toString(),
+        requestBindingHash,
+        providerPermitIdempotencyKey: "mtmgp-recovery-fixture",
+        providerPermitReferenceId: "mtmgp-recovery-fixture",
+        providerTransferIdempotencyKey: "mtmgt-recovery-fixture",
+        providerTransferReferenceId: "mtmgt-recovery-fixture",
+        reservedAt: now.toISOString(),
+      },
+      permitTransactionHash: permitHash,
+      transferTransactionHash: transferHash,
+    },
+    permitStatus: { status: "confirmed", blockNumber: 25_900_001n },
+    transferStatus: { status: "confirmed", blockNumber: 25_900_002n },
+    permitProvider: null,
+    transferProvider: null,
+  };
+  const store = {
+    get: vi.fn(async () => state.record),
+    reserve: vi.fn(async () => { throw new Error("resume must not reserve"); }),
+    complete: vi.fn(async (input: {
+      kind: "permit" | "transfer"; transactionHash: `0x${string}`;
+    }) => {
+      if (!state.record) throw new Error("missing signed request");
+      state.record = {
+        ...state.record,
+        permitTransactionHash: input.kind === "permit"
+          ? input.transactionHash : state.record.permitTransactionHash,
+        transferTransactionHash: input.kind === "transfer"
+          ? input.transactionHash : state.record.transferTransactionHash,
+      };
+      return state.record;
+    }),
+  };
+  const chain = {
+    prepare: vi.fn(async () => { throw new Error("resume must not recheck balance"); }),
+    assertPermitEffect: vi.fn(async () => {}),
+    transactionStatus: vi.fn(async (kind: "permit" | "transfer") =>
+      kind === "permit" ? state.permitStatus : state.transferStatus),
+  };
+  const sender = {
+    assertReady: vi.fn(async () => {}),
+    lookup: vi.fn(async (kind: "permit" | "transfer") =>
+      kind === "permit" ? state.permitProvider : state.transferProvider),
+    send: vi.fn(async (kind: "permit" | "transfer") =>
+      kind === "permit" ? permitHash : transferHash),
+  };
+  const handler = createMainTokenMigrationGaslessTransferV1({
+    configuration,
+    authenticator: {
+      async authenticate() {
+        return {
+          privyUserId: "did:privy:test", privySessionId: "session-test",
+          wallets: [account.address],
+        };
+      },
+    },
+    admissionStore: { async admit() {} } as never,
+    store: store as never, chain: chain as never, sender: sender as never,
+    now: () => state.now,
+  });
+  const resume = { action: "resume", walletAddress: account.address, amountRaw: "100" };
+  return { state, handler, store, chain, sender, resume };
+}
+
 describe("main token migration gasless permit transfer", () => {
   it("finishes the exact relay without counting progress as new transfer requests", async () => {
     const database = new PGlite();
@@ -451,7 +562,7 @@ describe("main token migration gasless permit transfer", () => {
           error: { code, message, requestId: expect.any(String) },
         });
       }
-      expect(reserve).toHaveBeenCalledTimes(boundary === "provider" ? 1 : 0);
+      expect(reserve).not.toHaveBeenCalled();
       expect(complete).not.toHaveBeenCalled();
       expect(lookup).not.toHaveBeenCalled();
       expect(send).not.toHaveBeenCalled();
@@ -464,6 +575,125 @@ describe("main token migration gasless permit transfer", () => {
       errors.mockRestore();
       warnings.mockRestore();
     }
+  });
+
+  it("resumes a completed signed transfer without balance checks or another signature", async () => {
+    const { handler, chain, sender, store, resume } = await recoveryFixture();
+    const response = await handler.post(request(resume));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      status: "confirmed", transferTransactionHash: transferHash,
+      transferBlockNumber: "25900002",
+    });
+    expect(chain.prepare).not.toHaveBeenCalled();
+    expect(chain.assertPermitEffect).not.toHaveBeenCalled();
+    expect(store.reserve).not.toHaveBeenCalled();
+    expect(sender.send).not.toHaveBeenCalled();
+  });
+
+  it("resumes only the already-authorized transfer during the open window", async () => {
+    const { state, handler, chain, sender, store, resume } = await recoveryFixture();
+    state.record = { ...state.record!, transferTransactionHash: null };
+    const response = await handler.post(request(resume));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      status: "transfer_submitted", transferTransactionHash: transferHash,
+    });
+    expect(chain.prepare).not.toHaveBeenCalled();
+    expect(chain.assertPermitEffect).toHaveBeenCalledOnce();
+    expect(store.reserve).not.toHaveBeenCalled();
+    expect(sender.send).toHaveBeenCalledExactlyOnceWith("transfer", state.record!.intent);
+  });
+
+  it("reads known receipts after closing without a provider send, policy call or reservation", async () => {
+    const { state, handler, chain, sender, store, resume } = await recoveryFixture();
+    state.now = new Date((configuration.deadlineTimestampExclusive + 60) * 1_000);
+    const response = await handler.post(request(resume));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ status: "confirmed" });
+    state.transferStatus = "pending";
+    expect(await (await handler.post(request(resume))).json()).toMatchObject({
+      status: "transfer_pending",
+    });
+    expect(chain.prepare).not.toHaveBeenCalled();
+    expect(sender.assertReady).not.toHaveBeenCalled();
+    expect(sender.lookup).toHaveBeenCalledExactlyOnceWith("transfer", state.record!.intent);
+    expect(sender.send).not.toHaveBeenCalled();
+    expect(store.reserve).not.toHaveBeenCalled();
+    expect(store.complete).not.toHaveBeenCalled();
+  });
+
+  it("recovers a previously sent hash after closing but never sends a missing transaction", async () => {
+    const { state, handler, chain, sender, store, resume } = await recoveryFixture();
+    state.now = new Date((configuration.deadlineTimestampExclusive + 60) * 1_000);
+    state.record = { ...state.record!, transferTransactionHash: null };
+    state.transferProvider = { status: "broadcasted", transactionHash: transferHash };
+    expect(await (await handler.post(request(resume))).json()).toMatchObject({
+      status: "transfer_submitted", transferTransactionHash: transferHash,
+    });
+    expect(await (await handler.post(request(resume))).json()).toMatchObject({ status: "confirmed" });
+    expect(store.complete).toHaveBeenCalledOnce();
+    state.record = { ...state.record!, transferTransactionHash: null };
+    state.transferProvider = null;
+    const response = await handler.post(request(resume));
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ error: { code: "relay_needs_attention" } });
+    expect(chain.prepare).not.toHaveBeenCalled();
+    expect(chain.assertPermitEffect).not.toHaveBeenCalled();
+    expect(sender.assertReady).not.toHaveBeenCalled();
+    expect(sender.send).not.toHaveBeenCalled();
+    expect(store.reserve).not.toHaveBeenCalled();
+  });
+
+  it("refuses missing or changed resume bindings without signing, reserving or sending", async () => {
+    const { state, handler, chain, sender, store, resume } = await recoveryFixture();
+    const changed = await handler.post(request({ ...resume, amountRaw: "101" }));
+    expect(changed.status).toBe(409);
+    const differentKey = request(resume);
+    differentKey.headers.set("idempotency-key", "different-request-key-0001");
+    expect((await handler.post(differentKey)).status).toBe(409);
+    state.record = null;
+    const missing = await handler.post(request(resume));
+    expect(missing.status).toBe(409);
+    expect(await missing.json()).toMatchObject({
+      error: { code: "gasless_request_not_found" },
+    });
+    expect(chain.prepare).not.toHaveBeenCalled();
+    expect(sender.send).not.toHaveBeenCalled();
+    expect(store.reserve).not.toHaveBeenCalled();
+  });
+
+  it("does not first-send an expired permit but recovers its already-known provider hash", async () => {
+    const { state, handler, sender, resume } = await recoveryFixture();
+    state.now = new Date((Number(state.record!.intent.permitDeadline) + 1) * 1_000);
+    state.record = { ...state.record!, permitTransactionHash: null, transferTransactionHash: null };
+    const expired = await handler.post(request(resume));
+    expect(expired.status).toBe(422);
+    expect(await expired.json()).toMatchObject({ error: { code: "permit_expired" } });
+    expect(sender.lookup).toHaveBeenCalledOnce();
+    expect(sender.send).not.toHaveBeenCalled();
+    state.permitProvider = { status: "broadcasted", transactionHash: permitHash };
+    expect(await (await handler.post(request(resume))).json()).toMatchObject({
+      status: "permit_submitted", permitTransactionHash: permitHash,
+    });
+    expect(sender.send).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])("stops a replaced provider transaction without adopting or resending it (known=%s)", async (known) => {
+    const { state, handler, sender, store, resume } = await recoveryFixture();
+    state.record = {
+      ...state.record!, permitTransactionHash: known ? permitHash : null,
+      transferTransactionHash: null,
+    };
+    state.permitStatus = "pending";
+    state.permitProvider = { status: "replaced", transactionHash: permitHash };
+    const response = await handler.post(request(resume));
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: { code: "relay_needs_attention", message: expect.stringContaining("Do not send V4 again") },
+    });
+    expect(store.complete).not.toHaveBeenCalled();
+    expect(sender.send).not.toHaveBeenCalled();
   });
 
   it("durably binds one root wallet and both exact relayer transactions", async () => {


### PR DESCRIPTION
## Outcome
- Current V4 holders, including post-start acquisitions, can use the token-bound permit relay with plain EOAs or EIP-7702 EOAs. Native ETH faucet eligibility is unchanged.
- Exact chain/token/runtime/domain/current-balance quorum remains required. Fixed destination, exact amount, signature, budget limits and idempotency remain enforced.
- Authenticated resume reuses an existing signed ledger intent without a second signature or a fresh token-balance requirement. Closed-window recovery is read-only; expired first sends and replaced provider transactions stop explicitly.
- Preserve pending markers and recover a crash before first submit with the same wallet/amount/key. Existing funded EOAs retain direct wallet transfers.

## Evidence
- 92 focused migration tests passed across 6 files.
- TypeScript, scoped ESLint and git diff --check passed.
- Independent source review found no P0/P1 blockers; final follow-up changes only an equivalent TypeScript narrowing predicate.
- Read-only chain preparation for the previously rejected holder passed against both configured production RPCs. No transaction was signed, reserved or broadcast.

## Release boundaries
No timer, recipient, provider policy, funding, Robinhood launch activation or schema change. Root integration owner will stage, perform desktop/mobile QA and promote only this verified production candidate. Finite sponsor budget/provider availability and unsupported contract-wallet signatures remain explicit constraints.
