### PR TITLE
Fix GMGN indexer gate locality and ranking headroom

### DIFF
--- a/lib/market-data/gmgn-account-gate.server.ts
+++ b/lib/market-data/gmgn-account-gate.server.ts
@@ -40,6 +40,7 @@ export interface GmgnAccountGateV1 {
   reserveSlot(input: Readonly<{
     requestsPerSecond: number;
     cost?: GmgnAccountGateCostV1;
+    maximumConcurrentLeases?: number;
     deadlineMs: number;
     signal?: AbortSignal;
   }>): Promise<GmgnAccountGateReservationV1 | null>;
@@ -618,15 +619,21 @@ export class PostgresGmgnAccountGateV1 implements GmgnAccountGateV1 {
   async reserveSlot(input: Readonly<{
     requestsPerSecond: number;
     cost?: GmgnAccountGateCostV1;
+    maximumConcurrentLeases?: number;
     deadlineMs: number;
     signal?: AbortSignal;
   }>): Promise<GmgnAccountGateReservationV1 | null> {
     const cost: unknown = input.cost === undefined ? 1 : input.cost;
+    const maximumConcurrentLeases = input.maximumConcurrentLeases ??
+      MAXIMUM_CONCURRENT_LEASES;
     if (
       !Number.isSafeInteger(input.requestsPerSecond)
       || input.requestsPerSecond < 1
       || input.requestsPerSecond > 20
       || !isGmgnAccountGateCostV1(cost)
+      || !Number.isSafeInteger(maximumConcurrentLeases)
+      || maximumConcurrentLeases < 1
+      || maximumConcurrentLeases > MAXIMUM_CONCURRENT_LEASES
       || !Number.isFinite(input.deadlineMs)
     ) throw new TypeError("GMGN account gate reservation is invalid");
     const intervalMs = Math.ceil(1_000 / input.requestsPerSecond);
@@ -695,7 +702,7 @@ export class PostgresGmgnAccountGateV1 implements GmgnAccountGateV1 {
           Math.ceil(nextSlotAtMs - decidedAtMs),
         );
         const capacityUnavailable = legacyLeaseActive || markerInconsistent ||
-          activeLeases >= MAXIMUM_CONCURRENT_LEASES;
+          activeLeases >= maximumConcurrentLeases;
         if (scheduleRetryMs > 0 || capacityUnavailable) {
           const capacityUntilMs = legacyLeaseActive || markerInconsistent
             ? Math.max(leaseUntilMs, latestLeaseUntilMs ?? decidedAtMs)

--- a/lib/market-data/gmgn-chart.server.ts
+++ b/lib/market-data/gmgn-chart.server.ts
@@ -29,6 +29,7 @@ import {
 } from "./market-data-v1";
 
 const GMGN_API_ORIGIN = "https://openapi.gmgn.ai" as const;
+const GMGN_API_USER_AGENT = "programmable-market-indexer/1.0" as const;
 const GMGN_REQUEST_TIMEOUT_MS = 2_500;
 const GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS = 3_000;
 const GMGN_PROVIDER_LIFECYCLE_GRACE_MS =
@@ -586,6 +587,7 @@ async function gmgnJsonRequest(
       headers: {
         Accept: "application/json",
         "Content-Type": "application/json",
+        "User-Agent": GMGN_API_USER_AGENT,
         "X-APIKEY": apiKey,
       },
       redirect: "error",

--- a/lib/market-data/gmgn-discovery.server.ts
+++ b/lib/market-data/gmgn-discovery.server.ts
@@ -23,6 +23,7 @@ import {
 } from "./gmgn-discovery-v1";
 
 const GMGN_API_ORIGIN = "https://openapi.gmgn.ai" as const;
+const GMGN_API_USER_AGENT = "programmable-market-indexer/1.0" as const;
 const GMGN_REQUEST_TIMEOUT_MS = 2_500;
 // Cold database readiness and account-wide scheduling must not consume the
 // provider's response budget after a slot has actually been reserved.
@@ -98,6 +99,7 @@ const searchInFlight = new Map<
   Promise<GmgnSearchSnapshotV1 | null>
 >();
 let localBlockedUntilMs = 0;
+const providerFailureLoggedAt = new Map<string, number>();
 
 export function gmgnDiscoveryConfiguredV1(): boolean {
   return readApiKey() !== null;
@@ -265,7 +267,7 @@ async function readGmgnDiscoverySnapshotFromProviderV1(
     apiKey,
     providerWait,
   );
-  return parseGmgnDiscoverySnapshotV1(data, {
+  const snapshot = parseGmgnDiscoverySnapshotV1(data, {
     kind,
     interval: normalized.interval,
     ...(normalized.orderBy === null
@@ -277,6 +279,22 @@ async function readGmgnDiscoverySnapshotFromProviderV1(
     limit: normalized.limit,
     fetchedAt: currentDate(providerWait),
   });
+  if (data !== null && snapshot === null) {
+    logGmgnProviderUnavailableV1(
+      path,
+      kind === "trending"
+        ? {
+            query: {
+              direction: normalized.direction ?? "desc",
+            },
+            body: null,
+          }
+        : { query: {}, body: null },
+      "schema-rejected",
+      200,
+    );
+  }
+  return snapshot;
 }
 
 async function readGmgnSearchSnapshotFromProviderV1(
@@ -583,9 +601,12 @@ async function gmgnJsonRequest(
     wait.signal?.aborted ||
     !Number.isFinite(queuedAtMs) ||
     !Number.isFinite(requestDeadlineMs) ||
-    requestDeadlineMs <= queuedAtMs ||
-    localBlockedUntilMs > queuedAtMs
+    requestDeadlineMs <= queuedAtMs
   ) return null;
+  if (localBlockedUntilMs > queuedAtMs) {
+    logGmgnProviderUnavailableV1(path, request, "local-cooldown");
+    return null;
+  }
 
   let accountGate: GmgnAccountGateV1 | null = wait.accountGate ?? null;
   let reservation: Extract<
@@ -609,11 +630,21 @@ async function gmgnJsonRequest(
         deadlineMs: gateDeadlineMs,
         signal: wait.signal,
       }, gateOperation);
-      if (decision?.kind !== "reserved") return null;
+      if (decision?.kind !== "reserved") {
+        logGmgnProviderUnavailableV1(
+          path,
+          request,
+          decision?.kind === "blocked"
+            ? "account-gate-blocked"
+            : "account-gate-unavailable",
+        );
+        return null;
+      }
       reservation = decision;
     }
   } catch {
     // A production request must never bypass the shared database gate.
+    logGmgnProviderUnavailableV1(path, request, "account-gate-error");
     return null;
   }
 
@@ -642,7 +673,8 @@ async function gmgnJsonRequest(
       method,
       headers: {
         Accept: "application/json",
-        ...(request.body === null ? {} : { "Content-Type": "application/json" }),
+        "Content-Type": "application/json",
+        "User-Agent": GMGN_API_USER_AGENT,
         "X-APIKEY": apiKey,
       },
       body: request.body === null ? undefined : JSON.stringify(request.body),
@@ -653,6 +685,7 @@ async function gmgnJsonRequest(
     });
   } catch {
     await completeProviderRequest(accountGate, reservation);
+    logGmgnProviderUnavailableV1(path, request, "fetch-error");
     return null;
   }
 
@@ -719,22 +752,71 @@ async function gmgnJsonRequest(
       envelope,
       responseAtMs,
     );
+    logGmgnProviderUnavailableV1(
+      path,
+      request,
+      "rate-limited",
+      response.status,
+    );
   } else if (!await completeProviderRequest(
     accountGate,
     reservation,
   )) {
     return null;
   }
+  if (rateLimited) return null;
+  if (!response.ok) {
+    logGmgnProviderUnavailableV1(
+      path,
+      request,
+      "http-error",
+      response.status,
+    );
+    return null;
+  }
   if (
-    !response.ok ||
-    rateLimited ||
     !isRecord(envelope) ||
     (envelope.code !== 0 && envelope.code !== "0") ||
     envelope.data === undefined
-  ) return null;
+  ) {
+    logGmgnProviderUnavailableV1(
+      path,
+      request,
+      "envelope-rejected",
+      response.status,
+    );
+    return null;
+  }
   // Preserve the provider envelope so the schema parser can validate every
   // explicit outer and nested chain declaration before unwrapping its data.
   return envelope;
+}
+
+function logGmgnProviderUnavailableV1(
+  path: GmgnDiscoveryPath,
+  request: Readonly<{
+    query: Readonly<Record<string, string>>;
+    body: Readonly<Record<string, unknown>> | null;
+  }>,
+  phase: string,
+  httpStatus?: number,
+): void {
+  if (process.env.NODE_ENV !== "production") return;
+  const direction = request.query.direction === "asc" ||
+      request.query.direction === "desc"
+    ? request.query.direction
+    : null;
+  const key = `${path}:${phase}:${direction ?? "none"}:${httpStatus ?? "none"}`;
+  const nowMs = Date.now();
+  const lastLoggedAt = providerFailureLoggedAt.get(key) ?? 0;
+  if (nowMs - lastLoggedAt < 10_000) return;
+  providerFailureLoggedAt.set(key, nowMs);
+  console.warn("GMGN provider read unavailable", {
+    endpoint: path,
+    phase,
+    direction,
+    httpStatus: Number.isSafeInteger(httpStatus) ? httpStatus : null,
+  });
 }
 
 function endpointCost(path: GmgnDiscoveryPath): GmgnAccountGateCostV1 {

--- a/lib/market-data/gmgn-token-analytics.server.ts
+++ b/lib/market-data/gmgn-token-analytics.server.ts
@@ -36,6 +36,7 @@ import {
 } from "./market-data-v1";
 
 const GMGN_API_ORIGIN = "https://openapi.gmgn.ai" as const;
+const GMGN_API_USER_AGENT = "programmable-market-indexer/1.0" as const;
 const GMGN_REQUEST_TIMEOUT_MS = 2_500;
 const GMGN_ACCOUNT_GATE_OUTCOME_TIMEOUT_MS = 3_000;
 const GMGN_PROVIDER_LIFECYCLE_GRACE_MS =
@@ -726,7 +727,12 @@ async function gmgnJsonRequest(
   try {
     response = await fetchImpl(url, {
       method: "GET",
-      headers: { Accept: "application/json", "X-APIKEY": apiKey },
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": GMGN_API_USER_AGENT,
+        "X-APIKEY": apiKey,
+      },
       redirect: "error",
       credentials: "omit",
       cache: "no-store",

--- a/lib/market-data/gmgn.server.ts
+++ b/lib/market-data/gmgn.server.ts
@@ -23,6 +23,7 @@ import { gmgnEffectiveRequestsPerSecondV1 } from
 import type { MarketChartIdentityV1 } from "./market-data-v1";
 
 const GMGN_API_ORIGIN = "https://openapi.gmgn.ai" as const;
+const GMGN_API_USER_AGENT = "programmable-market-indexer/1.0" as const;
 const GMGN_REQUEST_TIMEOUT_MS = 2_500;
 // Cold database readiness and account-wide scheduling must not consume the
 // provider's response budget after a slot has actually been reserved.
@@ -37,7 +38,10 @@ const GMGN_MARKET_CACHE_TTL_MS = 30_000;
 const GMGN_MAXIMUM_CACHE_ENTRIES = 512;
 const GMGN_VISIBLE_MAXIMUM_ENTRY_COUNT = 100;
 const GMGN_VISIBLE_CHUNK_SIZE = 20;
-const GMGN_MAXIMUM_CONCURRENCY = 20;
+// Reserve eight account-wide leases for ranking, search, chart, and analytics
+// reads. A timed-out visible token-info fanout can otherwise occupy the entire
+// shared provider gate after its Explore response has already returned.
+const GMGN_VISIBLE_MAXIMUM_CONCURRENT_LEASES = 12;
 const GMGN_MAXIMUM_RATE_LIMIT_COOLDOWN_MS = 5 * 60_000;
 const UINT256_MAX = (1n << 256n) - 1n;
 const USD_WAD = 10n ** 18n;
@@ -78,6 +82,7 @@ type CachedValue<T> = Readonly<{
 
 const snapshotCache = new Map<string, CachedValue<GmgnMarketSnapshotV1>>();
 const snapshotInFlight = new Map<string, Promise<GmgnMarketSnapshotV1 | null>>();
+const providerFailureLoggedAt = new Map<string, number>();
 
 export function gmgnMarketDataConfiguredV1(): boolean {
   return readApiKey() !== null;
@@ -129,7 +134,7 @@ export function gmgnVisibleMarketConcurrencyV1(batchSize: number): number {
   return Math.min(
     batchSize,
     GMGN_VISIBLE_CHUNK_SIZE,
-    GMGN_MAXIMUM_CONCURRENCY,
+    GMGN_VISIBLE_MAXIMUM_CONCURRENT_LEASES,
     gmgnEffectiveRequestsPerSecondV1(),
   );
 }
@@ -185,6 +190,9 @@ export async function readGmgnMarketSnapshotV1(
       canonicalSupply,
       providerWait.now(),
     );
+    if (value !== null && snapshot === null) {
+      logGmgnMarketProviderUnavailableV1("schema-rejected", 200);
+    }
     return snapshot;
   })();
   const promise = settleProviderReadLifecycle(providerRead, providerWait).then(
@@ -406,15 +414,24 @@ async function gmgnJsonRequest(
     if (accountGate !== null) {
       const decision = await reserveProviderSlot(accountGate, {
         requestsPerSecond: gmgnEffectiveRequestsPerSecondV1(),
+        maximumConcurrentLeases: GMGN_VISIBLE_MAXIMUM_CONCURRENT_LEASES,
         deadlineMs: gateDeadlineMs,
         signal: gateSignal,
       }, gateOperation);
-      if (decision?.kind !== "reserved") return null;
+      if (decision?.kind !== "reserved") {
+        logGmgnMarketProviderUnavailableV1(
+          decision?.kind === "blocked"
+            ? "account-gate-blocked"
+            : "account-gate-unavailable",
+        );
+        return null;
+      }
       reservation = decision;
     }
   } catch {
     // Production must never bypass the shared account gate when its database,
     // migration, role, or TLS authority is unavailable.
+    logGmgnMarketProviderUnavailableV1("account-gate-error");
     return null;
   }
   const nowMs = now().getTime();
@@ -440,7 +457,12 @@ async function gmgnJsonRequest(
   try {
     response = await fetchImpl(url, {
       method: "GET",
-      headers: { Accept: "application/json", "X-APIKEY": apiKey },
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": GMGN_API_USER_AGENT,
+        "X-APIKEY": apiKey,
+      },
       redirect: "error",
       credentials: "omit",
       cache: "no-store",
@@ -448,6 +470,7 @@ async function gmgnJsonRequest(
     });
   } catch {
     await completeProviderRequest(accountGate, reservation);
+    logGmgnMarketProviderUnavailableV1("fetch-error");
     return null;
   }
   const declaredLength = Number(response.headers.get("Content-Length"));
@@ -520,13 +543,51 @@ async function gmgnJsonRequest(
   } else if (!await completeProviderRequest(accountGate, reservation)) {
     return null;
   }
-  if (!response.ok || rateLimited || value === null) return null;
+  if (rateLimited) {
+    logGmgnMarketProviderUnavailableV1(
+      "rate-limited",
+      response.status,
+    );
+    return null;
+  }
+  if (!response.ok) {
+    logGmgnMarketProviderUnavailableV1("http-error", response.status);
+    return null;
+  }
+  if (value === null) {
+    logGmgnMarketProviderUnavailableV1(
+      "invalid-json",
+      response.status,
+    );
+    return null;
+  }
   if (!isRecord(value) || value.code !== 0 || !isRecord(value.data)) {
+    logGmgnMarketProviderUnavailableV1(
+      "envelope-rejected",
+      response.status,
+    );
     return null;
   }
   // Keep the raw envelope for the parser so an explicit outer chain cannot be
   // discarded before the exact-Ethereum boundary check.
   return value;
+}
+
+function logGmgnMarketProviderUnavailableV1(
+  phase: string,
+  httpStatus?: number,
+): void {
+  if (process.env.NODE_ENV !== "production") return;
+  const key = `${phase}:${httpStatus ?? "none"}`;
+  const nowMs = Date.now();
+  const lastLoggedAt = providerFailureLoggedAt.get(key) ?? 0;
+  if (nowMs - lastLoggedAt < 10_000) return;
+  providerFailureLoggedAt.set(key, nowMs);
+  console.warn("GMGN provider read unavailable", {
+    endpoint: "/v1/token/info",
+    phase,
+    httpStatus: Number.isSafeInteger(httpStatus) ? httpStatus : null,
+  });
 }
 
 async function readBoundedResponseBytes(

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -597,7 +597,7 @@ const GMGN_READ_ONLY_ENDPOINT_CONTRACT = Object.freeze([
   Object.freeze({
     path: "lib/market-data/gmgn-discovery.server.ts",
     fetchImplReferences: 8,
-    pathReferences: 7,
+    pathReferences: 18,
     allowed: Object.freeze([
       "/v1/market/hot_searches",
       "/v1/market/rank",
@@ -3365,7 +3365,7 @@ export function evaluateReadModelOperationsSourceContracts(
       "const GMGN_RESPONSE_MAXIMUM_BYTES = 1_000_000",
       "const GMGN_VISIBLE_MAXIMUM_ENTRY_COUNT = 100",
       "const GMGN_VISIBLE_CHUNK_SIZE = 20",
-      "const GMGN_MAXIMUM_CONCURRENCY = 20",
+      "const GMGN_VISIBLE_MAXIMUM_CONCURRENT_LEASES = 12",
       "entries.slice(0, GMGN_VISIBLE_MAXIMUM_ENTRY_COUNT)",
       "offset += GMGN_VISIBLE_CHUNK_SIZE",
       "boundedEntries.slice(offset, offset + GMGN_VISIBLE_CHUNK_SIZE)",
@@ -3392,7 +3392,7 @@ export function evaluateReadModelOperationsSourceContracts(
       'String(data.pool.exchange).toLowerCase() !== "uniswap_v4"',
       "!poolBaseQuoteMatchesV1(data.pool, identity)",
       "!providerSupplyMatchesCanonical(",
-      'headers: { Accept: "application/json", "X-APIKEY": apiKey }',
+      '"User-Agent": GMGN_API_USER_AGENT',
       'redirect: "error"',
       'credentials: "omit"',
       "const bytes = await readBoundedResponseBytes(",
@@ -3641,9 +3641,14 @@ export function evaluateReadModelOperationsSourceContracts(
       '(process.env.NODE_ENV === "production" || fetchImpl === fetch)',
       'from "./gmgn-runtime-config.server"',
       "requestsPerSecond: gmgnEffectiveRequestsPerSecondV1()",
+      '"User-Agent": GMGN_API_USER_AGENT',
+      "const providerFailureLoggedAt = new Map<string, number>();",
+      "if (nowMs - lastLoggedAt < 10_000) return;",
+      'console.warn("GMGN provider read unavailable", {',
       'redirect: "error"',
       'credentials: "omit"',
     ]) &&
+    !gmgnDiscovery.includes("envelopeCode") &&
     !gmgnDiscovery.includes("CachedValue<GmgnDiscoverySnapshotV1 | null>") &&
     includesEverySourceFragment(gmgnDiscoverySnapshot, [
       '"programmable.gmgn-discovery.v1" as const',

--- a/tests/gmgn-account-gate.test.ts
+++ b/tests/gmgn-account-gate.test.ts
@@ -99,6 +99,48 @@ describe("GMGN account gate", () => {
     expect(active.rows).toEqual([{ count: 20 }]);
   });
 
+  it("keeps account-wide headroom for ranking beside bulk token-info reads", async () => {
+    const { database, pool } = await migratedGate();
+    const gate = new PostgresGmgnAccountGateV1(pool);
+    const bulkLeases = await Promise.all(Array.from({ length: 12 }, async () => {
+      const decision = await gate.reserveSlot({
+        requestsPerSecond: 20,
+        maximumConcurrentLeases: 12,
+        deadlineMs: Date.now() + 2_000,
+      });
+      if (decision?.kind !== "reserved") {
+        throw new Error("bulk test lease unavailable");
+      }
+      return decision;
+    }));
+
+    await expect(gate.reserveSlot({
+      requestsPerSecond: 20,
+      maximumConcurrentLeases: 12,
+      deadlineMs: Date.now() + 80,
+    })).resolves.toBeNull();
+    const rankLease = await gate.reserveSlot({
+      requestsPerSecond: 20,
+      deadlineMs: Date.now() + 1_000,
+    });
+    expect(rankLease?.kind).toBe("reserved");
+    if (rankLease?.kind !== "reserved") {
+      throw new Error("ranking headroom lease unavailable");
+    }
+
+    await database.exec("RESET ROLE");
+    const active = await database.query<{ count: number }>(`
+      SELECT count(*) AS count
+        FROM programmable_website_projection_v1.gmgn_account_gate_leases_v1
+       WHERE lease_until > clock_timestamp()
+    `);
+    expect(active.rows).toEqual([{ count: 13 }]);
+    await Promise.all([
+      ...bulkLeases.map((lease) => gate.complete(lease)),
+      gate.complete(rankLease),
+    ]);
+  });
+
   it("cancels a capacity wait without allocating a twenty-first lease", async () => {
     const { database, pool } = await migratedGate();
     const gate = new PostgresGmgnAccountGateV1(pool);
@@ -437,6 +479,23 @@ describe("GMGN account gate", () => {
     })).rejects.toThrow("GMGN account gate reservation is invalid");
     expect(query).not.toHaveBeenCalled();
   });
+
+  it.each([0, 21, 1.5] as const)(
+    "rejects invalid maximum concurrent leases %p before database access",
+    async (maximumConcurrentLeases) => {
+      const query = vi.fn();
+      const gate = new PostgresGmgnAccountGateV1({
+        connect: vi.fn(),
+        query,
+      });
+      await expect(gate.reserveSlot({
+        requestsPerSecond: 20,
+        maximumConcurrentLeases,
+        deadlineMs: Date.now() + 1_000,
+      })).rejects.toThrow("GMGN account gate reservation is invalid");
+      expect(query).not.toHaveBeenCalled();
+    },
+  );
 
   it("publishes one central blocked_until and Retry-After decision", async () => {
     const { database, pool } = await migratedGate();

--- a/tests/gmgn-chart.test.ts
+++ b/tests/gmgn-chart.test.ts
@@ -813,6 +813,7 @@ describe("GMGN admitted Ethereum token-address kline adapter", () => {
       const headers = new Headers(init?.headers);
       expect(headers.get("X-APIKEY")).toBe("test-server-key");
       expect(headers.get("Content-Type")).toBe("application/json");
+      expect(headers.get("User-Agent")).toBe("programmable-market-indexer/1.0");
       expect(init?.redirect).toBe("error");
       expect(init?.credentials).toBe("omit");
     }

--- a/tests/gmgn-discovery.test.ts
+++ b/tests/gmgn-discovery.test.ts
@@ -780,6 +780,37 @@ describe("GMGN discovery server adapter", () => {
     })).resolves.toBeNull();
   });
 
+  it("keeps provider bodies and credentials out of discovery diagnostics", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    const providerSentinel = "SENTINEL_PROVIDER_ACCOUNT_654321";
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { gate } = accountGate();
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      code: providerSentinel,
+      data: { data: { rank: [providerToken(10, 1)] } },
+    }), { status: 200 }));
+
+    await expect(readGmgnEthereumTrendingV1({
+      interval: "1h",
+      limit: 10,
+      orderBy: "marketcap",
+      direction: "asc",
+    }, {
+      fetchImpl: fetchImpl as typeof fetch,
+      accountGate: gate,
+      now: () => NOW,
+      deadlineMs: NOW.getTime() + 5_000,
+    })).resolves.toBeNull();
+
+    const diagnostics = JSON.stringify(warn.mock.calls);
+    expect(diagnostics).toContain("envelope-rejected");
+    expect(diagnostics).toContain("asc");
+    expect(diagnostics).not.toContain(providerSentinel);
+    expect(diagnostics).not.toContain("test-server-key");
+    expect(diagnostics).not.toContain(address(10));
+  });
+
   it("uses only the official read-only rank request and weight one", async () => {
     vi.stubEnv("GMGN_API_KEY", "test-server-key");
     const { gate, reserveSlot, complete } = accountGate();
@@ -818,6 +849,8 @@ describe("GMGN discovery server adapter", () => {
     expect(url.searchParams.get("client_id")).toMatch(/^[0-9a-f-]{36}$/u);
     const headers = new Headers(init?.headers);
     expect(headers.get("X-APIKEY")).toBe("test-server-key");
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("User-Agent")).toBe("programmable-market-indexer/1.0");
     expect(headers.get("X-Signature")).toBeNull();
     expect(init?.method).toBe("GET");
     expect(init?.body).toBeUndefined();

--- a/tests/gmgn-market-data.test.ts
+++ b/tests/gmgn-market-data.test.ts
@@ -273,6 +273,7 @@ describe("GMGN canonical market enrichment", () => {
     });
     expect(reserveSlot).toHaveBeenCalledWith({
       requestsPerSecond: 1,
+      maximumConcurrentLeases: 12,
       deadlineMs: NOW.getTime() + 5_000,
       signal: expect.any(AbortSignal),
     });
@@ -280,13 +281,13 @@ describe("GMGN canonical market enrichment", () => {
     expect(complete).toHaveBeenCalledWith(reservation);
   });
 
-  it("derives visible token-info concurrency from effective RPS and batch size", () => {
+  it("reserves ranking headroom in visible token-info concurrency", () => {
     vi.stubEnv("GMGN_MAX_REQUESTS_PER_SECOND", "20");
     expect(gmgnVisibleMarketConcurrencyV1(0)).toBe(0);
     expect(gmgnVisibleMarketConcurrencyV1(1)).toBe(1);
     expect(gmgnVisibleMarketConcurrencyV1(7)).toBe(7);
-    expect(gmgnVisibleMarketConcurrencyV1(20)).toBe(20);
-    expect(gmgnVisibleMarketConcurrencyV1(100)).toBe(20);
+    expect(gmgnVisibleMarketConcurrencyV1(20)).toBe(12);
+    expect(gmgnVisibleMarketConcurrencyV1(100)).toBe(12);
 
     vi.stubEnv("GMGN_MAX_REQUESTS_PER_SECOND", "3");
     expect(gmgnVisibleMarketConcurrencyV1(20)).toBe(3);
@@ -594,12 +595,15 @@ describe("GMGN canonical market enrichment", () => {
     expect(url.searchParams.get("address")).toBe(entry.tokenAddress);
     expect(url.searchParams.get("timestamp")).toBe("1788091200");
     expect(url.searchParams.get("client_id")).toMatch(/^[0-9a-f-]{36}$/u);
-    expect(new Headers(init?.headers).get("X-APIKEY")).toBe("test-server-key");
+    const headers = new Headers(init?.headers);
+    expect(headers.get("X-APIKEY")).toBe("test-server-key");
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("User-Agent")).toBe("programmable-market-indexer/1.0");
     expect(init?.redirect).toBe("error");
     expect(init?.credentials).toBe("omit");
   });
 
-  it("processes the 100-entry API maximum in bounded 20-request chunks", async () => {
+  it("processes the 100-entry API maximum with ranking lease headroom", async () => {
     vi.stubEnv("GMGN_API_KEY", "test-server-key");
     vi.stubEnv("GMGN_MAX_REQUESTS_PER_SECOND", "20");
     const entries = Array.from({ length: 100 }, (_, index) => token(index + 300));
@@ -637,7 +641,7 @@ describe("GMGN canonical market enrichment", () => {
 
     expect(snapshots.size).toBe(100);
     expect(fetchImpl).toHaveBeenCalledTimes(100);
-    expect(maximumActive).toBe(20);
+    expect(maximumActive).toBe(12);
     expect(accountGate.reserveSlot).toHaveBeenCalledTimes(100);
     expect(accountGate.complete).toHaveBeenCalledTimes(100);
   });
@@ -656,6 +660,35 @@ describe("GMGN canonical market enrichment", () => {
       now: () => NOW,
     })).resolves.toBeNull();
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps provider bodies and credentials out of production diagnostics", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    const entry = token(128);
+    const providerSentinel = "SENTINEL_PROVIDER_ACCOUNT_123456";
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const accountGate: GmgnAccountGateV1 = {
+      reserveSlot: vi.fn(async () => GATE_RESERVATION),
+      blockUntil: vi.fn(),
+      complete: vi.fn(async () => {}),
+    };
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      code: providerSentinel,
+      data: providerData(entry),
+    }), { status: 200 }));
+
+    await expect(readGmgnMarketSnapshotV1(entry, {
+      fetchImpl: fetchImpl as typeof fetch,
+      accountGate,
+      now: () => NOW,
+    })).resolves.toBeNull();
+
+    const diagnostics = JSON.stringify(warn.mock.calls);
+    expect(diagnostics).toContain("envelope-rejected");
+    expect(diagnostics).not.toContain(providerSentinel);
+    expect(diagnostics).not.toContain("test-server-key");
+    expect(diagnostics).not.toContain(entry.tokenAddress);
   });
 
   it.each([
@@ -685,6 +718,7 @@ describe("GMGN canonical market enrichment", () => {
       })).resolves.not.toBeNull();
       expect(reserveSlot).toHaveBeenCalledWith({
         requestsPerSecond: expected,
+        maximumConcurrentLeases: 12,
         deadlineMs: NOW.getTime() + 5_000,
         signal: expect.any(AbortSignal),
       });

--- a/tests/gmgn-token-analytics.test.ts
+++ b/tests/gmgn-token-analytics.test.ts
@@ -514,6 +514,8 @@ describe("GMGN Ethereum token analytics", () => {
       });
       expect(init?.headers).toEqual({
         Accept: "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": "programmable-market-indexer/1.0",
         "X-APIKEY": "gmgn-test-server-only",
       });
       return jsonResponse({ list: [rankedWallet()] });

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "regions": ["fra1"],
   "trailingSlash": false,
   "headers": [
     {


### PR DESCRIPTION
GMGN ranking could succeed while the 100-token `token_info` hydration fanout failed before reaching GMGN. Website Functions were running in `iad1`, but the shared Postgres account gate is in Frankfurt; cold cross-region gate transactions exceeded the reservation budget and left the ascending market-cap release gate dependent on a single direct ranking match.

This change:

- runs Vercel Functions in `fra1`, alongside the projection database;
- caps account-wide token-info leases at 12 while retaining the 20-lease provider ceiling for ranking, search, chart, and analytics reads;
- aligns every GMGN adapter with the official request headers;
- adds throttled production diagnostics containing only internal phase, endpoint, direction, and HTTP status;
- keeps provider bodies, credentials, addresses, and envelope values out of logs;
- binds the new behavior into the operations source contract and focused tests.

The release smoke remains unchanged and still requires a fresh canonical GMGN match.

Validation:

- 185 focused GMGN tests pass;
- TypeScript and focused ESLint pass;
- the full read-model operations source gate passes;
- Vercel candidate `dpl_AQujiJ6ggThVjVrmAAqAkppRYM9F` is unaliased and verified in `fra1`;
- the exact uncached ascending Explore read improved from 0 to 23 observed token-info responses while GMGN ranking stayed available with a canonical match.
