### PR TITLE
Fix GMGN trending cache convergence

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -2521,7 +2521,9 @@ export async function GET(request: NextRequest) {
       {
         headers: {
           "Cache-Control":
-            "public, max-age=0, s-maxage=15, stale-while-revalidate=45",
+            options.sort === "trending"
+              ? "no-store"
+              : "public, max-age=0, s-maxage=15, stale-while-revalidate=45",
           "X-Programmable-Data-Quality": dataQuality.status,
           "X-Programmable-Chain-Id": String(options.chain),
           "X-Programmable-Launch-Source": launchSource,

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -3828,6 +3828,7 @@ export function evaluateReadModelOperationsSourceContracts(
       '"X-Programmable-Search-Ranking-Commitment":',
       'searchRanking !== null && searchRanking.asOfTime !== null',
       '? "+gmgn-search"',
+      'options.sort === "trending"\n              ? "no-store"',
       'options.sort === "trending"',
       "readGmgnEthereumTrendingV1(",
       '{ interval: "1h", limit: 100 }',

--- a/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
+++ b/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
@@ -4373,6 +4373,46 @@ test("staged smoke retries the whole bounded Trending pagination once on freshne
   assert.deepEqual(Object.fromEntries(pages), { 1: 2, 2: 2, 3: 1 });
 });
 
+test("staged smoke recovers when the first Trending ranking generation drifts", async () => {
+  const allEntries = Array.from({ length: 299 }, (_, index) => entry(index));
+  const paged = pagedCatalogTransform(allEntries);
+  let attempt = 0;
+  const pages = new Map();
+  const fetchImpl = stagedFetch((input) => {
+    const body = paged(input);
+    if (
+      input.url.pathname !== "/api/explore" ||
+      input.url.searchParams.get("sort") !== "trending"
+    ) return body;
+    const page = Number(input.url.searchParams.get("page"));
+    if (page === 1) attempt += 1;
+    pages.set(page, (pages.get(page) ?? 0) + 1);
+    return {
+      ...body,
+      discovery: liveTrendingDiscovery(
+        body.discovery,
+        allEntries.length,
+        NOW,
+        attempt === 1 && page === 2
+          ? `sha256:${"12".repeat(32)}`
+          : body.discovery.rankingCommitment,
+      ),
+    };
+  }, liveTrendingHeaders);
+
+  await runStagedStaticDexscreenerSmokeV1({
+    environment: {
+      STAGED_TARGET_URL: "https://candidate.vercel.app/",
+      VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+      GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+    },
+    fetchImpl,
+    appendOutput: () => {},
+  });
+
+  assert.deepEqual(Object.fromEntries(pages), { 1: 2, 2: 2, 3: 1 });
+});
+
 test("staged smoke fails closed after two Trending ranking identity drifts", async () => {
   const allEntries = Array.from({ length: 299 }, (_, index) => entry(index));
   const paged = pagedCatalogTransform(allEntries);

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -1042,6 +1042,7 @@ describe("Explore static identity and Dexscreener market contract", () => {
     const body = await json(response);
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
     expect(body.sort).toBe("trending");
     expect(body.sortMetric).toBe("gmgn-trending");
     expect(body.total).toBe(18);
@@ -1217,6 +1218,9 @@ describe("Explore static identity and Dexscreener market contract", () => {
     const response = await GET(request("sort=newest&page=1&limit=100"));
     const body = await json(response);
     expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=0, s-maxage=15, stale-while-revalidate=45",
+    );
     expect(body.total).toBe(TOKEN_COUNT + 1);
     expect(body.catalog).toMatchObject({
       identityCount: TOKEN_COUNT + 1,


### PR DESCRIPTION
The Stage gate correctly rejected the previous candidate because separately cached Trending pages retained different GMGN ranking generations across the bounded retry. That prevented the already-working GMGN Ethereum indexer from reaching production.

This change makes successful Trending responses `no-store`, while preserving the existing edge-cache policy for Newest and Market Cap. The shared GMGN discovery cache remains in place, so provider calls stay bounded. It also adds a regression test proving that a first-attempt ranking drift restarts the full pagination and converges on the second attempt. The production smoke implementation and every GMGN fail-closed requirement remain unchanged.

Validation:
- 66 Explore API tests
- 109 Stage and post-promotion smoke tests
- TypeScript
- ESLint on all changed files
- read-model operations source gate
- `git diff --check`
- two independent reviews with no P0/P1/P2 findings
