### PR TITLE
Keep network feedback clear of header menus

### DIFF
--- a/components/site-navigation.module.css
+++ b/components/site-navigation.module.css
@@ -180,6 +180,10 @@
   width: min(320px, calc(100vw - 32px));
 }
 
+.siteHeader:has(.mobileSheetOpen, .walletMenu) .chainFeedback {
+  display: none;
+}
+
 .headerWalletButton:disabled {
   cursor: wait;
   opacity: 0.62;


### PR DESCRIPTION
Final browser review after #607 found that a rejected-network message could cover the first navigation item when opening a header menu.

Hide that feedback while either header disclosure is open. This keeps all navigation and wallet actions visible and clickable without changing wallet requests, signing, or disconnect behavior.

Validation: all 12 existing browser interaction tests pass. Manual rendered mobile check reproduced the overlap before this change and verified both menus remain unobstructed afterward. This is a four-line CSS correction only.
