### PR TITLE
fix(web): make GMGN rank reads resilient

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -86,6 +86,10 @@ const GMGN_MARKET_CAP_HYDRATION_LIMIT = GMGN_TRENDING_MAXIMUM_LIMIT;
 const MARKET_CAP_SUPPLY_HYDRATION_LIMIT = 20;
 const MARKET_CAP_SUPPLY_HYDRATION_BUDGET_MS = 1_800;
 const GMGN_MARKET_CAP_HYDRATION_RESERVE_MS = 2_500;
+const GMGN_MARKET_CAP_RANK_REQUEST_BUDGET_MS = 2_500;
+const GMGN_MARKET_CAP_RETRY_MINIMUM_REMAINING_MS =
+  GMGN_MARKET_CAP_RANK_REQUEST_BUDGET_MS +
+  MARKET_CAP_SUPPLY_HYDRATION_BUDGET_MS + GMGN_MARKET_CAP_HYDRATION_RESERVE_MS;
 const CLASSIC_EXCLUSIONS = Object.freeze([
   "classic-v1",
   "classic-v2",
@@ -1150,17 +1154,31 @@ export async function GET(request: NextRequest) {
         "newest",
       );
       const direction = options.sort === "market-cap" ? "desc" : "asc";
+      const rankOptions = {
+        interval: "1h" as const,
+        limit: 100,
+        orderBy: "marketcap" as const,
+        direction,
+      } as const;
+      const rankWait = { signal: readSignal, deadlineMs };
       const rankRead = canonicalFilterUniverse.length === 0
         ? Promise.resolve(null)
-        : readGmgnEthereumTrendingV1({
-            interval: "1h",
-            limit: 100,
-            orderBy: "marketcap",
-            direction,
-          }, {
-            signal: readSignal,
-            deadlineMs,
-          }).catch(() => null);
+        : (async () => {
+            const first = await readGmgnEthereumTrendingV1(
+              rankOptions,
+              rankWait,
+            ).catch(() => null);
+            if (
+              first !== null ||
+              rankWait.signal.aborted ||
+              deadlineMs - Date.now() <
+                GMGN_MARKET_CAP_RETRY_MINIMUM_REMAINING_MS
+            ) return first;
+            return readGmgnEthereumTrendingV1(
+              rankOptions,
+              rankWait,
+            ).catch(() => null);
+          })();
       const [rankCandidate, searchSnapshot] = await Promise.all([
         rankRead,
         searchRead,

--- a/lib/market-data/gmgn-chart.server.ts
+++ b/lib/market-data/gmgn-chart.server.ts
@@ -30,6 +30,9 @@ import {
 
 const GMGN_API_ORIGIN = "https://openapi.gmgn.ai" as const;
 const GMGN_REQUEST_TIMEOUT_MS = 2_500;
+const GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS = 3_000;
+const GMGN_PROVIDER_LIFECYCLE_GRACE_MS =
+  GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS + 500;
 const GMGN_RESPONSE_MAXIMUM_BYTES = 1_000_000;
 const GMGN_CHART_CACHE_TTL_MS = 30_000;
 const GMGN_IDENTITY_CACHE_TTL_MS = 30_000;
@@ -182,7 +185,7 @@ export async function readGmgnMarketChartV1(
     });
     return chart;
   })();
-  const promise = settleProviderOperation(providerRead, providerWait).then(
+  const promise = settleProviderReadLifecycle(providerRead, providerWait).then(
     (settled) => {
       if (settled === PROVIDER_OPERATION_TIMED_OUT) return null;
       const chart = settled;
@@ -452,19 +455,21 @@ async function readGmgnChartIdentityProofV1(
     );
     return proof;
   })();
-  const promise = settleProviderOperation(providerRead, wait).then((settled) => {
-    if (settled === PROVIDER_OPERATION_TIMED_OUT) return null;
-    const proof = settled;
-    if (proof !== null) {
-      setCacheValue(
-        identityCache,
-        key,
-        proof,
-        wait.now().getTime() + GMGN_IDENTITY_CACHE_TTL_MS,
-      );
-    }
-    return proof;
-  }).catch(() => null).finally(() => {
+  const promise = settleProviderReadLifecycle(providerRead, wait).then(
+    (settled) => {
+      if (settled === PROVIDER_OPERATION_TIMED_OUT) return null;
+      const proof = settled;
+      if (proof !== null) {
+        setCacheValue(
+          identityCache,
+          key,
+          proof,
+          wait.now().getTime() + GMGN_IDENTITY_CACHE_TTL_MS,
+        );
+      }
+      return proof;
+    },
+  ).catch(() => null).finally(() => {
     if (identityInFlight.get(key) === promise) {
       identityInFlight.delete(key);
     }
@@ -565,7 +570,7 @@ async function gmgnJsonRequest(
   const nowMs = now().getTime();
   const remaining = requestDeadlineMs - nowMs;
   if (!Number.isFinite(remaining) || remaining <= 0) {
-    await completeProviderRequest(accountGate, reservation, wait);
+    await completeProviderRequest(accountGate, reservation);
     return null;
   }
   const url = new URL(path, GMGN_API_ORIGIN);
@@ -589,7 +594,7 @@ async function gmgnJsonRequest(
       signal: wait.signal,
     });
   } catch {
-    await completeProviderRequest(accountGate, reservation, wait);
+    await completeProviderRequest(accountGate, reservation);
     return null;
   }
   const declaredLength = Number(response.headers.get("Content-Length"));
@@ -598,16 +603,16 @@ async function gmgnJsonRequest(
     declaredLength > GMGN_RESPONSE_MAXIMUM_BYTES
   ) {
     if (response.status === 429) {
+      const responseAtMs = currentTimestampMs(now, nowMs);
       await publishProviderBlock(
         accountGate,
         reservation,
         response,
         null,
-        nowMs,
-        wait,
+        responseAtMs,
       );
     } else {
-      await completeProviderRequest(accountGate, reservation, wait);
+      await completeProviderRequest(accountGate, reservation);
     }
     return null;
   }
@@ -617,16 +622,16 @@ async function gmgnJsonRequest(
   );
   if (bytes === null) {
     if (response.status === 429) {
+      const responseAtMs = currentTimestampMs(now, nowMs);
       await publishProviderBlock(
         accountGate,
         reservation,
         response,
         null,
-        nowMs,
-        wait,
+        responseAtMs,
       );
     } else {
-      await completeProviderRequest(accountGate, reservation, wait);
+      await completeProviderRequest(accountGate, reservation);
     }
     return null;
   }
@@ -635,20 +640,21 @@ async function gmgnJsonRequest(
     text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   } catch {
     if (response.status === 429) {
+      const responseAtMs = currentTimestampMs(now, nowMs);
       await publishProviderBlock(
         accountGate,
         reservation,
         response,
         null,
-        nowMs,
-        wait,
+        responseAtMs,
       );
     } else {
-      await completeProviderRequest(accountGate, reservation, wait);
+      await completeProviderRequest(accountGate, reservation);
     }
     return null;
   }
   const value = safeJson(text);
+  const responseAtMs = currentTimestampMs(now, nowMs);
   const rateLimited = response.status === 429 || isRateLimitedEnvelope(value);
   if (rateLimited && accountGate !== null) {
     await publishProviderBlock(
@@ -656,10 +662,9 @@ async function gmgnJsonRequest(
       reservation,
       response,
       value,
-      nowMs,
-      wait,
+      responseAtMs,
     );
-  } else if (!await completeProviderRequest(accountGate, reservation, wait)) {
+  } else if (!await completeProviderRequest(accountGate, reservation)) {
     return null;
   }
   if (!response.ok || rateLimited || value === null) return null;
@@ -886,6 +891,11 @@ function readApiKey(): string | null {
   return value ? value : null;
 }
 
+function currentTimestampMs(now: () => Date, minimumMs: number): number {
+  const value = now().getTime();
+  return Number.isFinite(value) ? Math.max(minimumMs, value) : minimumMs;
+}
+
 function sharedProviderWait(
   wait: GmgnChartReadWaitV1,
 ): GmgnChartProviderReadWaitV1 {
@@ -919,7 +929,7 @@ async function settleProviderOperation<T>(
   let timer: ReturnType<typeof setTimeout> | null = null;
   let onAbort: (() => void) | null = null;
   try {
-    return await Promise.race([
+    const settled = await Promise.race([
       pending,
       new Promise<typeof PROVIDER_OPERATION_TIMED_OUT>((resolve) => {
         const timeout = () => resolve(PROVIDER_OPERATION_TIMED_OUT);
@@ -935,10 +945,45 @@ async function settleProviderOperation<T>(
         );
       }),
     ]);
+    if (settled === PROVIDER_OPERATION_TIMED_OUT) {
+      void pending.catch(() => undefined);
+    }
+    return settled;
   } finally {
     if (timer !== null) clearTimeout(timer);
     if (onAbort !== null) operation.signal.removeEventListener("abort", onAbort);
   }
+}
+
+async function settleProviderReadLifecycle<T>(
+  pending: Promise<T>,
+  requestOperation: ProviderOperationV1,
+): Promise<T | typeof PROVIDER_OPERATION_TIMED_OUT> {
+  const timely = await settleProviderOperation(pending, requestOperation);
+  if (timely !== PROVIDER_OPERATION_TIMED_OUT) return timely;
+
+  // The provider result is no longer admissible, but the singleflight remains
+  // alive while its exact database lease is released or provider-blocked.
+  await settleProviderOperation(pending, providerLifecycleOperation());
+  return PROVIDER_OPERATION_TIMED_OUT;
+}
+
+function providerLifecycleOperation(): ProviderOperationV1 {
+  const startedAtMs = Date.now();
+  return {
+    now: () => new Date(),
+    deadlineMs: startedAtMs + GMGN_PROVIDER_LIFECYCLE_GRACE_MS,
+    signal: AbortSignal.timeout(GMGN_PROVIDER_LIFECYCLE_GRACE_MS),
+  };
+}
+
+function providerOutcomeOperation(): ProviderOperationV1 {
+  const startedAtMs = Date.now();
+  return {
+    now: () => new Date(),
+    deadlineMs: startedAtMs + GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS,
+    signal: AbortSignal.timeout(GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS),
+  };
 }
 
 async function reserveProviderSlot(
@@ -949,13 +994,17 @@ async function reserveProviderSlot(
   const pending = accountGate.reserveSlot(input);
   const settled = await settleProviderOperation(pending, operation);
   if (settled !== PROVIDER_OPERATION_TIMED_OUT) return settled;
+  const lateOutcome = providerOutcomeOperation();
+  const lateDecision = await settleProviderOperation(pending, lateOutcome);
+  if (lateDecision !== PROVIDER_OPERATION_TIMED_OUT) {
+    if (lateDecision?.kind === "reserved") {
+      await completeProviderRequest(accountGate, lateDecision, lateOutcome);
+    }
+    return null;
+  }
   void pending.then(async (decision) => {
     if (decision?.kind !== "reserved") return;
-    try {
-      await accountGate.complete(decision);
-    } catch {
-      // The database retains its bounded lease when exact late cleanup fails.
-    }
+    await completeProviderRequest(accountGate, decision);
   }).catch(() => undefined);
   return null;
 }
@@ -1188,7 +1237,6 @@ async function publishProviderBlock(
   response: Response,
   envelope: unknown,
   nowMs: number,
-  operation: ProviderOperationV1,
 ): Promise<void> {
   if (accountGate === null || reservation === null) return;
   try {
@@ -1203,7 +1251,7 @@ async function publishProviderBlock(
         ? "http-429"
         : "provider-envelope",
     });
-    await settleProviderOperation(pending, operation);
+    await settleProviderOperation(pending, providerOutcomeOperation());
   } catch {
     // The read already fails soft. The shared gate will be checked again by the
     // next request rather than bypassed in this process.
@@ -1216,14 +1264,14 @@ async function completeProviderRequest(
     Awaited<ReturnType<GmgnAccountGateV1["reserveSlot"]>>,
     { kind: "reserved" }
   > | null,
-  operation: ProviderOperationV1,
+  outcomeOperation: ProviderOperationV1 = providerOutcomeOperation(),
 ): Promise<boolean> {
   if (accountGate === null) return true;
   if (reservation === null) return false;
   try {
     const settled = await settleProviderOperation(
       accountGate.complete(reservation),
-      operation,
+      outcomeOperation,
     );
     return settled !== PROVIDER_OPERATION_TIMED_OUT;
   } catch {

--- a/lib/market-data/gmgn-discovery.server.ts
+++ b/lib/market-data/gmgn-discovery.server.ts
@@ -22,6 +22,9 @@ import {
 
 const GMGN_API_ORIGIN = "https://openapi.gmgn.ai" as const;
 const GMGN_REQUEST_TIMEOUT_MS = 2_500;
+const GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS = 3_000;
+const GMGN_PROVIDER_LIFECYCLE_GRACE_MS =
+  GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS + 500;
 const GMGN_RESPONSE_MAXIMUM_BYTES = 1_000_000;
 const GMGN_DISCOVERY_CACHE_TTL_MS = 30_000;
 const GMGN_MAXIMUM_CACHE_ENTRIES = 64;
@@ -254,7 +257,7 @@ async function readThroughCache<Value>(
     const providerWait = providerWorkWait(wait);
     const operation = providerOperation(providerWait);
     const providerRead = read(providerWait);
-    const promise = settleProviderOperation(providerRead, operation).then(
+    const promise = settleProviderReadLifecycle(providerRead, operation).then(
       (settled) => settled === PROVIDER_OPERATION_TIMED_OUT ? null : settled,
     ).then((value) => {
       if (value !== null) {
@@ -312,7 +315,7 @@ async function settleProviderOperation<Value>(
   }
   let timer: ReturnType<typeof setTimeout> | null = null;
   try {
-    return await Promise.race([
+    const settled = await Promise.race([
       pending,
       new Promise<typeof PROVIDER_OPERATION_TIMED_OUT>((resolve) => {
         timer = setTimeout(
@@ -321,9 +324,45 @@ async function settleProviderOperation<Value>(
         );
       }),
     ]);
+    if (settled === PROVIDER_OPERATION_TIMED_OUT) {
+      void pending.catch(() => undefined);
+    }
+    return settled;
   } finally {
     if (timer !== null) clearTimeout(timer);
   }
+}
+
+async function settleProviderReadLifecycle<Value>(
+  pending: Promise<Value>,
+  requestOperation: ProviderOperationV1,
+): Promise<Value | typeof PROVIDER_OPERATION_TIMED_OUT> {
+  const timely = await settleProviderOperation(pending, requestOperation);
+  if (timely !== PROVIDER_OPERATION_TIMED_OUT) return timely;
+
+  // Keep the singleflight alive while a timed-out provider call finalizes its
+  // exact database lease, without accepting a late provider response.
+  await settleProviderOperation(
+    pending,
+    providerLifecycleOperation(),
+  );
+  return PROVIDER_OPERATION_TIMED_OUT;
+}
+
+function providerLifecycleOperation(): ProviderOperationV1 {
+  const startedAtMs = Date.now();
+  return Object.freeze({
+    now: () => new Date(),
+    deadlineMs: startedAtMs + GMGN_PROVIDER_LIFECYCLE_GRACE_MS,
+  });
+}
+
+function providerOutcomeOperation(): ProviderOperationV1 {
+  const startedAtMs = Date.now();
+  return Object.freeze({
+    now: () => new Date(),
+    deadlineMs: startedAtMs + GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS,
+  });
 }
 
 async function waitForCaller<Value>(
@@ -384,17 +423,20 @@ async function reserveProviderSlot(
   const pending = accountGate.reserveSlot(input);
   const settled = await settleProviderOperation(pending, operation);
   if (settled !== PROVIDER_OPERATION_TIMED_OUT) return settled;
+  const lateOutcome = providerOutcomeOperation();
+  const lateDecision = await settleProviderOperation(pending, lateOutcome);
+  if (lateDecision !== PROVIDER_OPERATION_TIMED_OUT) {
+    if (lateDecision?.kind === "reserved") {
+      await completeProviderRequest(accountGate, lateDecision, lateOutcome);
+    }
+    return null;
+  }
 
-  // A database query that ignores its AbortSignal may reserve after the local
-  // operation deadline. Release that exact late lease without allowing it to
-  // trigger a provider request or keep this singleflight pending.
+  // A gate implementation that outlives both bounded budgets must still
+  // release the exact late lease if it eventually commits.
   void pending.then(async (decision) => {
     if (decision?.kind !== "reserved") return;
-    try {
-      await accountGate.complete(decision);
-    } catch {
-      // The database gate retains its bounded five-minute lease on failure.
-    }
+    await completeProviderRequest(accountGate, decision);
   }).catch(() => undefined);
   return null;
 }
@@ -450,7 +492,7 @@ async function gmgnJsonRequest(
   const nowMs = now().getTime();
   const remainingMs = requestDeadlineMs - nowMs;
   if (!Number.isFinite(remainingMs) || remainingMs <= 0) {
-    await completeProviderRequest(accountGate, reservation, operation);
+    await completeProviderRequest(accountGate, reservation);
     return null;
   }
   const url = new URL(path, GMGN_API_ORIGIN);
@@ -482,7 +524,7 @@ async function gmgnJsonRequest(
       signal,
     });
   } catch {
-    await completeProviderRequest(accountGate, reservation, operation);
+    await completeProviderRequest(accountGate, reservation);
     return null;
   }
 
@@ -499,7 +541,6 @@ async function gmgnJsonRequest(
       response,
       null,
       responseAtMs,
-      operation,
     );
     return null;
   }
@@ -515,7 +556,6 @@ async function gmgnJsonRequest(
       response,
       null,
       responseAtMs,
-      operation,
     );
     return null;
   }
@@ -530,7 +570,6 @@ async function gmgnJsonRequest(
       response,
       null,
       responseAtMs,
-      operation,
     );
     return null;
   }
@@ -551,12 +590,10 @@ async function gmgnJsonRequest(
       response,
       envelope,
       responseAtMs,
-      operation,
     );
   } else if (!await completeProviderRequest(
     accountGate,
     reservation,
-    operation,
   )) {
     return null;
   }
@@ -585,10 +622,9 @@ async function finalizeRejectedResponse(
   response: Response,
   envelope: unknown,
   nowMs: number,
-  operation: ProviderOperationV1,
 ): Promise<void> {
   if (response.status !== 429) {
-    await completeProviderRequest(accountGate, reservation, operation);
+    await completeProviderRequest(accountGate, reservation);
     return;
   }
   const blockedUntilMs = providerCooldownFromResponse(
@@ -603,7 +639,6 @@ async function finalizeRejectedResponse(
     response,
     envelope,
     nowMs,
-    operation,
   );
 }
 
@@ -715,7 +750,6 @@ async function publishProviderBlock(
   response: Response,
   envelope: unknown,
   nowMs: number,
-  operation: ProviderOperationV1,
 ): Promise<void> {
   if (accountGate === null || reservation === null) return;
   try {
@@ -730,7 +764,7 @@ async function publishProviderBlock(
         ? "http-429"
         : "provider-envelope",
     });
-    await settleProviderOperation(pending, operation);
+    await settleProviderOperation(pending, providerOutcomeOperation());
   } catch {
     // This read already fails soft. A later production request must pass the
     // shared database gate again before another provider call can occur.
@@ -743,14 +777,14 @@ async function completeProviderRequest(
     Awaited<ReturnType<GmgnAccountGateV1["reserveSlot"]>>,
     { kind: "reserved" }
   > | null,
-  operation: ProviderOperationV1,
+  outcomeOperation: ProviderOperationV1 = providerOutcomeOperation(),
 ): Promise<boolean> {
   if (accountGate === null) return true;
   if (reservation === null) return false;
   try {
     const settled = await settleProviderOperation(
       accountGate.complete(reservation),
-      operation,
+      outcomeOperation,
     );
     return settled !== PROVIDER_OPERATION_TIMED_OUT;
   } catch {

--- a/lib/market-data/gmgn-token-analytics.server.ts
+++ b/lib/market-data/gmgn-token-analytics.server.ts
@@ -37,6 +37,9 @@ import {
 
 const GMGN_API_ORIGIN = "https://openapi.gmgn.ai" as const;
 const GMGN_REQUEST_TIMEOUT_MS = 2_500;
+const GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS = 3_000;
+const GMGN_PROVIDER_LIFECYCLE_GRACE_MS =
+  GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS + 500;
 const GMGN_RESPONSE_MAXIMUM_BYTES = 1_000_000;
 const GMGN_ANALYTICS_CACHE_TTL_MS = 30_000;
 const GMGN_MAXIMUM_CACHE_ENTRIES = 512;
@@ -645,7 +648,10 @@ async function readThroughCache<T>(
   if (active) return awaitSharedReadForCaller(active, wait);
   const providerWait = sharedProviderWait(wait);
   const providerRead = read(providerWait);
-  const promise = settleProviderOperation(providerRead, providerWait).then((settled) => {
+  const promise = settleProviderReadLifecycle(
+    providerRead,
+    providerWait,
+  ).then((settled) => {
     if (settled === PROVIDER_OPERATION_TIMED_OUT) return null;
     const value = settled;
     if (value !== null) {
@@ -707,7 +713,7 @@ async function gmgnJsonRequest(
   const nowMs = now().getTime();
   const remainingMs = requestDeadlineMs - nowMs;
   if (!Number.isFinite(remainingMs) || remainingMs <= 0) {
-    await completeProviderRequest(accountGate, reservation, wait);
+    await completeProviderRequest(accountGate, reservation);
     return null;
   }
   const url = new URL(path, GMGN_API_ORIGIN);
@@ -727,7 +733,7 @@ async function gmgnJsonRequest(
       signal: wait.signal,
     });
   } catch {
-    await completeProviderRequest(accountGate, reservation, wait);
+    await completeProviderRequest(accountGate, reservation);
     return null;
   }
   const declaredLength = Number(response.headers.get("Content-Length"));
@@ -735,13 +741,13 @@ async function gmgnJsonRequest(
     Number.isFinite(declaredLength) &&
     declaredLength > GMGN_RESPONSE_MAXIMUM_BYTES
   ) {
+    const responseAtMs = currentTimestampMs(now, nowMs);
     await finalizeRejectedResponse(
       accountGate,
       reservation,
       response,
       null,
-      nowMs,
-      wait,
+      responseAtMs,
     );
     return null;
   }
@@ -750,13 +756,13 @@ async function gmgnJsonRequest(
     GMGN_RESPONSE_MAXIMUM_BYTES,
   );
   if (bytes === null) {
+    const responseAtMs = currentTimestampMs(now, nowMs);
     await finalizeRejectedResponse(
       accountGate,
       reservation,
       response,
       null,
-      nowMs,
-      wait,
+      responseAtMs,
     );
     return null;
   }
@@ -764,23 +770,24 @@ async function gmgnJsonRequest(
   try {
     text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   } catch {
+    const responseAtMs = currentTimestampMs(now, nowMs);
     await finalizeRejectedResponse(
       accountGate,
       reservation,
       response,
       null,
-      nowMs,
-      wait,
+      responseAtMs,
     );
     return null;
   }
   const envelope = safeJson(text);
+  const responseAtMs = currentTimestampMs(now, nowMs);
   const rateLimited = response.status === 429 || isRateLimitedEnvelope(envelope);
   if (rateLimited) {
     const blockedUntilMs = providerCooldownFromResponse(
       response.headers,
       envelope,
-      nowMs,
+      responseAtMs,
     );
     localBlockedUntilMs = Math.max(localBlockedUntilMs, blockedUntilMs);
     await publishProviderBlock(
@@ -788,10 +795,9 @@ async function gmgnJsonRequest(
       reservation,
       response,
       envelope,
-      nowMs,
-      wait,
+      responseAtMs,
     );
-  } else if (!await completeProviderRequest(accountGate, reservation, wait)) {
+  } else if (!await completeProviderRequest(accountGate, reservation)) {
     return null;
   }
   if (!response.ok || rateLimited || !isRecord(envelope)) return null;
@@ -811,10 +817,9 @@ async function finalizeRejectedResponse(
   response: Response,
   envelope: unknown,
   nowMs: number,
-  operation: ProviderOperationV1,
 ): Promise<void> {
   if (response.status !== 429) {
-    await completeProviderRequest(accountGate, reservation, operation);
+    await completeProviderRequest(accountGate, reservation);
     return;
   }
   const blockedUntilMs = providerCooldownFromResponse(
@@ -829,7 +834,6 @@ async function finalizeRejectedResponse(
     response,
     envelope,
     nowMs,
-    operation,
   );
 }
 
@@ -871,6 +875,11 @@ function readApiKey(): string | null {
   return value ? value : null;
 }
 
+function currentTimestampMs(now: () => Date, minimumMs: number): number {
+  const value = now().getTime();
+  return Number.isFinite(value) ? Math.max(minimumMs, value) : minimumMs;
+}
+
 function sharedProviderWait(
   wait: GmgnTokenAnalyticsReadWaitV1,
 ): GmgnTokenAnalyticsProviderReadWaitV1 {
@@ -904,7 +913,7 @@ async function settleProviderOperation<T>(
   let timer: ReturnType<typeof setTimeout> | null = null;
   let onAbort: (() => void) | null = null;
   try {
-    return await Promise.race([
+    const settled = await Promise.race([
       pending,
       new Promise<typeof PROVIDER_OPERATION_TIMED_OUT>((resolve) => {
         const timeout = () => resolve(PROVIDER_OPERATION_TIMED_OUT);
@@ -920,10 +929,45 @@ async function settleProviderOperation<T>(
         );
       }),
     ]);
+    if (settled === PROVIDER_OPERATION_TIMED_OUT) {
+      void pending.catch(() => undefined);
+    }
+    return settled;
   } finally {
     if (timer !== null) clearTimeout(timer);
     if (onAbort !== null) operation.signal.removeEventListener("abort", onAbort);
   }
+}
+
+async function settleProviderReadLifecycle<T>(
+  pending: Promise<T>,
+  requestOperation: ProviderOperationV1,
+): Promise<T | typeof PROVIDER_OPERATION_TIMED_OUT> {
+  const timely = await settleProviderOperation(pending, requestOperation);
+  if (timely !== PROVIDER_OPERATION_TIMED_OUT) return timely;
+
+  // Preserve singleflight ownership while the timed-out request finalizes its
+  // exact account lease, but never admit the late provider payload.
+  await settleProviderOperation(pending, providerLifecycleOperation());
+  return PROVIDER_OPERATION_TIMED_OUT;
+}
+
+function providerLifecycleOperation(): ProviderOperationV1 {
+  const startedAtMs = Date.now();
+  return {
+    now: () => new Date(),
+    deadlineMs: startedAtMs + GMGN_PROVIDER_LIFECYCLE_GRACE_MS,
+    signal: AbortSignal.timeout(GMGN_PROVIDER_LIFECYCLE_GRACE_MS),
+  };
+}
+
+function providerOutcomeOperation(): ProviderOperationV1 {
+  const startedAtMs = Date.now();
+  return {
+    now: () => new Date(),
+    deadlineMs: startedAtMs + GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS,
+    signal: AbortSignal.timeout(GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS),
+  };
 }
 
 async function reserveProviderSlot(
@@ -934,13 +978,17 @@ async function reserveProviderSlot(
   const pending = accountGate.reserveSlot(input);
   const settled = await settleProviderOperation(pending, operation);
   if (settled !== PROVIDER_OPERATION_TIMED_OUT) return settled;
+  const lateOutcome = providerOutcomeOperation();
+  const lateDecision = await settleProviderOperation(pending, lateOutcome);
+  if (lateDecision !== PROVIDER_OPERATION_TIMED_OUT) {
+    if (lateDecision?.kind === "reserved") {
+      await completeProviderRequest(accountGate, lateDecision, lateOutcome);
+    }
+    return null;
+  }
   void pending.then(async (decision) => {
     if (decision?.kind !== "reserved") return;
-    try {
-      await accountGate.complete(decision);
-    } catch {
-      // The database retains its bounded lease when exact late cleanup fails.
-    }
+    await completeProviderRequest(accountGate, decision);
   }).catch(() => undefined);
   return null;
 }
@@ -1046,7 +1094,6 @@ async function publishProviderBlock(
   response: Response,
   envelope: unknown,
   nowMs: number,
-  operation: ProviderOperationV1,
 ): Promise<void> {
   if (accountGate === null || reservation === null) return;
   try {
@@ -1061,7 +1108,7 @@ async function publishProviderBlock(
         ? "http-429"
         : "provider-envelope",
     });
-    await settleProviderOperation(pending, operation);
+    await settleProviderOperation(pending, providerOutcomeOperation());
   } catch {
     // The read already fails soft. A future production request must pass the
     // shared gate again before another provider request can be made.
@@ -1074,14 +1121,14 @@ async function completeProviderRequest(
     Awaited<ReturnType<GmgnAccountGateV1["reserveSlot"]>>,
     { kind: "reserved" }
   > | null,
-  operation: ProviderOperationV1,
+  outcomeOperation: ProviderOperationV1 = providerOutcomeOperation(),
 ): Promise<boolean> {
   if (accountGate === null) return true;
   if (reservation === null) return false;
   try {
     const settled = await settleProviderOperation(
       accountGate.complete(reservation),
-      operation,
+      outcomeOperation,
     );
     return settled !== PROVIDER_OPERATION_TIMED_OUT;
   } catch {

--- a/lib/market-data/gmgn.server.ts
+++ b/lib/market-data/gmgn.server.ts
@@ -24,6 +24,9 @@ import type { MarketChartIdentityV1 } from "./market-data-v1";
 
 const GMGN_API_ORIGIN = "https://openapi.gmgn.ai" as const;
 const GMGN_REQUEST_TIMEOUT_MS = 2_500;
+const GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS = 3_000;
+const GMGN_PROVIDER_LIFECYCLE_GRACE_MS =
+  GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS + 500;
 const GMGN_RESPONSE_MAXIMUM_BYTES = 1_000_000;
 const GMGN_MARKET_CACHE_TTL_MS = 30_000;
 const GMGN_MAXIMUM_CACHE_ENTRIES = 512;
@@ -178,7 +181,7 @@ export async function readGmgnMarketSnapshotV1(
     );
     return snapshot;
   })();
-  const promise = settleProviderOperation(providerRead, providerWait).then(
+  const promise = settleProviderReadLifecycle(providerRead, providerWait).then(
     (settled) => {
       if (settled === PROVIDER_OPERATION_TIMED_OUT) return null;
       const snapshot = settled;
@@ -397,7 +400,7 @@ async function gmgnJsonRequest(
   const nowMs = now().getTime();
   const remaining = requestDeadlineMs - nowMs;
   if (!Number.isFinite(remaining) || remaining <= 0) {
-    await completeProviderRequest(accountGate, reservation, wait);
+    await completeProviderRequest(accountGate, reservation);
     return null;
   }
   const url = new URL(path, GMGN_API_ORIGIN);
@@ -417,7 +420,7 @@ async function gmgnJsonRequest(
       signal: wait.signal,
     });
   } catch {
-    await completeProviderRequest(accountGate, reservation, wait);
+    await completeProviderRequest(accountGate, reservation);
     return null;
   }
   const declaredLength = Number(response.headers.get("Content-Length"));
@@ -426,16 +429,16 @@ async function gmgnJsonRequest(
     declaredLength > GMGN_RESPONSE_MAXIMUM_BYTES
   ) {
     if (response.status === 429) {
+      const responseAtMs = currentTimestampMs(now, nowMs);
       await publishProviderBlock(
         accountGate,
         reservation,
         response,
         null,
-        nowMs,
-        wait,
+        responseAtMs,
       );
     } else {
-      await completeProviderRequest(accountGate, reservation, wait);
+      await completeProviderRequest(accountGate, reservation);
     }
     return null;
   }
@@ -445,16 +448,16 @@ async function gmgnJsonRequest(
   );
   if (bytes === null) {
     if (response.status === 429) {
+      const responseAtMs = currentTimestampMs(now, nowMs);
       await publishProviderBlock(
         accountGate,
         reservation,
         response,
         null,
-        nowMs,
-        wait,
+        responseAtMs,
       );
     } else {
-      await completeProviderRequest(accountGate, reservation, wait);
+      await completeProviderRequest(accountGate, reservation);
     }
     return null;
   }
@@ -463,20 +466,21 @@ async function gmgnJsonRequest(
     text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   } catch {
     if (response.status === 429) {
+      const responseAtMs = currentTimestampMs(now, nowMs);
       await publishProviderBlock(
         accountGate,
         reservation,
         response,
         null,
-        nowMs,
-        wait,
+        responseAtMs,
       );
     } else {
-      await completeProviderRequest(accountGate, reservation, wait);
+      await completeProviderRequest(accountGate, reservation);
     }
     return null;
   }
   const value = safeJson(text);
+  const responseAtMs = currentTimestampMs(now, nowMs);
   const rateLimited = response.status === 429 || isRateLimitedEnvelope(value);
   if (rateLimited && accountGate !== null) {
     await publishProviderBlock(
@@ -484,10 +488,9 @@ async function gmgnJsonRequest(
       reservation,
       response,
       value,
-      nowMs,
-      wait,
+      responseAtMs,
     );
-  } else if (!await completeProviderRequest(accountGate, reservation, wait)) {
+  } else if (!await completeProviderRequest(accountGate, reservation)) {
     return null;
   }
   if (!response.ok || rateLimited || value === null) return null;
@@ -537,6 +540,11 @@ function readApiKey(): string | null {
   return value ? value : null;
 }
 
+function currentTimestampMs(now: () => Date, minimumMs: number): number {
+  const value = now().getTime();
+  return Number.isFinite(value) ? Math.max(minimumMs, value) : minimumMs;
+}
+
 function sharedProviderWait(wait: GmgnReadWaitV1): GmgnProviderReadWaitV1 {
   const now = wait.now ?? (() => new Date());
   const startedAtMs = now().getTime();
@@ -568,7 +576,7 @@ async function settleProviderOperation<T>(
   let timer: ReturnType<typeof setTimeout> | null = null;
   let onAbort: (() => void) | null = null;
   try {
-    return await Promise.race([
+    const settled = await Promise.race([
       pending,
       new Promise<typeof PROVIDER_OPERATION_TIMED_OUT>((resolve) => {
         const timeout = () => resolve(PROVIDER_OPERATION_TIMED_OUT);
@@ -584,10 +592,48 @@ async function settleProviderOperation<T>(
         );
       }),
     ]);
+    if (settled === PROVIDER_OPERATION_TIMED_OUT) {
+      void pending.catch(() => undefined);
+    }
+    return settled;
   } finally {
     if (timer !== null) clearTimeout(timer);
     if (onAbort !== null) operation.signal.removeEventListener("abort", onAbort);
   }
+}
+
+async function settleProviderReadLifecycle<T>(
+  pending: Promise<T>,
+  requestOperation: ProviderOperationV1,
+): Promise<T | typeof PROVIDER_OPERATION_TIMED_OUT> {
+  const timely = await settleProviderOperation(pending, requestOperation);
+  if (timely !== PROVIDER_OPERATION_TIMED_OUT) return timely;
+
+  // The fetch result is already timed out, but the singleflight remains alive
+  // while gmgnJsonRequest releases or provider-blocks its exact account lease.
+  await settleProviderOperation(
+    pending,
+    providerLifecycleOperation(),
+  );
+  return PROVIDER_OPERATION_TIMED_OUT;
+}
+
+function providerLifecycleOperation(): ProviderOperationV1 {
+  const startedAtMs = Date.now();
+  return {
+    now: () => new Date(),
+    deadlineMs: startedAtMs + GMGN_PROVIDER_LIFECYCLE_GRACE_MS,
+    signal: AbortSignal.timeout(GMGN_PROVIDER_LIFECYCLE_GRACE_MS),
+  };
+}
+
+function providerOutcomeOperation(): ProviderOperationV1 {
+  const startedAtMs = Date.now();
+  return {
+    now: () => new Date(),
+    deadlineMs: startedAtMs + GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS,
+    signal: AbortSignal.timeout(GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS),
+  };
 }
 
 async function reserveProviderSlot(
@@ -598,13 +644,17 @@ async function reserveProviderSlot(
   const pending = accountGate.reserveSlot(input);
   const settled = await settleProviderOperation(pending, operation);
   if (settled !== PROVIDER_OPERATION_TIMED_OUT) return settled;
+  const lateOutcome = providerOutcomeOperation();
+  const lateDecision = await settleProviderOperation(pending, lateOutcome);
+  if (lateDecision !== PROVIDER_OPERATION_TIMED_OUT) {
+    if (lateDecision?.kind === "reserved") {
+      await completeProviderRequest(accountGate, lateDecision, lateOutcome);
+    }
+    return null;
+  }
   void pending.then(async (decision) => {
     if (decision?.kind !== "reserved") return;
-    try {
-      await accountGate.complete(decision);
-    } catch {
-      // The database retains its bounded lease when exact late cleanup fails.
-    }
+    await completeProviderRequest(accountGate, decision);
   }).catch(() => undefined);
   return null;
 }
@@ -726,7 +776,6 @@ async function publishProviderBlock(
   response: Response,
   envelope: unknown,
   nowMs: number,
-  operation: ProviderOperationV1,
 ): Promise<void> {
   if (accountGate === null || reservation === null) return;
   try {
@@ -741,7 +790,7 @@ async function publishProviderBlock(
         ? "http-429"
         : "provider-envelope",
     });
-    await settleProviderOperation(pending, operation);
+    await settleProviderOperation(pending, providerOutcomeOperation());
   } catch {
     // The provider response already fails soft. A later production request
     // must independently pass the database gate before another provider call.
@@ -754,14 +803,14 @@ async function completeProviderRequest(
     Awaited<ReturnType<GmgnAccountGateV1["reserveSlot"]>>,
     { kind: "reserved" }
   > | null,
-  operation: ProviderOperationV1,
+  outcomeOperation: ProviderOperationV1 = providerOutcomeOperation(),
 ): Promise<boolean> {
   if (accountGate === null) return true;
   if (reservation === null) return false;
   try {
     const settled = await settleProviderOperation(
       accountGate.complete(reservation),
-      operation,
+      outcomeOperation,
     );
     return settled !== PROVIDER_OPERATION_TIMED_OUT;
   } catch {

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -610,6 +610,33 @@ const GMGN_READ_ONLY_ENDPOINT_CONTRACT = Object.freeze([
   }),
 ]);
 
+const GMGN_PROVIDER_LIFECYCLE_CONTRACT = Object.freeze([
+  Object.freeze({
+    path: "lib/market-data/gmgn.server.ts",
+    lifecycleWaits: Object.freeze(["providerWait"]),
+    normalCompletionCount: 6,
+    providerBlockCount: 4,
+  }),
+  Object.freeze({
+    path: "lib/market-data/gmgn-chart.server.ts",
+    lifecycleWaits: Object.freeze(["providerWait", "wait"]),
+    normalCompletionCount: 6,
+    providerBlockCount: 4,
+  }),
+  Object.freeze({
+    path: "lib/market-data/gmgn-token-analytics.server.ts",
+    lifecycleWaits: Object.freeze(["providerWait"]),
+    normalCompletionCount: 4,
+    providerBlockCount: 2,
+  }),
+  Object.freeze({
+    path: "lib/market-data/gmgn-discovery.server.ts",
+    lifecycleWaits: Object.freeze(["operation"]),
+    normalCompletionCount: 4,
+    providerBlockCount: 2,
+  }),
+]);
+
 const PUBLIC_WALLET_FIELDS = Object.freeze([
   "address",
   "usdValue",
@@ -908,6 +935,139 @@ function exactGmgnReadOnlyEndpointContract(sourceByPath) {
 function directCallName(value) {
   const expression = unwrapReviewedExpression(value);
   return ts.isIdentifier(expression) ? expression.text : null;
+}
+
+function compactReviewedNode(node, sourceFile) {
+  return node.getText(sourceFile).replace(/\s+/gu, "");
+}
+
+function directNamedCalls(sourceFile, name) {
+  return collectTypeScriptNodes(
+    sourceFile,
+    (node) =>
+      ts.isCallExpression(node) && directCallName(node.expression) === name,
+  ).sort(
+    (left, right) => left.getStart(sourceFile) - right.getStart(sourceFile),
+  );
+}
+
+function exactGmgnProviderLifecycleAdapterContract(sourceFile, contract) {
+  const lifecycleCalls = directNamedCalls(
+    sourceFile,
+    "settleProviderReadLifecycle",
+  );
+  const lifecycleShapes = lifecycleCalls.map((call) =>
+    call.arguments.map((argument) => compactReviewedNode(argument, sourceFile)),
+  );
+  const expectedLifecycleShapes = contract.lifecycleWaits.map((wait) => [
+    "providerRead",
+    wait,
+  ]);
+  if (!exactJson(lifecycleShapes, expectedLifecycleShapes)) return false;
+
+  const settleCalls = directNamedCalls(sourceFile, "settleProviderOperation");
+  const settleShapes = settleCalls.map((call) =>
+    call.arguments.map((argument) => compactReviewedNode(argument, sourceFile)),
+  );
+  if (
+    !exactJson(settleShapes, [
+      ["pending", "requestOperation"],
+      ["pending", "providerLifecycleOperation()"],
+      ["pending", "operation"],
+      ["pending", "lateOutcome"],
+      ["pending", "providerOutcomeOperation()"],
+      ["accountGate.complete(reservation)", "outcomeOperation"],
+    ]) ||
+    settleShapes.some(([pending]) => pending === "providerRead")
+  ) return false;
+
+  const completionShapes = directNamedCalls(
+    sourceFile,
+    "completeProviderRequest",
+  ).map((call) =>
+    JSON.stringify(
+      call.arguments.map((argument) =>
+        compactReviewedNode(argument, sourceFile)
+      ),
+    )
+  ).sort();
+  const expectedCompletionShapes = [
+    ...Array.from(
+      { length: contract.normalCompletionCount },
+      () => JSON.stringify(["accountGate", "reservation"]),
+    ),
+    JSON.stringify(["accountGate", "lateDecision", "lateOutcome"]),
+    JSON.stringify(["accountGate", "decision"]),
+  ].sort();
+  if (!exactJson(completionShapes, expectedCompletionShapes)) return false;
+
+  const providerBlockCalls = directNamedCalls(
+    sourceFile,
+    "publishProviderBlock",
+  );
+  return providerBlockCalls.length === contract.providerBlockCount &&
+    providerBlockCalls.every((call) =>
+      call.arguments.length === 5 &&
+      exactIdentifier(call.arguments[0], "accountGate") &&
+      exactIdentifier(call.arguments[1], "reservation")
+    );
+}
+
+function exactGmgnProviderLifecycleContract(sourceByPath) {
+  return GMGN_PROVIDER_LIFECYCLE_CONTRACT.every((contract) => {
+    const sourceFile = reviewedTypeScriptSource(
+      contract.path,
+      sourceByPath.get(contract.path),
+    );
+    return sourceFile !== null &&
+      exactGmgnProviderLifecycleAdapterContract(sourceFile, contract);
+  });
+}
+
+function exactExploreGmgnMarketCapRetryContract(source) {
+  const sourceFile = reviewedTypeScriptSource(
+    "app/api/explore/route.ts",
+    source,
+  );
+  if (sourceFile === null) return false;
+  const declarations = constVariableDeclarations(sourceFile);
+  const directionDeclarations = declarations.get("direction") ?? [];
+  const rankOptionsDeclarations = declarations.get("rankOptions") ?? [];
+  if (
+    directionDeclarations.length !== 1 ||
+    rankOptionsDeclarations.length !== 1 ||
+    directionDeclarations[0].initializer === undefined ||
+    compactReviewedNode(directionDeclarations[0].initializer, sourceFile) !==
+      'options.sort==="market-cap"?"desc":"asc"'
+  ) return false;
+
+  const rankOptions = unwrapReviewedExpression(
+    rankOptionsDeclarations[0].initializer,
+  );
+  if (!ts.isObjectLiteralExpression(rankOptions)) return false;
+  const directionProperties = rankOptions.properties.filter((property) =>
+    ts.isShorthandPropertyAssignment(property) &&
+    property.name.text === "direction"
+  );
+  if (directionProperties.length !== 1) return false;
+
+  const trendingCalls = directNamedCalls(
+    sourceFile,
+    "readGmgnEthereumTrendingV1",
+  );
+  const rankCalls = trendingCalls.filter((call) =>
+    call.arguments.length === 2 &&
+    exactIdentifier(call.arguments[0], "rankOptions")
+  );
+  if (
+    rankCalls.length !== 2 ||
+    rankCalls.some((call) => !exactIdentifier(call.arguments[1], "rankWait"))
+  ) return false;
+  const retryFunction = nearestFunctionLike(rankCalls[0]);
+  return retryFunction !== null &&
+    retryFunction === nearestFunctionLike(rankCalls[1]) &&
+    trendingCalls.filter((call) => nearestFunctionLike(call) === retryFunction)
+      .length === 2;
 }
 
 function nearestFunctionLike(node) {
@@ -2649,14 +2809,14 @@ export function evaluateReadModelOperationsSourceContracts(
     source("lib/market-data/gmgn-discovery-v1.ts") ?? "";
   const gmgnCanonicalRanking =
     source("lib/market-data/gmgn-canonical-ranking.ts") ?? "";
-  const gmgnReadOnlyEndpointBoundary = exactGmgnReadOnlyEndpointContract(
-    new Map([
-      ["lib/market-data/gmgn.server.ts", gmgnMarket],
-      ["lib/market-data/gmgn-chart.server.ts", gmgnChart],
-      ["lib/market-data/gmgn-token-analytics.server.ts", gmgnTokenAnalytics],
-      ["lib/market-data/gmgn-discovery.server.ts", gmgnDiscovery],
-    ]),
-  );
+  const gmgnAdapterSources = new Map([
+    ["lib/market-data/gmgn.server.ts", gmgnMarket],
+    ["lib/market-data/gmgn-chart.server.ts", gmgnChart],
+    ["lib/market-data/gmgn-token-analytics.server.ts", gmgnTokenAnalytics],
+    ["lib/market-data/gmgn-discovery.server.ts", gmgnDiscovery],
+  ]);
+  const gmgnReadOnlyEndpointBoundary =
+    exactGmgnReadOnlyEndpointContract(gmgnAdapterSources);
   const gmgnAccountGate =
     source("lib/market-data/gmgn-account-gate.server.ts") ?? "";
   const gmgnMultiflightMigration =
@@ -3044,7 +3204,31 @@ export function evaluateReadModelOperationsSourceContracts(
     primaryRpcLaunchCatalogCacheContract,
     "the dRPC launch catalog cache is commitment-bound, singleflight, fresh for less than 60 seconds, and never serves stale data",
   );
+  const gmgnProviderLifecycleContract =
+    exactGmgnProviderLifecycleContract(gmgnAdapterSources) && [
+    gmgnMarket,
+    gmgnChart,
+    gmgnTokenAnalytics,
+    gmgnDiscovery,
+  ].every((adapter) =>
+    includesEverySourceFragment(adapter, [
+      "const GMGN_REQUEST_TIMEOUT_MS = 2_500",
+      "const GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS = 3_000",
+      "const GMGN_PROVIDER_LIFECYCLE_GRACE_MS =",
+      "settleProviderReadLifecycle(",
+      "providerLifecycleOperation()",
+      "providerOutcomeOperation()",
+      "const lateOutcome = providerOutcomeOperation();",
+      "await completeProviderRequest(accountGate, lateDecision, lateOutcome);",
+      "await completeProviderRequest(accountGate, decision);",
+      "await settleProviderOperation(pending, providerOutcomeOperation());",
+      "accountGate.complete(reservation),",
+      "outcomeOperation: ProviderOperationV1 = providerOutcomeOperation()",
+    ]) && !adapter.includes("await accountGate.complete(decision);")
+  );
   const fastLanePublicProviderContract =
+    gmgnProviderLifecycleContract &&
+    exactExploreGmgnMarketCapRetryContract(publicExplore) &&
     includesEverySourceFragment(envioClassicV3Catalog, [
       "getEnvioClassicCatalogBinding()",
       "catalogBinding.releaseBinding",
@@ -3184,7 +3368,6 @@ export function evaluateReadModelOperationsSourceContracts(
       "const pending = accountGate.reserveSlot(input);",
       "const settled = await settleProviderOperation(pending, operation);",
       "void pending.then(async (decision) => {",
-      "await accountGate.complete(decision);",
       "const pending = accountGate.blockUntil({",
       "blockedUntilMs: providerCooldownFromResponse(",
       "accountGate.complete(reservation),",
@@ -3306,7 +3489,6 @@ export function evaluateReadModelOperationsSourceContracts(
       "poolAttribution: input.identityProof.poolAttribution",
       "const pending = accountGate.reserveSlot(input);",
       "void pending.then(async (decision) => {",
-      "await accountGate.complete(decision);",
       '(process.env.NODE_ENV === "production" || fetchImpl === fetch)',
       'from "./gmgn-runtime-config.server"',
       "requestsPerSecond: gmgnEffectiveRequestsPerSecondV1()",
@@ -3376,7 +3558,6 @@ export function evaluateReadModelOperationsSourceContracts(
       "if (value !== null) {",
       "const pending = accountGate.reserveSlot(input);",
       "void pending.then(async (decision) => {",
-      "await accountGate.complete(decision);",
       '(process.env.NODE_ENV === "production" || fetchImpl === fetch)',
       'from "./gmgn-runtime-config.server"',
       "requestsPerSecond: gmgnEffectiveRequestsPerSecondV1()",
@@ -3415,7 +3596,6 @@ export function evaluateReadModelOperationsSourceContracts(
       "if (value !== null) {",
       "const pending = accountGate.reserveSlot(input);",
       "void pending.then(async (decision) => {",
-      "await accountGate.complete(decision);",
       '(process.env.NODE_ENV === "production" || fetchImpl === fetch)',
       'from "./gmgn-runtime-config.server"',
       "requestsPerSecond: gmgnEffectiveRequestsPerSecondV1()",
@@ -3490,6 +3670,11 @@ export function evaluateReadModelOperationsSourceContracts(
       "envioClassicV3IdentityCommitmentV1(",
       'orderBy: "marketcap"',
       "direction,",
+      "GMGN_MARKET_CAP_RETRY_MINIMUM_REMAINING_MS",
+      "const first = await readGmgnEthereumTrendingV1(",
+      "first !== null ||",
+      "deadlineMs - Date.now() <",
+      "rankOptions,",
       "rankCanonicalExploreMarketCapEntriesWithGmgnV1(",
       "rankCanonicalExploreMarketCapPrimaryWithGmgnV1(",
       "const unobserved = primary.rows.flatMap((row) =>",

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -911,6 +911,11 @@ describe("read-model operations source contract", () => {
       '"X-Programmable-Search-Ranking-Commitment":',
       '"X-Programmable-Search-Unbound":',
     ],
+    [
+      "no bounded same-direction GMGN market-cap retry",
+      "first !== null ||",
+      "true ||",
+    ],
   ])(
     "rejects the Explore fast-lane contract with %s",
     (_label, needle, replacement) => {
@@ -925,6 +930,31 @@ describe("read-model operations source contract", () => {
       );
     },
   );
+
+  it("rejects an opposite-direction GMGN market-cap retry", () => {
+    const path = "app/api/explore/route.ts";
+    const route = readFileSync(resolve(ROOT, path), "utf8");
+    const retry =
+      "return readGmgnEthereumTrendingV1(\n" +
+      "              rankOptions,\n" +
+      "              rankWait,";
+    const oppositeDirectionRetry =
+      "return readGmgnEthereumTrendingV1(\n" +
+      "              {\n" +
+      "                ...rankOptions,\n" +
+      "                direction: direction === \"asc\" ? \"desc\" : \"asc\",\n" +
+      "              },\n" +
+      "              rankWait,";
+    expect(route).toContain(retry);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        [path]: route.replace(retry, oppositeDirectionRetry),
+      },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-public-provider-split-source-contract",
+    );
+  });
 
   it.each([
     [
@@ -1231,6 +1261,115 @@ describe("read-model operations source contract", () => {
       sourceOverrides: {
         [path]: `${source}\nfunction configuredRequestsPerSecond() { return 20; }\n`,
       },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-public-provider-split-source-contract",
+    );
+  });
+
+  it.each([
+    "lib/market-data/gmgn.server.ts",
+    "lib/market-data/gmgn-chart.server.ts",
+    "lib/market-data/gmgn-token-analytics.server.ts",
+    "lib/market-data/gmgn-discovery.server.ts",
+  ])("rejects request-budget lease cleanup restored in %s", (path) => {
+    const source = readFileSync(resolve(ROOT, path), "utf8");
+    const freshOutcome =
+      "outcomeOperation: ProviderOperationV1 = providerOutcomeOperation()";
+    expect(source).toContain(freshOutcome);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        [path]: source.replace(
+          freshOutcome,
+          "outcomeOperation: ProviderOperationV1",
+        ),
+      },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-public-provider-split-source-contract",
+    );
+  });
+
+  it.each([
+    [
+      "the market snapshot singleflight",
+      "lib/market-data/gmgn.server.ts",
+      "const promise = settleProviderReadLifecycle(providerRead, providerWait).then(",
+      "const promise = settleProviderOperation(providerRead, providerWait).then(",
+    ],
+    [
+      "the outer chart singleflight",
+      "lib/market-data/gmgn-chart.server.ts",
+      "const promise = settleProviderReadLifecycle(providerRead, providerWait).then(",
+      "const promise = settleProviderOperation(providerRead, providerWait).then(",
+    ],
+    [
+      "the chart identity-proof singleflight",
+      "lib/market-data/gmgn-chart.server.ts",
+      "const promise = settleProviderReadLifecycle(providerRead, wait).then(",
+      "const promise = settleProviderOperation(providerRead, wait).then(",
+    ],
+    [
+      "the analytics singleflight",
+      "lib/market-data/gmgn-token-analytics.server.ts",
+      "const promise = settleProviderReadLifecycle(\n" +
+        "    providerRead,\n" +
+        "    providerWait,\n" +
+        "  ).then(",
+      "const promise = settleProviderOperation(\n" +
+        "    providerRead,\n" +
+        "    providerWait,\n" +
+        "  ).then(",
+    ],
+    [
+      "the discovery singleflight",
+      "lib/market-data/gmgn-discovery.server.ts",
+      "const promise = settleProviderReadLifecycle(providerRead, operation).then(",
+      "const promise = settleProviderOperation(providerRead, operation).then(",
+    ],
+  ])("rejects the legacy request-only settle in %s", (
+    _label,
+    path,
+    lifecycle,
+    requestOnly,
+  ) => {
+    const source = readFileSync(resolve(ROOT, path), "utf8");
+    expect(source).toContain(lifecycle);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: {
+        [path]: source.replace(lifecycle, requestOnly),
+      },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-public-provider-split-source-contract",
+    );
+  });
+
+  it("rejects normal GMGN completion under the consumed request wait", () => {
+    const path = "lib/market-data/gmgn.server.ts";
+    const source = readFileSync(resolve(ROOT, path), "utf8");
+    const fresh =
+      "await completeProviderRequest(accountGate, reservation);";
+    const consumed =
+      "await completeProviderRequest(accountGate, reservation, wait);";
+    expect(source).toContain(fresh);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: { [path]: source.replace(fresh, consumed) },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-public-provider-split-source-contract",
+    );
+  });
+
+  it("rejects GMGN provider blocking under the consumed request wait", () => {
+    const path = "lib/market-data/gmgn.server.ts";
+    const source = readFileSync(resolve(ROOT, path), "utf8");
+    const fresh =
+      "await settleProviderOperation(pending, providerOutcomeOperation());";
+    const consumed = "await settleProviderOperation(pending, operation);";
+    expect(source).toContain(fresh);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: { [path]: source.replace(fresh, consumed) },
     });
     expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
       "ops-public-provider-split-source-contract",

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -1618,6 +1618,130 @@ describe("Explore static identity and Dexscreener market contract", () => {
     });
   });
 
+  it("retries one fast-null GMGN rank read in the same direction", async () => {
+    const fresh = new Date().toISOString();
+    const ascSnapshot = {
+      ...discoverySnapshot(
+        "trending",
+        [entries[1]!],
+        [],
+        { orderBy: "marketcap", direction: "asc" },
+      ),
+      fetchedAt: fresh,
+    } as const;
+    mocks.readTrending
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(ascSnapshot);
+
+    const response = await GET(
+      request("sort=market-cap-asc&page=1&limit=5"),
+    );
+    const body = await json(response);
+
+    expect(response.status).toBe(200);
+    expect(body.ranking).toMatchObject({
+      direction: "asc",
+      gmgnStatus: "partial",
+      matchedTokenCount: 1,
+    });
+    expect(mocks.readTrending).toHaveBeenCalledTimes(2);
+    expect(mocks.readTrending.mock.calls.map(([options]) => options)).toEqual([
+      {
+        interval: "1h",
+        limit: 100,
+        orderBy: "marketcap",
+        direction: "asc",
+      },
+      {
+        interval: "1h",
+        limit: 100,
+        orderBy: "marketcap",
+        direction: "asc",
+      },
+    ]);
+  });
+
+  it("retries a null GMGN rank read at most once", async () => {
+    mocks.readTrending
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    const response = await GET(
+      request("sort=market-cap&page=1&limit=5"),
+    );
+    const body = await json(response);
+
+    expect(response.status).toBe(200);
+    expect(body.ranking).toMatchObject({
+      direction: "desc",
+      gmgnStatus: "unavailable",
+    });
+    expect(mocks.readTrending).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry GMGN rank when the remaining request budget is too small", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-01T12:00:00.000Z"));
+    try {
+      mocks.readTrending
+        .mockImplementationOnce(async () => {
+          vi.setSystemTime(Date.now() + 1_201);
+          return null;
+        });
+
+      const response = await GET(
+        request("sort=market-cap&page=1&limit=5"),
+      );
+      const body = await json(response);
+
+      expect(response.status).toBe(200);
+      expect(body.ranking.gmgnStatus).toBe("unavailable");
+      expect(mocks.readTrending).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retry GMGN rank after the request signal aborts", async () => {
+    const controller = new AbortController();
+    mocks.readTrending
+      .mockImplementationOnce(async () => {
+        controller.abort();
+        return null;
+      });
+
+    const response = await GET(new NextRequest(
+      "http://localhost/api/explore?sort=market-cap-asc&page=1&limit=5",
+      { signal: controller.signal },
+    ));
+    const body = await json(response);
+
+    expect(response.status).toBe(200);
+    expect(body.ranking.gmgnStatus).toBe("unavailable");
+    expect(mocks.readTrending).toHaveBeenCalledOnce();
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it("does not retry a valid GMGN rank snapshot with zero canonical matches", async () => {
+    mocks.readTrending.mockResolvedValueOnce(discoverySnapshot(
+      "trending",
+      [],
+      ["0xffffffffffffffffffffffffffffffffffffffff"],
+      { orderBy: "marketcap", direction: "desc" },
+    ));
+
+    const response = await GET(request("sort=market-cap&page=1&limit=5"));
+    const body = await json(response);
+
+    expect(response.status).toBe(200);
+    expect(body.ranking).toMatchObject({
+      direction: "desc",
+      gmgnStatus: "unavailable",
+      matchedTokenCount: 0,
+    });
+    expect(mocks.readTrending).toHaveBeenCalledOnce();
+  });
+
   it.each(["market-cap", "market-cap-asc"] as const)(
     "retains every identity and applies launch order for zero-qualified %s",
     async (sort) => {

--- a/tests/gmgn-chart.test.ts
+++ b/tests/gmgn-chart.test.ts
@@ -286,6 +286,7 @@ describe("GMGN admitted Ethereum token-address kline adapter", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
@@ -893,6 +894,153 @@ describe("GMGN admitted Ethereum token-address kline adapter", () => {
       expect(firstSignal).toBe(secondSignal);
     },
   );
+
+  it("awaits exact lease release after the outer provider timer wins", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    const entry = token(221);
+    const reservation = {
+      kind: "reserved" as const,
+      reservedAtMs: NOW.getTime(),
+      generation: 1,
+      holder: "00000000-0000-4000-8000-000000000021",
+    };
+    let resolveComplete!: () => void;
+    const completion = new Promise<void>((resolve) => {
+      resolveComplete = resolve;
+    });
+    const complete = vi.fn((_reservation: typeof reservation) => {
+      void _reservation;
+      return completion;
+    });
+    const accountGate: GmgnAccountGateV1 = {
+      reserveSlot: vi.fn(async () => reservation),
+      blockUntil: vi.fn(),
+      complete,
+    };
+    const fetchImpl = vi.fn(() => new Promise<Response>((_resolve, reject) => {
+      setTimeout(() => {
+        reject(new DOMException("provider timed out", "AbortError"));
+      }, 2_501);
+    }));
+    let readSettled = false;
+
+    const read = readGmgnMarketChartV1({
+      entry,
+      identity: identity(entry),
+      range: "1h",
+    }, {
+      fetchImpl: fetchImpl as typeof fetch,
+      accountGate,
+      now: () => new Date(),
+    }).finally(() => {
+      readSettled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(complete).not.toHaveBeenCalled();
+    expect(readSettled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(complete).toHaveBeenCalledOnce();
+    expect(complete).toHaveBeenCalledWith(reservation);
+    expect(readSettled).toBe(false);
+
+    resolveComplete();
+    await expect(read).resolves.toBeNull();
+  });
+
+  it("awaits a deferred kline 429 block beyond the request deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    const entry = token(224);
+    const firstReservation = {
+      kind: "reserved" as const,
+      reservedAtMs: NOW.getTime(),
+      generation: 1,
+      holder: "00000000-0000-4000-8000-000000000024",
+    };
+    const secondReservation = {
+      ...firstReservation,
+      generation: 2,
+      holder: "00000000-0000-4000-8000-000000000025",
+    };
+    const blockedUntilMs = NOW.getTime() + 2_499 + 2_000;
+    const blockedResult = {
+      blockedUntilMs,
+      retryAfterMs: 2_000,
+    };
+    let resolveBlockUntil!: (value: typeof blockedResult) => void;
+    const blockOutcome = new Promise<typeof blockedResult>((resolve) => {
+      resolveBlockUntil = resolve;
+    });
+    const blockUntil = vi.fn(() => blockOutcome);
+    const complete = vi.fn(async () => undefined);
+    const accountGate: GmgnAccountGateV1 = {
+      reserveSlot: vi.fn()
+        .mockResolvedValueOnce(firstReservation)
+        .mockResolvedValueOnce(secondReservation),
+      blockUntil,
+      complete,
+    };
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/v1/token/info") {
+        return Promise.resolve(new Response(JSON.stringify({
+          code: 0,
+          data: tokenInfo(entry),
+        }), { status: 200 }));
+      }
+      return new Promise<Response>((resolve) => {
+        setTimeout(() => {
+          resolve(new Response(JSON.stringify({
+            code: 429,
+            error: "RATE_LIMIT_EXCEEDED",
+            data: {},
+          }), { status: 429 }));
+        }, 2_499);
+      });
+    });
+    let readSettled = false;
+
+    const read = readGmgnMarketChartV1({
+      entry,
+      identity: identity(entry),
+      range: "1h",
+    }, {
+      fetchImpl: fetchImpl as typeof fetch,
+      accountGate,
+      now: () => new Date(),
+    }).finally(() => {
+      readSettled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(2_499);
+    expect(blockUntil).toHaveBeenCalledOnce();
+    expect(blockUntil).toHaveBeenCalledWith({
+      reservation: secondReservation,
+      blockedUntilMs,
+      providerSignal: "http-429",
+    });
+    expect(readSettled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(2_999);
+    expect(Date.now()).toBe(NOW.getTime() + 5_498);
+    expect(readSettled).toBe(false);
+
+    resolveBlockUntil(blockedResult);
+    await expect(read).resolves.toBeNull();
+    expect(complete).toHaveBeenCalledTimes(1);
+    expect(complete).toHaveBeenCalledWith(firstReservation);
+  });
 
   it("stops before kline when GMGN returns a non-address pool locator", async () => {
     vi.stubEnv("GMGN_API_KEY", "test-server-key");

--- a/tests/gmgn-discovery.test.ts
+++ b/tests/gmgn-discovery.test.ts
@@ -1080,6 +1080,70 @@ describe("GMGN discovery server adapter", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps a timed-out provider read pending until its exact lease is released", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    let releaseComplete!: () => void;
+    const completeDeferred = new Promise<void>((resolve) => {
+      releaseComplete = resolve;
+    });
+    const reserveSlot = vi.fn(async () => RESERVATION);
+    const complete = vi.fn((_reservation: typeof RESERVATION) => {
+      void _reservation;
+      return completeDeferred;
+    });
+    const gate = {
+      reserveSlot,
+      blockUntil: vi.fn(),
+      complete,
+    } satisfies GmgnAccountGateV1;
+    let providerRejected = false;
+    const fetchImpl = vi.fn(() => new Promise<Response>((_resolve, reject) => {
+      setTimeout(() => {
+        providerRejected = true;
+        reject(new DOMException("provider request timed out", "AbortError"));
+      }, 2_501);
+    }));
+
+    const publicRead = readGmgnEthereumTrendingV1({
+      interval: "5m",
+      limit: 97,
+    }, {
+      fetchImpl: fetchImpl as typeof fetch,
+      accountGate: gate,
+      now: () => new Date(),
+      deadlineMs: NOW.getTime() + 10_000,
+    });
+    let publicReadSettled = false;
+    void publicRead.then(
+      () => {
+        publicReadSettled = true;
+      },
+      () => {
+        publicReadSettled = true;
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(reserveSlot).toHaveResolvedWith(RESERVATION);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(providerRejected).toBe(false);
+    expect(complete).not.toHaveBeenCalled();
+    expect(publicReadSettled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(providerRejected).toBe(true);
+    expect(complete).toHaveBeenCalledOnce();
+    expect(complete.mock.calls[0]?.[0]).toBe(RESERVATION);
+    expect(publicReadSettled).toBe(false);
+
+    releaseComplete();
+    await expect(publicRead).resolves.toBeNull();
+    expect(publicReadSettled).toBe(true);
+  });
+
   it("fails soft for invalid controls, envelopes, and oversized bodies", async () => {
     vi.stubEnv("GMGN_API_KEY", "test-server-key");
     const fetchImpl = vi.fn();
@@ -1143,7 +1207,7 @@ describe("GMGN discovery server adapter", () => {
       now: () => NOW,
       deadlineMs: NOW.getTime() + 5_000,
     });
-    await vi.advanceTimersByTimeAsync(2_500);
+    await vi.advanceTimersByTimeAsync(5_500);
     await expect(stalledRead).resolves.toBeNull();
     expect(reserveSlot).toHaveBeenCalledOnce();
     expect(fetchImpl).not.toHaveBeenCalled();
@@ -1180,7 +1244,7 @@ describe("GMGN discovery server adapter", () => {
       deadlineMs: NOW.getTime() + 5_000,
     });
 
-    await vi.advanceTimersByTimeAsync(2_500);
+    await vi.advanceTimersByTimeAsync(5_500);
     await expect(stalledRead).resolves.toBeNull();
     expect(reserveSlot).toHaveBeenCalledOnce();
     expect(fetchImpl).not.toHaveBeenCalled();
@@ -1289,5 +1353,86 @@ describe("GMGN discovery server adapter", () => {
     })).resolves.toBeNull();
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(reserveSlot).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a timed-out 429 read pending for its fresh gate outcome budget", async () => {
+    vi.useFakeTimers();
+    const startedAt = new Date(NOW.getTime() + 10 * 60_000);
+    vi.setSystemTime(startedAt);
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+
+    let releaseBlock!: () => void;
+    const blockDeferred = new Promise<Readonly<{
+      blockedUntilMs: number;
+      retryAfterMs: number;
+    }>>((resolve) => {
+      releaseBlock = () => resolve({
+        blockedUntilMs: startedAt.getTime() + 3_749,
+        retryAfterMs: 1_250,
+      });
+    });
+    const reserveSlot = vi.fn(async () => RESERVATION);
+    const blockUntil = vi.fn(() => blockDeferred);
+    const complete = vi.fn(async () => undefined);
+    const gate = {
+      reserveSlot,
+      blockUntil,
+      complete,
+    } satisfies GmgnAccountGateV1;
+    let providerResponded = false;
+    const fetchImpl = vi.fn(() => new Promise<Response>((resolve) => {
+      setTimeout(() => {
+        providerResponded = true;
+        resolve(new Response(JSON.stringify({
+          code: 429,
+          error: "RATE_LIMIT_EXCEEDED",
+          data: {},
+        }), {
+          status: 429,
+          headers: { "Retry-After": "1" },
+        }));
+      }, 2_499);
+    }));
+
+    const publicRead = readGmgnEthereumTrendingV1({
+      interval: "1m",
+      limit: 98,
+    }, {
+      fetchImpl: fetchImpl as typeof fetch,
+      accountGate: gate,
+      now: () => new Date(),
+      deadlineMs: startedAt.getTime() + 10_000,
+    });
+    let publicReadSettled = false;
+    void publicRead.then(
+      () => {
+        publicReadSettled = true;
+      },
+      () => {
+        publicReadSettled = true;
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(2_499);
+    expect(providerResponded).toBe(true);
+    expect(blockUntil).toHaveBeenCalledOnce();
+    expect(blockUntil).toHaveBeenCalledWith({
+      reservation: RESERVATION,
+      blockedUntilMs: startedAt.getTime() + 3_749,
+      providerSignal: "http-429",
+    });
+    expect(publicReadSettled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(publicReadSettled).toBe(false);
+    await vi.advanceTimersByTimeAsync(2_998);
+    expect(publicReadSettled).toBe(false);
+    expect(complete).not.toHaveBeenCalled();
+
+    releaseBlock();
+    await expect(publicRead).resolves.toBeNull();
+    expect(publicReadSettled).toBe(true);
   });
 });

--- a/tests/gmgn-market-data.test.ts
+++ b/tests/gmgn-market-data.test.ts
@@ -944,6 +944,155 @@ describe("GMGN canonical market enrichment", () => {
     expect(blockUntil).not.toHaveBeenCalled();
   });
 
+  it("awaits exact lease cleanup after the real provider timer expires", async () => {
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    let resolveComplete!: () => void;
+    const completion = new Promise<void>((resolve) => {
+      resolveComplete = resolve;
+    });
+    const complete = vi.fn((_reservation: typeof GATE_RESERVATION) => {
+      void _reservation;
+      return completion;
+    });
+    const reserveSlot = vi.fn(async () => GATE_RESERVATION);
+    const accountGate: GmgnAccountGateV1 = {
+      reserveSlot,
+      blockUntil: vi.fn(),
+      complete,
+    };
+    const fetchImpl = vi.fn(() => new Promise<Response>((_resolve, reject) => {
+      setTimeout(
+        () => reject(new DOMException("timed out", "AbortError")),
+        2_501,
+      );
+    }));
+
+    let readSettled = false;
+    const read = readGmgnMarketSnapshotV1(token(111), {
+      fetchImpl: fetchImpl as typeof fetch,
+      accountGate,
+    });
+    void read.then(
+      () => {
+        readSettled = true;
+      },
+      () => {
+        readSettled = true;
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(2_499);
+    expect(complete).not.toHaveBeenCalled();
+    expect(readSettled).toBe(false);
+
+    // The public request times out at 2.500 ms. The provider notices one
+    // millisecond later and begins exact lease cleanup inside lifecycle grace.
+    await vi.advanceTimersByTimeAsync(2);
+    expect(complete).toHaveBeenCalledOnce();
+    expect(readSettled).toBe(false);
+
+    resolveComplete();
+    await expect(read).resolves.toBeNull();
+    expect(reserveSlot).toHaveBeenCalledOnce();
+    expect(complete).toHaveBeenCalledWith(GATE_RESERVATION);
+    expect(complete.mock.calls[0]?.[0]).toBe(GATE_RESERVATION);
+    expect(accountGate.blockUntil).not.toHaveBeenCalled();
+  });
+
+  it("bounds a provider that ignores its timeout by lifecycle grace", async () => {
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const accountGate: GmgnAccountGateV1 = {
+      reserveSlot: vi.fn(async () => GATE_RESERVATION),
+      blockUntil: vi.fn(),
+      complete: vi.fn(),
+    };
+    const fetchImpl = vi.fn(() => new Promise<Response>(() => {}));
+    let readSettled = false;
+    const read = readGmgnMarketSnapshotV1(token(112), {
+      fetchImpl: fetchImpl as typeof fetch,
+      accountGate,
+    });
+    void read.then(
+      () => {
+        readSettled = true;
+      },
+      () => {
+        readSettled = true;
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(readSettled).toBe(false);
+    await vi.advanceTimersByTimeAsync(3_499);
+    expect(readSettled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(read).resolves.toBeNull();
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(accountGate.complete).not.toHaveBeenCalled();
+  });
+
+  it("uses a fresh outcome deadline to publish a late provider 429", async () => {
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const blockedUntilMs = NOW.getTime() + 2_499 + 1_250;
+    let releaseBlock!: () => void;
+    const blockOutcome = {
+      blockedUntilMs,
+      retryAfterMs: 1_250,
+    };
+    const deferredBlock = new Promise<typeof blockOutcome>((resolve) => {
+      releaseBlock = () => resolve(blockOutcome);
+    });
+    const blockUntil = vi.fn(() => deferredBlock);
+    const accountGate: GmgnAccountGateV1 = {
+      reserveSlot: vi.fn(async () => GATE_RESERVATION),
+      blockUntil,
+      complete: vi.fn(),
+    };
+    const fetchImpl = vi.fn(() => new Promise<Response>((resolve) => {
+      setTimeout(() => resolve(new Response(JSON.stringify({
+        code: 429,
+        error: "RATE_LIMIT_EXCEEDED",
+        data: {},
+      }), { status: 429, headers: { "Retry-After": "1" } })), 2_499);
+    }));
+    let readSettled = false;
+    const read = readGmgnMarketSnapshotV1(token(113), {
+      fetchImpl: fetchImpl as typeof fetch,
+      accountGate,
+    });
+    void read.then(
+      () => {
+        readSettled = true;
+      },
+      () => {
+        readSettled = true;
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(2_499);
+    expect(blockUntil).toHaveBeenCalledOnce();
+    expect(readSettled).toBe(false);
+    await vi.advanceTimersByTimeAsync(2);
+    expect(readSettled).toBe(false);
+
+    releaseBlock();
+    await expect(read).resolves.toBeNull();
+    expect(blockUntil).toHaveBeenCalledWith({
+      reservation: GATE_RESERVATION,
+      blockedUntilMs,
+      providerSignal: "http-429",
+    });
+    expect(accountGate.complete).not.toHaveBeenCalled();
+  });
+
   it("fails soft when an errored fetch races a stale exact lease", async () => {
     vi.stubEnv("GMGN_API_KEY", "test-server-key");
     const complete = vi.fn(async () => {

--- a/tests/gmgn-token-analytics.test.ts
+++ b/tests/gmgn-token-analytics.test.ts
@@ -243,6 +243,7 @@ describe("GMGN Ethereum token analytics", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
@@ -657,6 +658,66 @@ describe("GMGN Ethereum token analytics", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps a timed-out provider read pending until its exact lease is released", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const market = identity(96);
+    const reservation = {
+      kind: "reserved" as const,
+      reservedAtMs: NOW.getTime(),
+      generation: 96,
+      holder: "00000000-0000-4000-8000-000000000096",
+    };
+    let releaseExactReservation!: () => void;
+    const exactRelease = new Promise<void>((resolve) => {
+      releaseExactReservation = resolve;
+    });
+    const complete = vi.fn((_reservation: typeof reservation) => {
+      void _reservation;
+      return exactRelease;
+    });
+    const gate: GmgnAccountGateV1 = {
+      reserveSlot: vi.fn(async () => reservation),
+      blockUntil: vi.fn(async () => ({
+        blockedUntilMs: Date.now(),
+        retryAfterMs: 0,
+      })),
+      complete,
+    };
+    const fetchImpl = vi.fn(() => new Promise<Response>((_resolve, reject) => {
+      setTimeout(
+        () => reject(new DOMException("provider request aborted", "AbortError")),
+        2_501,
+      );
+    }));
+
+    let publicReadSettled = false;
+    const publicRead = readGmgnTokenSecurityV1(market, {
+      fetchImpl: fetchImpl as typeof fetch,
+      accountGate: gate,
+      now: () => new Date(),
+    }).finally(() => {
+      publicReadSettled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(gate.complete).not.toHaveBeenCalled();
+    expect(publicReadSettled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(gate.complete).toHaveBeenCalledTimes(1);
+    expect(gate.complete).toHaveBeenCalledWith(reservation);
+    expect(complete.mock.calls[0]?.[0]).toBe(reservation);
+    expect(publicReadSettled).toBe(false);
+
+    releaseExactReservation();
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(publicRead).resolves.toBeNull();
+  });
+
   it("rejects unbounded or unknown ranking controls before any request", async () => {
     const fetchImpl = vi.fn();
     const market = identity(12);
@@ -702,5 +763,74 @@ describe("GMGN Ethereum token analytics", () => {
       { fetchImpl: secondFetch, now: () => new Date(NOW.getTime() + 1_000) },
     )).resolves.toBeNull();
     expect(secondFetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps a 429 read pending past its request deadline until the exact block is published", async () => {
+    vi.useFakeTimers();
+    const startedAt = new Date(NOW.getTime() + 120_000);
+    vi.setSystemTime(startedAt);
+    const blockedUntilMs = startedAt.getTime() + 2_499 + 1_250;
+    const market = identity(97);
+    const reservation = {
+      kind: "reserved" as const,
+      reservedAtMs: startedAt.getTime(),
+      generation: 97,
+      holder: "00000000-0000-4000-8000-000000000097",
+    };
+    let releaseExactBlock!: () => void;
+    const exactBlock = new Promise<void>((resolve) => {
+      releaseExactBlock = resolve;
+    });
+    const blockUntil = vi.fn(async () => {
+      await exactBlock;
+      return {
+        blockedUntilMs,
+        retryAfterMs: 1_250,
+      };
+    });
+    const gate: GmgnAccountGateV1 = {
+      reserveSlot: vi.fn(async () => reservation),
+      blockUntil,
+      complete: vi.fn(async () => {}),
+    };
+    const fetchImpl = vi.fn(() => new Promise<Response>((resolve) => {
+      setTimeout(() => resolve(jsonResponse({
+        code: 429,
+        error: "RATE_LIMIT_EXCEEDED",
+      }, 429, { "Retry-After": "1" })), 2_499);
+    }));
+
+    let publicReadSettled = false;
+    const publicRead = readGmgnTokenTopTradersV1(
+      market,
+      {},
+      {
+        fetchImpl: fetchImpl as typeof fetch,
+        accountGate: gate,
+        now: () => new Date(),
+      },
+    ).finally(() => {
+      publicReadSettled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(2_499);
+    expect(gate.blockUntil).toHaveBeenCalledWith({
+      reservation,
+      blockedUntilMs,
+      providerSignal: "http-429",
+    });
+    expect(gate.complete).not.toHaveBeenCalled();
+    expect(publicReadSettled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(2_900);
+    expect(publicReadSettled).toBe(false);
+
+    releaseExactBlock();
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(publicRead).resolves.toBeNull();
+    expect(blockUntil).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Timed-out GMGN reads could leave exact account-gate leases active until their five-minute expiry. A hydration burst could therefore consume every Pro-plan slot and make a later ascending market-cap read fall back even while GMGN itself was healthy. Late 429 responses also anchored cooldowns to request start, allowing the shared cooldown to expire before the response arrived.

This change keeps the public provider result bounded to 2.5 seconds while giving exact lease completion and provider-block publication a fresh, bounded outcome window. The outer singleflight waits through that lifecycle without admitting late provider data or caching it. Market-cap ranking retries one fast-null GMGN read only when the request is still active and has enough time, using the identical direction and options.

The regression suite now exercises real timeout timers, deferred exact cleanup, late 429 publication, lifecycle grace bounds, retry count, budget, abort, and same-direction behavior. The operations source contract binds every affected adapter callsite and rejects the old deadline wiring.

Validation:
- 5,480 tests passed; 33 skipped
- 469 focused GMGN/API/operations tests passed
- TypeScript and touched-file ESLint passed
- read-model operations gate passed
- production Next.js build passed
- independent P0/P1 review clean
