### PR TITLE
Bind relay preflight to the full dispatch ref

### DIFF
--- a/scripts/relay-existing-custom-launch-key.py
+++ b/scripts/relay-existing-custom-launch-key.py
@@ -204,7 +204,7 @@ def verify_source(environment):
             event = strict_json(event_file.read(262145))
     finally:
         os.close(event_descriptor)
-    require(isinstance(event, dict) and event.get("ref") == "production")
+    require(isinstance(event, dict) and event.get("ref") == REF)
     require(event.get("inputs") in (None, {}))
     require(
         event.get("repository", {}).get("id") == SOURCE_REPOSITORY_ID

--- a/scripts/test/relay-existing-custom-launch-key_test.py
+++ b/scripts/test/relay-existing-custom-launch-key_test.py
@@ -3,7 +3,9 @@
 import base64
 import ctypes
 import importlib.util
+import json
 from pathlib import Path
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -116,6 +118,71 @@ class ExistingKeyRelayTest(unittest.TestCase):
             'run.get("path") in (WORKFLOW, f"{WORKFLOW}@production")', source
         )
         self.assertNotIn("endswith(", source)
+
+    def test_verify_source_accepts_only_full_dispatch_ref_before_git_or_api(self):
+        class EventAccepted(Exception):
+            pass
+
+        source = {
+            "repository": RELAY.SOURCE_REPOSITORY,
+            "repositoryId": RELAY.SOURCE_REPOSITORY_ID,
+            "environment": "production",
+            "secret": RELAY.SOURCE_SECRET,
+            "ref": RELAY.REF,
+            "commit": "a" * 40,
+            "workflow": RELAY.WORKFLOW,
+            "workflowCommit": "a" * 40,
+            "runId": "1234",
+            "runAttempt": 1,
+            "actor": "hazarxyz",
+            "actorId": "258789013",
+        }
+        event = {
+            "inputs": None,
+            "ref": RELAY.REF,
+            "repository": {
+                "id": RELAY.SOURCE_REPOSITORY_ID,
+                "full_name": RELAY.SOURCE_REPOSITORY,
+            },
+            "sender": {"login": "hazarxyz", "id": 258789013},
+            "workflow": RELAY.WORKFLOW,
+        }
+
+        with tempfile.TemporaryDirectory() as directory:
+            event_path = Path(directory) / "event.json"
+            environment = {
+                "GITHUB_WORKSPACE": directory,
+                "GITHUB_EVENT_PATH": str(event_path),
+                "GH_TOKEN": "x",
+            }
+            with patch.object(
+                RELAY, "context_from_environment", return_value=source
+            ):
+                event_path.write_text(json.dumps(event), encoding="utf-8")
+                with patch.object(
+                    RELAY.subprocess, "run", side_effect=EventAccepted
+                ) as git, patch.object(RELAY, "request_json") as request:
+                    with self.assertRaises(EventAccepted):
+                        RELAY.verify_source(environment)
+                    self.assertEqual(git.call_count, 1)
+                    request.assert_not_called()
+
+                for invalid_ref in (
+                    "production",
+                    "refs/heads/main",
+                    "refs/tags/production",
+                ):
+                    event_path.write_text(
+                        json.dumps({**event, "ref": invalid_ref}),
+                        encoding="utf-8",
+                    )
+                    with self.subTest(ref=invalid_ref), patch.object(
+                        RELAY.subprocess, "run"
+                    ) as git, patch.object(RELAY, "request_json") as request:
+                        with self.assertRaises(RELAY.RelayRejected):
+                            RELAY.verify_source(environment)
+                        git.assert_not_called()
+                        request.assert_not_called()
 
     def test_workflow_has_no_recipient_input_or_write_token(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- bind the relay event payload to GitHub’s fully qualified workflow_dispatch ref
- keep the existing fixed production ref as the sole accepted value
- prove short, mutated branch, and tag refs fail before any git or API call

## Root cause

GitHub’s workflow_dispatch payload supplies a fully qualified ref such as refs/heads/production. The relay compared that payload field to the short string production, so both prior attempts failed before HTTPS and before source-secret injection.

Official payload reference: https://github.com/octokit/webhooks/blob/7dd7fa56498a827a08b71919fae89428f5e8e283/payload-examples/api.github.com/workflow_dispatch/payload.json

## Verification

- 9 focused relay tests passed
- actionlint passed for the unchanged relay workflow
- git diff --check passed
- independent review approved

This PR does not dispatch the relay, read either secret, install a destination secret, merge production, or deploy anything.