### PR TITLE
Fix empty market observation windows

### DIFF
--- a/lib/market-data/explore-market.server.ts
+++ b/lib/market-data/explore-market.server.ts
@@ -183,8 +183,8 @@ export async function readExploreMarketEntriesV1(
       fallbackRequestedCount: fallbackEntries.length,
       fallbackObservedCount,
       fallbackQualifiedCount,
-      oldestFetchedAt: sourceTimes[0] ?? null,
-      newestFetchedAt: sourceTimes.at(-1) ?? null,
+      oldestFetchedAt: observedCount === 0 ? null : sourceTimes[0] ?? null,
+      newestFetchedAt: observedCount === 0 ? null : sourceTimes.at(-1) ?? null,
     },
   };
 }

--- a/tests/explore-market-gmgn.test.ts
+++ b/tests/explore-market-gmgn.test.ts
@@ -401,6 +401,49 @@ describe("Explore GMGN primary with Dexscreener fallback", () => {
     expect(exploreMarketPriceSourcesV1(result.marketRead)).toEqual([]);
   });
 
+  it("clears the observation window when no market source observed the page", async () => {
+    const first = entry(6);
+    mocks.readGmgn.mockResolvedValue(new Map());
+    mocks.readDex.mockResolvedValueOnce({
+      entries: [{
+        ...first,
+        valuation: {
+          status: "unavailable" as const,
+          reason: "source-unavailable" as const,
+        },
+      }],
+      observedEntryIds: [],
+      marketRead: {
+        provider: "dexscreener" as const,
+        status: "complete" as const,
+        currency: "USD" as const,
+        requestedCount: 1,
+        observedCount: 0,
+        qualifiedCount: 0,
+        unavailableCount: 1,
+        oldestFetchedAt: NOW,
+        newestFetchedAt: NOW,
+      },
+    });
+
+    const result = await readExploreMarketEntriesV1([first]);
+
+    expect(result.marketRead).toMatchObject({
+      provider: "gmgn",
+      fallbackProvider: "dexscreener",
+      status: "complete",
+      requestedCount: 1,
+      observedCount: 0,
+      qualifiedCount: 0,
+      gmgnObservedCount: 0,
+      fallbackObservedCount: 0,
+      oldestFetchedAt: null,
+      newestFetchedAt: null,
+    });
+    expect(exploreMarketSourcesV1(result.marketRead)).toEqual([]);
+    expect(exploreMarketPriceSourcesV1(result.marketRead)).toEqual([]);
+  });
+
   it("reserves the request budget for the bounded batch fallback", async () => {
     const first = entry(7);
     mocks.readGmgn.mockResolvedValue(new Map());


### PR DESCRIPTION
Stage exposed a latent public market-read contract mismatch while paginating the complete 299-token Ethereum catalog. A successful Dexscreener provider attempt with no exact identity observation still contributed attempt timestamps to the GMGN-plus-fallback aggregate, so the response published a non-empty observation window alongside `observedCount: 0`. The exact release smoke correctly rejected that contradictory shape.

This PR keeps the provider result and health semantics unchanged while normalizing the public observation window to `null/null` whenever the aggregate observed count is zero. Real GMGN or exact Dexscreener observations continue to preserve their timestamps.

Validation:

- `npm test`: 5,446 passed, 33 skipped
- focused market suites: 72/72
- staged static public API smoke contract: 90/90
- read-model operations source gate: passed
- `npm run typecheck`: passed
- touched ESLint: passed
- `npm run build`: passed
- independent review: no P0/P1 findings

Stage evidence that led to this fix:

- run `33508671736`
- immutable candidate `dpl_8pB9VpF7bCdN4e428xivpiHcQgXY`
- Envio/Router catalog probe and Custom V2 gate passed
- failing page: `/api/explore?limit=100&page=2&sort=newest`
- exact mismatch: zero observations with non-null `oldestFetchedAt` and `newestFetchedAt`
