### PR TITLE
Add exact Privy policy owner signing client

### DIFF
--- a/app/ops/privy-policy-owner/page.tsx
+++ b/app/ops/privy-policy-owner/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { PrivyPolicyOwner } from "@/components/privy-policy-owner";
+
+export const metadata: Metadata = {
+  title: "Policy owner authorization · Programmable",
+  description: "Review and sign the exact prepared Custom Launch policy request.",
+  robots: { index: false, follow: false },
+};
+
+export default function PrivyPolicyOwnerPage() {
+  return <PrivyPolicyOwner />;
+}

--- a/components/privy-policy-owner.module.css
+++ b/components/privy-policy-owner.module.css
@@ -1,0 +1,82 @@
+.page {
+  width: min(100%, 1180px);
+  margin: 0 auto;
+  padding: 64px 24px 96px;
+  color: var(--text);
+}
+
+.header { max-width: 680px; }
+.eyebrow {
+  margin: 0 0 16px;
+  color: var(--text-soft);
+  font-family: var(--font-plex-mono), monospace;
+  font-size: 12px;
+  line-height: 16px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.header h1 {
+  margin: 0;
+  font-size: 36px;
+  font-weight: 600;
+  line-height: 40px;
+  letter-spacing: -0.035em;
+  text-wrap: balance;
+}
+.intro { margin: 24px 0 0; font-size: 18px; line-height: 28px; color: var(--text-soft); text-wrap: pretty; }
+.layout { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 48px; align-items: start; margin-top: 48px; }
+.page h2 { margin: 0 0 24px; font-size: 20px; line-height: 28px; font-weight: 600; }
+.operations { display: grid; gap: 8px; padding: 0; margin: 0 0 24px; border: 0; }
+.operations legend { margin-bottom: 8px; color: var(--text-soft); font-size: 14px; line-height: 20px; }
+.operations label { display: flex; align-items: center; gap: 12px; min-height: 44px; padding: 8px 12px; border: 1px solid var(--border-strong); border-radius: 8px; cursor: pointer; }
+.operations label:has(:checked) { background: var(--surface); border-color: var(--text-soft); }
+.operations input, .acknowledgement input { appearance: auto; -webkit-appearance: auto; width: 20px; height: 20px; flex: 0 0 auto; margin: 0; padding: 0; border: initial; background: initial; accent-color: var(--text); }
+.consequence { font-size: 18px; line-height: 28px; margin: 0 0 24px; text-wrap: pretty; }
+.facts { margin: 0; display: grid; gap: 16px; }
+.facts > div { min-width: 0; }
+.facts dt { color: var(--text-soft); font-size: 12px; line-height: 16px; margin-bottom: 4px; }
+.facts dd { margin: 0; font-size: 14px; line-height: 20px; }
+.facts dd span { display: block; margin-top: 4px; color: var(--text-soft); }
+.page code { overflow-wrap: anywhere; font-family: var(--font-plex-mono), monospace; font-size: 12px; line-height: 20px; }
+.explanation { color: var(--text-soft); font-size: 14px; line-height: 20px; text-wrap: pretty; margin: 24px 0 0; }
+.details { margin-top: 24px; }
+.details summary { cursor: pointer; min-height: 44px; padding-block: 12px; font-size: 14px; line-height: 20px; text-decoration: underline; text-underline-offset: 4px; }
+.details .facts { margin-top: 16px; }
+.console { min-width: 0; padding: 32px; border: 1px solid var(--panel-border); border-radius: 16px; background: var(--surface); }
+.console > .explanation { margin-top: 0; }
+.session { margin-top: 24px; display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px; font-size: 14px; line-height: 20px; }
+.secondary, .primary { min-height: 44px; padding: 8px 12px; border: 1px solid var(--text); border-radius: 8px; font: inherit; font-size: 16px; font-weight: 600; line-height: 24px; cursor: pointer; }
+.secondary { background: var(--surface-raised); color: var(--text); }
+.primary { width: 100%; background: var(--text); color: var(--body-background); }
+.primary:disabled, .secondary:disabled, .fileInput:disabled { cursor: not-allowed; opacity: 0.55; }
+.hint { color: var(--text-soft); font-size: 12px; line-height: 20px; margin: 12px 0 0; text-wrap: pretty; }
+.acknowledgement { display: flex; align-items: flex-start; gap: 12px; min-height: 44px; margin-top: 24px; cursor: pointer; font-size: 14px; line-height: 20px; }
+.console .importHeading { margin: 32px 0 16px; }
+.fileLabel { display: block; font-size: 14px; line-height: 20px; margin-bottom: 8px; }
+.fileInput { display: block; width: 100%; min-width: 0; min-height: 44px; border: 1px solid var(--border-strong); border-radius: 8px; background: var(--surface-raised); color: var(--text); font-size: 16px; line-height: 24px; padding: 8px; }
+.fileInput::file-selector-button { padding: 4px 8px; margin-inline-end: 8px; border: 1px solid var(--border-strong); border-radius: 4px; background: var(--surface); color: var(--text); font: inherit; cursor: pointer; }
+.request { margin-top: 24px; padding: 16px; border: 1px solid var(--border-strong); border-radius: 8px; }
+.timer { font-size: 14px; font-weight: 600; line-height: 20px; margin: 0 0 16px; font-variant-numeric: tabular-nums; }
+.error { color: var(--danger); font-size: 14px; line-height: 20px; margin: 16px 0; }
+.error:empty { margin-block: 24px 0; }
+.status { color: var(--text); font-size: 14px; line-height: 20px; margin: 16px 0 0; text-wrap: pretty; }
+.status:empty { margin: 0; }
+.back { display: inline-flex; align-items: center; min-height: 44px; margin-top: 32px; color: var(--text-soft); font-size: 14px; text-decoration: underline; text-underline-offset: 4px; }
+.page :is(button, input, a, summary):focus-visible { outline: 2px solid var(--focus); outline-offset: 4px; }
+@media (hover: hover) and (pointer: fine) {
+  .secondary:not(:disabled):hover, .operations label:hover { background: var(--surface-soft); }
+  .primary:not(:disabled):hover { opacity: 0.88; }
+}
+@media (max-width: 54rem) {
+  .layout { grid-template-columns: minmax(0, 1fr); gap: 32px; }
+  .page { padding-top: 40px; }
+  .console { padding: 24px; }
+}
+@media (max-width: 25rem) {
+  .page { padding-inline: 16px; }
+  .header h1 { font-size: 30px; line-height: 36px; }
+  .console { padding: 16px; }
+}
+@media (forced-colors: active) {
+  .page :is(button, input, a, summary):focus-visible { outline-color: Highlight; }
+}

--- a/components/privy-policy-owner.tsx
+++ b/components/privy-policy-owner.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useEffect, useRef, useState, type ChangeEvent, type FormEvent } from "react";
+import { useWallet } from "@/components/wallet-provider";
+import {
+  privyPolicyOwnerErrorMessage,
+  REVIEWED_PRIVY_POLICY_BINDINGS,
+  REVIEWED_PRIVY_POLICY_BODY_SHA256,
+  type PrivyPolicyOwnerOperation,
+  type PrivyPolicyOwnerReview,
+} from "@/lib/privy-policy-owner/handoff";
+import styles from "./privy-policy-owner.module.css";
+
+type ReviewCapability = ReturnType<typeof useWallet>["reviewPrivyPolicyOwnerRequest"];
+type ImportedRequest = Readonly<{
+  text: string;
+  review: PrivyPolicyOwnerReview;
+  reviewedBy: ReviewCapability;
+}>;
+
+function downloadSignature(text: string) {
+  const url = URL.createObjectURL(new Blob([text], { type: "application/json" }));
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "privy-policy-app-user-signature-v4.json";
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  // The URL contains no signature text and is only a short-lived local Blob handle.
+  setTimeout(() => URL.revokeObjectURL(url), 1_000);
+}
+
+export function PrivyPolicyOwner() {
+  const {
+    authReady, authenticated, connecting, openWallet, preloadWallet,
+    reviewPrivyPolicyOwnerRequest, signPrivyPolicyOwnerRequest,
+  } = useWallet();
+  const [operation, setOperation] = useState<PrivyPolicyOwnerOperation>("reconcile");
+  const [acknowledged, setAcknowledged] = useState(false);
+  const [request, setRequest] = useState<ImportedRequest | null>(null);
+  const [busy, setBusy] = useState<"review" | "sign" | null>(null);
+  const [error, setError] = useState("");
+  const [status, setStatus] = useState("");
+  const [now, setNow] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const revisionRef = useRef(0);
+  const signingRef = useRef(false);
+
+  useEffect(() => {
+    if (!request) return;
+    const timer = setInterval(() => setNow(Date.now()), 500);
+    return () => clearInterval(timer);
+  }, [request]);
+  useEffect(() => () => { revisionRef.current += 1; }, []);
+
+  const sessionMatches = authReady && authenticated
+    && request?.reviewedBy === reviewPrivyPolicyOwnerRequest;
+  const secondsLeft = request
+    ? Math.max(0, Math.ceil((Date.parse(request.review.artifact.expiresAt) - now) / 1_000))
+    : 0;
+  const expired = request !== null && secondsLeft === 0;
+  const readyToSign = Boolean(request && sessionMatches && !expired && acknowledged && !busy);
+
+  function chooseOperation(next: PrivyPolicyOwnerOperation) {
+    revisionRef.current += 1;
+    setOperation(next);
+    setRequest(null);
+    setAcknowledged(false);
+    setError("");
+    setStatus("");
+    if (inputRef.current) inputRef.current.value = "";
+  }
+
+  async function importRequest(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.currentTarget.files?.[0];
+    const revision = ++revisionRef.current;
+    setRequest(null);
+    setError("");
+    setStatus("");
+    if (!file) return;
+    if (file.size === 0 || file.size > 65_536) {
+      setError("Choose the operator request JSON file, no larger than 64 KiB.");
+      return;
+    }
+    if (!authReady || !authenticated) {
+      setError("Sign in with the existing policy owner account before importing a request.");
+      return;
+    }
+    setBusy("review");
+    try {
+      const text = await file.text();
+      const review = await reviewPrivyPolicyOwnerRequest({ text, operation });
+      if (revision !== revisionRef.current) return;
+      setNow(Date.now());
+      setRequest({ text, review, reviewedBy: reviewPrivyPolicyOwnerRequest });
+      setStatus("Request verified for this owner session. Signing does not apply the policy.");
+    } catch (cause) {
+      if (revision === revisionRef.current) setError(privyPolicyOwnerErrorMessage(cause));
+    } finally {
+      if (revision === revisionRef.current) setBusy(null);
+    }
+  }
+
+  async function signRequest(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (signingRef.current) return;
+    if (!readyToSign || !request) {
+      setError("Review the policy, confirm your consent, and import a fresh request from the operator.");
+      return;
+    }
+    signingRef.current = true;
+    const revision = revisionRef.current;
+    setBusy("sign");
+    setError("");
+    setStatus("Waiting for your policy authorization signature…");
+    try {
+      const signature = await signPrivyPolicyOwnerRequest({
+        text: request.text,
+        operation,
+        reviewedRequestArtifactSha256: request.review.requestArtifactSha256,
+      });
+      if (revision !== revisionRef.current) return;
+      downloadSignature(signature);
+      setRequest(null);
+      setAcknowledged(false);
+      if (inputRef.current) inputRef.current.value = "";
+      setStatus("Signature downloaded. Return it immediately to the operator before the original request expires. No policy was applied by this page.");
+    } catch (cause) {
+      if (revision === revisionRef.current) {
+        setError(privyPolicyOwnerErrorMessage(cause));
+        setStatus("");
+      }
+    } finally {
+      signingRef.current = false;
+      if (revision === revisionRef.current) setBusy(null);
+    }
+  }
+
+  return (
+    <section className={styles.page} aria-labelledby="owner-policy-title">
+      <header className={styles.header}>
+        <p className={styles.eyebrow}>Custom Launch / policy owner</p>
+        <h1 id="owner-policy-title">Authorize the prepared policy</h1>
+        <p className={styles.intro}>
+          Sign one exact Privy policy request with the existing owner account.
+          This page downloads your signature; only the operator can apply the change.
+        </p>
+      </header>
+
+      <div className={styles.layout}>
+        <div className={styles.review}>
+          <h2>1. Review the policy change</h2>
+          <fieldset className={styles.operations} disabled={busy !== null}>
+            <legend>Choose the prepared operation</legend>
+            <label><input type="radio" name="operation" value="reconcile" checked={operation === "reconcile"}
+              onChange={() => chooseOperation("reconcile")} /> Add Robinhood</label>
+            <label><input type="radio" name="operation" value="rollback" checked={operation === "rollback"}
+              onChange={() => chooseOperation("rollback")} /> Restore Ethereum only</label>
+          </fieldset>
+          <p className={styles.consequence}>
+            {operation === "reconcile"
+              ? "Keep the Ethereum permit rule and add the equivalent restricted rule for Robinhood Chain."
+              : "Remove the Robinhood permit rule and restore the reviewed Ethereum only policy."}
+          </p>
+          <dl className={styles.facts}>
+            <div><dt>Ethereum · chain 1</dt><dd><code>0x755509eA6e3F5Ec1aA2E797bb68f1B87DD8b886b</code><span>Unchanged</span></dd></div>
+            <div><dt>Robinhood · chain 4663</dt><dd><code>0xeD617CE7f82e2AB589aDeFFD319D1D872Bc8De06</code><span>{operation === "reconcile" ? "Add restricted permit rule" : "Remove permit rule"}</span></dd></div>
+          </dl>
+          <p className={styles.explanation}>
+            Only <code>eth_signTypedData_v4</code> is allowed, for <code>SafeMessage(message:bytes)</code> with
+            the exact chain and verifying contract above. The message must be in the existing condition set.
+            All other requests remain denied.
+          </p>
+          <p className={styles.explanation}>
+            The policy owner, wallets, quorums and condition set are unchanged. No funds move and no blockchain transaction is sent here.
+          </p>
+          <details className={styles.details}>
+            <summary>Show exact policy bindings</summary>
+            <dl className={styles.facts}>
+              {Object.entries(REVIEWED_PRIVY_POLICY_BINDINGS).map(([key, value]) =>
+                <div key={key}><dt>{key}</dt><dd><code>{value}</code></dd></div>)}
+              <div><dt>Reviewed request body</dt><dd><code>{REVIEWED_PRIVY_POLICY_BODY_SHA256[operation]}</code></dd></div>
+              <div><dt>Typed data domain</dt><dd><code>chainId:uint256, verifyingContract:address</code></dd></div>
+            </dl>
+          </details>
+        </div>
+
+        <form className={styles.console} onSubmit={signRequest}>
+          <h2>2. Prepare to sign</h2>
+          <p className={styles.explanation}>
+            Review and sign in first. Then ask the operator to prepare the file: its 30 second window cannot be extended.
+          </p>
+          <div className={styles.session}>
+            <span>{authReady && authenticated ? "Signed in · owner checked on import" : "Owner sign in required"}</span>
+            <button type="button" className={styles.secondary} onClick={openWallet}
+              onFocus={preloadWallet} onPointerEnter={preloadWallet} disabled={busy !== null || connecting}>
+              {connecting ? "Connecting…" : authenticated ? "Manage session" : "Connect owner wallet"}
+            </button>
+          </div>
+          <p className={styles.hint}>Use the existing linked owner wallet. The imported file must match the signed in Privy account.</p>
+          <label className={styles.acknowledgement}>
+            <input type="checkbox" checked={acknowledged} disabled={busy !== null}
+              onChange={(event) => setAcknowledged(event.target.checked)} />
+            <span>I reviewed the exact policy change above and authorize this operation.</span>
+          </label>
+
+          <h2 className={styles.importHeading}>3. Import the fresh request</h2>
+          <label className={styles.fileLabel} htmlFor="owner-policy-request">Prepared request JSON</label>
+          <input ref={inputRef} className={styles.fileInput} id="owner-policy-request" type="file"
+            accept="application/json,.json" onChange={importRequest}
+            disabled={busy !== null || !authReady || !authenticated}
+            aria-invalid={error ? true : undefined} aria-describedby="owner-policy-file-hint owner-policy-error" />
+          <p id="owner-policy-file-hint" className={styles.hint}>Unmodified operator artifact · maximum 64 KiB · no API keys or private keys</p>
+          {request ? <div className={styles.request}>
+            <p className={styles.timer} aria-live="off">
+              {expired ? "Request expired — ask for a fresh file" : `${secondsLeft} seconds remaining`}
+            </p>
+            {!sessionMatches ? <p>Your owner session changed. Import a fresh request.</p> : null}
+            <dl className={styles.facts}>
+              <div><dt>Request digest</dt><dd><code>{request.review.artifact.requestSha256}</code></dd></div>
+              <div><dt>Source policy digest</dt><dd><code>{request.review.artifact.sourcePolicySha256}</code></dd></div>
+              <div><dt>Target policy digest</dt><dd><code>{request.review.artifact.targetPolicySha256}</code></dd></div>
+            </dl>
+          </div> : null}
+          <p className={styles.error} id="owner-policy-error" role="alert">{error}</p>
+          <button type="submit" className={styles.primary} disabled={!readyToSign} aria-busy={busy === "sign"}>
+            {busy === "review" ? "Verifying request…" : busy === "sign" ? "Sign policy request · waiting…" : "Sign policy request"}
+          </button>
+          <p className={styles.status} role="status" aria-atomic="true">
+            {expired ? "Request expired. Ask the operator for a fresh file." : status}
+          </p>
+          <p className={styles.hint}>The signature authorizes only the original request until its original expiry. It is not a deployment or launch confirmation.</p>
+        </form>
+      </div>
+      <a className={styles.back} href="/profile">Back to profile</a>
+    </section>
+  );
+}

--- a/components/wallet-provider-runtime.ts
+++ b/components/wallet-provider-runtime.ts
@@ -1,6 +1,7 @@
 export {
   getIdentityToken,
   PrivyProvider,
+  useAuthorizationSignature,
   useIdentityToken,
   useLinkAccount,
   useLogin,

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -20,6 +20,7 @@ import {
   useContext,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -96,6 +97,11 @@ import {
   type BrowserWalletLoginLease,
 } from "../lib/wallet-login-lock";
 import { runWithBrowserWalletRequestLock } from "../lib/wallet-request-lock";
+import type {
+  PrivyPolicyOwnerOperation,
+  PrivyPolicyOwnerReview,
+  PrivyPolicyOwnerSession,
+} from "@/lib/privy-policy-owner/handoff";
 import {
   loginConnectedEthereumWalletWithSiwe,
   selectInjectedEthereumProvider,
@@ -172,6 +178,15 @@ type WalletContextValue = {
   reauthorizeGithub: () => Promise<void>;
   setUsername: (username: string) => void;
   signLaunchMessage: (signingMessageBase64Url: string) => Promise<string>;
+  reviewPrivyPolicyOwnerRequest: (input: Readonly<{
+    text: string;
+    operation: PrivyPolicyOwnerOperation;
+  }>) => Promise<PrivyPolicyOwnerReview>;
+  signPrivyPolicyOwnerRequest: (input: Readonly<{
+    text: string;
+    operation: PrivyPolicyOwnerOperation;
+    reviewedRequestArtifactSha256: string;
+  }>) => Promise<string>;
   signPredictionPermit: (input: Readonly<{
     deadline: bigint;
     factoryAddress: Address;
@@ -240,6 +255,7 @@ export function shouldEagerLoadWalletRuntime(pathname: string) {
     "/token",
     "/developers/api-keys",
     "/admin/partners",
+    "/ops/privy-policy-owner",
   ].some(
     (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
   );
@@ -1033,6 +1049,12 @@ function DeferredWalletProvider({
       signLaunchMessage: async () => {
         throw new Error("Wallet sign-in is still loading");
       },
+      reviewPrivyPolicyOwnerRequest: async () => {
+        throw new Error("OWNER_HANDOFF_SESSION_CHANGED");
+      },
+      signPrivyPolicyOwnerRequest: async () => {
+        throw new Error("OWNER_HANDOFF_SESSION_CHANGED");
+      },
       signPredictionPermit: async () => {
         throw new Error("Wallet sign-in is still loading");
       },
@@ -1159,6 +1181,7 @@ function PrivyWalletBridge({
 }>) {
   const {
     getIdentityToken: getPrivyIdentityToken,
+    useAuthorizationSignature,
     useIdentityToken,
     useLinkAccount,
     useLogin,
@@ -1198,6 +1221,7 @@ function PrivyWalletBridge({
   }, [identityToken]);
   const { sendTransaction: sendPrivyTransaction } = usePrivySendTransaction();
   const { signMessage: signPrivyMessage } = usePrivySignMessage();
+  const { generateAuthorizationSignature } = useAuthorizationSignature();
   const { ready: walletsReady, wallets } = useWallets();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -1253,6 +1277,66 @@ function PrivyWalletBridge({
   });
 
   const activeAuthenticated = authenticated && !sessionSuppressed;
+  const ownerUserId = user?.id ?? null;
+  const ownerSessionRef = useRef<PrivyPolicyOwnerSession>({
+    ready: false,
+    authenticated: false,
+    userId: null,
+  });
+  const ownerSigningRef = useRef(false);
+  useLayoutEffect(() => {
+    ownerSessionRef.current = {
+      ready,
+      authenticated: activeAuthenticated,
+      userId: ownerUserId,
+    };
+    return () => {
+      ownerSessionRef.current = { ready: false, authenticated: false, userId: null };
+    };
+  }, [activeAuthenticated, ready, ownerUserId]);
+  const reviewPrivyPolicyOwnerRequest = useCallback(async (input: Readonly<{
+    text: string;
+    operation: PrivyPolicyOwnerOperation;
+  }>) => {
+    const session = ownerSessionRef.current;
+    if (!ready || !activeAuthenticated || !ownerUserId
+      || !session.ready || !session.authenticated || !session.userId
+      || session.userId !== ownerUserId) {
+      throw new Error("OWNER_HANDOFF_SESSION_CHANGED");
+    }
+    const { reviewPrivyPolicyOwnerRequest: review } = await import(
+      "@/lib/privy-policy-owner/handoff"
+    );
+    const result = await review({ ...input, userId: session.userId, nowMilliseconds: Date.now() });
+    const current = ownerSessionRef.current;
+    if (!current.ready || !current.authenticated || current.userId !== session.userId) {
+      throw new Error("OWNER_HANDOFF_SESSION_CHANGED");
+    }
+    if (Date.now() >= Date.parse(result.artifact.expiresAt)) {
+      throw new Error("OWNER_HANDOFF_REQUEST_EXPIRED_OR_CLOCK_INVALID");
+    }
+    return result;
+  }, [activeAuthenticated, ready, ownerUserId]);
+  const signPrivyPolicyOwnerRequest = useCallback(async (input: Readonly<{
+    text: string;
+    operation: PrivyPolicyOwnerOperation;
+    reviewedRequestArtifactSha256: string;
+  }>) => {
+    if (ownerSigningRef.current) throw new Error("OWNER_HANDOFF_SIGNING_IN_PROGRESS");
+    ownerSigningRef.current = true;
+    try {
+      const { signReviewedPrivyPolicyOwnerRequest } = await import(
+        "@/lib/privy-policy-owner/handoff"
+      );
+      return await signReviewedPrivyPolicyOwnerRequest({
+        ...input,
+        readSession: () => ownerSessionRef.current,
+        signAuthorization: generateAuthorizationSignature,
+      });
+    } finally {
+      ownerSigningRef.current = false;
+    }
+  }, [generateAuthorizationSignature]);
   useEffect(() => {
     if (!ready) return;
     persistWalletSessionHint(activeAuthenticated);
@@ -2607,6 +2691,8 @@ function PrivyWalletBridge({
       reauthorizeGithub,
       setUsername,
       signLaunchMessage,
+      reviewPrivyPolicyOwnerRequest,
+      signPrivyPolicyOwnerRequest,
       signPredictionPermit,
       signPredictionTokenPermit,
       signMainTokenMigrationPermit,
@@ -2650,6 +2736,8 @@ function PrivyWalletBridge({
       sendPredictionV2Transaction,
       sendTransaction,
       signLaunchMessage,
+      reviewPrivyPolicyOwnerRequest,
+      signPrivyPolicyOwnerRequest,
       signPredictionPermit,
       signPredictionTokenPermit,
       signMainTokenMigrationPermit,
@@ -2741,6 +2829,12 @@ function UnconfiguredWalletProvider({ children }: { children: ReactNode }) {
       setUsername: () => undefined,
       signLaunchMessage: async () => {
         throw new Error("Wallet sign-in is unavailable");
+      },
+      reviewPrivyPolicyOwnerRequest: async () => {
+        throw new Error("OWNER_HANDOFF_SESSION_CHANGED");
+      },
+      signPrivyPolicyOwnerRequest: async () => {
+        throw new Error("OWNER_HANDOFF_SESSION_CHANGED");
       },
       signPredictionPermit: async () => {
         throw new Error("Wallet sign-in is unavailable");

--- a/lib/privy-policy-owner/handoff.ts
+++ b/lib/privy-policy-owner/handoff.ts
@@ -1,0 +1,126 @@
+import {
+  digestPrivyOwnerUserV4,
+  parsePrivyPolicyAppUserSignatureV4,
+  PRIVY_POLICY_APP_USER_SIGNATURE_VERSION_V4,
+  serializePrivyOwnerArtifactV4,
+  validatePrivyPolicyAppUserRequestV4,
+} from "./wire";
+
+/** Reviewed whole-policy request bodies. These pins are not imported from a file. */
+export const REVIEWED_PRIVY_POLICY_BINDINGS = Object.freeze({
+  appId: "cms0vmhok003f0cl93ou53auq",
+  policyId: "sf86euttztysqlocsx2url2y",
+  ownerId: "wtlwv5eybvh4mmj3xdqof9vw",
+  conditionSetId: "urs76jlku0tb9bitkc4lxb7d",
+});
+
+export const REVIEWED_PRIVY_POLICY_BODY_SHA256 = Object.freeze({
+  reconcile: "sha256:e2bac07a38ee5bc0ad6e106e4b9598bc4018be56152e8ca9c06ef4bd1db36232",
+  rollback: "sha256:106bb02ae31a19ba5ffab6a3582a02e46cd8a1be27c1ee99a5139faca282276c",
+});
+
+export type PrivyPolicyOwnerOperation = keyof typeof REVIEWED_PRIVY_POLICY_BODY_SHA256;
+export type PrivyPolicyOwnerReview = Awaited<ReturnType<typeof reviewPrivyPolicyOwnerRequest>>;
+export type PrivyPolicyOwnerSession = Readonly<{
+  ready: boolean;
+  authenticated: boolean;
+  userId: string | null;
+}>;
+
+export async function reviewPrivyPolicyOwnerRequest(input: Readonly<{
+  text: string;
+  operation: PrivyPolicyOwnerOperation;
+  userId: string;
+  nowMilliseconds: number;
+}>) {
+  if (input.operation !== "reconcile" && input.operation !== "rollback") {
+    throw new Error("OWNER_HANDOFF_OPERATION_INVALID");
+  }
+  return validatePrivyPolicyAppUserRequestV4({
+    text: input.text,
+    nowMilliseconds: input.nowMilliseconds,
+    expected: {
+      bindings: REVIEWED_PRIVY_POLICY_BINDINGS,
+      operation: input.operation,
+      requestBodySha256: REVIEWED_PRIVY_POLICY_BODY_SHA256[input.operation],
+      ownerUserSha256: await digestPrivyOwnerUserV4(input.userId),
+    },
+  });
+}
+
+function requireSameSession(
+  readSession: () => PrivyPolicyOwnerSession,
+  expectedUserId?: string,
+): string {
+  const session = readSession();
+  if (!session.ready || !session.authenticated || !session.userId
+    || (expectedUserId !== undefined && session.userId !== expectedUserId)) {
+    throw new Error("OWNER_HANDOFF_SESSION_CHANGED");
+  }
+  return session.userId;
+}
+
+function requireUnexpired(review: PrivyPolicyOwnerReview, nowMilliseconds: number) {
+  if (!Number.isSafeInteger(nowMilliseconds)
+    || nowMilliseconds < Date.parse(review.artifact.createdAt)
+    || nowMilliseconds >= Date.parse(review.artifact.expiresAt)) {
+    throw new Error("OWNER_HANDOFF_REQUEST_EXPIRED_OR_CLOCK_INVALID");
+  }
+}
+
+/** Accepts only the pinned policy artifact, never arbitrary bytes or SDK requests. */
+export async function signReviewedPrivyPolicyOwnerRequest(input: Readonly<{
+  text: string;
+  operation: PrivyPolicyOwnerOperation;
+  reviewedRequestArtifactSha256: string;
+  readSession: () => PrivyPolicyOwnerSession;
+  signAuthorization: (bytes: Uint8Array) => Promise<{ signature: string }>;
+  now?: () => number;
+}>): Promise<string> {
+  const now = input.now ?? Date.now;
+  const userId = requireSameSession(input.readSession);
+  const review = await reviewPrivyPolicyOwnerRequest({
+    text: input.text,
+    operation: input.operation,
+    userId,
+    nowMilliseconds: now(),
+  });
+  requireSameSession(input.readSession, userId);
+  requireUnexpired(review, now());
+  if (review.requestArtifactSha256 !== input.reviewedRequestArtifactSha256) {
+    throw new Error("OWNER_HANDOFF_REVIEW_CHANGED");
+  }
+  // SDK consumes the original RFC 8785 bytes. No reformatting or re-expiry.
+  const result = await input.signAuthorization(review.requestBytes);
+  requireSameSession(input.readSession, userId);
+  requireUnexpired(review, now());
+  const artifact = serializePrivyOwnerArtifactV4({
+    schemaVersion: PRIVY_POLICY_APP_USER_SIGNATURE_VERSION_V4,
+    requestArtifactSha256: review.requestArtifactSha256,
+    requestSha256: review.artifact.requestSha256,
+    authorizationSignature: result.signature,
+  });
+  parsePrivyPolicyAppUserSignatureV4(artifact, {
+    requestArtifactSha256: review.requestArtifactSha256,
+    requestSha256: review.artifact.requestSha256,
+  });
+  return artifact;
+}
+
+/** Never render raw SDK errors, which may contain request or session details. */
+export function privyPolicyOwnerErrorMessage(error: unknown): string {
+  const code = error instanceof Error ? error.message : "";
+  if (code === "OWNER_HANDOFF_REQUEST_EXPIRED_OR_CLOCK_INVALID") {
+    return "This request expired or your clock differs. Ask the operator for a fresh 30 second request.";
+  }
+  if (code === "OWNER_HANDOFF_SESSION_CHANGED") {
+    return "Your owner session changed. Sign in again and import a fresh request.";
+  }
+  if (code === "OWNER_HANDOFF_BINDING_MISMATCH") {
+    return "This file does not match the selected operation, reviewed policy, or signed in owner. Check with the operator.";
+  }
+  if (code.startsWith("OWNER_HANDOFF_")) {
+    return "This file could not be verified. Use the unmodified request from the operator.";
+  }
+  return "The request could not be signed. Check your owner session and ask the operator for a fresh request.";
+}

--- a/lib/privy-policy-owner/wire.ts
+++ b/lib/privy-policy-owner/wire.ts
@@ -1,0 +1,215 @@
+/** Browser-safe wire validation; no credentials, SDK, filesystem or provider calls. */
+export const PRIVY_POLICY_APP_USER_REQUEST_VERSION_V4 =
+  "programmable.privy-permit-policy.app-user-request.v4";
+export const PRIVY_POLICY_APP_USER_SIGNATURE_VERSION_V4 =
+  "programmable.privy-permit-policy.app-user-signature.v4";
+export const PRIVY_POLICY_APP_USER_REQUEST_LIFETIME_MS_V4 = 30_000;
+
+export type PrivyPolicyAppUserBindingsV4 = Readonly<{
+  appId: string;
+  policyId: string;
+  ownerId: string;
+  conditionSetId: string;
+}>;
+
+export type PrivyPolicyAppUserRequestV4 = Readonly<{
+  schemaVersion: typeof PRIVY_POLICY_APP_USER_REQUEST_VERSION_V4;
+  operation: "reconcile" | "rollback";
+  bindings: PrivyPolicyAppUserBindingsV4;
+  ownerUserSha256: string;
+  createdAt: string;
+  expiresAt: string;
+  sourcePolicySha256: string;
+  targetPolicySha256: string;
+  rollbackArtifactSha256: string;
+  requestBodySha256: string;
+  requestBytesBase64: string;
+  requestSha256: string;
+}>;
+
+export type PrivyPolicyAppUserSignatureV4 = Readonly<{
+  schemaVersion: typeof PRIVY_POLICY_APP_USER_SIGNATURE_VERSION_V4;
+  requestArtifactSha256: string;
+  requestSha256: string;
+  authorizationSignature: string;
+}>;
+
+export type PrivyPolicyAppUserRequestExpectationV4 = Readonly<{
+  bindings: PrivyPolicyAppUserBindingsV4;
+  operation: "reconcile" | "rollback";
+  /** Derived from the reviewed builder, never copied from the imported file. */
+  requestBodySha256: string;
+  /** Derive from the authenticated AppUser, not a user-supplied identifier. */
+  ownerUserSha256: string;
+}>;
+
+/** RFC-8785-compatible for this closed JSON wire; no newline in signing bytes. */
+export function canonicalPrivyOwnerJsonV4(value: unknown): string {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number" && Number.isSafeInteger(value)) {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalPrivyOwnerJsonV4).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) =>
+      `${JSON.stringify(key)}:${canonicalPrivyOwnerJsonV4(Reflect.get(value, key))}`
+    ).join(",")}}`;
+  }
+  throw new TypeError("OWNER_HANDOFF_NON_JSON_VALUE");
+}
+
+export async function digestPrivyOwnerBytesV4(
+  value: string | Uint8Array,
+): Promise<string> {
+  const bytes = typeof value === "string" ? new TextEncoder().encode(value) : value;
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", new Uint8Array(bytes));
+  return `sha256:${Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0")).join("")}`;
+}
+
+export async function digestPrivyOwnerUserV4(userId: string): Promise<string> {
+  if (!/^did:privy:[a-zA-Z0-9]{1,128}$/u.test(userId)) {
+    throw new TypeError("OWNER_HANDOFF_USER_INVALID");
+  }
+  return digestPrivyOwnerBytesV4(`programmable.privy-policy-owner-user.v4\0${userId}`);
+}
+
+export function encodePrivyOwnerBytesBase64V4(bytes: Uint8Array): string {
+  return btoa(Array.from(bytes, (byte) => String.fromCharCode(byte)).join(""));
+}
+
+export function decodePrivyOwnerBytesBase64V4(value: unknown): Uint8Array {
+  if (typeof value !== "string" || value.length < 4 || value.length > 65_536
+    || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u.test(value)) {
+    throw new TypeError("OWNER_HANDOFF_BASE64_INVALID");
+  }
+  const bytes = Uint8Array.from(atob(value), (character) => character.charCodeAt(0));
+  if (encodePrivyOwnerBytesBase64V4(bytes) !== value) {
+    throw new TypeError("OWNER_HANDOFF_BASE64_INVALID");
+  }
+  return bytes;
+}
+
+export function serializePrivyOwnerArtifactV4(value: unknown): string {
+  return `${canonicalPrivyOwnerJsonV4(value)}\n`;
+}
+
+export async function validatePrivyPolicyAppUserRequestV4(input: Readonly<{
+  text: string;
+  expected: PrivyPolicyAppUserRequestExpectationV4;
+  nowMilliseconds: number;
+}>): Promise<Readonly<{
+  artifact: PrivyPolicyAppUserRequestV4;
+  requestBytes: Uint8Array;
+  requestArtifactSha256: string;
+  request: Readonly<Record<string, unknown>>;
+}>> {
+  const value = parseCanonicalArtifact(input.text);
+  exactKeys(value, ["schemaVersion", "operation", "bindings", "ownerUserSha256",
+    "createdAt", "expiresAt", "sourcePolicySha256", "targetPolicySha256",
+    "rollbackArtifactSha256", "requestBodySha256", "requestBytesBase64", "requestSha256"]);
+  const bindings = record(value.bindings);
+  exactKeys(bindings, ["appId", "policyId", "ownerId", "conditionSetId"]);
+  for (const key of ["policyId", "ownerId", "conditionSetId"]) {
+    if (typeof bindings[key] !== "string" || !/^[a-z0-9]{24}$/u.test(bindings[key])) {
+      throw new TypeError("OWNER_HANDOFF_BINDING_INVALID");
+    }
+  }
+  if (typeof bindings.appId !== "string" || !/^[a-z0-9]{1,128}$/u.test(bindings.appId)
+    || canonicalPrivyOwnerJsonV4(bindings) !== canonicalPrivyOwnerJsonV4(input.expected.bindings)
+    || value.schemaVersion !== PRIVY_POLICY_APP_USER_REQUEST_VERSION_V4
+    || (value.operation !== "reconcile" && value.operation !== "rollback")
+    || value.operation !== input.expected.operation
+    || value.ownerUserSha256 !== input.expected.ownerUserSha256
+    || value.requestBodySha256 !== input.expected.requestBodySha256) {
+    throw new TypeError("OWNER_HANDOFF_BINDING_MISMATCH");
+  }
+  for (const key of ["ownerUserSha256", "sourcePolicySha256", "targetPolicySha256",
+    "rollbackArtifactSha256", "requestBodySha256", "requestSha256"]) {
+    if (typeof value[key] !== "string" || !/^sha256:[0-9a-f]{64}$/u.test(value[key])) {
+      throw new TypeError("OWNER_HANDOFF_DIGEST_INVALID");
+    }
+  }
+  const created = timestamp(value.createdAt);
+  const expires = timestamp(value.expiresAt);
+  if (!Number.isSafeInteger(input.nowMilliseconds) || created > input.nowMilliseconds
+    || expires - created !== PRIVY_POLICY_APP_USER_REQUEST_LIFETIME_MS_V4
+    || input.nowMilliseconds >= expires) {
+    throw new TypeError("OWNER_HANDOFF_REQUEST_EXPIRED_OR_CLOCK_INVALID");
+  }
+  const requestBytes = decodePrivyOwnerBytesBase64V4(value.requestBytesBase64);
+  const requestText = new TextDecoder("utf-8", { fatal: true }).decode(requestBytes);
+  const request = record(JSON.parse(requestText));
+  exactKeys(request, ["version", "method", "url", "body", "headers"]);
+  const headers = record(request.headers);
+  exactKeys(headers, ["privy-app-id", "privy-request-expiry"]);
+  if (requestText !== canonicalPrivyOwnerJsonV4(request)
+    || request.version !== 1 || request.method !== "PATCH"
+    || request.url !== `https://api.privy.io/v1/policies/${bindings.policyId}`
+    || headers["privy-app-id"] !== bindings.appId
+    || headers["privy-request-expiry"] !== String(expires)
+    || await digestPrivyOwnerBytesV4(requestBytes) !== value.requestSha256
+    || await digestPrivyOwnerBytesV4(canonicalPrivyOwnerJsonV4(request.body))
+      !== input.expected.requestBodySha256) {
+    throw new TypeError("OWNER_HANDOFF_REQUEST_BYTES_MISMATCH");
+  }
+  return Object.freeze({
+    artifact: value as PrivyPolicyAppUserRequestV4,
+    requestBytes,
+    request,
+    requestArtifactSha256: await digestPrivyOwnerBytesV4(input.text),
+  });
+}
+
+export function parsePrivyPolicyAppUserSignatureV4(
+  text: string,
+  expected: Readonly<{ requestArtifactSha256: string; requestSha256: string }>,
+): PrivyPolicyAppUserSignatureV4 {
+  const value = parseCanonicalArtifact(text);
+  exactKeys(value, ["schemaVersion", "requestArtifactSha256", "requestSha256", "authorizationSignature"]);
+  if (value.schemaVersion !== PRIVY_POLICY_APP_USER_SIGNATURE_VERSION_V4
+    || value.requestArtifactSha256 !== expected.requestArtifactSha256
+    || value.requestSha256 !== expected.requestSha256
+    || typeof value.authorizationSignature !== "string"
+    || !/^[\x21-\x7e]{1,8192}$/u.test(value.authorizationSignature)) {
+    throw new TypeError("OWNER_HANDOFF_SIGNATURE_BINDING_INVALID");
+  }
+  return value as PrivyPolicyAppUserSignatureV4;
+}
+
+function parseCanonicalArtifact(text: string): Record<string, unknown> {
+  if (typeof text !== "string" || new TextEncoder().encode(text).length > 65_536) {
+    throw new TypeError("OWNER_HANDOFF_ARTIFACT_SIZE_INVALID");
+  }
+  const value = record(JSON.parse(text));
+  if (serializePrivyOwnerArtifactV4(value) !== text) {
+    throw new TypeError("OWNER_HANDOFF_ARTIFACT_NON_CANONICAL");
+  }
+  return value;
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("OWNER_HANDOFF_OBJECT_INVALID");
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): void {
+  if (Object.keys(value).sort().join("\0") !== [...keys].sort().join("\0")) {
+    throw new TypeError("OWNER_HANDOFF_FIELDS_INVALID");
+  }
+}
+
+function timestamp(value: unknown): number {
+  if (typeof value !== "string") throw new TypeError("OWNER_HANDOFF_TIME_INVALID");
+  const time = Date.parse(value);
+  if (!Number.isSafeInteger(time) || time < 0 || new Date(time).toISOString() !== value) {
+    throw new TypeError("OWNER_HANDOFF_TIME_INVALID");
+  }
+  return time;
+}

--- a/tests/privy-policy-owner-handoff.test.ts
+++ b/tests/privy-policy-owner-handoff.test.ts
@@ -1,0 +1,363 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  privyPolicyOwnerErrorMessage,
+  REVIEWED_PRIVY_POLICY_BINDINGS,
+  REVIEWED_PRIVY_POLICY_BODY_SHA256,
+  reviewPrivyPolicyOwnerRequest,
+  signReviewedPrivyPolicyOwnerRequest,
+  type PrivyPolicyOwnerOperation,
+  type PrivyPolicyOwnerSession,
+} from "../lib/privy-policy-owner/handoff";
+
+const OWNER_USER = "did:privy:OwnerHandoffTestOnly";
+const OTHER_USER = "did:privy:DifferentTestOwner";
+const CREATED = Date.parse("2026-08-31T20:00:00.000Z");
+const NOW = CREATED + 1_000;
+const EXPIRES = CREATED + 30_000;
+const BINDINGS = {
+  appId: "cms0vmhok003f0cl93ou53auq",
+  policyId: "sf86euttztysqlocsx2url2y",
+  ownerId: "wtlwv5eybvh4mmj3xdqof9vw",
+  conditionSetId: "urs76jlku0tb9bitkc4lxb7d",
+};
+
+// Independent Node hashing and fixture serialization exercise the browser wire
+// against exact builder-derived PATCH bodies, without bypassing production pins.
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) =>
+      `${JSON.stringify(key)}:${canonical(Reflect.get(value, key))}`
+    ).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function digest(value: string | Uint8Array): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function serialize(value: unknown): string {
+  return `${canonical(value)}\n`;
+}
+
+function reviewedBody(operation: PrivyPolicyOwnerOperation) {
+  const rules = [
+    ["Mainnet", "1", "0x755509eA6e3F5Ec1aA2E797bb68f1B87DD8b886b"],
+    ["Robinhood", "4663", "0xeD617CE7f82e2AB589aDeFFD319D1D872Bc8De06"],
+  ].map(([network, chainId, authority]) => ({
+    name: `Allow admitted ${network} permit SafeMessage`,
+    method: "eth_signTypedData_v4",
+    action: "ALLOW",
+    conditions: [
+      { field_source: "ethereum_typed_data_domain", field: "chainId", operator: "eq", value: chainId },
+      { field_source: "ethereum_typed_data_domain", field: "verifyingContract", operator: "eq", value: authority },
+      {
+        field_source: "ethereum_typed_data_message",
+        typed_data: {
+          types: {
+            EIP712Domain: [
+              { name: "chainId", type: "uint256" },
+              { name: "verifyingContract", type: "address" },
+            ],
+            SafeMessage: [{ name: "message", type: "bytes" }],
+          },
+          primary_type: "SafeMessage",
+        },
+        field: "message",
+        operator: "in_condition_set",
+        value: BINDINGS.conditionSetId,
+      },
+    ],
+  }));
+  return {
+    name: "Programmable permit SafeMessage condition set v2",
+    rules: operation === "reconcile" ? rules : rules.slice(0, 1),
+  };
+}
+
+function fixture(
+  operation: PrivyPolicyOwnerOperation = "reconcile",
+  created = CREATED,
+  expires = EXPIRES,
+) {
+  const request = {
+    version: 1,
+    method: "PATCH",
+    url: `https://api.privy.io/v1/policies/${BINDINGS.policyId}`,
+    headers: {
+      "privy-app-id": BINDINGS.appId,
+      "privy-request-expiry": String(expires),
+    },
+    body: reviewedBody(operation),
+  };
+  const requestBytes = new TextEncoder().encode(canonical(request));
+  const artifact = {
+    schemaVersion: "programmable.privy-permit-policy.app-user-request.v4",
+    operation,
+    bindings: { ...BINDINGS },
+    ownerUserSha256: digest(`programmable.privy-policy-owner-user.v4\0${OWNER_USER}`),
+    createdAt: new Date(created).toISOString(),
+    expiresAt: new Date(expires).toISOString(),
+    sourcePolicySha256: digest("test source policy"),
+    targetPolicySha256: digest("test target policy"),
+    rollbackArtifactSha256: digest("test rollback artifact"),
+    requestBodySha256: digest(canonical(request.body)),
+    requestBytesBase64: Buffer.from(requestBytes).toString("base64"),
+    requestSha256: digest(requestBytes),
+  };
+  const text = serialize(artifact);
+  return { request, artifact, text, requestBytes };
+}
+
+function replaceRequest(subject: ReturnType<typeof fixture>, request: unknown): string {
+  const bytes = new TextEncoder().encode(canonical(request));
+  return serialize({
+    ...subject.artifact,
+    requestBytesBase64: Buffer.from(bytes).toString("base64"),
+    requestSha256: digest(bytes),
+  });
+}
+
+function review(text: string, operation: PrivyPolicyOwnerOperation = "reconcile", now = NOW) {
+  return reviewPrivyPolicyOwnerRequest({ text, operation, userId: OWNER_USER, nowMilliseconds: now });
+}
+
+function ownerSession(): PrivyPolicyOwnerSession {
+  return { ready: true, authenticated: true, userId: OWNER_USER };
+}
+
+function signInput(subject = fixture()) {
+  return {
+    text: subject.text,
+    operation: subject.artifact.operation,
+    reviewedRequestArtifactSha256: digest(subject.text),
+    readSession: ownerSession,
+    now: () => NOW,
+    signAuthorization: vi.fn(async () => ({ signature: "opaque.sdk-signature:v1/+=_~" })),
+  };
+}
+
+describe("reviewed Privy policy owner request", () => {
+  it.each(["reconcile", "rollback"] as const)("accepts only the independently reconstructed %s body", async (operation) => {
+    const subject = fixture(operation);
+    expect(REVIEWED_PRIVY_POLICY_BINDINGS).toEqual(BINDINGS);
+    expect(subject.artifact.requestBodySha256).toBe(REVIEWED_PRIVY_POLICY_BODY_SHA256[operation]);
+    const result = await review(subject.text, operation);
+    expect(result.requestBytes).toEqual(subject.requestBytes);
+    expect(result.requestArtifactSha256).toBe(digest(subject.text));
+    expect(result.artifact).toEqual(subject.artifact);
+    expect(result.request).toEqual(subject.request);
+    expect(new TextDecoder().decode(result.requestBytes)).not.toMatch(/\n$/u);
+  });
+
+  it("derives the owner binding from the authenticated DID", async () => {
+    await expect(reviewPrivyPolicyOwnerRequest({
+      text: fixture().text, operation: "reconcile", userId: OTHER_USER, nowMilliseconds: NOW,
+    })).rejects.toThrow("OWNER_HANDOFF_BINDING_MISMATCH");
+  });
+
+  it.each(["appId", "policyId", "ownerId", "conditionSetId"] as const)("rejects a different %s", async (key) => {
+    const subject = fixture();
+    subject.artifact.bindings[key] = "aaaaaaaaaaaaaaaaaaaaaaaa";
+    await expect(review(serialize(subject.artifact))).rejects.toThrow(/OWNER_HANDOFF_BINDING/u);
+  });
+
+  it("does not treat the reviewed rollback as reconcile consent", async () => {
+    await expect(review(fixture("rollback").text)).rejects.toThrow("OWNER_HANDOFF_BINDING_MISMATCH");
+  });
+
+  it("rejects an arbitrary policy even when all attacker-controlled digests are recomputed", async () => {
+    const subject = fixture();
+    subject.request.body.rules = [];
+    subject.artifact.requestBodySha256 = digest(canonical(subject.request.body));
+    const input = { ...signInput(subject), text: replaceRequest(subject, subject.request) };
+    input.reviewedRequestArtifactSha256 = digest(input.text);
+    await expect(signReviewedPrivyPolicyOwnerRequest(input)).rejects.toThrow("OWNER_HANDOFF_BINDING_MISMATCH");
+    expect(input.signAuthorization).not.toHaveBeenCalled();
+  });
+
+  it("checks the actual request body rather than trusting its pinned digest field", async () => {
+    const subject = fixture();
+    subject.request.body.rules = [];
+    await expect(review(replaceRequest(subject, subject.request)))
+      .rejects.toThrow("OWNER_HANDOFF_REQUEST_BYTES_MISMATCH");
+  });
+
+  it.each([
+    ["method", "POST"],
+    ["url", "https://api.privy.io/v1/wallets/aaaaaaaaaaaaaaaaaaaaaaaa"],
+  ] as const)("rejects another signed %s", async (key, value) => {
+    const subject = fixture();
+    subject.request[key] = value;
+    await expect(review(replaceRequest(subject, subject.request)))
+      .rejects.toThrow("OWNER_HANDOFF_REQUEST_BYTES_MISMATCH");
+  });
+
+  it("rejects a changed request-expiry header", async () => {
+    const subject = fixture();
+    subject.request.headers["privy-request-expiry"] = String(EXPIRES + 1);
+    await expect(review(replaceRequest(subject, subject.request)))
+      .rejects.toThrow("OWNER_HANDOFF_REQUEST_BYTES_MISMATCH");
+  });
+
+  it("rejects transport credentials and owner changes in the signed request", async () => {
+    const subject = fixture();
+    const request = {
+      ...subject.request,
+      headers: { ...subject.request.headers, authorization: "test-only-credential" },
+      body: { ...subject.request.body, owner_id: "aaaaaaaaaaaaaaaaaaaaaaaa" },
+    };
+    await expect(review(replaceRequest(subject, request))).rejects.toThrow("OWNER_HANDOFF_FIELDS_INVALID");
+  });
+
+  it("rejects unknown artifact fields and noncanonical artifact bytes", async () => {
+    const subject = fixture();
+    await expect(review(serialize({ ...subject.artifact, unreviewed: true })))
+      .rejects.toThrow("OWNER_HANDOFF_FIELDS_INVALID");
+    await expect(review(subject.text.trimEnd())).rejects.toThrow("OWNER_HANDOFF_ARTIFACT_NON_CANONICAL");
+    await expect(review(JSON.stringify(subject.artifact, null, 2) + "\n"))
+      .rejects.toThrow("OWNER_HANDOFF_ARTIFACT_NON_CANONICAL");
+  });
+
+  it("rejects a signing-byte newline even with its matching digest", async () => {
+    const subject = fixture();
+    const bytes = new TextEncoder().encode(canonical(subject.request) + "\n");
+    await expect(review(serialize({
+      ...subject.artifact,
+      requestBytesBase64: Buffer.from(bytes).toString("base64"),
+      requestSha256: digest(bytes),
+    }))).rejects.toThrow("OWNER_HANDOFF_REQUEST_BYTES_MISMATCH");
+  });
+
+  it.each([
+    ["expired", CREATED, EXPIRES, EXPIRES],
+    ["future", CREATED, EXPIRES, CREATED - 1],
+    ["extended", CREATED, EXPIRES + 1, NOW],
+    ["shortened", CREATED, EXPIRES - 1, NOW],
+    ["fractional clock", CREATED, EXPIRES, NOW + 0.5],
+  ] as const)("rejects %s request timing", async (_name, created, expires, now) => {
+    await expect(review(fixture("reconcile", created, expires).text, "reconcile", now))
+      .rejects.toThrow("OWNER_HANDOFF_REQUEST_EXPIRED_OR_CLOCK_INVALID");
+  });
+
+  it("accepts the last millisecond but never extends the original expiry", async () => {
+    const result = await review(fixture().text, "reconcile", EXPIRES - 1);
+    expect(result.request.headers).toEqual({
+      "privy-app-id": BINDINGS.appId, "privy-request-expiry": String(EXPIRES),
+    });
+  });
+});
+
+describe("explicit policy owner signing", () => {
+  it.each(["reconcile", "rollback"] as const)("passes original %s bytes and preserves the opaque SDK signature", async (operation) => {
+    const subject = fixture(operation);
+    const input = signInput(subject);
+    const text = await signReviewedPrivyPolicyOwnerRequest(input);
+    expect(input.signAuthorization).toHaveBeenCalledExactlyOnceWith(subject.requestBytes);
+    expect(text).toBe(serialize({
+      schemaVersion: "programmable.privy-permit-policy.app-user-signature.v4",
+      requestArtifactSha256: digest(subject.text),
+      requestSha256: subject.artifact.requestSha256,
+      authorizationSignature: "opaque.sdk-signature:v1/+=_~",
+    }));
+  });
+
+  it("requires consent for the exact imported artifact, not just an equivalent policy", async () => {
+    const subject = fixture();
+    const input = signInput(subject);
+    subject.artifact.rollbackArtifactSha256 = digest("different rollback artifact");
+    input.text = serialize(subject.artifact);
+    await expect(signReviewedPrivyPolicyOwnerRequest(input)).rejects.toThrow("OWNER_HANDOFF_REVIEW_CHANGED");
+    expect(input.signAuthorization).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { ready: false, authenticated: true, userId: OWNER_USER },
+    { ready: true, authenticated: false, userId: OWNER_USER },
+    { ready: true, authenticated: true, userId: null },
+  ])("rejects a missing ready authenticated session before signing: %j", async (session) => {
+    const input = { ...signInput(), readSession: () => session };
+    await expect(signReviewedPrivyPolicyOwnerRequest(input)).rejects.toThrow("OWNER_HANDOFF_SESSION_CHANGED");
+    expect(input.signAuthorization).not.toHaveBeenCalled();
+  });
+
+  it("rejects a valid but different owner session before signing", async () => {
+    const input = { ...signInput(), readSession: () => ({ ...ownerSession(), userId: OTHER_USER }) };
+    await expect(signReviewedPrivyPolicyOwnerRequest(input)).rejects.toThrow("OWNER_HANDOFF_BINDING_MISMATCH");
+    expect(input.signAuthorization).not.toHaveBeenCalled();
+  });
+
+  it("rechecks session identity after asynchronous validation", async () => {
+    const input = {
+      ...signInput(),
+      readSession: vi.fn().mockReturnValueOnce(ownerSession()).mockReturnValue({ ...ownerSession(), userId: OTHER_USER }),
+    };
+    await expect(signReviewedPrivyPolicyOwnerRequest(input)).rejects.toThrow("OWNER_HANDOFF_SESSION_CHANGED");
+    expect(input.signAuthorization).not.toHaveBeenCalled();
+  });
+
+  it("rechecks expiry after asynchronous validation before invoking the SDK", async () => {
+    const input = { ...signInput(), now: vi.fn().mockReturnValueOnce(NOW).mockReturnValue(EXPIRES) };
+    await expect(signReviewedPrivyPolicyOwnerRequest(input))
+      .rejects.toThrow("OWNER_HANDOFF_REQUEST_EXPIRED_OR_CLOCK_INVALID");
+    expect(input.signAuthorization).not.toHaveBeenCalled();
+  });
+
+  it("does not release a signature when the session changes while awaiting the SDK", async () => {
+    let session = ownerSession();
+    const input = {
+      ...signInput(),
+      readSession: () => session,
+      signAuthorization: vi.fn(async () => {
+        session = { ...session, userId: OTHER_USER };
+        return { signature: "test-only-signature" };
+      }),
+    };
+    await expect(signReviewedPrivyPolicyOwnerRequest(input)).rejects.toThrow("OWNER_HANDOFF_SESSION_CHANGED");
+    expect(input.signAuthorization).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not release a signature that expires while awaiting the SDK", async () => {
+    let now = NOW;
+    const input = {
+      ...signInput(),
+      now: () => now,
+      signAuthorization: vi.fn(async () => {
+        now = EXPIRES;
+        return { signature: "test-only-signature" };
+      }),
+    };
+    await expect(signReviewedPrivyPolicyOwnerRequest(input))
+      .rejects.toThrow("OWNER_HANDOFF_REQUEST_EXPIRED_OR_CLOCK_INVALID");
+    expect(input.signAuthorization).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["", "line\r\nbreak", "has space", "\u007f", "é", "a".repeat(8_193)])(
+    "rejects an unsafe or oversized opaque signature (case %#)", async (signature) => {
+      const input = { ...signInput(), signAuthorization: vi.fn(async () => ({ signature })) };
+      await expect(signReviewedPrivyPolicyOwnerRequest(input))
+        .rejects.toThrow("OWNER_HANDOFF_SIGNATURE_BINDING_INVALID");
+    },
+  );
+
+  it("accepts the documented maximum safe opaque signature without rewriting it", async () => {
+    const signature = "a".repeat(8_192);
+    const input = { ...signInput(), signAuthorization: vi.fn(async () => ({ signature })) };
+    const result = JSON.parse(await signReviewedPrivyPolicyOwnerRequest(input));
+    expect(result.authorizationSignature).toBe(signature);
+  });
+
+  it("does not expose raw provider errors or request/session material in UI errors", () => {
+    const sensitive = "test-only-session-token-and-request";
+    for (const error of [new Error(sensitive), { message: sensitive }, sensitive, new Error(`OWNER_HANDOFF_${sensitive}`)]) {
+      const message = privyPolicyOwnerErrorMessage(error);
+      expect(message).not.toContain(sensitive);
+      expect(message).toMatch(/request|file/u);
+    }
+    expect(privyPolicyOwnerErrorMessage(new Error("OWNER_HANDOFF_REQUEST_EXPIRED_OR_CLOCK_INVALID")))
+      .toContain("fresh 30 second request");
+  });
+});


### PR DESCRIPTION
## Summary

- add an internal owner-signing page for the reviewed Robinhood V4 Privy policy handoff
- accept only the exact reconcile or rollback request bodies, with session owner binding and a 30-second expiry
- require explicit consent and export only the canonical signature artifact; no provider submission occurs in the browser

## Verification

- 41 boundary tests passed
- TypeScript program completed with zero diagnostics
- scoped ESLint completed with zero warnings or errors
- desktop and 390px mobile browser QA passed, including rejection paths and a clean console
- independent backend/frontend wire parity check passed

This PR does not sign a real request, mutate the Privy policy, or deploy production.