### PR TITLE
fix(release): preserve fresh Robinhood capture handoff

### DIFF
--- a/.github/workflows/finalize-robinhood-custom-launch-promotion.yml
+++ b/.github/workflows/finalize-robinhood-custom-launch-promotion.yml
@@ -2,12 +2,18 @@ name: Finalize Robinhood custom-launch promotion
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - production
+    paths:
+      - release/robinhood-chain-4663/backend-promotion-input.public.json
+      - release/robinhood-chain-4663/backend-promotion-input.attestation.json
 
 permissions:
   contents: read
 
 concurrency:
-  group: robinhood-custom-launch-promotion
+  group: robinhood-custom-launch-promotion-${{ github.sha }}
   cancel-in-progress: false
 
 jobs:
@@ -15,7 +21,7 @@ jobs:
     name: Authorize and attest Phase B
     if: >-
       github.repository_id == 1314365508 &&
-      github.event_name == 'workflow_dispatch' &&
+      (github.event_name == 'workflow_dispatch' || github.event_name == 'push') &&
       github.ref == 'refs/heads/production' &&
       github.ref_protected == true
     runs-on: ubuntu-latest
@@ -41,6 +47,7 @@ jobs:
       - name: Bind detached checkout to protected origin production
         env:
           GH_TOKEN: ${{ github.token }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
           askpass="$RUNNER_TEMP/programmable-git-askpass"
@@ -66,6 +73,29 @@ jobs:
           test -z "$(git symbolic-ref -q HEAD || true)"
           test "$(git remote get-url origin)" = "https://github.com/$GITHUB_REPOSITORY"
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          case "$GITHUB_EVENT_NAME" in
+            workflow_dispatch)
+              ;;
+            push)
+              [[ "$PUSH_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+              test "$PUSH_BASE_SHA" != "0000000000000000000000000000000000000000"
+              git cat-file -e "$PUSH_BASE_SHA^{commit}"
+              expected_changes=(
+                'release/robinhood-chain-4663/backend-promotion-input.attestation.json'
+                'release/robinhood-chain-4663/backend-promotion-input.public.json'
+              )
+              mapfile -t actual_changes < <(
+                git diff --no-renames --name-only "$PUSH_BASE_SHA" "$GITHUB_SHA" | LC_ALL=C sort
+              )
+              test "${#actual_changes[@]}" -eq "${#expected_changes[@]}"
+              for index in "${!expected_changes[@]}"; do
+                test "${actual_changes[$index]}" = "${expected_changes[$index]}"
+              done
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
 
       - name: Set up exact Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
@@ -103,9 +133,13 @@ jobs:
           npm ci --ignore-scripts --no-audit --no-fund
 
       # Evidence #1 and the separately attested public-safe backend handoff are
-      # landed by a reviewed evidence PR. The private backend raw capture never
-      # crosses repositories. A default public-repository GITHUB_TOKEN is not
-      # treated as authority to read the private backend repository.
+      # landed by a reviewed evidence PR. Its exact protected-production merge
+      # automatically starts this non-writing producer before the freshness
+      # window can be consumed by a second manual dispatch. Manual dispatch is
+      # retained only as a fail-closed recovery path. The private backend raw
+      # capture never crosses repositories. A default public-repository
+      # GITHUB_TOKEN is not treated as authority to read the private backend
+      # repository.
       - name: Bind exact tracked portable evidence set
         id: imported
         run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -35,6 +35,8 @@ jobs:
       indexer: ${{ steps.scope.outputs.indexer }}
       interface: ${{ steps.scope.outputs.interface }}
       read_model: ${{ steps.scope.outputs.read_model }}
+      robinhood_phase_b_evidence: ${{ steps.scope.outputs.robinhood_phase_b_evidence }}
+      robinhood_phase_b_evidence_exact: ${{ steps.scope.outputs.robinhood_phase_b_evidence_exact }}
 
     steps:
       - name: Check out complete change history
@@ -79,6 +81,10 @@ jobs:
           # changing or narrowing any trusted-base legacy result.
           if ! grep -Eq '^custom_v2=(true|false)$' "$RUNNER_TEMP/verify-scope.txt"; then
             echo 'custom_v2=true' >> "$RUNNER_TEMP/verify-scope.txt"
+          fi
+          if ! grep -Eq '^robinhood_phase_b_evidence=(true|false)$' "$RUNNER_TEMP/verify-scope.txt"; then
+            echo 'robinhood_phase_b_evidence=false' >> "$RUNNER_TEMP/verify-scope.txt"
+            echo 'robinhood_phase_b_evidence_exact=false' >> "$RUNNER_TEMP/verify-scope.txt"
           fi
           cat "$RUNNER_TEMP/verify-scope.txt" >> "$GITHUB_OUTPUT"
 
@@ -255,11 +261,15 @@ jobs:
         run: exit 1
 
       - name: Check out repository
-        if: needs.scope.outputs.contracts == 'true'
+        if: >-
+          needs.scope.outputs.contracts == 'true' ||
+          needs.scope.outputs.robinhood_phase_b_evidence == 'true'
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Set up Node.js
-        if: needs.scope.outputs.contracts == 'true'
+        if: >-
+          needs.scope.outputs.contracts == 'true' ||
+          needs.scope.outputs.robinhood_phase_b_evidence == 'true'
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24.14.0
@@ -283,6 +293,56 @@ jobs:
           npm ci
           pipx install slither-analyzer==0.11.5
 
+      - name: Reject partial or mixed Robinhood Phase B backend evidence imports
+        if: >-
+          needs.scope.outputs.robinhood_phase_b_evidence == 'true' &&
+          needs.scope.outputs.robinhood_phase_b_evidence_exact != 'true'
+        run: exit 1
+
+      - name: Install locked dependencies for exact Robinhood Phase B backend evidence
+        if: needs.scope.outputs.robinhood_phase_b_evidence_exact == 'true'
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Install exact Cosign verifier for Robinhood Phase B backend evidence
+        if: needs.scope.outputs.robinhood_phase_b_evidence_exact == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          cosign_dir="$(mktemp -d "$RUNNER_TEMP/cosign-v3.1.3.XXXXXX")"
+          chmod 0700 "$cosign_dir"
+          cosign="$cosign_dir/cosign-linux-amd64"
+          curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+            "https://github.com/sigstore/cosign/releases/download/v3.1.3/cosign-linux-amd64" \
+            --output "$cosign"
+          printf '%s  %s\n' \
+            '4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71' \
+            "$cosign" | sha256sum --check --strict
+          chmod 0700 "$cosign"
+          echo "PROGRAMMABLE_COSIGN_BIN=$cosign" >> "$GITHUB_ENV"
+
+      - name: Verify exact fresh Robinhood Phase B backend evidence
+        if: needs.scope.outputs.robinhood_phase_b_evidence_exact == 'true'
+        run: |
+          set -euo pipefail
+          for evidence_path in \
+            release/robinhood-chain-4663/backend-promotion-input.attestation.json \
+            release/robinhood-chain-4663/backend-promotion-input.public.json
+          do
+            test "$(git ls-files --stage -- "$evidence_path" | awk '{print $1}')" = "100644"
+            test -f "$evidence_path"
+            test ! -L "$evidence_path"
+            test "$(stat -c '%a' "$evidence_path")" = "644"
+          done
+          node contracts/scripts/finalize-robinhood-custom-launch-deployment.mjs \
+            verify-backend-import \
+            --stage release/robinhood-chain-4663/programmable-stage-bundle.json \
+            --backend-input release/robinhood-chain-4663/backend-promotion-input.public.json \
+            --backend-attestation-bundle \
+              release/robinhood-chain-4663/backend-promotion-input.attestation.json \
+            --repository-root "$GITHUB_WORKSPACE"
+
       - name: Verify contracts
         if: needs.scope.outputs.contracts == 'true'
         run: npm run contracts:verify:ci
@@ -300,7 +360,10 @@ jobs:
         run: npm run test:contract-release:ci
 
       - name: Skip unaffected contracts
-        if: needs.scope.result == 'success' && needs.scope.outputs.contracts != 'true'
+        if: >-
+          needs.scope.result == 'success' &&
+          needs.scope.outputs.contracts != 'true' &&
+          needs.scope.outputs.robinhood_phase_b_evidence != 'true'
         run: echo "No contract paths changed."
 
   custom-v2:

--- a/contracts/scripts/finalize-robinhood-custom-launch-deployment.mjs
+++ b/contracts/scripts/finalize-robinhood-custom-launch-deployment.mjs
@@ -108,6 +108,7 @@ function usage() {
     "  finalize-robinhood-custom-launch-deployment.mjs assemble-stage --input <path> [--output <path>] [--repository-root <path>]",
     "  finalize-robinhood-custom-launch-deployment.mjs verify-stage --stage <path> --capture <path> [--repository-root <path>]",
     "  finalize-robinhood-custom-launch-deployment.mjs stage-backend-assets --stage <path> --capture <path> --capture-attestation-bundle <path> --stage-attestation-bundle <path> --backend-service-root <path> [--repository-root <path>]",
+    "  finalize-robinhood-custom-launch-deployment.mjs verify-backend-import --stage <path> --backend-input <path> --backend-attestation-bundle <path> [--repository-root <path>]",
     "  finalize-robinhood-custom-launch-deployment.mjs authorize-backend --stage <path> --capture <path> --backend-input <path> --backend-attestation-bundle <path> [--output <path>] [--repository-root <path>]",
     "  finalize-robinhood-custom-launch-deployment.mjs promote --stage <path> --capture <path> --backend-input <path> --backend-attestation-bundle <path> --backend-authorization <path> --backend-authorization-attestation-bundle <path> [--output <path>] [--repository-root <path>]",
     "  finalize-robinhood-custom-launch-deployment.mjs verify-promotion --bundle <path> --stage <path> --capture <path> --backend-input <path> --backend-attestation-bundle <path> --backend-authorization <path> --backend-authorization-attestation-bundle <path> [--repository-root <path>]",
@@ -115,6 +116,7 @@ function usage() {
     "  finalize-robinhood-custom-launch-deployment.mjs apply --bundle <path> --stage <path> --capture <path> --backend-input <path> --backend-attestation-bundle <path> --backend-authorization <path> --backend-authorization-attestation-bundle <path> [--repository-root <path>]",
     "",
     "assemble-stage exclusively creates the closed phase-A asset handoff.",
+    "verify-backend-import performs a fresh, read-only validation of the exact public input, stage binding and protected-main Sigstore identity.",
     "promote requires the public-safe backend/Fly evidence, its portable attestation and the separately attested backend authorization.",
     "materialize-release-assets exclusively emits exact live/binding bytes to an empty external tree.",
     "apply is read-only: it fresh-rechecks L2/L1, Sourcify and backend state against landed evidence.",
@@ -124,7 +126,8 @@ function usage() {
 function parseCli(argv) {
   const [command, ...rest] = argv;
   if (!new Set([
-    "assemble-stage", "verify-stage", "stage-backend-assets", "authorize-backend", "promote",
+    "assemble-stage", "verify-stage", "stage-backend-assets", "verify-backend-import",
+    "authorize-backend", "promote",
     "verify-promotion", "materialize-release-assets", "apply",
   ]).has(command)
     || rest.length % 2 !== 0) {
@@ -158,6 +161,7 @@ function parseCli(argv) {
       "--stage", "--capture", "--capture-attestation-bundle",
       "--stage-attestation-bundle", "--backend-service-root",
     ],
+    "verify-backend-import": ["--stage", "--backend-input", "--backend-attestation-bundle"],
     "authorize-backend": ["--stage", "--capture", "--backend-input",
       "--backend-attestation-bundle"],
     promote: ["--stage", "--capture", "--backend-input", "--backend-attestation-bundle",
@@ -1306,6 +1310,58 @@ async function authorizeBackend(options, dependencies) {
   };
 }
 
+async function verifyBackendImport(options, dependencies) {
+  const [stageFile, backendInputFile, backendAttestationBundleFile] =
+    await readEvidenceSet([
+      () => readJsonPath(options.stagePath, { label: "stage bundle" }),
+      () => readJsonPath(options.backendInputPath, {
+        label: "backend promotion public input", maximumBytes: 16 * 1024 * 1024,
+      }),
+      () => readOpaquePath(options.backendAttestationBundlePath,
+        "backend portable attestation bundle"),
+    ]);
+  const backend = validateRobinhoodBackendPromotionPublicInput({
+    input: backendInputFile.value,
+    stageBundle: stageFile.value,
+    now: dependencies.backendDependencies?.now,
+  });
+  const authorizeCapture = dependencies.authorizeBackendCapture
+    ?? verifySigstoreBackendCaptureAttestation;
+  const captureResult = await authorizeCapture({
+    inputFile: backendInputFile,
+    attestationBundleFile: backendAttestationBundleFile,
+    stageBundle: stageFile.value,
+    backendReleaseEvidence: backend.backendReleaseEvidence,
+    now: dependencies.backendVerificationNow,
+  });
+  const authorization = captureResult?.authorization ?? captureResult;
+  validateRobinhoodBackendCaptureAuthorization({
+    authorization,
+    inputBytes: backendInputFile.bytes,
+    attestationBundleBytes: backendAttestationBundleFile.bytes,
+    input: backendInputFile.value,
+    allowTestOnly: dependencies.backendDependencies?.allowTestOnly === true,
+  });
+  return {
+    command: "verify-backend-import",
+    stagePath: path.resolve(options.stagePath),
+    backendInputPath: path.resolve(options.backendInputPath),
+    backendAttestationBundlePath: path.resolve(options.backendAttestationBundlePath),
+    backendPromotionPublicInputSha256: sha256Digest(backendInputFile.bytes),
+    backendPromotionPublicInputDigest: backendInputFile.value.publicInputDigest,
+    backendPromotionInputDigest:
+      backend.backendReleaseEvidence.backendPromotionInputDigest,
+    backendReleaseEvidenceDigest:
+      backend.backendReleaseEvidence.backendReleaseEvidenceDigest,
+    backendSource: structuredClone(backendInputFile.value.backendSource),
+    captureVerificationDigest: authorization.verificationDigest,
+    releaseReady: false,
+    publicAuthorization: false,
+    publicWrites: false,
+    wroteLiveArtifacts: false,
+  };
+}
+
 async function promotionSidecars(
   options,
   dependencies,
@@ -1655,6 +1711,9 @@ export async function runRobinhoodPostdeploymentCli(argv, dependencies = {}) {
   if (options.command === "verify-stage") return verifyStage(options, dependencies);
   if (options.command === "stage-backend-assets") {
     return stageBackendAssets(options, dependencies);
+  }
+  if (options.command === "verify-backend-import") {
+    return verifyBackendImport(options, dependencies);
   }
   if (options.command === "authorize-backend") return authorizeBackend(options, dependencies);
   if (options.command === "promote") return promote(options, dependencies);

--- a/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
@@ -927,6 +927,69 @@ test("legacy caller summaries and unsigned production-shaped input never become 
   }
 });
 
+test("focused backend evidence import verifies fresh exact public bytes without writing release state", async () => {
+  const fixture = await fixtureRepository();
+  try {
+    const built = await buildInput(fixture);
+    const stageResult = await runRobinhoodPostdeploymentCli([
+      "assemble-stage", "--input", built.path, "--repository-root", fixture.root,
+    ], cliDependencies(built));
+    const stage = JSON.parse(await readFile(stageResult.outputPath, "utf8"));
+    const backend = testBackendEvidence(stage);
+    const backendPath = path.join(fixture.root, ROBINHOOD_BACKEND_PROMOTION_PUBLIC_INPUT_PATH);
+    const attestationPath = path.join(fixture.root, ROBINHOOD_BACKEND_ATTESTATION_BUNDLE_PATH);
+    await mkdir(path.dirname(backendPath), { recursive: true });
+    await writeFile(backendPath, backend.inputBytes);
+    await writeFile(attestationPath, backend.attestationBundleBytes);
+    let verificationCalls = 0;
+    const dependencies = {
+      backendDependencies: backend.dependencies,
+      authorizeBackendCapture: async ({ inputFile, attestationBundleFile }) => {
+        verificationCalls += 1;
+        assert.equal(inputFile.bytes.equals(backend.inputBytes), true);
+        assert.equal(attestationBundleFile.bytes.equals(backend.attestationBundleBytes), true);
+        return backend.captureAuthorization;
+      },
+    };
+    const result = await runRobinhoodPostdeploymentCli([
+      "verify-backend-import",
+      "--stage", stageResult.outputPath,
+      "--backend-input", backendPath,
+      "--backend-attestation-bundle", attestationPath,
+      "--repository-root", fixture.root,
+    ], dependencies);
+    assert.equal(result.command, "verify-backend-import");
+    assert.equal(result.backendPromotionPublicInputSha256, sha256Digest(backend.inputBytes));
+    assert.equal(result.backendPromotionPublicInputDigest, backend.input.publicInputDigest);
+    assert.deepEqual(result.backendSource, backend.input.backendSource);
+    assert.equal(result.releaseReady, false);
+    assert.equal(result.publicAuthorization, false);
+    assert.equal(result.publicWrites, false);
+    assert.equal(result.wroteLiveArtifacts, false);
+    assert.equal(verificationCalls, 1);
+    await assert.rejects(
+      readFile(path.join(fixture.root, ROBINHOOD_BACKEND_AUTHORIZATION_PATH)),
+      /ENOENT/u,
+    );
+    await assert.rejects(() => runRobinhoodPostdeploymentCli([
+      "verify-backend-import",
+      "--stage", stageResult.outputPath,
+      "--backend-input", backendPath,
+      "--backend-attestation-bundle", attestationPath,
+      "--repository-root", fixture.root,
+    ], {
+      ...dependencies,
+      backendDependencies: {
+        ...backend.dependencies,
+        now: () => new Date("2026-08-29T12:16:01Z"),
+      },
+    }), /stale or future-dated/u);
+    assert.equal(verificationCalls, 1, "stale evidence must fail before Sigstore verification");
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("test-only Phase B remains closed and canonical apply rejects it", async () => {
   const fixture = await fixtureRepository();
   try {

--- a/docs/operations/releases/custom-launch-v4/POSTDEPLOYMENT.md
+++ b/docs/operations/releases/custom-launch-v4/POSTDEPLOYMENT.md
@@ -49,6 +49,23 @@ outside-repository artifact tree, preserves attestation bytes, and uploads the e
 public-safe handoff files. It accepts no operator-supplied trusted root and serializes no
 credentials.
 
+The backend input retains its fifteen-minute observation age and ten-minute capture-authorization
+delay; repository integration does not extend either limit. A backend evidence-import PR must
+change exactly the public input and its attestation, and nothing else. The trusted-base Verify path
+routes that exact pair through the required `Contracts` status, which installs the pinned verifier
+and freshly checks the public schema, Stage A binding, exact Sigstore subject and protected-backend
+workflow identity. A partial or mixed import fails that required status. All unrelated changes keep
+the normal full verification scope.
+
+Merging that exact two-file PR into protected `production` automatically starts the
+repository-non-writing Phase B finalizer at the merge commit. The push path rechecks that its
+complete `before..HEAD` diff is exactly the same two files before reading evidence; a manual
+dispatch remains available only as a recovery path and does not relax freshness. This removes the
+unbounded operator pause between a protected merge and Phase B without granting a workflow
+permission to commit, push, deploy, sign a wallet transaction, or place the eight output files in
+public production. The workflow still creates the bound GitHub attestations and restricted Actions
+artifact required by the later evidence PR.
+
 An authenticated Phase A bundle is always non-public:
 
 ```text
@@ -287,6 +304,17 @@ does not produce the public-safe artifact and must not be uploaded as public evi
 `authorize-backend` accepts the public-safe backend input and its portable attestation only. The
 private raw input is deliberately not a CLI argument. The production workflow also supplies all
 Phase A portable evidence shown above.
+
+Before importing, prepare the evidence branch and PR metadata against the current protected
+`production` tip. Only after every other prerequisite is ready, capture and authenticate the fresh
+backend artifact, replace the two absent evidence paths with those exact bytes, and push the exact
+two-file commit. Immediately arm the repository's existing squash auto-merge so protected
+`production` merges as soon as its five app-bound required statuses succeed; do not leave a manual
+merge pause inside the freshness window. Do not add documentation, workflow, source, generated
+output, or the private raw capture to that PR. The protected merge is the authorization event for
+the automatic finalizer; if auto-merge cannot be armed, the focused required check fails, or the
+automatic finalizer reports stale evidence, obtain a new backend capture and update the
+still-unmerged evidence PR rather than extending the time window.
 
 ```sh
 npm run contracts:robinhood:postdeploy:authorize-backend -- \

--- a/scripts/ci/classify-verify-paths.mjs
+++ b/scripts/ci/classify-verify-paths.mjs
@@ -9,7 +9,28 @@ const EMPTY_SCOPE = Object.freeze({
   indexer: false,
   interface: false,
   read_model: false,
+  robinhood_phase_b_evidence: false,
+  robinhood_phase_b_evidence_exact: false,
 });
+
+const FULL_SCOPE_KEYS = Object.freeze([
+  "contracts",
+  "custom_v2",
+  "database",
+  "dependencies",
+  "indexer",
+  "interface",
+  "read_model",
+]);
+
+export const ROBINHOOD_PHASE_B_BACKEND_EVIDENCE_PATHS = Object.freeze([
+  "release/robinhood-chain-4663/backend-promotion-input.attestation.json",
+  "release/robinhood-chain-4663/backend-promotion-input.public.json",
+]);
+
+const ROBINHOOD_PHASE_B_BACKEND_EVIDENCE_PATH_SET = new Set(
+  ROBINHOOD_PHASE_B_BACKEND_EVIDENCE_PATHS,
+);
 
 const CUSTOM_V2_EXACT_PATHS = new Set([
   "config/custom-registry-v2.deployment.prelaunch.json",
@@ -69,7 +90,7 @@ export const READ_MODEL_CONTRACT_DOC_PATHS = Object.freeze([
 ]);
 
 function markAll(scope) {
-  for (const key of Object.keys(scope)) {
+  for (const key of FULL_SCOPE_KEYS) {
     scope[key] = true;
   }
 }
@@ -92,8 +113,22 @@ export function classifyVerifyPaths(
   // This is a distinct verification intent, not a changed-path claim.
   if (customV2Release) scope.custom_v2 = true;
 
+  const uniquePaths = new Set(paths.filter(Boolean));
+  const robinhoodEvidencePaths = [...uniquePaths].filter((candidate) =>
+    ROBINHOOD_PHASE_B_BACKEND_EVIDENCE_PATH_SET.has(candidate));
+  scope.robinhood_phase_b_evidence = robinhoodEvidencePaths.length > 0;
+  scope.robinhood_phase_b_evidence_exact =
+    uniquePaths.size === ROBINHOOD_PHASE_B_BACKEND_EVIDENCE_PATHS.length
+    && robinhoodEvidencePaths.length === ROBINHOOD_PHASE_B_BACKEND_EVIDENCE_PATHS.length;
+
   for (const path of paths) {
     if (!path) continue;
+
+    // This one short-lived, cryptographically attested evidence pair has a
+    // dedicated protected Contracts check. The check rejects partial or mixed
+    // imports and verifies the exact subject, Sigstore identity, stage binding,
+    // and unchanged ten-minute authorization window before merge.
+    if (ROBINHOOD_PHASE_B_BACKEND_EVIDENCE_PATH_SET.has(path)) continue;
 
     // This closed generation-2 surface has its own production proof and
     // staged health contract. In particular, flipping the versioned Registry

--- a/scripts/ci/classify-verify-paths.test.mjs
+++ b/scripts/ci/classify-verify-paths.test.mjs
@@ -7,6 +7,7 @@ import {
   DATABASE_RUNTIME_SOURCE_PATHS,
   DATABASE_RUNTIME_TEST_PATHS,
   READ_MODEL_CONTRACT_DOC_PATHS,
+  ROBINHOOD_PHASE_B_BACKEND_EVIDENCE_PATHS,
 } from "./classify-verify-paths.mjs";
 
 const none = {
@@ -17,7 +18,40 @@ const none = {
   indexer: false,
   interface: false,
   read_model: false,
+  robinhood_phase_b_evidence: false,
+  robinhood_phase_b_evidence_exact: false,
 };
+
+test("routes only the exact Robinhood Phase B backend pair through its short-lived evidence gate", () => {
+  assert.deepEqual(classifyVerifyPaths(ROBINHOOD_PHASE_B_BACKEND_EVIDENCE_PATHS), {
+    ...none,
+    robinhood_phase_b_evidence: true,
+    robinhood_phase_b_evidence_exact: true,
+  });
+  assert.deepEqual(classifyVerifyPaths([
+    ROBINHOOD_PHASE_B_BACKEND_EVIDENCE_PATHS[0],
+  ]), {
+    ...none,
+    robinhood_phase_b_evidence: true,
+  });
+  assert.deepEqual(classifyVerifyPaths([
+    ...ROBINHOOD_PHASE_B_BACKEND_EVIDENCE_PATHS,
+    "README.md",
+  ]), {
+    ...none,
+    robinhood_phase_b_evidence: true,
+  });
+  assert.deepEqual(classifyVerifyPaths([], { forceAll: true }), {
+    ...none,
+    contracts: true,
+    custom_v2: true,
+    database: true,
+    dependencies: true,
+    indexer: true,
+    interface: true,
+    read_model: true,
+  });
+});
 
 test("routes the versioned Custom V2 surface without legacy market lanes", () => {
   for (const path of [
@@ -238,6 +272,15 @@ test("keeps protected jobs fail closed and production pushes path scoped", () =>
     /git show "\$BASE_SHA:scripts\/ci\/classify-verify-paths\.mjs"/u,
   );
   assert.doesNotMatch(workflow, /FORCE_ALL:/u);
+  assert.match(workflow, /robinhood_phase_b_evidence: \$\{\{ steps\.scope\.outputs\.robinhood_phase_b_evidence \}\}/u);
+  assert.match(workflow, /robinhood_phase_b_evidence_exact: \$\{\{ steps\.scope\.outputs\.robinhood_phase_b_evidence_exact \}\}/u);
+  assert.match(workflow, /Reject partial or mixed Robinhood Phase B backend evidence imports/u);
+  assert.match(workflow, /Install exact Cosign verifier for Robinhood Phase B backend evidence/u);
+  assert.match(workflow, /verify-backend-import/u);
+  assert.match(workflow, /4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71/u);
+  assert.match(workflow, /git ls-files --stage -- "\$evidence_path"/u);
+  assert.match(workflow, /test "\$\(stat -c '%a' "\$evidence_path"\)" = "644"/u);
+  assert.match(workflow, /needs\.scope\.outputs\.robinhood_phase_b_evidence_exact != 'true'\n        run: exit 1/u);
   assert.match(
     workflow,
     /BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \|\| github\.event\.before \}\}/u,

--- a/scripts/test/programmable-launch-release-workflow.test.mjs
+++ b/scripts/test/programmable-launch-release-workflow.test.mjs
@@ -514,6 +514,9 @@ test("Robinhood Phase A workflow contract mutations fail closed", () => {
 function robinhoodPromotionFailures(value) {
   const required = [
     "github.repository_id == 1314365508",
+    "push:",
+    "(github.event_name == 'workflow_dispatch' || github.event_name == 'push')",
+    "group: robinhood-custom-launch-promotion-${{ github.sha }}",
     "github.ref == 'refs/heads/production'",
     "github.ref_protected == true",
     "environment: production",
@@ -534,6 +537,10 @@ function robinhoodPromotionFailures(value) {
     "test \"$GITHUB_WORKFLOW_REF\" = \"$GITHUB_REPOSITORY/.github/workflows/finalize-robinhood-custom-launch-promotion.yml@$GITHUB_REF\"",
     "test -z \"$(git symbolic-ref -q HEAD || true)\"",
     "test \"$(git remote get-url origin)\" = \"https://github.com/$GITHUB_REPOSITORY\"",
+    "PUSH_BASE_SHA: ${{ github.event.before }}",
+    "git diff --no-renames --name-only \"$PUSH_BASE_SHA\" \"$GITHUB_SHA\"",
+    "test \"${#actual_changes[@]}\" -eq \"${#expected_changes[@]}\"",
+    "test \"${actual_changes[$index]}\" = \"${expected_changes[$index]}\"",
     cleanCheckoutAssertion,
     "actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444",
     "node-version: 24.14.0",
@@ -647,11 +654,20 @@ test("Robinhood Phase B workflow accepts only portable public-safe producer evid
   assert.equal(robinhoodPromotionSource.includes("actions/download-artifact@"), false);
   assert.equal(robinhoodPromotionSource.includes("inputs.phase_a_artifact"), false);
   assert.equal(robinhoodPromotionSource.includes("inputs.backend_artifact"), false);
+  assert.equal(robinhoodPromotionSource.includes("pull_request:"), false);
   assert.equal(robinhoodPromotionSource.includes("create-storage-record: false"), false);
 });
 
 test("Robinhood Phase B workflow contract mutations fail closed", () => {
   const mutations = [
+    robinhoodPromotionSource.replace(
+      "(github.event_name == 'workflow_dispatch' || github.event_name == 'push')",
+      "true",
+    ),
+    robinhoodPromotionSource.replace(
+      "group: robinhood-custom-launch-promotion-${{ github.sha }}",
+      "group: robinhood-custom-launch-promotion",
+    ),
     robinhoodPromotionSource.replace("github.ref == 'refs/heads/production'", "true"),
     robinhoodPromotionSource.replace("github.ref_protected == true", "true"),
     robinhoodPromotionSource.replace("persist-credentials: false", "persist-credentials: true"),
@@ -665,6 +681,14 @@ test("Robinhood Phase B workflow contract mutations fail closed", () => {
     ),
     robinhoodPromotionSource.replace(cleanCheckoutAssertion, "true"),
     replaceLast(robinhoodPromotionSource, cleanCheckoutAssertion, "true"),
+    robinhoodPromotionSource.replace(
+      "git diff --no-renames --name-only \"$PUSH_BASE_SHA\" \"$GITHUB_SHA\"",
+      "printf '%s\\n' \"${expected_changes[@]}\"",
+    ),
+    robinhoodPromotionSource.replace(
+      "test \"${#actual_changes[@]}\" -eq \"${#expected_changes[@]}\"",
+      "true",
+    ),
     robinhoodPromotionSource.replace("test ! -L \"$evidence_path\"", "true"),
     robinhoodPromotionSource.replace(
       "git cat-file -e \"$GITHUB_SHA:release/robinhood-chain-4663/$evidence_file\"",


### PR DESCRIPTION
Closes the Phase B timing contradiction without extending either freshness window.

- adds an exact-two-file protected PR lane for the backend public capture evidence
- keeps the 15-minute observation and 10-minute authorization bounds unchanged
- triggers the finalizer from the protected production push and binds before..SHA to those exact paths
- preserves full attestation, artifact, Cosign, Sigstore, source SHA/tree, and protected-branch checks

Validation:
- classifier/workflow tests 23/23
- Robinhood postdeployment suite 24/24
- focused import test 1/1
- ESLint, syntax, YAML, actionlint, and diff checks green
- independent review APPROVE

No deploy, public promotion, wallet signature, or onchain action is performed by this PR.