### PR TITLE
Fix staged market observation smoke

### DIFF
--- a/scripts/smoke-static-dexscreener-public-apis.mjs
+++ b/scripts/smoke-static-dexscreener-public-apis.mjs
@@ -1073,6 +1073,9 @@ function exactVisibleMarketRead(response, tokens, nowMs) {
 
 function exactDetailMarketRead(response, token, launchSource, nowMs) {
   const provider = response.headers.get("x-programmable-market-provider");
+  const marketStatus = response.headers.get(
+    "x-programmable-market-read-status",
+  );
   const hasGmgn = token?.gmgnMarketData !== undefined;
   const gmgnQualified = qualifiedGmgnFdv(token, nowMs);
   const dexscreenerQualified = qualifiedDexscreenerFdv(token, nowMs);
@@ -1085,9 +1088,7 @@ function exactDetailMarketRead(response, token, launchSource, nowMs) {
     response.headers.get("x-programmable-launch-source") !== launchSource ||
     response.headers.get("x-programmable-read-source") !==
       `${launchSource}+${provider}` ||
-    !MARKET_READ_STATUSES.has(
-      response.headers.get("x-programmable-market-read-status"),
-    ) ||
+    !MARKET_READ_STATUSES.has(marketStatus) ||
     response.headers.get("x-programmable-market-as-of") !== marketAsOf ||
     ![gmgnQualified, dexscreenerQualified, unavailable].includes(true) ||
     (hasGmgn && !exactGmgnSnapshot(token, nowMs)) ||
@@ -1095,19 +1096,23 @@ function exactDetailMarketRead(response, token, launchSource, nowMs) {
     (provider === "gmgn" && (!gmgnQualified || hasGmgn === false)) ||
     (provider === "gmgn+dexscreener" && gmgnQualified)
   ) return false;
-  const marketSources = [
-    ...(hasGmgn ? ["gmgn"] : []),
-    ...(dexscreenerQualified ? ["dexscreener"] : []),
-  ];
-  const priceSources = [
-    ...(gmgnQualified ? ["gmgn"] : []),
-    ...(dexscreenerQualified ? ["dexscreener"] : []),
-  ];
-  return exactSourceHeader(
-    response,
-    "x-programmable-market-source",
-    marketSources,
-  ) && exactSourceHeader(
+  const marketSource = response.headers.get("x-programmable-market-source");
+  const allowedMarketSources = provider === "dexscreener"
+    ? new Set([null, "dexscreener"])
+    : provider === "gmgn"
+    ? new Set(["gmgn"])
+    : new Set([null, "gmgn", "dexscreener", "gmgn+dexscreener"]);
+  const priceSources = gmgnQualified
+    ? ["gmgn"]
+    : dexscreenerQualified
+    ? ["dexscreener"]
+    : [];
+  return (marketStatus !== "unavailable" || marketSource === null) &&
+    allowedMarketSources.has(marketSource) &&
+    (
+      priceSources.length === 0 ||
+      marketSource?.split("+").includes(priceSources[0]) === true
+    ) && exactSourceHeader(
     response,
     "x-programmable-price-source",
     priceSources,

--- a/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
+++ b/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
@@ -1007,6 +1007,7 @@ test("staged smoke rejects a detail observation outside the selected provider", 
           extraHeaders: url.pathname === "/api/explore/token"
             ? {
                 ...extraHeaders,
+                "x-programmable-market-read-status": "complete",
                 "x-programmable-market-source": "gmgn",
               }
             : extraHeaders,

--- a/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
+++ b/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
@@ -964,6 +964,89 @@ test("staged smoke accepts identity-only Explore and token responses", async () 
   assert.match(output[0][1], /detail_market_provider=dexscreener/u);
 });
 
+test("staged smoke accepts an exact detail observation without a qualified valuation", async () => {
+  const result = await runStagedStaticDexscreenerSmokeV1({
+    environment: {
+      STAGED_TARGET_URL: "https://candidate.vercel.app/",
+      VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+      PROGRAMMABLE_REQUIRE_GMGN_MARKET: "false",
+      GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+    },
+    fetchImpl: stagedFetch(
+      undefined,
+      ({ extraHeaders, omittedHeaders, url }) => ({
+        extraHeaders: url.pathname === "/api/explore/token"
+          ? {
+              ...extraHeaders,
+              "x-programmable-market-read-status": "complete",
+              "x-programmable-market-source": "dexscreener",
+            }
+          : extraHeaders,
+        omittedHeaders,
+      }),
+    ),
+    appendOutput: () => undefined,
+  });
+
+  assert.equal(result.detailMarketProvider, "dexscreener");
+  assert.equal(result.detailStatus, "verified-identity-market-unavailable");
+});
+
+test("staged smoke rejects a detail observation outside the selected provider", async () => {
+  await assert.rejects(
+    runStagedStaticDexscreenerSmokeV1({
+      environment: {
+        STAGED_TARGET_URL: "https://candidate.vercel.app/",
+        VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+        PROGRAMMABLE_REQUIRE_GMGN_MARKET: "false",
+        GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+      },
+      fetchImpl: stagedFetch(
+        undefined,
+        ({ extraHeaders, omittedHeaders, url }) => ({
+          extraHeaders: url.pathname === "/api/explore/token"
+            ? {
+                ...extraHeaders,
+                "x-programmable-market-source": "gmgn",
+              }
+            : extraHeaders,
+          omittedHeaders,
+        }),
+      ),
+      appendOutput: () => undefined,
+    }),
+    /Token detail identity or market contract is invalid/u,
+  );
+});
+
+test("staged smoke rejects a detail observation on an unavailable market read", async () => {
+  await assert.rejects(
+    runStagedStaticDexscreenerSmokeV1({
+      environment: {
+        STAGED_TARGET_URL: "https://candidate.vercel.app/",
+        VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+        PROGRAMMABLE_REQUIRE_GMGN_MARKET: "false",
+        GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+      },
+      fetchImpl: stagedFetch(
+        undefined,
+        ({ extraHeaders, omittedHeaders, url }) => ({
+          extraHeaders: url.pathname === "/api/explore/token"
+            ? {
+                ...extraHeaders,
+                "x-programmable-market-read-status": "unavailable",
+                "x-programmable-market-source": "dexscreener",
+              }
+            : extraHeaders,
+          omittedHeaders,
+        }),
+      ),
+      appendOutput: () => undefined,
+    }),
+    /Token detail identity or market contract is invalid/u,
+  );
+});
+
 test("staged smoke reports GMGN visible and detail providers dynamically", async () => {
   const output = [];
   const requests = [];
@@ -1013,7 +1096,7 @@ test("staged smoke requires a complete GMGN detail runtime read", async () => {
         PROGRAMMABLE_REQUIRE_GMGN_MARKET: "true",
         GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
       },
-      fetchImpl: gmgnStagedFetch({ detailReadStatus: "unavailable" }),
+      fetchImpl: gmgnStagedFetch({ detailReadStatus: "partial" }),
       appendOutput: () => undefined,
     }),
     /Token detail GMGN market contract is required/u,

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -666,6 +666,37 @@ describe("Token detail static identity and Dexscreener market contract", () => {
     );
   });
 
+  it("reports an exact Dexscreener observation without claiming a qualified price", async () => {
+    mocks.readDex.mockResolvedValueOnce({
+      entries: [{
+        ...entry,
+        valuation: { status: "unavailable", reason: "source-unavailable" },
+      }],
+      marketRead: {
+        ...marketRead("complete"),
+        observedCount: 1,
+        qualifiedCount: 0,
+        unavailableCount: 1,
+      },
+    });
+
+    const response = await GET(request());
+    const body = await json(response);
+    expect(response.status).toBe(200);
+    expect(body.token).toMatchObject({
+      id: entry.id,
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+    });
+    expect(response.headers.get("x-programmable-market-read-status")).toBe(
+      "complete",
+    );
+    expect(response.headers.get("x-programmable-market-source")).toBe(
+      "dexscreener",
+    );
+    expect(response.headers.get("x-programmable-price-source")).toBeNull();
+    expect(response.headers.get("x-programmable-market-as-of")).toBeNull();
+  });
+
   it("retains the identity when the market adapter unexpectedly throws", async () => {
     mocks.readDex.mockRejectedValueOnce(new Error("Dex outage"));
     const response = await GET(request());


### PR DESCRIPTION
The production-candidate smoke rejected a valid token-detail response and stopped Stage after the deployment and identity gates had passed. Dexscreener had returned an exact market observation below Programmable's valuation publication threshold, so the API correctly exposed `Market-Source: dexscreener`, omitted `Price-Source`, and kept valuation unavailable.

This change validates market observation provenance independently from qualified price provenance in the detail smoke. It keeps provider-specific source bounds, requires unavailable reads to omit market observations, and retains the exact GMGN release requirement. Regression coverage includes the observed-but-unqualified Stage response and rejects provider drift or observations on unavailable reads.

Validation:
- `node --test scripts/test/smoke-static-dexscreener-public-apis.test.mjs` (53/53)
- `npm run perf:read-model:ops-gate`
- focused data-pipeline contract suite (147 passed, 1 skipped)
- ESLint and `git diff --check`
