### PR TITLE
fix(web): make GMGN market-cap pagination durable

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { unstable_cache } from "next/cache";
 
 import {
   buildExploreDataQuality,
@@ -29,6 +28,7 @@ import {
 } from "../../../lib/market-data/gmgn-discovery.server";
 import {
   GMGN_TRENDING_MAXIMUM_LIMIT,
+  isGmgnDiscoverySnapshotV1,
   normalizeGmgnSearchQueryV1,
   type GmgnDiscoverySnapshotV1,
   type GmgnSearchSnapshotV1,
@@ -77,6 +77,17 @@ import { isCustomLaunchRegistryPublicReadEnabled } from
 import type { ExploreSort } from "../../../lib/onchain/types";
 import { canonicalSha256 } from
   "../../../lib/server/projection-target/hashing";
+import {
+  canonicalizeJson,
+  parseStrictJson,
+} from "../../../lib/server/projection-target/canonical-json";
+import {
+  EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_AGE_MS,
+  EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_BYTES,
+  exploreMarketCapAuthorityStorageCommitmentV1,
+  getProductionExploreMarketCapAuthorityStoreV1,
+  type ExploreMarketCapAuthorityCandidateV1,
+} from "../../../lib/market-data/explore-market-cap-authority.server";
 import type { ExploreEntry } from "../../../lib/tokens";
 import { tryParseViewChainId } from "../../../lib/view-chain";
 
@@ -91,11 +102,11 @@ const GMGN_MARKET_CAP_RANK_REQUEST_BUDGET_MS = 2_500;
 const GMGN_MARKET_CAP_RETRY_MINIMUM_REMAINING_MS =
   GMGN_MARKET_CAP_RANK_REQUEST_BUDGET_MS +
   MARKET_CAP_SUPPLY_HYDRATION_BUDGET_MS + GMGN_MARKET_CAP_HYDRATION_RESERVE_MS;
-const EXPLORE_MARKET_CAP_CACHE_REVALIDATE_SECONDS = 60;
-// Explore responses may spend up to 60 seconds in the public edge cache. Keep
-// both the completed composition and every provider ordering observation
-// inside the remaining 235-second origin budget of the five-minute contract.
-const EXPLORE_MARKET_CAP_CACHE_MAXIMUM_AGE_MS = 235_000;
+const MARKET_CAP_AUTHORITY_BUILD_BUDGET_MS = FAST_LANE_REQUEST_BUDGET_MS;
+const MARKET_CAP_AUTHORITY_PUBLISH_RESERVE_MS = 3_000;
+const MARKET_CAP_REQUEST_BUDGET_MS = 12_000;
+const SHA256_COMMITMENT = /^sha256:[0-9a-f]{64}$/u;
+const UNSIGNED_INTEGER = /^(?:0|[1-9][0-9]*)$/u;
 const CLASSIC_EXCLUSIONS = Object.freeze([
   "classic-v1",
   "classic-v2",
@@ -141,6 +152,7 @@ const EXPLORE_QUERY_PARAMETERS = new Set([
   "model",
   "page",
   "q",
+  "rankingCommitment",
   "socials",
   "sort",
 ]);
@@ -738,6 +750,22 @@ function marketCapAppliedV1(input: Readonly<{
   return "launch-order";
 }
 
+function marketCapRankingIdentityCommitmentV1(
+  orderedEntries: readonly ExploreEntry[],
+  direction: "asc" | "desc",
+): `sha256:${string}` {
+  return canonicalSha256(
+    "programmable.explore-market-cap-ranking-identity-commitment.v1",
+    {
+      direction,
+      orderedCanonicalEntries: orderedEntries.map((entry, index) => ({
+        index,
+        ...exactOrderedMarketIdentityV1(entry),
+      })),
+    },
+  );
+}
+
 export function exploreMarketCapRankingV1(
   canonicalEntries: readonly ExploreEntry[],
   snapshot: GmgnDiscoverySnapshotV1 | null,
@@ -780,28 +808,9 @@ export function exploreMarketCapRankingV1(
     : hybrid.fallbackQualifiedEntryCount > 0
       ? "dexscreener" as const
       : "canonical-launch-order" as const;
-  const rankingCommitment = canonicalSha256(
-    "programmable.explore-market-cap-ranking-commitment.v1",
-    {
-      direction,
-      gmgnSnapshot: snapshot === null || coverage.gmgnSnapshotCount === 0
-        ? null
-        : {
-            interval: snapshot.interval,
-            orderBy: snapshot.orderBy,
-            direction: snapshot.direction,
-            requestedLimit: snapshot.requestedLimit,
-            fetchedAt: snapshot.fetchedAt,
-          },
-      orderedCanonicalEntries: hybrid.rows.map((row, index) => ({
-        index,
-        id: row.entry.id,
-        tokenAddress: row.tokenAddress,
-        source: row.orderingSource,
-        valueWad: row.orderingValueWad,
-        asOfTime: row.orderingAsOfTime,
-      })),
-    },
+  const rankingCommitment = marketCapRankingIdentityCommitmentV1(
+    hybrid.entries,
+    direction,
   );
   return {
     orderedEntries: hybrid.entries,
@@ -859,44 +868,550 @@ export function exploreMarketCapRankingV1(
   };
 }
 
-type CachedExploreMarketCapCompositionV1 = Readonly<{
-  schemaVersion: "programmable.explore-market-cap-composition.v1";
+type ExactOrderedMarketIdentityV1 = Readonly<{
+  id: string;
+  tokenAddress: string | null;
+  marketIdentities: ReturnType<typeof exploreEntryMarketIdentitiesV1>;
+}>;
+
+type ExploreMarketCapProviderEvidenceV1 = Readonly<{
+  id: string;
+  valueWad: string | null;
+  asOfTime: string | null;
+}>;
+
+type ExploreMarketCapFilterFacetV1 = Readonly<{
+  id: string;
+  name: string;
+  symbol: string | null;
+  modelId: string | null;
+  category: "classic" | "custom";
+  hasSocials: boolean;
+}>;
+
+type ExploreMarketCapAuthorityV1 = Readonly<{
+  schemaVersion: "programmable.explore-market-cap-authority.v2";
   inputCommitment: `sha256:${string}`;
   direction: "asc" | "desc";
-  assembledAt: string;
-  orderedEntryIds: readonly string[];
-  orderingAsOfTimes: readonly (string | null)[];
+  generatedAt: string;
+  rankSnapshot: GmgnDiscoverySnapshotV1 | null;
+  filterFacets: readonly ExploreMarketCapFilterFacetV1[];
+  gmgnHydrationEligibleEntryIds: readonly string[];
+  gmgnRequestedEntryIds: readonly string[];
+  gmgnEvidence: readonly ExploreMarketCapProviderEvidenceV1[];
+  dexscreenerRequestedEntryIds: readonly string[];
+  dexscreenerEvidence: readonly ExploreMarketCapProviderEvidenceV1[];
+  orderedIdentities: readonly ExactOrderedMarketIdentityV1[];
   ranking: ExploreMarketCapRankingV1;
 }>;
 
-function exploreMarketCapCompositionInputCommitmentV1(
-  entries: readonly ExploreEntry[],
+function exactOrderedMarketIdentityV1(
+  entry: ExploreEntry,
+): ExactOrderedMarketIdentityV1 {
+  return Object.freeze({
+    id: entry.id,
+    tokenAddress: entry.tokenAddress?.toLowerCase() ?? null,
+    marketIdentities: Object.freeze(
+      exploreEntryMarketIdentitiesV1(entry).map((identity) =>
+        Object.freeze({ ...identity })
+      ),
+    ),
+  });
+}
+
+function exploreMarketCapFilterFacetV1(
+  entry: ExploreEntry,
+): ExploreMarketCapFilterFacetV1 {
+  const category = entry.launchCategoryProvenance.category;
+  return Object.freeze({
+    id: entry.id,
+    name: entry.name,
+    symbol: entry.symbol ?? null,
+    modelId: entry.exploreKind === "custom-project" ? entry.modelId : null,
+    category: category === "classic" || category === "custom"
+      ? category
+      : entry.exploreKind === "custom-project" ? "custom" : "classic",
+    hasSocials: entry.links?.some(
+      (link) => link.kind === "x" || link.kind === "telegram",
+    ) ?? false,
+  });
+}
+
+function marketCapAuthorityPinCommitmentV1(
+  orderedEntries: readonly ExploreEntry[],
+  filterFacets: readonly ExploreMarketCapFilterFacetV1[],
   direction: "asc" | "desc",
-): `sha256:${string}` {
+): `sha256:${string}` | null {
+  const facetsById = new Map(
+    filterFacets.map((facet) => [facet.id, facet] as const),
+  );
+  if (
+    facetsById.size !== filterFacets.length ||
+    orderedEntries.length !== filterFacets.length
+  ) return null;
+  const orderedCanonicalEntries = orderedEntries.flatMap((entry, index) => {
+    const filterFacet = facetsById.get(entry.id);
+    return filterFacet === undefined
+      ? []
+      : [{
+          index,
+          identity: exactOrderedMarketIdentityV1(entry),
+          filterFacet,
+        }];
+  });
+  if (orderedCanonicalEntries.length !== orderedEntries.length) return null;
   return canonicalSha256(
-    "programmable.explore-market-cap-composition-input.v1",
-    { direction, entries },
+    "programmable.explore-market-cap-authority-pin.v2",
+    { direction, orderedCanonicalEntries },
   );
 }
 
-async function assembleExploreMarketCapCompositionV1(
-  filteredNewest: readonly ExploreEntry[],
-  direction: "asc" | "desc",
-): Promise<Readonly<{
+function exploreMarketCapAuthorityInputCommitmentV1(
+  entries: readonly ExploreEntry[],
+): `sha256:${string}` {
+  return canonicalSha256(
+    "programmable.explore-market-cap-authority-input.v2",
+    {
+      orderedCanonicalIdentities: entries.map((entry, index) => ({
+        index,
+        ...exactOrderedMarketIdentityV1(entry),
+      })),
+    },
+  );
+}
+
+function currentMarketCapAuthorityTimestampV1(
+  value: string,
+  nowMs: number,
+): boolean {
+  const timestampMs = Date.parse(value);
+  return Number.isFinite(timestampMs) &&
+    new Date(timestampMs).toISOString() === value &&
+    Number.isFinite(nowMs) && timestampMs <= nowMs &&
+    nowMs - timestampMs <= EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_AGE_MS;
+}
+
+function valuedEntryProviderTimeV1(
+  entry: ValuedExploreEntry,
+): string | null {
+  if (
+    entry.valuation.status === "available" &&
+      typeof entry.valuation.asOfTime === "string"
+  ) return entry.valuation.asOfTime;
+  return typeof entry.gmgnMarketData?.fetchedAt === "string"
+    ? entry.gmgnMarketData.fetchedAt
+    : null;
+}
+
+function exactEntryMapV1(
+  entries: readonly ExploreEntry[],
+): ReadonlyMap<string, ExploreEntry> | null {
+  const byId = new Map<string, ExploreEntry>();
+  for (const entry of entries) {
+    if (byId.has(entry.id)) return null;
+    byId.set(entry.id, entry);
+  }
+  return byId;
+}
+
+function exactAuthorityOrderedEntriesV1(
+  authority: ExploreMarketCapAuthorityV1,
+  canonicalEntries: readonly ExploreEntry[],
+): readonly ExploreEntry[] | null {
+  const byId = exactEntryMapV1(canonicalEntries);
+  if (byId === null || authority.orderedIdentities.length !== byId.size) {
+    return null;
+  }
+  const seen = new Set<string>();
+  const ordered: ExploreEntry[] = [];
+  for (const identity of authority.orderedIdentities) {
+    const entry = byId.get(identity.id);
+    if (
+      entry === undefined || seen.has(identity.id) ||
+      canonicalizeJson(identity) !==
+        canonicalizeJson(exactOrderedMarketIdentityV1(entry))
+    ) return null;
+    seen.add(identity.id);
+    ordered.push(entry);
+  }
+  return seen.size === byId.size ? Object.freeze(ordered) : null;
+}
+
+function exactStringIdsV1(
+  values: readonly string[],
+  canonicalById: ReadonlyMap<string, ExploreEntry>,
+): boolean {
+  return values.length === new Set(values).size &&
+    values.every((value) => canonicalById.has(value));
+}
+
+function compactProviderEvidenceV1(
+  entries: readonly ValuedExploreEntry[],
+  provider: "gmgn" | "dexscreener",
+  now: Date,
+): readonly ExploreMarketCapProviderEvidenceV1[] {
+  const seen = new Set<string>();
+  const result: ExploreMarketCapProviderEvidenceV1[] = [];
+  for (const entry of entries) {
+    if (seen.has(entry.id)) continue;
+    const asOfTime = valuedEntryProviderTimeV1(entry);
+    const currentAsOfTime = asOfTime !== null &&
+      currentMarketCapAuthorityTimestampV1(asOfTime, now.getTime())
+      ? asOfTime
+      : null;
+    if (entry.valuation.status === "available") {
+      if (
+        entry.valuation.source !== provider ||
+        currentAsOfTime === null ||
+        !UNSIGNED_INTEGER.test(entry.valuation.valueWad) ||
+        BigInt(entry.valuation.valueWad) === 0n
+      ) continue;
+      result.push(Object.freeze({
+        id: entry.id,
+        valueWad: entry.valuation.valueWad,
+        asOfTime: currentAsOfTime,
+      }));
+    } else {
+      result.push(Object.freeze({
+        id: entry.id,
+        valueWad: null,
+        asOfTime: currentAsOfTime,
+      }));
+    }
+    seen.add(entry.id);
+  }
+  return Object.freeze(result);
+}
+
+function providerEvidenceEntriesV1(
+  evidence: readonly ExploreMarketCapProviderEvidenceV1[],
+  canonicalById: ReadonlyMap<string, ExploreEntry>,
+  provider: "gmgn" | "dexscreener",
+): readonly ValuedExploreEntry[] | null {
+  const seen = new Set<string>();
+  const result: ValuedExploreEntry[] = [];
+  for (const item of evidence) {
+    const entry = canonicalById.get(item.id);
+    if (entry === undefined || seen.has(item.id)) return null;
+    seen.add(item.id);
+    result.push(Object.freeze({
+      ...entry,
+      valuation: item.valueWad === null
+        ? Object.freeze({
+            status: "unavailable" as const,
+            reason: "source-unavailable" as const,
+          })
+        : Object.freeze({
+            status: "available" as const,
+            metric: "fdv" as const,
+            supplyBasis: "total" as const,
+            currency: "usd" as const,
+            valueWad: item.valueWad,
+            freshness: "provider-recent" as const,
+            source: provider,
+            asOfTime: item.asOfTime!,
+          }),
+    }));
+  }
+  return Object.freeze(result);
+}
+
+function entriesForExactIdsV1(
+  ids: readonly string[],
+  canonicalById: ReadonlyMap<string, ExploreEntry>,
+): readonly ExploreEntry[] | null {
+  if (!exactStringIdsV1(ids, canonicalById)) return null;
+  return Object.freeze(ids.map((id) => canonicalById.get(id)!));
+}
+
+function authorityFallbackInputV1(
+  authority: ExploreMarketCapAuthorityV1,
+  canonicalEntries: readonly ExploreEntry[],
+): Parameters<typeof rankCanonicalExploreMarketCapEntriesWithGmgnV1>[2] | null {
+  const canonicalById = exactEntryMapV1(canonicalEntries);
+  if (
+    canonicalById === null ||
+    authority.filterFacets.length !== canonicalById.size ||
+    authority.filterFacets.length !==
+      new Set(authority.filterFacets.map((facet) => facet.id)).size ||
+    authority.filterFacets.some((facet) => !canonicalById.has(facet.id)) ||
+    !exactStringIdsV1(
+      authority.gmgnHydrationEligibleEntryIds,
+      canonicalById,
+    )
+  ) return null;
+  const gmgnRequestedEntries = entriesForExactIdsV1(
+    authority.gmgnRequestedEntryIds,
+    canonicalById,
+  );
+  const dexscreenerRequestedEntries = entriesForExactIdsV1(
+    authority.dexscreenerRequestedEntryIds,
+    canonicalById,
+  );
+  const gmgnEntries = providerEvidenceEntriesV1(
+    authority.gmgnEvidence,
+    canonicalById,
+    "gmgn",
+  );
+  const dexscreenerEntries = providerEvidenceEntriesV1(
+    authority.dexscreenerEvidence,
+    canonicalById,
+    "dexscreener",
+  );
+  if (
+    gmgnRequestedEntries === null || dexscreenerRequestedEntries === null ||
+    gmgnEntries === null || dexscreenerEntries === null
+  ) return null;
+  const gmgnRequestedIds = new Set(authority.gmgnRequestedEntryIds);
+  const dexscreenerRequestedIds = new Set(
+    authority.dexscreenerRequestedEntryIds,
+  );
+  if (
+    authority.gmgnEvidence.some((item) => !gmgnRequestedIds.has(item.id)) ||
+    authority.dexscreenerEvidence.some(
+      (item) => !dexscreenerRequestedIds.has(item.id),
+    )
+  ) return null;
+  return Object.freeze({
+    gmgnHydrationLimit: GMGN_MARKET_CAP_HYDRATION_LIMIT,
+    gmgnHydrationEligibleEntryCount:
+      authority.gmgnHydrationEligibleEntryIds.length,
+    gmgnRequestedEntries,
+    gmgnEntries,
+    dexscreenerRequestedEntries,
+    dexscreenerEntries,
+  });
+}
+
+function frozenFilterIdsV1(
+  authority: ExploreMarketCapAuthorityV1,
+  input: Readonly<{
+    query: string;
+    socials: "yes" | "no" | null;
+    model: "classic" | "custom" | null;
+  }>,
+): ReadonlySet<string> {
+  const normalized = input.query.trim().toLowerCase().replace(/^\$/u, "");
+  const tokenAddressById = new Map(
+    authority.orderedIdentities.map((identity) => [
+      identity.id,
+      identity.tokenAddress,
+    ] as const),
+  );
+  return new Set(authority.filterFacets.flatMap((facet) => {
+    if (input.model !== null && facet.category !== input.model) return [];
+    if (
+      input.socials !== null &&
+      facet.hasSocials !== (input.socials === "yes")
+    ) return [];
+    if (
+      normalized !== "" &&
+      !facet.name.toLowerCase().includes(normalized) &&
+      !(facet.symbol?.toLowerCase().includes(normalized) ?? false) &&
+      !(tokenAddressById.get(facet.id)?.includes(normalized) ?? false) &&
+      !(facet.modelId?.toLowerCase().includes(normalized) ?? false)
+    ) return [];
+    return [facet.id];
+  }));
+}
+
+function marketCapAuthorityCurrentV1(
+  authority: ExploreMarketCapAuthorityV1,
+  input: Readonly<{
+    inputCommitment: `sha256:${string}`;
+    direction: "asc" | "desc";
+    canonicalEntries: readonly ExploreEntry[];
+    now?: Date;
+  }>,
+): boolean {
+  const now = input.now ?? new Date();
+  const nowMs = now.getTime();
+  const ordered = exactAuthorityOrderedEntriesV1(
+    authority,
+    input.canonicalEntries,
+  );
+  const fallback = authorityFallbackInputV1(
+    authority,
+    input.canonicalEntries,
+  );
+  const authorityPin = ordered === null
+    ? null
+    : marketCapAuthorityPinCommitmentV1(
+        ordered,
+        authority.filterFacets,
+        input.direction,
+      );
+  if (
+    authority.schemaVersion !==
+      "programmable.explore-market-cap-authority.v2" ||
+    authority.inputCommitment !== input.inputCommitment ||
+    authority.direction !== input.direction || ordered === null ||
+    fallback === null || authorityPin === null ||
+    !currentMarketCapAuthorityTimestampV1(authority.generatedAt, nowMs) ||
+    authority.ranking.direction !== input.direction ||
+    authority.ranking.totalCount !== input.canonicalEntries.length ||
+    authority.ranking.canonicalEntryCount !== input.canonicalEntries.length ||
+    authority.ranking.rankingCommitment !== authorityPin
+  ) return false;
+  const providerTimes = [
+    ...(authority.rankSnapshot === null
+      ? []
+      : [authority.rankSnapshot.fetchedAt]),
+    ...authority.gmgnEvidence.flatMap((item) =>
+      item.asOfTime === null ? [] : [item.asOfTime]
+    ),
+    ...authority.dexscreenerEvidence.flatMap((item) =>
+      item.asOfTime === null ? [] : [item.asOfTime]
+    ),
+  ];
+  if (!providerTimes.every((value) =>
+    currentMarketCapAuthorityTimestampV1(value, nowMs)
+  )) return false;
+  const rebuilt = exploreMarketCapRankingV1(
+    sortExploreEntries(input.canonicalEntries, "newest"),
+    authority.rankSnapshot,
+    fallback,
+    input.direction,
+    now,
+  );
+  return canonicalizeJson({
+    ...rebuilt.ranking,
+    rankingCommitment: authorityPin,
+  }) === canonicalizeJson(authority.ranking) &&
+    rebuilt.ranking.rankingCommitment ===
+      marketCapRankingIdentityCommitmentV1(ordered, input.direction) &&
+    rebuilt.orderedEntries.every((entry, index) => entry.id === ordered[index]?.id);
+}
+
+function filterEntriesByIdsV1<Entry extends ExploreEntry>(
+  entries: readonly Entry[],
+  ids: ReadonlySet<string>,
+): readonly Entry[] {
+  return entries.filter((entry) => ids.has(entry.id));
+}
+
+function projectExploreMarketCapAuthorityV1(
+  authority: ExploreMarketCapAuthorityV1,
+  canonicalEntries: readonly ExploreEntry[],
+  input: Readonly<{
+    inputCommitment: `sha256:${string}`;
+    direction: "asc" | "desc";
+    query: string;
+    socials: "yes" | "no" | null;
+    model: "classic" | "custom" | null;
+    now?: Date;
+  }>,
+): Readonly<{
   orderedEntries: readonly ExploreEntry[];
-  orderingAsOfTimes: readonly (string | null)[];
   ranking: ExploreMarketCapRankingV1;
-}>> {
-  const deadlineMs = Date.now() + FAST_LANE_REQUEST_BUDGET_MS;
-  const readSignal = AbortSignal.timeout(FAST_LANE_REQUEST_BUDGET_MS);
+}> | null {
+  const now = input.now ?? new Date();
+  if (!marketCapAuthorityCurrentV1(authority, {
+    inputCommitment: input.inputCommitment,
+    direction: input.direction,
+    canonicalEntries,
+    now,
+  })) return null;
+  const authorityOrder = exactAuthorityOrderedEntriesV1(
+    authority,
+    canonicalEntries,
+  );
+  const fullFallback = authorityFallbackInputV1(authority, canonicalEntries);
+  if (authorityOrder === null || fullFallback === null) return null;
+  if (input.query === "" && input.socials === null && input.model === null) {
+    return Object.freeze({
+      orderedEntries: authorityOrder,
+      ranking: authority.ranking,
+    });
+  }
+  const filteredIds = frozenFilterIdsV1(authority, input);
+  const filteredNewest = sortExploreEntries(
+    canonicalEntries.filter((entry) => filteredIds.has(entry.id)),
+    "newest",
+  );
+  const frozenFilteredOrder = authorityOrder.filter((entry) =>
+    filteredIds.has(entry.id)
+  );
+  const ranked = exploreMarketCapRankingV1(
+    filteredNewest,
+    authority.rankSnapshot,
+    {
+      gmgnHydrationLimit: GMGN_MARKET_CAP_HYDRATION_LIMIT,
+      gmgnHydrationEligibleEntryCount:
+        authority.gmgnHydrationEligibleEntryIds.filter((id) =>
+          filteredIds.has(id)
+        ).length,
+      gmgnRequestedEntries: filterEntriesByIdsV1(
+        fullFallback.gmgnRequestedEntries,
+        filteredIds,
+      ),
+      gmgnEntries: filterEntriesByIdsV1(
+        fullFallback.gmgnEntries,
+        filteredIds,
+      ),
+      dexscreenerRequestedEntries: filterEntriesByIdsV1(
+        fullFallback.dexscreenerRequestedEntries,
+        filteredIds,
+      ),
+      dexscreenerEntries: filterEntriesByIdsV1(
+        fullFallback.dexscreenerEntries,
+        filteredIds,
+      ),
+    },
+    input.direction,
+    now,
+  );
+  if (
+    ranked.orderedEntries.length !== frozenFilteredOrder.length ||
+    ranked.orderedEntries.some(
+      (entry, index) => entry.id !== frozenFilteredOrder[index]?.id,
+    ) ||
+    ranked.ranking.rankingCommitment !==
+      marketCapRankingIdentityCommitmentV1(
+        frozenFilteredOrder,
+        input.direction,
+      )
+  ) return null;
+  return Object.freeze({
+    orderedEntries: Object.freeze(frozenFilteredOrder),
+    // The public pin names the retained full-universe generation. Query,
+    // model, and social filters are deterministic projections of that one
+    // identity order and therefore share its page/limit-independent pin.
+    ranking: Object.freeze({
+      ...ranked.ranking,
+      rankingCommitment: authority.ranking.rankingCommitment,
+    }),
+  });
+}
+
+async function buildExploreMarketCapAuthorityV1(
+  canonicalEntries: readonly ExploreEntry[],
+  inputCommitment: `sha256:${string}`,
+  direction: "asc" | "desc",
+  input: Readonly<{ deadlineMs: number }>,
+): Promise<ExploreMarketCapAuthorityCandidateV1> {
+  const authorityDeadlineMs = Math.min(
+    input.deadlineMs - MARKET_CAP_AUTHORITY_PUBLISH_RESERVE_MS,
+    Date.now() + MARKET_CAP_AUTHORITY_BUILD_BUDGET_MS,
+  );
+  if (authorityDeadlineMs <= Date.now()) {
+    throw new TypeError("Market-cap authority build deadline elapsed");
+  }
+  const authoritySignal = AbortSignal.timeout(
+    Math.max(1, authorityDeadlineMs - Date.now()),
+  );
+  const newestEntries = sortExploreEntries(canonicalEntries, "newest");
   const rankOptions = {
     interval: "1h" as const,
     limit: 100,
     orderBy: "marketcap" as const,
     direction,
   } as const;
-  const rankWait = { signal: readSignal, deadlineMs };
-  const rankCandidate = filteredNewest.length === 0
+  const rankWait = {
+    signal: authoritySignal,
+    deadlineMs: authorityDeadlineMs,
+  };
+  const rankCandidate = canonicalEntries.length === 0
     ? null
     : await (async () => {
         const first = await readGmgnEthereumTrendingV1(
@@ -906,7 +1421,7 @@ async function assembleExploreMarketCapCompositionV1(
         if (
           first !== null ||
           rankWait.signal.aborted ||
-          deadlineMs - Date.now() <
+          authorityDeadlineMs - Date.now() <
             GMGN_MARKET_CAP_RETRY_MINIMUM_REMAINING_MS
         ) return first;
         return readGmgnEthereumTrendingV1(
@@ -916,15 +1431,19 @@ async function assembleExploreMarketCapCompositionV1(
       })();
   const rank = rankCandidate?.kind === "trending" &&
       rankCandidate.orderBy === "marketcap" &&
-      rankCandidate.direction === direction
+      rankCandidate.direction === direction &&
+      currentMarketCapAuthorityTimestampV1(
+        rankCandidate.fetchedAt,
+        Date.now(),
+      )
     ? rankCandidate
     : null;
-  const marketCapNow = new Date();
+  const authorityNow = new Date();
   const primary = rankCanonicalExploreMarketCapPrimaryWithGmgnV1(
-    filteredNewest,
+    newestEntries,
     rank === null ? [] : [rank],
     direction,
-    marketCapNow,
+    authorityNow,
   );
   const unobserved = primary.rows.flatMap((row) =>
     row.gmgn === null ? [row.entry] : []
@@ -932,13 +1451,16 @@ async function assembleExploreMarketCapCompositionV1(
   const supplyRequested = unobserved.filter(
     canonicalTokenSupplyHydrationRequiredV1,
   ).slice(0, MARKET_CAP_SUPPLY_HYDRATION_LIMIT);
-  const hydratedSupply = supplyRequested.length === 0
+  const supplyDeadlineMs = authorityDeadlineMs -
+    GMGN_MARKET_CAP_HYDRATION_RESERVE_MS;
+  const hydratedSupply = supplyRequested.length === 0 ||
+      supplyDeadlineMs <= Date.now()
     ? []
     : await hydrateMissingCanonicalTokenSupplyBoundedV1(
         supplyRequested,
         {
-          signal: readSignal,
-          deadlineMs: deadlineMs - GMGN_MARKET_CAP_HYDRATION_RESERVE_MS,
+          signal: authoritySignal,
+          deadlineMs: supplyDeadlineMs,
           maximumDurationMs: MARKET_CAP_SUPPLY_HYDRATION_BUDGET_MS,
         },
       ).catch(() => supplyRequested);
@@ -954,19 +1476,19 @@ async function assembleExploreMarketCapCompositionV1(
   const hydrationUniverse = unobserved.map((entry) =>
     hydratedSupplyById.get(entry.id) ?? entry
   );
-  const gmgnHydrationEligible = hydrationUniverse.filter(
-    gmgnVisibleMarketEntryEligibleV1,
-  );
+  const gmgnHydrationEligible = primary.coverage.gmgnMatchedEntryCount === 0
+    ? []
+    : hydrationUniverse.filter(gmgnVisibleMarketEntryEligibleV1);
   const gmgnRequested = gmgnHydrationEligible.slice(
     0,
     GMGN_MARKET_CAP_HYDRATION_LIMIT,
   );
-  const gmgnHydrationDeadlineMs = deadlineMs -
+  const gmgnHydrationDeadlineMs = authorityDeadlineMs -
     GMGN_MARKET_CAP_HYDRATION_RESERVE_MS;
   const gmgnSnapshots = gmgnRequested.length > 0 &&
       gmgnHydrationDeadlineMs > Date.now()
     ? await readGmgnExploreSnapshotsV1(gmgnRequested, {
-        signal: readSignal,
+        signal: authoritySignal,
         deadlineMs: gmgnHydrationDeadlineMs,
       }).catch(() => new Map())
     : new Map();
@@ -978,7 +1500,13 @@ async function assembleExploreMarketCapCompositionV1(
       snapshot,
       new Date(),
     );
-    return hydrated === null ? [] : [hydrated];
+    const providerTime = hydrated === null
+      ? null
+      : valuedEntryProviderTimeV1(hydrated);
+    return hydrated === null || providerTime === null ||
+        !currentMarketCapAuthorityTimestampV1(providerTime, Date.now())
+      ? []
+      : [hydrated];
   });
   const gmgnQualifiedIds = new Set(gmgnHydratedEntries.flatMap((entry) =>
     valuationSortValue(entry) === null ? [] : [entry.id]
@@ -988,184 +1516,311 @@ async function assembleExploreMarketCapCompositionV1(
   );
   const fallback = await readDexscreenerExploreEntriesV1(
     dexscreenerRequested,
-    { signal: readSignal, deadlineMs },
+    {
+      signal: authoritySignal,
+      deadlineMs: authorityDeadlineMs,
+    },
+  ).catch(() => ({ entries: [] as readonly ValuedExploreEntry[] }));
+  const dexscreenerEntries = fallback.entries.filter((entry) => {
+    const providerTime = valuedEntryProviderTimeV1(entry);
+    return providerTime === null || currentMarketCapAuthorityTimestampV1(
+      providerTime,
+      Date.now(),
+    );
+  });
+  const generatedAt = new Date().toISOString();
+  const generatedAtDate = new Date(generatedAt);
+  const gmgnEvidence = compactProviderEvidenceV1(
+    gmgnHydratedEntries,
+    "gmgn",
+    generatedAtDate,
   );
-  return exploreMarketCapRankingV1(
-    filteredNewest,
+  const dexscreenerEvidence = compactProviderEvidenceV1(
+    dexscreenerEntries,
+    "dexscreener",
+    generatedAtDate,
+  );
+  const canonicalById = exactEntryMapV1(newestEntries);
+  if (canonicalById === null) {
+    throw new TypeError("Market-cap canonical identities conflict");
+  }
+  const compactGmgnEntries = providerEvidenceEntriesV1(
+    gmgnEvidence,
+    canonicalById,
+    "gmgn",
+  );
+  const compactDexscreenerEntries = providerEvidenceEntriesV1(
+    dexscreenerEvidence,
+    canonicalById,
+    "dexscreener",
+  );
+  if (compactGmgnEntries === null || compactDexscreenerEntries === null) {
+    throw new TypeError("Market-cap provider evidence conflicts");
+  }
+  const ranked = exploreMarketCapRankingV1(
+    newestEntries,
     rank,
     {
       gmgnHydrationLimit: GMGN_MARKET_CAP_HYDRATION_LIMIT,
       gmgnHydrationEligibleEntryCount: gmgnHydrationEligible.length,
-      gmgnRequestedEntries: gmgnRequested,
-      gmgnEntries: gmgnHydratedEntries,
-      dexscreenerRequestedEntries: dexscreenerRequested,
-      dexscreenerEntries: fallback.entries,
+      gmgnRequestedEntries: gmgnRequested.map((entry) =>
+        canonicalById.get(entry.id)!
+      ),
+      gmgnEntries: compactGmgnEntries,
+      dexscreenerRequestedEntries: dexscreenerRequested.map((entry) =>
+        canonicalById.get(entry.id)!
+      ),
+      dexscreenerEntries: compactDexscreenerEntries,
     },
     direction,
-    new Date(),
+    generatedAtDate,
   );
-}
-
-// The Next Data Cache binds the complete provider composition, not just GMGN's
-// rank prefix, across serverless isolates. The callback receives no caller
-// signal: a timed-out request may stop waiting while the bounded fill finishes.
-const readDurablyCachedExploreMarketCapCompositionV1 = unstable_cache(
-  async (
-    inputCommitment: `sha256:${string}`,
-    direction: "asc" | "desc",
-    entries: readonly ExploreEntry[],
-  ): Promise<CachedExploreMarketCapCompositionV1> => {
-    if (
-      exploreMarketCapCompositionInputCommitmentV1(entries, direction) !==
-        inputCommitment
-    ) throw new Error("Explore market-cap cache input is not bound");
-    const composed = await assembleExploreMarketCapCompositionV1(
-      entries,
-      direction,
-    );
-    const assembledAt = new Date().toISOString();
-    if (
-      !currentExploreMarketCapOrderingTimesV1(
-        composed.orderingAsOfTimes,
-        entries.length,
-        composed.ranking.qualifiedCount,
-      ) ||
-      (composed.ranking.asOfTime === null &&
-        (composed.ranking.observedTokenCount > 0 ||
-          composed.ranking.qualifiedCount > 0)) ||
-      (composed.ranking.asOfTime !== null &&
-        !currentExploreMarketCapTimestampV1(composed.ranking.asOfTime))
-    ) throw new Error("Explore market-cap provider snapshot is stale");
-    return Object.freeze({
-      schemaVersion: "programmable.explore-market-cap-composition.v1",
-      inputCommitment,
-      direction,
-      assembledAt,
-      orderedEntryIds: Object.freeze(
-        composed.orderedEntries.map((entry) => entry.id),
-      ),
-      orderingAsOfTimes: Object.freeze([...composed.orderingAsOfTimes]),
-      ranking: composed.ranking,
-    });
-  },
-  ["programmable-explore-market-cap-composition-v1"],
-  { revalidate: EXPLORE_MARKET_CAP_CACHE_REVALIDATE_SECONDS },
-);
-
-function currentExploreMarketCapTimestampV1(value: string): boolean {
-  const observedAtMs = Date.parse(value);
-  const nowMs = Date.now();
-  return Number.isFinite(observedAtMs) &&
-    new Date(observedAtMs).toISOString() === value &&
-    observedAtMs <= nowMs &&
-    nowMs - observedAtMs <= EXPLORE_MARKET_CAP_CACHE_MAXIMUM_AGE_MS;
-}
-
-function currentExploreMarketCapOrderingTimesV1(
-  value: unknown,
-  expectedLength: number,
-  expectedQualifiedCount: number,
-): value is readonly (string | null)[] {
-  if (!Array.isArray(value) || value.length !== expectedLength) return false;
-  let qualifiedCount = 0;
-  for (const observedAt of value) {
-    if (observedAt === null) continue;
-    if (
-      typeof observedAt !== "string" ||
-      !currentExploreMarketCapTimestampV1(observedAt)
-    ) return false;
-    qualifiedCount += 1;
-  }
-  return qualifiedCount === expectedQualifiedCount;
-}
-
-async function waitForExploreMarketCapCompositionV1(
-  pending: Promise<CachedExploreMarketCapCompositionV1>,
-  signal: AbortSignal,
-  deadlineMs: number,
-): Promise<CachedExploreMarketCapCompositionV1> {
-  if (signal.aborted || deadlineMs <= Date.now()) {
-    throw signal.reason ?? new DOMException("Aborted", "AbortError");
-  }
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    const finish = (callback: () => void) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      signal.removeEventListener("abort", abort);
-      callback();
-    };
-    const abort = () => finish(() => reject(
-      signal.reason ?? new DOMException("Aborted", "AbortError"),
-    ));
-    signal.addEventListener("abort", abort, { once: true });
-    const timer = setTimeout(abort, Math.max(0, deadlineMs - Date.now()));
-    pending.then(
-      (value) => finish(() => resolve(value)),
-      (error: unknown) => finish(() => reject(error)),
-    );
-  });
-}
-
-async function readBoundExploreMarketCapCompositionV1(
-  entries: readonly ExploreEntry[],
-  direction: "asc" | "desc",
-  wait: Readonly<{ signal: AbortSignal; deadlineMs: number }>,
-): Promise<Readonly<{
-  orderedEntries: readonly ExploreEntry[];
-  ranking: ExploreMarketCapRankingV1;
-}>> {
-  const inputCommitment = exploreMarketCapCompositionInputCommitmentV1(
-    entries,
+  const filterFacets = Object.freeze(
+    canonicalEntries.map(exploreMarketCapFilterFacetV1),
+  );
+  const rankingCommitment = marketCapAuthorityPinCommitmentV1(
+    ranked.orderedEntries,
+    filterFacets,
     direction,
   );
-  const cached = await waitForExploreMarketCapCompositionV1(
-    readDurablyCachedExploreMarketCapCompositionV1(
-      inputCommitment,
-      direction,
-      entries,
-    ),
-    wait.signal,
-    wait.deadlineMs,
-  );
-  if (
-    cached.schemaVersion !==
-      "programmable.explore-market-cap-composition.v1" ||
-    cached.inputCommitment !== inputCommitment ||
-    cached.direction !== direction ||
-    !currentExploreMarketCapTimestampV1(cached.assembledAt) ||
-    cached.ranking.direction !== direction ||
-    cached.ranking.canonicalEntryCount !== entries.length ||
-    cached.ranking.totalCount !== entries.length ||
-    !/^sha256:[0-9a-f]{64}$/u.test(cached.ranking.rankingCommitment) ||
-    (cached.ranking.asOfTime === null &&
-      (cached.ranking.observedTokenCount > 0 ||
-        cached.ranking.qualifiedCount > 0)) ||
-    (cached.ranking.asOfTime !== null &&
-      !currentExploreMarketCapTimestampV1(cached.ranking.asOfTime)) ||
-    cached.orderedEntryIds.length !== entries.length ||
-    !currentExploreMarketCapOrderingTimesV1(
-      cached.orderingAsOfTimes,
-      entries.length,
-      cached.ranking.qualifiedCount,
-    )
-  ) throw new Error("Explore market-cap cache result is invalid or stale");
-  const entriesById = new Map(entries.map((entry) => [entry.id, entry]));
-  if (entriesById.size !== entries.length) {
-    throw new Error("Explore market-cap cache input identities are duplicated");
+  if (rankingCommitment === null) {
+    throw new TypeError("Market-cap authority filter facets conflict");
   }
-  const orderedIds = new Set(cached.orderedEntryIds);
-  if (
-    orderedIds.size !== entries.length ||
-    cached.orderedEntryIds.some((id) => !entriesById.has(id))
-  ) throw new Error("Explore market-cap cache order is not a permutation");
-  return Object.freeze({
-    orderedEntries: Object.freeze(
-      cached.orderedEntryIds.map((id) => entriesById.get(id)!),
-    ),
-    ranking: cached.ranking,
+  const authorityRanking = Object.freeze({
+    ...ranked.ranking,
+    rankingCommitment,
   });
+  const authority: ExploreMarketCapAuthorityV1 = Object.freeze({
+    schemaVersion: "programmable.explore-market-cap-authority.v2",
+    inputCommitment,
+    direction,
+    generatedAt,
+    rankSnapshot: rank,
+    filterFacets,
+    gmgnHydrationEligibleEntryIds: Object.freeze(
+      gmgnHydrationEligible.map((entry) => entry.id),
+    ),
+    gmgnRequestedEntryIds: Object.freeze(
+      gmgnRequested.map((entry) => entry.id),
+    ),
+    gmgnEvidence,
+    dexscreenerRequestedEntryIds: Object.freeze(
+      dexscreenerRequested.map((entry) => entry.id),
+    ),
+    dexscreenerEvidence,
+    orderedIdentities: Object.freeze(
+      ranked.orderedEntries.map(exactOrderedMarketIdentityV1),
+    ),
+    ranking: authorityRanking,
+  });
+  const canonicalAuthority = canonicalizeJson(authority);
+  const evidenceTimes = [
+    ...(rank === null ? [] : [rank.fetchedAt]),
+    ...gmgnEvidence.flatMap((item) =>
+      item.asOfTime === null ? [] : [item.asOfTime]
+    ),
+    ...dexscreenerEvidence.flatMap((item) =>
+      item.asOfTime === null ? [] : [item.asOfTime]
+    ),
+  ].map((value) => Date.parse(value));
+  const validUntilMs = Math.min(
+    Date.parse(generatedAt) + EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_AGE_MS,
+    ...evidenceTimes.map((value) =>
+      value + EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_AGE_MS
+    ),
+  );
+  if (!Number.isFinite(validUntilMs) || validUntilMs <= Date.now()) {
+    throw new TypeError("Market-cap provider evidence is stale");
+  }
+  return Object.freeze({
+    canonicalAuthority,
+    authorityCommitment:
+      exploreMarketCapAuthorityStorageCommitmentV1(canonicalAuthority),
+    rankingCommitment,
+    gmgnStatus: ranked.ranking.matchedTokenCount === 0
+      ? "unavailable"
+      : ranked.ranking.matchedTokenCount === canonicalEntries.length
+        ? "complete"
+        : "partial",
+    generatedAt,
+    validUntil: new Date(validUntilMs).toISOString(),
+  });
+}
+
+function parseExploreMarketCapAuthorityV1(
+  canonicalAuthority: string,
+): ExploreMarketCapAuthorityV1 | null {
+  try {
+    const parsed = parseStrictJson(canonicalAuthority, {
+      maximumBytes: EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_BYTES,
+      maximumDepth: 64,
+    });
+    if (
+      canonicalizeJson(parsed) !== canonicalAuthority ||
+      !isRecordV1(parsed) ||
+      !hasExactKeysV1(parsed, [
+        "schemaVersion", "inputCommitment", "direction", "generatedAt",
+        "rankSnapshot", "filterFacets", "gmgnHydrationEligibleEntryIds",
+        "gmgnRequestedEntryIds", "gmgnEvidence",
+        "dexscreenerRequestedEntryIds", "dexscreenerEvidence",
+        "orderedIdentities", "ranking",
+      ]) ||
+      parsed.schemaVersion !==
+        "programmable.explore-market-cap-authority.v2" ||
+      typeof parsed.inputCommitment !== "string" ||
+      !SHA256_COMMITMENT.test(parsed.inputCommitment) ||
+      (parsed.direction !== "asc" && parsed.direction !== "desc") ||
+      typeof parsed.generatedAt !== "string" ||
+      !exactIsoTimestampV1(parsed.generatedAt) ||
+      !exactGmgnDiscoverySnapshotV1(parsed.rankSnapshot) ||
+      !exactFilterFacetArrayV1(parsed.filterFacets) ||
+      !exactStringArrayV1(parsed.gmgnHydrationEligibleEntryIds) ||
+      !exactStringArrayV1(parsed.gmgnRequestedEntryIds) ||
+      !exactProviderEvidenceArrayV1(parsed.gmgnEvidence) ||
+      !exactStringArrayV1(parsed.dexscreenerRequestedEntryIds) ||
+      !exactProviderEvidenceArrayV1(parsed.dexscreenerEvidence) ||
+      !exactOrderedIdentityArrayV1(parsed.orderedIdentities) ||
+      !isRecordV1(parsed.ranking) ||
+      parsed.ranking.schemaVersion !==
+        "programmable.explore-market-cap-ranking.v1" ||
+      parsed.ranking.direction !== parsed.direction ||
+      typeof parsed.ranking.rankingCommitment !== "string" ||
+      !SHA256_COMMITMENT.test(parsed.ranking.rankingCommitment)
+    ) return null;
+    return parsed as unknown as ExploreMarketCapAuthorityV1;
+  } catch {
+    return null;
+  }
+}
+
+function exactFilterFacetArrayV1(
+  value: unknown,
+): value is readonly ExploreMarketCapFilterFacetV1[] {
+  if (!Array.isArray(value) || value.length > 10_000) return false;
+  const ids = new Set<string>();
+  for (const item of value) {
+    if (
+      !isRecordV1(item) || !hasExactKeysV1(item, [
+        "id", "name", "symbol", "modelId", "category", "hasSocials",
+      ]) ||
+      typeof item.id !== "string" || item.id.length > 1_024 ||
+      ids.has(item.id) || typeof item.name !== "string" ||
+      item.name.length > 4_096 ||
+      (item.symbol !== null &&
+        (typeof item.symbol !== "string" || item.symbol.length > 1_024)) ||
+      (item.modelId !== null &&
+        (typeof item.modelId !== "string" || item.modelId.length > 1_024)) ||
+      (item.category !== "classic" && item.category !== "custom") ||
+      typeof item.hasSocials !== "boolean"
+    ) return false;
+    ids.add(item.id);
+  }
+  return true;
+}
+
+function isRecordV1(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeysV1(
+  value: Readonly<Record<string, unknown>>,
+  keys: readonly string[],
+): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length &&
+    actual.every((key, index) => key === expected[index]);
+}
+
+function exactIsoTimestampV1(value: string): boolean {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value;
+}
+
+function exactStringArrayV1(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.length <= 10_000 &&
+    value.every((item) => typeof item === "string" && item.length <= 1_024) &&
+    value.length === new Set(value).size;
+}
+
+function exactProviderEvidenceArrayV1(
+  value: unknown,
+): value is readonly ExploreMarketCapProviderEvidenceV1[] {
+  if (!Array.isArray(value) || value.length > 10_000) return false;
+  const ids = new Set<string>();
+  for (const item of value) {
+    if (
+      !isRecordV1(item) ||
+      !hasExactKeysV1(item, ["id", "valueWad", "asOfTime"]) ||
+      typeof item.id !== "string" || item.id.length > 1_024 ||
+      ids.has(item.id) ||
+      (item.valueWad !== null &&
+        (typeof item.valueWad !== "string" ||
+          !UNSIGNED_INTEGER.test(item.valueWad) ||
+          BigInt(item.valueWad) === 0n)) ||
+      (item.asOfTime !== null &&
+        (typeof item.asOfTime !== "string" ||
+          !exactIsoTimestampV1(item.asOfTime))) ||
+      (item.valueWad !== null && item.asOfTime === null)
+    ) return false;
+    ids.add(item.id);
+  }
+  return true;
+}
+
+function exactOrderedIdentityArrayV1(
+  value: unknown,
+): value is readonly ExactOrderedMarketIdentityV1[] {
+  if (!Array.isArray(value) || value.length > 10_000) return false;
+  const ids = new Set<string>();
+  for (const item of value) {
+    if (
+      !isRecordV1(item) ||
+      !hasExactKeysV1(item, ["id", "tokenAddress", "marketIdentities"]) ||
+      typeof item.id !== "string" || item.id.length > 1_024 ||
+      ids.has(item.id) ||
+      (item.tokenAddress !== null &&
+        (typeof item.tokenAddress !== "string" ||
+          !/^0x[0-9a-f]{40}$/u.test(item.tokenAddress))) ||
+      !Array.isArray(item.marketIdentities) ||
+      item.marketIdentities.length > 10_000 ||
+      !item.marketIdentities.every((identity) =>
+        isRecordV1(identity) && hasExactKeysV1(identity, [
+          "chainId", "protocol", "tokenAddress", "poolId", "quoteAddress",
+        ]) && identity.chainId === "1" && identity.protocol === "uniswap_v4" &&
+        typeof identity.tokenAddress === "string" &&
+        /^0x[0-9a-f]{40}$/u.test(identity.tokenAddress) &&
+        typeof identity.poolId === "string" &&
+        /^0x[0-9a-f]{64}$/u.test(identity.poolId) &&
+        typeof identity.quoteAddress === "string" &&
+        /^0x[0-9a-f]{40}$/u.test(identity.quoteAddress)
+      )
+    ) return false;
+    ids.add(item.id);
+  }
+  return true;
+}
+
+function exactGmgnDiscoverySnapshotV1(
+  value: unknown,
+): value is GmgnDiscoverySnapshotV1 | null {
+  if (value === null) return true;
+  if (
+    !isRecordV1(value) || !isGmgnDiscoverySnapshotV1(value) ||
+    !hasExactKeysV1(value, [
+      "schemaVersion", "source", "chainId", "providerChain", "kind",
+      "interval", "orderBy", "direction", "requestedLimit", "fetchedAt",
+      "providerVersion", "providerItemCount", "discardedProviderItemCount",
+      "duplicateProviderItemCount", "tokens",
+    ])
+  ) return false;
+  return value.tokens.every((token) =>
+    hasExactKeysV1(token, [
+      "chain", "tokenAddress", "rank", "visitingCount", "hotLevel",
+      "swaps", "buys", "sells", "holderCount", "priceUsd",
+      "marketCapUsd", "liquidityUsd", "volumeUsd",
+    ])
+  );
 }
 
 function generatedAgeMs(generatedAt: string): number | null {
@@ -1174,10 +1829,15 @@ function generatedAgeMs(generatedAt: string): number | null {
 }
 
 export async function GET(request: NextRequest) {
-  const deadlineMs = Date.now() + FAST_LANE_REQUEST_BUDGET_MS;
+  const rawSort = request.nextUrl.searchParams.get("sort");
+  const requestBudgetMs = rawSort === "market-cap" ||
+      rawSort === "market-cap-asc"
+    ? MARKET_CAP_REQUEST_BUDGET_MS
+    : FAST_LANE_REQUEST_BUDGET_MS;
+  const deadlineMs = Date.now() + requestBudgetMs;
   const readSignal = AbortSignal.any([
     request.signal,
-    AbortSignal.timeout(FAST_LANE_REQUEST_BUDGET_MS),
+    AbortSignal.timeout(requestBudgetMs),
   ]);
   const search = request.nextUrl.searchParams;
   if (!hasCanonicalQueryShape(search) || !hasCanonicalPaginationShape(search)) {
@@ -1220,6 +1880,27 @@ export async function GET(request: NextRequest) {
     );
   }
   const requestedSort = parseExploreSort(search.get("sort"));
+  const requestedPage = integerQuery(search.get("page"), 1);
+  const requestedRankingCommitment = search.get("rankingCommitment");
+  const ethereumMarketCapSort = chain === 1 &&
+    (requestedSort === "market-cap" || requestedSort === "market-cap-asc");
+  if (
+    (requestedRankingCommitment !== null &&
+      (!ethereumMarketCapSort ||
+        !SHA256_COMMITMENT.test(requestedRankingCommitment))) ||
+    (ethereumMarketCapSort && requestedPage > 1 &&
+      requestedRankingCommitment === null)
+  ) {
+    return NextResponse.json(
+      {
+        error: requestedRankingCommitment === null
+          ? "Market-cap pages after page 1 require rankingCommitment"
+          : "Unsupported market-cap ranking commitment",
+        code: "MARKET_CAP_RANKING_COMMITMENT_REQUIRED",
+      },
+      { status: 400, headers: { "Cache-Control": "no-store" } },
+    );
+  }
   if (requestedSort === "trending" && chain !== 1) {
     return NextResponse.json(
       { error: "Trending discovery is available on Ethereum only" },
@@ -1262,7 +1943,7 @@ export async function GET(request: NextRequest) {
       chain,
       query,
       sort: requestedSort,
-      page: integerQuery(search.get("page"), 1),
+      page: requestedPage,
       pageSize: integerQuery(search.get("limit"), 9),
       socials,
       model,
@@ -1443,8 +2124,10 @@ export async function GET(request: NextRequest) {
       includedSources.add("registry.custom-launched");
     }
     if (routerAvailable) includedSources.add(ROUTER_CUSTOM_LAUNCH_SOURCE);
+    const marketCapSortRequested = options.sort === "market-cap" ||
+      options.sort === "market-cap-asc";
     const searchRead: Promise<GmgnSearchSnapshotV1 | null> =
-      options.query === ""
+      options.query === "" || marketCapSortRequested
         ? Promise.resolve(null)
         : readGmgnEthereumSearchV1(options.query, {
             signal: readSignal,
@@ -1456,36 +2139,87 @@ export async function GET(request: NextRequest) {
     let discovery: ExploreDiscoveryRankingV1 | null = null;
     let searchRanking: ExploreSearchRankingV1 | null = null;
     if (options.sort === "market-cap" || options.sort === "market-cap-asc") {
-      const localFilteredNewest = sortExploreEntries(
-        filterExploreEntries(
-          presentedPublicEntries,
-          options.query,
-          options.socials,
-          options.model,
-        ),
-        "newest",
-      );
       const direction = options.sort === "market-cap" ? "desc" : "asc";
-      const searchSnapshot = await searchRead;
-      const searchResult = options.query === ""
-        ? null
-        : rankExploreSearchEntriesV1(
-            presentedPublicEntries,
-            searchSnapshot,
-            {
-              query: options.query,
-              socials: options.socials,
-              model: options.model,
-              fallbackSort: "newest",
-            },
-          );
-      if (searchResult !== null) searchRanking = searchResult.search;
-      const filteredNewest = searchResult?.entries ?? localFilteredNewest;
-      const ranked = await readBoundExploreMarketCapCompositionV1(
-        filteredNewest,
+      const authorityInputCommitment =
+        exploreMarketCapAuthorityInputCommitmentV1(
+          presentedPublicEntries,
+        );
+      const projectionInput = {
+        inputCommitment: authorityInputCommitment,
         direction,
-        { signal: readSignal, deadlineMs },
+        query: options.query,
+        socials: options.socials,
+        model: options.model,
+      } as const;
+      const rankingCommitment = requestedRankingCommitment as
+        `sha256:${string}` | null;
+      const authorityStore = getProductionExploreMarketCapAuthorityStoreV1();
+      const resolution = rankingCommitment === null
+        ? await authorityStore.resolve({
+            inputCommitment: authorityInputCommitment,
+            direction,
+            build: () => buildExploreMarketCapAuthorityV1(
+              presentedPublicEntries,
+              authorityInputCommitment,
+              direction,
+              { deadlineMs },
+            ),
+            deadlineMs,
+            signal: readSignal,
+          })
+        : await authorityStore.resolve({
+            inputCommitment: authorityInputCommitment,
+            direction,
+            rankingCommitment,
+            acceptPinnedAuthority: (canonicalAuthority) => {
+              const candidate = parseExploreMarketCapAuthorityV1(
+                canonicalAuthority,
+              );
+              if (candidate === null) return false;
+              const candidateProjection =
+                projectExploreMarketCapAuthorityV1(
+                  candidate,
+                  presentedPublicEntries,
+                  projectionInput,
+                );
+              return candidateProjection?.ranking.rankingCommitment ===
+                rankingCommitment;
+            },
+            deadlineMs,
+            signal: readSignal,
+          });
+      if (resolution.kind === "ranking-conflict") {
+        return NextResponse.json(
+          {
+            error: "Market-cap ranking changed; restart from page 1",
+            code: "MARKET_CAP_RANKING_RESTART_REQUIRED",
+          },
+          {
+            status: 409,
+            headers: {
+              "Cache-Control": "no-store",
+              "X-Programmable-Ranking-Restart": "required",
+            },
+          },
+        );
+      }
+      if (resolution.kind !== "ready") {
+        throw new Error("Market-cap ordering authority is unavailable");
+      }
+      const authority = parseExploreMarketCapAuthorityV1(
+        resolution.canonicalAuthority,
       );
+      if (authority === null) {
+        throw new Error("Market-cap ordering authority is invalid");
+      }
+      const ranked = projectExploreMarketCapAuthorityV1(
+        authority,
+        presentedPublicEntries,
+        projectionInput,
+      );
+      if (ranked === null) {
+        throw new Error("Market-cap ordering authority is unavailable");
+      }
       marketCapRanking = ranked.ranking;
       const identityPage = paginateEntries(ranked.orderedEntries, options);
       const valued = await readExploreMarketEntriesV1(

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -2061,6 +2061,42 @@ function exploreProviderOrderCommitmentKey(value: ExplorePayload) {
   });
 }
 
+function exploreMarketCapRankingCommitment(value: ExplorePayload) {
+  return value.ranking?.requested === "market-cap"
+    ? value.ranking.rankingCommitment
+    : undefined;
+}
+
+function readResolvedExploreMarketCapRankingCommitment(
+  search: URLSearchParams,
+) {
+  const collectionIdentity = canonicalExploreCollectionIdentity(search);
+  let commitment: `sha256:${string}` | undefined;
+  for (const [key, cached] of resolvedExplorePayloads) {
+    if (Date.now() - cached.updatedAt >= RESOLVED_EXPLORE_PAYLOAD_TTL_MS) {
+      resolvedExplorePayloads.delete(key);
+      continue;
+    }
+    if (
+      cached.collectionIdentity === collectionIdentity &&
+      cached.payload.page === 1
+    ) {
+      commitment = exploreMarketCapRankingCommitment(cached.payload) ??
+        commitment;
+    }
+  }
+  return commitment;
+}
+
+function expireResolvedExploreCollectionPayloads(search: URLSearchParams) {
+  const collectionIdentity = canonicalExploreCollectionIdentity(search);
+  for (const [key, cached] of resolvedExplorePayloads) {
+    if (cached.collectionIdentity === collectionIdentity) {
+      resolvedExplorePayloads.delete(key);
+    }
+  }
+}
+
 function parseExplorePayload(value: unknown): ExplorePayload {
   if (!isRecord(value)) {
     throw new Error("The token registry returned an invalid response");
@@ -2312,6 +2348,7 @@ function canonicalExploreSearchIdentity(search: URLSearchParams) {
 function canonicalExploreCollectionIdentity(search: URLSearchParams) {
   const canonical = new URLSearchParams(search);
   canonical.delete("page");
+  canonical.delete("rankingCommitment");
   canonical.sort();
   return canonical.toString();
 }
@@ -2493,6 +2530,9 @@ async function fetchExplorePayload(
       const body: unknown = await response.json().catch(() => null);
       signal.throwIfAborted();
       if (timedOut) throw new Error("Tokens took too long to respond");
+      if (response.status === 409) {
+        throw new ExploreRankingRestartError(readApiError(body));
+      }
       if (response.status !== 200) {
         throw new Error(readApiError(body));
       }
@@ -2548,6 +2588,13 @@ async function fetchExplorePayload(
     }
   }
   throw new Error("Tokens are temporarily unavailable");
+}
+
+class ExploreRankingRestartError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ExploreRankingRestartError";
+  }
 }
 
 export function loadExplorePayload(
@@ -2616,7 +2663,48 @@ export async function loadExplorePage(
   contentKey: string,
   search: URLSearchParams,
 ) {
-  return loadExplorePayload(contentKey, new URLSearchParams(search));
+  const requestedSearch = new URLSearchParams(search);
+  const contract = exploreRequestContract(requestedSearch);
+  const sort = requestedSearch.get("sort");
+  const requiresRankingPin = contract.page > 1 &&
+    (sort === "market-cap" || sort === "market-cap-asc");
+  if (!requiresRankingPin || requestedSearch.has("rankingCommitment")) {
+    return loadExplorePayload(contentKey, requestedSearch);
+  }
+
+  const firstPageContentKey = `${contentKey}\u0000market-cap-ranking-page:1`;
+  const loadPinnedPage = async () => {
+    const firstPageSearch = new URLSearchParams(requestedSearch);
+    firstPageSearch.set("page", "1");
+    firstPageSearch.delete("rankingCommitment");
+    const cachedRankingCommitment =
+      readResolvedExploreMarketCapRankingCommitment(firstPageSearch);
+    const firstPage = cachedRankingCommitment === undefined
+      ? await loadExplorePayload(firstPageContentKey, firstPageSearch)
+      : null;
+    const rankingCommitment = cachedRankingCommitment ??
+      (firstPage === null
+        ? undefined
+        : exploreMarketCapRankingCommitment(firstPage));
+    if (rankingCommitment === undefined) {
+      throw new Error("Tokens changed while filters were loading");
+    }
+    const pinnedSearch = new URLSearchParams(requestedSearch);
+    pinnedSearch.set("rankingCommitment", rankingCommitment);
+    return loadExplorePayload(contentKey, pinnedSearch);
+  };
+
+  try {
+    return await loadPinnedPage();
+  } catch (error) {
+    if (!(error instanceof ExploreRankingRestartError)) throw error;
+    abortExplorePayload(contentKey);
+    expireResolvedExplorePayloadCache(contentKey);
+    abortExplorePayload(firstPageContentKey);
+    expireResolvedExplorePayloadCache(firstPageContentKey);
+    expireResolvedExploreCollectionPayloads(requestedSearch);
+    return loadPinnedPage();
+  }
 }
 
 async function loadExploreModelDatasetAttempt(
@@ -2636,6 +2724,14 @@ async function loadExploreModelDatasetAttempt(
   const firstPageCatalog = firstPage.catalog;
   const firstPageProviderOrderCommitment =
     exploreProviderOrderCommitmentKey(firstPage);
+  const marketCapSort = firstPageSearch.get("sort") === "market-cap" ||
+    firstPageSearch.get("sort") === "market-cap-asc";
+  const rankingCommitment = marketCapSort
+    ? exploreMarketCapRankingCommitment(firstPage)
+    : undefined;
+  if (marketCapSort && rankingCommitment === undefined) {
+    throw new Error("Tokens changed while filters were loading");
+  }
   if (firstPage.totalPages <= 1) {
     if (firstPage.page !== 1 || firstPage.tokens.length !== firstPage.total) {
       throw new Error("Tokens changed while filters were loading");
@@ -2649,6 +2745,9 @@ async function loadExploreModelDatasetAttempt(
       const page = index + 2;
       const pageSearch = new URLSearchParams(firstPageSearch);
       pageSearch.set("page", String(page));
+      if (rankingCommitment !== undefined) {
+        pageSearch.set("rankingCommitment", rankingCommitment);
+      }
       const payload = await loadExplorePayload(
         `${contentKey}\u0000model-page:${page}`,
         pageSearch,
@@ -2797,7 +2896,8 @@ export async function loadExploreModelDataset(
   } catch (error) {
     if (
       !(error instanceof Error) ||
-      error.message !== "Tokens changed while filters were loading"
+      (error.message !== "Tokens changed while filters were loading" &&
+        !(error instanceof ExploreRankingRestartError))
     ) {
       throw error;
     }

--- a/docs/operations/WEBSITE-PROJECTION-DATABASE-OPERATOR-V1.md
+++ b/docs/operations/WEBSITE-PROJECTION-DATABASE-OPERATOR-V1.md
@@ -1,7 +1,7 @@
 # Website projection database operator v1
 
 This is the repository operator for the Website projection database migrations
-`0001` through `0007`. It does not deploy the Website, change stage
+`0001` through `0008`. It does not deploy the Website, change stage
 workflows, or configure Custom bindings. Run it only from the exact reviewed
 production commit, with a fresh secret-manager session and an independently
 verified production target identity.
@@ -32,6 +32,18 @@ reservation waits for an existing lease to complete or expire. Provider roles
 retain no access. Each gate transition prunes to the
 latest 256 generations, so the gate path contains at most 512 decision rows
 without an owner cron or broad maintenance privilege.
+
+Migration `0008` adds private forced-RLS Explore market-cap authority head and
+immutable generation tables. The runtime may select, insert and delete exact
+head/generation rows, but may update only the head's generation, lease and
+timestamp columns. Provider roles retain no access. A published generation is
+valid for no more than 235 seconds, stores at most 16 MiB of canonical authority
+data, and remains available for a pinned follow-up page while the runtime keeps
+the newest 32 generations per authority. Expired generations and orphan heads
+are removed through those same bounded delete grants. Runtime readiness attests
+both tables, ownership, the exact seven-policy set, forced RLS, required and
+forbidden grants, provider-role exclusion, and TLS-bound role identity before
+the authority store serves a request.
 
 ## One bounded existing-prefix adoption
 
@@ -104,7 +116,7 @@ Any row, extra object, missing object, alternate membership, other role-bit
 drift, partial evidence, lock race, or re-read drift rolls the complete
 transaction back. After a successful adoption, retain its JSON result, run the
 normal `apply` command with the same exact successor plan to apply only `0004`
-through `0007`, then run `verify`. Adoption, apply, and verify remain database
+through `0008`, then run `verify`. Adoption, apply, and verify remain database
 evidence only; they do not enable Custom or authorize a Website deployment.
 
 ## Secret-manager session
@@ -129,7 +141,7 @@ npm run --silent db:website-projection:operator -- dry-run \
   --expected-project-ref '<verified-project-ref>'
 ```
 
-Review the full Git commit/tree, seven ordered file/execution hashes, and
+Review the full Git commit/tree, eight ordered file/execution hashes, and
 `planSha256`. Plan generation requires an exact clean, tracked migration
 directory. Dry-run connects without mutations and fails closed on unproven
 objects, non-prefix evidence, target mismatch, role drift, or catalog drift.
@@ -147,10 +159,24 @@ all six rows to that same exact identity. File and execution hashes, commit,
 tree, plan and order commitments remain exact in both forms; another historical
 branch plan is not a valid substitute.
 
-For this release, dry-run must report only `0007` pending against that exact
-prefix. Retain that output, apply the reviewed plan through the owner-controlled
-command below, and require a current seven-row `verify` result before Website
-promotion. The Stage workflow never applies database migrations.
+The only accepted Production 0007 predecessor is the live-verified plan at
+commit `9d81af890e14e39aef415399b7df80745670483c`, tree
+`4f9b85231f731fad47713676ad1dde53f77bc4d2`, plan commitment
+`0xbb99064008299faf0173b4fd0199017358327a02f091436c4ef878f36df14ea8`,
+and order commitment
+`0x3097a113366d96591241f9ed423b2fef1beb551959e04a6663847b3a1f55ee56`.
+The retained production operator receipts prove a dry-run from six rows with
+only `0007` pending, an apply containing only `0007`, and a current seven-row
+verify on project `mnnvlrqwhfoppogslsje`. For the adopted production database,
+rows `0001` through `0005` retain the frozen retained-plan identity, row `0006`
+retains the six-migration predecessor identity above, and row `0007` retains
+this exact seven-migration identity. A fresh database created wholly by the
+seven-migration predecessor may bind all seven rows to that exact identity.
+
+For this release, dry-run must report only `0008` pending against that exact
+0007 predecessor. Retain that output, apply the reviewed plan through the
+owner-controlled command below, and require a current eight-row `verify` result
+before Website promotion. The Stage workflow never applies database migrations.
 
 ## Irreversible apply
 
@@ -181,7 +207,7 @@ npm run --silent db:website-projection:operator -- verify \
   --expected-project-ref '<verified-project-ref>'
 ```
 
-Success requires `current`, seven exact evidence rows, the constrained role graph,
+Success requires `current`, eight exact evidence rows, the constrained role graph,
 and application/operator catalog fingerprints matching the last atomic evidence
 row. Pending exits 2; drift is an error. Retain the verify JSON with the plan,
 dry-run result, and apply result.
@@ -219,7 +245,7 @@ current in the database, while its migration order and byte commitments must
 match the current rotation checkout.
 
 The operator reuses the authenticated migration boundary above, requires the
-exact current seven-row migration evidence and catalog fingerprints, takes a
+exact current eight-row migration evidence and catalog fingerprints, takes a
 shared migration advisory lock, and changes only the password with `ALTER ROLE`
 inside one database transaction. It then authenticates a fresh connection through the
 exact Frankfurt Supavisor transaction endpoint as

--- a/docs/operations/WEBSITE-PROJECTION-TARGET-V1.md
+++ b/docs/operations/WEBSITE-PROJECTION-TARGET-V1.md
@@ -40,6 +40,7 @@ before starting the runtime, in this exact order:
 5. `ops/website-projection-target/migrations/0005_generic_launch_materializations_v2.sql`
 6. `ops/website-projection-target/migrations/0006_gmgn_account_gate_v1.sql`
 7. `ops/website-projection-target/migrations/0007_gmgn_account_gate_multiflight_v1.sql`
+8. `ops/website-projection-target/migrations/0008_explore_market_cap_authority_v1.sql`
 
 `0001` creates the private schema, immutable projection and credential-use
 tables, policies and initial indexes. `0002` then upgrades finalized Custom
@@ -55,7 +56,13 @@ instances. `0007` adds the private forced-RLS lease table used for at most 20
 concurrent account-wide reservations; a 21st reservation waits for a lease to
 complete or expire. Its `(gate_id, generation)` primary key,
 unique `(gate_id, lease_holder)` binding, singleton foreign key and exact lease
-times prevent a holder or generation from being reused. Together they provide:
+times prevent a holder or generation from being reused. `0008` adds the private
+Explore market-cap authority head and immutable generation tables. One
+compare-and-swap lease serializes each complete canonical-universe commitment
+and sort direction across runtime instances. A published generation remains
+pin-addressable for at most 235 seconds; the runtime keeps at most 32 retained
+generations per authority and removes expired orphan heads without a broad
+maintenance role. Together they provide:
 
 - a primary key on `(lane, projection_key)`;
 - a global unique index on `idempotency_key`;
@@ -72,6 +79,9 @@ times prevent a holder or generation from being reused. Together they provide:
   failure release, and the
   latest 256 generations of reservation, completion, and provider-block
   decisions (at most 512 gate-path rows);
+- a durable Explore market-cap ordering authority with one current head,
+  immutable commitment-addressed generations, 32 retained generations,
+  a 16 MiB canonical payload ceiling, and a maximum pin lifetime of 235 seconds;
 - lane-specific constraints requiring complete entitlement metadata and forbidding
   that metadata on custom-launch records;
 - enabled and forced RLS on every application table;
@@ -128,13 +138,22 @@ GRANT INSERT, DELETE
 GRANT SELECT, INSERT, DELETE
   ON programmable_website_projection_v1.gmgn_account_gate_leases_v1
   TO programmable_website_projection_runtime;
+GRANT SELECT, INSERT, DELETE
+  ON programmable_website_projection_v1.explore_market_cap_authority_heads_v1,
+     programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+  TO programmable_website_projection_runtime;
+GRANT UPDATE (
+  current_generation, lease_generation, lease_holder, lease_until, updated_at
+) ON programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+  TO programmable_website_projection_runtime;
 GRANT EXECUTE ON FUNCTION
   programmable_website_projection_v1.enforce_approval_v3_capacity_v1()
   TO programmable_website_projection_runtime;
 ```
 
 Do not grant `UPDATE` on the immutable projection or credential tables. Do not
-grant `DELETE` except on the GMGN decision history and exact lease table, or
+grant `DELETE` except on the GMGN decision history, exact lease table, and the
+two bounded Explore authority tables, or
 grant `TRUNCATE`, schema
 creation, role management, or access to approval-service tables. The narrowly
 scoped column-level `UPDATE` grant on the
@@ -153,6 +172,13 @@ provider ban instead advances the generation and publishes the bounded shared
 cooldown. The runtime attests the exact current role,
 grants, RLS/force-RLS state, policies, provider-role exclusion, table ownership,
 and live `pg_stat_ssl` connection before serving requests.
+The Explore authority path separately calls
+`assertExploreMarketCapAuthorityReadiness` before its first database operation.
+That readiness probe requires both authority tables, their owner, the exact
+seven-policy set, forced RLS, the documented runtime grants, forbidden-grant
+absence, provider-role exclusion, and the same live TLS-bound runtime role. A
+readiness failure disables the authority read instead of accepting an
+instance-local pagination order.
 
 Put the dedicated role's connection string in
 `PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL`, its exact role name in
@@ -392,17 +418,21 @@ exact `0001` through `0006` database remains a safe legacy single-flight prefix,
 but it is not multiflight release evidence and cannot authorize this release's
 GMGN Pro throughput claim.
 
-1. migrations `0001` through `0007` were applied in that exact order on the
+1. migrations `0001` through `0008` were applied in that exact order on the
    intended hosted database, their exact reviewed digests are retained, and live
    catalog proof confirms the complete application schema, including the `0002`
    wallet/profile changes and the `0006` GMGN gate singleton, policies, grants,
    decision history and constraints, plus the `0007` lease table, foreign and
-   unique bindings, three runtime policies and least-privilege grants;
+   unique bindings, three runtime policies and least-privilege grants, plus the
+   `0008` authority head/generation tables, constraints, indexes, exact
+   seven-policy set, forced RLS and narrow runtime grants;
 2. the runtime uses the dedicated least-privilege role, the base production
    readiness attestation proves the existing `0001` through `0005` contract,
    and the separate GMGN runtime attestation proves the usable `0006`/`0007`
    relations, ownership, grants, forced RLS, exact policy set and provider-role
-   exclusion against that hosted database. The operator catalog proof in step 1,
+   exclusion, and `assertExploreMarketCapAuthorityReadiness` proves the complete
+   `0008` authority relation, grant and policy posture against that hosted
+   database. The operator catalog proof in step 1,
    rather than this runtime probe, binds the full column, constraint and index
    definitions;
 3. Supabase Postgres SSL enforcement is enabled, the current Server root

--- a/docs/operations/custom-v2-production-stage-gate.md
+++ b/docs/operations/custom-v2-production-stage-gate.md
@@ -104,8 +104,11 @@ The staged public smoke records both `gmgn_requests_per_second` and
 fails closed unless the health response proves exactly 20 requests per second
 and `providers[0].accountGateMode=multiflight-v1`. The
 `legacy-singleflight-v1` mode from a database through migration `0006` is a
-rolling-availability prefix only; Stage does not apply migration `0007`, and
-that mode cannot authorize promotion at Pro throughput.
+rolling-availability prefix only; Stage never applies database migrations,
+including `0007` or `0008`, and that mode cannot authorize promotion at Pro
+throughput. Market-cap pagination additionally requires the current `0008`
+Explore authority readiness before the staged smoke can accept a cross-page
+ranking commitment.
 
 Trending pagination records
 `discovery_consistency=ranking-identity+monotonic-current-freshness`. The

--- a/lib/market-data/explore-market-cap-authority.server.ts
+++ b/lib/market-data/explore-market-cap-authority.server.ts
@@ -1,0 +1,974 @@
+import "server-only";
+
+import { randomUUID } from "node:crypto";
+
+import {
+  canonicalizeJson,
+  parseStrictJson,
+} from "../server/projection-target/canonical-json";
+import { canonicalSha256 } from
+  "../server/projection-target/hashing";
+import type {
+  ProjectionTargetPostgresClientV1,
+  ProjectionTargetPostgresPoolV1,
+} from "../server/projection-target/postgres-store";
+import {
+  createProductionProjectionTargetPostgresPoolV1,
+  type ProductionProjectionTargetPostgresPoolV1,
+} from "../server/projection-target/website-target";
+
+export const EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_AGE_MS = 235_000;
+export const EXPLORE_MARKET_CAP_AUTHORITY_POSITIVE_REFRESH_MS = 60_000;
+export const EXPLORE_MARKET_CAP_AUTHORITY_UNAVAILABLE_REFRESH_MS = 10_000;
+export const EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_BYTES = 16 * 1_024 * 1_024;
+const EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_RETAINED_GENERATIONS = 32;
+// The provider build is bounded to eight seconds. The extra seven seconds keep
+// a slow successful build from losing its lease while its immutable generation
+// is validated and published.
+const EXPLORE_MARKET_CAP_AUTHORITY_LEASE_MS = 15_000;
+const EXPLORE_MARKET_CAP_AUTHORITY_POLL_MINIMUM_MS = 250;
+const EXPLORE_MARKET_CAP_AUTHORITY_TRANSACTION_MS = 2_500;
+const EXPLORE_MARKET_CAP_AUTHORITY_CLAIM_RESERVE_MS = 3_000;
+const DIGEST = /^sha256:[0-9a-f]{64}$/u;
+
+export type ExploreMarketCapAuthorityDirectionV1 = "asc" | "desc";
+
+export type ExploreMarketCapAuthorityCandidateV1 = Readonly<{
+  canonicalAuthority: string;
+  authorityCommitment: `sha256:${string}`;
+  rankingCommitment: `sha256:${string}`;
+  gmgnStatus: "complete" | "partial" | "unavailable";
+  generatedAt: string;
+  validUntil: string;
+}>;
+
+export type ExploreMarketCapAuthorityResolutionV1 =
+  | Readonly<{ kind: "ready"; canonicalAuthority: string }>
+  | Readonly<{ kind: "ranking-conflict" }>
+  | Readonly<{ kind: "unavailable" }>;
+
+export type ExploreMarketCapAuthorityResolveInputV1 = Readonly<{
+  inputCommitment: `sha256:${string}`;
+  direction: ExploreMarketCapAuthorityDirectionV1;
+  rankingCommitment?: `sha256:${string}`;
+  acceptPinnedAuthority?: (canonicalAuthority: string) => boolean;
+  build?: () => Promise<ExploreMarketCapAuthorityCandidateV1>;
+  deadlineMs: number;
+  signal?: AbortSignal;
+}>;
+
+interface AuthorityHeadRowV1 extends Record<string, unknown> {
+  input_commitment: string;
+  direction: string;
+  current_generation: string | number | bigint;
+  lease_generation: string | number | bigint | null;
+  lease_holder: string | null;
+  lease_until: Date | string;
+  decided_at: Date | string;
+  canonical_authority: string | null;
+  generated_at: Date | string | null;
+  refresh_after: Date | string | null;
+  valid_until: Date | string | null;
+  authority_commitment: string | null;
+}
+
+interface AuthorityGenerationRowV1 extends Record<string, unknown> {
+  canonical_authority: string;
+  authority_commitment: string;
+}
+
+type ClaimDecisionV1 =
+  | Readonly<{ kind: "ready"; canonicalAuthority: string }>
+  | Readonly<{
+      kind: "build";
+      holder: string;
+      generation: number;
+      decidedAtMs: number;
+      fallbackCanonicalAuthority: string | null;
+      fallbackValidUntilMs: number | null;
+    }>
+  | Readonly<{ kind: "wait" }>;
+
+type CurrentDecisionV1 =
+  | Readonly<{ kind: "ready"; canonicalAuthority: string }>
+  | Readonly<{ kind: "claim" }>
+  | Readonly<{ kind: "wait" }>;
+
+export class PostgresExploreMarketCapAuthorityStoreV1 {
+  readonly #pool: ProjectionTargetPostgresPoolV1;
+  readonly #assertReady: () => Promise<void>;
+  readonly #delay: (ms: number, signal?: AbortSignal) => Promise<boolean>;
+  readonly #garbageCollectionEnabled: boolean;
+
+  constructor(
+    pool: ProjectionTargetPostgresPoolV1,
+    options: Readonly<{
+      assertReady?: () => Promise<void>;
+      delay?: (ms: number, signal?: AbortSignal) => Promise<boolean>;
+      garbageCollection?: boolean;
+    }> = {},
+  ) {
+    if (
+      pool === null || typeof pool !== "object" ||
+      typeof pool.connect !== "function" || typeof pool.query !== "function"
+    ) throw new TypeError("Explore market-cap authority pool is invalid");
+    this.#pool = pool;
+    this.#assertReady = options.assertReady ?? (async () => {});
+    this.#delay = options.delay ?? abortableDelay;
+    this.#garbageCollectionEnabled = options.garbageCollection ?? true;
+  }
+
+  async resolve(
+    input: ExploreMarketCapAuthorityResolveInputV1,
+  ): Promise<ExploreMarketCapAuthorityResolutionV1> {
+    validateResolveInput(input);
+    try {
+      if (input.signal?.aborted) {
+        return Object.freeze({ kind: "unavailable" });
+      }
+      await settleBeforeDeadline(this.#assertReady(), input.deadlineMs);
+      const authorityKey = authorityKeyV1(
+        input.inputCommitment,
+        input.direction,
+      );
+      if (input.rankingCommitment !== undefined) {
+        const candidates = await settleBeforeDeadline(
+          this.#readPinnedCandidates(
+            authorityKey,
+            input.rankingCommitment,
+            input.deadlineMs,
+          ),
+          input.deadlineMs,
+        );
+        for (const canonicalAuthority of candidates) {
+          if (input.acceptPinnedAuthority!(canonicalAuthority)) {
+            return Object.freeze({ kind: "ready", canonicalAuthority });
+          }
+        }
+        return Object.freeze({ kind: "ranking-conflict" });
+      }
+
+      let pollMs = EXPLORE_MARKET_CAP_AUTHORITY_POLL_MINIMUM_MS;
+      while (
+        !input.signal?.aborted && Date.now() < input.deadlineMs
+      ) {
+        const current = await settleBeforeDeadline(
+          this.#readCurrentDecision(authorityKey, input, input.deadlineMs),
+          input.deadlineMs,
+        );
+        if (current.kind === "ready") return current;
+        const decision = current.kind === "claim"
+          ? await settleBeforeDeadline(
+              this.#claimCurrentOrBuild(authorityKey, input),
+              input.deadlineMs,
+            )
+          : current;
+        if (decision.kind === "ready") return decision;
+        if (decision.kind === "build") {
+          let candidate: ExploreMarketCapAuthorityCandidateV1;
+          try {
+            candidate = validateCandidate(
+              await settleBeforeDeadline(input.build!(), input.deadlineMs),
+              decision.decidedAtMs,
+            );
+          } catch {
+            await this.#releaseLease(
+              authorityKey,
+              decision.holder,
+              decision.generation,
+              input.deadlineMs,
+            );
+            return readyFallbackV1(decision) ??
+              Object.freeze({ kind: "unavailable" });
+          }
+          let published: boolean;
+          try {
+            published = await settleBeforeDeadline(
+              this.#publish(
+                authorityKey,
+                decision,
+                candidate,
+                input.deadlineMs,
+              ),
+              input.deadlineMs,
+            );
+          } catch {
+            await this.#releaseLease(
+              authorityKey,
+              decision.holder,
+              decision.generation,
+              input.deadlineMs,
+            );
+            return readyFallbackV1(decision) ??
+              Object.freeze({ kind: "unavailable" });
+          }
+          if (published) {
+            return Object.freeze({
+              kind: "ready",
+              canonicalAuthority: candidate.canonicalAuthority,
+            });
+          }
+          const fallback = readyFallbackV1(decision);
+          if (fallback !== null) return fallback;
+          continue;
+        }
+        const remainingMs = input.deadlineMs - Date.now();
+        if (remainingMs <= 0) break;
+        const waited = await this.#delay(
+          Math.min(
+            pollMs + Math.floor(Math.random() * 100),
+            remainingMs,
+          ),
+          input.signal,
+        );
+        if (!waited) break;
+        pollMs = Math.min(1_000, pollMs * 2);
+      }
+    } catch {
+      // The public route fails closed without exposing database details.
+    }
+    return Object.freeze({ kind: "unavailable" });
+  }
+
+  async #readCurrentDecision(
+    authorityKey: `sha256:${string}`,
+    input: ExploreMarketCapAuthorityResolveInputV1,
+    deadlineMs: number,
+  ): Promise<CurrentDecisionV1> {
+    const client = await connectBeforeDeadline(this.#pool, deadlineMs);
+    let transactionOpen = false;
+    try {
+      await client.query("BEGIN");
+      transactionOpen = true;
+      await configureTransaction(client, deadlineMs);
+      const result = await client.query<AuthorityHeadRowV1>(`
+        SELECT head.input_commitment, head.direction,
+               head.current_generation, head.lease_generation,
+               head.lease_holder, head.lease_until,
+               generation.canonical_authority,
+               generation.authority_commitment,
+               generation.generated_at, generation.refresh_after,
+               generation.valid_until,
+               pg_catalog.clock_timestamp() AS decided_at
+          FROM programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+            AS head
+          LEFT JOIN programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+            AS generation
+            ON generation.authority_key = head.authority_key
+           AND generation.generation = head.current_generation
+         WHERE head.authority_key = $1
+         LIMIT 1
+      `, [authorityKey]);
+      await client.query("COMMIT");
+      transactionOpen = false;
+      if (result.rows.length === 0) {
+        return Object.freeze({ kind: "claim" });
+      }
+      const row = exactlyOne(result.rows);
+      if (
+        row.input_commitment !== input.inputCommitment ||
+        row.direction !== input.direction
+      ) throw new TypeError("Explore market-cap authority key conflicts");
+      const decidedAtMs = timestampMs(row.decided_at);
+      const validUntilMs = nullableTimestampMs(row.valid_until);
+      const refreshAfterMs = nullableTimestampMs(row.refresh_after);
+      const currentIsValid = row.canonical_authority !== null &&
+        row.authority_commitment !== null &&
+        validStoredAuthorityV1(
+          row.canonical_authority,
+          row.authority_commitment,
+        ) && validUntilMs !== null && validUntilMs >= decidedAtMs;
+      if (
+        currentIsValid && refreshAfterMs !== null &&
+        refreshAfterMs > decidedAtMs
+      ) {
+        return Object.freeze({
+          kind: "ready",
+          canonicalAuthority: row.canonical_authority!,
+        });
+      }
+      if (
+        row.lease_holder !== null &&
+        timestampMs(row.lease_until) > decidedAtMs
+      ) {
+        return currentIsValid
+          ? Object.freeze({
+              kind: "ready" as const,
+              canonicalAuthority: row.canonical_authority!,
+            })
+          : Object.freeze({ kind: "wait" as const });
+      }
+      return Object.freeze({ kind: "claim" });
+    } catch (error) {
+      if (transactionOpen) await rollbackQuietly(client);
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async #readPinnedCandidates(
+    authorityKey: `sha256:${string}`,
+    rankingCommitment: `sha256:${string}`,
+    deadlineMs: number,
+  ): Promise<readonly string[]> {
+    const client = await connectBeforeDeadline(this.#pool, deadlineMs);
+    let transactionOpen = false;
+    try {
+      await client.query("BEGIN");
+      transactionOpen = true;
+      await configureTransaction(client, deadlineMs);
+      const result = await client.query<AuthorityGenerationRowV1>(`
+        SELECT generation.canonical_authority,
+               generation.authority_commitment
+          FROM programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+            AS generation
+         WHERE generation.authority_key = $1
+           AND generation.ranking_commitment = $2
+           AND generation.generated_at <= pg_catalog.clock_timestamp()
+           AND generation.valid_until >= pg_catalog.clock_timestamp()
+         ORDER BY generation.generation DESC
+         LIMIT 1
+      `, [authorityKey, rankingCommitment]);
+      await client.query("COMMIT");
+      transactionOpen = false;
+      return Object.freeze(result.rows.flatMap((row) =>
+        validStoredAuthorityV1(
+            row.canonical_authority,
+            row.authority_commitment,
+          )
+          ? [row.canonical_authority]
+          : []
+      ));
+    } catch (error) {
+      if (transactionOpen) await rollbackQuietly(client);
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async #claimCurrentOrBuild(
+    authorityKey: `sha256:${string}`,
+    input: ExploreMarketCapAuthorityResolveInputV1,
+  ): Promise<ClaimDecisionV1> {
+    const client = await connectBeforeDeadline(this.#pool, input.deadlineMs);
+    let transactionOpen = false;
+    try {
+      await client.query("BEGIN");
+      transactionOpen = true;
+      await configureTransaction(client, input.deadlineMs);
+      await client.query(
+        "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+        [authorityKey],
+      );
+      await client.query(`
+        INSERT INTO programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+          (authority_key, input_commitment, direction)
+        VALUES ($1, $2, $3)
+        ON CONFLICT DO NOTHING
+      `, [authorityKey, input.inputCommitment, input.direction]);
+      const result = await client.query<AuthorityHeadRowV1>(`
+        SELECT head.input_commitment, head.direction,
+               head.current_generation, head.lease_generation,
+               head.lease_holder, head.lease_until,
+               generation.canonical_authority,
+               generation.authority_commitment,
+               generation.generated_at, generation.refresh_after,
+               generation.valid_until,
+               pg_catalog.clock_timestamp() AS decided_at
+          FROM programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+            AS head
+          LEFT JOIN programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+            AS generation
+            ON generation.authority_key = head.authority_key
+           AND generation.generation = head.current_generation
+         WHERE head.authority_key = $1
+         FOR UPDATE OF head
+      `, [authorityKey]);
+      const row = exactlyOne(result.rows);
+      if (
+        row.input_commitment !== input.inputCommitment ||
+        row.direction !== input.direction
+      ) throw new TypeError("Explore market-cap authority key conflicts");
+      const decidedAtMs = timestampMs(row.decided_at);
+      const validUntilMs = nullableTimestampMs(row.valid_until);
+      const refreshAfterMs = nullableTimestampMs(row.refresh_after);
+      const leaseUntilMs = timestampMs(row.lease_until);
+      const currentGeneration = nonNegativeInteger(row.current_generation);
+      const currentIsValid = row.canonical_authority !== null &&
+        row.authority_commitment !== null &&
+        validStoredAuthorityV1(
+          row.canonical_authority,
+          row.authority_commitment,
+        ) &&
+        validUntilMs !== null && validUntilMs >= decidedAtMs;
+      if (
+        currentIsValid && refreshAfterMs !== null &&
+        refreshAfterMs > decidedAtMs
+      ) {
+        await client.query("COMMIT");
+        transactionOpen = false;
+        return Object.freeze({
+          kind: "ready",
+          canonicalAuthority: row.canonical_authority!,
+        });
+      }
+      if (row.lease_holder !== null && leaseUntilMs > decidedAtMs) {
+        await client.query("COMMIT");
+        transactionOpen = false;
+        return currentIsValid
+          ? Object.freeze({
+              kind: "ready" as const,
+              canonicalAuthority: row.canonical_authority!,
+            })
+          : Object.freeze({ kind: "wait" as const });
+      }
+      if (
+        input.deadlineMs - decidedAtMs <
+          EXPLORE_MARKET_CAP_AUTHORITY_CLAIM_RESERVE_MS
+      ) {
+        await client.query("COMMIT");
+        transactionOpen = false;
+        return currentIsValid
+          ? Object.freeze({
+              kind: "ready" as const,
+              canonicalAuthority: row.canonical_authority!,
+            })
+          : Object.freeze({ kind: "wait" as const });
+      }
+      const holder = randomUUID();
+      const generation = currentGeneration + 1;
+      const leaseUntil = new Date(
+        Math.min(
+          decidedAtMs + EXPLORE_MARKET_CAP_AUTHORITY_LEASE_MS,
+          input.deadlineMs,
+        ),
+      ).toISOString();
+      const updated = await client.query<Record<string, unknown>>(`
+        UPDATE programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+           SET lease_generation = $2,
+               lease_holder = $3::uuid,
+               lease_until = $4::timestamptz,
+               updated_at = $5::timestamptz
+         WHERE authority_key = $1
+        RETURNING authority_key
+      `, [
+        authorityKey,
+        generation,
+        holder,
+        leaseUntil,
+        new Date(decidedAtMs).toISOString(),
+      ]);
+      if (updated.rowCount !== 1) {
+        throw new TypeError("Explore market-cap authority lease is unavailable");
+      }
+      await client.query("COMMIT");
+      transactionOpen = false;
+      return Object.freeze({
+        kind: "build",
+        holder,
+        generation,
+        decidedAtMs,
+        fallbackCanonicalAuthority: currentIsValid
+          ? row.canonical_authority
+          : null,
+        fallbackValidUntilMs: currentIsValid ? validUntilMs : null,
+      });
+    } catch (error) {
+      if (transactionOpen) await rollbackQuietly(client);
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async #publish(
+    authorityKey: `sha256:${string}`,
+    claim: Extract<ClaimDecisionV1, { kind: "build" }>,
+    candidate: ExploreMarketCapAuthorityCandidateV1,
+    deadlineMs: number,
+  ): Promise<boolean> {
+    const client = await connectBeforeDeadline(this.#pool, deadlineMs);
+    let transactionOpen = false;
+    let clientReleased = false;
+    try {
+      await client.query("BEGIN");
+      transactionOpen = true;
+      await configureTransaction(
+        client,
+        deadlineMs,
+      );
+      await client.query(
+        "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+        [authorityKey],
+      );
+      const lease = exactlyOne((await client.query<{
+        lease_generation: string | number | bigint | null;
+        lease_holder: string | null;
+        lease_until: Date | string;
+        decided_at: Date | string;
+      } & Record<string, unknown>>(`
+        SELECT head.lease_generation, head.lease_holder, head.lease_until,
+               pg_catalog.clock_timestamp() AS decided_at
+          FROM programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+            AS head
+         WHERE head.authority_key = $1
+         FOR UPDATE
+      `, [authorityKey])).rows);
+      const decidedAtMs = timestampMs(lease.decided_at);
+      if (
+        lease.lease_holder !== claim.holder ||
+        nullableNonNegativeInteger(lease.lease_generation) !== claim.generation ||
+        timestampMs(lease.lease_until) <= decidedAtMs ||
+        Date.parse(candidate.validUntil) <= decidedAtMs
+      ) {
+        await client.query("ROLLBACK");
+        transactionOpen = false;
+        return false;
+      }
+      const refreshMs = candidate.gmgnStatus === "unavailable"
+        ? EXPLORE_MARKET_CAP_AUTHORITY_UNAVAILABLE_REFRESH_MS
+        : EXPLORE_MARKET_CAP_AUTHORITY_POSITIVE_REFRESH_MS;
+      const refreshAfter = new Date(
+        Math.min(
+          Date.parse(candidate.validUntil),
+          Date.parse(candidate.generatedAt) + refreshMs,
+        ),
+      ).toISOString();
+      const inserted = await client.query<Record<string, unknown>>(`
+        INSERT INTO programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+          (authority_key, generation, authority_commitment,
+           ranking_commitment, gmgn_status, generated_at, refresh_after,
+           valid_until, canonical_authority)
+        VALUES ($1, $2, $3, $4, $5, $6::timestamptz, $7::timestamptz,
+                $8::timestamptz, $9)
+        ON CONFLICT DO NOTHING
+        RETURNING authority_key
+      `, [
+        authorityKey,
+        claim.generation,
+        candidate.authorityCommitment,
+        candidate.rankingCommitment,
+        candidate.gmgnStatus,
+        candidate.generatedAt,
+        refreshAfter,
+        candidate.validUntil,
+        candidate.canonicalAuthority,
+      ]);
+      if (inserted.rowCount !== 1) {
+        throw new TypeError("Explore market-cap authority generation conflicts");
+      }
+      const updated = await client.query<Record<string, unknown>>(`
+        UPDATE programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+           SET current_generation = $2,
+               lease_generation = NULL,
+               lease_holder = NULL,
+               lease_until = TIMESTAMPTZ 'epoch',
+               updated_at = $3::timestamptz
+         WHERE authority_key = $1
+           AND lease_generation = $2
+           AND lease_holder = $4::uuid
+        RETURNING authority_key
+      `, [
+        authorityKey,
+        claim.generation,
+        new Date(decidedAtMs).toISOString(),
+        claim.holder,
+      ]);
+      if (updated.rowCount !== 1) {
+        throw new TypeError("Explore market-cap authority publish conflicts");
+      }
+      await client.query(`
+        DELETE FROM programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+         WHERE authority_key = $1
+           AND (
+             valid_until < $2::timestamptz
+             OR generation NOT IN (
+               SELECT retained.generation
+                 FROM programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+                   AS retained
+                WHERE retained.authority_key = $1
+                ORDER BY retained.generation DESC
+                LIMIT ${EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_RETAINED_GENERATIONS}
+             )
+           )
+      `, [authorityKey, new Date(decidedAtMs).toISOString()]);
+      await client.query("COMMIT");
+      transactionOpen = false;
+      client.release();
+      clientReleased = true;
+      if (
+        this.#garbageCollectionEnabled && Date.now() < deadlineMs
+      ) {
+        await this.#garbageCollect(authorityKey, deadlineMs)
+          .catch(() => undefined);
+      }
+      return true;
+    } catch (error) {
+      if (transactionOpen) await rollbackQuietly(client);
+      throw error;
+    } finally {
+      if (!clientReleased) client.release();
+    }
+  }
+
+  async #releaseLease(
+    authorityKey: `sha256:${string}`,
+    holder: string,
+    generation: number,
+    deadlineMs: number,
+  ): Promise<void> {
+    const query = this.#pool.query(`
+      UPDATE programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+         SET lease_generation = NULL,
+             lease_holder = NULL,
+             lease_until = TIMESTAMPTZ 'epoch',
+             updated_at = pg_catalog.clock_timestamp()
+       WHERE authority_key = $1
+         AND lease_generation = $2
+         AND lease_holder = $3::uuid
+    `, [authorityKey, generation, holder]);
+    await settleBeforeDeadline(query, deadlineMs).catch(() => undefined);
+  }
+
+  async #garbageCollect(
+    currentAuthorityKey: `sha256:${string}`,
+    requestDeadlineMs: number,
+  ): Promise<void> {
+    const deadlineMs = Math.min(requestDeadlineMs, Date.now() + 1_000);
+    const client = await connectBeforeDeadline(this.#pool, deadlineMs);
+    let transactionOpen = false;
+    try {
+      await client.query("BEGIN");
+      transactionOpen = true;
+      await configureTransaction(client, deadlineMs);
+      await client.query(`
+        DELETE FROM programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+         WHERE ctid IN (
+           SELECT generation.ctid
+             FROM programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+               AS generation
+            WHERE generation.authority_key <> $1
+              AND generation.valid_until < pg_catalog.clock_timestamp()
+            ORDER BY generation.valid_until
+            LIMIT 256
+         )
+      `, [currentAuthorityKey]);
+      await client.query(`
+        DELETE FROM programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+         WHERE ctid IN (
+           SELECT head.ctid
+             FROM programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+               AS head
+            WHERE head.authority_key <> $1
+              AND head.lease_until <= pg_catalog.clock_timestamp()
+              AND head.updated_at < pg_catalog.clock_timestamp() -
+                INTERVAL '235 seconds'
+              AND NOT EXISTS (
+                SELECT 1
+                  FROM programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+                    AS generation
+                 WHERE generation.authority_key = head.authority_key
+                   AND generation.valid_until >= pg_catalog.clock_timestamp()
+              )
+            ORDER BY head.updated_at
+            LIMIT 64
+         )
+      `, [currentAuthorityKey]);
+      await client.query("COMMIT");
+      transactionOpen = false;
+    } catch (error) {
+      if (transactionOpen) await rollbackQuietly(client);
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+}
+
+function authorityKeyV1(
+  inputCommitment: `sha256:${string}`,
+  direction: ExploreMarketCapAuthorityDirectionV1,
+): `sha256:${string}` {
+  return canonicalSha256(
+    "programmable.explore-market-cap-authority-key.v1",
+    { inputCommitment, direction },
+  );
+}
+
+function readyFallbackV1(
+  decision: Extract<ClaimDecisionV1, { kind: "build" }>,
+): Extract<ExploreMarketCapAuthorityResolutionV1, { kind: "ready" }> | null {
+  return decision.fallbackCanonicalAuthority !== null &&
+      decision.fallbackValidUntilMs !== null &&
+      decision.fallbackValidUntilMs >= Date.now()
+    ? Object.freeze({
+        kind: "ready" as const,
+        canonicalAuthority: decision.fallbackCanonicalAuthority,
+      })
+    : null;
+}
+
+function validateResolveInput(
+  input: ExploreMarketCapAuthorityResolveInputV1,
+): void {
+  if (
+    !DIGEST.test(input.inputCommitment) ||
+    (input.direction !== "asc" && input.direction !== "desc") ||
+    !Number.isFinite(input.deadlineMs)
+  ) throw new TypeError("Explore market-cap authority request is invalid");
+  const pinned = input.rankingCommitment !== undefined;
+  if (
+    pinned !== (input.acceptPinnedAuthority !== undefined) ||
+    (pinned && !DIGEST.test(input.rankingCommitment!)) ||
+    (!pinned && typeof input.build !== "function")
+  ) throw new TypeError("Explore market-cap authority request is invalid");
+}
+
+function validateCandidate(
+  candidate: ExploreMarketCapAuthorityCandidateV1,
+  decidedAtMs: number,
+): ExploreMarketCapAuthorityCandidateV1 {
+  if (
+    !candidate || typeof candidate !== "object" ||
+    !DIGEST.test(candidate.authorityCommitment) ||
+    !DIGEST.test(candidate.rankingCommitment) ||
+    !["complete", "partial", "unavailable"].includes(candidate.gmgnStatus)
+  ) throw new TypeError("Explore market-cap authority candidate is invalid");
+  const parsed = parseStrictJson(candidate.canonicalAuthority, {
+    maximumBytes: EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_BYTES,
+    maximumDepth: 64,
+  });
+  if (canonicalizeJson(parsed) !== candidate.canonicalAuthority) {
+    throw new TypeError("Explore market-cap authority JSON is not canonical");
+  }
+  if (
+    candidate.authorityCommitment !==
+      exploreMarketCapAuthorityStorageCommitmentV1(
+        candidate.canonicalAuthority,
+      )
+  ) {
+    throw new TypeError("Explore market-cap authority commitment is invalid");
+  }
+  const generatedAtMs = exactTimestampMs(candidate.generatedAt);
+  const validUntilMs = exactTimestampMs(candidate.validUntil);
+  if (
+    generatedAtMs > decidedAtMs + 10_000 ||
+    validUntilMs <= decidedAtMs ||
+    validUntilMs <= generatedAtMs ||
+    validUntilMs - generatedAtMs >
+      EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_AGE_MS
+  ) throw new TypeError("Explore market-cap authority lifetime is invalid");
+  return Object.freeze({ ...candidate });
+}
+
+export function exploreMarketCapAuthorityStorageCommitmentV1(
+  canonicalAuthority: string,
+): `sha256:${string}` {
+  return canonicalSha256(
+    "programmable.explore-market-cap-authority-storage.v1",
+    { canonicalAuthority },
+  );
+}
+
+function validStoredAuthorityV1(
+  canonicalAuthority: string,
+  authorityCommitment: string,
+): boolean {
+  if (!DIGEST.test(authorityCommitment)) return false;
+  try {
+    const parsed = parseStrictJson(canonicalAuthority, {
+      maximumBytes: EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_BYTES,
+      maximumDepth: 64,
+    });
+    return canonicalizeJson(parsed) === canonicalAuthority &&
+      exploreMarketCapAuthorityStorageCommitmentV1(canonicalAuthority) ===
+        authorityCommitment;
+  } catch {
+    return false;
+  }
+}
+
+async function configureTransaction(
+  client: ProjectionTargetPostgresClientV1,
+  deadlineMs: number,
+) {
+  await client.query(
+    "SELECT set_config('statement_timeout', $1, true)",
+    [postgresDuration(deadlineMs - Date.now())],
+  );
+}
+
+function connectBeforeDeadline(
+  pool: ProjectionTargetPostgresPoolV1,
+  deadlineMs: number,
+): Promise<ProjectionTargetPostgresClientV1> {
+  const connection = pool.connect();
+  const remainingMs = Math.ceil(deadlineMs - Date.now());
+  if (remainingMs <= 0) {
+    void connection.then((client) => client.release(), () => undefined);
+    return Promise.reject(
+      new TypeError("Explore market-cap authority deadline elapsed"),
+    );
+  }
+  return new Promise((resolve, reject) => {
+    let decided = false;
+    const timer = globalThis.setTimeout(() => {
+      decided = true;
+      reject(new TypeError("Explore market-cap authority deadline elapsed"));
+    }, remainingMs);
+    void connection.then((client) => {
+      if (decided) {
+        client.release();
+        return;
+      }
+      decided = true;
+      globalThis.clearTimeout(timer);
+      resolve(client);
+    }, (error: unknown) => {
+      if (decided) return;
+      decided = true;
+      globalThis.clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
+
+function settleBeforeDeadline<T>(
+  operation: Promise<T>,
+  deadlineMs: number,
+): Promise<T> {
+  const remainingMs = Math.ceil(deadlineMs - Date.now());
+  if (remainingMs <= 0) {
+    void operation.catch(() => undefined);
+    return Promise.reject(
+      new TypeError("Explore market-cap authority deadline elapsed"),
+    );
+  }
+  return new Promise((resolve, reject) => {
+    let decided = false;
+    const timer = globalThis.setTimeout(() => {
+      decided = true;
+      reject(new TypeError("Explore market-cap authority deadline elapsed"));
+    }, remainingMs);
+    void operation.then((value) => {
+      if (decided) return;
+      decided = true;
+      globalThis.clearTimeout(timer);
+      resolve(value);
+    }, (error: unknown) => {
+      if (decided) return;
+      decided = true;
+      globalThis.clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
+
+function postgresDuration(remainingMs: number): string {
+  const bounded = Math.max(
+    1,
+    Math.min(
+      EXPLORE_MARKET_CAP_AUTHORITY_TRANSACTION_MS,
+      Math.ceil(remainingMs),
+    ),
+  );
+  return `${bounded}ms`;
+}
+
+function exactlyOne<Row>(rows: readonly Row[]): Row {
+  if (rows.length !== 1) {
+    throw new TypeError("Explore market-cap authority row is unavailable");
+  }
+  return rows[0]!;
+}
+
+function timestampMs(value: Date | string): number {
+  const result = value instanceof Date ? value.getTime() : Date.parse(value);
+  if (!Number.isFinite(result)) {
+    throw new TypeError("Explore market-cap authority timestamp is invalid");
+  }
+  return result;
+}
+
+function nullableTimestampMs(value: Date | string | null): number | null {
+  return value === null ? null : timestampMs(value);
+}
+
+function exactTimestampMs(value: string): number {
+  const result = Date.parse(value);
+  if (!Number.isFinite(result) || new Date(result).toISOString() !== value) {
+    throw new TypeError("Explore market-cap authority timestamp is invalid");
+  }
+  return result;
+}
+
+function nonNegativeInteger(value: string | number | bigint): number {
+  const result = Number(value);
+  if (!Number.isSafeInteger(result) || result < 0) {
+    throw new TypeError("Explore market-cap authority generation is invalid");
+  }
+  return result;
+}
+
+function nullableNonNegativeInteger(
+  value: string | number | bigint | null,
+): number | null {
+  return value === null ? null : nonNegativeInteger(value);
+}
+
+async function rollbackQuietly(client: ProjectionTargetPostgresClientV1) {
+  await client.query("ROLLBACK").catch(() => undefined);
+}
+
+function abortableDelay(ms: number, signal?: AbortSignal): Promise<boolean> {
+  if (signal?.aborted) return Promise.resolve(false);
+  return new Promise((resolve) => {
+    const timer = globalThis.setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve(true);
+    }, ms);
+    const onAbort = () => {
+      globalThis.clearTimeout(timer);
+      resolve(false);
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+let productionAuthorityStore:
+PostgresExploreMarketCapAuthorityStoreV1 | null = null;
+
+export function getProductionExploreMarketCapAuthorityStoreV1():
+PostgresExploreMarketCapAuthorityStoreV1 {
+  if (productionAuthorityStore !== null) return productionAuthorityStore;
+  const pool: ProductionProjectionTargetPostgresPoolV1 =
+    createProductionProjectionTargetPostgresPoolV1(
+    environmentValue("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_URL"),
+    environmentPem("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_CA_PEM"),
+    environmentValue("PROGRAMMABLE_WEBSITE_PROJECTION_DATABASE_ROLE"),
+    );
+  productionAuthorityStore = new PostgresExploreMarketCapAuthorityStoreV1(
+    pool,
+    {
+      assertReady: () => pool.assertExploreMarketCapAuthorityReadiness(),
+    },
+  );
+  return productionAuthorityStore;
+}
+
+function environmentValue(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new TypeError(`${name} is not configured`);
+  return value;
+}
+
+function environmentPem(name: string): string {
+  const value = environmentValue(name).replaceAll("\\n", "\n");
+  if (
+    !value.includes("-----BEGIN CERTIFICATE-----") ||
+    !value.includes("-----END CERTIFICATE-----")
+  ) throw new TypeError(`${name} is invalid`);
+  return value;
+}

--- a/lib/market-data/gmgn-discovery.server.ts
+++ b/lib/market-data/gmgn-discovery.server.ts
@@ -24,6 +24,11 @@ import {
 
 const GMGN_API_ORIGIN = "https://openapi.gmgn.ai" as const;
 const GMGN_REQUEST_TIMEOUT_MS = 2_500;
+// Cold database readiness and account-wide scheduling must not consume the
+// provider's response budget after a slot has actually been reserved.
+const GMGN_ACCOUNT_GATE_WAIT_TIMEOUT_MS = 5_000;
+const GMGN_PROVIDER_WORK_TIMEOUT_MS =
+  GMGN_ACCOUNT_GATE_WAIT_TIMEOUT_MS + GMGN_REQUEST_TIMEOUT_MS;
 const GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS = 3_000;
 const GMGN_PROVIDER_LIFECYCLE_GRACE_MS =
   GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS + 500;
@@ -408,15 +413,16 @@ function providerWorkWait(
     accountGate: callerWait.accountGate,
     now,
     deadlineMs: Number.isFinite(startedAtMs)
-      ? startedAtMs + GMGN_REQUEST_TIMEOUT_MS
-      : Date.now() + GMGN_REQUEST_TIMEOUT_MS,
+      ? startedAtMs + GMGN_PROVIDER_WORK_TIMEOUT_MS
+      : Date.now() + GMGN_PROVIDER_WORK_TIMEOUT_MS,
   });
 }
 
 function providerOperation(wait: GmgnDiscoveryReadWaitV1): ProviderOperationV1 {
   const now = wait.now ?? (() => new Date());
   return Object.freeze({
-    deadlineMs: wait.deadlineMs ?? now().getTime() + GMGN_REQUEST_TIMEOUT_MS,
+    deadlineMs: wait.deadlineMs ??
+      now().getTime() + GMGN_PROVIDER_WORK_TIMEOUT_MS,
     now,
   });
 }
@@ -572,7 +578,7 @@ async function gmgnJsonRequest(
   const now = wait.now ?? (() => new Date());
   const queuedAtMs = now().getTime();
   const requestDeadlineMs = wait.deadlineMs ??
-    queuedAtMs + GMGN_REQUEST_TIMEOUT_MS;
+    queuedAtMs + GMGN_PROVIDER_WORK_TIMEOUT_MS;
   if (
     wait.signal?.aborted ||
     !Number.isFinite(queuedAtMs) ||
@@ -586,7 +592,11 @@ async function gmgnJsonRequest(
     Awaited<ReturnType<GmgnAccountGateV1["reserveSlot"]>>,
     { kind: "reserved" }
   > | null = null;
-  const operation = Object.freeze({ deadlineMs: requestDeadlineMs, now });
+  const gateDeadlineMs = Math.min(
+    requestDeadlineMs,
+    queuedAtMs + GMGN_ACCOUNT_GATE_WAIT_TIMEOUT_MS,
+  );
+  const gateOperation = Object.freeze({ deadlineMs: gateDeadlineMs, now });
   try {
     if (
       accountGate === null &&
@@ -596,9 +606,9 @@ async function gmgnJsonRequest(
       const decision = await reserveProviderSlot(accountGate, {
         requestsPerSecond: gmgnEffectiveRequestsPerSecondV1(),
         cost: endpointCost(path),
-        deadlineMs: requestDeadlineMs,
+        deadlineMs: gateDeadlineMs,
         signal: wait.signal,
-      }, operation);
+      }, gateOperation);
       if (decision?.kind !== "reserved") return null;
       reservation = decision;
     }

--- a/lib/market-data/gmgn.server.ts
+++ b/lib/market-data/gmgn.server.ts
@@ -24,6 +24,11 @@ import type { MarketChartIdentityV1 } from "./market-data-v1";
 
 const GMGN_API_ORIGIN = "https://openapi.gmgn.ai" as const;
 const GMGN_REQUEST_TIMEOUT_MS = 2_500;
+// Cold database readiness and account-wide scheduling must not consume the
+// provider's response budget after a slot has actually been reserved.
+const GMGN_ACCOUNT_GATE_WAIT_TIMEOUT_MS = 5_000;
+const GMGN_PROVIDER_WORK_TIMEOUT_MS =
+  GMGN_ACCOUNT_GATE_WAIT_TIMEOUT_MS + GMGN_REQUEST_TIMEOUT_MS;
 const GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS = 3_000;
 const GMGN_PROVIDER_LIFECYCLE_GRACE_MS =
   GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS + 500;
@@ -377,6 +382,20 @@ async function gmgnJsonRequest(
     Awaited<ReturnType<GmgnAccountGateV1["reserveSlot"]>>,
     { kind: "reserved" }
   > | null = null;
+  const gateDeadlineMs = Math.min(
+    requestDeadlineMs,
+    queueTimeMs + GMGN_ACCOUNT_GATE_WAIT_TIMEOUT_MS,
+  );
+  const gateTimeoutMs = Math.max(1, gateDeadlineMs - queueTimeMs);
+  const gateSignal = AbortSignal.any([
+    wait.signal,
+    AbortSignal.timeout(gateTimeoutMs),
+  ]);
+  const gateOperation: ProviderOperationV1 = {
+    deadlineMs: gateDeadlineMs,
+    now,
+    signal: gateSignal,
+  };
   try {
     if (
       accountGate === null
@@ -387,9 +406,9 @@ async function gmgnJsonRequest(
     if (accountGate !== null) {
       const decision = await reserveProviderSlot(accountGate, {
         requestsPerSecond: gmgnEffectiveRequestsPerSecondV1(),
-        deadlineMs: requestDeadlineMs,
-        signal: wait.signal,
-      }, wait);
+        deadlineMs: gateDeadlineMs,
+        signal: gateSignal,
+      }, gateOperation);
       if (decision?.kind !== "reserved") return null;
       reservation = decision;
     }
@@ -410,6 +429,13 @@ async function gmgnJsonRequest(
   }
   url.searchParams.set("timestamp", String(Math.floor(nowMs / 1_000)));
   url.searchParams.set("client_id", crypto.randomUUID());
+  const providerHttpTimeout = AbortSignal.timeout(
+    Math.max(1, Math.min(GMGN_REQUEST_TIMEOUT_MS, remaining)),
+  );
+  const providerHttpSignal = AbortSignal.any([
+    wait.signal,
+    providerHttpTimeout,
+  ]);
   let response: Response;
   try {
     response = await fetchImpl(url, {
@@ -418,7 +444,7 @@ async function gmgnJsonRequest(
       redirect: "error",
       credentials: "omit",
       cache: "no-store",
-      signal: wait.signal,
+      signal: providerHttpSignal,
     });
   } catch {
     await completeProviderRequest(accountGate, reservation);
@@ -554,9 +580,9 @@ function sharedProviderWait(wait: GmgnReadWaitV1): GmgnProviderReadWaitV1 {
     now,
     accountGate: wait.accountGate,
     deadlineMs: Number.isFinite(startedAtMs)
-      ? startedAtMs + GMGN_REQUEST_TIMEOUT_MS
-      : Date.now() + GMGN_REQUEST_TIMEOUT_MS,
-    signal: AbortSignal.timeout(GMGN_REQUEST_TIMEOUT_MS),
+      ? startedAtMs + GMGN_PROVIDER_WORK_TIMEOUT_MS
+      : Date.now() + GMGN_PROVIDER_WORK_TIMEOUT_MS,
+    signal: AbortSignal.timeout(GMGN_PROVIDER_WORK_TIMEOUT_MS),
   };
 }
 

--- a/lib/public-openapi.ts
+++ b/lib/public-openapi.ts
@@ -334,6 +334,16 @@ export const programmablePublicOpenApi = {
               default: "newest",
             },
           },
+          {
+            name: "rankingCommitment",
+            in: "query",
+            description:
+              "Required for page > 1 with sort=market-cap or sort=market-cap-asc. Pass the exact ranking.rankingCommitment returned by page 1 to keep every page on the same retained ranking generation. If that generation is no longer retained, restart from page 1.",
+            schema: {
+              type: "string",
+              pattern: "^sha256:[0-9a-f]{64}$",
+            },
+          },
         ],
         responses: {
           "200": {
@@ -350,6 +360,10 @@ export const programmablePublicOpenApi = {
             },
           },
           "400": jsonResponse(component("ApiError"), "Invalid query shape."),
+          "409": jsonResponse(
+            component("ApiError"),
+            "The requested market-cap ranking generation is no longer retained; restart pagination from page 1.",
+          ),
           "503": jsonResponse(
             component("ApiError"),
             "The verified identity source is temporarily unavailable.",

--- a/lib/server/projection-target/website-target.ts
+++ b/lib/server/projection-target/website-target.ts
@@ -134,6 +134,38 @@ extends Record<string, unknown> {
   ssl_bits: number | null;
 }
 
+export interface ExploreMarketCapAuthoritySecurityAttestationRowV1
+extends Record<string, unknown> {
+  runtime_role: string;
+  session_role: string;
+  rolsuper: boolean;
+  rolcreaterole: boolean;
+  rolcreatedb: boolean;
+  rolreplication: boolean;
+  rolbypassrls: boolean;
+  schema_usage: boolean;
+  schema_create: boolean;
+  heads_select: boolean;
+  heads_insert: boolean;
+  heads_delete: boolean;
+  heads_update: boolean;
+  heads_forbidden_access: boolean;
+  generations_select: boolean;
+  generations_insert: boolean;
+  generations_delete: boolean;
+  generations_forbidden_access: boolean;
+  heads_rls: boolean;
+  heads_force_rls: boolean;
+  generations_rls: boolean;
+  generations_force_rls: boolean;
+  expected_policies: boolean;
+  provider_roles_excluded: boolean;
+  ssl: boolean;
+  ssl_version: string | null;
+  ssl_cipher: string | null;
+  ssl_bits: number | null;
+}
+
 export interface VerifiedPostgresTlsConfigurationV1 {
   readonly connectionString: string;
   readonly servername: string;
@@ -390,11 +422,12 @@ export function verifiedPostgresTlsConfigurationV1(
   });
 }
 
-interface ProductionProjectionTargetPostgresPoolV1
+export interface ProductionProjectionTargetPostgresPoolV1
 extends ProjectionTargetPostgresPoolV1 {
   assertProductionReadiness(): Promise<void>;
   assertGmgnAccountGateReadiness(): Promise<void>;
   assertGmgnAccountGateMultiflightReadiness(): Promise<void>;
+  assertExploreMarketCapAuthorityReadiness(): Promise<void>;
 }
 
 class NodePostgresProjectionTargetPoolV1
@@ -407,6 +440,8 @@ implements ProductionProjectionTargetPostgresPoolV1 {
   #gmgnReadinessAttestedAtMs = 0;
   #gmgnMultiflightReadiness: Promise<void> | null = null;
   #gmgnMultiflightReadinessAttestedAtMs = 0;
+  #exploreMarketCapAuthorityReadiness: Promise<void> | null = null;
+  #exploreMarketCapAuthorityReadinessAttestedAtMs = 0;
 
   constructor(pool: Pool, expectedRuntimeRole: string) {
     this.#pool = pool;
@@ -468,6 +503,26 @@ implements ProductionProjectionTargetPostgresPoolV1 {
       throw error;
     } finally {
       this.#gmgnMultiflightReadiness = null;
+    }
+  }
+
+  async assertExploreMarketCapAuthorityReadiness(): Promise<void> {
+    if (
+      this.#exploreMarketCapAuthorityReadinessAttestedAtMs > 0 &&
+      Date.now() - this.#exploreMarketCapAuthorityReadinessAttestedAtMs < 30_000
+    ) return;
+    this.#exploreMarketCapAuthorityReadiness ??=
+      this.#performExploreMarketCapAuthorityReadinessAttestation()
+        .then(() => {
+          this.#exploreMarketCapAuthorityReadinessAttestedAtMs = Date.now();
+        });
+    try {
+      await this.#exploreMarketCapAuthorityReadiness;
+    } catch (error) {
+      this.#exploreMarketCapAuthorityReadinessAttestedAtMs = 0;
+      throw error;
+    } finally {
+      this.#exploreMarketCapAuthorityReadiness = null;
     }
   }
 
@@ -844,6 +899,152 @@ implements ProductionProjectionTargetPostgresPoolV1 {
     }
   }
 
+  async #performExploreMarketCapAuthorityReadinessAttestation(): Promise<void> {
+    const client = await this.#pool.connect();
+    try {
+      const result = await client.query<
+      ExploreMarketCapAuthoritySecurityAttestationRowV1>(`
+        SELECT current_user::text AS runtime_role,
+               session_user::text AS session_role,
+               role.rolsuper, role.rolcreaterole, role.rolcreatedb,
+               role.rolreplication, role.rolbypassrls,
+               has_schema_privilege(current_user,
+                 'programmable_website_projection_v1', 'USAGE') AS schema_usage,
+               has_schema_privilege(current_user,
+                 'programmable_website_projection_v1', 'CREATE') AS schema_create,
+               has_table_privilege(current_user,
+                 'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                 'SELECT') AS heads_select,
+               has_table_privilege(current_user,
+                 'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                 'INSERT') AS heads_insert,
+               has_table_privilege(current_user,
+                 'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                 'DELETE') AS heads_delete,
+               (
+                 has_column_privilege(current_user,
+                   'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                   'current_generation', 'UPDATE')
+                 AND has_column_privilege(current_user,
+                   'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                   'lease_generation', 'UPDATE')
+                 AND has_column_privilege(current_user,
+                   'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                   'lease_holder', 'UPDATE')
+                 AND has_column_privilege(current_user,
+                   'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                   'lease_until', 'UPDATE')
+                 AND has_column_privilege(current_user,
+                   'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                   'updated_at', 'UPDATE')
+               ) AS heads_update,
+               (
+                 has_table_privilege(current_user,
+                   'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                   'UPDATE,TRUNCATE,REFERENCES,TRIGGER')
+                 OR has_column_privilege(current_user,
+                   'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                   'authority_key', 'UPDATE')
+                 OR has_column_privilege(current_user,
+                   'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                   'input_commitment', 'UPDATE')
+                 OR has_column_privilege(current_user,
+                   'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                   'direction', 'UPDATE')
+                 OR has_any_column_privilege(current_user,
+                   'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                   'REFERENCES')
+               ) AS heads_forbidden_access,
+               has_table_privilege(current_user,
+                 'programmable_website_projection_v1.explore_market_cap_authority_generations_v1',
+                 'SELECT') AS generations_select,
+               has_table_privilege(current_user,
+                 'programmable_website_projection_v1.explore_market_cap_authority_generations_v1',
+                 'INSERT') AS generations_insert,
+               has_table_privilege(current_user,
+                 'programmable_website_projection_v1.explore_market_cap_authority_generations_v1',
+                 'DELETE') AS generations_delete,
+               (
+                 has_table_privilege(current_user,
+                   'programmable_website_projection_v1.explore_market_cap_authority_generations_v1',
+                   'UPDATE,TRUNCATE,REFERENCES,TRIGGER')
+                 OR has_any_column_privilege(current_user,
+                   'programmable_website_projection_v1.explore_market_cap_authority_generations_v1',
+                   'UPDATE,REFERENCES')
+               ) AS generations_forbidden_access,
+               heads.relrowsecurity AS heads_rls,
+               heads.relforcerowsecurity AS heads_force_rls,
+               generations.relrowsecurity AS generations_rls,
+               generations.relforcerowsecurity AS generations_force_rls,
+               (
+                 SELECT count(*) = 7
+                    AND bool_and(
+                      policies.roles = ARRAY['programmable_website_projection_runtime']::name[]
+                    )
+                    AND string_agg(
+                      policies.policyname || ':' || policies.cmd,
+                      ',' ORDER BY policies.policyname
+                    ) = 'explore_market_cap_authority_generations_v1_runtime_delete:DELETE,explore_market_cap_authority_generations_v1_runtime_insert:INSERT,explore_market_cap_authority_generations_v1_runtime_select:SELECT,explore_market_cap_authority_heads_v1_runtime_delete:DELETE,explore_market_cap_authority_heads_v1_runtime_insert:INSERT,explore_market_cap_authority_heads_v1_runtime_select:SELECT,explore_market_cap_authority_heads_v1_runtime_update:UPDATE'
+                   FROM pg_policies AS policies
+                  WHERE policies.schemaname = 'programmable_website_projection_v1'
+                    AND policies.tablename IN (
+                      'explore_market_cap_authority_heads_v1',
+                      'explore_market_cap_authority_generations_v1'
+                    )
+               ) AS expected_policies,
+               NOT EXISTS (
+                 SELECT 1
+                   FROM pg_roles AS provider_role
+                  WHERE provider_role.rolname IN ('anon', 'authenticated', 'service_role')
+                    AND (
+                      has_table_privilege(provider_role.rolname,
+                        'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                        'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+                      OR has_table_privilege(provider_role.rolname,
+                        'programmable_website_projection_v1.explore_market_cap_authority_generations_v1',
+                        'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+                      OR has_any_column_privilege(provider_role.rolname,
+                        'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                        'SELECT,INSERT,UPDATE,REFERENCES')
+                      OR has_any_column_privilege(provider_role.rolname,
+                        'programmable_website_projection_v1.explore_market_cap_authority_generations_v1',
+                        'SELECT,INSERT,UPDATE,REFERENCES')
+                    )
+               ) AS provider_roles_excluded,
+               COALESCE(ssl.ssl, false) AS ssl,
+               ssl.version AS ssl_version,
+               ssl.cipher AS ssl_cipher,
+               ssl.bits AS ssl_bits
+          FROM pg_roles AS role
+          JOIN pg_namespace AS schema
+            ON schema.nspname = 'programmable_website_projection_v1'
+          JOIN pg_class AS heads
+            ON heads.relnamespace = schema.oid
+           AND heads.relname = 'explore_market_cap_authority_heads_v1'
+          JOIN pg_class AS generations
+            ON generations.relnamespace = schema.oid
+           AND generations.relname = 'explore_market_cap_authority_generations_v1'
+          LEFT JOIN pg_stat_ssl AS ssl ON ssl.pid = pg_backend_pid()
+         WHERE role.rolname = current_user
+           AND pg_get_userbyid(schema.nspowner) <> current_user
+           AND pg_get_userbyid(heads.relowner) <> current_user
+           AND pg_get_userbyid(generations.relowner) <> current_user
+      `);
+      const value = result.rows[0];
+      if (result.rows.length !== 1 || value === undefined) {
+        throw new TypeError(
+          "Explore market-cap authority database attestation failed",
+        );
+      }
+      assertExploreMarketCapAuthoritySecurityAttestationV1(
+        value,
+        this.#expectedRuntimeRole,
+      );
+    } finally {
+      client.release();
+    }
+  }
+
   async connect(): Promise<ProjectionTargetPostgresClientV1> {
     const client = await this.#pool.connect();
     return new NodePostgresProjectionTargetClientV1(client);
@@ -931,6 +1132,33 @@ export function assertGmgnAccountGateMultiflightSecurityAttestationV1(
   ) {
     throw new TypeError(
       "GMGN account gate multiflight database attestation failed",
+    );
+  }
+}
+
+export function assertExploreMarketCapAuthoritySecurityAttestationV1(
+  value: Readonly<ExploreMarketCapAuthoritySecurityAttestationRowV1>,
+  expectedRuntimeRole: string,
+): void {
+  if (
+    value.runtime_role !== expectedRuntimeRole ||
+    value.runtime_role !== "programmable_website_projection_runtime" ||
+    value.session_role !== value.runtime_role ||
+    value.rolsuper || value.rolcreaterole || value.rolcreatedb ||
+    value.rolreplication || value.rolbypassrls ||
+    !value.schema_usage || value.schema_create ||
+    !value.heads_select || !value.heads_insert || !value.heads_delete ||
+    !value.heads_update || value.heads_forbidden_access ||
+    !value.generations_select || !value.generations_insert ||
+    !value.generations_delete || value.generations_forbidden_access ||
+    !value.heads_rls || !value.heads_force_rls ||
+    !value.generations_rls || !value.generations_force_rls ||
+    !value.expected_policies || !value.provider_roles_excluded ||
+    !value.ssl || value.ssl_version === null ||
+    value.ssl_cipher === null || (value.ssl_bits ?? 0) < 128
+  ) {
+    throw new TypeError(
+      "Explore market-cap authority database attestation failed",
     );
   }
 }

--- a/ops/website-projection-target/migrations/0008_explore_market_cap_authority_v1.sql
+++ b/ops/website-projection-target/migrations/0008_explore_market_cap_authority_v1.sql
@@ -1,0 +1,147 @@
+BEGIN;
+
+CREATE TABLE programmable_website_projection_v1.explore_market_cap_authority_heads_v1 (
+  authority_key text PRIMARY KEY,
+  input_commitment text NOT NULL,
+  direction text NOT NULL,
+  current_generation bigint NOT NULL DEFAULT 0,
+  lease_generation bigint,
+  lease_holder uuid,
+  lease_until timestamptz NOT NULL DEFAULT TIMESTAMPTZ 'epoch',
+  updated_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+  CONSTRAINT explore_market_cap_authority_heads_v1_key_check
+    CHECK (authority_key ~ '^sha256:[0-9a-f]{64}$'),
+  CONSTRAINT explore_market_cap_authority_heads_v1_input_check
+    CHECK (input_commitment ~ '^sha256:[0-9a-f]{64}$'),
+  CONSTRAINT explore_market_cap_authority_heads_v1_direction_check
+    CHECK (direction IN ('asc', 'desc')),
+  CONSTRAINT explore_market_cap_authority_heads_v1_generation_check
+    CHECK (
+      current_generation >= 0
+      AND (
+        (lease_generation IS NULL AND lease_holder IS NULL)
+        OR (
+          lease_generation = current_generation + 1
+          AND lease_holder IS NOT NULL
+          AND lease_until > TIMESTAMPTZ 'epoch'
+        )
+      )
+    )
+);
+
+CREATE TABLE programmable_website_projection_v1.explore_market_cap_authority_generations_v1 (
+  authority_key text NOT NULL,
+  generation bigint NOT NULL,
+  authority_commitment text NOT NULL,
+  ranking_commitment text NOT NULL,
+  gmgn_status text NOT NULL,
+  generated_at timestamptz NOT NULL,
+  refresh_after timestamptz NOT NULL,
+  valid_until timestamptz NOT NULL,
+  canonical_authority text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT pg_catalog.clock_timestamp(),
+  CONSTRAINT explore_market_cap_authority_generations_v1_pk
+    PRIMARY KEY (authority_key, generation),
+  CONSTRAINT explore_market_cap_authority_generations_v1_head_fk
+    FOREIGN KEY (authority_key)
+    REFERENCES programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+    (authority_key)
+    ON DELETE CASCADE,
+  CONSTRAINT explore_market_cap_authority_generations_v1_generation_check
+    CHECK (generation >= 1),
+  CONSTRAINT explore_market_cap_authority_generations_v1_commitments_check
+    CHECK (
+      authority_commitment ~ '^sha256:[0-9a-f]{64}$'
+      AND ranking_commitment ~ '^sha256:[0-9a-f]{64}$'
+    ),
+  CONSTRAINT explore_market_cap_authority_generations_v1_status_check
+    CHECK (gmgn_status IN ('complete', 'partial', 'unavailable')),
+  CONSTRAINT explore_market_cap_authority_generations_v1_time_check
+    CHECK (
+      generated_at >= TIMESTAMPTZ 'epoch'
+      AND refresh_after > generated_at
+      AND valid_until >= refresh_after
+      AND valid_until <= generated_at + INTERVAL '235 seconds'
+    ),
+  CONSTRAINT explore_market_cap_authority_generations_v1_size_check
+    CHECK (octet_length(canonical_authority) BETWEEN 2 AND 16777216)
+);
+
+CREATE INDEX explore_market_cap_authority_generations_v1_expiry_idx
+  ON programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+  (valid_until);
+
+CREATE INDEX explore_market_cap_authority_generations_v1_ranking_idx
+  ON programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+  (authority_key, ranking_commitment, generation DESC);
+
+ALTER TABLE programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+  FORCE ROW LEVEL SECURITY;
+ALTER TABLE programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+  FORCE ROW LEVEL SECURITY;
+
+REVOKE ALL
+  ON programmable_website_projection_v1.explore_market_cap_authority_heads_v1,
+     programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+  FROM PUBLIC;
+
+DO $roles$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+    EXECUTE 'REVOKE ALL ON programmable_website_projection_v1.explore_market_cap_authority_heads_v1, programmable_website_projection_v1.explore_market_cap_authority_generations_v1 FROM anon';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    EXECUTE 'REVOKE ALL ON programmable_website_projection_v1.explore_market_cap_authority_heads_v1, programmable_website_projection_v1.explore_market_cap_authority_generations_v1 FROM authenticated';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+    EXECUTE 'REVOKE ALL ON programmable_website_projection_v1.explore_market_cap_authority_heads_v1, programmable_website_projection_v1.explore_market_cap_authority_generations_v1 FROM service_role';
+  END IF;
+END
+$roles$;
+
+CREATE POLICY explore_market_cap_authority_heads_v1_runtime_select
+  ON programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+  AS PERMISSIVE FOR SELECT TO programmable_website_projection_runtime
+  USING (true);
+CREATE POLICY explore_market_cap_authority_heads_v1_runtime_insert
+  ON programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+  AS PERMISSIVE FOR INSERT TO programmable_website_projection_runtime
+  WITH CHECK (true);
+CREATE POLICY explore_market_cap_authority_heads_v1_runtime_update
+  ON programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+  AS PERMISSIVE FOR UPDATE TO programmable_website_projection_runtime
+  USING (true) WITH CHECK (true);
+CREATE POLICY explore_market_cap_authority_heads_v1_runtime_delete
+  ON programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+  AS PERMISSIVE FOR DELETE TO programmable_website_projection_runtime
+  USING (true);
+
+CREATE POLICY explore_market_cap_authority_generations_v1_runtime_select
+  ON programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+  AS PERMISSIVE FOR SELECT TO programmable_website_projection_runtime
+  USING (true);
+CREATE POLICY explore_market_cap_authority_generations_v1_runtime_insert
+  ON programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+  AS PERMISSIVE FOR INSERT TO programmable_website_projection_runtime
+  WITH CHECK (true);
+CREATE POLICY explore_market_cap_authority_generations_v1_runtime_delete
+  ON programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+  AS PERMISSIVE FOR DELETE TO programmable_website_projection_runtime
+  USING (true);
+
+GRANT SELECT, INSERT, DELETE
+  ON programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+  TO programmable_website_projection_runtime;
+GRANT UPDATE (
+  current_generation, lease_generation, lease_holder, lease_until, updated_at
+) ON programmable_website_projection_v1.explore_market_cap_authority_heads_v1
+  TO programmable_website_projection_runtime;
+GRANT SELECT, INSERT, DELETE
+  ON programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+  TO programmable_website_projection_runtime;
+
+COMMIT;

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -2823,6 +2823,12 @@ export function evaluateReadModelOperationsSourceContracts(
     source(
       "ops/website-projection-target/migrations/0007_gmgn_account_gate_multiflight_v1.sql",
     ) ?? "";
+  const exploreMarketCapAuthorityMigration =
+    source(
+      "ops/website-projection-target/migrations/0008_explore_market_cap_authority_v1.sql",
+    ) ?? "";
+  const exploreMarketCapAuthorityStore =
+    source("lib/market-data/explore-market-cap-authority.server.ts") ?? "";
   const websiteProjectionOperatorCore =
     source("scripts/website-projection-db-operator-core.mjs") ?? "";
   const websiteProjectionPostgres =
@@ -3691,7 +3697,10 @@ export function evaluateReadModelOperationsSourceContracts(
       ),
     ) &&
     includesEverySourceFragment(publicExplore, [
-      'import { unstable_cache } from "next/cache";',
+      "EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_AGE_MS,",
+      "EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_BYTES,",
+      "exploreMarketCapAuthorityStorageCommitmentV1,",
+      "getProductionExploreMarketCapAuthorityStoreV1,",
       "readEnvioClassicV3CatalogV1({",
       "readProductionCustomExploreDirectoryV1(",
       "readFinalizedRouterCustomIdentitySnapshotV1({",
@@ -3704,12 +3713,14 @@ export function evaluateReadModelOperationsSourceContracts(
       'orderBy: "marketcap"',
       "direction,",
       "GMGN_MARKET_CAP_RETRY_MINIMUM_REMAINING_MS",
-      "const EXPLORE_MARKET_CAP_CACHE_REVALIDATE_SECONDS = 60",
-      "const EXPLORE_MARKET_CAP_CACHE_MAXIMUM_AGE_MS = 235_000",
-      '"programmable.explore-market-cap-composition-input.v1"',
+      "const MARKET_CAP_AUTHORITY_PUBLISH_RESERVE_MS = 3_000;",
+      '"programmable.explore-market-cap-authority.v2"',
+      '"programmable.explore-market-cap-authority-pin.v2"',
+      '"programmable.explore-market-cap-authority-input.v2"',
+      "orderedCanonicalIdentities: entries.map((entry, index) => ({",
       "const first = await readGmgnEthereumTrendingV1(",
       "first !== null ||",
-      "deadlineMs - Date.now() <",
+      "authorityDeadlineMs - Date.now() <",
       "rankOptions,",
       "rankCanonicalExploreMarketCapEntriesWithGmgnV1(",
       "rankCanonicalExploreMarketCapPrimaryWithGmgnV1(",
@@ -3718,28 +3729,34 @@ export function evaluateReadModelOperationsSourceContracts(
       "MARKET_CAP_SUPPLY_HYDRATION_LIMIT",
       "MARKET_CAP_SUPPLY_HYDRATION_BUDGET_MS",
       "exactExploreMarketIdentityV1(candidate, original)",
-      "const gmgnHydrationEligible = hydrationUniverse.filter(",
+      "const gmgnHydrationEligible = primary.coverage.gmgnMatchedEntryCount === 0",
+      ": hydrationUniverse.filter(gmgnVisibleMarketEntryEligibleV1)",
       "readGmgnExploreSnapshotsV1(gmgnRequested, {",
       "gmgnTokenInfoFallbackEntryV1(",
       "const dexscreenerRequested = hydrationUniverse.filter(",
-      "readDexscreenerExploreEntriesV1(\n        dexscreenerRequested,",
+      "readDexscreenerExploreEntriesV1(\n    dexscreenerRequested,",
       "exploreMarketCapRankingV1(",
-      "const readDurablyCachedExploreMarketCapCompositionV1 = unstable_cache(",
-      '["programmable-explore-market-cap-composition-v1"]',
-      "{ revalidate: EXPLORE_MARKET_CAP_CACHE_REVALIDATE_SECONDS }",
-      "cached.inputCommitment !== inputCommitment",
-      "Explore market-cap provider snapshot is stale",
-      "composed.ranking.qualifiedCount > 0",
-      "orderingAsOfTimes: Object.freeze([...composed.orderingAsOfTimes])",
-      "currentExploreMarketCapOrderingTimesV1(",
-      "qualifiedCount === expectedQualifiedCount",
-      "!currentExploreMarketCapTimestampV1(observedAt)",
-      "cached.orderingAsOfTimes,",
-      "!currentExploreMarketCapTimestampV1(cached.assembledAt)",
-      "new Date(observedAtMs).toISOString() === value",
-      "cached.orderedEntryIds.length !== entries.length",
-      "orderedIds.size !== entries.length",
-      "readBoundExploreMarketCapCompositionV1(",
+      "new Date(timestampMs).toISOString() === value",
+      "nowMs - timestampMs <= EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_AGE_MS",
+      "authority.orderedIdentities.length !== byId.size",
+      "return seen.size === byId.size ? Object.freeze(ordered) : null;",
+      "authority.inputCommitment !== input.inputCommitment",
+      "!currentMarketCapAuthorityTimestampV1(authority.generatedAt, nowMs)",
+      "currentMarketCapAuthorityTimestampV1(value, nowMs)",
+      "authority.ranking.rankingCommitment !== authorityPin",
+      "buildExploreMarketCapAuthorityV1(",
+      "const canonicalAuthority = canonicalizeJson(authority);",
+      "exploreMarketCapAuthorityStorageCommitmentV1(canonicalAuthority)",
+      "validUntil: new Date(validUntilMs).toISOString()",
+      "parseStrictJson(canonicalAuthority, {",
+      "maximumBytes: EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_BYTES,",
+      "rankingCommitment: authority.ranking.rankingCommitment,",
+      "const authorityStore = getProductionExploreMarketCapAuthorityStoreV1();",
+      "? await authorityStore.resolve({",
+      "acceptPinnedAuthority: (canonicalAuthority) => {",
+      'resolution.kind === "ranking-conflict"',
+      'code: "MARKET_CAP_RANKING_RESTART_REQUIRED"',
+      "projectExploreMarketCapAuthorityV1(",
       "readExploreMarketEntriesV1(\n        identityPage.tokens,",
       'registryCustomStatus === "current" && routerCustomStatus === "current"',
       'requested: "market-cap"',
@@ -3934,6 +3951,7 @@ export function evaluateReadModelOperationsSourceContracts(
       '"X-Programmable-Read-Source": `${launchSource}+${chart.source}`',
       "TOKEN_CHART_CACHE_CONTROL",
     ]) &&
+    !publicExplore.includes("unstable_cache") &&
     !publicChart.includes('"programmable.market-chart-error.v1"') &&
     gmgnChartReadStart >= 0 &&
     gmgnChartAcceptanceStart > gmgnChartReadStart &&
@@ -3991,7 +4009,7 @@ export function evaluateReadModelOperationsSourceContracts(
     ]) &&
       includesEverySourceFragment(websiteProjectionOperatorCore, [
         '"0007_gmgn_account_gate_multiflight_v1.sql"',
-        "MIGRATION_FILE = /^(000[1-7])_([a-z][a-z0-9_]*)\\.sql$/u",
+        "MIGRATION_FILE = /^(000[1-8])_([a-z][a-z0-9_]*)\\.sql$/u",
       ]) &&
       includesEverySourceFragment(websiteProjectionPostgres, [
         "const EVIDENCE_0007_DDL",
@@ -4018,19 +4036,101 @@ export function evaluateReadModelOperationsSourceContracts(
       includesEverySourceFragment(websiteProjectionTargetRunbook, [
         "at most 20",
         "a 21st reservation waits",
-        "migrations `0001` through `0007`",
+        "migrations `0001` through `0008`",
         "safe legacy single-flight prefix",
         "cannot authorize this release's GMGN Pro throughput claim",
       ]) &&
       includesEverySourceFragment(websiteProjectionOperatorRunbook, [
-        "`0001` through `0007`",
+        "`0001` through `0008`",
         "at most 20 active holder-bound leases",
         "a 21st reservation waits",
-        "seven ordered file/execution hashes",
-        "dry-run must report only `0007` pending",
+        "eight ordered file/execution hashes",
+        "dry-run must report only `0008` pending",
         "The Stage workflow never applies database migrations",
       ]),
     "migration 0007, operator inventory, hosted readiness and runbooks bind the exact 20-flight GMGN account gate while 0006 remains a rolling-only prefix",
+  );
+  check(
+    "ops-explore-market-cap-authority-migration",
+    includesEverySourceFragment(exploreMarketCapAuthorityMigration, [
+      "CREATE TABLE programmable_website_projection_v1.explore_market_cap_authority_heads_v1",
+      "CREATE TABLE programmable_website_projection_v1.explore_market_cap_authority_generations_v1",
+      "PRIMARY KEY (authority_key, generation)",
+      "FOREIGN KEY (authority_key)",
+      "ON DELETE CASCADE",
+      "valid_until <= generated_at + INTERVAL '235 seconds'",
+      "octet_length(canonical_authority) BETWEEN 2 AND 16777216",
+      "explore_market_cap_authority_generations_v1_ranking_idx",
+      "ENABLE ROW LEVEL SECURITY",
+      "FORCE ROW LEVEL SECURITY",
+      "explore_market_cap_authority_heads_v1_runtime_select",
+      "explore_market_cap_authority_heads_v1_runtime_insert",
+      "explore_market_cap_authority_heads_v1_runtime_update",
+      "explore_market_cap_authority_heads_v1_runtime_delete",
+      "explore_market_cap_authority_generations_v1_runtime_select",
+      "explore_market_cap_authority_generations_v1_runtime_insert",
+      "explore_market_cap_authority_generations_v1_runtime_delete",
+      "GRANT UPDATE (",
+      "current_generation, lease_generation, lease_holder, lease_until, updated_at",
+      "rolname = 'anon'",
+      "rolname = 'authenticated'",
+      "rolname = 'service_role'",
+    ]) &&
+      includesEverySourceFragment(websiteProjectionOperatorCore, [
+        '"0008_explore_market_cap_authority_v1.sql"',
+        "WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_COMMIT",
+        '"9d81af890e14e39aef415399b7df80745670483c"',
+        "WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_SHA256",
+        '"0xbb99064008299faf0173b4fd0199017358327a02f091436c4ef878f36df14ea8"',
+        "WEBSITE_PROJECTION_PREDECESSOR_0007_ORDER_SHA256",
+        '"0x3097a113366d96591241f9ed423b2fef1beb551959e04a6663847b3a1f55ee56"',
+        "validateWebsiteProjectionPredecessor0007Plan",
+        "websiteProjectionPredecessor0007Plan",
+      ]) &&
+      includesEverySourceFragment(websiteProjectionPostgres, [
+        "const EVIDENCE_0008_DDL",
+        "CHECK (ordinal BETWEEN 1 AND 8)",
+        "CHECK (version ~ '^000[1-8]$')",
+        "if (migration.ordinal === 8)",
+        "await executeSimple(transaction, EVIDENCE_0008_DDL)",
+        "const FINAL_EXPLORE_MARKET_CAP_AUTHORITY_PRIVILEGES",
+        "explore_market_cap_authority_heads_v1",
+        "explore_market_cap_authority_generations_v1",
+      ]) &&
+      includesEverySourceFragment(exploreMarketCapAuthorityStore, [
+        "EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_AGE_MS = 235_000",
+        "EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_RETAINED_GENERATIONS = 32;",
+        "DELETE FROM programmable_website_projection_v1.explore_market_cap_authority_generations_v1",
+        "DELETE FROM programmable_website_projection_v1.explore_market_cap_authority_heads_v1",
+        "assertReady: () => pool.assertExploreMarketCapAuthorityReadiness()",
+      ]) &&
+      includesEverySourceFragment(websiteProjectionTarget, [
+        "assertExploreMarketCapAuthorityReadiness(): Promise<void>",
+        "assertExploreMarketCapAuthoritySecurityAttestationV1(",
+        "heads_select",
+        "heads_insert",
+        "heads_delete",
+        "heads_update",
+        "heads_forbidden_access",
+        "generations_select",
+        "generations_insert",
+        "generations_delete",
+        "generations_forbidden_access",
+        "expected_policies",
+        "provider_roles_excluded",
+      ]) &&
+      includesEverySourceFragment(websiteProjectionTargetRunbook, [
+        "0008_explore_market_cap_authority_v1.sql",
+        "32 retained generations",
+        "235 seconds",
+        "assertExploreMarketCapAuthorityReadiness",
+      ]) &&
+      includesEverySourceFragment(websiteProjectionOperatorRunbook, [
+        "0007 predecessor",
+        "dry-run must report only `0008` pending",
+        "current eight-row `verify` result",
+      ]),
+    "migration 0008, exact production predecessor evidence, operator closure, least-privilege runtime readiness and bounded durable generation retention bind Explore market-cap pagination to one cross-instance authority",
   );
   const publicProfileAndActionRoutes = [
     publicCreatorProfile,
@@ -4447,7 +4547,8 @@ export function evaluateReadModelOperationsSourceContracts(
         "new Set(highestIdentities).size !== highestIdentities.length",
         "Highest market-cap page is outside the paged catalog",
         "Market-cap ranking changed during pagination",
-        "JSON.stringify(highestSecondPage.body.ranking) !==",
+        "highestSecondPage.body.ranking.rankingCommitment !==",
+        "stableMarketCapRankingMetadata(highestSecondPage.body.ranking) !==",
         "highestIdentities.includes(identity)",
         "function exactMarketCapRanking(response, canonicalTokens, direction, nowMs)",
         "function exactRequiredGmgnMarketCapRanking(response, nowMs)",

--- a/scripts/smoke-static-dexscreener-public-apis.mjs
+++ b/scripts/smoke-static-dexscreener-public-apis.mjs
@@ -56,6 +56,10 @@ const TRENDING_SNAPSHOT_ATTEMPTS = 2;
 const TRENDING_DISCOVERY_VOLATILE_KEYS = new Set([
   "asOfTime",
 ]);
+const MARKET_CAP_RANKING_SEPARATE_KEYS = new Set([
+  "asOfTime",
+  "rankingCommitment",
+]);
 const GMGN_CANONICAL_SCAN_MAXIMUM_PAGES = 8;
 const PROVIDER_RECENT_MAXIMUM_AGE_MS = 5 * 60_000;
 const MINIMUM_FDV_LIQUIDITY_USD_WAD = 10_000n * 10n ** 18n;
@@ -1416,6 +1420,14 @@ function exactMarketCapRanking(response, canonicalTokens, direction, nowMs) {
       ranking.rankingCommitment;
 }
 
+function stableMarketCapRankingMetadata(ranking) {
+  return JSON.stringify(Object.fromEntries(
+    MARKET_CAP_RANKING_KEYS
+      .filter((key) => !MARKET_CAP_RANKING_SEPARATE_KEYS.has(key))
+      .map((key) => [key, ranking[key]]),
+  ));
+}
+
 function exactRequiredGmgnMarketCapRanking(response, nowMs) {
   const ranking = response.body?.ranking;
   return ranking?.gmgnStatus !== "unavailable" &&
@@ -2360,7 +2372,10 @@ export async function runStagedStaticDexscreenerSmokeV1(input = {}) {
       if (highest.body.totalPages > 1) {
         const highestSecondPage = await request(
           `/api/explore?limit=${VISIBLE_EXPLORE_PAGE_SIZE}` +
-            "&page=2&sort=market-cap",
+            "&page=2&sort=market-cap" +
+            `&rankingCommitment=${encodeURIComponent(
+              highest.body.ranking.rankingCommitment,
+            )}`,
         );
         const highestSecondPageTokens = Array.isArray(
           highestSecondPage.body?.tokens,
@@ -2401,9 +2416,7 @@ export async function runStagedStaticDexscreenerSmokeV1(input = {}) {
             completeCatalogTokens,
             "desc",
             now().getTime(),
-          )
-        ) throw new Error("Market-cap pagination commitment is invalid");
-        if (
+          ) ||
           secondPageIdentities.some((identity) => identity === null) ||
           new Set(secondPageIdentities).size !== secondPageIdentities.length ||
           secondPageIdentities.some((identity) =>
@@ -2411,14 +2424,28 @@ export async function runStagedStaticDexscreenerSmokeV1(input = {}) {
           )
         ) throw new Error("Market-cap pagination commitment is invalid");
         if (
-          JSON.stringify(highestSecondPage.body.ranking) !==
-            JSON.stringify(highest.body.ranking) ||
+          highestSecondPage.body.ranking.rankingCommitment !==
+            highest.body.ranking.rankingCommitment
+        ) {
+          throw new ExploreMarketCapSnapshotDriftError(
+            "Market-cap ranking changed during pagination",
+          );
+        }
+        if (
+          stableMarketCapRankingMetadata(highestSecondPage.body.ranking) !==
+            stableMarketCapRankingMetadata(highest.body.ranking)
+        ) {
+          throw new ExploreMarketCapSnapshotDriftError(
+            "Market-cap ranking invariants changed during pagination",
+          );
+        }
+        if (
           secondPageIdentities.some((identity) =>
             highestIdentities.includes(identity)
           )
         ) {
           throw new ExploreMarketCapSnapshotDriftError(
-            "Market-cap ranking changed during pagination",
+            "Market-cap ranking order overlapped during pagination",
           );
         }
       }

--- a/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
+++ b/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
@@ -3713,6 +3713,103 @@ test("staged smoke binds market-cap ranking to the complete paged identity set",
   assert.equal(result.discoveryMatchedCount, 0);
 });
 
+test("staged smoke retries a transient market-cap page overlap", async () => {
+  const allEntries = Array.from({ length: 299 }, (_, index) => entry(index));
+  const paged = pagedCatalogTransform(allEntries);
+  const waits = [];
+  const pageTwoPins = [];
+  let snapshotAttempt = 0;
+  const result = await runStagedStaticDexscreenerSmokeV1({
+    environment: {
+      STAGED_TARGET_URL: "https://candidate.vercel.app/",
+      VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+      GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+    },
+    fetchImpl: stagedFetch((input) => {
+      const body = paged(input);
+      if (
+        input.url.pathname === "/api/explore" &&
+        input.url.searchParams.get("sort") === "market-cap" &&
+        input.url.searchParams.get("page") === "1"
+      ) snapshotAttempt += 1;
+      if (
+        input.url.pathname === "/api/explore" &&
+        input.url.searchParams.get("sort") === "market-cap" &&
+        input.url.searchParams.get("page") === "2"
+      ) {
+        pageTwoPins.push(input.url.searchParams.get("rankingCommitment"));
+      }
+      if (
+        snapshotAttempt === 1 &&
+        input.url.pathname === "/api/explore" &&
+        input.url.searchParams.get("sort") === "market-cap" &&
+        input.url.searchParams.get("page") === "2"
+      ) {
+        return {
+          ...body,
+          tokens: allEntries.slice(0, Number(input.url.searchParams.get("limit"))),
+        };
+      }
+      return body;
+    }),
+    appendOutput: () => undefined,
+    waitForCatalogConvergence: async (milliseconds) => {
+      waits.push(milliseconds);
+    },
+  });
+
+  assert.equal(result.detailStatus, "verified-identity-market-unavailable");
+  assert.equal(snapshotAttempt, 2);
+  assert.deepEqual(pageTwoPins, [
+    `sha256:${"cd".repeat(32)}`,
+    `sha256:${"cd".repeat(32)}`,
+  ]);
+  assert.deepEqual(waits, [16_000]);
+});
+
+test("staged smoke fails closed after persistent market-cap ranking drift", async () => {
+  const allEntries = Array.from({ length: 299 }, (_, index) => entry(index));
+  const paged = pagedCatalogTransform(allEntries);
+  const waits = [];
+  let snapshotAttempt = 0;
+  await assert.rejects(
+    runStagedStaticDexscreenerSmokeV1({
+      environment: {
+        STAGED_TARGET_URL: "https://candidate.vercel.app/",
+        VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+        GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+      },
+      fetchImpl: stagedFetch((input) => {
+        const body = paged(input);
+        if (
+          input.url.pathname === "/api/explore" &&
+          input.url.searchParams.get("sort") === "market-cap" &&
+          input.url.searchParams.get("page") === "1"
+        ) snapshotAttempt += 1;
+        return input.url.pathname === "/api/explore" &&
+            input.url.searchParams.get("sort") === "market-cap" &&
+            input.url.searchParams.get("page") === "2"
+          ? {
+              ...body,
+              ranking: {
+                ...body.ranking,
+                rankingCommitment: `sha256:${"ee".repeat(32)}`,
+              },
+            }
+          : body;
+      }),
+      appendOutput: () => undefined,
+      waitForCatalogConvergence: async (milliseconds) => {
+        waits.push(milliseconds);
+      },
+    }),
+    /Market-cap ranking changed during pagination after 3 bounded attempts/u,
+  );
+
+  assert.equal(snapshotAttempt, 3);
+  assert.deepEqual(waits, [16_000, 16_000]);
+});
+
 test("staged smoke accepts current and last-known-good Router reads for one paged identity snapshot", async () => {
   const allEntries = Array.from({ length: 299 }, (_, index) => entry(index));
   const paged = pagedCatalogTransform(allEntries);

--- a/scripts/website-projection-db-credential-rotation.test.mjs
+++ b/scripts/website-projection-db-credential-rotation.test.mjs
@@ -48,6 +48,7 @@ const FILES = [
   "0005_generic_launch_materializations_v2.sql",
   "0006_gmgn_account_gate_v1.sql",
   "0007_gmgn_account_gate_multiflight_v1.sql",
+  "0008_explore_market_cap_authority_v1.sql",
 ];
 const BACKEND_HANDOFF_CONTRACT = path.join(
   WORKSPACE,
@@ -200,7 +201,7 @@ test("ALTER ROLE password is transaction-safe and does not retain the plaintext 
 
 test("lost credential commit acknowledgement fails closed as WPR01", async () => {
   const posture = Object.freeze({
-    migrationEvidence: Object.freeze({ migrationCount: 7 }),
+    migrationEvidence: Object.freeze({ migrationCount: 8 }),
     catalogSha256: DIGEST,
     operatorCatalogSha256: DIGEST,
     runtimeRoleStatus: "current",
@@ -294,7 +295,7 @@ test("receipt is secret-free and records single-password forward recovery", () =
       database: "postgres",
     },
     migrationEvidence: {
-      migrationCount: 7,
+      migrationCount: 8,
       planSha256: DIGEST,
       repositoryCommit: OID,
       repositoryTree: OID,

--- a/scripts/website-projection-db-operator-core.mjs
+++ b/scripts/website-projection-db-operator-core.mjs
@@ -56,6 +56,15 @@ export const WEBSITE_PROJECTION_PREDECESSOR_0006_PLAN_SHA256 =
 export const WEBSITE_PROJECTION_PREDECESSOR_0006_ORDER_SHA256 =
   "0x603f0721eadf7e55131c4c2800b46b41dd0fa08ec09613d3f02d019cb65d300c";
 export const WEBSITE_PROJECTION_PREDECESSOR_0006_MIGRATION_COUNT = 6;
+export const WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_COMMIT =
+  "9d81af890e14e39aef415399b7df80745670483c";
+export const WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_TREE =
+  "4f9b85231f731fad47713676ad1dde53f77bc4d2";
+export const WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_SHA256 =
+  "0xbb99064008299faf0173b4fd0199017358327a02f091436c4ef878f36df14ea8";
+export const WEBSITE_PROJECTION_PREDECESSOR_0007_ORDER_SHA256 =
+  "0x3097a113366d96591241f9ed423b2fef1beb551959e04a6663847b3a1f55ee56";
+export const WEBSITE_PROJECTION_PREDECESSOR_0007_MIGRATION_COUNT = 7;
 export const WEBSITE_PROJECTION_ADOPTION_TARGET_PROJECT_REF =
   "mnnvlrqwhfoppogslsje";
 export const WEBSITE_PROJECTION_ADOPTION_CURRENT_OPERATOR_COMMIT =
@@ -71,12 +80,13 @@ export const WEBSITE_PROJECTION_MIGRATION_FILES = Object.freeze([
   "0005_generic_launch_materializations_v2.sql",
   "0006_gmgn_account_gate_v1.sql",
   "0007_gmgn_account_gate_multiflight_v1.sql",
+  "0008_explore_market_cap_authority_v1.sql",
 ]);
 
 const GIT_OBJECT = /^[0-9a-f]{40}$/u;
 const HEX_SHA256 = /^0x[0-9a-f]{64}$/u;
 const PROJECT_REF = /^[a-z0-9]{20}$/u;
-const MIGRATION_FILE = /^(000[1-7])_([a-z][a-z0-9_]*)\.sql$/u;
+const MIGRATION_FILE = /^(000[1-8])_([a-z][a-z0-9_]*)\.sql$/u;
 const TRANSACTION_WRAPPER = /^BEGIN;\r?\n([\s\S]+)\r?\nCOMMIT;\r?\n?$/u;
 
 function isPlainObject(value) {
@@ -148,9 +158,11 @@ async function discoverWebsiteProjectionPlanFiles({
   if (names.length !== migrationFiles.length
     || names.some((name, index) =>
       name !== migrationFiles[index])) {
-    const count = migrationFiles.length === 7
-      ? "seven"
-      : migrationFiles.length === 6 ? "six" : "five";
+    const count = migrationFiles.length === 8
+      ? "eight"
+      : migrationFiles.length === 7
+        ? "seven"
+        : migrationFiles.length === 6 ? "six" : "five";
     throw new Error(
       `migration directory must contain exactly the ${count} canonical files`,
     );
@@ -286,6 +298,10 @@ export function validateWebsiteProjectionPlan(value) {
     value?.migrationCount ===
       WEBSITE_PROJECTION_PREDECESSOR_0006_MIGRATION_COUNT
   ) return validateWebsiteProjectionPredecessor0006Plan(value);
+  if (
+    value?.migrationCount ===
+      WEBSITE_PROJECTION_PREDECESSOR_0007_MIGRATION_COUNT
+  ) return validateWebsiteProjectionPredecessor0007Plan(value);
   const plan = validateWebsiteProjectionPlanFiles(
     value,
     WEBSITE_PROJECTION_MIGRATION_FILES,
@@ -329,10 +345,7 @@ export function websiteProjectionPredecessor0006Plan(successorPlan) {
     successorPlan?.migrationCount ===
       WEBSITE_PROJECTION_PREDECESSOR_0006_MIGRATION_COUNT
   ) return validateWebsiteProjectionPredecessor0006Plan(successorPlan);
-  validateWebsiteProjectionPlanFiles(
-    successorPlan,
-    WEBSITE_PROJECTION_MIGRATION_FILES,
-  );
+  validateWebsiteProjectionPlan(successorPlan);
   const migrations = Object.freeze(successorPlan.migrations.slice(
     0,
     WEBSITE_PROJECTION_PREDECESSOR_0006_MIGRATION_COUNT,
@@ -354,6 +367,62 @@ export function websiteProjectionPredecessor0006Plan(successorPlan) {
       !== WEBSITE_PROJECTION_PREDECESSOR_0006_ORDER_SHA256) {
     throw new Error(
       "website projection successor does not preserve the exact reviewed 0001-0006 plan",
+    );
+  }
+  return plan;
+}
+
+export function validateWebsiteProjectionPredecessor0007Plan(value) {
+  validateWebsiteProjectionPlanFiles(
+    value,
+    WEBSITE_PROJECTION_MIGRATION_FILES.slice(
+      0,
+      WEBSITE_PROJECTION_PREDECESSOR_0007_MIGRATION_COUNT,
+    ),
+  );
+  if (
+    value.repositoryCommit !== WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_COMMIT
+    || value.repositoryTree !== WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_TREE
+    || value.planSha256 !== WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_SHA256
+    || value.orderSha256 !== WEBSITE_PROJECTION_PREDECESSOR_0007_ORDER_SHA256
+  ) {
+    throw new Error(
+      "website projection 0007 predecessor migration plan is invalid",
+    );
+  }
+  return value;
+}
+
+export function websiteProjectionPredecessor0007Plan(successorPlan) {
+  if (
+    successorPlan?.migrationCount ===
+      WEBSITE_PROJECTION_PREDECESSOR_0007_MIGRATION_COUNT
+  ) return validateWebsiteProjectionPredecessor0007Plan(successorPlan);
+  validateWebsiteProjectionPlanFiles(
+    successorPlan,
+    WEBSITE_PROJECTION_MIGRATION_FILES,
+  );
+  const migrations = Object.freeze(successorPlan.migrations.slice(
+    0,
+    WEBSITE_PROJECTION_PREDECESSOR_0007_MIGRATION_COUNT,
+  ));
+  const predecessor = {
+    ...successorPlan,
+    repositoryCommit: WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_COMMIT,
+    repositoryTree: WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_TREE,
+    migrationCount: WEBSITE_PROJECTION_PREDECESSOR_0007_MIGRATION_COUNT,
+    orderSha256: WEBSITE_PROJECTION_PREDECESSOR_0007_ORDER_SHA256,
+    migrations,
+  };
+  const plan = Object.freeze({
+    ...predecessor,
+    planSha256: sha256(canonicalJson(planPayload(predecessor))),
+  });
+  validateWebsiteProjectionPredecessor0007Plan(plan);
+  if (migrationOrderSha256(plan.migrations)
+      !== WEBSITE_PROJECTION_PREDECESSOR_0007_ORDER_SHA256) {
+    throw new Error(
+      "website projection successor does not preserve the exact reviewed 0001-0007 plan",
     );
   }
   return plan;
@@ -522,9 +591,23 @@ export function compareWebsiteProjectionEvidence({
     : null;
   const predecessor0006Prefix = predecessor0006Plan !== null
     && evidenceRows[0]?.plan_sha256 === predecessor0006Plan.planSha256;
+  const predecessor0007EvidencePresent = evidenceRows[0]?.plan_sha256 ===
+      WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_SHA256
+    || evidenceRows[WEBSITE_PROJECTION_PREDECESSOR_0006_MIGRATION_COUNT]
+      ?.plan_sha256 === WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_SHA256;
+  const predecessor0007Plan = predecessor0007EvidencePresent
+      && plan.migrationCount >=
+        WEBSITE_PROJECTION_PREDECESSOR_0007_MIGRATION_COUNT
+    ? websiteProjectionPredecessor0007Plan(plan)
+    : null;
+  const predecessor0007Prefix = predecessor0007Plan !== null
+    && evidenceRows[0]?.plan_sha256 === predecessor0007Plan.planSha256;
   for (const [index, row] of evidenceRows.entries()) {
     let evidencePlan = plan;
-    if (predecessor0006Prefix
+    if (predecessor0007Prefix
+      && index < WEBSITE_PROJECTION_PREDECESSOR_0007_MIGRATION_COUNT) {
+      evidencePlan = predecessor0007Plan;
+    } else if (predecessor0006Prefix
       && index < WEBSITE_PROJECTION_PREDECESSOR_0006_MIGRATION_COUNT) {
       evidencePlan = predecessor0006Plan;
     } else if (retainedPlan !== null
@@ -534,6 +617,10 @@ export function compareWebsiteProjectionEvidence({
       && index === WEBSITE_PROJECTION_RETAINED_MIGRATION_COUNT
       && row?.plan_sha256 === predecessor0006Plan?.planSha256) {
       evidencePlan = predecessor0006Plan;
+    } else if (predecessor0007Plan !== null
+      && index < WEBSITE_PROJECTION_PREDECESSOR_0007_MIGRATION_COUNT
+      && row?.plan_sha256 === predecessor0007Plan.planSha256) {
+      evidencePlan = predecessor0007Plan;
     }
     const migration = evidencePlan.migrations[index];
     if (!migration || !isPlainObject(row)

--- a/scripts/website-projection-db-operator.test.mjs
+++ b/scripts/website-projection-db-operator.test.mjs
@@ -27,10 +27,15 @@ import {
   validateWebsiteProjectionPlan,
   validateWebsiteProjectionRuntimePassword,
   websiteProjectionPredecessor0006Plan,
+  websiteProjectionPredecessor0007Plan,
   WEBSITE_PROJECTION_PREDECESSOR_0006_ORDER_SHA256,
   WEBSITE_PROJECTION_PREDECESSOR_0006_PLAN_COMMIT,
   WEBSITE_PROJECTION_PREDECESSOR_0006_PLAN_SHA256,
   WEBSITE_PROJECTION_PREDECESSOR_0006_PLAN_TREE,
+  WEBSITE_PROJECTION_PREDECESSOR_0007_ORDER_SHA256,
+  WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_COMMIT,
+  WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_SHA256,
+  WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_TREE,
   WEBSITE_PROJECTION_RETAINED_ORDER_SHA256,
   WEBSITE_PROJECTION_RETAINED_PLAN_COMMIT,
   WEBSITE_PROJECTION_RETAINED_PLAN_SHA256,
@@ -63,6 +68,7 @@ const MIGRATIONS = [
   "0005_generic_launch_materializations_v2.sql",
   "0006_gmgn_account_gate_v1.sql",
   "0007_gmgn_account_gate_multiflight_v1.sql",
+  "0008_explore_market_cap_authority_v1.sql",
 ];
 
 function migrationSql(index) {
@@ -127,7 +133,7 @@ function appliedEvidenceRow(plan, migration) {
   };
 }
 
-test("plan discovery binds the exact seven files, source bytes and execution bodies", async (t) => {
+test("plan discovery binds the exact eight files, source bytes and execution bodies", async (t) => {
   const { workspace } = await fixture();
   t.after(() => rm(workspace, { recursive: true, force: true }));
   const plan = await discoverWebsiteProjectionPlan({
@@ -136,10 +142,10 @@ test("plan discovery binds the exact seven files, source bytes and execution bod
     repositoryTree: TREE,
   });
   assert.equal(plan.migrationRoot, "ops/website-projection-target/migrations");
-  assert.equal(plan.migrationCount, 7);
+  assert.equal(plan.migrationCount, 8);
   assert.deepEqual(plan.migrations.map(({ file }) => path.posix.basename(file)), MIGRATIONS);
   assert.deepEqual(plan.migrations.map(({ version }) => version), [
-    "0001", "0002", "0003", "0004", "0005", "0006", "0007",
+    "0001", "0002", "0003", "0004", "0005", "0006", "0007", "0008",
   ]);
   assert.ok(plan.migrations.every(({ fileSha256, executionSha256 }) =>
     /^0x[0-9a-f]{64}$/u.test(fileSha256)
@@ -158,19 +164,19 @@ test("plan discovery rejects missing, extra, linked and unwrapped migration inpu
       repositoryCommit: COMMIT,
       repositoryTree: TREE,
     }),
-    /exactly the seven canonical files/u,
+    /exactly the eight canonical files/u,
   );
 
   const extra = await fixture();
   t.after(() => rm(extra.workspace, { recursive: true, force: true }));
-  await writeFile(path.join(extra.root, "0007_unreviewed.sql"), migrationSql(7));
+  await writeFile(path.join(extra.root, "0009_unreviewed.sql"), migrationSql(9));
   await assert.rejects(
     discoverWebsiteProjectionPlan({
       workspace: extra.workspace,
       repositoryCommit: COMMIT,
       repositoryTree: TREE,
     }),
-    /exactly the seven canonical files/u,
+    /exactly the eight canonical files/u,
   );
 
   const linked = await fixture();
@@ -259,7 +265,7 @@ test("evidence comparison permits only an exact prefix on the exact target", asy
   assert.equal(state.status, "pending");
   assert.equal(state.appliedCount, 1);
   assert.deepEqual(state.pending.map(({ version }) => version), [
-    "0002", "0003", "0004", "0005", "0006", "0007",
+    "0002", "0003", "0004", "0005", "0006", "0007", "0008",
   ]);
   assert.equal(state.catalogSha256, row.catalog_sha256);
 
@@ -332,7 +338,9 @@ test("evidence comparison accepts only the exact frozen 0006 predecessor", async
     applicationSchemaPresent: true,
     evidenceRows: retainedThen0006,
   });
-  assert.deepEqual(retainedState.pending.map(({ version }) => version), ["0007"]);
+  assert.deepEqual(retainedState.pending.map(({ version }) => version), [
+    "0007", "0008",
+  ]);
 
   const predecessorOnly = predecessorPlan.migrations.map((migration) =>
     appliedEvidenceRow(predecessorPlan, migration));
@@ -343,7 +351,9 @@ test("evidence comparison accepts only the exact frozen 0006 predecessor", async
     applicationSchemaPresent: true,
     evidenceRows: predecessorOnly,
   });
-  assert.deepEqual(predecessorState.pending.map(({ version }) => version), ["0007"]);
+  assert.deepEqual(predecessorState.pending.map(({ version }) => version), [
+    "0007", "0008",
+  ]);
 
   for (const [label, mutate] of [
     ["plan", (row) => {
@@ -360,6 +370,88 @@ test("evidence comparison accepts only the exact frozen 0006 predecessor", async
   ]) {
     const drifted = structuredClone(retainedThen0006);
     mutate(drifted[5]);
+    assert.throws(() => compareWebsiteProjectionEvidence({
+      plan: successorPlan,
+      expectedProjectRef: PROJECT_REF,
+      evidenceTablePresent: true,
+      applicationSchemaPresent: true,
+      evidenceRows: drifted,
+    }), /exact plan prefix/u, `${label} drift must fail closed`);
+  }
+});
+
+test("evidence comparison accepts only the exact production 0007 predecessor", async () => {
+  const workspace = path.resolve(new URL("..", import.meta.url).pathname);
+  const successorPlan = await discoverWebsiteProjectionPlan({
+    workspace,
+    repositoryCommit: COMMIT,
+    repositoryTree: TREE,
+  });
+  const retained = retainedPlan(successorPlan);
+  const predecessor0006 = websiteProjectionPredecessor0006Plan(successorPlan);
+  const predecessor0007 = websiteProjectionPredecessor0007Plan(successorPlan);
+
+  assert.equal(
+    predecessor0007.planSha256,
+    WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_SHA256,
+  );
+  assert.equal(
+    predecessor0007.repositoryCommit,
+    WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_COMMIT,
+  );
+  assert.equal(
+    predecessor0007.repositoryTree,
+    WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_TREE,
+  );
+  assert.equal(
+    predecessor0007.orderSha256,
+    WEBSITE_PROJECTION_PREDECESSOR_0007_ORDER_SHA256,
+  );
+  assert.equal(
+    predecessor0007.migrations[6].fileSha256,
+    "0x741af426e5a0e9f8dafbf92ebe1c8be7acdec7c5e412331abfad7095618dfc18",
+  );
+  assert.equal(
+    predecessor0007.migrations[6].executionSha256,
+    "0x07770c4378ec0588eb101798a85128bac1fb38ee5ec3180dd0ce4d99ff98a7fd",
+  );
+
+  const productionPredecessorRows = [
+    ...retained.migrations.map((migration) =>
+      appliedEvidenceRow(retained, migration)),
+    appliedEvidenceRow(predecessor0006, predecessor0006.migrations[5]),
+    appliedEvidenceRow(predecessor0007, predecessor0007.migrations[6]),
+  ];
+  const productionState = compareWebsiteProjectionEvidence({
+    plan: successorPlan,
+    expectedProjectRef: PROJECT_REF,
+    evidenceTablePresent: true,
+    applicationSchemaPresent: true,
+    evidenceRows: productionPredecessorRows,
+  });
+  assert.equal(productionState.appliedCount, 7);
+  assert.deepEqual(productionState.pending.map(({ version }) => version), [
+    "0008",
+  ]);
+
+  const predecessorOnly = predecessor0007.migrations.map((migration) =>
+    appliedEvidenceRow(predecessor0007, migration));
+  assert.deepEqual(compareWebsiteProjectionEvidence({
+    plan: successorPlan,
+    expectedProjectRef: PROJECT_REF,
+    evidenceTablePresent: true,
+    applicationSchemaPresent: true,
+    evidenceRows: predecessorOnly,
+  }).pending.map(({ version }) => version), ["0008"]);
+
+  for (const [label, mutate] of [
+    ["plan", (row) => { row.plan_sha256 = `0x${"1".repeat(64)}`; }],
+    ["commit", (row) => { row.repository_commit = "2".repeat(40); }],
+    ["tree", (row) => { row.repository_tree = "3".repeat(40); }],
+    ["execution", (row) => { row.execution_sha256 = `0x${"4".repeat(64)}`; }],
+  ]) {
+    const drifted = structuredClone(productionPredecessorRows);
+    mutate(drifted[6]);
     assert.throws(() => compareWebsiteProjectionEvidence({
       plan: successorPlan,
       expectedProjectRef: PROJECT_REF,
@@ -1083,7 +1175,7 @@ test("database operator bootstraps, applies, resumes and detects catalog drift",
   assert.equal(applied.status, "current");
   assert.equal(applied.roleCreated, true);
   assert.deepEqual(applied.appliedThisRun, [
-    "0001", "0002", "0003", "0004", "0005", "0006", "0007",
+    "0001", "0002", "0003", "0004", "0005", "0006", "0007", "0008",
   ]);
   assert.match(applied.catalogSha256, /^0x[0-9a-f]{64}$/u);
 
@@ -1201,14 +1293,17 @@ test("adopt-existing records exact evidence atomically without replaying applica
     sessionIdentity: fixture.sessionIdentity,
   });
   assert.equal(continued.status, "current");
-  assert.deepEqual(continued.appliedThisRun, ["0004", "0005", "0006", "0007"]);
+  assert.deepEqual(continued.appliedThisRun, [
+    "0004", "0005", "0006", "0007", "0008",
+  ]);
 });
 
-test("exact production 0006 predecessor advances only 0007 and verifies seven rows", async (t) => {
+test("exact production 0007 predecessor advances only 0008 and verifies eight rows", async (t) => {
   const fixture = await pgliteExistingApplicationFixture(t);
   const successorPlan = fixture.plan;
   const retainedPrefixPlan = retainedPlan(successorPlan);
   const predecessor0006Plan = websiteProjectionPredecessor0006Plan(successorPlan);
+  const predecessor0007Plan = websiteProjectionPredecessor0007Plan(successorPlan);
   await adoptExistingWebsiteProjectionDatabase({
     ...pgliteAdoptionAuditOptions(),
     sql: fixture.sql,
@@ -1253,13 +1348,33 @@ test("exact production 0006 predecessor advances only 0007 and verifies seven ro
   assert.deepEqual(predecessorApply.appliedThisRun, ["0006"]);
   assert.equal(predecessorApply.status, "current");
 
+  const predecessor0007Pending = await inspectWebsiteProjectionDatabase({
+    sql: fixture.sql,
+    plan: predecessor0007Plan,
+    expectedProjectRef: PROJECT_REF,
+    sessionIdentity: fixture.sessionIdentity,
+  });
+  assert.deepEqual(
+    predecessor0007Pending.pending.map(({ version }) => version),
+    ["0007"],
+  );
+  const predecessor0007Apply = await applyWebsiteProjectionMigrations({
+    sql: fixture.sql,
+    workspace: fixture.workspace,
+    plan: predecessor0007Plan,
+    expectedProjectRef: PROJECT_REF,
+    sessionIdentity: fixture.sessionIdentity,
+  });
+  assert.deepEqual(predecessor0007Apply.appliedThisRun, ["0007"]);
+  assert.equal(predecessor0007Apply.status, "current");
+
   const pending = await inspectWebsiteProjectionDatabase({
     sql: fixture.sql,
     plan: successorPlan,
     expectedProjectRef: PROJECT_REF,
     sessionIdentity: fixture.sessionIdentity,
   });
-  assert.deepEqual(pending.pending.map(({ version }) => version), ["0007"]);
+  assert.deepEqual(pending.pending.map(({ version }) => version), ["0008"]);
   const advanced = await applyWebsiteProjectionMigrations({
     sql: fixture.sql,
     workspace: fixture.workspace,
@@ -1267,7 +1382,7 @@ test("exact production 0006 predecessor advances only 0007 and verifies seven ro
     expectedProjectRef: PROJECT_REF,
     sessionIdentity: fixture.sessionIdentity,
   });
-  assert.deepEqual(advanced.appliedThisRun, ["0007"]);
+  assert.deepEqual(advanced.appliedThisRun, ["0008"]);
   assert.equal(advanced.status, "current");
 
   const verified = await inspectWebsiteProjectionDatabase({
@@ -1277,7 +1392,7 @@ test("exact production 0006 predecessor advances only 0007 and verifies seven ro
     sessionIdentity: fixture.sessionIdentity,
   });
   assert.equal(verified.status, "current");
-  assert.equal(verified.appliedCount, 7);
+  assert.equal(verified.appliedCount, 8);
 
   const evidence = await fixture.database.query(`
     SELECT ordinal::integer, plan_sha256, repository_commit, repository_tree
@@ -1296,6 +1411,12 @@ test("exact production 0006 predecessor advances only 0007 and verifies seven ro
   });
   assert.deepEqual(evidence.rows[6], {
     ordinal: 7,
+    plan_sha256: WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_SHA256,
+    repository_commit: WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_COMMIT,
+    repository_tree: WEBSITE_PROJECTION_PREDECESSOR_0007_PLAN_TREE,
+  });
+  assert.deepEqual(evidence.rows[7], {
+    ordinal: 8,
     plan_sha256: successorPlan.planSha256,
     repository_commit: successorPlan.repositoryCommit,
     repository_tree: successorPlan.repositoryTree,
@@ -1370,7 +1491,64 @@ test("exact production 0006 predecessor advances only 0007 and verifies seven ro
          FROM pg_class
         WHERE oid =
           'programmable_website_projection_v1.gmgn_account_gate_leases_v1'::regclass)
-        AS leases_rls_forced
+        AS leases_rls_forced,
+      has_table_privilege('programmable_website_projection_runtime',
+        'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+        'SELECT,INSERT,DELETE') AS authority_heads_required,
+      has_column_privilege('programmable_website_projection_runtime',
+        'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+        'current_generation', 'UPDATE')
+        AND has_column_privilege('programmable_website_projection_runtime',
+        'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+        'lease_generation', 'UPDATE')
+        AND has_column_privilege('programmable_website_projection_runtime',
+        'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+        'lease_holder', 'UPDATE')
+        AND has_column_privilege('programmable_website_projection_runtime',
+        'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+        'lease_until', 'UPDATE')
+        AND has_column_privilege('programmable_website_projection_runtime',
+        'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+        'updated_at', 'UPDATE') AS authority_heads_update,
+      has_column_privilege('programmable_website_projection_runtime',
+        'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+        'authority_key', 'UPDATE')
+        OR has_column_privilege('programmable_website_projection_runtime',
+        'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+        'input_commitment', 'UPDATE')
+        OR has_column_privilege('programmable_website_projection_runtime',
+        'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+        'direction', 'UPDATE') AS authority_heads_identity_update,
+      has_table_privilege('programmable_website_projection_runtime',
+        'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+        'TRUNCATE,REFERENCES,TRIGGER') AS authority_heads_forbidden,
+      has_table_privilege('programmable_website_projection_runtime',
+        'programmable_website_projection_v1.explore_market_cap_authority_generations_v1',
+        'SELECT,INSERT,DELETE') AS authority_generations_required,
+      has_table_privilege('programmable_website_projection_runtime',
+        'programmable_website_projection_v1.explore_market_cap_authority_generations_v1',
+        'UPDATE,TRUNCATE,REFERENCES,TRIGGER') AS authority_generations_forbidden,
+      (SELECT bool_and(relrowsecurity AND relforcerowsecurity)
+         FROM pg_class
+        WHERE oid IN (
+          'programmable_website_projection_v1.explore_market_cap_authority_heads_v1'::regclass,
+          'programmable_website_projection_v1.explore_market_cap_authority_generations_v1'::regclass
+        )) AS authority_rls_forced,
+      EXISTS (
+        SELECT 1
+          FROM unnest(ARRAY['anon', 'authenticated', 'service_role'])
+            AS provider_role(role_name)
+         WHERE has_table_privilege(
+           role_name,
+           'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+           'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
+         )
+            OR has_table_privilege(
+           role_name,
+           'programmable_website_projection_v1.explore_market_cap_authority_generations_v1',
+           'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
+         )
+      ) AS authority_provider_access
   `)).rows[0];
   assert.deepEqual(privileges, {
     gate_select: true,
@@ -1386,6 +1564,14 @@ test("exact production 0006 predecessor advances only 0007 and verifies seven ro
     leases_delete: true,
     leases_forbidden: false,
     leases_rls_forced: true,
+    authority_heads_required: true,
+    authority_heads_update: true,
+    authority_heads_identity_update: false,
+    authority_heads_forbidden: false,
+    authority_generations_required: true,
+    authority_generations_forbidden: false,
+    authority_rls_forced: true,
+    authority_provider_access: false,
   });
 });
 

--- a/scripts/website-projection-db-postgres.mjs
+++ b/scripts/website-projection-db-postgres.mjs
@@ -255,6 +255,16 @@ ALTER TABLE programmable_website_projection_migrations.migration_evidence_v1
     CHECK (version ~ '^000[1-7]$');
 `;
 
+const EVIDENCE_0008_DDL = `
+ALTER TABLE programmable_website_projection_migrations.migration_evidence_v1
+  DROP CONSTRAINT migration_evidence_v1_ordinal_check,
+  DROP CONSTRAINT migration_evidence_v1_version_check,
+  ADD CONSTRAINT migration_evidence_v1_ordinal_check
+    CHECK (ordinal BETWEEN 1 AND 8),
+  ADD CONSTRAINT migration_evidence_v1_version_check
+    CHECK (version ~ '^000[1-8]$');
+`;
+
 function evidenceDdl(plan) {
   validateWebsiteProjectionPlan(plan);
   return EVIDENCE_DDL.replace(
@@ -322,6 +332,17 @@ GRANT SELECT (gate_id, generation)
 const FINAL_GMGN_MULTIFLIGHT_PRIVILEGES = `
 GRANT SELECT, INSERT, DELETE
   ON programmable_website_projection_v1.gmgn_account_gate_leases_v1
+  TO programmable_website_projection_runtime;
+`;
+
+const FINAL_EXPLORE_MARKET_CAP_AUTHORITY_PRIVILEGES = `
+GRANT SELECT, INSERT, DELETE
+  ON programmable_website_projection_v1.explore_market_cap_authority_heads_v1,
+     programmable_website_projection_v1.explore_market_cap_authority_generations_v1
+  TO programmable_website_projection_runtime;
+GRANT UPDATE (
+  current_generation, lease_generation, lease_holder, lease_until, updated_at
+) ON programmable_website_projection_v1.explore_market_cap_authority_heads_v1
   TO programmable_website_projection_runtime;
 `;
 
@@ -1711,6 +1732,9 @@ async function applyOneMigration({
     if (migration.ordinal === 7) {
       await executeSimple(transaction, EVIDENCE_0007_DDL);
     }
+    if (migration.ordinal === 8) {
+      await executeSimple(transaction, EVIDENCE_0008_DDL);
+    }
     await executeSimple(transaction, executionSource);
     if (migration.ordinal === plan.migrationCount) {
       await executeSimple(transaction, FINAL_PRIVILEGES);
@@ -1719,6 +1743,12 @@ async function applyOneMigration({
       }
       if (plan.migrationCount >= 7) {
         await executeSimple(transaction, FINAL_GMGN_MULTIFLIGHT_PRIVILEGES);
+      }
+      if (plan.migrationCount >= 8) {
+        await executeSimple(
+          transaction,
+          FINAL_EXPLORE_MARKET_CAP_AUTHORITY_PRIVILEGES,
+        );
       }
     }
     const roleGraph = await readRoleGraph(transaction, migration.ordinal);

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -818,10 +818,10 @@ describe("read-model operations source contract", () => {
       "ignoreGmgnAccountGateMultiflightSecurityAttestationV1(",
     ],
     [
-      "the only-pending-0007 operator instruction",
+      "the exact 20-flight operator instruction",
       "docs/operations/WEBSITE-PROJECTION-DATABASE-OPERATOR-V1.md",
-      "dry-run must report only `0007` pending",
-      "dry-run may report any prefix pending",
+      "at most 20 active holder-bound leases",
+      "at most 21 active holder-bound leases",
     ],
   ])(
     "rejects a GMGN multiflight release without %s",
@@ -833,6 +833,69 @@ describe("read-model operations source contract", () => {
       });
       expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
         "ops-gmgn-account-gate-multiflight-migration",
+      );
+    },
+  );
+
+  it.each([
+    [
+      "forced RLS on the authority tables",
+      "ops/website-projection-target/migrations/0008_explore_market_cap_authority_v1.sql",
+      "FORCE ROW LEVEL SECURITY;",
+      "DISABLE ROW LEVEL SECURITY;",
+    ],
+    [
+      "migration 0008 in the exact operator inventory",
+      "scripts/website-projection-db-operator-core.mjs",
+      '"0008_explore_market_cap_authority_v1.sql"',
+      '"0008_unreviewed.sql"',
+    ],
+    [
+      "the live-verified 0007 predecessor commitment",
+      "scripts/website-projection-db-operator-core.mjs",
+      '"0xbb99064008299faf0173b4fd0199017358327a02f091436c4ef878f36df14ea8"',
+      `"0x${"1".repeat(64)}"`,
+    ],
+    [
+      "eight-row migration evidence",
+      "scripts/website-projection-db-postgres.mjs",
+      "CHECK (ordinal BETWEEN 1 AND 8)",
+      "CHECK (ordinal BETWEEN 1 AND 7)",
+    ],
+    [
+      "the final authority grant reset",
+      "scripts/website-projection-db-postgres.mjs",
+      "const FINAL_EXPLORE_MARKET_CAP_AUTHORITY_PRIVILEGES",
+      "const IGNORED_EXPLORE_MARKET_CAP_AUTHORITY_PRIVILEGES",
+    ],
+    [
+      "the runtime authority readiness attestation",
+      "lib/server/projection-target/website-target.ts",
+      "assertExploreMarketCapAuthoritySecurityAttestationV1(",
+      "ignoreExploreMarketCapAuthoritySecurityAttestationV1(",
+    ],
+    [
+      "bounded retained generations",
+      "lib/market-data/explore-market-cap-authority.server.ts",
+      "EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_RETAINED_GENERATIONS = 32;",
+      "EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_RETAINED_GENERATIONS = 31;",
+    ],
+    [
+      "the only-pending-0008 operator instruction",
+      "docs/operations/WEBSITE-PROJECTION-DATABASE-OPERATOR-V1.md",
+      "dry-run must report only `0008` pending",
+      "dry-run may report any prefix pending",
+    ],
+  ])(
+    "rejects an Explore market-cap authority release without %s",
+    (_label, path, needle, replacement) => {
+      const source = readFileSync(resolve(ROOT, path), "utf8");
+      expect(source).toContain(needle);
+      const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+        sourceOverrides: { [path]: source.replaceAll(needle, replacement) },
+      });
+      expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+        "ops-explore-market-cap-authority-migration",
       );
     },
   );
@@ -917,44 +980,49 @@ describe("read-model operations source contract", () => {
       "true ||",
     ],
     [
-      "no durable full market-cap composition",
-      "const readDurablyCachedExploreMarketCapCompositionV1 = unstable_cache(",
-      "const readDurablyCachedExploreMarketCapCompositionV1 = passthrough(",
+      "no durable market-cap authority store",
+      "const authorityStore = getProductionExploreMarketCapAuthorityStoreV1();",
+      "const authorityStore = disabledMarketCapAuthorityStore();",
     ],
     [
-      "an unbound market-cap composition cache result",
-      "cached.inputCommitment !== inputCommitment",
+      "an authority detached from its canonical input",
+      "authority.inputCommitment !== input.inputCommitment",
       "false",
     ],
     [
-      "an unbounded market-cap composition cache age",
-      "const EXPLORE_MARKET_CAP_CACHE_MAXIMUM_AGE_MS = 235_000",
-      "const EXPLORE_MARKET_CAP_CACHE_MAXIMUM_AGE_MS = 300_000",
-    ],
-    [
-      "a non-canonical market-cap composition timestamp",
-      "new Date(observedAtMs).toISOString() === value",
+      "an unbounded market-cap authority age",
+      "nowMs - timestampMs <= EXPLORE_MARKET_CAP_AUTHORITY_MAXIMUM_AGE_MS",
       "true",
     ],
     [
-      "no persisted per-row market-cap ordering observations",
-      "orderingAsOfTimes: Object.freeze([...composed.orderingAsOfTimes])",
-      "orderingAsOfTimes: Object.freeze([])",
-    ],
-    [
-      "a stale per-row market-cap ordering observation",
-      "!currentExploreMarketCapTimestampV1(observedAt)",
-      "false",
-    ],
-    [
-      "a per-row market-cap observation count detached from qualification",
-      "qualifiedCount === expectedQualifiedCount",
+      "a non-canonical market-cap authority timestamp",
+      "new Date(timestampMs).toISOString() === value",
       "true",
     ],
     [
-      "a market-cap cache order that is not a full permutation",
-      "orderedIds.size !== entries.length",
+      "a public pin detached from frozen filter facets",
+      '"programmable.explore-market-cap-authority-pin.v2"',
+      '"programmable.explore-market-cap-authority-unbound.v2"',
+    ],
+    [
+      "stale provider evidence admitted into an authority",
+      "currentMarketCapAuthorityTimestampV1(value, nowMs)",
+      "true",
+    ],
+    [
+      "a retained pin conflict silently accepted",
+      'resolution.kind === "ranking-conflict"',
       "false",
+    ],
+    [
+      "a market-cap authority order that is not a full permutation",
+      "return seen.size === byId.size ? Object.freeze(ordered) : null;",
+      "return Object.freeze(ordered);",
+    ],
+    [
+      "a filtered page that replaces the retained public pin",
+      "rankingCommitment: authority.ranking.rankingCommitment,",
+      "rankingCommitment: ranked.ranking.rankingCommitment,",
     ],
     [
       "a discovery ranking identity coupled to observed freshness",
@@ -2128,8 +2196,8 @@ describe("read-model operations source contract", () => {
     ],
     [
       "a cross-page market-cap ranking drift accepted",
-      "JSON.stringify(highestSecondPage.body.ranking) !==",
-      "JSON.stringify(highestSecondPage.body.ranking) ===",
+      "highestSecondPage.body.ranking.rankingCommitment !==",
+      "highestSecondPage.body.ranking.rankingCommitment ===",
     ],
     [
       "cross-page market-cap membership overlap accepted",

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -5,6 +5,93 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
+const durableMarketCapCacheHarness = vi.hoisted(() => {
+  type Candidate = Readonly<{
+    canonicalAuthority: string;
+    rankingCommitment: string;
+    gmgnStatus: "complete" | "partial" | "unavailable";
+    generatedAt: string;
+    validUntil: string;
+  }>;
+  type Generation = Candidate & Readonly<{ refreshAfterMs: number }>;
+  type ResolveInput = Readonly<{
+    inputCommitment: string;
+    direction: "asc" | "desc";
+    rankingCommitment?: string;
+    acceptPinnedAuthority?: (canonicalAuthority: string) => boolean;
+    build?: () => Promise<Candidate>;
+  }>;
+  const entries = new Map<string, Generation[]>();
+  const pending = new Map<string, Promise<Generation | null>>();
+  const resolve = vi.fn(async (input: ResolveInput) => {
+    const key = `${input.inputCommitment}:${input.direction}`;
+    const generations = entries.get(key) ?? [];
+    const nowMs = Date.now();
+    if (input.rankingCommitment !== undefined) {
+      for (const generation of [...generations].reverse()) {
+        if (
+          generation.rankingCommitment === input.rankingCommitment &&
+          Date.parse(generation.validUntil) >= nowMs &&
+          input.acceptPinnedAuthority?.(generation.canonicalAuthority)
+        ) {
+          return { kind: "ready" as const,
+            canonicalAuthority: generation.canonicalAuthority };
+        }
+      }
+      return { kind: "ranking-conflict" as const };
+    }
+    const current = generations.at(-1);
+    if (
+      current !== undefined && Date.parse(current.validUntil) >= nowMs &&
+      current.refreshAfterMs > nowMs
+    ) {
+      return { kind: "ready" as const,
+        canonicalAuthority: current.canonicalAuthority };
+    }
+    if (input.build === undefined) return { kind: "unavailable" as const };
+    let fill = pending.get(key);
+    if (fill === undefined) {
+      fill = input.build().then((candidate) => {
+        const generatedAtMs = Date.parse(candidate.generatedAt);
+        const validUntilMs = Date.parse(candidate.validUntil);
+        if (!Number.isFinite(generatedAtMs) || validUntilMs < Date.now()) {
+          return null;
+        }
+        const generation: Generation = {
+          ...candidate,
+          refreshAfterMs: Math.min(
+            validUntilMs,
+            generatedAtMs +
+              (candidate.gmgnStatus === "unavailable" ? 10_000 : 60_000),
+          ),
+        };
+        const retained = (entries.get(key) ?? []).filter(
+          (item) => Date.parse(item.validUntil) >= Date.now(),
+        );
+        retained.push(generation);
+        entries.set(key, retained.slice(-32));
+        return generation;
+      }).catch(() => null).finally(() => pending.delete(key));
+      pending.set(key, fill);
+    }
+    const generation = await fill;
+    return generation === null
+      ? { kind: "unavailable" as const }
+      : { kind: "ready" as const,
+          canonicalAuthority: generation.canonicalAuthority };
+  });
+  return { entries, pending, resolve };
+});
+
+vi.mock("../lib/market-data/explore-market-cap-authority.server", async (
+  importOriginal,
+) => ({
+  ...await importOriginal(),
+  getProductionExploreMarketCapAuthorityStoreV1: () => ({
+    resolve: durableMarketCapCacheHarness.resolve,
+  }),
+}));
+
 import type { ValuedExploreEntry } from "../lib/explore-financial-data";
 import { SHARD_PUBLIC_PRESENTATION_V1 } from
   "../lib/custom-launch/router-trade-adapters-v1";
@@ -120,7 +207,11 @@ vi.mock("../lib/alchemy/router-custom-public.server", () => ({
   ].join("+"),
 }));
 
-import { GET, paginateTrendingExploreEntriesV1 } from "../app/api/explore/route";
+import {
+  exploreMarketCapRankingV1,
+  GET,
+  paginateTrendingExploreEntriesV1,
+} from "../app/api/explore/route";
 import { customGraphExploreEntry } from "./launch-stamp-surface-fixture";
 
 const NOW = "2026-08-16T08:00:00.000Z";
@@ -437,8 +528,8 @@ function marketRead(input: Readonly<{
 function valued(
   input: readonly ExploreEntry[],
   qualifiedIndexes: ReadonlySet<number> = new Set(input.map((_entry, index) => index)),
+  asOfTime = new Date(Date.now() - 30_000).toISOString(),
 ): readonly ValuedExploreEntry[] {
-  const observedAt = new Date().toISOString();
   return input.map((entry, index) => qualifiedIndexes.has(index)
     ? {
         ...entry,
@@ -450,7 +541,7 @@ function valued(
           valueWad: (BigInt(entry.tokenAddress ?? "0x0") * 10n ** 18n).toString(),
           freshness: "provider-recent" as const,
           source: "dexscreener" as const,
-          asOfTime: observedAt,
+          asOfTime,
         },
       }
     : {
@@ -517,6 +608,7 @@ describe("Explore static identity and Dexscreener market contract", () => {
   });
 
   beforeEach(() => {
+    durableMarketCapCacheHarness.entries.clear();
     vi.clearAllMocks();
     mocks.durableCache.clear();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
@@ -1339,10 +1431,24 @@ describe("Explore static identity and Dexscreener market contract", () => {
     mocks.readCatalog.mockResolvedValue(catalog({ entries: eligibleEntries }));
     mocks.gmgnEligible.mockReturnValue(true);
     const fetchedAt = new Date(Date.now() - 2_000).toISOString();
+    mocks.readTrending.mockResolvedValue({
+      ...discoverySnapshot(
+        "trending",
+        [eligibleEntries[3]!],
+        [],
+        { orderBy: "marketcap", direction: "desc" },
+      ),
+      fetchedAt,
+    });
     mocks.readGmgn.mockImplementation(async (
       input: readonly ExploreEntry[],
     ) => {
-      expect(input).toEqual([...eligibleEntries].reverse());
+      expect(input).toEqual([
+        eligibleEntries[4]!,
+        eligibleEntries[2]!,
+        eligibleEntries[1]!,
+        eligibleEntries[0]!,
+      ]);
       return new Map([
         [eligibleEntries[4]!.id, gmgnMarketSnapshot(eligibleEntries[4]!, {
           fdvUsd: 10,
@@ -1388,15 +1494,15 @@ describe("Explore static identity and Dexscreener market contract", () => {
       status: "partial",
       gmgnStatus: "partial",
       applied:
-        "gmgn-token-info-fdv-then-dexscreener-fdv-then-launch-order",
+        "gmgn-market-cap-then-gmgn-token-info-fdv-then-dexscreener-fdv-then-launch-order",
       metricOrder:
         "gmgn-market-cap>gmgn-token-info-fdv>dexscreener-fdv>canonical-launch-order",
-      matchedTokenCount: 0,
+      matchedTokenCount: 1,
       gmgnHydrationLimit: 100,
-      gmgnHydrationEligibleCount: 5,
-      gmgnHydrationRequestedCount: 5,
-      gmgnHydrationObservedCount: 3,
-      gmgnHydrationQualifiedCount: 2,
+      gmgnHydrationEligibleCount: 4,
+      gmgnHydrationRequestedCount: 4,
+      gmgnHydrationObservedCount: 2,
+      gmgnHydrationQualifiedCount: 1,
       gmgnHydrationDeferredCount: 0,
       fallbackRequestedCount: 3,
       fallbackQualifiedCount: 2,
@@ -1428,10 +1534,17 @@ describe("Explore static identity and Dexscreener market contract", () => {
       })],
     ]));
     const drifted = await json(await GET(
-      request("sort=market-cap&page=2&limit=2"),
+      request(
+        `sort=market-cap&page=2&limit=2&rankingCommitment=${
+          encodeURIComponent(body.ranking.rankingCommitment)
+        }`,
+      ),
     ));
     expect(drifted.ranking.rankingCommitment).toBe(
       body.ranking.rankingCommitment,
+    );
+    expect(drifted.tokens.map((entry: ExploreEntry) => entry.id)).toEqual(
+      body.tokens.slice(2, 4).map((entry: ExploreEntry) => entry.id),
     );
     expect(mocks.readGmgn).toHaveBeenCalledOnce();
     expect(mocks.readDex.mock.calls.filter(([input]) =>
@@ -1496,13 +1609,18 @@ describe("Explore static identity and Dexscreener market contract", () => {
 
       vi.setSystemTime(Date.now() + 2_000);
       const expiredResponse = await GET(
-        request("sort=market-cap&page=2&limit=1"),
+        request(
+          `sort=market-cap&page=2&limit=1&rankingCommitment=${encodeURIComponent(
+            first.ranking.rankingCommitment,
+          )}`,
+        ),
       );
       const expired = await json(expiredResponse);
 
-      expect(expiredResponse.status).toBe(503);
+      expect(expiredResponse.status).toBe(409);
       expect(expired).toEqual({
-        error: "Token data is temporarily unavailable",
+        error: "Market-cap ranking changed; restart from page 1",
+        code: "MARKET_CAP_RANKING_RESTART_REQUIRED",
       });
       expect(first.ranking.asOfTime).toBe(freshRankAt);
       expect(mocks.readTrending).toHaveBeenCalledOnce();
@@ -1510,6 +1628,25 @@ describe("Explore static identity and Dexscreener market contract", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("skips token_info fanout when the direct GMGN rank is unavailable", async () => {
+    mocks.gmgnEligible.mockReturnValue(true);
+    mocks.readTrending.mockResolvedValue(null);
+
+    const response = await GET(request("sort=market-cap&page=1&limit=5"));
+    const body = await json(response);
+
+    expect(response.status).toBe(200);
+    expect(mocks.readTrending).toHaveBeenCalledTimes(2);
+    expect(mocks.readGmgn).not.toHaveBeenCalled();
+    expect(mocks.readDex.mock.calls[0]?.[0]).toHaveLength(TOKEN_COUNT);
+    expect(body.ranking).toMatchObject({
+      matchedTokenCount: 0,
+      gmgnHydrationEligibleCount: 0,
+      gmgnHydrationRequestedCount: 0,
+      gmgnStatus: "unavailable",
+    });
   });
 
   it("bounds Registry Custom supply hydration before GMGN token info", async () => {
@@ -1546,6 +1683,15 @@ describe("Explore static identity and Dexscreener market contract", () => {
       typeof entry.totalSupplyRaw === "string"
     );
     const fetchedAt = new Date(Date.now() - 1_000).toISOString();
+    mocks.readTrending.mockResolvedValue({
+      ...discoverySnapshot(
+        "trending",
+        [customEntries[24]!],
+        [],
+        { orderBy: "marketcap", direction: "desc" },
+      ),
+      fetchedAt,
+    });
     mocks.readGmgn.mockImplementation(async (
       input: readonly ExploreEntry[],
     ) => new Map([[input[0]!.id, gmgnMarketSnapshot(input[0]!, {
@@ -1564,18 +1710,19 @@ describe("Explore static identity and Dexscreener market contract", () => {
       (entry: ExploreEntry) => entry.exploreKind === "custom-project" &&
         typeof entry.totalSupplyRaw === "string",
     )).toBe(true);
-    expect(mocks.readDex.mock.calls[0]?.[0]).toHaveLength(24);
+    expect(mocks.readDex.mock.calls[0]?.[0]).toHaveLength(23);
     expect(body.ranking).toMatchObject({
       source: "gmgn+dexscreener",
       status: "complete",
       gmgnStatus: "partial",
-      applied: "gmgn-token-info-fdv-then-dexscreener-fdv",
+      applied:
+        "gmgn-market-cap-then-gmgn-token-info-fdv-then-dexscreener-fdv",
       gmgnHydrationEligibleCount: 20,
       gmgnHydrationRequestedCount: 20,
       gmgnHydrationObservedCount: 1,
       gmgnHydrationQualifiedCount: 1,
-      fallbackRequestedCount: 24,
-      fallbackQualifiedCount: 24,
+      fallbackRequestedCount: 23,
+      fallbackQualifiedCount: 23,
       canonicalTailCount: 0,
       qualifiedCount: 25,
       totalCount: 25,
@@ -1598,7 +1745,11 @@ describe("Explore static identity and Dexscreener market contract", () => {
     const descResponse = await GET(request("sort=market-cap&page=1&limit=5"));
     const desc = await json(descResponse);
     const descSecondPage = await json(await GET(
-      request("sort=market-cap&page=2&limit=5"),
+      request(
+        `sort=market-cap&page=2&limit=5&rankingCommitment=${
+          encodeURIComponent(desc.ranking.rankingCommitment)
+        }`,
+      ),
     ));
 
     expect(desc.tokens.slice(0, 2).map((entry: ExploreEntry) => entry.id)).toEqual([
@@ -1694,6 +1845,278 @@ describe("Explore static identity and Dexscreener market contract", () => {
       signal: expect.any(AbortSignal),
       deadlineMs: expect.any(Number),
     }));
+  });
+
+  it("commits only to the frozen market-cap identity order", () => {
+    const canonicalEntries = entries.slice(0, 3);
+    const firstFetchedAt = new Date(Date.now() - 2_000).toISOString();
+    const secondFetchedAt = new Date(Date.now() - 1_000).toISOString();
+    const fallback = {
+      gmgnHydrationLimit: 100,
+      gmgnHydrationEligibleEntryCount: 0,
+      gmgnRequestedEntries: [] as const,
+      gmgnEntries: [] as const,
+      dexscreenerRequestedEntries: canonicalEntries,
+      dexscreenerEntries: [] as const,
+    };
+    const first = exploreMarketCapRankingV1(
+      canonicalEntries,
+      {
+        ...discoverySnapshot(
+          "trending",
+          [canonicalEntries[0]!, canonicalEntries[2]!],
+          [],
+          { orderBy: "marketcap", direction: "desc" },
+        ),
+        fetchedAt: firstFetchedAt,
+      },
+      fallback,
+      "desc",
+    );
+    const refreshed = exploreMarketCapRankingV1(
+      canonicalEntries,
+      {
+        ...discoverySnapshot(
+          "trending",
+          [canonicalEntries[0]!, canonicalEntries[2]!],
+          [],
+          { orderBy: "marketcap", direction: "desc" },
+        ),
+        fetchedAt: secondFetchedAt,
+      },
+      fallback,
+      "desc",
+    );
+    const reranked = exploreMarketCapRankingV1(
+      canonicalEntries,
+      {
+        ...discoverySnapshot(
+          "trending",
+          [canonicalEntries[2]!, canonicalEntries[0]!],
+          [],
+          { orderBy: "marketcap", direction: "desc" },
+        ),
+        fetchedAt: secondFetchedAt,
+      },
+      fallback,
+      "desc",
+    );
+
+    expect(refreshed.ranking.rankingCommitment).toBe(
+      first.ranking.rankingCommitment,
+    );
+    expect(refreshed.ranking.asOfTime).not.toBe(first.ranking.asOfTime);
+    expect(reranked.ranking.rankingCommitment).not.toBe(
+      first.ranking.rankingCommitment,
+    );
+  });
+
+  it("freezes a cold partial fallback across pages when provider data warms", async () => {
+    let providerWarm = false;
+    let fullAuthorityReads = 0;
+    mocks.readDex.mockImplementation(async (input: readonly ExploreEntry[]) => {
+      if (input.length === TOKEN_COUNT) {
+        fullAuthorityReads += 1;
+        const qualified = providerWarm
+          ? new Set([input.length - 1])
+          : new Set<number>();
+        return {
+          entries: valued(input, qualified),
+          marketRead: marketRead({
+            requested: input.length,
+            qualified: qualified.size,
+            observed: qualified.size,
+          }),
+        };
+      }
+      return {
+        entries: valued(input),
+        marketRead: marketRead({
+          requested: input.length,
+          qualified: input.length,
+        }),
+      };
+    });
+
+    const first = await json(await GET(
+      request("sort=market-cap&page=1&limit=8"),
+    ));
+    providerWarm = true;
+    const second = await json(await GET(
+      request(
+        `sort=market-cap&page=2&limit=8&rankingCommitment=${
+          encodeURIComponent(first.ranking.rankingCommitment)
+        }`,
+      ),
+    ));
+    const expectedOrder = [...entries].reverse().map((entry) => entry.id);
+    const firstIds = first.tokens.map((entry: ExploreEntry) => entry.id);
+    const secondIds = second.tokens.map((entry: ExploreEntry) => entry.id);
+
+    expect(fullAuthorityReads).toBe(1);
+    expect(first.ranking.rankingCommitment).toBe(
+      second.ranking.rankingCommitment,
+    );
+    expect(firstIds).toEqual(expectedOrder.slice(0, 8));
+    expect(secondIds).toEqual(expectedOrder.slice(8, 16));
+    expect(new Set([...firstIds, ...secondIds]).size).toBe(16);
+  });
+
+  it("binds query facets to the pin and retains the old filtered generation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-01T12:00:00.000Z"));
+    try {
+      const first = await json(await GET(request(
+        "sort=market-cap&q=token&page=1&limit=8",
+      )));
+      const frozenOrder = [...entries]
+        .filter((entry) => entry.name.toLowerCase().includes("token"))
+        .reverse()
+        .map((entry) => entry.id);
+      const changedPresentation = entries.map((entry) =>
+        entry.id === entries[19]!.id
+          ? { ...entry, name: "Renamed without the search term" }
+          : entry
+      );
+      mocks.readCatalog.mockResolvedValue(catalog({
+        entries: changedPresentation,
+        generatedAt: "2026-08-16T08:00:30.000Z",
+        asOfBlock: "25740030",
+      }));
+
+      vi.setSystemTime(Date.now() + 60_000);
+      const refreshed = await json(await GET(request(
+        "sort=market-cap&q=token&page=1&limit=8",
+      )));
+      expect(refreshed.ranking.rankingCommitment).not.toBe(
+        first.ranking.rankingCommitment,
+      );
+      expect(refreshed.total).toBe(first.total - 1);
+
+      const oldSecond = await json(await GET(request(
+        `sort=market-cap&q=token&page=2&limit=8&rankingCommitment=${
+          encodeURIComponent(first.ranking.rankingCommitment)
+        }`,
+      )));
+      expect(oldSecond.total).toBe(first.total);
+      expect(first.tokens.map((entry: ExploreEntry) => entry.id)).toEqual(
+        frozenOrder.slice(0, 8),
+      );
+      expect(oldSecond.tokens.map((entry: ExploreEntry) => entry.id)).toEqual(
+        frozenOrder.slice(8, 16),
+      );
+      expect(oldSecond.ranking.rankingCommitment).toBe(
+        first.ranking.rankingCommitment,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("accepts the shared authority at 235 seconds and fails closed after it", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-01T12:00:00.000Z"));
+    try {
+      let fullAuthorityReads = 0;
+      mocks.readDex.mockImplementation(async (input: readonly ExploreEntry[]) => {
+        if (input.length === TOKEN_COUNT) fullAuthorityReads += 1;
+        return {
+          entries: valued(input, undefined, new Date().toISOString()),
+          marketRead: marketRead({
+            requested: input.length,
+            qualified: input.length,
+          }),
+        };
+      });
+
+      const initial = await GET(
+        request("sort=market-cap&page=1&limit=8"),
+      );
+      const initialBody = await json(initial);
+      expect(initial.status).toBe(200);
+      const pinnedPageTwo =
+        `sort=market-cap&page=2&limit=8&rankingCommitment=${
+          encodeURIComponent(initialBody.ranking.rankingCommitment)
+        }`;
+
+      vi.setSystemTime(Date.now() + 235_000);
+      const boundary = await GET(
+        request(pinnedPageTwo),
+      );
+      expect(boundary.status).toBe(200);
+
+      vi.setSystemTime(Date.now() + 1);
+      const expired = await GET(
+        request(pinnedPageTwo),
+      );
+      expect(expired.status).toBe(409);
+      expect(expired.headers.get("cache-control")).toBe("no-store");
+      expect(await json(expired)).toEqual({
+        error: "Market-cap ranking changed; restart from page 1",
+        code: "MARKET_CAP_RANKING_RESTART_REQUIRED",
+      });
+      expect(fullAuthorityReads).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("recovers an unavailable rank after 10 seconds without drifting old pages", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-01T12:00:00.000Z"));
+    try {
+      mocks.readTrending.mockResolvedValue(null);
+      const first = await json(await GET(request(
+        "sort=market-cap&page=1&limit=8",
+      )));
+      const oldOrder = [...entries].reverse().map((entry) => entry.id);
+      expect(first.ranking.matchedTokenCount).toBe(0);
+
+      vi.setSystemTime(Date.now() + 10_000);
+      mocks.readTrending.mockResolvedValue({
+        ...discoverySnapshot(
+          "trending",
+          [entries[0]!],
+          [],
+          { orderBy: "marketcap", direction: "desc" },
+        ),
+        fetchedAt: new Date().toISOString(),
+      });
+      const recovered = await json(await GET(request(
+        "sort=market-cap&page=1&limit=8",
+      )));
+      expect(recovered.ranking.matchedTokenCount).toBe(1);
+      expect(recovered.ranking.rankingCommitment).not.toBe(
+        first.ranking.rankingCommitment,
+      );
+
+      const oldSecond = await json(await GET(request(
+        `sort=market-cap&page=2&limit=8&rankingCommitment=${
+          encodeURIComponent(first.ranking.rankingCommitment)
+        }`,
+      )));
+      const newSecond = await json(await GET(request(
+        `sort=market-cap&page=2&limit=8&rankingCommitment=${
+          encodeURIComponent(recovered.ranking.rankingCommitment)
+        }`,
+      )));
+      const recoveredOrder = [
+        entries[0]!.id,
+        ...oldOrder.filter((id) => id !== entries[0]!.id),
+      ];
+      expect(oldSecond.tokens.map((entry: ExploreEntry) => entry.id)).toEqual(
+        oldOrder.slice(8, 16),
+      );
+      expect(newSecond.tokens.map((entry: ExploreEntry) => entry.id)).toEqual(
+        recoveredOrder.slice(8, 16),
+      );
+      expect(new Set([
+        ...first.tokens.map((entry: ExploreEntry) => entry.id),
+        ...oldSecond.tokens.map((entry: ExploreEntry) => entry.id),
+      ]).size).toBe(16);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("reports a fresh ascending GMGN rank without canonical overlap", async () => {
@@ -1812,7 +2235,7 @@ describe("Explore static identity and Dexscreener market contract", () => {
     }
   });
 
-  it("stops waiting for a composed cache fill after request abort", async () => {
+  it("keeps a shared rank fill independent from the request signal", async () => {
     const controller = new AbortController();
     mocks.readTrending
       .mockImplementationOnce(async () => {
@@ -1826,8 +2249,8 @@ describe("Explore static identity and Dexscreener market contract", () => {
     ));
     const body = await json(response);
 
-    expect(response.status).toBe(503);
-    expect(body).toEqual({ error: "Token data is temporarily unavailable" });
+    expect(response.status).toBe(200);
+    expect(body.ranking.gmgnStatus).toBe("unavailable");
     expect(mocks.readTrending).toHaveBeenCalledTimes(2);
     expect(controller.signal.aborted).toBe(true);
   });
@@ -1898,7 +2321,9 @@ describe("Explore static identity and Dexscreener market contract", () => {
     ) => {
       expect(wait.signal).toBeInstanceOf(AbortSignal);
       expect(wait.deadlineMs).toBeGreaterThan(Date.now());
-      expect(wait.deadlineMs - Date.now()).toBeLessThanOrEqual(8_000);
+      expect(wait.deadlineMs - Date.now()).toBeLessThanOrEqual(
+        input.length === largeCatalog.length ? 8_000 : 12_000,
+      );
       return {
         entries: valued(input, new Set()),
         marketRead: marketRead({
@@ -2011,6 +2436,32 @@ describe("Explore static identity and Dexscreener market contract", () => {
       expect(mocks.readDex).not.toHaveBeenCalled();
     },
   );
+
+  it("requires an exact retained ranking pin after market-cap page 1", async () => {
+    const missing = await GET(request("sort=market-cap&page=2&limit=5"));
+    expect(missing.status).toBe(400);
+    expect(missing.headers.get("cache-control")).toBe("no-store");
+    expect(await json(missing)).toMatchObject({
+      code: "MARKET_CAP_RANKING_COMMITMENT_REQUIRED",
+    });
+
+    const malformed = await GET(request(
+      "sort=market-cap&page=2&limit=5&rankingCommitment=sha256%3Abad",
+    ));
+    expect(malformed.status).toBe(400);
+
+    const unknown = await GET(request(
+      `sort=market-cap&page=2&limit=5&rankingCommitment=${
+        encodeURIComponent(`sha256:${"ee".repeat(32)}`)
+      }`,
+    ));
+    expect(unknown.status).toBe(409);
+    expect(unknown.headers.get("cache-control")).toBe("no-store");
+    expect(await json(unknown)).toEqual({
+      error: "Market-cap ranking changed; restart from page 1",
+      code: "MARKET_CAP_RANKING_RESTART_REQUIRED",
+    });
+  });
 
   it("contains no runtime dRPC or Bitquery dependency", () => {
     for (const relative of [

--- a/tests/explore-market-cap-authority-store.test.ts
+++ b/tests/explore-market-cap-authority-store.test.ts
@@ -1,0 +1,718 @@
+import { readFile } from "node:fs/promises";
+
+import { PGlite } from "@electric-sql/pglite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  exploreMarketCapAuthorityStorageCommitmentV1,
+  PostgresExploreMarketCapAuthorityStoreV1,
+  type ExploreMarketCapAuthorityCandidateV1,
+} from "../lib/market-data/explore-market-cap-authority.server";
+import { canonicalizeJson } from
+  "../lib/server/projection-target/canonical-json";
+import { canonicalSha256 } from
+  "../lib/server/projection-target/hashing";
+import type {
+  ProjectionTargetPostgresClientV1,
+  ProjectionTargetPostgresPoolV1,
+  ProjectionTargetPostgresQueryResultV1,
+} from "../lib/server/projection-target/postgres-store";
+
+const INPUT_COMMITMENT = digest("input");
+const RANKING_ONE = digest("ranking-one");
+const RANKING_TWO = digest("ranking-two");
+const databases: PGlite[] = [];
+
+afterEach(async () => {
+  await Promise.all(databases.splice(0).map((database) => database.close()));
+});
+
+describe("Postgres explore market-cap authority store", () => {
+  it("claims, builds, and atomically publishes a cold generation", async () => {
+    const { database, pool } = await migratedAuthorityStore();
+    const store = authorityStore(pool);
+    const built = candidate("cold", RANKING_ONE);
+    const build = vi.fn(async () => built);
+
+    await expect(store.resolve(unpinned(build))).resolves.toEqual({
+      kind: "ready",
+      canonicalAuthority: built.canonicalAuthority,
+    });
+    expect(build).toHaveBeenCalledOnce();
+
+    await database.exec("RESET ROLE");
+    const state = await database.query<{
+      current_generation: bigint;
+      lease_generation: bigint | null;
+      lease_holder: string | null;
+      generations: bigint;
+    }>(`
+      SELECT head.current_generation, head.lease_generation,
+             head.lease_holder,
+             (SELECT count(*)
+                FROM programmable_website_projection_v1
+                  .explore_market_cap_authority_generations_v1) AS generations
+        FROM programmable_website_projection_v1
+          .explore_market_cap_authority_heads_v1 AS head
+    `);
+    expect(state.rows).toEqual([{
+      current_generation: 1,
+      lease_generation: null,
+      lease_holder: null,
+      generations: 1,
+    }]);
+  });
+
+  it("serves a fresh generation without taking the refresh lock", async () => {
+    const { pool } = await migratedAuthorityStore();
+    const current = candidate("fresh-lock-free", RANKING_ONE);
+    await authorityStore(pool).resolve(unpinned(async () => current));
+    const recordedPool = new RecordingPool(pool);
+    const unexpectedBuild = vi.fn(async () =>
+      candidate("must-not-build", RANKING_TWO)
+    );
+
+    await expect(authorityStore(recordedPool).resolve(
+      unpinned(unexpectedBuild),
+    )).resolves.toEqual({
+      kind: "ready",
+      canonicalAuthority: current.canonicalAuthority,
+    });
+    expect(unexpectedBuild).not.toHaveBeenCalled();
+    expect(recordedPool.queries.join("\n")).toContain(
+      "explore_market_cap_authority_heads_v1",
+    );
+    expect(recordedPool.queries.join("\n")).not.toMatch(
+      /pg_advisory_xact_lock|FOR UPDATE|SET lease_generation/u,
+    );
+  });
+
+  it("awaits bounded global cleanup after the authority commit", async () => {
+    const { pool } = await migratedAuthorityStore();
+    const cleanupEntered = Promise.withResolvers<void>();
+    const releaseCleanup = Promise.withResolvers<void>();
+    const cleanupPool = new DelayedGlobalCleanupPool(
+      pool,
+      cleanupEntered,
+      releaseCleanup,
+    );
+    const store = new PostgresExploreMarketCapAuthorityStoreV1(cleanupPool, {
+      delay: (ms, signal) => abortableDelay(Math.min(ms, 2), signal),
+    });
+    const built = candidate("awaited-cleanup", RANKING_ONE);
+    let settled = false;
+    const resolution = store.resolve(unpinned(async () => built)).then(
+      (value) => {
+        settled = true;
+        return value;
+      },
+    );
+
+    await cleanupEntered.promise;
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    releaseCleanup.resolve();
+    await expect(resolution).resolves.toEqual({
+      kind: "ready",
+      canonicalAuthority: built.canonicalAuthority,
+    });
+  });
+
+  it("allows only one cold build across two store instances and makes the loser reread", async () => {
+    const { pool } = await migratedAuthorityStore();
+    const firstStore = authorityStore(pool);
+    const enteredLoserPoll = Promise.withResolvers<void>();
+    const releaseLoserPoll = Promise.withResolvers<void>();
+    const secondStore = new PostgresExploreMarketCapAuthorityStoreV1(pool, {
+      delay: async () => {
+        enteredLoserPoll.resolve();
+        await releaseLoserPoll.promise;
+        return true;
+      },
+      garbageCollection: false,
+    });
+    const enteredBuild = Promise.withResolvers<void>();
+    const releaseBuild = Promise.withResolvers<void>();
+    let buildCount = 0;
+    const build = vi.fn(async () => {
+      buildCount += 1;
+      enteredBuild.resolve();
+      await releaseBuild.promise;
+      return candidate("winner", RANKING_ONE);
+    });
+
+    const first = firstStore.resolve(unpinned(build));
+    await enteredBuild.promise;
+    const second = secondStore.resolve(unpinned(build));
+    await enteredLoserPoll.promise;
+    expect(buildCount).toBe(1);
+    releaseBuild.resolve();
+    const firstResult = await first;
+    releaseLoserPoll.resolve();
+    const results = [firstResult, await second];
+    expect(build).toHaveBeenCalledOnce();
+    expect(results).toEqual([
+      { kind: "ready", canonicalAuthority: canonical("winner") },
+      { kind: "ready", canonicalAuthority: canonical("winner") },
+    ]);
+  });
+
+  it("takes over an expired lease and publishes its successor", async () => {
+    const { database, pool } = await migratedAuthorityStore();
+    await database.exec("RESET ROLE");
+    await database.query(`
+      INSERT INTO programmable_website_projection_v1
+        .explore_market_cap_authority_heads_v1
+        (authority_key, input_commitment, direction, lease_generation,
+         lease_holder, lease_until)
+      VALUES ($1, $2, 'desc', 1, '11111111-1111-4111-8111-111111111111',
+              pg_catalog.clock_timestamp() - INTERVAL '1 second')
+    `, [authorityKey(), INPUT_COMMITMENT]);
+    await database.exec("SET ROLE programmable_website_projection_runtime");
+    const replacement = candidate("takeover", RANKING_ONE);
+
+    await expect(authorityStore(pool).resolve(unpinned(async () => replacement)))
+      .resolves.toEqual({
+        kind: "ready",
+        canonicalAuthority: replacement.canonicalAuthority,
+      });
+
+    await database.exec("RESET ROLE");
+    const state = await database.query<{
+      current_generation: bigint;
+      lease_generation: bigint | null;
+      canonical_authority: string;
+    }>(`
+      SELECT head.current_generation, head.lease_generation,
+             generation.canonical_authority
+        FROM programmable_website_projection_v1
+          .explore_market_cap_authority_heads_v1 AS head
+        JOIN programmable_website_projection_v1
+          .explore_market_cap_authority_generations_v1 AS generation
+          ON generation.authority_key = head.authority_key
+         AND generation.generation = head.current_generation
+    `);
+    expect(state.rows).toEqual([{
+      current_generation: 1,
+      lease_generation: null,
+      canonical_authority: replacement.canonicalAuthority,
+    }]);
+  });
+
+  it("caps a late committed claim at the request deadline so it cannot strand a lease", async () => {
+    const { database, pool } = await migratedAuthorityStore();
+    const commitApplied = Promise.withResolvers<void>();
+    const releaseCommitResult = Promise.withResolvers<void>();
+    const lateConnectionReleased = Promise.withResolvers<void>();
+    const delayedPool = new DelayedFirstCommitPool(
+      pool,
+      commitApplied,
+      releaseCommitResult,
+      lateConnectionReleased,
+    );
+    const abandonedBuild = vi.fn(async () =>
+      candidate("must-not-build", RANKING_ONE)
+    );
+    const deadlineMs = Date.now() + 3_300;
+    const lateClaim = authorityStore(delayedPool).resolve({
+      ...unpinned(abandonedBuild),
+      deadlineMs,
+    });
+    await commitApplied.promise;
+
+    await expect(lateClaim).resolves.toEqual({ kind: "unavailable" });
+    expect(abandonedBuild).not.toHaveBeenCalled();
+    releaseCommitResult.resolve();
+    await lateConnectionReleased.promise;
+
+    await database.exec("RESET ROLE");
+    const stranded = await database.query<{
+      lease_holder: string | null;
+      lease_until: Date | string;
+    }>(`
+      SELECT lease_holder, lease_until
+        FROM programmable_website_projection_v1
+          .explore_market_cap_authority_heads_v1
+    `);
+    expect(stranded.rows).toHaveLength(1);
+    expect(stranded.rows[0]!.lease_holder).not.toBeNull();
+    expect(new Date(stranded.rows[0]!.lease_until).getTime())
+      .toBeLessThanOrEqual(deadlineMs);
+    await database.exec("SET ROLE programmable_website_projection_runtime");
+
+    const winner = candidate("late-claim-takeover", RANKING_TWO);
+    await expect(authorityStore(pool).resolve(unpinned(async () => winner)))
+      .resolves.toEqual({
+        kind: "ready",
+        canonicalAuthority: winner.canonicalAuthority,
+      });
+  }, 10_000);
+
+  it("prevents a superseded builder from publishing over the lease winner", async () => {
+    const { database, pool } = await migratedAuthorityStore();
+    const firstStore = authorityStore(pool);
+    const secondStore = authorityStore(pool);
+    const firstEntered = Promise.withResolvers<void>();
+    const releaseFirst = Promise.withResolvers<void>();
+    const firstCandidate = candidate("superseded", RANKING_ONE);
+    const winner = candidate("winner", RANKING_TWO);
+    const first = firstStore.resolve(unpinned(async () => {
+      firstEntered.resolve();
+      await releaseFirst.promise;
+      return firstCandidate;
+    }));
+    await firstEntered.promise;
+
+    await database.exec("RESET ROLE");
+    await database.query(`
+      UPDATE programmable_website_projection_v1
+        .explore_market_cap_authority_heads_v1
+         SET lease_until = pg_catalog.clock_timestamp() - INTERVAL '1 second'
+    `);
+    await database.exec("SET ROLE programmable_website_projection_runtime");
+    await expect(secondStore.resolve(unpinned(async () => winner)))
+      .resolves.toEqual({
+        kind: "ready",
+        canonicalAuthority: winner.canonicalAuthority,
+      });
+    releaseFirst.resolve();
+    await expect(first).resolves.toEqual({
+      kind: "ready",
+      canonicalAuthority: winner.canonicalAuthority,
+    });
+
+    await database.exec("RESET ROLE");
+    const generations = await database.query<{
+      generation: bigint;
+      canonical_authority: string;
+    }>(`
+      SELECT generation, canonical_authority
+        FROM programmable_website_projection_v1
+          .explore_market_cap_authority_generations_v1
+       ORDER BY generation
+    `);
+    expect(generations.rows).toEqual([{
+      generation: 1,
+      canonical_authority: winner.canonicalAuthority,
+    }]);
+  });
+
+  it("retains and resolves an exact old generation by ranking commitment", async () => {
+    const { database, pool } = await migratedAuthorityStore();
+    const store = authorityStore(pool);
+    const first = candidate("first", RANKING_ONE);
+    const second = candidate("second", RANKING_TWO);
+    await expect(store.resolve(unpinned(async () => first)))
+      .resolves.toMatchObject({ kind: "ready" });
+    await expireRefresh(database);
+    await expect(store.resolve(unpinned(async () => second)))
+      .resolves.toEqual({
+        kind: "ready",
+        canonicalAuthority: second.canonicalAuthority,
+      });
+
+    await expect(store.resolve(pinned(RANKING_ONE, (authority) =>
+      authority === first.canonicalAuthority
+    ))).resolves.toEqual({
+      kind: "ready",
+      canonicalAuthority: first.canonicalAuthority,
+    });
+    await expect(store.resolve(pinned(RANKING_ONE, () => false)))
+      .resolves.toEqual({ kind: "ranking-conflict" });
+  });
+
+  it.each([
+    ["payload", canonicalizeJson({ label: "tampered" }), digest("wrong")],
+    ["commitment", canonical("original"), digest("wrong")],
+  ])("fails closed when the stored %s is corrupt", async (
+    _case,
+    corruptAuthority,
+    corruptCommitment,
+  ) => {
+    const { database, pool } = await migratedAuthorityStore();
+    const store = authorityStore(pool);
+    const original = candidate("original", RANKING_ONE);
+    await store.resolve(unpinned(async () => original));
+    await database.exec("RESET ROLE");
+    await database.query(`
+      UPDATE programmable_website_projection_v1
+        .explore_market_cap_authority_generations_v1
+         SET canonical_authority = $1,
+             authority_commitment = $2,
+             generated_at = pg_catalog.clock_timestamp() - INTERVAL '61 seconds',
+             refresh_after = pg_catalog.clock_timestamp() - INTERVAL '1 second',
+             valid_until = pg_catalog.clock_timestamp() + INTERVAL '100 seconds'
+    `, [corruptAuthority, corruptCommitment]);
+    await database.exec("SET ROLE programmable_website_projection_runtime");
+    const build = vi.fn(async () => {
+      throw new Error("provider unavailable");
+    });
+
+    await expect(store.resolve(unpinned(build)))
+      .resolves.toEqual({ kind: "unavailable" });
+    expect(build).toHaveBeenCalledOnce();
+    await expect(store.resolve(pinned(RANKING_ONE, () => true)))
+      .resolves.toEqual({ kind: "ranking-conflict" });
+  });
+
+  it("returns unavailable when readiness fails or the request deadline has elapsed", async () => {
+    const { pool } = await migratedAuthorityStore();
+    const build = vi.fn(async () => candidate("unused", RANKING_ONE));
+    const readinessFailure = new PostgresExploreMarketCapAuthorityStoreV1(pool, {
+      assertReady: async () => {
+        throw new Error("attestation failed");
+      },
+      garbageCollection: false,
+    });
+    await expect(readinessFailure.resolve(unpinned(build)))
+      .resolves.toEqual({ kind: "unavailable" });
+    expect(build).not.toHaveBeenCalled();
+
+    await expect(authorityStore(pool).resolve({
+      ...unpinned(build),
+      deadlineMs: Date.now() - 1,
+    })).resolves.toEqual({ kind: "unavailable" });
+    expect(build).not.toHaveBeenCalled();
+  });
+
+  it("bounds unresolved readiness and transaction work by the request deadline", async () => {
+    const { pool } = await migratedAuthorityStore();
+    const build = vi.fn(async () => candidate("unused", RANKING_ONE));
+    const unresolvedReadiness = new PostgresExploreMarketCapAuthorityStoreV1(
+      pool,
+      {
+        assertReady: () => new Promise<void>(() => {}),
+        garbageCollection: false,
+      },
+    );
+    const readinessStartedAt = Date.now();
+    await expect(unresolvedReadiness.resolve({
+      ...unpinned(build),
+      deadlineMs: readinessStartedAt + 30,
+    })).resolves.toEqual({ kind: "unavailable" });
+    expect(Date.now() - readinessStartedAt).toBeLessThan(500);
+    expect(build).not.toHaveBeenCalled();
+
+    const hangingQuery = vi.fn();
+    const unresolvedQuery = <
+    Row extends Record<string, unknown> = Record<string, unknown>
+    >(
+      text: string,
+      values: readonly unknown[] = [],
+    ): Promise<ProjectionTargetPostgresQueryResultV1<Row>> => {
+      hangingQuery(text, values);
+      return new Promise(() => {});
+    };
+    const hangingPool: ProjectionTargetPostgresPoolV1 = {
+      connect: async () => ({ query: unresolvedQuery, release: vi.fn() }),
+      query: unresolvedQuery,
+    };
+    const unresolvedTransaction = authorityStore(hangingPool);
+    const transactionStartedAt = Date.now();
+    await expect(unresolvedTransaction.resolve({
+      ...unpinned(build),
+      deadlineMs: transactionStartedAt + 30,
+    })).resolves.toEqual({ kind: "unavailable" });
+    expect(Date.now() - transactionStartedAt).toBeLessThan(500);
+    expect(hangingQuery).toHaveBeenCalledWith("BEGIN", []);
+    expect(build).not.toHaveBeenCalled();
+  });
+
+  it("serves a still-valid last-known generation when its refresh build fails", async () => {
+    const { database, pool } = await migratedAuthorityStore();
+    const store = authorityStore(pool);
+    const lastKnown = candidate("last-known-good", RANKING_ONE);
+    await store.resolve(unpinned(async () => lastKnown));
+    await expireRefresh(database);
+    const failedRefresh = vi.fn(async () => {
+      throw new Error("provider unavailable");
+    });
+
+    await expect(store.resolve(unpinned(failedRefresh))).resolves.toEqual({
+      kind: "ready",
+      canonicalAuthority: lastKnown.canonicalAuthority,
+    });
+    expect(failedRefresh).toHaveBeenCalledOnce();
+  });
+});
+
+function unpinned(
+  build: () => Promise<ExploreMarketCapAuthorityCandidateV1>,
+) {
+  return Object.freeze({
+    inputCommitment: INPUT_COMMITMENT,
+    direction: "desc" as const,
+    build,
+    deadlineMs: Date.now() + 5_000,
+  });
+}
+
+function pinned(
+  rankingCommitment: `sha256:${string}`,
+  acceptPinnedAuthority: (canonicalAuthority: string) => boolean,
+) {
+  return Object.freeze({
+    inputCommitment: INPUT_COMMITMENT,
+    direction: "desc" as const,
+    rankingCommitment,
+    acceptPinnedAuthority,
+    deadlineMs: Date.now() + 5_000,
+  });
+}
+
+function candidate(
+  label: string,
+  rankingCommitment: `sha256:${string}`,
+): ExploreMarketCapAuthorityCandidateV1 {
+  const generatedAt = new Date().toISOString();
+  const canonicalAuthority = canonical(label);
+  return Object.freeze({
+    canonicalAuthority,
+    authorityCommitment:
+      exploreMarketCapAuthorityStorageCommitmentV1(canonicalAuthority),
+    rankingCommitment,
+    gmgnStatus: "complete",
+    generatedAt,
+    validUntil: new Date(Date.parse(generatedAt) + 200_000).toISOString(),
+  });
+}
+
+function canonical(label: string): string {
+  return canonicalizeJson({ label });
+}
+
+function digest(label: string): `sha256:${string}` {
+  return canonicalSha256("programmable.test-explore-market-cap-authority.v1", {
+    label,
+  });
+}
+
+function authorityKey(): `sha256:${string}` {
+  return canonicalSha256(
+    "programmable.explore-market-cap-authority-key.v1",
+    { direction: "desc", inputCommitment: INPUT_COMMITMENT },
+  );
+}
+
+function authorityStore(pool: ProjectionTargetPostgresPoolV1) {
+  return new PostgresExploreMarketCapAuthorityStoreV1(pool, {
+    delay: (ms, signal) => abortableDelay(Math.min(ms, 2), signal),
+    garbageCollection: false,
+  });
+}
+
+async function expireRefresh(database: PGlite): Promise<void> {
+  await database.exec("RESET ROLE");
+  await database.exec(`
+    UPDATE programmable_website_projection_v1
+      .explore_market_cap_authority_generations_v1
+       SET generated_at = pg_catalog.clock_timestamp() - INTERVAL '61 seconds',
+           refresh_after = pg_catalog.clock_timestamp() - INTERVAL '1 second',
+           valid_until = pg_catalog.clock_timestamp() + INTERVAL '100 seconds'
+  `);
+  await database.exec("SET ROLE programmable_website_projection_runtime");
+}
+
+async function migratedAuthorityStore(): Promise<Readonly<{
+  database: PGlite;
+  pool: ProjectionTargetPostgresPoolV1;
+}>> {
+  const database = new PGlite();
+  databases.push(database);
+  await database.exec(`
+    CREATE ROLE programmable_website_projection_runtime NOLOGIN;
+    CREATE ROLE anon NOLOGIN;
+    CREATE ROLE authenticated NOLOGIN;
+    CREATE ROLE service_role NOLOGIN;
+    CREATE SCHEMA programmable_website_projection_v1;
+    REVOKE ALL ON SCHEMA programmable_website_projection_v1 FROM PUBLIC;
+    GRANT USAGE ON SCHEMA programmable_website_projection_v1
+      TO programmable_website_projection_runtime;
+  `);
+  const migration = await readFile(new URL(
+    "../ops/website-projection-target/migrations/0008_explore_market_cap_authority_v1.sql",
+    import.meta.url,
+  ), "utf8");
+  await database.exec(migration);
+  await database.exec("SET ROLE programmable_website_projection_runtime");
+  return Object.freeze({ database, pool: new SerializedPGlitePool(database) });
+}
+
+class SerializedPGlitePool implements ProjectionTargetPostgresPoolV1 {
+  private connectionTail = Promise.resolve();
+
+  constructor(private readonly database: PGlite) {}
+
+  async connect(): Promise<ProjectionTargetPostgresClientV1> {
+    let unlock = () => {};
+    const previous = this.connectionTail;
+    this.connectionTail = new Promise<void>((resolve) => {
+      unlock = resolve;
+    });
+    await previous;
+    let released = false;
+    return {
+      query: <Row extends Record<string, unknown>>(
+        text: string,
+        values: readonly unknown[] = [],
+      ) => this.directQuery<Row>(text, values),
+      release() {
+        if (released) return;
+        released = true;
+        unlock();
+      },
+    };
+  }
+
+  async query<Row extends Record<string, unknown> = Record<string, unknown>>(
+    text: string,
+    values: readonly unknown[] = [],
+  ): Promise<ProjectionTargetPostgresQueryResultV1<Row>> {
+    const client = await this.connect();
+    try {
+      return await client.query<Row>(text, values);
+    } finally {
+      client.release();
+    }
+  }
+
+  private async directQuery<
+    Row extends Record<string, unknown> = Record<string, unknown>,
+  >(
+    text: string,
+    values: readonly unknown[] = [],
+  ): Promise<ProjectionTargetPostgresQueryResultV1<Row>> {
+    const result = await this.database.query<Row>(text, [...values]);
+    return Object.freeze({
+      rows: result.rows,
+      rowCount: result.affectedRows ?? result.rows.length,
+    });
+  }
+}
+
+class DelayedFirstCommitPool implements ProjectionTargetPostgresPoolV1 {
+  private delayed = false;
+  private leaseMutationSeen = false;
+
+  constructor(
+    private readonly delegate: ProjectionTargetPostgresPoolV1,
+    private readonly commitApplied: PromiseWithResolvers<void>,
+    private readonly releaseCommitResult: PromiseWithResolvers<void>,
+    private readonly lateConnectionReleased: PromiseWithResolvers<void>,
+  ) {}
+
+  async connect(): Promise<ProjectionTargetPostgresClientV1> {
+    const client = await this.delegate.connect();
+    let delayedConnection = false;
+    return {
+      query: async <Row extends Record<string, unknown>>(
+        text: string,
+        values: readonly unknown[] = [],
+      ) => {
+        const result = await client.query<Row>(text, values);
+        if (text.includes("SET lease_generation = $2")) {
+          this.leaseMutationSeen = true;
+        }
+        if (
+          !this.delayed && this.leaseMutationSeen && text === "COMMIT"
+        ) {
+          this.delayed = true;
+          delayedConnection = true;
+          this.commitApplied.resolve();
+          await this.releaseCommitResult.promise;
+        }
+        return result;
+      },
+      release: () => {
+        client.release();
+        if (delayedConnection) this.lateConnectionReleased.resolve();
+      },
+    };
+  }
+
+  query<Row extends Record<string, unknown> = Record<string, unknown>>(
+    text: string,
+    values: readonly unknown[] = [],
+  ): Promise<ProjectionTargetPostgresQueryResultV1<Row>> {
+    return this.delegate.query<Row>(text, values);
+  }
+}
+
+class RecordingPool implements ProjectionTargetPostgresPoolV1 {
+  readonly queries: string[] = [];
+
+  constructor(private readonly delegate: ProjectionTargetPostgresPoolV1) {}
+
+  async connect(): Promise<ProjectionTargetPostgresClientV1> {
+    const client = await this.delegate.connect();
+    return {
+      query: <Row extends Record<string, unknown>>(
+        text: string,
+        values: readonly unknown[] = [],
+      ) => {
+        this.queries.push(text);
+        return client.query<Row>(text, values);
+      },
+      release: () => client.release(),
+    };
+  }
+
+  async query<
+  Row extends Record<string, unknown> = Record<string, unknown>
+  >(
+    text: string,
+    values: readonly unknown[] = [],
+  ): Promise<ProjectionTargetPostgresQueryResultV1<Row>> {
+    this.queries.push(text);
+    return this.delegate.query<Row>(text, values);
+  }
+}
+
+class DelayedGlobalCleanupPool implements ProjectionTargetPostgresPoolV1 {
+  private delayed = false;
+
+  constructor(
+    private readonly delegate: ProjectionTargetPostgresPoolV1,
+    private readonly entered: PromiseWithResolvers<void>,
+    private readonly releaseQuery: PromiseWithResolvers<void>,
+  ) {}
+
+  async connect(): Promise<ProjectionTargetPostgresClientV1> {
+    const client = await this.delegate.connect();
+    return {
+      query: async <Row extends Record<string, unknown>>(
+        text: string,
+        values: readonly unknown[] = [],
+      ) => {
+        const result = await client.query<Row>(text, values);
+        if (!this.delayed && text.includes("WHERE ctid IN")) {
+          this.delayed = true;
+          this.entered.resolve();
+          await this.releaseQuery.promise;
+        }
+        return result;
+      },
+      release: () => client.release(),
+    };
+  }
+
+  query<Row extends Record<string, unknown> = Record<string, unknown>>(
+    text: string,
+    values: readonly unknown[] = [],
+  ): Promise<ProjectionTargetPostgresQueryResultV1<Row>> {
+    return this.delegate.query<Row>(text, values);
+  }
+}
+
+function abortableDelay(ms: number, signal?: AbortSignal): Promise<boolean> {
+  if (signal?.aborted) return Promise.resolve(false);
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(true), ms);
+    signal?.addEventListener("abort", () => {
+      clearTimeout(timer);
+      resolve(false);
+    }, { once: true });
+  });
+}

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -583,6 +583,43 @@ function unavailableMarketCapRanking(
   } as const;
 }
 
+function unavailableGmgnMarketRead(total: number) {
+  return {
+    provider: "gmgn",
+    status: "unavailable",
+    currency: "USD",
+    requestedCount: total,
+    observedCount: 0,
+    qualifiedCount: 0,
+    unavailableCount: total,
+    oldestFetchedAt: null,
+    newestFetchedAt: null,
+    fallbackProvider: "dexscreener",
+    gmgnObservedCount: 0,
+    gmgnQualifiedCount: 0,
+    fallbackRequestedCount: total,
+    fallbackObservedCount: 0,
+    fallbackQualifiedCount: 0,
+  } as const;
+}
+
+function sparseDexscreenerMarketCapRanking(
+  total: number,
+  qualified: number,
+  rankingCommitment: `sha256:${string}`,
+) {
+  return {
+    ...unavailableMarketCapRanking(total, rankingCommitment),
+    source: "dexscreener",
+    status: "partial",
+    applied: "qualified-fdv-then-launch-order",
+    fallbackQualifiedCount: qualified,
+    canonicalTailCount: total - qualified,
+    qualifiedCount: qualified,
+    asOfTime: "2026-08-16T08:00:00.000Z",
+  } as const;
+}
+
 describe("Explore provider-ranked revalidation", () => {
   const entries = Array.from(
     { length: 4 },
@@ -1606,6 +1643,74 @@ describe("Explore refresh state", () => {
     )).rejects.toThrow("Tokens changed while filters were loading");
   });
 
+  it("pins model pages and restarts the whole dataset after a ranking 409", async () => {
+    const tokens = Array.from(
+      { length: EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE + 1 },
+      (_, index) => modelFilterEntry(index, "unavailable"),
+    );
+    const firstCommitment = `sha256:${"64".repeat(32)}` as const;
+    const recoveredCommitment = `sha256:${"65".repeat(32)}` as const;
+    let request = 0;
+    const requestedPins: Array<string | null> = [];
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        request += 1;
+        const url = new URL(String(input), "https://example.test");
+        const page = Number(url.searchParams.get("page"));
+        const pageSize = Number(url.searchParams.get("limit"));
+        requestedPins.push(url.searchParams.get("rankingCommitment"));
+        const commitment = request <= 2 ? firstCommitment : recoveredCommitment;
+        if (request === 2) {
+          return new Response(
+            JSON.stringify({
+              error: "Market-cap ranking changed; restart from page 1",
+            }),
+            { status: 409 },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            status: "ready",
+            tokens: tokens.slice((page - 1) * pageSize, page * pageSize),
+            page,
+            pageSize,
+            total: tokens.length,
+            totalPages: 2,
+            catalog: { ...catalogBoundary, identityCount: tokens.length },
+            dataQuality: modelPageDataQuality(
+              0,
+              tokens.slice((page - 1) * pageSize, page * pageSize).length,
+            ),
+            marketRead: unavailableGmgnMarketRead(tokens.length),
+            ranking: unavailableMarketCapRanking(tokens.length, commitment),
+          }),
+          {
+            status: 200,
+            headers: { "X-Programmable-Market-Read-Status": "unavailable" },
+          },
+        );
+      });
+
+    await expect(
+      loadExploreModelDataset(
+        "ranking-restart-model-dataset",
+        new URLSearchParams({ sort: "market-cap", page: "1", limit: "9" }),
+      ),
+    ).resolves.toMatchObject({
+      total: tokens.length,
+      tokens: tokens.map((token) => expect.objectContaining({ id: token.id })),
+      ranking: { rankingCommitment: recoveredCommitment },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(requestedPins).toEqual([
+      null,
+      firstCommitment,
+      null,
+      recoveredCommitment,
+    ]);
+  });
+
   it("rejects model pages from different provider-order commitments", async () => {
     const tokens = Array.from(
       { length: EXPLORE_MODEL_FILTER_SERVER_PAGE_SIZE + 1 },
@@ -1859,11 +1964,10 @@ describe("Explore refresh state", () => {
           category: "transport",
           phase,
         },
-        ranking: {
-          status: "unavailable",
-          requested: "fdv",
-          applied: "launch-order",
-        },
+        ranking: unavailableMarketCapRanking(
+          tokens.length,
+          `sha256:${"66".repeat(32)}`,
+        ),
       }), {
         status: 200,
         headers: {
@@ -1978,20 +2082,35 @@ describe("Explore refresh state", () => {
                   category: "transport",
                   phase: "market-price",
                 },
-                ranking: {
-                  status: "unavailable",
-                  requested: "fdv",
-                  applied: "launch-order",
-                },
+                ranking: unavailableMarketCapRanking(
+                  tokens.length,
+                  `sha256:${"67".repeat(32)}`,
+                ),
               }
-            : {}),
+            : {
+                marketRead: {
+                  provider: "dexscreener",
+                  status: "complete",
+                  currency: "USD",
+                  requestedCount: tokens.length,
+                  observedCount: tokens.length,
+                  qualifiedCount: tokens.length,
+                  unavailableCount: 0,
+                  oldestFetchedAt: "2026-08-16T08:00:00.000Z",
+                  newestFetchedAt: "2026-08-16T08:00:00.000Z",
+                },
+                ranking: unavailableMarketCapRanking(
+                  tokens.length,
+                  `sha256:${"67".repeat(32)}`,
+                ),
+              }),
         }), {
           status: 200,
           headers: {
             "Content-Type": "application/json",
             "X-Programmable-Market-Read-Status": degraded
               ? "transport-unavailable"
-              : "current",
+              : "complete",
           },
         });
       },
@@ -2035,6 +2154,250 @@ describe("Explore refresh state", () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
     },
   );
+
+  it.each(["market-cap", "market-cap-asc"] as const)(
+    "pins a direct second %s page to the first-page ranking commitment",
+    async (sort) => {
+      const commitment = `sha256:${"61".repeat(32)}` as const;
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (input) => {
+          const url = new URL(String(input), "https://example.test");
+          const page = Number(url.searchParams.get("page"));
+          expect(url.searchParams.get("sort")).toBe(sort);
+          expect(url.searchParams.get("rankingCommitment")).toBe(
+            page === 1 ? null : commitment,
+          );
+          return new Response(
+            JSON.stringify({
+              ...payload,
+              page,
+              dataQuality: modelPageDataQuality(0, 0),
+              ranking: {
+                ...unavailableMarketCapRanking(payload.total, commitment),
+                direction: sort === "market-cap" ? "desc" : "asc",
+              },
+              marketRead: unavailableGmgnMarketRead(payload.total),
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+                "X-Programmable-Market-Read-Status": "unavailable",
+              },
+            },
+          );
+        });
+
+      await expect(
+        loadExplorePage(
+          `pinned-direct-${sort}-page-two`,
+          new URLSearchParams({ sort, page: "2", limit: "9" }),
+        ),
+      ).resolves.toMatchObject({ page: 2 });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("keeps one first-page market-cap commitment across page navigation", async () => {
+    const commitment = `sha256:${"69".repeat(32)}` as const;
+    const requestedPins: Array<string | null> = [];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input) => {
+        const url = new URL(String(input), "https://example.test");
+        const page = Number(url.searchParams.get("page"));
+        requestedPins.push(url.searchParams.get("rankingCommitment"));
+        return new Response(JSON.stringify({
+          ...payload,
+          page,
+          total: 27,
+          totalPages: 3,
+          dataQuality: modelPageDataQuality(0, 0),
+          marketRead: {
+            provider: "dexscreener",
+            status: "complete",
+            currency: "USD",
+            requestedCount: 27,
+            observedCount: 0,
+            qualifiedCount: 0,
+            unavailableCount: 27,
+            oldestFetchedAt: null,
+            newestFetchedAt: null,
+          },
+          ranking: unavailableMarketCapRanking(27, commitment),
+        }), {
+          status: 200,
+          headers: { "X-Programmable-Market-Read-Status": "complete" },
+        });
+      },
+    );
+
+    await loadExplorePage(
+      "market-cap-session-page-one",
+      new URLSearchParams({
+        q: "session-ranking",
+        sort: "market-cap",
+        page: "1",
+        limit: "9",
+      }),
+    );
+    await loadExplorePage(
+      "market-cap-session-page-two",
+      new URLSearchParams({
+        q: "session-ranking",
+        sort: "market-cap",
+        page: "2",
+        limit: "9",
+      }),
+    );
+    await loadExplorePage(
+      "market-cap-session-page-three",
+      new URLSearchParams({
+        q: "session-ranking",
+        sort: "market-cap",
+        page: "3",
+        limit: "9",
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(requestedPins).toEqual([null, commitment, commitment]);
+  });
+
+  it("restarts direct market-cap pagination once after a 409", async () => {
+    const firstCommitment = `sha256:${"62".repeat(32)}` as const;
+    const recoveredCommitment = `sha256:${"63".repeat(32)}` as const;
+    let request = 0;
+    const requestedUrls: URL[] = [];
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        request += 1;
+        const url = new URL(String(input), "https://example.test");
+        requestedUrls.push(url);
+        const page = Number(url.searchParams.get("page"));
+        const commitment = request <= 2 ? firstCommitment : recoveredCommitment;
+        if (request === 2) {
+          return new Response(
+            JSON.stringify({
+              error: "Market-cap ranking changed; restart from page 1",
+            }),
+            { status: 409 },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            ...payload,
+            page,
+            dataQuality: modelPageDataQuality(0, 0),
+            marketRead: unavailableGmgnMarketRead(payload.total),
+            ranking: unavailableMarketCapRanking(payload.total, commitment),
+          }),
+          {
+            status: 200,
+            headers: { "X-Programmable-Market-Read-Status": "unavailable" },
+          },
+        );
+      });
+
+    await expect(
+      loadExplorePage(
+        "restart-direct-market-cap-page-two",
+        new URLSearchParams({
+          q: "restart-ranking",
+          sort: "market-cap",
+          page: "2",
+          limit: "9",
+        }),
+      ),
+    ).resolves.toMatchObject({
+      page: 2,
+      ranking: { rankingCommitment: recoveredCommitment },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(
+      requestedUrls.map((url) => ({
+        page: url.searchParams.get("page"),
+        rankingCommitment: url.searchParams.get("rankingCommitment"),
+      })),
+    ).toEqual([
+      { page: "1", rankingCommitment: null },
+      { page: "2", rankingCommitment: firstCommitment },
+      { page: "1", rankingCommitment: null },
+      { page: "2", rankingCommitment: recoveredCommitment },
+    ]);
+  });
+
+  it("purges a separately cached page-one pin before a 409 restart", async () => {
+    const staleCommitment = `sha256:${"64".repeat(32)}` as const;
+    const recoveredCommitment = `sha256:${"65".repeat(32)}` as const;
+    const requestedUrls: URL[] = [];
+    let request = 0;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input) => {
+        request += 1;
+        const url = new URL(String(input), "https://example.test");
+        requestedUrls.push(url);
+        const page = Number(url.searchParams.get("page"));
+        if (request === 2) {
+          return new Response(JSON.stringify({
+            error: "Market-cap ranking changed; restart from page 1",
+          }), { status: 409 });
+        }
+        const commitment = request === 1
+          ? staleCommitment
+          : recoveredCommitment;
+        return new Response(JSON.stringify({
+          ...payload,
+          page,
+          dataQuality: modelPageDataQuality(0, 0),
+          marketRead: {
+            provider: "dexscreener",
+            status: "complete",
+            currency: "USD",
+            requestedCount: payload.total,
+            observedCount: 0,
+            qualifiedCount: 0,
+            unavailableCount: payload.total,
+            oldestFetchedAt: null,
+            newestFetchedAt: null,
+          },
+          ranking: unavailableMarketCapRanking(payload.total, commitment),
+        }), {
+          status: 200,
+          headers: { "X-Programmable-Market-Read-Status": "complete" },
+        });
+      },
+    );
+    const search = {
+      q: "seeded-restart-ranking",
+      sort: "market-cap",
+      limit: "9",
+    } as const;
+
+    await loadExplorePage(
+      "seeded-restart-market-cap-page-one",
+      new URLSearchParams({ ...search, page: "1" }),
+    );
+    await expect(loadExplorePage(
+      "seeded-restart-market-cap-page-two",
+      new URLSearchParams({ ...search, page: "2" }),
+    )).resolves.toMatchObject({
+      page: 2,
+      ranking: { rankingCommitment: recoveredCommitment },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(requestedUrls.map((url) => ({
+      page: url.searchParams.get("page"),
+      rankingCommitment: url.searchParams.get("rankingCommitment"),
+    }))).toEqual([
+      { page: "1", rankingCommitment: null },
+      { page: "2", rankingCommitment: staleCommitment },
+      { page: "1", rankingCommitment: null },
+      { page: "2", rankingCommitment: recoveredCommitment },
+    ]);
+  });
 
   it("presents total-supply valuation using the public market cap label", () => {
     const token = {
@@ -2894,13 +3257,11 @@ describe("Explore refresh state", () => {
             oldestFetchedAt: "2026-08-16T08:00:00.000Z",
             newestFetchedAt: "2026-08-16T08:00:00.000Z",
           },
-          ranking: {
-            status: "partial",
-            requested: "fdv",
-            applied: "qualified-fdv-then-launch-order",
-            qualifiedCount: 18,
-            totalCount: 351,
-          },
+          ranking: sparseDexscreenerMarketCapRanking(
+            351,
+            18,
+            `sha256:${"68".repeat(32)}`,
+          ),
         }), {
           status: 200,
           headers: { "X-Programmable-Market-Read-Status": "complete" },

--- a/tests/gmgn-discovery.test.ts
+++ b/tests/gmgn-discovery.test.ts
@@ -826,7 +826,7 @@ describe("GMGN discovery server adapter", () => {
     expect(reserveSlot).toHaveBeenCalledWith({
       requestsPerSecond: 1,
       cost: 1,
-      deadlineMs: NOW.getTime() + 2_500,
+      deadlineMs: NOW.getTime() + 5_000,
       signal: undefined,
     });
     expect(complete).toHaveBeenCalledWith(RESERVATION);
@@ -876,10 +876,64 @@ describe("GMGN discovery server adapter", () => {
     expect(reserveSlot).toHaveBeenCalledWith({
       requestsPerSecond: 1,
       cost: 1,
-      deadlineMs: NOW.getTime() + 2_500,
+      deadlineMs: NOW.getTime() + 5_000,
       signal: undefined,
     });
     expect(complete).toHaveBeenCalledWith(RESERVATION);
+  });
+
+  it("keeps the GMGN HTTP budget after a cold shared-gate reservation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    const reservation = {
+      ...RESERVATION,
+      reservedAtMs: NOW.getTime() + 3_000,
+    };
+    const reserveSlot = vi.fn(() => new Promise<typeof reservation>((resolve) => {
+      setTimeout(() => resolve(reservation), 3_000);
+    }));
+    const complete = vi.fn(async () => {});
+    const gate = {
+      reserveSlot,
+      blockUntil: vi.fn(),
+      complete,
+    } satisfies GmgnAccountGateV1;
+    let providerSignal: AbortSignal | null | undefined;
+    const fetchImpl = vi.fn((
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      providerSignal = init?.signal;
+      return Promise.resolve(new Response(JSON.stringify(
+        rankResponse([providerToken(16, 1)]),
+      ), { status: 200 }));
+    });
+
+    const read = readGmgnEthereumTrendingV1({
+      interval: "1m",
+      limit: 96,
+    }, {
+      fetchImpl: fetchImpl as typeof fetch,
+      accountGate: gate,
+      now: () => new Date(),
+      deadlineMs: NOW.getTime() + 8_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(read).resolves.toMatchObject({
+      tokens: [{ tokenAddress: address(16) }],
+    });
+    expect(reserveSlot).toHaveBeenCalledWith({
+      requestsPerSecond: 1,
+      cost: 1,
+      deadlineMs: NOW.getTime() + 5_000,
+      signal: undefined,
+    });
+    expect(providerSignal?.aborted).toBe(false);
+    expect(complete).toHaveBeenCalledWith(reservation);
   });
 
   it("requests isolated official market-cap rankings in either direction", async () => {
@@ -995,7 +1049,7 @@ describe("GMGN discovery server adapter", () => {
     expect(reserveSlot).toHaveBeenCalledWith({
       requestsPerSecond: 1,
       cost: 3,
-      deadlineMs: NOW.getTime() + 2_500,
+      deadlineMs: NOW.getTime() + 5_000,
       signal: undefined,
     });
   });
@@ -1351,13 +1405,13 @@ describe("GMGN discovery server adapter", () => {
     expect(reserveSlot).toHaveBeenNthCalledWith(1, {
       requestsPerSecond: 20,
       cost: 1,
-      deadlineMs: NOW.getTime() + 2_500,
+      deadlineMs: NOW.getTime() + 5_000,
       signal: undefined,
     });
     expect(reserveSlot).toHaveBeenNthCalledWith(2, {
       requestsPerSecond: 1,
       cost: 1,
-      deadlineMs: NOW.getTime() + 2_500,
+      deadlineMs: NOW.getTime() + 5_000,
       signal: undefined,
     });
   });
@@ -1542,6 +1596,11 @@ describe("GMGN discovery server adapter", () => {
     await expect(stalledRead).resolves.toBeNull();
     expect(reserveSlot).toHaveBeenCalledOnce();
     expect(fetchImpl).not.toHaveBeenCalled();
+
+    // The caller's five-second budget is independent from the detached
+    // provider lifecycle. Let its bounded late-outcome cleanup finish before
+    // proving that the same cache key can start a new request.
+    await vi.advanceTimersByTimeAsync(2_500);
 
     vi.useRealTimers();
     const { gate } = accountGate();

--- a/tests/gmgn-market-data.test.ts
+++ b/tests/gmgn-market-data.test.ts
@@ -227,6 +227,59 @@ describe("GMGN canonical market enrichment", () => {
     },
   );
 
+  it("keeps the token-info HTTP budget after a cold shared-gate reservation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    const entry = token(133);
+    const reservation = {
+      ...GATE_RESERVATION,
+      reservedAtMs: NOW.getTime() + 3_000,
+    };
+    const reserveSlot = vi.fn(() => new Promise<typeof reservation>((resolve) => {
+      setTimeout(() => resolve(reservation), 3_000);
+    }));
+    const complete = vi.fn(async () => {});
+    const accountGate: GmgnAccountGateV1 = {
+      reserveSlot,
+      blockUntil: vi.fn(),
+      complete,
+    };
+    let providerSignal: AbortSignal | null | undefined;
+    const fetchImpl = vi.fn((
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      providerSignal = init?.signal;
+      return Promise.resolve(new Response(JSON.stringify({
+        code: 0,
+        data: providerData(entry),
+      }), { status: 200 }));
+    });
+
+    const read = readGmgnMarketSnapshotV1(entry, {
+      fetchImpl: fetchImpl as typeof fetch,
+      accountGate,
+      now: () => new Date(),
+      deadlineMs: NOW.getTime() + 8_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(read).resolves.toMatchObject({
+      source: "gmgn",
+      identity: identity(entry),
+    });
+    expect(reserveSlot).toHaveBeenCalledWith({
+      requestsPerSecond: 1,
+      deadlineMs: NOW.getTime() + 5_000,
+      signal: expect.any(AbortSignal),
+    });
+    expect(providerSignal?.aborted).toBe(false);
+    expect(complete).toHaveBeenCalledWith(reservation);
+  });
+
   it("derives visible token-info concurrency from effective RPS and batch size", () => {
     vi.stubEnv("GMGN_MAX_REQUESTS_PER_SECOND", "20");
     expect(gmgnVisibleMarketConcurrencyV1(0)).toBe(0);
@@ -632,7 +685,7 @@ describe("GMGN canonical market enrichment", () => {
       })).resolves.not.toBeNull();
       expect(reserveSlot).toHaveBeenCalledWith({
         requestsPerSecond: expected,
-        deadlineMs: NOW.getTime() + 2_500,
+        deadlineMs: NOW.getTime() + 5_000,
         signal: expect.any(AbortSignal),
       });
     },
@@ -993,7 +1046,7 @@ describe("GMGN canonical market enrichment", () => {
     expect(complete).not.toHaveBeenCalled();
     expect(readSettled).toBe(false);
 
-    // The public request times out at 2.500 ms. The provider notices one
+    // The provider HTTP budget expires at 2.500 ms. The fetch notices one
     // millisecond later and begins exact lease cleanup inside lifecycle grace.
     await vi.advanceTimersByTimeAsync(2);
     expect(complete).toHaveBeenCalledOnce();
@@ -1031,7 +1084,7 @@ describe("GMGN canonical market enrichment", () => {
       },
     );
 
-    await vi.advanceTimersByTimeAsync(2_500);
+    await vi.advanceTimersByTimeAsync(7_500);
     expect(readSettled).toBe(false);
     await vi.advanceTimersByTimeAsync(3_499);
     expect(readSettled).toBe(false);

--- a/tests/public-explore-openapi-contract.test.ts
+++ b/tests/public-explore-openapi-contract.test.ts
@@ -284,6 +284,7 @@ describe("public Explore OpenAPI contract", () => {
       "model",
       "socials",
       "sort",
+      "rankingCommitment",
     ]);
     expect(parameters.get("chain")?.schema).toEqual({
       type: "integer",
@@ -308,6 +309,19 @@ describe("public Explore OpenAPI contract", () => {
       default: "newest",
     });
     expect(parameters.get("sort")?.description).toContain("chain=1");
+    expect(parameters.get("rankingCommitment")).toMatchObject({
+      in: "query",
+      schema: {
+        type: "string",
+        pattern: "^sha256:[0-9a-f]{64}$",
+      },
+    });
+    expect(parameters.get("rankingCommitment")?.description).toContain(
+      "Required for page > 1",
+    );
+    expect(operation.responses["409"].description).toContain(
+      "restart pagination from page 1",
+    );
   });
 
   it("documents canonical-intersected Trending metadata and headers", () => {

--- a/tests/website-projection-target.test.ts
+++ b/tests/website-projection-target.test.ts
@@ -45,11 +45,13 @@ import type {
 } from "../lib/server/projection-target/protocol";
 import {
   createWebsiteProjectionTargetV1,
+  assertExploreMarketCapAuthoritySecurityAttestationV1,
   assertGmgnAccountGateMultiflightSecurityAttestationV1,
   assertGmgnAccountGateSecurityAttestationV1,
   assertProjectionTargetSecurityAttestationV1,
   assertProductionDatabaseLoginRoleV1,
   verifiedPostgresTlsConfigurationV1,
+  type ExploreMarketCapAuthoritySecurityAttestationRowV1,
   type GmgnAccountGateMultiflightSecurityAttestationRowV1,
   type GmgnAccountGateSecurityAttestationRowV1,
   type ProjectionTargetSecurityAttestationRowV1,
@@ -1444,6 +1446,290 @@ describe("Website projection target", () => {
     }
   });
 
+  it("fails the market-cap authority readiness attestation for every weakened axis", () => {
+    const secure = exploreMarketCapAuthoritySecurityAttestationFixture();
+    expect(() => assertExploreMarketCapAuthoritySecurityAttestationV1(
+      secure,
+      "programmable_website_projection_runtime",
+    )).not.toThrow();
+    for (const mutation of [
+      { runtime_role: "unexpected_runtime_role" },
+      { session_role: "unexpected_session_role" },
+      { rolsuper: true },
+      { rolcreaterole: true },
+      { rolcreatedb: true },
+      { rolreplication: true },
+      { rolbypassrls: true },
+      { schema_usage: false },
+      { schema_create: true },
+      { heads_select: false },
+      { heads_insert: false },
+      { heads_delete: false },
+      { heads_update: false },
+      { heads_forbidden_access: true },
+      { generations_select: false },
+      { generations_insert: false },
+      { generations_delete: false },
+      { generations_forbidden_access: true },
+      { heads_rls: false },
+      { heads_force_rls: false },
+      { generations_rls: false },
+      { generations_force_rls: false },
+      { expected_policies: false },
+      { provider_roles_excluded: false },
+      { ssl: false },
+      { ssl_version: null },
+      { ssl_cipher: null },
+      { ssl_bits: 127 },
+    ] satisfies Array<Partial<
+      ExploreMarketCapAuthoritySecurityAttestationRowV1
+    >>) {
+      expect(() => assertExploreMarketCapAuthoritySecurityAttestationV1(
+        { ...secure, ...mutation },
+        "programmable_website_projection_runtime",
+      )).toThrow("Explore market-cap authority database attestation failed");
+    }
+    expect(() => assertExploreMarketCapAuthoritySecurityAttestationV1(
+      secure,
+      "different_expected_role",
+    )).toThrow("Explore market-cap authority database attestation failed");
+  });
+
+  it("applies market-cap authority storage with forced RLS and exact runtime grants", async () => {
+    const database = await pgliteExploreMarketCapAuthorityDatabase();
+    const state = await database.query<{
+      heads_rls: boolean;
+      heads_force_rls: boolean;
+      generations_rls: boolean;
+      generations_force_rls: boolean;
+      expected_policies: boolean;
+      providers_excluded: boolean;
+    }>(`
+      SELECT heads.relrowsecurity AS heads_rls,
+             heads.relforcerowsecurity AS heads_force_rls,
+             generations.relrowsecurity AS generations_rls,
+             generations.relforcerowsecurity AS generations_force_rls,
+             (
+               SELECT count(*) = 7
+                 AND bool_and(
+                   policies.roles =
+                     ARRAY['programmable_website_projection_runtime']::name[]
+                 )
+                 AND string_agg(
+                   policies.policyname || ':' || policies.cmd,
+                   ',' ORDER BY policies.policyname
+                 ) = 'explore_market_cap_authority_generations_v1_runtime_delete:DELETE,explore_market_cap_authority_generations_v1_runtime_insert:INSERT,explore_market_cap_authority_generations_v1_runtime_select:SELECT,explore_market_cap_authority_heads_v1_runtime_delete:DELETE,explore_market_cap_authority_heads_v1_runtime_insert:INSERT,explore_market_cap_authority_heads_v1_runtime_select:SELECT,explore_market_cap_authority_heads_v1_runtime_update:UPDATE'
+                 FROM pg_policies AS policies
+                WHERE policies.schemaname = 'programmable_website_projection_v1'
+                  AND policies.tablename IN (
+                    'explore_market_cap_authority_heads_v1',
+                    'explore_market_cap_authority_generations_v1'
+                  )
+             ) AS expected_policies,
+             NOT EXISTS (
+               SELECT 1
+                 FROM pg_roles AS role
+                WHERE role.rolname IN ('anon', 'authenticated', 'service_role')
+                  AND (
+                    has_table_privilege(
+                      role.rolname,
+                      'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                      'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
+                    )
+                    OR has_table_privilege(
+                      role.rolname,
+                      'programmable_website_projection_v1.explore_market_cap_authority_generations_v1',
+                      'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
+                    )
+                    OR has_any_column_privilege(
+                      role.rolname,
+                      'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+                      'SELECT,INSERT,UPDATE,REFERENCES'
+                    )
+                    OR has_any_column_privilege(
+                      role.rolname,
+                      'programmable_website_projection_v1.explore_market_cap_authority_generations_v1',
+                      'SELECT,INSERT,UPDATE,REFERENCES'
+                    )
+                  )
+             ) AS providers_excluded
+        FROM pg_namespace AS schema
+        JOIN pg_class AS heads
+          ON heads.relnamespace = schema.oid
+         AND heads.relname = 'explore_market_cap_authority_heads_v1'
+        JOIN pg_class AS generations
+          ON generations.relnamespace = schema.oid
+         AND generations.relname =
+           'explore_market_cap_authority_generations_v1'
+       WHERE schema.nspname = 'programmable_website_projection_v1'
+    `);
+    expect(state.rows).toEqual([{
+      heads_rls: true,
+      heads_force_rls: true,
+      generations_rls: true,
+      generations_force_rls: true,
+      expected_policies: true,
+      providers_excluded: true,
+    }]);
+
+    const authorityKey = `sha256:${"a".repeat(64)}`;
+    const inputCommitment = `sha256:${"b".repeat(64)}`;
+    const authorityCommitment = `sha256:${"c".repeat(64)}`;
+    const rankingCommitment = `sha256:${"d".repeat(64)}`;
+    await database.exec("SET ROLE programmable_website_projection_runtime");
+    const runtimePrivileges = await database.query<{
+      heads_select_insert_delete: boolean;
+      heads_allowed_updates: boolean;
+      heads_forbidden_updates: boolean;
+      generations_select_insert_delete: boolean;
+      generations_forbidden_mutation: boolean;
+    }>(`
+      SELECT
+        has_table_privilege(
+          current_user,
+          'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+          'SELECT,INSERT,DELETE'
+        ) AS heads_select_insert_delete,
+        (
+          SELECT bool_and(has_column_privilege(
+            current_user,
+            'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+            column_name,
+            'UPDATE'
+          ))
+            FROM unnest(ARRAY[
+              'current_generation', 'lease_generation', 'lease_holder',
+              'lease_until', 'updated_at'
+            ]) AS columns(column_name)
+        ) AS heads_allowed_updates,
+        (
+          SELECT bool_or(has_column_privilege(
+            current_user,
+            'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+            column_name,
+            'UPDATE'
+          ))
+            FROM unnest(ARRAY[
+              'authority_key', 'input_commitment', 'direction'
+            ]) AS columns(column_name)
+        ) AS heads_forbidden_updates,
+        has_table_privilege(
+          current_user,
+          'programmable_website_projection_v1.explore_market_cap_authority_generations_v1',
+          'SELECT,INSERT,DELETE'
+        ) AS generations_select_insert_delete,
+        (
+          has_table_privilege(
+            current_user,
+            'programmable_website_projection_v1.explore_market_cap_authority_generations_v1',
+            'UPDATE,TRUNCATE,REFERENCES,TRIGGER'
+          )
+          OR has_any_column_privilege(
+            current_user,
+            'programmable_website_projection_v1.explore_market_cap_authority_generations_v1',
+            'UPDATE,REFERENCES'
+          )
+        ) AS generations_forbidden_mutation
+    `);
+    expect(runtimePrivileges.rows).toEqual([{
+      heads_select_insert_delete: true,
+      heads_allowed_updates: true,
+      heads_forbidden_updates: false,
+      generations_select_insert_delete: true,
+      generations_forbidden_mutation: false,
+    }]);
+    await database.query(`
+      INSERT INTO programmable_website_projection_v1
+        .explore_market_cap_authority_heads_v1 (
+          authority_key, input_commitment, direction
+        ) VALUES ($1, $2, 'desc')
+    `, [authorityKey, inputCommitment]);
+    await database.query(`
+      UPDATE programmable_website_projection_v1
+        .explore_market_cap_authority_heads_v1
+         SET current_generation = 1,
+             updated_at = pg_catalog.clock_timestamp()
+       WHERE authority_key = $1
+    `, [authorityKey]);
+    await database.query(`
+      INSERT INTO programmable_website_projection_v1
+        .explore_market_cap_authority_generations_v1 (
+          authority_key, generation, authority_commitment,
+          ranking_commitment, gmgn_status, generated_at,
+          refresh_after, valid_until, canonical_authority
+        ) VALUES (
+          $1, 1, $2, $3, 'complete',
+          TIMESTAMPTZ '2026-09-01T12:00:00Z',
+          TIMESTAMPTZ '2026-09-01T12:01:00Z',
+          TIMESTAMPTZ '2026-09-01T12:03:55Z',
+          '{}'
+        )
+    `, [authorityKey, authorityCommitment, rankingCommitment]);
+    await expect(database.query(`
+      UPDATE programmable_website_projection_v1
+        .explore_market_cap_authority_heads_v1
+         SET direction = 'asc'
+       WHERE authority_key = $1
+    `, [authorityKey])).rejects.toThrow(/permission denied/u);
+    await expect(database.query(`
+      UPDATE programmable_website_projection_v1
+        .explore_market_cap_authority_generations_v1
+         SET gmgn_status = 'partial'
+       WHERE authority_key = $1
+    `, [authorityKey])).rejects.toThrow(/permission denied/u);
+    await expect(database.exec(`
+      TRUNCATE programmable_website_projection_v1
+        .explore_market_cap_authority_generations_v1
+    `)).rejects.toThrow(/permission denied/u);
+    const readable = await database.query<{ count: string }>(`
+      SELECT count(*)::text AS count
+        FROM programmable_website_projection_v1
+          .explore_market_cap_authority_generations_v1
+    `);
+    expect(readable.rows).toEqual([{ count: "1" }]);
+
+    await database.exec("RESET ROLE");
+    await database.exec(`
+      GRANT SELECT (authority_key)
+        ON programmable_website_projection_v1
+          .explore_market_cap_authority_heads_v1
+        TO anon
+    `);
+    const columnGrant = await database.query<{
+      table_select: boolean;
+      any_column_select: boolean;
+    }>(`
+      SELECT has_table_privilege(
+               'anon',
+               'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+               'SELECT'
+             ) AS table_select,
+             has_any_column_privilege(
+               'anon',
+               'programmable_website_projection_v1.explore_market_cap_authority_heads_v1',
+               'SELECT'
+             ) AS any_column_select
+    `);
+    expect(columnGrant.rows).toEqual([{
+      table_select: false,
+      any_column_select: true,
+    }]);
+    await database.exec(`
+      REVOKE SELECT (authority_key)
+        ON programmable_website_projection_v1
+          .explore_market_cap_authority_heads_v1
+        FROM anon
+    `);
+    for (const providerRole of ["anon", "authenticated", "service_role"]) {
+      await database.exec(`SET ROLE ${providerRole}`);
+      await expect(database.query(`
+        SELECT * FROM programmable_website_projection_v1
+          .explore_market_cap_authority_heads_v1
+      `)).rejects.toThrow(/permission denied/u);
+      await database.exec("RESET ROLE");
+    }
+  });
+
   it("forces RLS, excludes provider roles, and enforces lane-specific metadata", async () => {
     const pool = await pglitePool();
     const state = await pool.query<{
@@ -1573,6 +1859,29 @@ async function pglitePool(): Promise<ProjectionTargetPostgresPoolV1> {
     SET ROLE programmable_website_projection_runtime;
   `);
   return new PGliteProjectionPool(database);
+}
+
+async function pgliteExploreMarketCapAuthorityDatabase(): Promise<PGlite> {
+  const database = new PGlite();
+  databases.push(database);
+  await database.exec(`
+    CREATE ROLE programmable_website_projection_runtime NOLOGIN;
+    CREATE ROLE anon NOLOGIN;
+    CREATE ROLE authenticated NOLOGIN;
+    CREATE ROLE service_role NOLOGIN;
+    CREATE SCHEMA programmable_website_projection_v1;
+    REVOKE ALL ON SCHEMA programmable_website_projection_v1 FROM PUBLIC;
+    REVOKE ALL ON SCHEMA programmable_website_projection_v1
+      FROM anon, authenticated, service_role;
+    GRANT USAGE ON SCHEMA programmable_website_projection_v1
+      TO programmable_website_projection_runtime;
+  `);
+  const migration = await readFile(new URL(
+    "../ops/website-projection-target/migrations/0008_explore_market_cap_authority_v1.sql",
+    import.meta.url,
+  ), "utf8");
+  await database.exec(migration);
+  return database;
 }
 
 class PGliteProjectionPool implements ProjectionTargetPostgresPoolV1 {
@@ -1958,6 +2267,40 @@ GmgnAccountGateMultiflightSecurityAttestationRowV1 {
     gmgn_leases_forbidden_access: false,
     gmgn_leases_rls: true,
     gmgn_leases_force_rls: true,
+    expected_policies: true,
+    provider_roles_excluded: true,
+    ssl: true,
+    ssl_version: "TLSv1.3",
+    ssl_cipher: "TLS_AES_256_GCM_SHA384",
+    ssl_bits: 256,
+  };
+}
+
+function exploreMarketCapAuthoritySecurityAttestationFixture():
+ExploreMarketCapAuthoritySecurityAttestationRowV1 {
+  return {
+    runtime_role: "programmable_website_projection_runtime",
+    session_role: "programmable_website_projection_runtime",
+    rolsuper: false,
+    rolcreaterole: false,
+    rolcreatedb: false,
+    rolreplication: false,
+    rolbypassrls: false,
+    schema_usage: true,
+    schema_create: false,
+    heads_select: true,
+    heads_insert: true,
+    heads_delete: true,
+    heads_update: true,
+    heads_forbidden_access: false,
+    generations_select: true,
+    generations_insert: true,
+    generations_delete: true,
+    generations_forbidden_access: false,
+    heads_rls: true,
+    heads_force_rls: true,
+    generations_rls: true,
+    generations_force_rls: true,
     expected_policies: true,
     provider_roles_excluded: true,
     ssl: true,


### PR DESCRIPTION
Ethereum market-cap pagination could cross Vercel instances and combine two independently refreshed GMGN compositions. That made page order drift possible even when each response was locally valid, and the browser could retry a stale ranking pin after a catalog change.

This change moves the complete GMGN plus token-info plus Dexscreener market-cap composition behind a versioned Postgres authority. The authority binds the exact canonical Ethereum identity set and frozen filter facets, publishes with lease and CAS semantics, retains bounded generations for pinned pagination, and returns a typed 409 when a requested generation can no longer be served. The client now carries the page-one commitment and clears every cached payload for that collection before its single automatic 409 restart.

The provider path also keeps GMGN Pro reads within the shared account gate and request deadline, skips token-info fanout when the direct rank is unavailable, and preserves canonical Programmable-only membership with deterministic fallback ordering. Migration 0008 adds the private forced-RLS authority tables and least-privilege runtime policies. It must be applied from the exact merged production commit before staging the application.

Validation:

- `npm test`: 5,553 passed, 33 skipped
- `npm run build`: passed
- `npm run lint`: 0 errors; 69 pre-existing warnings
- Explore API: 56/56
- Explore client: 80/80
- staged public smoke: 103/103
- read-model source contract: 312/312
- database operator and rotation: 34/34
