### PR TITLE
Provision the relay sealed-box runtime

### DIFF
--- a/.github/workflows/relay-existing-custom-launch-key.yml
+++ b/.github/workflows/relay-existing-custom-launch-key.yml
@@ -27,7 +27,7 @@ jobs:
       github.event.sender.login == 'hazarxyz' &&
       github.event.sender.id == 258789013
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 8
     environment: production
     steps:
       - name: Check out exact protected production source
@@ -39,6 +39,26 @@ jobs:
           submodules: false
           sparse-checkout: scripts/relay-existing-custom-launch-key.py
           sparse-checkout-cone-mode: false
+
+      - name: Provision the sealed-box runtime before API-key injection
+        run: |
+          set -euo pipefail
+          sudo env DEBIAN_FRONTEND=noninteractive \
+            apt-get update -qq -o Acquire::Retries=3
+          sudo env DEBIAN_FRONTEND=noninteractive \
+            apt-get install -y -qq --no-install-recommends libsodium23
+          python3 -I -B - <<'PY'
+          import ctypes
+          import ctypes.util
+
+          library = ctypes.util.find_library("sodium")
+          if not library:
+              raise SystemExit("SEALED_BOX_RUNTIME_UNAVAILABLE")
+          sodium = ctypes.CDLL(library)
+          sodium.sodium_init.restype = ctypes.c_int
+          if sodium.sodium_init() < 0:
+              raise SystemExit("SEALED_BOX_RUNTIME_UNAVAILABLE")
+          PY
 
       - name: Verify source and preinstalled sealed-box runtime without the API key
         env:


### PR DESCRIPTION
## Summary

- install Canonical's libsodium23 runtime on the pinned Ubuntu 24.04 runner
- prove the shared library initializes before the existing fail-closed preflight
- keep all runtime provisioning ahead of GitHub-token and source API-key injection

## Verification

- independent review approved with no blocking finding
- Ubuntu Noble amd64 package availability confirmed from Canonical
- 8 focused relay tests passed
- actionlint, Custom V2 workflow contract tests, and git diff checks passed
- signed commit: 129ccce72b3f1b763a1ed05cc6e2329967bcc069

The prior dispatch failed before source-secret injection and produced no relay artifact. This change does not dispatch the relay, read the source secret, install the destination secret, or deploy production.