### PR TITLE
Fix topbar wallet actions and actual network switching

### DIFF
--- a/components/main-token-migration.module.css
+++ b/components/main-token-migration.module.css
@@ -843,7 +843,7 @@
 
 @media (max-width: 40rem) {
   .page {
-    min-height: calc(100svh - 72px);
+    min-height: calc(100svh - var(--header-height));
     padding-bottom: 36px;
   }
 
@@ -860,6 +860,8 @@
 
   .hero h1 {
     font-size: clamp(34px, 10vw, 40px);
+    max-width: 100%;
+    white-space: normal;
   }
 
   .chainFlow {
@@ -888,8 +890,8 @@
   }
 
   .officialNotice {
-    font-size: 10.5px;
-    line-height: 1.4;
+    font-size: 12px;
+    line-height: 1.5;
     margin-top: 6px;
     padding: 6px 8px;
   }

--- a/components/site-navigation.module.css
+++ b/components/site-navigation.module.css
@@ -93,8 +93,8 @@
 
 .headerWalletButton {
   align-items: center;
-  background: rgb(255 255 255 / 0.055);
-  border: 1px solid rgb(255 255 255 / 0.09);
+  background: transparent;
+  border: 0;
   border-radius: 12px;
   color: var(--navigation-glass-ink);
   display: inline-flex;
@@ -106,10 +106,78 @@
   justify-content: center;
   padding: 0 12px;
   transition:
-    background-color 160ms cubic-bezier(0.32, 0.72, 0, 1),
+    opacity 160ms cubic-bezier(0.32, 0.72, 0, 1),
     transform 160ms cubic-bezier(0.32, 0.72, 0, 1);
   white-space: nowrap;
   width: 144px;
+}
+
+.headerWallet {
+  flex: none;
+  position: relative;
+}
+
+.headerChain {
+  display: flex;
+  flex: none;
+}
+
+.walletMenu,
+.chainFeedback {
+  background: rgb(14 15 18 / 0.98);
+  border: 1px solid rgb(255 255 255 / 0.1);
+  border-radius: 16px;
+  box-shadow: 0 20px 48px rgb(0 0 0 / 0.45);
+  color: var(--navigation-glass-ink);
+  position: absolute;
+  z-index: 91;
+}
+
+.walletMenu {
+  display: grid;
+  gap: 2px;
+  inset-inline-end: 0;
+  padding: 8px;
+  top: calc(100% + 8px);
+  width: 216px;
+}
+
+.walletMenu > a,
+.walletMenu > button {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 9px;
+  color: inherit;
+  display: flex;
+  font: inherit;
+  font-size: 14px;
+  min-height: 44px;
+  padding: 8px 12px;
+  text-align: start;
+  text-decoration: none;
+}
+
+.walletMenu > :is(a, button):focus-visible {
+  outline: 2px solid var(--brand-ivory);
+  outline-offset: -2px;
+}
+
+.walletMenu > button[aria-disabled="true"] { opacity: 0.6; }
+
+.walletFeedback,
+.chainFeedback {
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 0;
+  overflow-wrap: anywhere;
+  padding: 8px 12px;
+}
+
+.chainFeedback {
+  inset-inline-end: 16px;
+  top: calc(100% + 4px);
+  width: min(320px, calc(100vw - 32px));
 }
 
 .headerWalletButton:disabled {
@@ -304,10 +372,12 @@
   }
 
   .mobileSocials :global(.header-social-link:hover),
-  .headerWalletButton:hover:not(:disabled) {
+  .walletMenu > :is(a, button):hover:not(:disabled) {
     background: rgb(255 255 255 / 0.09);
     color: var(--navigation-glass-ink);
   }
+
+  .headerWalletButton:hover:not(:disabled) { opacity: 0.72; }
 }
 
 @media (max-width: 60rem) {

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -119,7 +119,19 @@ function shortenAddress(address: string) {
   return `${address.slice(0, 6)}…${address.slice(-4)}`;
 }
 
-function HeaderWalletButton({ onOpen }: Readonly<{ onOpen: () => void }>) {
+function HeaderWalletButton({
+  open,
+  triggerRef,
+  onOpen,
+  onToggle,
+  onClose,
+}: Readonly<{
+  open: boolean;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+  onOpen: () => void;
+  onToggle: () => void;
+  onClose: () => void;
+}>) {
   const {
     wallet,
     hasSession,
@@ -127,7 +139,24 @@ function HeaderWalletButton({ onOpen }: Readonly<{ onOpen: () => void }>) {
     disconnecting,
     openWallet,
     preloadWallet,
+    disconnect,
   } = useWallet();
+  const menuId = useId();
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const busyRef = useRef(false);
+  const [feedback, setFeedback] = useState("");
+  const menuOpen = open && wallet !== null;
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const closeOnOutsidePress = (event: PointerEvent) => {
+      if (event.target instanceof Node && !wrapperRef.current?.contains(event.target)) {
+        onClose();
+      }
+    };
+    document.addEventListener("pointerdown", closeOnOutsidePress);
+    return () => document.removeEventListener("pointerdown", closeOnOutsidePress);
+  }, [menuOpen, onClose]);
   const label = disconnecting
     ? "Disconnecting"
     : connecting
@@ -139,22 +168,72 @@ function HeaderWalletButton({ onOpen }: Readonly<{ onOpen: () => void }>) {
           : "Connect wallet";
 
   return (
-    <button
-      className={styles.headerWalletButton}
-      type="button"
-      disabled={connecting || disconnecting}
-      aria-busy={connecting || disconnecting || undefined}
-      aria-haspopup="dialog"
-      aria-label={wallet ? `Manage wallet ${shortenAddress(wallet.account)}` : label}
-      onFocus={preloadWallet}
-      onPointerEnter={preloadWallet}
-      onClick={() => {
-        onOpen();
-        openWallet();
+    <div
+      className={styles.headerWallet}
+      ref={wrapperRef}
+      onBlur={(event) => {
+        if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) return;
+        window.requestAnimationFrame(() => {
+          if (!wrapperRef.current?.contains(document.activeElement)) onClose();
+        });
       }}
     >
-      {label}
-    </button>
+      <button
+        ref={triggerRef}
+        className={styles.headerWalletButton}
+        type="button"
+        disabled={connecting || disconnecting}
+        aria-busy={connecting || disconnecting || undefined}
+        aria-haspopup={wallet ? undefined : "dialog"}
+        aria-controls={wallet ? menuId : undefined}
+        aria-expanded={wallet ? menuOpen : undefined}
+        aria-label={wallet ? `Wallet ${shortenAddress(wallet.account)}` : label}
+        onFocus={preloadWallet}
+        onPointerEnter={preloadWallet}
+        onClick={() => {
+          setFeedback("");
+          onOpen();
+          if (wallet) onToggle();
+          else {
+            onClose();
+            openWallet();
+          }
+        }}
+      >
+        {label}
+      </button>
+      {menuOpen && wallet ? (
+        <div className={styles.walletMenu} id={menuId} role="group" aria-label="Wallet actions">
+          <Link href="/profile" prefetch={false} onClick={onClose}>Profile</Link>
+          <button type="button" onClick={async () => {
+            try {
+              await navigator.clipboard.writeText(wallet.account);
+              setFeedback("Address copied");
+            } catch {
+              setFeedback("Could not copy address. Try again.");
+            }
+          }}>Copy Address</button>
+          <button type="button" aria-disabled={disconnecting || undefined} aria-busy={disconnecting || undefined} onClick={async () => {
+            if (busyRef.current) return;
+            busyRef.current = true;
+            setFeedback("");
+            try {
+              if (await disconnect({ showDialogOnFailure: false })) {
+                onClose();
+                window.requestAnimationFrame(() => triggerRef.current?.focus());
+              } else {
+                setFeedback("Unable to disconnect. Try again.");
+              }
+            } catch {
+              setFeedback("Unable to disconnect. Try again.");
+            } finally {
+              busyRef.current = false;
+            }
+          }}>{disconnecting ? "Disconnecting…" : "Disconnect"}</button>
+          <p className={feedback ? styles.walletFeedback : "sr-only"} role="status" aria-live="polite">{feedback}</p>
+        </div>
+      ) : null}
+    </div>
   );
 }
 
@@ -230,32 +309,67 @@ function viewChainLabel(viewChainId: ViewChainId) {
 
 function HeaderChainToggle({
   triggerRef,
+  onStart,
   onSelect,
 }: Readonly<{
   triggerRef: RefObject<HTMLButtonElement | null>;
+  onStart: () => void;
   onSelect: (viewChainId: ViewChainId) => void;
 }>) {
   const { hydrated, viewChainId, setViewChainId } = useViewChain();
+  const { wallet, authReady, hasSession, connecting, disconnecting, switchingNetwork, switchNetwork } = useWallet();
+  const pendingRef = useRef(false);
+  const accountRef = useRef(wallet?.account);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState("");
+  useEffect(() => {
+    accountRef.current = wallet?.account;
+  }, [wallet?.account]);
   const alternateViewChainId: ViewChainId = viewChainId === 1 ? 4663 : 1;
   const currentLabel = viewChainLabel(viewChainId);
   const alternateLabel = viewChainLabel(alternateViewChainId);
 
   return (
-    <button
-      ref={triggerRef}
-      className={styles.chainTrigger}
-      type="button"
-      aria-busy={!hydrated || undefined}
-      aria-label={`Viewing ${currentLabel}. Switch to ${alternateLabel}`}
-      disabled={!hydrated}
-      title={`Switch to ${alternateLabel}`}
-      onClick={() => {
-        setViewChainId(alternateViewChainId);
-        onSelect(alternateViewChainId);
-      }}
-    >
-      <ViewChainMark viewChainId={viewChainId} />
-    </button>
+    <div className={styles.headerChain}>
+      <button
+        ref={triggerRef}
+        className={styles.chainTrigger}
+        type="button"
+        aria-busy={!hydrated || pending || switchingNetwork || undefined}
+        aria-label={`Viewing ${currentLabel}. Switch to ${alternateLabel}`}
+        disabled={!hydrated || (hasSession && !authReady) || connecting || disconnecting || pending || switchingNetwork}
+        title={`Switch to ${alternateLabel}`}
+        onClick={async () => {
+          if (pendingRef.current) return;
+          onStart();
+          setError("");
+          pendingRef.current = true;
+          setPending(true);
+          try {
+            if (wallet && !(await switchNetwork(String(alternateViewChainId)))) {
+              setError(`Network unchanged. Confirm ${alternateLabel} in your wallet and try again.`);
+              return;
+            }
+            if (accountRef.current !== wallet?.account) {
+              setError("Your wallet changed. Please try again.");
+              return;
+            }
+            setViewChainId(alternateViewChainId);
+            onSelect(alternateViewChainId);
+          } catch {
+            setError("Network unchanged. Please try again.");
+          } finally {
+            pendingRef.current = false;
+            setPending(false);
+          }
+        }}
+      >
+        <ViewChainMark viewChainId={viewChainId} />
+      </button>
+      <p className={error ? styles.chainFeedback : "sr-only"} role="status" aria-live="polite">
+        {error || (pending ? `Confirm ${alternateLabel} in your wallet` : "")}
+      </p>
+    </div>
   );
 }
 
@@ -266,16 +380,20 @@ export function SiteHeader() {
   const headerRef = useRef<HTMLElement>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const chainButtonRef = useRef<HTMLButtonElement>(null);
+  const walletButtonRef = useRef<HTMLButtonElement>(null);
   const [menuPath, setMenuPath] = useState<string | null>(null);
+  const [walletMenuPath, setWalletMenuPath] = useState<string | null>(null);
   const menuOpen = menuPath === pathname;
+  const walletMenuOpen = walletMenuPath === pathname;
 
   useEffect(() => {
-    if (!menuOpen) return;
+    if (!menuOpen && !walletMenuOpen) return;
 
     const closeOnOutsidePress = (event: PointerEvent) => {
       if (!(event.target instanceof Node)) return;
-      if (menuOpen && !headerRef.current?.contains(event.target)) {
+      if (!headerRef.current?.contains(event.target)) {
         setMenuPath(null);
+        setWalletMenuPath(null);
       }
     };
 
@@ -284,6 +402,10 @@ export function SiteHeader() {
       if (menuOpen) {
         setMenuPath(null);
         menuButtonRef.current?.focus();
+      }
+      if (walletMenuOpen) {
+        setWalletMenuPath(null);
+        walletButtonRef.current?.focus();
       }
     };
 
@@ -294,7 +416,7 @@ export function SiteHeader() {
       document.removeEventListener("pointerdown", closeOnOutsidePress);
       document.removeEventListener("keydown", closeOnEscape);
     };
-  }, [menuOpen]);
+  }, [menuOpen, walletMenuOpen]);
 
   function closeOnFocusLeave(event: FocusEvent<HTMLElement>) {
     if (!menuOpen) return;
@@ -342,6 +464,10 @@ export function SiteHeader() {
         <div className={`header-actions ${styles.headerActions}`}>
           <HeaderChainToggle
             triggerRef={chainButtonRef}
+            onStart={() => {
+              setMenuPath(null);
+              setWalletMenuPath(null);
+            }}
             onSelect={(selectedViewChainId) => {
               setMenuPath(null);
               if (pathname.startsWith("/token/")) {
@@ -360,7 +486,15 @@ export function SiteHeader() {
               });
             }}
           />
-          <HeaderWalletButton onOpen={() => setMenuPath(null)} />
+          <HeaderWalletButton
+            triggerRef={walletButtonRef}
+            open={walletMenuOpen}
+            onOpen={() => setMenuPath(null)}
+            onToggle={() => {
+              setWalletMenuPath(walletMenuOpen ? null : pathname);
+            }}
+            onClose={() => setWalletMenuPath(null)}
+          />
           <button
             ref={menuButtonRef}
             className={styles.menuButton}
@@ -369,6 +503,7 @@ export function SiteHeader() {
             aria-expanded={menuOpen}
             aria-label={menuOpen ? "Close menu" : "Open menu"}
             onClick={() => {
+              setWalletMenuPath(null);
               setMenuPath(menuOpen ? null : pathname);
             }}
           >

--- a/playwright.wallet-lock.config.ts
+++ b/playwright.wallet-lock.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests/browser",
-  testMatch: "wallet-request-lock.spec.ts",
+  testMatch: ["wallet-request-lock.spec.ts", "site-header.spec.ts"],
   fullyParallel: false,
   workers: 1,
   retries: 0,

--- a/tests/browser/fixtures/site-header-server.mjs
+++ b/tests/browser/fixtures/site-header-server.mjs
@@ -1,0 +1,98 @@
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { resolve, sep } from "node:path";
+import { build } from "esbuild";
+
+// Exercise the production header with deterministic wallet outcomes, without
+// connecting, signing, or sending requests to a real wallet.
+export async function createSiteHeaderServer() {
+  const root = process.cwd();
+  const state = `
+    import React, {createContext, useContext, useState} from 'react';
+    const Context = createContext(null);
+    export function Fixture({children}) {
+      const [wallet, setWallet] = useState({account:'0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', chainId:'0x1'});
+      const [viewChainId, setViewChainId] = useState(1);
+      const [pending, setPending] = useState(false);
+      const [disconnecting, setDisconnecting] = useState(false);
+      const [reject, setReject] = useState(false);
+      const [failDisconnect, setFailDisconnect] = useState(false);
+      const [requests, setRequests] = useState([]);
+      const [dialog, setDialog] = useState(false);
+      const [disconnectOptions, setDisconnectOptions] = useState('');
+      const value = {
+        wallet, authReady: !!wallet, hasSession: !!wallet, connecting:false,
+        disconnecting, switchingNetwork:pending, preloadWallet:()=>{},
+        openWallet:()=>setDialog(true),
+        switchNetwork:async (chain) => {
+          setRequests(previous=>[...previous, chain]); setPending(true);
+          await new Promise(resolve=>setTimeout(resolve,250));
+          setPending(false);
+          if(reject) return false;
+          setWallet(current=>current && {...current, chainId:'0x'+Number(chain).toString(16)});
+          return true;
+        },
+        disconnect:async (options) => {
+          setDisconnectOptions(JSON.stringify(options));
+          setDisconnecting(true);
+          await new Promise(resolve=>setTimeout(resolve,250));
+          setDisconnecting(false);
+          if(failDisconnect) return false;
+          setWallet(null); return true;
+        },
+        hydrated:true, viewChainId, setViewChainId,
+      };
+      return <Context.Provider value={value}>{children}<main style={{padding:24}}>
+        <h1>Header interaction fixture</h1><p>Deterministic test wallet. No real wallet requests.</p>
+        <button aria-pressed={reject} onClick={()=>setReject(!reject)}>Reject network switch</button>
+        <button aria-pressed={failDisconnect} onClick={()=>setFailDisconnect(!failDisconnect)}>Fail disconnect</button>
+        <button onClick={()=>setWallet(null)}>Use anonymous session</button>
+        <p data-testid="requests">{requests.join(',')}</p>
+        <p data-testid="wallet-chain">{wallet?.chainId ?? 'disconnected'}</p>
+        <p data-testid="disconnect-options">{disconnectOptions}</p>
+        <a href="#outside">Outside control</a>
+        {dialog ? <div role="dialog" aria-label="Connect wallet fixture">Connect wallet fixture</div> : null}
+      </main></Context.Provider>;
+    }
+    export const useWallet = () => useContext(Context);
+    export const useViewChain = () => useContext(Context);
+  `;
+  const bundled = await build({
+    stdin: {
+      contents: `import React from 'react'; import {createRoot} from 'react-dom/client'; import {SiteHeader} from './components/site-navigation'; import {Fixture} from 'fixture-state'; import './app/globals.css'; import './app/interface.css'; createRoot(document.getElementById('root')).render(<Fixture><SiteHeader/></Fixture>);`,
+      loader: "tsx", resolveDir: root,
+    },
+    bundle: true, format: "esm", platform: "browser", write: false,
+    outdir: "/fixture-output", jsx: "automatic",
+    define: { "process.env.NODE_ENV": '"production"' },
+    external: ["/brand/*", "/fonts/*"],
+    plugins: [{ name: "wallet-fixture", setup(plugin) {
+      plugin.onResolve({filter:/^(fixture-state|@\/components\/(wallet-provider|view-chain))$/},()=>({path:"state",namespace:"fixture"}));
+      plugin.onResolve({filter:/^next\/(navigation|link|image)$/}, args=>({path:args.path,namespace:"fixture"}));
+      plugin.onLoad({filter:/.*/,namespace:"fixture"}, args=>({
+        loader:"tsx", resolveDir:root,
+        contents: args.path === "state" ? state : args.path === "next/navigation"
+          ? `export const usePathname=()=>window.location.pathname; export const useRouter=()=>({prefetch:()=>{}, replace:(url)=>window.history.replaceState(null,'',url)});`
+          : args.path === "next/link"
+            ? `import React from 'react'; export default function Link({prefetch,...props}) { return <a {...props}/>; }`
+            : `import React from 'react'; export default function Image({priority,fill,...props}) { return <img {...props}/>; }`,
+      }));
+    }}],
+  });
+  const sources = new Map(bundled.outputFiles.map(file=>[file.path.endsWith('.css') ? '/fixture.css':'/fixture.js',file.contents]));
+  return createServer(async (request,response)=>{
+    const url = new URL(request.url, 'http://localhost');
+    if(sources.has(url.pathname)) {
+      response.setHeader('Content-Type',url.pathname.endsWith('.css')?'text/css':'text/javascript');
+      response.end(sources.get(url.pathname)); return;
+    }
+    if(url.pathname.startsWith('/brand/') || url.pathname.startsWith('/fonts/')) {
+      const base=resolve(root,'public'); const file=resolve(base,'.'+url.pathname);
+      if(!file.startsWith(base+sep)) {response.writeHead(404);response.end();return;}
+      try {response.setHeader('Content-Type',file.endsWith('.svg')?'image/svg+xml':file.endsWith('.woff2')?'font/woff2':'image/png');response.end(await readFile(file));}
+      catch {response.writeHead(404);response.end();} return;
+    }
+    response.setHeader('Content-Type','text/html');
+    response.end('<!doctype html><html data-theme="dark"><head><meta name="viewport" content="width=device-width, initial-scale=1"><link rel="stylesheet" href="/fixture.css"><style>body{background:#000;color:#fff;font-family:Arial,sans-serif}main label{display:block;margin:16px 0}main button{padding:12px} .header-inner{max-width:1320px}</style></head><body><div id="root"></div><script type="module" src="/fixture.js"></script></body></html>');
+  });
+}

--- a/tests/browser/site-header.spec.ts
+++ b/tests/browser/site-header.spec.ts
@@ -1,0 +1,120 @@
+import { once } from "node:events";
+import type { Server } from "node:http";
+import { expect, test } from "@playwright/test";
+// @ts-expect-error The fixture is shared with the manual browser QA host.
+import { createSiteHeaderServer } from "./fixtures/site-header-server.mjs";
+
+let server: Server;
+let origin: string;
+test.beforeAll(async () => {
+  server = await createSiteHeaderServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Missing fixture port");
+  origin = `http://127.0.0.1:${address.port}`;
+});
+test.afterAll(async () => { server.close(); await once(server, "close"); });
+test.beforeEach(async ({ page }) => { await page.goto(origin); });
+
+const walletName = "Wallet 0xaaaa…aaaa";
+const toRobinhood = "Viewing Ethereum. Switch to Robinhood";
+const toEthereum = "Viewing Robinhood. Switch to Ethereum";
+
+test("wallet opens only its actions; copy, Escape, outside click and focus work", async ({page,context}) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  const trigger = page.getByRole("button", {name:walletName,exact:true});
+  await trigger.click();
+  const menu = page.getByRole("group",{name:"Wallet actions",exact:true});
+  await expect(menu.getByRole("link")).toHaveText(["Profile"]);
+  await expect(menu.getByRole("button")).toHaveText(["Copy Address","Disconnect"]);
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await menu.getByRole("button",{name:"Copy Address",exact:true}).click();
+  await expect(menu.getByRole("status")).toHaveText("Address copied");
+  expect(await page.evaluate(()=>navigator.clipboard.readText())).toBe("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  await page.keyboard.press("Escape");
+  await expect(menu).toHaveCount(0);
+  await expect(trigger).toBeFocused();
+  await trigger.click();
+  await page.keyboard.press("Tab");
+  await expect(menu.getByRole("link",{name:"Profile",exact:true})).toBeFocused();
+  await page.getByRole("link",{name:"Outside control"}).click();
+  await expect(menu).toHaveCount(0);
+  await expect(trigger).toHaveCSS("background-color","rgba(0, 0, 0, 0)");
+});
+
+test("disconnect failure stays inline and success returns to connect",async ({page})=>{
+  await page.getByRole("button",{name:"Fail disconnect"}).click();
+  await page.getByRole("button",{name:walletName,exact:true}).click();
+  await page.getByRole("button",{name:"Disconnect",exact:true}).click();
+  await expect(page.getByText("Unable to disconnect. Try again.")).toBeVisible();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(page.getByTestId("disconnect-options")).toHaveText('{"showDialogOnFailure":false}');
+  await page.getByRole("button",{name:"Fail disconnect"}).click();
+  await page.getByRole("button",{name:walletName,exact:true}).click();
+  await page.getByRole("button",{name:"Disconnect",exact:true}).click();
+  await expect(page.getByRole("button",{name:"Connect wallet",exact:true})).toBeVisible();
+  await expect(page.getByRole("button",{name:"Connect wallet",exact:true})).toBeFocused();
+  await expect(page.getByRole("group",{name:"Wallet actions",exact:true})).toHaveCount(0);
+});
+
+test("chain switch waits for wallet success and suppresses duplicate requests",async ({page})=>{
+  const toggle=page.getByRole("button",{name:toRobinhood,exact:true});
+  await toggle.evaluate((button:HTMLButtonElement)=>{button.click();button.click();});
+  await expect(toggle).toBeDisabled();
+  await expect(page.getByTestId("requests")).toHaveText("4663");
+  await expect(page.getByRole("button",{name:toEthereum,exact:true})).toBeEnabled();
+  await expect(page.getByTestId("wallet-chain")).toHaveText("0x1237");
+  await page.getByRole("button",{name:toEthereum,exact:true}).click();
+  await expect(page.getByRole("button",{name:toRobinhood,exact:true})).toBeEnabled();
+  await expect(page.getByTestId("wallet-chain")).toHaveText("0x1");
+  await expect(page.getByTestId("requests")).toHaveText("4663,1");
+});
+
+test("rejected network switch leaves the view and wallet unchanged",async ({page})=>{
+  await page.getByRole("button",{name:"Reject network switch"}).click();
+  await page.getByRole("button",{name:toRobinhood,exact:true}).click();
+  await expect(page.getByText("Network unchanged. Confirm Robinhood in your wallet and try again.")).toBeVisible();
+  await expect(page.getByRole("button",{name:toRobinhood,exact:true})).toBeEnabled();
+  await expect(page.getByTestId("wallet-chain")).toHaveText("0x1");
+});
+
+test("anonymous browsing can change chain without a wallet request",async ({page})=>{
+  await page.getByRole("button",{name:"Use anonymous session"}).click();
+  await page.getByRole("button",{name:toRobinhood,exact:true}).click();
+  await expect(page.getByRole("button",{name:toEthereum,exact:true})).toBeEnabled();
+  await expect(page.getByTestId("requests")).toBeEmpty();
+});
+
+test("session changes during a pending switch do not commit an outdated result",async ({page})=>{
+  await page.getByRole("button",{name:toRobinhood,exact:true}).click();
+  await page.getByRole("button",{name:"Use anonymous session"}).click();
+  await expect(page.getByText("Your wallet changed. Please try again.")).toBeVisible();
+  await expect(page.getByRole("button",{name:toRobinhood,exact:true})).toBeEnabled();
+});
+
+test("anonymous Connect wallet closes navigation before opening login",async ({page})=>{
+  await page.getByRole("button",{name:"Use anonymous session"}).click();
+  await page.getByRole("button",{name:"Open menu",exact:true}).click();
+  await page.getByRole("button",{name:"Connect wallet",exact:true}).click();
+  await expect(page.getByRole("dialog",{name:"Connect wallet fixture"})).toBeVisible();
+  await expect(page.getByRole("button",{name:"Open menu",exact:true})).toHaveAttribute("aria-expanded","false");
+});
+
+for(const width of [320,390,1440]) {
+  test(`header menus fit at ${width}px and remain mutually exclusive`,async ({page})=>{
+    await page.setViewportSize({width,height:844});
+    await page.getByRole("button",{name:walletName,exact:true}).click();
+    const menu=page.getByRole("group",{name:"Wallet actions",exact:true});
+    const box=await menu.boundingBox();
+    expect(box?.x).toBeGreaterThanOrEqual(0);
+    expect((box?.x??0)+(box?.width??0)).toBeLessThanOrEqual(width);
+    await page.getByRole("button",{name:"Open menu",exact:true}).click();
+    await expect(menu).toHaveCount(0);
+    await expect(page.getByRole("navigation",{name:"Menu navigation",exact:true})).toBeVisible();
+    await page.getByRole("button",{name:walletName,exact:true}).click();
+    await expect(menu).toBeVisible();
+    await expect(page.getByRole("button",{name:"Open menu",exact:true})).toHaveAttribute("aria-expanded","false");
+    expect(await page.evaluate(()=>document.documentElement.scrollWidth)).toBe(width);
+  });
+}

--- a/tests/interaction-accessibility.test.ts
+++ b/tests/interaction-accessibility.test.ts
@@ -199,8 +199,8 @@ describe("interaction accessibility", () => {
       '.querySelector<HTMLElement>("a, button:not(:disabled)")',
     );
     expect(source).toContain("menuButtonRef.current?.focus()");
-    expect(source).toContain('aria-haspopup="dialog"');
-    expect(source).toContain("onOpen();\n        openWallet();");
+    expect(source).toContain('aria-haspopup={wallet ? undefined : "dialog"}');
+    expect(source).toContain("aria-expanded={wallet ? menuOpen : undefined}");
   });
 
   it("keeps the sticky header and its wallet disclosure above page content", () => {


### PR DESCRIPTION
The topbar wallet action opened the full wallet manager, while its network toggle only changed the website view. This made common wallet actions cumbersome and left MetaMask on the previous network.

This change gives the connected wallet a transparent trigger and a small disclosure containing Profile, Copy Address, and Disconnect. Copy and disconnect failures stay inline; Escape, outside clicks, keyboard focus, and mutually exclusive header menus are handled. Anonymous users still open the existing connection flow.

The chain toggle now calls the selected wallet's existing verified network-switch method before changing the view. Cancellation, verification failure, repeated clicks, and account changes cannot commit a misleading view change. Anonymous browsing remains independent of a wallet. No transaction, signing flow, chain configuration, or activation flag changes.

Mobile Migrate safety copy is more readable, its heading can wrap on narrow screens, and its page height uses the shared header token.

Validation:
- 12 rendered browser interaction tests, including async disconnect, switch rejection, duplicate clicks, session changes, and 320/390/1440px menus.
- 64 focused regression tests; full lint has no errors.
- Local production build and bundle checks passed. Local build used the existing shared-dependency workaround; no build configuration change is committed. Canonical build is required in CI.
- Manual browser review of desktop/mobile header and Migrate, including 320px width and clean browser console. Connected-wallet review uses a deterministic fixture, not a real signed wallet action.
