### PR TITLE
fix(migration): safely recover expired unused gasless permits

### DIFF
--- a/components/main-token-migration.tsx
+++ b/components/main-token-migration.tsx
@@ -173,6 +173,7 @@ export type GasSponsorshipState =
 
 type GaslessTransferStatus =
   | "signature_required"
+  | "recovery_available"
   | "permit_submitted"
   | "permit_pending"
   | "transfer_submitted"
@@ -191,15 +192,34 @@ type GaslessTransferResponse = Readonly<{
   permitTransactionHash: Hex | null;
   transferTransactionHash: Hex | null;
   transferBlockNumber: string | null;
+  previousRequestBindingHash?: `sha256:${string}`;
 }>;
 
 type GaslessStage = "idle" | "preparing" | "signing" | "relaying" | "reconciling";
 
-type StoredGaslessTransferProgress = Readonly<{
-  schema: "programmable-main-token-migration-gasless-ui/v1";
+export type StoredGaslessTransferProgress = Readonly<{
   account: string;
   amountRaw: string;
+} & ({ schema: "programmable-main-token-migration-gasless-ui/v1" } | {
+  schema: "programmable-main-token-migration-gasless-ui/v2";
+  idempotencyKey: string;
+  previousRequestBindingHash: `sha256:${string}`;
+})>;
+
+type GaslessRecoveryReview = Readonly<{
+  progress: StoredGaslessTransferProgress;
+  idempotencyKey: string;
+  previousRequestBindingHash: `sha256:${string}` | null;
 }>;
+
+export function gaslessRecoveryIdempotencyKey(previousRequestBindingHash: `sha256:${string}`) {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(previousRequestBindingHash)) {
+    throw new Error("The previous transfer binding is invalid.");
+  }
+  // Tabs recovering the same parent must never save competing request keys.
+  // This is an idempotency locator, not a credential or authorization token.
+  return `gasless-recovery-${MAIN_TOKEN_MIGRATION_RELEASE_ID}-${previousRequestBindingHash.slice(7)}`;
+}
 
 type GasSponsorshipEndpointResult = Readonly<{
   body: MainTokenGasSponsorshipResponse;
@@ -266,33 +286,104 @@ function clearGaslessTransferProgress() {
   window.dispatchEvent(new Event(migrationRecoveryEvent));
 }
 
-function storedGaslessTransferProgress(): StoredGaslessTransferProgress | null {
+export function storedGaslessTransferProgress(): StoredGaslessTransferProgress | null {
   try {
     const source = window.localStorage.getItem(gaslessTransferProgressStorageKey);
     if (!source) return null;
     const value = JSON.parse(source) as Record<string, unknown>;
-    if (Object.keys(value).sort().join("\0") !==
-        ["account", "amountRaw", "schema"].sort().join("\0") ||
-      value.schema !== "programmable-main-token-migration-gasless-ui/v1" ||
+    const recovery = value.schema === "programmable-main-token-migration-gasless-ui/v2";
+    const keys = recovery
+      ? ["account", "amountRaw", "schema", "idempotencyKey", "previousRequestBindingHash"]
+      : ["account", "amountRaw", "schema"];
+    if (Object.keys(value).sort().join("\0") !== keys.sort().join("\0") ||
+      (!recovery && value.schema !== "programmable-main-token-migration-gasless-ui/v1") ||
       typeof value.account !== "string" ||
       !isAddress(value.account, { strict: true }) ||
       value.account !== getAddress(value.account).toLowerCase() ||
       typeof value.amountRaw !== "string" ||
-      !positiveIntegerPattern.test(value.amountRaw)) return null;
-    return Object.freeze({
-      schema: value.schema,
+      !positiveIntegerPattern.test(value.amountRaw) ||
+      migrationGaslessResumeAmount({ account: value.account, amountRaw: value.amountRaw }, value.account) === null ||
+      (recovery && (typeof value.idempotencyKey !== "string" ||
+        !/^[a-zA-Z0-9:_-]{16,200}$/u.test(value.idempotencyKey) ||
+        typeof value.previousRequestBindingHash !== "string" ||
+        !digestPattern.test(value.previousRequestBindingHash)))) return null;
+    const common = {
       account: value.account,
       amountRaw: value.amountRaw,
-    });
+    };
+    return recovery
+      ? Object.freeze({ ...common,
+          schema: "programmable-main-token-migration-gasless-ui/v2",
+          idempotencyKey: value.idempotencyKey as string,
+          previousRequestBindingHash: value.previousRequestBindingHash as `sha256:${string}`,
+        })
+      : Object.freeze({ ...common, schema: "programmable-main-token-migration-gasless-ui/v1" });
   } catch {
     return null;
   }
+}
+
+function sameGaslessProgress(
+  current: StoredGaslessTransferProgress | null,
+  expected: StoredGaslessTransferProgress,
+) {
+  return current !== null && current.schema === expected.schema &&
+    current.account === expected.account && current.amountRaw === expected.amountRaw &&
+    (current.schema !== "programmable-main-token-migration-gasless-ui/v2" ||
+      (expected.schema === current.schema && current.idempotencyKey === expected.idempotencyKey &&
+        current.previousRequestBindingHash === expected.previousRequestBindingHash));
+}
+
+export function assertGaslessRecoveryProgress(expected: StoredGaslessTransferProgress) {
+  if (!sameGaslessProgress(storedGaslessTransferProgress(), expected)) {
+    throw new Error("This saved transfer changed in another tab. Refresh and check it before continuing.");
+  }
+}
+
+export function persistGaslessRecoveryProgress(
+  previous: StoredGaslessTransferProgress,
+  idempotencyKey: string,
+  previousRequestBindingHash: `sha256:${string}`,
+): StoredGaslessTransferProgress {
+  assertGaslessRecoveryProgress(previous);
+  if (!/^[a-zA-Z0-9:_-]{16,200}$/u.test(idempotencyKey) ||
+    !digestPattern.test(previousRequestBindingHash)) {
+    throw new Error("The new transfer recovery details are invalid. Nothing was submitted.");
+  }
+  const value: StoredGaslessTransferProgress = {
+    schema: "programmable-main-token-migration-gasless-ui/v2",
+    account: previous.account,
+    amountRaw: previous.amountRaw,
+    idempotencyKey,
+    previousRequestBindingHash,
+  };
+  const source = JSON.stringify(value);
+  const previousSource = window.localStorage.getItem(gaslessTransferProgressStorageKey);
+  try {
+    // The key and predecessor travel in one atomic marker, never separate writes.
+    window.localStorage.setItem(gaslessTransferProgressStorageKey, source);
+    if (window.localStorage.getItem(gaslessTransferProgressStorageKey) !== source) {
+      throw new Error("Recovery state was not persisted");
+    }
+  } catch {
+    if (previousSource !== null) {
+      try {
+        if (window.localStorage.getItem(gaslessTransferProgressStorageKey) === source) {
+          window.localStorage.setItem(gaslessTransferProgressStorageKey, previousSource);
+        }
+      } catch { /* No new submit is allowed. */ }
+    }
+    throw new Error("This browser could not save the new request. Nothing was submitted. Keep this page open and contact migration support.");
+  }
+  window.dispatchEvent(new Event(migrationRecoveryEvent));
+  return value;
 }
 
 export function parseGaslessTransferResponse(
   input: unknown,
   expectedAccount: string,
   expectedAmountRaw: bigint,
+  expectedPreviousRequestBindingHash?: `sha256:${string}`,
 ): GaslessTransferResponse {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new Error("The gasless transfer response is invalid.");
@@ -304,10 +395,20 @@ export function parseGaslessTransferResponse(
     "transferBlockNumber", "transferTransactionHash", "walletAddress",
   ];
   const statuses: readonly GaslessTransferStatus[] = [
-    "signature_required", "permit_submitted", "permit_pending",
+    "signature_required", "recovery_available", "permit_submitted", "permit_pending",
     "transfer_submitted", "transfer_pending", "confirmed",
   ];
   const status = value.status as GaslessTransferStatus;
+  const hasPredecessor = Object.hasOwn(value, "previousRequestBindingHash");
+  if (hasPredecessor) exactKeys.push("previousRequestBindingHash");
+  const predecessorValid = hasPredecessor
+    ? typeof value.previousRequestBindingHash === "string" &&
+      digestPattern.test(value.previousRequestBindingHash) &&
+      (status === "recovery_available"
+        ? value.previousRequestBindingHash === value.requestBindingHash
+        : status === "signature_required" &&
+          value.previousRequestBindingHash === expectedPreviousRequestBindingHash)
+    : status !== "recovery_available" && expectedPreviousRequestBindingHash === undefined;
   const permitHashValid = value.permitTransactionHash === null ||
     (typeof value.permitTransactionHash === "string" &&
       transactionHashPattern.test(value.permitTransactionHash));
@@ -317,7 +418,9 @@ export function parseGaslessTransferResponse(
   const transferBlockValid = value.transferBlockNumber === null ||
     (typeof value.transferBlockNumber === "string" &&
       positiveIntegerPattern.test(value.transferBlockNumber));
-  const statusHashesValid = status === "signature_required"
+  const statusHashesValid = status === "recovery_available"
+    ? value.transferTransactionHash === null
+    : status === "signature_required"
     ? value.permitTransactionHash === null &&
       value.transferTransactionHash === null
     : status === "permit_submitted" || status === "permit_pending"
@@ -344,7 +447,7 @@ export function parseGaslessTransferResponse(
     !positiveIntegerPattern.test(value.permitDeadline) ||
     typeof value.requestBindingHash !== "string" ||
     !digestPattern.test(value.requestBindingHash) ||
-    !permitHashValid || !transferHashValid || !transferBlockValid ||
+    !predecessorValid || !permitHashValid || !transferHashValid || !transferBlockValid ||
     (status !== "confirmed" && value.transferBlockNumber !== null) ||
     !statusHashesValid) {
     throw new Error("The gasless transfer response is invalid.");
@@ -365,6 +468,9 @@ export function parseGaslessTransferResponse(
       ? null
       : (value.transferTransactionHash as string).toLowerCase() as Hex,
     transferBlockNumber: value.transferBlockNumber as string | null,
+    ...(hasPredecessor ? {
+      previousRequestBindingHash: value.previousRequestBindingHash as `sha256:${string}`,
+    } : {}),
   });
 }
 
@@ -1196,6 +1302,9 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
   const [gaslessStage, setGaslessStage] = useState<GaslessStage>("idle");
   const [gaslessProgress, setGaslessProgress] =
     useState<StoredGaslessTransferProgress | null>(null);
+  const [gaslessRecoveryReview, setGaslessRecoveryReview] =
+    useState<GaslessRecoveryReview | null>(null);
+  const [gaslessNeedsSupport, setGaslessNeedsSupport] = useState(false);
   const [accountCodeObservation, setAccountCodeObservation] =
     useState<AccountCodeObservation | null>(null);
   const amountInputRef = useRef<HTMLInputElement>(null);
@@ -1439,6 +1548,8 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
     const restore = () => {
       const restored = storedGaslessTransferProgress();
       setGaslessProgress(restored);
+      setGaslessRecoveryReview((current) => current && sameGaslessProgress(restored, current.progress)
+        ? current : null);
       if (restored && !hasTrackedTransfer) {
         if (wallet?.account.toLowerCase() === restored.account) {
           setAmount(formatUnits(BigInt(restored.amountRaw), MAIN_TOKEN_DECIMALS));
@@ -1961,16 +2072,27 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
     amountRaw: bigint,
     resumeExisting = false,
     preservePendingRequest = false,
+    recoveryReview: GaslessRecoveryReview | null = null,
   ) {
     const accessToken = await getAccessToken();
     if (!accessToken) {
       throw new Error("Reconnect this wallet before using the gasless transfer.");
     }
-    const idempotencyKey = gaslessTransferIdempotencyKey(
-      account,
-      gaslessIdempotencyKeysRef.current,
-      resumeExisting || preservePendingRequest,
-    );
+    const savedProgress = storedGaslessTransferProgress();
+    if (resumeExisting || preservePendingRequest || recoveryReview) {
+      if (!savedProgress || migrationGaslessResumeAmount(savedProgress, account) !== amountRaw) {
+        throw new Error("The saved transfer is unavailable. Refresh and check it before continuing.");
+      }
+      if (recoveryReview) assertGaslessRecoveryProgress(recoveryReview.progress);
+    }
+    const idempotencyKey = recoveryReview?.idempotencyKey ??
+      (savedProgress?.schema === "programmable-main-token-migration-gasless-ui/v2"
+        ? savedProgress.idempotencyKey
+        : gaslessTransferIdempotencyKey(
+            account,
+            gaslessIdempotencyKeysRef.current,
+            resumeExisting || preservePendingRequest,
+          ));
     const headers = {
       Accept: "application/json",
       Authorization: `Bearer ${accessToken}`,
@@ -1978,13 +2100,18 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
       "Idempotency-Key": idempotencyKey,
     };
     setSubmission({ kind: "submitting" });
+    setGaslessNeedsSupport(false);
     let submitBody: string;
+    let submittedProgress: StoredGaslessTransferProgress | null = null;
     if (resumeExisting) {
       setGaslessStage("reconciling");
       submitBody = JSON.stringify({
         action: "resume",
         walletAddress: account,
         amountRaw: amountRaw.toString(),
+        ...(savedProgress?.schema === "programmable-main-token-migration-gasless-ui/v2"
+          ? { previousRequestBindingHash: savedProgress.previousRequestBindingHash }
+          : {}),
       });
     } else {
       if (!trustedTransferWindowOpen()) {
@@ -1992,9 +2119,12 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
       }
       setGaslessStage("preparing");
       const prepareBody = JSON.stringify({
-        action: "prepare",
+        action: recoveryReview?.previousRequestBindingHash ? "prepare_recovery" : "prepare",
         walletAddress: account,
         amountRaw: amountRaw.toString(),
+        ...(recoveryReview?.previousRequestBindingHash
+          ? { previousRequestBindingHash: recoveryReview.previousRequestBindingHash }
+          : {}),
       });
       let prepared: GaslessTransferResponse | null = null;
       let prepareFailure = "The gasless transfer is temporarily unavailable.";
@@ -2010,11 +2140,17 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
             await response.json(),
             account,
             amountRaw,
+            recoveryReview?.previousRequestBindingHash ?? undefined,
           );
           break;
         }
         prepareFailure = (await gaslessTransferFailure(response)).message;
         if ((response.status !== 429 && response.status !== 503) || attempt === 4) {
+          if (recoveryReview && (response.status === 409 || response.status === 422)) {
+            // The server no longer offers this recovery. Keep the durable marker
+            // and return to checking its status, never blindly re-sign it.
+            setGaslessRecoveryReview(null);
+          }
           throw new Error(prepareFailure);
         }
         await waitForMigrationRetry(sponsorshipRetryAfterMs(response));
@@ -2023,6 +2159,10 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
       if (prepared.status !== "signature_required") {
         throw new Error("The gasless transfer request is not ready for review.");
       }
+      if (!trustedTransferWindowOpen()) {
+        throw new Error("New transfers are closed. Your previous request is still saved.");
+      }
+      if (recoveryReview) assertGaslessRecoveryProgress(recoveryReview.progress);
       if (!sessionActiveRef.current) return;
       setGaslessStage("signing");
       const permit = await signMainTokenMigrationPermit({
@@ -2031,22 +2171,36 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
         spender: getAddress(prepared.sponsorAddress),
         value: amountRaw,
       });
+      if (!sessionActiveRef.current) return;
+      if (!trustedTransferWindowOpen()) {
+        throw new Error("New transfers closed during wallet review. Nothing new was submitted.");
+      }
+      if (recoveryReview) assertGaslessRecoveryProgress(recoveryReview.progress);
       // An unsigned request cannot transfer V4 and must not leave a stuck marker.
       // Persist before submit so a lost response always resumes this exact intent.
-      const progress = persistGaslessTransferProgress(account, amountRaw);
+      const progress = recoveryReview?.previousRequestBindingHash
+        ? persistGaslessRecoveryProgress(recoveryReview.progress, idempotencyKey,
+            recoveryReview.previousRequestBindingHash)
+        : persistGaslessTransferProgress(account, amountRaw);
       setGaslessProgress(progress);
+      submittedProgress = progress;
+      setGaslessRecoveryReview(null);
       setGaslessStage("relaying");
       submitBody = JSON.stringify({
-        action: "submit",
+        action: recoveryReview?.previousRequestBindingHash ? "submit_recovery" : "submit",
         walletAddress: account,
         amountRaw: amountRaw.toString(),
         nonce: prepared.nonce,
         permitDeadline: prepared.permitDeadline,
         permitSignature: permit.signature,
         requestBindingHash: prepared.requestBindingHash,
+        ...(recoveryReview?.previousRequestBindingHash
+          ? { previousRequestBindingHash: recoveryReview.previousRequestBindingHash }
+          : {}),
       });
     }
     for (let attempt = 0; attempt < 60; attempt += 1) {
+      if (submittedProgress) assertGaslessRecoveryProgress(submittedProgress);
       const response = await fetch(gaslessTransferEndpoint, {
         method: "POST",
         cache: "no-store",
@@ -2057,14 +2211,27 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
         const failure = await gaslessTransferFailure(response);
         if (resumeExisting && response.status === 409 &&
           failure.code === "gasless_request_not_found" && trustedTransferWindowOpen()) {
-          // A crash before the first submit can leave only the local marker.
-          // Retry once with its same binding; never clear it or start a second key.
-          await reviewGaslessTransfer(account, amountRaw, false, true);
+          // A crash before submit may leave only the local marker. Offer a
+          // separate wallet review using its SAME key; status checks never sign.
+          if (!savedProgress) throw new Error(failure.message);
+          assertGaslessRecoveryProgress(savedProgress);
+          setGaslessRecoveryReview({
+            progress: savedProgress,
+            idempotencyKey,
+            previousRequestBindingHash:
+              savedProgress.schema === "programmable-main-token-migration-gasless-ui/v2"
+                ? savedProgress.previousRequestBindingHash : null,
+          });
+          setSubmission({ kind: "idle" });
+          setGaslessStage("idle");
           return;
         }
         if ((response.status === 429 || response.status === 503) && attempt < 59) {
           await waitForMigrationRetry(sponsorshipRetryAfterMs(response));
           continue;
+        }
+        if (failure.code === "relay_needs_attention" || failure.code === "permit_expired") {
+          setGaslessNeedsSupport(true);
         }
         throw new Error(failure.message);
       }
@@ -2073,6 +2240,20 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
         account,
         amountRaw,
       );
+      if (result.status === "recovery_available") {
+        if (!resumeExisting || !savedProgress || !result.previousRequestBindingHash) {
+          throw new Error("Check the previous transfer before reviewing a new approval.");
+        }
+        assertGaslessRecoveryProgress(savedProgress);
+        setGaslessRecoveryReview({
+          progress: savedProgress,
+          idempotencyKey: gaslessRecoveryIdempotencyKey(result.previousRequestBindingHash),
+          previousRequestBindingHash: result.previousRequestBindingHash,
+        });
+        setSubmission({ kind: "idle" });
+        setGaslessStage("idle");
+        return;
+      }
       if (result.status === "signature_required") {
         throw new Error("The existing transfer could not be reconciled. Contact migration support before sending again.");
       }
@@ -2088,6 +2269,7 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
         persistMigrationTransfer(confirmed);
         clearGaslessTransferProgress();
         setGaslessProgress(null);
+        setGaslessRecoveryReview(null);
         setConfirmationIssue("");
         setSubmission(confirmed);
         setGaslessStage("idle");
@@ -2122,6 +2304,16 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
       try {
         if (!onMainnet) {
           await switchNetwork(String(MAIN_TOKEN_MIGRATION_CHAIN_ID));
+          return;
+        }
+        if (gaslessRecoveryReview && trustedTransferWindowOpen()) {
+          if (!acknowledged) {
+            setSubmission({ kind: "error", message: "Confirm that you control this same wallet address on Robinhood." });
+            acknowledgementRef.current?.focus();
+            return;
+          }
+          await reviewGaslessTransfer(getAddress(wallet.account), resumeAmountRaw,
+            false, true, gaslessRecoveryReview);
           return;
         }
         // Resume uses only the stored signed intent. It may read receipts after
@@ -2286,8 +2478,14 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
         ? !onMainnet
           ? switchingNetwork ? "Switching network" : "Switch to Ethereum"
           : visibleSubmission.kind === "submitting"
-            ? "Checking previous transfer"
-            : "Resume gasless transfer"
+            ? gaslessStage === "signing"
+              ? "Confirm exact amount in wallet"
+              : gaslessStage === "relaying"
+                ? "Relaying gasless transfer"
+                : "Checking previous transfer"
+            : gaslessRecoveryReview && transferWindowOpen
+              ? "Review new transfer"
+              : "Resume gasless transfer"
       : phase === "checking"
       ? "Checking migration window"
       : phase === "preview"
@@ -2544,18 +2742,29 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
                 {gaslessTransferPath ? (
                   <div
                     className={styles.walletTypeStatus}
-                    data-status="eoa"
+                    data-status={canResumeGaslessTransfer ? "unavailable" : "eoa"}
                     role="status"
                   >
-                    <strong>{canResumeGaslessTransfer
-                      ? "Previous transfer"
+                    <strong>{gaslessRecoveryReview
+                      ? gaslessRecoveryReview.previousRequestBindingHash
+                        ? "Previous approval expired" : "New wallet review needed"
+                      : gaslessNeedsSupport ? "Transfer needs support"
+                      : canResumeGaslessTransfer ? "Previous transfer"
                       : gaslessStage === "signing"
                         ? "Ready for wallet review"
                         : gaslessStage === "relaying"
                           ? "Transfer in progress"
                           : "Gasless transfer checks"}</strong>
                     <span>
-                      {canResumeGaslessTransfer
+                      {gaslessRecoveryReview
+                        ? !transferWindowOpen
+                          ? "New transfers are closed. Your previous request is saved; contact migration support."
+                          : gaslessRecoveryReview.previousRequestBindingHash
+                            ? "The previous approval expired without a transfer. Select Review new transfer to approve the same amount again in your wallet."
+                            : "No submitted request was found. Select Review new transfer to approve the saved amount again in your wallet."
+                        : gaslessNeedsSupport
+                          ? "The previous request could not be safely restarted. Contact migration support before sending again."
+                        : canResumeGaslessTransfer
                         ? "Check the saved request. Submitted transfers need no new signature. After the deadline, only existing transactions can be checked."
                         : "Select Check gasless transfer. Your current V4 balance and sponsorship are checked before wallet review. No ETH top-up is needed."}
                     </span>
@@ -2878,7 +3087,9 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
             </header>
             <p>
               {unresolvedGaslessTransfer
-                ? "A gasless transfer is already in progress. Do not send V4 separately."
+                ? gaslessRecoveryReview
+                  ? "Your previous request is saved. Use the wallet transfer steps to review a new approval. Do not send V4 separately."
+                  : "A gasless transfer still needs to be checked. Do not send V4 separately."
                 : accountCodeStatus === "contract"
                   ? "Contact migration support before sending from a smart-contract wallet."
                   : transferWindowOpen
@@ -2893,6 +3104,8 @@ function MainTokenMigrationSession({ sponsorshipRequestGate }: {
                     ? "Your gasless transfer is being processed. Do not send V4 again."
                     : !onMainnet
                       ? "Switch this wallet to Ethereum before resuming. Do not send V4 again."
+                      : gaslessRecoveryReview && transferWindowOpen
+                        ? "Select Review new transfer to approve the saved amount in your wallet."
                       : primaryLabel === "Resume gasless transfer"
                         ? "Select Resume gasless transfer. Do not send V4 separately."
                         : "Do not send V4 again. Contact migration support to check the pending transfer."}{" "}

--- a/config/main-token-migration-gasless-transfer-contract.v1.json
+++ b/config/main-token-migration-gasless-transfer-contract.v1.json
@@ -12,7 +12,17 @@
   "migrationWallet": "0x228Be90653fDDAa408fB6cf9ca0AEC311dbE9A0D",
   "eligibleWalletCode": "plain-eoa-or-eip-7702-delegation-indicator",
   "holderEligibility": "current-token-balance-including-post-start-acquisitions",
-  "actions": ["prepare", "submit", "resume"],
+  "actions": ["prepare", "submit", "resume", "prepare_recovery", "submit_recovery"],
+  "expiredPermitRecovery": {
+    "maximumAttemptsPerHolder": 3,
+    "requiresFreshWalletSignature": true,
+    "requiresFinalizedExpiry": true,
+    "requiresUnchangedPermitNonce": true,
+    "requiresZeroSponsorAllowance": true,
+    "requiresNoTransferSubmission": true,
+    "history": "append-only-predecessor-bound-attempts",
+    "budget": "all-attempt-reservations-remain-counted"
+  },
   "walletReview": {
     "standard": "EIP-2612 Permit",
     "binds": [
@@ -45,6 +55,10 @@
     "sharedBudget",
     "durableHolderReplayGuard",
     "authenticatedExistingIntentResume",
+    "finalizedExpiredPermitRecovery",
+    "freshRecoverySignature",
+    "appendOnlyAttemptHistory",
+    "atomicPredecessorBinding",
     "exactTransactionReadback"
   ]
 }

--- a/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-READINESS-V1.md
+++ b/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-READINESS-V1.md
@@ -55,6 +55,16 @@ belong only in the deployment secret manager and private release evidence.
       reference fails closed without a token transfer.
 - [ ] Resume uses only the existing signed intent and exact account/amount/idempotency binding, even if its token balance is now lower.
 - [ ] Resume after the window is receipt-only; expired unsent permits and replaced provider hashes never cause blind resubmission.
+- [ ] Recovery is offered only after dual-RPC finalized expiry, unchanged permit nonce, zero sponsor allowance and
+      absence of any stored/provider transfer submission. Ambiguous lookups and RPC disagreement block recovery.
+- [ ] A new attempt requires explicit fresh wallet approval and is bound to the exact predecessor, holder, amount,
+      release and sponsor. Preparation alone reserves nothing; submit rechecks the proof.
+- [ ] Concurrent recovery requests append at most one successor. Older requests cannot overwrite or send for a newer
+      attempt. Immutable original intents, aliases, completions and recovery history remain available.
+- [ ] All attempt reservations still count against the shared native/gasless budget, the original faucet guard remains,
+      and no holder exceeds three total signed attempts.
+- [ ] Cancelling fresh approval or a browser-storage failure preserves the existing marker. A lost response resumes the
+      exact successor without an automatic additional signature or another attempt.
 - [ ] Shared budget exhaustion fails closed. Current-holder eligibility is not an unlimited or Sybil-resistant gas guarantee.
 
 ## Release evidence

--- a/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-V1.md
+++ b/docs/operations/MAIN-TOKEN-MIGRATION-GAS-SPONSOR-V1.md
@@ -84,7 +84,7 @@ supported by this token's EIP-2612 owner-signature path. The wallet reviews a pe
 token, the dedicated sponsor as spender, exact raw amount, current nonce and a deadline of at most 20 minutes. The
 server recovers the exact connected owner before reserving anything.
 
-The private ledger stores one request binding plus separate deterministic provider references for `permit` and
+The private ledger stores each signed attempt with its request binding and separate deterministic provider references for `permit` and
 `transferFrom`. The sponsor first submits the byte-exact permit. Only after two providers confirm its successful
 receipt and the allowance is visible may the sponsor call `transferFrom(owner, fixedMigrationWallet, exactAmount)`.
 Both calls have zero native value, 100,000-gas ceilings and share the existing release budget and durable holder replay
@@ -94,8 +94,35 @@ never signs automatically and never treats a provider response as a confirmed to
 An authenticated `resume` request binds the same linked holder, amount and idempotency key to an already signed private
 ledger intent. It cannot create a reservation or change the amount. It resumes without another signature or a fresh
 balance requirement, so a completed transfer remains recoverable after the wallet balance decreases. After the
-window closes, recovery only reads existing receipts and does not send transactions. Expired permits with no known
-submission and replaced or failed provider transactions require explicit support reconciliation, not blind resubmission.
+window closes, recovery only reads existing receipts and does not send transactions.
+
+### Expired, unused permit recovery
+
+During the open window, an authenticated resume may return `recovery_available`. This is an offer to review a new
+attempt, not a successful transfer and not permission to reuse the old signature. The server must first establish
+all of these facts:
+
+- Two independent RPCs agree on a finalized canonical block whose timestamp is past the old permit deadline.
+- The holder's permit nonce still equals the old signed nonce and its allowance to the sponsor is zero.
+- No transfer transaction is stored or returned for the old provider reference. Provider errors, ambiguous lookups
+  and any possible transfer submission stop recovery.
+- The holder, release, sponsor, amount and predecessor request binding are unchanged, and the release is still open.
+
+`prepare_recovery` and `submit_recovery` carry `previousRequestBindingHash` and a fresh idempotency key. Preparation
+does not consume a budget reservation. The holder explicitly reviews and signs a fresh permit; submit rechecks the
+recovery conditions. An atomic predecessor check under the shared release advisory lock appends the new attempt and
+its history edge. No previous intent, signature, completion or alias is deleted or rewritten. Each attempt has its
+own provider references and completion records, and stale predecessor requests cannot send for the successor.
+
+At most three signed attempts exist per holder, including the original. All reservations remain counted against
+the shared gas budget; recovery does not reset spending limits or the native ETH faucet guard. The browser preserves
+its old marker on cancellation and writes an atomic successor marker only after signing and before submitting.
+Lost responses resume the exact successor rather than silently starting another attempt. It stores no permit
+signature in browser storage.
+
+An executed permit, changed nonce, nonzero sponsor allowance, possible transfer submission, exhausted attempt limit
+or unavailable proof still requires support. A provider status of `replaced` by itself is never sufficient evidence
+to restart. No new attempt can start after the migration window closes.
 
 The release budget and per-holder/principal admission limits bound spending, but do not make arbitrary current-holder
 eligibility Sybil-resistant. Splitting tokens among many wallets can consume the finite budget. Keep funding bounded,

--- a/lib/server/main-token-migration-gasless-transfer-store-v1.ts
+++ b/lib/server/main-token-migration-gasless-transfer-store-v1.ts
@@ -27,6 +27,7 @@ const DECIMAL = /^(?:0|[1-9][0-9]*)$/u;
 const POSITIVE_DECIMAL = /^[1-9][0-9]*$/u;
 const SAFE_RELEASE_ID = /^[a-z0-9][a-z0-9.-]{0,127}$/u;
 const SAFE_REFERENCE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u;
+export const MAIN_TOKEN_MIGRATION_GASLESS_MAX_RECOVERIES_V1 = 2;
 
 type Row = Readonly<{
   credential_id: string;
@@ -66,6 +67,8 @@ export type MainTokenMigrationGaslessRecordV1 = Readonly<{
   intent: MainTokenMigrationGaslessIntentV1;
   permitTransactionHash: Hex | null;
   transferTransactionHash: Hex | null;
+  recoveryAttempt?: number;
+  previousRequestBindingHash?: `sha256:${string}`;
 }>;
 
 type CompletionKind = "permit" | "transfer";
@@ -90,11 +93,34 @@ type RootGuardV1 = Readonly<{
   requestBindingHash: `sha256:${string}`;
 }>;
 
+type RecoveryEdgeV1 = Readonly<{
+  schema: "programmable-main-token-migration-gasless-recovery/v1";
+  recoveryAttempt: number;
+  previousHolderCredentialId: string;
+  holderCredentialId: string;
+  previousRequestBindingHash: `sha256:${string}`;
+  requestBindingHash: `sha256:${string}`;
+  idempotencyBindingHash: `sha256:${string}`;
+  recoveryProof: MainTokenMigrationGaslessRecoveryProofV1;
+}>;
+
+export type MainTokenMigrationGaslessRecoveryProofV1 = Readonly<{
+  finalizedBlockNumber: string;
+  finalizedBlockHash: Hex;
+  finalizedBlockTimestamp: string;
+  nonce: string;
+  allowanceRaw: "0";
+}>;
+
 type Lookup = Readonly<{ releaseId: string; walletAddress: Address }>;
 type ReserveInput = Readonly<{
   lookup: Lookup;
   idempotencyBindingHash: `sha256:${string}`;
   intent: MainTokenMigrationGaslessIntentV1;
+}>;
+type RecoverInput = ReserveInput & Readonly<{
+  previousRequestBindingHash: `sha256:${string}`;
+  recoveryProof: MainTokenMigrationGaslessRecoveryProofV1;
 }>;
 type CompleteInput = Readonly<{
   lookup: Lookup;
@@ -110,6 +136,10 @@ export interface MainTokenMigrationGaslessStoreV1 {
     idempotencyBindingHash: `sha256:${string}`;
     intent: MainTokenMigrationGaslessIntentV1;
   }>): Promise<Readonly<{
+    kind: "created" | "existing";
+    record: MainTokenMigrationGaslessRecordV1;
+  }>>;
+  recover(input: RecoverInput): Promise<Readonly<{
     kind: "created" | "existing";
     record: MainTokenMigrationGaslessRecordV1;
   }>>;
@@ -166,8 +196,7 @@ export function createMainTokenMigrationGaslessPostgresStoreV1(
           FROM programmable_website_projection_v1.credential_uses
          WHERE credential_id = ANY($1::text[])
          ORDER BY credential_id
-      `, [[holderId(input), completionId(input, "permit"),
-        completionId(input, "transfer")]]);
+      `, [recordIds(input)]);
       return recordFromRows(result.rows, input);
     },
 
@@ -183,22 +212,21 @@ export function createMainTokenMigrationGaslessPostgresStoreV1(
         const alias = aliasId(input.lookup.releaseId, input.idempotencyBindingHash);
         const root = rootId(input.lookup.releaseId, intent.rootWalletAddress);
         const existing = await selectRows(client, [
-          holder,
+          ...recordIds(input.lookup),
           alias,
           root,
-          completionId(input.lookup, "permit"),
-          completionId(input.lookup, "transfer"),
         ]);
         const existingRecord = recordFromRows(existing, input.lookup);
         const aliasRow = existing.find((row) => row.credential_id === alias);
         const rootRow = existing.find((row) => row.credential_id === root);
         if (existingRecord) {
-          if (existingRecord.intent.requestBindingHash !==
+          if (existingRecord.recoveryAttempt || existingRecord.intent.requestBindingHash !==
             intent.requestBindingHash || !aliasRow || !rootRow) throw conflict();
           const parsedAlias = parseAlias(aliasRow);
           const parsedRoot = parseRootGuard(rootRow);
           if (parsedAlias.holderCredentialId !== holder ||
-            parsedRoot.holderCredentialId !== holder) throw conflict();
+            parsedAlias.requestBindingHash !== intent.requestBindingHash ||
+            !rootGuardMatches(parsedRoot, intent, holder)) throw conflict();
           return Object.freeze({
             kind: "existing" as const,
             record: existingRecord,
@@ -232,6 +260,82 @@ export function createMainTokenMigrationGaslessPostgresStoreV1(
       });
     },
 
+    async recover(input: RecoverInput) {
+      validateLookup(input.lookup);
+      if (!DIGEST.test(input.idempotencyBindingHash) ||
+        !DIGEST.test(input.previousRequestBindingHash)) {
+        throw new TypeError("Gasless migration recovery binding is invalid");
+      }
+      const intent = validateIntent(input.intent, input.lookup);
+      await pool.assertProductionReadiness();
+      return transaction(pool, input.lookup.releaseId, async (client) => {
+        const alias = aliasId(input.lookup.releaseId, input.idempotencyBindingHash);
+        const root = rootId(input.lookup.releaseId, intent.rootWalletAddress);
+        const rows = await selectRows(client, [...recordIds(input.lookup), alias, root]);
+        const current = recordFromRows(rows, input.lookup);
+        if (!current) throw conflict();
+        const base = rows.find((row) => row.credential_id === holderId(input.lookup));
+        const rootRow = rows.find((row) => row.credential_id === root);
+        if (!base || !rootRow ||
+          !rootGuardMatches(parseRootGuard(rootRow), parseIntent(base), holderId(input.lookup))) {
+          throw unavailable();
+        }
+        const aliasRow = rows.find((row) => row.credential_id === alias);
+        const attempt = current.recoveryAttempt ?? 0;
+        if (current.intent.requestBindingHash === intent.requestBindingHash) {
+          const edgeRow = rows.find((row) => row.credential_id === recoveryId(input.lookup, attempt));
+          if (!attempt || !edgeRow || !aliasRow ||
+            current.previousRequestBindingHash !== input.previousRequestBindingHash) throw conflict();
+          const edge = parseRecoveryEdge(edgeRow);
+          const parsedAlias = parseAlias(aliasRow);
+          if (edge.idempotencyBindingHash !== input.idempotencyBindingHash ||
+            parsedAlias.holderCredentialId !== holderId(input.lookup, attempt) ||
+            parsedAlias.requestBindingHash !== intent.requestBindingHash ||
+            canonicalizeJson(current.intent) !== canonicalizeJson(intent)) throw conflict();
+          return Object.freeze({ kind: "existing" as const, record: current });
+        }
+        if (aliasRow || current.intent.requestBindingHash !== input.previousRequestBindingHash ||
+          current.transferTransactionHash || attempt >= MAIN_TOKEN_MIGRATION_GASLESS_MAX_RECOVERIES_V1) {
+          throw conflict();
+        }
+        assertRecoveryIntent(current.intent, intent);
+        const recoveryProof = validateRecoveryProof(input.recoveryProof, current.intent, intent);
+        const reserved = await readSharedReservedBudget(client, input.lookup.releaseId);
+        if (reserved + BigInt(intent.reservedTotalWei) > BigInt(intent.totalBudgetWei)) {
+          throw budgetExhausted();
+        }
+        const nextAttempt = attempt + 1;
+        const holder = holderId(input.lookup, nextAttempt);
+        const edge: RecoveryEdgeV1 = {
+          schema: "programmable-main-token-migration-gasless-recovery/v1",
+          recoveryAttempt: nextAttempt,
+          previousHolderCredentialId: holderId(input.lookup, attempt),
+          holderCredentialId: holder,
+          previousRequestBindingHash: current.intent.requestBindingHash,
+          requestBindingHash: intent.requestBindingHash,
+          idempotencyBindingHash: input.idempotencyBindingHash,
+          recoveryProof,
+        };
+        await insertRow(client, holder, intent.requestBindingHash, intent);
+        await insertRow(client, recoveryId(input.lookup, nextAttempt), intent.requestBindingHash, edge);
+        await insertRow(client, alias, intent.requestBindingHash, {
+          schema: "programmable-main-token-migration-gasless-idempotency/v1",
+          holderCredentialId: holder,
+          requestBindingHash: intent.requestBindingHash,
+        } satisfies AliasV1);
+        return Object.freeze({
+          kind: "created" as const,
+          record: Object.freeze({
+            intent,
+            permitTransactionHash: null,
+            transferTransactionHash: null,
+            recoveryAttempt: nextAttempt,
+            previousRequestBindingHash: current.intent.requestBindingHash,
+          }),
+        });
+      });
+    },
+
     async complete(input: CompleteInput) {
       validateLookup(input.lookup);
       if ((input.kind !== "permit" && input.kind !== "transfer") ||
@@ -241,11 +345,7 @@ export function createMainTokenMigrationGaslessPostgresStoreV1(
       }
       await pool.assertProductionReadiness();
       return transaction(pool, input.lookup.releaseId, async (client) => {
-        const rows = await selectRows(client, [
-          holderId(input.lookup),
-          completionId(input.lookup, "permit"),
-          completionId(input.lookup, "transfer"),
-        ]);
+        const rows = await selectRows(client, recordIds(input.lookup));
         const record = recordFromRows(rows, input.lookup);
         if (!record) throw unavailable();
         const expectedReference = input.kind === "permit"
@@ -270,12 +370,12 @@ export function createMainTokenMigrationGaslessPostgresStoreV1(
         };
         await insertRow(
           client,
-          completionId(input.lookup, input.kind),
+          completionId(input.lookup, input.kind, record.recoveryAttempt),
           record.intent.requestBindingHash,
           completion,
         );
         return Object.freeze({
-          intent: record.intent,
+          ...record,
           permitTransactionHash: input.kind === "permit"
             ? input.transactionHash
             : record.permitTransactionHash,
@@ -366,20 +466,49 @@ async function insertRow(
 }
 
 function recordFromRows(rows: readonly Row[], lookup: Lookup) {
-  const holder = rows.find((row) => row.credential_id === holderId(lookup));
-  if (!holder) return null;
-  const intent = parseIntent(holder);
-  if (intent.releaseId !== lookup.releaseId ||
-    intent.walletAddress.toLowerCase() !== lookup.walletAddress.toLowerCase() ||
-    holder.request_binding_hash !== intent.requestBindingHash) throw unavailable();
-  const permit = completionFromRows(rows, lookup, "permit", intent);
-  const transfer = completionFromRows(rows, lookup, "transfer", intent);
-  if (transfer && !permit) throw unavailable();
-  return Object.freeze({
-    intent,
-    permitTransactionHash: permit?.transactionHash ?? null,
-    transferTransactionHash: transfer?.transactionHash ?? null,
-  });
+  let record: MainTokenMigrationGaslessRecordV1 | null = null;
+  let chainEnded = false;
+  for (let attempt = 0; attempt <= MAIN_TOKEN_MIGRATION_GASLESS_MAX_RECOVERIES_V1; attempt++) {
+    const holder = rows.find((row) => row.credential_id === holderId(lookup, attempt));
+    const edgeRow = attempt
+      ? rows.find((row) => row.credential_id === recoveryId(lookup, attempt))
+      : undefined;
+    const hasCompletion = ["permit", "transfer"].some((kind) => rows.some((row) =>
+      row.credential_id === completionId(lookup, kind as CompletionKind, attempt)));
+    if (!holder) {
+      if (edgeRow || hasCompletion) throw unavailable();
+      chainEnded = true;
+      continue;
+    }
+    if (chainEnded) throw unavailable();
+    const intent = parseIntent(holder);
+    if (intent.releaseId !== lookup.releaseId ||
+      intent.walletAddress.toLowerCase() !== lookup.walletAddress.toLowerCase() ||
+      holder.request_binding_hash !== intent.requestBindingHash) throw unavailable();
+    let previousRequestBindingHash: `sha256:${string}` | undefined;
+    if (attempt) {
+      if (!record || !edgeRow || record.transferTransactionHash) throw unavailable();
+      const edge = parseRecoveryEdge(edgeRow);
+      if (edge.recoveryAttempt !== attempt ||
+        edge.holderCredentialId !== holderId(lookup, attempt) ||
+        edge.previousHolderCredentialId !== holderId(lookup, attempt - 1) ||
+        edge.previousRequestBindingHash !== record.intent.requestBindingHash ||
+        edge.requestBindingHash !== intent.requestBindingHash) throw unavailable();
+      assertRecoveryIntent(record.intent, intent);
+      validateRecoveryProof(edge.recoveryProof, record.intent, intent);
+      previousRequestBindingHash = record.intent.requestBindingHash;
+    }
+    const permit = completionFromRows(rows, lookup, "permit", intent, attempt);
+    const transfer = completionFromRows(rows, lookup, "transfer", intent, attempt);
+    if (transfer && !permit) throw unavailable();
+    record = Object.freeze({
+      intent,
+      permitTransactionHash: permit?.transactionHash ?? null,
+      transferTransactionHash: transfer?.transactionHash ?? null,
+      ...(attempt ? { recoveryAttempt: attempt, previousRequestBindingHash } : {}),
+    });
+  }
+  return record;
 }
 
 function completionFromRows(
@@ -387,9 +516,10 @@ function completionFromRows(
   lookup: Lookup,
   kind: CompletionKind,
   intent: MainTokenMigrationGaslessIntentV1,
+  attempt = 0,
 ) {
   const row = rows.find((candidate) =>
-    candidate.credential_id === completionId(lookup, kind));
+    candidate.credential_id === completionId(lookup, kind, attempt));
   if (!row) return null;
   const completion = parseCompletion(row);
   const reference = kind === "permit"
@@ -398,6 +528,63 @@ function completionFromRows(
   if (completion.kind !== kind || completion.providerReferenceId !== reference ||
     row.request_binding_hash !== intent.requestBindingHash) throw unavailable();
   return completion;
+}
+
+function assertRecoveryIntent(
+  previous: MainTokenMigrationGaslessIntentV1,
+  next: MainTokenMigrationGaslessIntentV1,
+) {
+  for (const key of ["releaseId", "walletAddress", "rootWalletAddress", "sponsorAddress",
+    "amountRaw", "nonce", "totalBudgetWei"] as const) {
+    if (previous[key] !== next[key]) throw conflict();
+  }
+  const oldReferences = new Set([
+    previous.providerPermitIdempotencyKey, previous.providerPermitReferenceId,
+    previous.providerTransferIdempotencyKey, previous.providerTransferReferenceId,
+  ]);
+  const newReferences = [next.providerPermitIdempotencyKey, next.providerPermitReferenceId,
+    next.providerTransferIdempotencyKey, next.providerTransferReferenceId];
+  if (BigInt(next.permitDeadline) <= BigInt(previous.permitDeadline) ||
+    next.requestBindingHash === previous.requestBindingHash ||
+    next.permitSignature === previous.permitSignature ||
+    newReferences.some((reference) => oldReferences.has(reference)) ||
+    next.providerPermitIdempotencyKey === next.providerTransferIdempotencyKey ||
+    next.providerPermitReferenceId === next.providerTransferReferenceId ||
+    Date.parse(next.reservedAt) < Date.parse(previous.reservedAt)) throw conflict();
+}
+
+function validateRecoveryProof(
+  input: MainTokenMigrationGaslessRecoveryProofV1,
+  previous: MainTokenMigrationGaslessIntentV1,
+  next: MainTokenMigrationGaslessIntentV1,
+): MainTokenMigrationGaslessRecoveryProofV1 {
+  const value = object(parseCanonical(canonicalizeJson(input)));
+  exactKeys(value, ["finalizedBlockNumber", "finalizedBlockHash", "finalizedBlockTimestamp",
+    "nonce", "allowanceRaw"]);
+  if (!positiveDecimal(value.finalizedBlockNumber) ||
+    typeof value.finalizedBlockHash !== "string" || !HASH.test(value.finalizedBlockHash) ||
+    !positiveDecimal(value.finalizedBlockTimestamp) || !decimal(value.nonce) ||
+    value.allowanceRaw !== "0" || value.nonce !== previous.nonce ||
+    BigInt(value.finalizedBlockTimestamp) <= BigInt(previous.permitDeadline) ||
+    BigInt(value.finalizedBlockTimestamp) >= BigInt(next.permitDeadline)) throw conflict();
+  return Object.freeze({
+    finalizedBlockNumber: value.finalizedBlockNumber,
+    finalizedBlockHash: value.finalizedBlockHash as Hex,
+    finalizedBlockTimestamp: value.finalizedBlockTimestamp,
+    nonce: value.nonce,
+    allowanceRaw: "0",
+  });
+}
+
+function rootGuardMatches(
+  guard: RootGuardV1,
+  intent: MainTokenMigrationGaslessIntentV1,
+  holder: string,
+) {
+  return guard.holderCredentialId === holder &&
+    guard.requestBindingHash === intent.requestBindingHash &&
+    guard.walletAddress === intent.walletAddress &&
+    guard.rootWalletAddress === intent.rootWalletAddress;
 }
 
 function validateIntent(value: MainTokenMigrationGaslessIntentV1, lookup: Lookup) {
@@ -528,6 +715,25 @@ function parseRootGuard(row: Row): RootGuardV1 {
   });
 }
 
+function parseRecoveryEdge(row: Row): RecoveryEdgeV1 {
+  const value = object(parseCanonical(row.canonical_use));
+  exactKeys(value, ["schema", "recoveryAttempt", "previousHolderCredentialId",
+    "holderCredentialId", "previousRequestBindingHash", "requestBindingHash",
+    "idempotencyBindingHash", "recoveryProof"]);
+  if (value.schema !== "programmable-main-token-migration-gasless-recovery/v1" ||
+    typeof value.recoveryAttempt !== "number" || !Number.isInteger(value.recoveryAttempt) ||
+    value.recoveryAttempt < 1 || value.recoveryAttempt > MAIN_TOKEN_MIGRATION_GASLESS_MAX_RECOVERIES_V1 ||
+    typeof value.previousHolderCredentialId !== "string" ||
+    typeof value.holderCredentialId !== "string" ||
+    typeof value.previousRequestBindingHash !== "string" || !DIGEST.test(value.previousRequestBindingHash) ||
+    typeof value.requestBindingHash !== "string" || !DIGEST.test(value.requestBindingHash) ||
+    typeof value.idempotencyBindingHash !== "string" || !DIGEST.test(value.idempotencyBindingHash) ||
+    row.request_binding_hash !== value.requestBindingHash) throw unavailable();
+  // The proof's exact shape and temporal binding are checked against both intents.
+  object(value.recoveryProof);
+  return value as RecoveryEdgeV1;
+}
+
 function parseCanonical(source: string) {
   const value = parseStrictJson(source, { maximumBytes: 24_576, maximumDepth: 8 });
   if (canonicalizeJson(value) !== source) throw unavailable();
@@ -564,12 +770,30 @@ function validateLookup(input: Lookup) {
   }
 }
 
-function holderId(input: Lookup) {
-  return `${PREFIX}:holder:${input.releaseId}:${input.walletAddress.toLowerCase()}`;
+function holderId(input: Lookup, attempt = 0) {
+  return `${PREFIX}:holder:${input.releaseId}:${input.walletAddress.toLowerCase()}${attemptSuffix(attempt)}`;
 }
 
-function completionId(input: Lookup, kind: CompletionKind) {
-  return `${PREFIX}:${kind}:${input.releaseId}:${input.walletAddress.toLowerCase()}`;
+function completionId(input: Lookup, kind: CompletionKind, attempt = 0) {
+  return `${PREFIX}:${kind}:${input.releaseId}:${input.walletAddress.toLowerCase()}${attemptSuffix(attempt)}`;
+}
+
+function recoveryId(input: Lookup, attempt: number) {
+  return `${PREFIX}:recovery:${input.releaseId}:${input.walletAddress.toLowerCase()}:attempt:${attempt}`;
+}
+
+function attemptSuffix(attempt: number) {
+  return attempt ? `:attempt:${attempt}` : "";
+}
+
+function recordIds(input: Lookup) {
+  const ids: string[] = [];
+  for (let attempt = 0; attempt <= MAIN_TOKEN_MIGRATION_GASLESS_MAX_RECOVERIES_V1; attempt++) {
+    ids.push(holderId(input, attempt), completionId(input, "permit", attempt),
+      completionId(input, "transfer", attempt));
+    if (attempt) ids.push(recoveryId(input, attempt));
+  }
+  return ids;
 }
 
 function aliasId(releaseId: string, binding: string) {

--- a/lib/server/main-token-migration-gasless-transfer-v1.ts
+++ b/lib/server/main-token-migration-gasless-transfer-v1.ts
@@ -12,6 +12,7 @@ import {
   keccak256,
   parseAbi,
   recoverTypedDataAddress,
+  TransactionReceiptNotFoundError,
   toHex,
   type Address,
   type Hex,
@@ -104,15 +105,23 @@ type PrepareRequest = Readonly<{
   action: "prepare" | "resume";
   walletAddress: Address;
   amountRaw: bigint;
+  previousRequestBindingHash?: `sha256:${string}`;
+}>;
+type RecoveryPrepareRequest = Readonly<{
+  action: "prepare_recovery";
+  walletAddress: Address;
+  amountRaw: bigint;
+  previousRequestBindingHash: `sha256:${string}`;
 }>;
 type SubmitRequest = Readonly<{
-  action: "submit";
+  action: "submit" | "submit_recovery";
   walletAddress: Address;
   amountRaw: bigint;
   nonce: bigint;
   permitDeadline: bigint;
   permitSignature: Hex;
   requestBindingHash: `sha256:${string}`;
+  previousRequestBindingHash?: `sha256:${string}`;
 }>;
 
 export class MainTokenMigrationGaslessErrorV1 extends Error {
@@ -179,14 +188,79 @@ export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
         };
         await input.admissionStore.admit({
           ...admission,
-          operation: parsed.action === "prepare" ? "read" : "progress",
+          operation: parsed.action === "prepare" || parsed.action === "prepare_recovery"
+            ? "read" : "progress",
         });
         const lookup = {
           releaseId: input.configuration.releaseId,
           walletAddress: parsed.walletAddress,
         };
         const existing = await input.store.get(lookup);
-        if (parsed.action !== "submit") {
+        const isRecovery = parsed.action === "prepare_recovery" ||
+          parsed.action === "submit_recovery";
+        let recoveryProof: Awaited<ReturnType<typeof input.chain.assertRecoverable>> | undefined;
+        if (isRecovery) {
+          if (!existing || !parsed.previousRequestBindingHash) {
+            throw new MainTokenMigrationGaslessErrorV1(409, "gasless_request_not_found");
+          }
+          // A response may be lost after the append. The identical new key can
+          // resume that exact successor, never create a second reservation.
+          const currentBinding = deriveMainTokenMigrationGaslessBindingV1({
+            baseRequestBindingHash: baseBindings.requestBindingHash,
+            nonce: BigInt(existing.intent.nonce),
+            permitDeadline: BigInt(existing.intent.permitDeadline),
+          });
+          const alreadyRecovered = currentBinding === existing.intent.requestBindingHash &&
+            existing.previousRequestBindingHash === parsed.previousRequestBindingHash;
+          if (!alreadyRecovered) {
+            if (existing.intent.requestBindingHash !== parsed.previousRequestBindingHash ||
+              existing.intent.amountRaw !== parsed.amountRaw.toString()) {
+              throw new MainTokenMigrationGaslessErrorV1(409, "idempotency_conflict");
+            }
+            const oldKeyBinding = deriveMainTokenMigrationGaslessBindingV1({
+              baseRequestBindingHash: baseBindings.requestBindingHash,
+              nonce: BigInt(existing.intent.nonce),
+              permitDeadline: BigInt(existing.intent.permitDeadline),
+            });
+            if (oldKeyBinding === existing.intent.requestBindingHash) {
+              throw new MainTokenMigrationGaslessErrorV1(409, "recovery_key_required");
+            }
+            recoveryProof = await assertMainTokenMigrationGaslessRecoveryEligibleV1({ ...input, record: existing, now: now() });
+          }
+          if (parsed.action === "prepare_recovery") {
+            if (alreadyRecovered) {
+              return prepareResponse(existing.intent, parsed.previousRequestBindingHash);
+            }
+            const observation = await input.chain.prepare({
+              configuration: input.configuration,
+              walletAddress: parsed.walletAddress,
+              amountRaw: parsed.amountRaw,
+            });
+            if (observation.nonce !== BigInt(existing.intent.nonce)) {
+              throw new MainTokenMigrationGaslessErrorV1(409, "permit_nonce_changed");
+            }
+            const permitDeadline = newPermitDeadline(input.configuration, now());
+            return json({
+              schema: "programmable-main-token-migration-gasless-transfer/v1",
+              status: "signature_required",
+              walletAddress: parsed.walletAddress,
+              amountRaw: parsed.amountRaw.toString(),
+              sponsorAddress: input.configuration.sponsorAddress,
+              nonce: observation.nonce.toString(),
+              permitDeadline: permitDeadline.toString(),
+              requestBindingHash: deriveMainTokenMigrationGaslessBindingV1({
+                baseRequestBindingHash: baseBindings.requestBindingHash,
+                nonce: observation.nonce,
+                permitDeadline,
+              }),
+              previousRequestBindingHash: parsed.previousRequestBindingHash,
+              permitTransactionHash: null,
+              transferTransactionHash: null,
+              transferBlockNumber: null,
+            }, 200);
+          }
+        }
+        if (parsed.action === "prepare" || parsed.action === "resume") {
           if (existing) {
             const binding = deriveMainTokenMigrationGaslessBindingV1({
               baseRequestBindingHash: baseBindings.requestBindingHash,
@@ -195,23 +269,60 @@ export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
             });
             if (binding !== existing.intent.requestBindingHash ||
               existing.intent.amountRaw !== parsed.amountRaw.toString()) {
+              if (parsed.action === "resume" &&
+                parsed.previousRequestBindingHash === existing.intent.requestBindingHash &&
+                existing.intent.amountRaw === parsed.amountRaw.toString()) {
+                throw new MainTokenMigrationGaslessErrorV1(409, "gasless_request_not_found");
+              }
               throw new MainTokenMigrationGaslessErrorV1(
                 409,
                 "idempotency_conflict",
               );
             }
+            if (parsed.previousRequestBindingHash &&
+              existing.previousRequestBindingHash !== parsed.previousRequestBindingHash) {
+              throw new MainTokenMigrationGaslessErrorV1(409, "idempotency_conflict");
+            }
             if (parsed.action === "resume") {
               const allowSend = windowOpen(input.configuration, now());
               if (allowSend) await input.sender.assertReady();
-              return await progressTransfer({
-                chain: input.chain,
-                configuration: input.configuration,
-                now: now(),
-                record: existing,
-                sender: input.sender,
-                store: input.store,
-                allowSend,
-              });
+              if (allowSend && !existing.transferTransactionHash &&
+                BigInt(existing.intent.permitDeadline) <
+                  BigInt(Math.floor(now().getTime() / 1_000))) {
+                try {
+                  await assertMainTokenMigrationGaslessRecoveryEligibleV1({
+                    ...input, record: existing, now: now(),
+                  });
+                  return recoveryResponse(existing);
+                } catch (error) {
+                  if (!(error instanceof MainTokenMigrationGaslessErrorV1) ||
+                    !["recovery_not_available", "recovery_wait_finality"]
+                      .includes(error.code)) throw error;
+                }
+              }
+              try {
+                return await progressTransfer({
+                  chain: input.chain,
+                  configuration: input.configuration,
+                  now: now(),
+                  record: existing,
+                  sender: input.sender,
+                  store: input.store,
+                  allowSend,
+                });
+              } catch (error) {
+                if (!allowSend || !(error instanceof MainTokenMigrationGaslessErrorV1) ||
+                  !["relay_needs_attention", "permit_expired", "permit_reverted"]
+                    .includes(error.code)) throw error;
+                try {
+                  await assertMainTokenMigrationGaslessRecoveryEligibleV1({ ...input, record: existing, now: now() });
+                } catch (recoveryError) {
+                  if (recoveryError instanceof MainTokenMigrationGaslessErrorV1 &&
+                    recoveryError.code === "recovery_not_available") throw error;
+                  throw recoveryError;
+                }
+                return recoveryResponse(existing);
+              }
             }
             return prepareResponse(existing.intent);
           }
@@ -225,11 +336,7 @@ export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
             walletAddress: parsed.walletAddress,
             amountRaw: parsed.amountRaw,
           });
-          const permitDeadline = BigInt(Math.min(
-            Math.floor(now().getTime() / 1_000) + PERMIT_VALIDITY_SECONDS,
-            input.configuration.deadlineTimestampExclusive -
-              DEADLINE_SAFETY_SECONDS,
-          ));
+          const permitDeadline = newPermitDeadline(input.configuration, now());
           const binding = deriveMainTokenMigrationGaslessBindingV1({
             baseRequestBindingHash: baseBindings.requestBindingHash,
             nonce: observation.nonce,
@@ -250,6 +357,9 @@ export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
           }, 200);
         }
 
+        if (parsed.action !== "submit" && parsed.action !== "submit_recovery") {
+          throw new MainTokenMigrationGaslessErrorV1(400, "request_invalid");
+        }
         const expectedBinding = deriveMainTokenMigrationGaslessBindingV1({
           baseRequestBindingHash: baseBindings.requestBindingHash,
           nonce: parsed.nonce,
@@ -276,7 +386,7 @@ export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
         }
 
         let record = existing;
-        if (!record) {
+        if (!record || recoveryProof) {
           // Only a new durable reservation consumes the new-transfer budget.
           // Identical signed retries still pass the bounded progress admission,
           // signature verification and immutable binding checks above/below.
@@ -322,7 +432,8 @@ export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
             schema: "programmable-main-token-migration-gasless-intent/v1",
             releaseId: input.configuration.releaseId,
             walletAddress: parsed.walletAddress,
-            rootWalletAddress: observation.rootWalletAddress,
+            rootWalletAddress: recoveryProof && existing
+              ? existing.intent.rootWalletAddress : observation.rootWalletAddress,
             sponsorAddress: input.configuration.sponsorAddress,
             amountRaw: parsed.amountRaw.toString(),
             nonce: parsed.nonce.toString(),
@@ -348,11 +459,19 @@ export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
           });
           // An unavailable sponsor must not consume the wallet's durable slot.
           await input.sender.assertReady();
-          record = (await input.store.reserve({
-            lookup,
-            idempotencyBindingHash: baseBindings.idempotencyBindingHash,
-            intent,
-          })).record;
+          record = recoveryProof && parsed.previousRequestBindingHash
+            ? (await input.store.recover({
+                lookup,
+                idempotencyBindingHash: baseBindings.idempotencyBindingHash,
+                previousRequestBindingHash: parsed.previousRequestBindingHash,
+                recoveryProof,
+                intent,
+              })).record
+            : (await input.store.reserve({
+                lookup,
+                idempotencyBindingHash: baseBindings.idempotencyBindingHash,
+                intent,
+              })).record;
         } else if (record.intent.requestBindingHash !== expectedBinding ||
           record.intent.amountRaw !== parsed.amountRaw.toString() ||
           record.intent.nonce !== parsed.nonce.toString() ||
@@ -374,6 +493,51 @@ export function createMainTokenMigrationGaslessTransferV1(input: Readonly<{
       }
     },
   });
+}
+
+/** Read-only eligibility proof. It never reserves, signs or broadcasts. */
+export async function assertMainTokenMigrationGaslessRecoveryEligibleV1(input: Readonly<{
+  configuration: MainTokenMigrationGasSponsorConfigurationV1;
+  record: MainTokenMigrationGaslessRecordV1;
+  chain: ReturnType<typeof createMainTokenMigrationGaslessChainV1>;
+  sender: ReturnType<typeof createMainTokenMigrationGaslessSenderV1>;
+  store: MainTokenMigrationGaslessStoreV1;
+  now: Date;
+}>) {
+  assertWindowOpen(input.configuration, input.now);
+  const { record } = input;
+  if (record.intent.releaseId !== input.configuration.releaseId ||
+    record.intent.sponsorAddress.toLowerCase() !==
+      input.configuration.sponsorAddress.toLowerCase() ||
+    record.transferTransactionHash || (record.recoveryAttempt ?? 0) >= 2) {
+    throw new MainTokenMigrationGaslessErrorV1(409, "recovery_not_available");
+  }
+  await assertCurrentAttempt(input.store, record);
+  const [permit, transfer] = await Promise.all([
+    input.sender.lookup("permit", record.intent),
+    input.sender.lookup("transfer", record.intent),
+  ]);
+  // Even a queued, failed or replaced transferFrom could consume a future
+  // allowance. Only an authoritative empty lookup is eligible for recovery.
+  if (transfer !== null || permit?.status === "confirmed" || permit?.status === "finalized") {
+    throw new MainTokenMigrationGaslessErrorV1(409, "recovery_not_available");
+  }
+  const proof = await input.chain.assertRecoverable(record, permit?.transactionHash);
+  await assertCurrentAttempt(input.store, record);
+  return proof;
+}
+
+async function assertCurrentAttempt(
+  store: MainTokenMigrationGaslessStoreV1,
+  record: MainTokenMigrationGaslessRecordV1,
+) {
+  const current = await store.get({
+    releaseId: record.intent.releaseId,
+    walletAddress: record.intent.walletAddress,
+  });
+  if (!current || current.intent.requestBindingHash !== record.intent.requestBindingHash) {
+    throw new MainTokenMigrationGaslessErrorV1(409, "idempotency_conflict");
+  }
 }
 
 async function progressTransfer(input: Readonly<{
@@ -399,6 +563,7 @@ async function progressTransfer(input: Readonly<{
       }
       assertProviderRetryWindow(record.intent, input.now);
     }
+    await assertCurrentAttempt(input.store, record);
     const hash = recoveredHash ?? await input.sender.send("permit", record.intent);
     record = await input.store.complete({
       lookup: {
@@ -434,6 +599,7 @@ async function progressTransfer(input: Readonly<{
       // be reconciled by its receipt, not rejected for already using it.
       await input.chain.assertPermitEffect(record);
     }
+    await assertCurrentAttempt(input.store, record);
     const hash = recoveredHash ?? await input.sender.send("transfer", record.intent);
     record = await input.store.complete({
       lookup: {
@@ -510,6 +676,101 @@ export function createMainTokenMigrationGaslessChainV1(
     }),
   ];
   return Object.freeze({
+    async assertRecoverable(
+      record: MainTokenMigrationGaslessRecordV1,
+      providerPermitHash?: Hex | null,
+    ) {
+      if (record.transferTransactionHash) {
+        throw new MainTokenMigrationGaslessErrorV1(409, "recovery_not_available");
+      }
+      try {
+        const finalizedHeads = await Promise.all(clients.map((client) =>
+          client.getBlock({ blockTag: "finalized" })));
+        if (finalizedHeads.some((block) => block.number === null || !block.hash)) {
+          throw new MainTokenMigrationGaslessErrorV1(503, "rpc_quorum_unavailable");
+        }
+        const leftFinalized = finalizedHeads[0]!.number!;
+        const rightFinalized = finalizedHeads[1]!.number!;
+        const finalizedBlockNumber = leftFinalized < rightFinalized
+          ? leftFinalized : rightFinalized;
+        const latestHeads = await Promise.all(clients.map((client) =>
+          client.getBlockNumber()));
+        const latestBlockNumber = latestHeads[0] < latestHeads[1]
+          ? latestHeads[0] : latestHeads[1];
+        if (latestBlockNumber < finalizedBlockNumber) {
+          throw new MainTokenMigrationGaslessErrorV1(503, "rpc_quorum_unavailable");
+        }
+        const readState = async (client: PublicClient, blockNumber: bigint) => {
+          const [chainId, block, code, domain, nonce, allowance] = await Promise.all([
+            client.getChainId(),
+            client.getBlock({ blockNumber }),
+            client.getCode({ address: MAIN_TOKEN_ADDRESS, blockNumber }),
+            client.readContract({ address: MAIN_TOKEN_ADDRESS, abi: TOKEN_ABI,
+              functionName: "DOMAIN_SEPARATOR", blockNumber }),
+            client.readContract({ address: MAIN_TOKEN_ADDRESS, abi: TOKEN_ABI,
+              functionName: "nonces", args: [record.intent.walletAddress], blockNumber }),
+            client.readContract({ address: MAIN_TOKEN_ADDRESS, abi: TOKEN_ABI,
+              functionName: "allowance",
+              args: [record.intent.walletAddress, record.intent.sponsorAddress], blockNumber }),
+          ]);
+          return { chainId, block, code, domain, nonce, allowance };
+        };
+        const [finalized, latest] = await Promise.all([
+          Promise.all(clients.map((client) => readState(client, finalizedBlockNumber))),
+          Promise.all(clients.map((client) => readState(client, latestBlockNumber))),
+        ]);
+        for (const [states, number] of [
+          [finalized, finalizedBlockNumber], [latest, latestBlockNumber],
+        ] as const) {
+          const [left, right] = states;
+          if (!left || !right || left.chainId !== MAIN_TOKEN_MIGRATION_CHAIN_ID ||
+            right.chainId !== MAIN_TOKEN_MIGRATION_CHAIN_ID ||
+            left.block.number !== number || right.block.number !== number ||
+            !left.block.hash || left.block.hash !== right.block.hash ||
+            left.block.timestamp !== right.block.timestamp ||
+            !left.code || left.code !== right.code ||
+            keccak256(left.code) !== MAIN_TOKEN_RUNTIME_CODE_KECCAK256 ||
+            left.domain !== right.domain ||
+            left.domain.toLowerCase() !== MAIN_TOKEN_PERMIT_DOMAIN_SEPARATOR.toLowerCase() ||
+            left.nonce !== right.nonce || left.allowance !== right.allowance) {
+            throw new MainTokenMigrationGaslessErrorV1(503, "rpc_quorum_unavailable");
+          }
+          if (left.nonce !== BigInt(record.intent.nonce) || left.allowance !== 0n) {
+            throw new MainTokenMigrationGaslessErrorV1(409, "recovery_not_available");
+          }
+        }
+        const finalizedState = finalized[0]!;
+        if (finalizedState.block.timestamp <= BigInt(record.intent.permitDeadline)) {
+          throw new MainTokenMigrationGaslessErrorV1(409, "recovery_wait_finality");
+        }
+        const hashes = [...new Set([
+          record.permitTransactionHash, providerPermitHash,
+        ].filter((hash): hash is Hex => Boolean(hash)))];
+        await Promise.all(clients.flatMap((client) => hashes.map(async (hash) => {
+          try {
+            const receipt = await client.getTransactionReceipt({ hash });
+            if (receipt.transactionHash !== hash || receipt.status === "success") {
+              throw new MainTokenMigrationGaslessErrorV1(409, "recovery_not_available");
+            }
+          } catch (error) {
+            // An actual eth_getTransactionReceipt null is absence. Transport
+            // timeouts, malformed receipts and all other ambiguity fail closed.
+            if (!(error instanceof TransactionReceiptNotFoundError)) throw error;
+          }
+        })));
+        return Object.freeze({
+          finalizedBlockNumber: finalizedBlockNumber.toString(),
+          finalizedBlockHash: finalizedState.block.hash!,
+          finalizedBlockTimestamp: finalizedState.block.timestamp.toString(),
+          nonce: finalizedState.nonce.toString(),
+          allowanceRaw: "0" as const,
+        });
+      } catch (error) {
+        if (error instanceof MainTokenMigrationGaslessErrorV1) throw error;
+        throw new MainTokenMigrationGaslessErrorV1(503, "rpc_quorum_unavailable");
+      }
+    },
+
     async prepare(input: Readonly<{
       configuration: MainTokenMigrationGasSponsorConfigurationV1;
       walletAddress: Address;
@@ -822,18 +1083,23 @@ function assertSenderIntent(
   }
 }
 
-function parseRequest(input: unknown): PrepareRequest | SubmitRequest {
+function parseRequest(input: unknown): PrepareRequest | RecoveryPrepareRequest | SubmitRequest {
   if (!input || Array.isArray(input) || typeof input !== "object") {
     throw new MainTokenMigrationGaslessErrorV1(400, "request_invalid");
   }
   const value = input as Record<string, unknown>;
-  const common = value.action === "prepare" || value.action === "resume"
+  const recovery = value.action === "prepare_recovery" || value.action === "submit_recovery";
+  const recoveryResume = value.action === "resume" &&
+    Object.hasOwn(value, "previousRequestBindingHash");
+  const common = value.action === "prepare" || value.action === "resume" ||
+    value.action === "prepare_recovery"
     ? ["action", "amountRaw", "walletAddress"]
     : ["action", "amountRaw", "nonce", "permitDeadline", "permitSignature",
       "requestBindingHash", "walletAddress"];
+  if (recovery || recoveryResume) common.push("previousRequestBindingHash");
   if (Object.keys(value).sort().join("\0") !== common.sort().join("\0") ||
     (value.action !== "prepare" && value.action !== "resume" &&
-      value.action !== "submit") ||
+      value.action !== "submit" && !recovery) ||
     typeof value.walletAddress !== "string" ||
     !isAddress(value.walletAddress, { strict: true }) ||
     typeof value.amountRaw !== "string" || !DECIMAL.test(value.amountRaw)) {
@@ -844,8 +1110,22 @@ function parseRequest(input: unknown): PrepareRequest | SubmitRequest {
     throw new MainTokenMigrationGaslessErrorV1(400, "request_invalid");
   }
   const walletAddress = getAddress(value.walletAddress);
+  if ((recovery || recoveryResume) && (typeof value.previousRequestBindingHash !== "string" ||
+    !DIGEST.test(value.previousRequestBindingHash))) {
+    throw new MainTokenMigrationGaslessErrorV1(400, "request_invalid");
+  }
+  if (value.action === "prepare_recovery") {
+    return Object.freeze({
+      action: value.action, walletAddress, amountRaw,
+      previousRequestBindingHash: value.previousRequestBindingHash as `sha256:${string}`,
+    });
+  }
   if (value.action === "prepare" || value.action === "resume") {
-    return Object.freeze({ action: value.action, walletAddress, amountRaw });
+    return Object.freeze({ action: value.action, walletAddress, amountRaw,
+      ...(recoveryResume ? {
+        previousRequestBindingHash: value.previousRequestBindingHash as `sha256:${string}`,
+      } : {}),
+    });
   }
   if (typeof value.nonce !== "string" || !ZERO_DECIMAL.test(value.nonce) ||
     typeof value.permitDeadline !== "string" || !DECIMAL.test(value.permitDeadline) ||
@@ -856,17 +1136,38 @@ function parseRequest(input: unknown): PrepareRequest | SubmitRequest {
     throw new MainTokenMigrationGaslessErrorV1(400, "request_invalid");
   }
   return Object.freeze({
-    action: "submit",
+    action: value.action as "submit" | "submit_recovery",
     walletAddress,
     amountRaw,
     nonce: BigInt(value.nonce),
     permitDeadline: BigInt(value.permitDeadline),
     permitSignature: value.permitSignature.toLowerCase() as Hex,
     requestBindingHash: value.requestBindingHash as `sha256:${string}`,
+    ...(recovery ? {
+      previousRequestBindingHash: value.previousRequestBindingHash as `sha256:${string}`,
+    } : {}),
   });
 }
 
-function prepareResponse(intent: MainTokenMigrationGaslessIntentV1) {
+function newPermitDeadline(
+  configuration: MainTokenMigrationGasSponsorConfigurationV1,
+  now: Date,
+) {
+  const nowSeconds = Math.floor(now.getTime() / 1_000);
+  const deadline = Math.min(
+    nowSeconds + PERMIT_VALIDITY_SECONDS,
+    configuration.deadlineTimestampExclusive - DEADLINE_SAFETY_SECONDS,
+  );
+  if (deadline <= nowSeconds + 30) {
+    throw new MainTokenMigrationGaslessErrorV1(409, "recovery_window_closed");
+  }
+  return BigInt(deadline);
+}
+
+function prepareResponse(
+  intent: MainTokenMigrationGaslessIntentV1,
+  previousRequestBindingHash?: `sha256:${string}`,
+) {
   return json({
     schema: "programmable-main-token-migration-gasless-transfer/v1",
     status: "signature_required",
@@ -877,6 +1178,24 @@ function prepareResponse(intent: MainTokenMigrationGaslessIntentV1) {
     permitDeadline: intent.permitDeadline,
     requestBindingHash: intent.requestBindingHash,
     permitTransactionHash: null,
+    transferTransactionHash: null,
+    transferBlockNumber: null,
+    ...(previousRequestBindingHash ? { previousRequestBindingHash } : {}),
+  }, 200);
+}
+
+function recoveryResponse(record: MainTokenMigrationGaslessRecordV1) {
+  return json({
+    schema: "programmable-main-token-migration-gasless-transfer/v1",
+    status: "recovery_available",
+    walletAddress: record.intent.walletAddress,
+    amountRaw: record.intent.amountRaw,
+    sponsorAddress: record.intent.sponsorAddress,
+    nonce: record.intent.nonce,
+    permitDeadline: record.intent.permitDeadline,
+    requestBindingHash: record.intent.requestBindingHash,
+    previousRequestBindingHash: record.intent.requestBindingHash,
+    permitTransactionHash: record.permitTransactionHash,
     transferTransactionHash: null,
     transferBlockNumber: null,
   }, 200);
@@ -940,6 +1259,14 @@ function errorResponse(error: unknown) {
   }
   const message = failure.status === 401 || failure.status === 403
     ? "Reconnect this wallet and try again."
+    : failure.code === "recovery_wait_finality"
+      ? "The previous approval must expire on finalized Ethereum blocks before a new signature is safe. Check again shortly."
+    : failure.code === "recovery_not_available"
+      ? "This saved transfer cannot safely restart. Contact migration support with this request ID."
+    : failure.code === "recovery_key_required"
+      ? "A new transfer needs its own request key. Refresh the page and review the new transfer again."
+    : failure.code === "recovery_window_closed"
+      ? "There is not enough time left to safely request a new approval."
     : failure.code === "relay_needs_attention" || failure.code === "permit_expired"
       ? "This gasless request needs migration support. Do not send V4 again; contact support with this request ID."
     : failure.code === "gasless_request_not_found"

--- a/tests/main-token-migration-gas-sponsor-contract.test.ts
+++ b/tests/main-token-migration-gas-sponsor-contract.test.ts
@@ -242,7 +242,17 @@ describe("main token migration gas sponsor activation contract", () => {
       migrationWallet: manifest.migrationWallet,
       eligibleWalletCode: "plain-eoa-or-eip-7702-delegation-indicator",
       holderEligibility: "current-token-balance-including-post-start-acquisitions",
-      actions: ["prepare", "submit", "resume"],
+      actions: ["prepare", "submit", "resume", "prepare_recovery", "submit_recovery"],
+      expiredPermitRecovery: {
+        maximumAttemptsPerHolder: 3,
+        requiresFreshWalletSignature: true,
+        requiresFinalizedExpiry: true,
+        requiresUnchangedPermitNonce: true,
+        requiresZeroSponsorAllowance: true,
+        requiresNoTransferSubmission: true,
+        history: "append-only-predecessor-bound-attempts",
+        budget: "all-attempt-reservations-remain-counted",
+      },
       walletReview: {
         standard: "EIP-2612 Permit",
         binds: [
@@ -279,6 +289,10 @@ describe("main token migration gas sponsor activation contract", () => {
       "sharedBudget",
       "durableHolderReplayGuard",
       "authenticatedExistingIntentResume",
+      "finalizedExpiredPermitRecovery",
+      "freshRecoverySignature",
+      "appendOnlyAttemptHistory",
+      "atomicPredecessorBinding",
       "exactTransactionReadback",
     ]) {
       expect(gaslessContract.serverEnforces).toContain(boundary);

--- a/tests/main-token-migration-gas-sponsorship-ui.test.ts
+++ b/tests/main-token-migration-gas-sponsorship-ui.test.ts
@@ -2,21 +2,27 @@ import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  assertGaslessRecoveryProgress,
   createMigrationRequestGate,
   gasSponsorshipDisplayKind,
   gasSponsorshipErrorMessage,
   gasSponsorshipFailure,
   gasSponsorshipState,
   gaslessTransferFailure,
+  gaslessRecoveryIdempotencyKey,
   gaslessTransferIdempotencyKey,
   hasEnoughMigrationGas,
   migrationGaslessResumeAmount,
   migrationTransferRoute,
+  parseGaslessTransferResponse,
   parseGasSponsorshipResponse,
+  persistGaslessRecoveryProgress,
   sponsorshipRetryAfterMs,
   waitForMigrationRetry,
+  storedGaslessTransferProgress,
   type MainTokenGasSponsorshipResponse,
   type MainTokenGasSponsorshipStatus,
+  type StoredGaslessTransferProgress,
 } from "../components/main-token-migration";
 import {
   MAIN_TOKEN_MIGRATION_RELEASE_ID,
@@ -28,6 +34,39 @@ const SCHEMA =
 const WALLET = "0x1111111111111111111111111111111111111111";
 const OTHER_WALLET = "0x2222222222222222222222222222222222222222";
 const TX_HASH = `0x${"ab".repeat(32)}` as const;
+const PARENT_BINDING = `sha256:${"ac".repeat(32)}` as const;
+const CHILD_BINDING = `sha256:${"bc".repeat(32)}` as const;
+const PROGRESS_KEY = `programmable:main-token-migration:gasless-progress:${MAIN_TOKEN_MIGRATION_RELEASE_ID}`;
+const NEW_REQUEST_KEY = "gasless-new-request-123456789";
+
+function gaslessResponse(status: string, overrides: Record<string, unknown> = {}) {
+  return {
+    schema: "programmable-main-token-migration-gasless-transfer/v1",
+    status,
+    walletAddress: WALLET,
+    amountRaw: "100",
+    sponsorAddress: OTHER_WALLET,
+    nonce: "0",
+    permitDeadline: "1788160000",
+    requestBindingHash: PARENT_BINDING,
+    permitTransactionHash: TX_HASH,
+    transferTransactionHash: null,
+    transferBlockNumber: null,
+    previousRequestBindingHash: PARENT_BINDING,
+    ...overrides,
+  };
+}
+
+function recoveryStorage(progress: StoredGaslessTransferProgress) {
+  const values = new Map<string, string>([[PROGRESS_KEY, JSON.stringify(progress)]]);
+  const localStorage = {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => { values.set(key, value); }),
+    removeItem: vi.fn((key: string) => { values.delete(key); }),
+  };
+  vi.stubGlobal("window", { localStorage, dispatchEvent: vi.fn() });
+  return { values, localStorage };
+}
 
 function response(
   status: MainTokenGasSponsorshipStatus,
@@ -244,16 +283,128 @@ describe("main token migration gas sponsorship UI contract", () => {
     const review = source.slice(source.indexOf("  async function reviewGaslessTransfer("),
       source.indexOf("  async function reviewTransfer()"));
     expect(review.indexOf("const permit = await signMainTokenMigrationPermit")).toBeLessThan(
-      review.indexOf("const progress = persistGaslessTransferProgress"),
+      review.indexOf("const progress = recoveryReview?.previousRequestBindingHash"),
+    );
+    expect(review.indexOf("persistGaslessRecoveryProgress(recoveryReview.progress")).toBeLessThan(
+      review.indexOf('action: recoveryReview?.previousRequestBindingHash ? "submit_recovery" : "submit"'),
     );
     const beforeConfirmation = review.slice(0, review.indexOf('result.status === "confirmed"'));
     expect(beforeConfirmation).not.toContain("clearGaslessTransferProgress()");
     expect(review).toContain('action: "resume"');
+    const resume = review.slice(review.indexOf("if (resumeExisting)"), review.indexOf("} else {"));
+    expect(resume).toContain("previousRequestBindingHash: savedProgress.previousRequestBindingHash");
     expect(review).toContain("resumeExisting || preservePendingRequest");
     expect(review).toContain('resumeExisting && response.status === 409 &&');
     expect(review).toContain('failure.code === "gasless_request_not_found" && trustedTransferWindowOpen()');
-    expect(review).toContain("reviewGaslessTransfer(account, amountRaw, false, true)");
+    expect(review).not.toContain("await reviewGaslessTransfer(");
+    expect(review).toContain("setGaslessRecoveryReview({");
     expect(source).not.toContain('Gasless transfer available');
+  });
+
+  it("accepts recovery only with an exact server predecessor and no possible transfer hash", () => {
+    const offer = gaslessResponse("recovery_available");
+    expect(parseGaslessTransferResponse(offer, WALLET, 100n).status).toBe("recovery_available");
+    for (const change of [
+      { previousRequestBindingHash: CHILD_BINDING },
+      { previousRequestBindingHash: undefined },
+      { requestBindingHash: CHILD_BINDING },
+      { transferTransactionHash: TX_HASH },
+      { transferBlockNumber: "10" },
+      { walletAddress: OTHER_WALLET },
+      { amountRaw: "101" },
+      { extra: true },
+    ]) {
+      expect(() => parseGaslessTransferResponse({ ...offer, ...change }, WALLET, 100n)).toThrow();
+    }
+    expect(parseGaslessTransferResponse({ ...offer, permitTransactionHash: null }, WALLET, 100n)
+      .permitTransactionHash).toBeNull();
+  });
+
+  it("binds recovery wallet review to the exact parent rather than accepting any fresh approval", () => {
+    const prepared = gaslessResponse("signature_required", {
+      requestBindingHash: CHILD_BINDING,
+      permitTransactionHash: null,
+    });
+    expect(parseGaslessTransferResponse(prepared, WALLET, 100n, PARENT_BINDING)
+      .previousRequestBindingHash).toBe(PARENT_BINDING);
+    expect(() => parseGaslessTransferResponse(prepared, WALLET, 100n, CHILD_BINDING)).toThrow();
+    expect(() => parseGaslessTransferResponse(prepared, WALLET, 100n)).toThrow();
+    const withoutParent: Record<string, unknown> = { ...prepared };
+    delete withoutParent.previousRequestBindingHash;
+    expect(() => parseGaslessTransferResponse(withoutParent, WALLET, 100n, PARENT_BINDING)).toThrow();
+    expect(parseGaslessTransferResponse(withoutParent, WALLET, 100n).status).toBe("signature_required");
+  });
+
+  it("atomically saves a recovery key with its parent and restores that exact request after refresh", () => {
+    const old: StoredGaslessTransferProgress = {
+      schema: "programmable-main-token-migration-gasless-ui/v1", account: WALLET, amountRaw: "100",
+    };
+    const { localStorage, values } = recoveryStorage(old);
+    expect(storedGaslessTransferProgress()).toEqual(old);
+    const recovered = persistGaslessRecoveryProgress(old, NEW_REQUEST_KEY, PARENT_BINDING);
+    expect(recovered).toEqual({ ...old, schema: "programmable-main-token-migration-gasless-ui/v2",
+      idempotencyKey: NEW_REQUEST_KEY, previousRequestBindingHash: PARENT_BINDING });
+    expect(localStorage.setItem).toHaveBeenCalledOnce();
+    expect(localStorage.setItem).toHaveBeenCalledWith(PROGRESS_KEY, JSON.stringify(recovered));
+    expect(storedGaslessTransferProgress()).toEqual(recovered);
+    expect(values.get(PROGRESS_KEY)).not.toContain("permitSignature");
+    expect(localStorage.removeItem).not.toHaveBeenCalled();
+  });
+
+  it("uses the same fresh recovery key across tabs for one parent and a new key for the next parent", () => {
+    const firstTab = gaslessRecoveryIdempotencyKey(PARENT_BINDING);
+    const secondTab = gaslessRecoveryIdempotencyKey(PARENT_BINDING);
+    expect(firstTab).toBe(secondTab);
+    expect(firstTab).toMatch(/^[a-zA-Z0-9:_-]{16,200}$/u);
+    expect(firstTab).not.toBe(gaslessRecoveryIdempotencyKey(CHILD_BINDING));
+    expect(() => gaslessRecoveryIdempotencyKey("sha256:invalid")).toThrow();
+  });
+
+  it("preserves the original request when saving a signed recovery fails", () => {
+    const old: StoredGaslessTransferProgress = {
+      schema: "programmable-main-token-migration-gasless-ui/v1", account: WALLET, amountRaw: "100",
+    };
+    const { localStorage, values } = recoveryStorage(old);
+    localStorage.setItem.mockImplementation(() => { throw new Error("Storage is full"); });
+    expect(() => persistGaslessRecoveryProgress(old, NEW_REQUEST_KEY, PARENT_BINDING))
+      .toThrow("Nothing was submitted");
+    expect(values.get(PROGRESS_KEY)).toBe(JSON.stringify(old));
+    expect(storedGaslessTransferProgress()).toEqual(old);
+    expect(localStorage.removeItem).not.toHaveBeenCalled();
+  });
+
+  it("does not overwrite a newer attempt from another tab or accept malformed v2 progress", () => {
+    const old: StoredGaslessTransferProgress = {
+      schema: "programmable-main-token-migration-gasless-ui/v1", account: WALLET, amountRaw: "100",
+    };
+    const { values, localStorage } = recoveryStorage(old);
+    const newer = persistGaslessRecoveryProgress(old, NEW_REQUEST_KEY, PARENT_BINDING);
+    localStorage.setItem.mockClear();
+    expect(() => assertGaslessRecoveryProgress(old)).toThrow("changed in another tab");
+    expect(() => persistGaslessRecoveryProgress(old, "gasless-third-request-123456789", CHILD_BINDING)).toThrow();
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+    expect(storedGaslessTransferProgress()).toEqual(newer);
+    for (const change of [{ idempotencyKey: "short" }, { previousRequestBindingHash: "wrong" },
+      { amountRaw: (MAIN_TOKEN_TOTAL_SUPPLY_RAW + 1n).toString() }, { permitSignature: TX_HASH }]) {
+      values.set(PROGRESS_KEY, JSON.stringify({ ...newer, ...change }));
+      expect(storedGaslessTransferProgress()).toBeNull();
+    }
+  });
+
+  it("requires a distinct user action for fresh recovery and keeps status checks available after closure", () => {
+    const source = readFileSync(new URL("../components/main-token-migration.tsx", import.meta.url), "utf8");
+    expect(source).toContain('gaslessRecoveryReview && trustedTransferWindowOpen()');
+    expect(source).toContain('gaslessRecoveryReview && transferWindowOpen');
+    expect(source).toContain('"Review new transfer"');
+    expect(source).toContain('data-status={canResumeGaslessTransfer ? "unavailable" : "eoa"}');
+    const click = source.slice(source.indexOf("  async function reviewTransfer()"),
+      source.indexOf("  async function reviewTransferOnce()"));
+    expect(click.indexOf("transferInFlightRef.current = true")).toBeLessThan(click.indexOf("await reviewTransferOnce()"));
+    const sign = source.slice(source.indexOf("const permit = await signMainTokenMigrationPermit"),
+      source.indexOf('for (let attempt = 0; attempt < 60; attempt += 1)'));
+    expect(sign.indexOf("!trustedTransferWindowOpen()")).toBeLessThan(sign.indexOf("persistGaslessRecoveryProgress("));
+    expect(sign).not.toContain("clearGaslessTransferProgress");
+    expect(source).toContain('(!transferWindowOpen && !canResumeGaslessTransfer)');
   });
 
   it("honors the full Retry-After minimum and falls back safely", () => {

--- a/tests/main-token-migration-gasless-recovery-chain-v1.test.ts
+++ b/tests/main-token-migration-gasless-recovery-chain-v1.test.ts
@@ -1,0 +1,216 @@
+import { TransactionReceiptNotFoundError, type Address, type Hex } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ createPublicClient: vi.fn() }));
+vi.mock("server-only", () => ({}));
+vi.mock("viem", async (importOriginal) => ({
+  ...await importOriginal<typeof import("viem")>(),
+  createPublicClient: mocks.createPublicClient,
+}));
+vi.mock("../lib/main-token-migration", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/main-token-migration")>();
+  const { keccak256 } = await import("viem");
+  return {
+    ...actual,
+    // Unit-only executable bytes and their derived pin, never live-chain evidence.
+    MAIN_TOKEN_RUNTIME_CODE_KECCAK256: keccak256("0x6001600055"),
+  };
+});
+
+import {
+  MAIN_TOKEN_ADDRESS,
+  MAIN_TOKEN_MIGRATION_RELEASE_ID,
+  MAIN_TOKEN_NAME,
+  MAIN_TOKEN_PERMIT_DOMAIN_SEPARATOR,
+} from "../lib/main-token-migration";
+import { createMainTokenMigrationGaslessChainV1 } from
+  "../lib/server/main-token-migration-gasless-transfer-v1";
+import type { MainTokenMigrationGaslessRecordV1 } from
+  "../lib/server/main-token-migration-gasless-transfer-store-v1";
+
+const holder = "0x0000000000000000000000000000000000000011" as Address;
+const sponsor = "0x0000000000000000000000000000000000000022" as Address;
+const finalizedNumber = 25_900_000n;
+const finalizedHash = `0x${"12".repeat(32)}` as Hex;
+const latestNumber = finalizedNumber + 10n;
+const latestHash = `0x${"13".repeat(32)}` as Hex;
+const expiredDeadline = 1_788_170_000n;
+
+type State = {
+  chainId: number;
+  finalizedTimestamp: bigint;
+  finalizedHash: Hex;
+  latestHash: Hex;
+  finalizedNonce: bigint;
+  latestNonce: bigint;
+  finalizedAllowance: bigint;
+  latestAllowance: bigint;
+  tokenCode: Hex;
+  domain: Hex;
+};
+
+function fixture() {
+  const state: State = {
+    chainId: 1,
+    finalizedTimestamp: expiredDeadline + 1n,
+    finalizedHash,
+    latestHash,
+    finalizedNonce: 3n,
+    latestNonce: 3n,
+    finalizedAllowance: 0n,
+    latestAllowance: 0n,
+    tokenCode: "0x6001600055",
+    domain: MAIN_TOKEN_PERMIT_DOMAIN_SEPARATOR,
+  };
+  const states = [{ ...state }, { ...state }];
+  const clients = states.map((s, index) => ({
+    getChainId: vi.fn(async () => s.chainId),
+    getBlockNumber: vi.fn(async () => latestNumber + BigInt(index)),
+    getBlock: vi.fn(async (input: { blockTag?: string; blockNumber?: bigint }) => {
+      const number = input.blockTag === "finalized"
+        ? finalizedNumber + BigInt(index) : input.blockNumber;
+      if (number === undefined) throw new Error("An explicit canonical block is required");
+      const finalized = number <= finalizedNumber + 1n;
+      return {
+        number,
+        hash: finalized ? s.finalizedHash : s.latestHash,
+        timestamp: finalized ? s.finalizedTimestamp : expiredDeadline + 100n,
+      };
+    }),
+    getCode: vi.fn(async ({ address }: { address: Address }) =>
+      address.toLowerCase() === MAIN_TOKEN_ADDRESS.toLowerCase() ? s.tokenCode : "0x"),
+    readContract: vi.fn(async (input: { functionName: string; blockNumber?: bigint }) => {
+      if (input.blockNumber !== finalizedNumber && input.blockNumber !== latestNumber) {
+        throw new Error("Contract read must use a common explicit block");
+      }
+      const finalized = input.blockNumber === finalizedNumber;
+      if (input.functionName === "name") return MAIN_TOKEN_NAME;
+      if (input.functionName === "DOMAIN_SEPARATOR") return s.domain;
+      if (input.functionName === "nonces") return finalized ? s.finalizedNonce : s.latestNonce;
+      if (input.functionName === "allowance") return finalized ? s.finalizedAllowance : s.latestAllowance;
+      if (input.functionName === "balanceOf") return 100n;
+      throw new Error("Unexpected contract read");
+    }),
+    getTransactionReceipt: vi.fn(async () => {
+      throw new Error("Unclassified receipt error must fail closed");
+    }),
+  }));
+  clients.forEach((client) => mocks.createPublicClient.mockReturnValueOnce(client));
+  const chain = createMainTokenMigrationGaslessChainV1([
+    { endpoint: "https://primary.invalid" }, { endpoint: "https://secondary.invalid" },
+  ] as never);
+  const record: MainTokenMigrationGaslessRecordV1 = {
+    intent: {
+      schema: "programmable-main-token-migration-gasless-intent/v1",
+      releaseId: MAIN_TOKEN_MIGRATION_RELEASE_ID,
+      walletAddress: holder,
+      rootWalletAddress: holder,
+      sponsorAddress: sponsor,
+      amountRaw: "100",
+      nonce: "3",
+      permitDeadline: expiredDeadline.toString(),
+      permitSignature: `0x${"11".repeat(65)}`,
+      permitGasLimit: "100000",
+      transferGasLimit: "100000",
+      maxFeePerGasWei: "1000000000",
+      maxPriorityFeePerGasWei: "100000000",
+      reservedTotalWei: "200000000000000",
+      totalBudgetWei: "1000000000000000000",
+      requestBindingHash: `sha256:${"44".repeat(32)}`,
+      providerPermitIdempotencyKey: "expired-recovery-permit-fixture",
+      providerPermitReferenceId: "expired-recovery-permit-fixture",
+      providerTransferIdempotencyKey: "expired-recovery-transfer-fixture",
+      providerTransferReferenceId: "expired-recovery-transfer-fixture",
+      reservedAt: "2026-08-31T09:00:00.000Z",
+    },
+    permitTransactionHash: null,
+    transferTransactionHash: null,
+  };
+  return { states, clients, chain, record };
+}
+
+beforeEach(() => mocks.createPublicClient.mockReset());
+
+describe("expired gasless permit recovery chain proof", () => {
+  it("proves expiry from a common finalized block and unused allowance at both canonical reads", async () => {
+    const { chain, record, clients } = fixture();
+    await expect(chain.assertRecoverable(record)).resolves.toMatchObject({
+      finalizedBlockNumber: finalizedNumber.toString(),
+      finalizedBlockHash: finalizedHash,
+      finalizedBlockTimestamp: (expiredDeadline + 1n).toString(),
+      nonce: "3",
+      allowanceRaw: "0",
+    });
+    for (const client of clients) {
+      expect(client.getBlock).toHaveBeenCalledWith({ blockTag: "finalized" });
+      expect(client.readContract).toHaveBeenCalledWith(expect.objectContaining({
+        functionName: "nonces", blockNumber: finalizedNumber,
+      }));
+      expect(client.readContract).toHaveBeenCalledWith(expect.objectContaining({
+        functionName: "allowance", blockNumber: latestNumber,
+      }));
+    }
+  });
+
+  it.each([
+    { finalizedTimestamp: expiredDeadline },
+    { finalizedTimestamp: expiredDeadline - 1n },
+    { finalizedNonce: 4n },
+    { latestNonce: 4n },
+    { finalizedAllowance: 100n },
+    { latestAllowance: 100n },
+    { chainId: 4663 },
+    { tokenCode: "0x6002" as Hex },
+    { domain: `0x${"55".repeat(32)}` as Hex },
+  ])("rejects unusable or changed state even when providers agree (%#)", async (override) => {
+    const { chain, record, states } = fixture();
+    states.forEach((state) => Object.assign(state, override));
+    await expect(chain.assertRecoverable(record)).rejects.toThrow();
+  });
+
+  it.each([
+    { finalizedHash: `0x${"66".repeat(32)}` as Hex },
+    { latestHash: `0x${"66".repeat(32)}` as Hex },
+    { finalizedTimestamp: expiredDeadline + 2n },
+    { latestNonce: 4n },
+    { latestAllowance: 100n },
+  ])("rejects RPC disagreement (%#)", async (override) => {
+    const { chain, record, states } = fixture();
+    Object.assign(states[1], override);
+    await expect(chain.assertRecoverable(record)).rejects.toThrow();
+  });
+
+  it("does not replace an unavailable finalized read with latest state", async () => {
+    const { chain, record, clients } = fixture();
+    clients[1]!.getBlock.mockRejectedValueOnce(new Error("finalized unavailable"));
+    await expect(chain.assertRecoverable(record)).rejects.toThrow();
+  });
+
+  it("does not treat arbitrary receipt errors as proof that a known permit never executed", async () => {
+    const { chain, record } = fixture();
+    await expect(chain.assertRecoverable({
+      ...record, permitTransactionHash: `0x${"77".repeat(32)}`,
+    })).rejects.toThrow();
+  });
+
+  it("accepts authoritative null receipts for an expired, unused known permit", async () => {
+    const { chain, record, clients } = fixture();
+    const hash = `0x${"77".repeat(32)}` as Hex;
+    for (const client of clients) {
+      client.getTransactionReceipt.mockRejectedValue(new TransactionReceiptNotFoundError({ hash }));
+    }
+    await expect(chain.assertRecoverable({ ...record, permitTransactionHash: hash }))
+      .resolves.toMatchObject({ nonce: "3", allowanceRaw: "0" });
+  });
+
+  it("rejects a successful permit receipt from either RPC", async () => {
+    const { chain, record, clients } = fixture();
+    const hash = `0x${"77".repeat(32)}` as Hex;
+    clients[0]!.getTransactionReceipt.mockRejectedValue(new TransactionReceiptNotFoundError({ hash }));
+    clients[1]!.getTransactionReceipt.mockImplementation(async () => {
+      return { transactionHash: hash, status: "success" } as never;
+    });
+    await expect(chain.assertRecoverable({ ...record, permitTransactionHash: hash }))
+      .rejects.toThrow();
+  });
+});

--- a/tests/main-token-migration-gasless-recovery-store-v1.test.ts
+++ b/tests/main-token-migration-gasless-recovery-store-v1.test.ts
@@ -1,0 +1,312 @@
+import { createHash } from "node:crypto";
+import { PGlite } from "@electric-sql/pglite";
+import { keccak256, stringToHex, type Address, type Hex } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { buildMainTokenMigrationPermitTypedData } from "../lib/main-token-migration";
+import {
+  createMainTokenMigrationGaslessPostgresStoreV1,
+  MAIN_TOKEN_MIGRATION_GASLESS_PREFIX_V1,
+  type MainTokenMigrationGaslessIntentV1,
+  type MainTokenMigrationGaslessRecoveryProofV1,
+  type MainTokenMigrationGaslessStoreV1,
+} from "../lib/server/main-token-migration-gasless-transfer-store-v1";
+import {
+  createMainTokenMigrationGasSponsorPostgresStoreV1,
+  type MainTokenMigrationGasSponsorIntentV1,
+} from "../lib/server/main-token-migration-gas-sponsor-store-v1";
+import { canonicalizeJson } from "../lib/server/projection-target/canonical-json";
+import type {
+  ProjectionTargetPostgresClientV1,
+  ProjectionTargetPostgresQueryResultV1,
+} from "../lib/server/projection-target/postgres-store";
+
+const account = privateKeyToAccount(keccak256(stringToHex("gasless recovery store fixture")));
+const sponsorAddress = "0x0060f9E57FCcc0611ef44809B257919e78Aa99Ac";
+const otherWallet = "0x1111111111111111111111111111111111111111";
+const releaseId = "recovery-store-test-v1";
+const lookup = { releaseId, walletAddress: account.address };
+const prefix = MAIN_TOKEN_MIGRATION_GASLESS_PREFIX_V1;
+const walletKey = `${releaseId}:${account.address.toLowerCase()}`;
+const holder = `${prefix}:holder:${walletKey}`;
+const reservedTotalWei = "200000000000000";
+const totalBudgetWei = "600000000000000";
+
+function digest(value: string): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function transactionHash(value: string): Hex {
+  return keccak256(stringToHex(value));
+}
+
+async function intent(attempt = 0): Promise<MainTokenMigrationGaslessIntentV1> {
+  const deadline = 1_788_169_000n + BigInt(attempt) * 1_200n;
+  const signature = await account.signTypedData(buildMainTokenMigrationPermitTypedData({
+    owner: account.address, spender: sponsorAddress, value: 100n, nonce: 0n, deadline,
+  }));
+  return {
+    schema: "programmable-main-token-migration-gasless-intent/v1",
+    releaseId,
+    walletAddress: account.address,
+    rootWalletAddress: account.address,
+    sponsorAddress,
+    amountRaw: "100",
+    nonce: "0",
+    permitDeadline: deadline.toString(),
+    permitSignature: signature,
+    permitGasLimit: "100000",
+    transferGasLimit: "100000",
+    maxFeePerGasWei: "1000000000",
+    maxPriorityFeePerGasWei: "100000000",
+    reservedTotalWei,
+    totalBudgetWei,
+    requestBindingHash: digest(`request-${attempt}`),
+    providerPermitIdempotencyKey: `permit-key-${attempt}`,
+    providerPermitReferenceId: `permit-reference-${attempt}`,
+    providerTransferIdempotencyKey: `transfer-key-${attempt}`,
+    providerTransferReferenceId: `transfer-reference-${attempt}`,
+    reservedAt: new Date((1_788_168_000 + attempt * 1_200) * 1_000).toISOString(),
+  };
+}
+
+function proof(previous: MainTokenMigrationGaslessIntentV1): MainTokenMigrationGaslessRecoveryProofV1 {
+  return {
+    finalizedBlockNumber: "25876000",
+    finalizedBlockHash: transactionHash(`finalized-${previous.requestBindingHash}`),
+    finalizedBlockTimestamp: (BigInt(previous.permitDeadline) + 1n).toString(),
+    nonce: previous.nonce,
+    allowanceRaw: "0",
+  };
+}
+
+describe("append-only gasless recovery store", () => {
+  let database: PGlite;
+  let pool: TestPool;
+  let store: MainTokenMigrationGaslessStoreV1;
+  let base: MainTokenMigrationGaslessIntentV1;
+  let next: MainTokenMigrationGaslessIntentV1;
+
+  beforeEach(async () => {
+    database = new PGlite();
+    await database.exec(`
+      CREATE SCHEMA programmable_website_projection_v1;
+      CREATE TABLE programmable_website_projection_v1.credential_uses (
+        credential_id text PRIMARY KEY,
+        request_binding_hash text NOT NULL,
+        canonical_use text NOT NULL,
+        created_at timestamptz NOT NULL DEFAULT clock_timestamp()
+      );
+    `);
+    pool = new TestPool(database);
+    store = createMainTokenMigrationGaslessPostgresStoreV1(pool);
+    base = await intent();
+    next = await intent(1);
+    await store.reserve({ lookup, idempotencyBindingHash: digest("alias-0"), intent: base });
+  });
+
+  afterEach(async () => database.close());
+
+  const recover = (store: MainTokenMigrationGaslessStoreV1,
+    previous: MainTokenMigrationGaslessIntentV1, next: MainTokenMigrationGaslessIntentV1,
+    alias = "alias-1") => store.recover({
+    lookup, idempotencyBindingHash: digest(alias), previousRequestBindingHash: previous.requestBindingHash,
+    recoveryProof: proof(previous), intent: next,
+  });
+
+  it("appends a new attempt without changing the old intent, alias, root or permit completion", async () => {
+    await store.complete({ lookup, kind: "permit", providerReferenceId: base.providerPermitReferenceId,
+      transactionHash: transactionHash("old-permit") });
+    const before = await rows(database);
+    const result = await recover(store, base, next);
+    expect(result.kind).toBe("created");
+    expect(result.record).toMatchObject({ intent: next, recoveryAttempt: 1,
+      previousRequestBindingHash: base.requestBindingHash,
+      permitTransactionHash: null, transferTransactionHash: null });
+    expect(await store.get(lookup)).toEqual(result.record);
+    const after = await rows(database);
+    for (const row of before) expect(after.find((value) => value.credential_id === row.credential_id)).toEqual(row);
+    expect(after).toHaveLength(before.length + 3);
+    expect(after.some((row) => row.credential_id === `${holder}:attempt:1`)).toBe(true);
+    const edge = after.find((row) => row.credential_id === `${prefix}:recovery:${walletKey}:attempt:1`)!;
+    expect(JSON.parse(edge.canonical_use)).toMatchObject({ recoveryProof: proof(base) });
+    const duplicate = await recover(store, base, next);
+    expect(duplicate).toEqual({ kind: "existing", record: result.record });
+    expect(await rows(database)).toEqual(after);
+  });
+
+  it("rejects an original reservation and stale predecessor after recovery", async () => {
+    await recover(store, base, next);
+    await expect(store.reserve({ lookup, idempotencyBindingHash: digest("alias-0"), intent: base }))
+      .rejects.toMatchObject({ code: "conflict" });
+    await expect(recover(store, base, await intent(2), "stale-alias"))
+      .rejects.toMatchObject({ code: "conflict" });
+    await expect(recover(store, base, { ...next, reservedAt: base.reservedAt }))
+      .rejects.toMatchObject({ code: "conflict" });
+    expect(await rows(database)).toHaveLength(6);
+  });
+
+  it("requires a fresh idempotency alias and serializes against an existing successor", async () => {
+    await expect(recover(store, base, next, "alias-0")).rejects.toMatchObject({ code: "conflict" });
+    await recover(store, base, next);
+    await expect(recover(store, base, next, "different-alias")).rejects.toMatchObject({ code: "conflict" });
+    expect(await rows(database)).toHaveLength(6);
+  });
+
+  it("rolls back the new holder when a later append fails", async () => {
+    const before = await rows(database);
+    pool.failOnceOnInsertId = `${prefix}:recovery:${walletKey}:attempt:1`;
+    await expect(recover(store, base, next)).rejects.toMatchObject({ code: "unavailable" });
+    expect(await rows(database)).toEqual(before);
+    expect(await store.get(lookup)).toMatchObject({ intent: base });
+    expect((await recover(store, base, next)).kind).toBe("created");
+  });
+
+  it("bounds recovery to two attempts without releasing prior reservations", async () => {
+    await recover(store, base, next);
+    const second = await intent(2);
+    await recover(store, next, second, "alias-2");
+    expect(await store.get(lookup)).toMatchObject({ recoveryAttempt: 2, intent: second });
+    await expect(recover(store, second, await intent(3), "alias-3"))
+      .rejects.toMatchObject({ code: "conflict" });
+    expect(await rows(database)).toHaveLength(9);
+  });
+
+  it("rejects changed identities, amount, nonce and stale signed/provider bindings atomically", async () => {
+    const mutations: Partial<MainTokenMigrationGaslessIntentV1>[] = [
+      { rootWalletAddress: otherWallet }, { sponsorAddress: otherWallet }, { amountRaw: "101" },
+      { nonce: "1" }, { permitDeadline: base.permitDeadline }, { permitSignature: base.permitSignature },
+      { requestBindingHash: base.requestBindingHash },
+      { providerPermitReferenceId: base.providerTransferReferenceId },
+      { providerTransferIdempotencyKey: base.providerPermitIdempotencyKey },
+      { providerTransferReferenceId: next.providerPermitReferenceId },
+    ];
+    for (const mutation of mutations) {
+      await expect(recover(store, base, { ...next, ...mutation })).rejects.toBeInstanceOf(Error);
+      expect(await rows(database)).toHaveLength(3);
+    }
+    await expect(store.recover({ lookup: { ...lookup, walletAddress: otherWallet },
+      idempotencyBindingHash: digest("other-wallet"), previousRequestBindingHash: base.requestBindingHash,
+      recoveryProof: proof(base), intent: { ...next, walletAddress: otherWallet } }))
+      .rejects.toMatchObject({ code: "conflict" });
+  });
+
+  it("requires finalized expiry, unchanged nonce and zero allowance in durable proof", async () => {
+    const mutations = [
+      { finalizedBlockTimestamp: base.permitDeadline },
+      { finalizedBlockTimestamp: next.permitDeadline },
+      { finalizedBlockNumber: "0" }, { finalizedBlockHash: "0x1234" },
+      { nonce: "1" }, { allowanceRaw: "1" },
+    ];
+    for (const mutation of mutations) {
+      await expect(store.recover({ lookup, idempotencyBindingHash: digest("alias-1"),
+        previousRequestBindingHash: base.requestBindingHash, intent: next,
+        recoveryProof: { ...proof(base), ...mutation } as MainTokenMigrationGaslessRecoveryProofV1,
+      })).rejects.toMatchObject({ code: "conflict" });
+      expect(await rows(database)).toHaveLength(3);
+    }
+  });
+
+  it("never recovers after a known transfer and never completes a superseded provider reference", async () => {
+    await recover(store, base, next);
+    await expect(store.complete({ lookup, kind: "permit", providerReferenceId: base.providerPermitReferenceId,
+      transactionHash: transactionHash("old-permit") })).rejects.toMatchObject({ code: "unavailable" });
+    await expect(store.complete({ lookup, kind: "transfer", providerReferenceId: next.providerTransferReferenceId,
+      transactionHash: transactionHash("new-transfer") })).rejects.toMatchObject({ code: "unavailable" });
+    await store.complete({ lookup, kind: "permit", providerReferenceId: next.providerPermitReferenceId,
+      transactionHash: transactionHash("new-permit") });
+    const completed = await store.complete({ lookup, kind: "transfer", providerReferenceId: next.providerTransferReferenceId,
+      transactionHash: transactionHash("new-transfer") });
+    expect(completed).toMatchObject({ recoveryAttempt: 1, transferTransactionHash: transactionHash("new-transfer") });
+    expect((await rows(database)).some((row) => row.credential_id === `${prefix}:transfer:${walletKey}:attempt:1`)).toBe(true);
+    await expect(recover(store, next, await intent(2), "alias-2")).rejects.toMatchObject({ code: "conflict" });
+  });
+
+  it("fails closed on missing or tampered recovery edges and orphan completions", async () => {
+    await recover(store, base, next);
+    const edgeId = `${prefix}:recovery:${walletKey}:attempt:1`;
+    const edge = (await rows(database)).find((row) => row.credential_id === edgeId)!;
+    await database.query("DELETE FROM programmable_website_projection_v1.credential_uses WHERE credential_id = $1", [edgeId]);
+    await expect(store.get(lookup)).rejects.toBeInstanceOf(Error);
+    await database.query("INSERT INTO programmable_website_projection_v1.credential_uses VALUES ($1,$2,$3)",
+      [edge.credential_id, edge.request_binding_hash, edge.canonical_use]);
+    const bad = { ...JSON.parse(edge.canonical_use), previousRequestBindingHash: digest("not-parent") };
+    await database.query("UPDATE programmable_website_projection_v1.credential_uses SET canonical_use = $2 WHERE credential_id = $1",
+      [edgeId, canonicalizeJson(bad)]);
+    await expect(store.get(lookup)).rejects.toBeInstanceOf(Error);
+    await database.query("UPDATE programmable_website_projection_v1.credential_uses SET canonical_use = $2 WHERE credential_id = $1",
+      [edgeId, edge.canonical_use]);
+    await database.query("INSERT INTO programmable_website_projection_v1.credential_uses VALUES ($1,$2,$3)",
+      [`${prefix}:permit:${walletKey}:attempt:2`, next.requestBindingHash, canonicalizeJson({
+        schema: "programmable-main-token-migration-gasless-completion/v1", kind: "permit",
+        providerReferenceId: next.providerPermitReferenceId, transactionHash: transactionHash("orphan"),
+      })]);
+    await expect(store.get(lookup)).rejects.toBeInstanceOf(Error);
+  });
+
+  it("counts every attempt against the unchanged native sponsor shared budget", async () => {
+    await recover(store, base, next);
+    await recover(store, next, await intent(2), "alias-2");
+    const native = createMainTokenMigrationGasSponsorPostgresStoreV1(pool);
+    await expect(native.reserve(nativeReservation(totalBudgetWei)))
+      .rejects.toMatchObject({ code: "budget_exhausted" });
+    expect(await rows(database)).toHaveLength(9);
+  });
+
+  it("counts a native sponsorship when reserving a fresh gasless attempt", async () => {
+    const native = createMainTokenMigrationGasSponsorPostgresStoreV1(pool);
+    await native.reserve(nativeReservation(totalBudgetWei));
+    await recover(store, base, next);
+    const before = await rows(database);
+    await expect(recover(store, next, await intent(2), "alias-2"))
+      .rejects.toMatchObject({ code: "budget_exhausted" });
+    expect(await rows(database)).toEqual(before);
+  });
+});
+
+function nativeReservation(budget: string) {
+  const requestBindingHash = digest("native-request");
+  const nativeIntent: MainTokenMigrationGasSponsorIntentV1 = {
+    schema: "programmable-main-token-migration-gas-sponsorship-intent/v1", releaseId,
+    walletAddress: otherWallet, sponsorAddress, amountRaw: "100", topUpWei: "130000000000000",
+    totalBudgetWei: budget, sponsorGasLimit: "21000", sponsorMaxFeePerGasWei: "2000000000",
+    sponsorMaxPriorityFeePerGasWei: "1000000000", reservedTotalWei: "172000000000000",
+    estimatedTransferGas: "52000", feePerGasWei: "2000000000", requestBindingHash,
+    providerIdempotencyKey: "native-key", providerReferenceId: "native-reference",
+    reservedAt: new Date(1_788_168_000_000).toISOString(),
+  };
+  return { lookup: { releaseId, walletAddress: otherWallet as Address },
+    idempotencyBindingHash: digest("native-alias"), requestBindingHash,
+    eligibility: { rootWalletAddress: otherWallet as Address, walletAddress: otherWallet as Address,
+      transferHash: null, transferBlockNumber: null, transferLogIndex: null }, intent: nativeIntent };
+}
+
+async function rows(database: PGlite) {
+  const result = await database.query<{ credential_id: string; request_binding_hash: string; canonical_use: string }>(
+    "SELECT credential_id, request_binding_hash, canonical_use FROM programmable_website_projection_v1.credential_uses ORDER BY credential_id",
+  );
+  return result.rows;
+}
+
+class TestPool {
+  failOnceOnInsertId: string | null = null;
+  constructor(private readonly database: PGlite) {}
+  async assertProductionReadiness() {}
+  async connect(): Promise<ProjectionTargetPostgresClientV1> {
+    return { query: <Row extends Record<string, unknown>>(text: string, values: readonly unknown[] = []) =>
+      this.query<Row>(text, values), release() {} };
+  }
+  async query<Row extends Record<string, unknown> = Record<string, unknown>>(
+    text: string, values: readonly unknown[] = [],
+  ): Promise<ProjectionTargetPostgresQueryResultV1<Row>> {
+    if (text.includes("INSERT INTO") && values[0] === this.failOnceOnInsertId) {
+      this.failOnceOnInsertId = null;
+      throw new Error("Injected append failure");
+    }
+    const result = await this.database.query<Row>(text, [...values]);
+    return { rows: result.rows, rowCount: result.affectedRows ?? result.rows.length };
+  }
+}

--- a/tests/main-token-migration-gasless-transfer-v1.test.ts
+++ b/tests/main-token-migration-gasless-transfer-v1.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   createMainTokenMigrationGaslessTransferV1,
   deriveMainTokenMigrationGaslessBindingV1,
+  MainTokenMigrationGaslessErrorV1,
 } from "../lib/server/main-token-migration-gasless-transfer-v1";
 import type {
   MainTokenMigrationGaslessRecordV1,
@@ -54,13 +55,13 @@ const configuration = {
   totalBudgetWei: 1_000_000_000_000_000_000n,
 } as const;
 
-function request(body: unknown) {
+function request(body: unknown, key = idempotencyKey) {
   return new Request("https://programmable.market/api/main-token-migration/gasless-transfer", {
     method: "POST",
     headers: {
       authorization: "Bearer test",
       "content-type": "application/json",
-      "idempotency-key": idempotencyKey,
+      "idempotency-key": key,
       origin: "https://programmable.market",
       "sec-fetch-site": "same-origin",
     },
@@ -97,6 +98,7 @@ async function recoveryFixture() {
     transferStatus: ReceiptStatus;
     permitProvider: ProviderStatus | null;
     transferProvider: ProviderStatus | null;
+    recoveryAllowed: boolean;
   } = {
     now,
     record: {
@@ -130,10 +132,23 @@ async function recoveryFixture() {
     transferStatus: { status: "confirmed", blockNumber: 25_900_002n },
     permitProvider: null,
     transferProvider: null,
+    recoveryAllowed: false,
   };
   const store = {
     get: vi.fn(async () => state.record),
     reserve: vi.fn(async () => { throw new Error("resume must not reserve"); }),
+    recover: vi.fn(async (input: {
+      intent: MainTokenMigrationGaslessRecordV1["intent"];
+      previousRequestBindingHash: `sha256:${string}`;
+    }) => {
+      state.record = {
+        intent: input.intent,
+        previousRequestBindingHash: input.previousRequestBindingHash,
+        recoveryAttempt: (state.record?.recoveryAttempt ?? 0) + 1,
+        permitTransactionHash: null, transferTransactionHash: null,
+      };
+      return { kind: "created" as const, record: state.record };
+    }),
     complete: vi.fn(async (input: {
       kind: "permit" | "transfer"; transactionHash: `0x${string}`;
     }) => {
@@ -149,6 +164,18 @@ async function recoveryFixture() {
     }),
   };
   const chain = {
+    assertRecoverable: vi.fn(async () => {
+      if (!state.recoveryAllowed || !state.record) {
+        throw new MainTokenMigrationGaslessErrorV1(409, "recovery_not_available");
+      }
+      return {
+        finalizedBlockNumber: "25900000",
+        finalizedBlockHash: `0x${"44".repeat(32)}` as const,
+        finalizedBlockTimestamp: String(Math.floor(state.now.getTime() / 1000) - 60),
+        nonce: state.record.intent.nonce,
+        allowanceRaw: "0" as const,
+      };
+    }),
     prepare: vi.fn(async () => { throw new Error("resume must not recheck balance"); }),
     assertPermitEffect: vi.fn(async () => {}),
     transactionStatus: vi.fn(async (kind: "permit" | "transfer") =>
@@ -670,7 +697,7 @@ describe("main token migration gasless permit transfer", () => {
     const expired = await handler.post(request(resume));
     expect(expired.status).toBe(422);
     expect(await expired.json()).toMatchObject({ error: { code: "permit_expired" } });
-    expect(sender.lookup).toHaveBeenCalledOnce();
+    expect(sender.lookup).toHaveBeenCalledWith("permit", state.record!.intent);
     expect(sender.send).not.toHaveBeenCalled();
     state.permitProvider = { status: "broadcasted", transactionHash: permitHash };
     expect(await (await handler.post(request(resume))).json()).toMatchObject({
@@ -799,6 +826,163 @@ describe("main token migration gasless permit transfer", () => {
       await database.close();
     }
   }, 10_000);
+});
+
+describe("expired never-executed gasless recovery", () => {
+  const newKey = "gasless-recovery-new-key-0001";
+
+  async function expiredFixture() {
+    const fixture = await recoveryFixture();
+    fixture.state.now = new Date(now.getTime() + 60 * 60 * 1000);
+    fixture.state.record = { ...fixture.state.record!, transferTransactionHash: null };
+    fixture.state.permitStatus = "pending";
+    fixture.state.permitProvider = { status: "replaced", transactionHash: permitHash };
+    fixture.state.recoveryAllowed = true;
+    fixture.chain.prepare.mockImplementation(async () => ({
+      nonce: 0n,
+      feePerGasWei: 1_000_000_000n,
+      maxPriorityFeePerGasWei: 100_000_000n,
+      sponsorBalanceWei: 1_000_000_000_000_000_000n,
+      rootWalletAddress: account.address,
+    }) as never);
+    return fixture;
+  }
+
+  it("offers recovery only after full server proof without reserving or sending", async () => {
+    const { state, handler, store, chain, sender, resume } = await expiredFixture();
+    const response = await handler.post(request(resume));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      status: "recovery_available",
+      previousRequestBindingHash: state.record!.intent.requestBindingHash,
+      requestBindingHash: state.record!.intent.requestBindingHash,
+      transferTransactionHash: null,
+    });
+    expect(chain.assertRecoverable).toHaveBeenCalledOnce();
+    expect(sender.lookup).toHaveBeenCalledWith("transfer", state.record!.intent);
+    expect(store.reserve).not.toHaveBeenCalled();
+    expect(store.recover).not.toHaveBeenCalled();
+    expect(sender.send).not.toHaveBeenCalled();
+  });
+
+  it("requires explicit fresh signature and resumes the appended attempt after a lost response", async () => {
+    const { state, handler, store, sender, resume } = await expiredFixture();
+    const predecessor = state.record!.intent;
+    const previousRequestBindingHash = predecessor.requestBindingHash;
+    const prepare = {
+      action: "prepare_recovery", walletAddress: account.address,
+      amountRaw: "100", previousRequestBindingHash,
+    };
+    const preparedResponse = await handler.post(request(prepare, newKey));
+    expect(preparedResponse.status).toBe(200);
+    const prepared = await preparedResponse.json();
+    expect(prepared.status).toBe("signature_required");
+    expect(prepared.previousRequestBindingHash).toBe(previousRequestBindingHash);
+    expect(BigInt(prepared.permitDeadline)).toBeGreaterThan(BigInt(predecessor.permitDeadline));
+    expect(store.recover).not.toHaveBeenCalled();
+    expect(sender.send).not.toHaveBeenCalled();
+
+    // Crash/network failure BEFORE submit reached the server: the new marker
+    // is distinguishable from a different old request, without auto-signing.
+    const notSubmitted = await handler.post(request({
+      ...resume, previousRequestBindingHash,
+    }, newKey));
+    expect(notSubmitted.status).toBe(409);
+    expect(await notSubmitted.json()).toMatchObject({ error: { code: "gasless_request_not_found" } });
+
+    const permitSignature = await account.signTypedData(buildMainTokenMigrationPermitTypedData({
+      owner: account.address, spender: sponsorAddress, value: 100n,
+      nonce: BigInt(prepared.nonce), deadline: BigInt(prepared.permitDeadline),
+    }));
+    const submitted = {
+      action: "submit_recovery", walletAddress: account.address, amountRaw: "100",
+      previousRequestBindingHash, nonce: prepared.nonce,
+      permitDeadline: prepared.permitDeadline, requestBindingHash: prepared.requestBindingHash,
+      permitSignature,
+    };
+    state.permitProvider = null;
+    const response = await handler.post(request(submitted, newKey));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ status: "permit_submitted" });
+    expect(store.recover).toHaveBeenCalledOnce();
+    expect(sender.send).toHaveBeenCalledOnce();
+    expect(state.record!.intent.providerPermitReferenceId).not.toBe(predecessor.providerPermitReferenceId);
+    expect(state.record!.intent.providerTransferReferenceId).not.toBe(predecessor.providerTransferReferenceId);
+
+    const retry = await handler.post(request(submitted, newKey));
+    expect(retry.status).toBe(200);
+    expect(await retry.json()).toMatchObject({ status: "permit_pending" });
+    const resumed = await handler.post(request({ ...resume, previousRequestBindingHash }, newKey));
+    expect(resumed.status).toBe(200);
+    expect(store.recover).toHaveBeenCalledOnce();
+    expect(sender.send).toHaveBeenCalledOnce();
+
+    const stale = await handler.post(request(resume));
+    expect(stale.status).toBe(409);
+    const staleSubmit = await handler.post(request({
+      action: "submit", walletAddress: account.address, amountRaw: "100",
+      nonce: predecessor.nonce, permitDeadline: predecessor.permitDeadline,
+      permitSignature: predecessor.permitSignature,
+      requestBindingHash: predecessor.requestBindingHash,
+    }));
+    expect(staleSubmit.status).toBe(409);
+    expect(sender.send).toHaveBeenCalledOnce();
+  });
+
+  it.each(["queued", "pending", "replaced", "failed", "confirmed", "provider_error"])(
+    "never offers recovery with any provider transfer record (%s)", async (status) => {
+      const { state, handler, chain, sender, resume } = await expiredFixture();
+      state.transferProvider = { status, transactionHash: null };
+      const response = await handler.post(request(resume));
+      expect(response.status).toBe(409);
+      expect(await response.json()).not.toHaveProperty("status", "recovery_available");
+      expect(chain.assertRecoverable).not.toHaveBeenCalled();
+      expect(sender.send).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["confirmed", "finalized"])("rejects provider permit %s despite client expectations", async (status) => {
+    const { state, handler, sender, resume } = await expiredFixture();
+    state.permitProvider = { status, transactionHash: permitHash };
+    const response = await handler.post(request({
+      action: "prepare_recovery", walletAddress: account.address, amountRaw: "100",
+      previousRequestBindingHash: state.record!.intent.requestBindingHash,
+    }, newKey));
+    expect(response.status).toBe(409);
+    expect(sender.send).not.toHaveBeenCalled();
+    expect(resume.action).toBe("resume");
+  });
+
+  it("fails closed on provider timeout, insufficient finality, and attempt exhaustion", async () => {
+    const { state, handler, chain, sender, resume } = await expiredFixture();
+    sender.lookup.mockRejectedValueOnce(new MainTokenMigrationGaslessErrorV1(503, "provider_unavailable"));
+    expect((await handler.post(request(resume))).status).toBe(503);
+    chain.assertRecoverable.mockRejectedValueOnce(new MainTokenMigrationGaslessErrorV1(409, "recovery_wait_finality"));
+    const waiting = await handler.post(request({
+      action: "prepare_recovery", walletAddress: account.address, amountRaw: "100",
+      previousRequestBindingHash: state.record!.intent.requestBindingHash,
+    }, newKey));
+    expect(waiting.status).toBe(409);
+    state.record = { ...state.record!, recoveryAttempt: 2 };
+    const exhausted = await handler.post(request(resume));
+    expect(exhausted.status).toBe(409);
+    expect(sender.send).not.toHaveBeenCalled();
+  });
+
+  it("rejects old key, substituted parent and client-declared recovery eligibility", async () => {
+    const { state, handler, store, sender } = await expiredFixture();
+    const body = {
+      action: "prepare_recovery", walletAddress: account.address, amountRaw: "100",
+      previousRequestBindingHash: state.record!.intent.requestBindingHash,
+    };
+    expect((await handler.post(request(body))).status).toBe(409);
+    expect((await handler.post(request({ ...body,
+      previousRequestBindingHash: `sha256:${"99".repeat(32)}`,
+    }, newKey))).status).toBe(409);
+    expect((await handler.post(request({ ...body, recoveryEligible: true }, newKey))).status).toBe(400);
+    expect(store.recover).not.toHaveBeenCalled();
+    expect(sender.send).not.toHaveBeenCalled();
+  });
 });
 
 class GaslessTestPool {


### PR DESCRIPTION
## Scope
Permit recovery for all holders with an expired, demonstrably unused gasless attempt. No address exceptions, countdown changes, wallet signing, provider policy changes or schema migration.

## Safety
- Server independently proves finalized expiry, unchanged finalized/current permit nonce, zero sponsor allowance, exact token identity and no provider transfer record.
- Explicit fresh wallet review. Status polling never signs. Predecessor-bound deterministic recovery keys preserve refresh, lost-response and cross-tab safety.
- Append-only original history and at most two successors. Existing shared release budget counts every attempt. Stale requests and completions cannot control a successor.

## Verification
- 84 focused chain, handler, real PGlite store, UI and contract tests passed.
- Full TypeScript check, scoped ESLint and git diff --check passed.
- Independent source/security review; exact candidate binding recorded by integration owner.
- Read-only real-holder proof passed using production private ledger, provider lookup and two independent Ethereum RPCs. No reservations, signatures or broadcasts.

Production release and desktop/mobile QA remain separate required evidence.