### PR TITLE
Fix GMGN market-cap authority refresh

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -23,6 +23,7 @@ import {
 } from "../../../lib/market-data/gmgn-canonical-ranking";
 import {
   readGmgnEthereumHotSearchesV1,
+  readGmgnEthereumMarketCapAuthorityRankV1,
   readGmgnEthereumSearchV1,
   readGmgnEthereumTrendingV1,
 } from "../../../lib/market-data/gmgn-discovery.server";
@@ -106,8 +107,8 @@ const GMGN_MARKET_CAP_RETRY_MINIMUM_REMAINING_MS =
 const MARKET_CAP_AUTHORITY_BUILD_BUDGET_MS = FAST_LANE_REQUEST_BUDGET_MS;
 const MARKET_CAP_AUTHORITY_PUBLISH_RESERVE_MS = 3_000;
 const MARKET_CAP_REQUEST_BUDGET_MS = 12_000;
-const EXPLORE_MARKET_CAP_AUTHORITY_COMPOSITION_POLICY_V3 =
-  "gmgn-qualified-rank+oldest-first-sentinels+cyclic-supply+same-bucket-supply-priority+cyclic-token-info+dexscreener.v3";
+const EXPLORE_MARKET_CAP_AUTHORITY_COMPOSITION_POLICY_V4 =
+  "gmgn-qualified-rank+shared-authority-fresh-read+oldest-first-sentinels+cyclic-supply+same-bucket-supply-priority+cyclic-token-info+dexscreener.v4";
 const SHA256_COMMITMENT = /^sha256:[0-9a-f]{64}$/u;
 const UNSIGNED_INTEGER = /^(?:0|[1-9][0-9]*)$/u;
 const CLASSIC_EXCLUSIONS = Object.freeze([
@@ -973,9 +974,9 @@ export function exploreMarketCapAuthorityInputCommitmentV1(
   entries: readonly ExploreEntry[],
 ): `sha256:${string}` {
   return canonicalSha256(
-    "programmable.explore-market-cap-authority-input.v3",
+    "programmable.explore-market-cap-authority-input.v4",
     {
-      compositionPolicy: EXPLORE_MARKET_CAP_AUTHORITY_COMPOSITION_POLICY_V3,
+      compositionPolicy: EXPLORE_MARKET_CAP_AUTHORITY_COMPOSITION_POLICY_V4,
       orderedCanonicalIdentities: entries.map((entry, index) => ({
         index,
         ...exactOrderedMarketIdentityV1(entry),
@@ -1493,7 +1494,7 @@ async function buildExploreMarketCapAuthorityV1(
   const rankCandidate = canonicalEntries.length === 0
     ? null
     : await (async () => {
-        const first = await readGmgnEthereumTrendingV1(
+        const first = await readGmgnEthereumMarketCapAuthorityRankV1(
           rankOptions,
           rankWait,
         ).catch(() => null);
@@ -1503,7 +1504,7 @@ async function buildExploreMarketCapAuthorityV1(
           authorityDeadlineMs - Date.now() <
             GMGN_MARKET_CAP_RETRY_MINIMUM_REMAINING_MS
         ) return first;
-        return readGmgnEthereumTrendingV1(
+        return readGmgnEthereumMarketCapAuthorityRankV1(
           rankOptions,
           rankWait,
         ).catch(() => null);

--- a/lib/market-data/gmgn-discovery.server.ts
+++ b/lib/market-data/gmgn-discovery.server.ts
@@ -77,6 +77,15 @@ export type GmgnTrendingReadOptionsV1 = GmgnDiscoveryReadOptionsV1 & Readonly<{
   direction?: "asc" | "desc";
 }>;
 
+export type GmgnMarketCapAuthorityRankReadOptionsV1 = Readonly<{
+  interval: "1h";
+  limit: typeof GMGN_TRENDING_MAXIMUM_LIMIT;
+  orderBy: "marketcap";
+  direction: "asc" | "desc";
+}>;
+
+type GmgnDiscoveryCacheModeV1 = "durable" | "shared-authority";
+
 type CachedValue<T> = Readonly<{
   expiresAtMs: number;
   value: T;
@@ -110,6 +119,18 @@ export async function readGmgnEthereumTrendingV1(
   wait: GmgnDiscoveryReadWaitV1 = {},
 ): Promise<GmgnDiscoverySnapshotV1 | null> {
   return readGmgnEthereumDiscoveryV1("trending", options, wait);
+}
+
+export async function readGmgnEthereumMarketCapAuthorityRankV1(
+  options: GmgnMarketCapAuthorityRankReadOptionsV1,
+  wait: GmgnDiscoveryReadWaitV1 = {},
+): Promise<GmgnDiscoverySnapshotV1 | null> {
+  return readGmgnEthereumDiscoveryV1(
+    "trending",
+    options,
+    wait,
+    "shared-authority",
+  );
 }
 
 export async function readGmgnEthereumHotSearchesV1(
@@ -148,6 +169,7 @@ async function readGmgnEthereumDiscoveryV1(
   kind: GmgnDiscoveryKindV1,
   options: GmgnTrendingReadOptionsV1,
   wait: GmgnDiscoveryReadWaitV1,
+  cacheMode: GmgnDiscoveryCacheModeV1 = "durable",
 ): Promise<GmgnDiscoverySnapshotV1 | null> {
   const apiKey = readApiKey();
   const normalized = normalizeOptions(kind, options);
@@ -163,6 +185,30 @@ async function readGmgnEthereumDiscoveryV1(
     normalized.orderBy ?? "default",
     normalized.direction ?? "default",
   ].join(":");
+  if (cacheMode === "shared-authority") {
+    if (
+      kind !== "trending" ||
+      normalized.interval !== "1h" ||
+      normalized.limit !== GMGN_TRENDING_MAXIMUM_LIMIT ||
+      normalized.orderBy !== "marketcap" ||
+      normalized.direction === null
+    ) return null;
+    // The caller holds the shared Postgres authority lease. Await a fresh
+    // module-local singleflight before those exact bytes can be published as
+    // cross-isolate pagination authority; do not admit Next's stale SWR value.
+    return readThroughCache(
+      discoveryCache,
+      discoveryInFlight,
+      key,
+      wait,
+      (providerWait) => readGmgnDiscoverySnapshotFromProviderV1(
+        kind,
+        normalized,
+        apiKey,
+        providerWait,
+      ),
+    );
+  }
   if (durableCacheEligible(wait)) {
     const durable = await waitForCaller(
       readDurablyCachedGmgnDiscoverySnapshotV1(
@@ -359,7 +405,7 @@ const readDurablyCachedGmgnDiscoverySnapshotV1 = unstable_cache(
     }
     return snapshot;
   },
-  ["programmable-gmgn-ethereum-discovery-v2"],
+  ["programmable-gmgn-ethereum-discovery-v3"],
   { revalidate: GMGN_DURABLE_CACHE_REVALIDATE_SECONDS },
 );
 

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -1051,11 +1051,11 @@ function exactExploreGmgnMarketCapRetryContract(source) {
   );
   if (directionProperties.length !== 1) return false;
 
-  const trendingCalls = directNamedCalls(
+  const authorityRankCalls = directNamedCalls(
     sourceFile,
-    "readGmgnEthereumTrendingV1",
+    "readGmgnEthereumMarketCapAuthorityRankV1",
   );
-  const rankCalls = trendingCalls.filter((call) =>
+  const rankCalls = authorityRankCalls.filter((call) =>
     call.arguments.length === 2 &&
     exactIdentifier(call.arguments[0], "rankOptions")
   );
@@ -1066,7 +1066,9 @@ function exactExploreGmgnMarketCapRetryContract(source) {
   const retryFunction = nearestFunctionLike(rankCalls[0]);
   return retryFunction !== null &&
     retryFunction === nearestFunctionLike(rankCalls[1]) &&
-    trendingCalls.filter((call) => nearestFunctionLike(call) === retryFunction)
+    authorityRankCalls.filter((call) =>
+      nearestFunctionLike(call) === retryFunction
+    )
       .length === 2;
 }
 
@@ -3630,7 +3632,14 @@ export function evaluateReadModelOperationsSourceContracts(
       "if (durableCacheEligible(wait))",
       "readDurablyCachedGmgnDiscoverySnapshotV1(",
       "if (durableSnapshotCurrent(durable.snapshot.fetchedAt))",
-      '["programmable-gmgn-ethereum-discovery-v2"]',
+      'export async function readGmgnEthereumMarketCapAuthorityRankV1(',
+      'type GmgnDiscoveryCacheModeV1 = "durable" | "shared-authority";',
+      'if (cacheMode === "shared-authority") {',
+      'normalized.interval !== "1h"',
+      "normalized.limit !== GMGN_TRENDING_MAXIMUM_LIMIT",
+      'normalized.orderBy !== "marketcap"',
+      "return readThroughCache(\n      discoveryCache,\n      discoveryInFlight,\n      key,\n      wait,",
+      '["programmable-gmgn-ethereum-discovery-v3"]',
       "{ revalidate: GMGN_DURABLE_CACHE_REVALIDATE_SECONDS }",
       "wait.fetchImpl === undefined",
       'return path === "/v1/market/hot_searches" ? 3 : 1;',
@@ -3726,12 +3735,12 @@ export function evaluateReadModelOperationsSourceContracts(
       "const MARKET_CAP_AUTHORITY_PUBLISH_RESERVE_MS = 3_000;",
       '"programmable.explore-market-cap-authority.v2"',
       '"programmable.explore-market-cap-authority-pin.v2"',
-      '"programmable.explore-market-cap-authority-input.v3"',
-      "EXPLORE_MARKET_CAP_AUTHORITY_COMPOSITION_POLICY_V3",
-      '"gmgn-qualified-rank+oldest-first-sentinels+cyclic-supply+same-bucket-supply-priority+cyclic-token-info+dexscreener.v3"',
-      "compositionPolicy: EXPLORE_MARKET_CAP_AUTHORITY_COMPOSITION_POLICY_V3",
+      '"programmable.explore-market-cap-authority-input.v4"',
+      "EXPLORE_MARKET_CAP_AUTHORITY_COMPOSITION_POLICY_V4",
+      '"gmgn-qualified-rank+shared-authority-fresh-read+oldest-first-sentinels+cyclic-supply+same-bucket-supply-priority+cyclic-token-info+dexscreener.v4"',
+      "compositionPolicy: EXPLORE_MARKET_CAP_AUTHORITY_COMPOSITION_POLICY_V4",
       "orderedCanonicalIdentities: entries.map((entry, index) => ({",
-      "const first = await readGmgnEthereumTrendingV1(",
+      "const first = await readGmgnEthereumMarketCapAuthorityRankV1(",
       "first !== null ||",
       "authorityDeadlineMs - Date.now() <",
       "rankOptions,",

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -987,19 +987,25 @@ describe("read-model operations source contract", () => {
     ],
     [
       "a legacy market-cap authority input policy domain",
+      '"programmable.explore-market-cap-authority-input.v4"',
       '"programmable.explore-market-cap-authority-input.v3"',
-      '"programmable.explore-market-cap-authority-input.v2"',
     ],
     [
       "an authority input detached from its composition policy",
-      "compositionPolicy: EXPLORE_MARKET_CAP_AUTHORITY_COMPOSITION_POLICY_V3",
+      "compositionPolicy: EXPLORE_MARKET_CAP_AUTHORITY_COMPOSITION_POLICY_V4",
       'compositionPolicy: "legacy-prefix-token-info"',
     ],
     [
       "a drifted market-cap authority composition policy",
-      '"gmgn-qualified-rank+oldest-first-sentinels+cyclic-supply+' +
-        'same-bucket-supply-priority+cyclic-token-info+dexscreener.v3"',
+      '"gmgn-qualified-rank+shared-authority-fresh-read+' +
+        'oldest-first-sentinels+cyclic-supply+same-bucket-supply-priority+' +
+        'cyclic-token-info+dexscreener.v4"',
       '"gmgn-prefix-token-info+dexscreener.v2"',
+    ],
+    [
+      "a market-cap authority builder detached from its fresh rank read",
+      "const first = await readGmgnEthereumMarketCapAuthorityRankV1(",
+      "const first = await readGmgnEthereumTrendingV1(",
     ],
     [
       "a non-rotating canonical supply hydration prefix",
@@ -1130,11 +1136,11 @@ describe("read-model operations source contract", () => {
     const path = "app/api/explore/route.ts";
     const route = readFileSync(resolve(ROOT, path), "utf8");
     const retry =
-      "return readGmgnEthereumTrendingV1(\n" +
+      "return readGmgnEthereumMarketCapAuthorityRankV1(\n" +
       "          rankOptions,\n" +
       "          rankWait,";
     const oppositeDirectionRetry =
-      "return readGmgnEthereumTrendingV1(\n" +
+      "return readGmgnEthereumMarketCapAuthorityRankV1(\n" +
       "          {\n" +
       "            ...rankOptions,\n" +
       "            direction: direction === \"asc\" ? \"desc\" : \"asc\",\n" +
@@ -1343,6 +1349,12 @@ describe("read-model operations source contract", () => {
       "lib/market-data/gmgn-discovery.server.ts",
       "return envelope;",
       "return envelope.data;",
+    ],
+    [
+      "a market-cap authority rank restored to stale Next SWR",
+      "lib/market-data/gmgn-discovery.server.ts",
+      'if (cacheMode === "shared-authority") {',
+      'if (cacheMode === "disabled-shared-authority") {',
     ],
     [
       "an ignored nested discovery chain",

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -166,6 +166,7 @@ vi.mock("../lib/market-data/gmgn.server", () => ({
 }));
 vi.mock("../lib/market-data/gmgn-discovery.server", () => ({
   readGmgnEthereumTrendingV1: mocks.readTrending,
+  readGmgnEthereumMarketCapAuthorityRankV1: mocks.readTrending,
   readGmgnEthereumHotSearchesV1: mocks.readHotSearches,
   readGmgnEthereumSearchV1: mocks.readSearch,
 }));
@@ -669,10 +670,12 @@ describe("Explore static identity and Dexscreener market contract", () => {
     )).toHaveLength(100);
   });
 
-  it("does not reuse a legacy v2 authority under the v3 composition policy", async () => {
+  it("does not reuse a pre-fix v3 authority under the v4 composition policy", async () => {
     const legacyInputCommitment = canonicalSha256(
-      "programmable.explore-market-cap-authority-input.v2",
+      "programmable.explore-market-cap-authority-input.v3",
       {
+        compositionPolicy:
+          "gmgn-qualified-rank+oldest-first-sentinels+cyclic-supply+same-bucket-supply-priority+cyclic-token-info+dexscreener.v3",
         orderedCanonicalIdentities: entries.map((entry, index) => ({
           index,
           id: entry.id,
@@ -691,7 +694,7 @@ describe("Explore static identity and Dexscreener market contract", () => {
     const nowMs = Date.now();
     const legacyKey = `${legacyInputCommitment}:desc`;
     durableMarketCapCacheHarness.entries.set(legacyKey, [{
-      canonicalAuthority: "legacy-v2-authority",
+      canonicalAuthority: "pre-fix-v3-authority",
       rankingCommitment: `sha256:${"11".repeat(32)}`,
       gmgnStatus: "partial",
       generatedAt: new Date(nowMs - 1_000).toISOString(),
@@ -718,7 +721,7 @@ describe("Explore static identity and Dexscreener market contract", () => {
       `${currentInputCommitment}:desc`,
     )).toBe(true);
     expect(durableMarketCapCacheHarness.entries.get(legacyKey)?.[0]
-      ?.canonicalAuthority).toBe("legacy-v2-authority");
+      ?.canonicalAuthority).toBe("pre-fix-v3-authority");
   });
 
   it("separates discovery ranking identity from observed freshness", () => {

--- a/tests/gmgn-discovery.test.ts
+++ b/tests/gmgn-discovery.test.ts
@@ -48,6 +48,7 @@ import {
 } from "../lib/market-data/gmgn-canonical-ranking";
 import {
   readGmgnEthereumHotSearchesV1,
+  readGmgnEthereumMarketCapAuthorityRankV1,
   readGmgnEthereumSearchV1,
   readGmgnEthereumTrendingV1,
 } from "../lib/market-data/gmgn-discovery.server";
@@ -1296,6 +1297,50 @@ describe("GMGN discovery server adapter", () => {
       deadlineMs: Date.now() + 5_000,
     })).resolves.toBeNull();
     expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("awaits a fresh rank inside the shared market-cap authority lease", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    const { gate } = accountGate();
+    durableCacheHarness.productionAccountGate.mockReturnValue(gate);
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(
+        rankResponse([providerToken(79, 1)]),
+      ), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(
+        rankResponse([providerToken(80, 1)]),
+      ), { status: 200 }));
+    vi.stubGlobal("fetch", fetchImpl);
+    const options = {
+      interval: "1h" as const,
+      limit: 100 as const,
+      orderBy: "marketcap" as const,
+      direction: "asc" as const,
+    };
+
+    await expect(readGmgnEthereumTrendingV1(options, {
+      deadlineMs: NOW.getTime() + 5_000,
+    })).resolves.toMatchObject({
+      tokens: [{ tokenAddress: address(79) }],
+    });
+    expect(durableCacheHarness.entries.size).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(235_001);
+    await expect(readGmgnEthereumMarketCapAuthorityRankV1(options, {
+      deadlineMs: Date.now() + 5_000,
+    })).resolves.toMatchObject({
+      tokens: [{ tokenAddress: address(80) }],
+    });
+    await expect(readGmgnEthereumMarketCapAuthorityRankV1(options, {
+      deadlineMs: Date.now() + 5_000,
+    })).resolves.toMatchObject({
+      tokens: [{ tokenAddress: address(80) }],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(durableCacheHarness.entries.size).toBe(1);
   });
 
   it("does not start a durable fill for a caller that cannot wait", async () => {


### PR DESCRIPTION
The Ethereum market-cap release gate could receive a Next.js stale-while-revalidate GMGN rank snapshot even after that snapshot exceeded the API's five-minute freshness contract. The Postgres authority builder then failed closed, so a valid GMGN Pro response could not become the shared pagination authority.

This change adds a dedicated GMGN market-cap authority read. It is restricted at runtime to the exact Ethereum 1h / 100 / marketcap / asc-or-desc request, bypasses the stale Next Data Cache path, and still uses the existing module-local singleflight, account-wide GMGN gate, request deadlines, and Postgres authority lease. The authority input domain and composition policy move to V4 so pre-fix V3 generations cannot be reused.

Validation:
- 434 focused Vitest tests passed
- 330 read-model operations contract tests passed
- 124 release smoke contract tests passed
- TypeScript passed
- ESLint passed on all changed files
- read-model operations gate passed
- git diff --check passed
- two independent read-only reviews found no P0/P1 blocker
