### PR TITLE
Fix GMGN account gate lease recovery

### DIFF
--- a/lib/market-data/gmgn-account-gate.server.ts
+++ b/lib/market-data/gmgn-account-gate.server.ts
@@ -9,7 +9,12 @@ import {
 } from "../server/projection-target/website-target";
 
 const GATE_ID = "gmgn-openapi-v1" as const;
-const MAXIMUM_BLOCK_MS = 5 * 60_000;
+const MAXIMUM_PROVIDER_COOLDOWN_MS = 5 * 60_000;
+// Callers stop awaiting provider work and exact cleanup within six seconds;
+// holder/generation fencing keeps any late outcome safe. Keep nine seconds of
+// failure margin without letting a dead invocation hold scarce account-wide
+// capacity for the provider cooldown.
+const MAXIMUM_RESERVATION_LEASE_MS = 15_000;
 const MAXIMUM_TRANSACTION_MS = 2_500;
 const HISTORY_RETENTION_GENERATIONS = 256;
 // GMGN's documented account ceiling is 20 requests per second. Keep the
@@ -155,7 +160,7 @@ const RESERVE_SLOT_SQL = `
            next_slot_at = $6::timestamptz
              + ($1::integer * $4::integer * INTERVAL '1 millisecond'),
            lease_holder = $5::uuid,
-           lease_until = $7::timestamptz,
+           lease_until = GREATEST(gate.lease_until, $7::timestamptz),
            updated_at = $6::timestamptz
      WHERE gate.gate_id = $2
     RETURNING gate.gate_id, gate.generation, $6::timestamptz AS decided_at,
@@ -165,7 +170,7 @@ const RESERVE_SLOT_SQL = `
     INSERT INTO programmable_website_projection_v1.gmgn_account_gate_leases_v1 (
       gate_id, generation, lease_holder, reserved_at, lease_until
     )
-    SELECT gate_id, generation, $3::uuid, decided_at, lease_until
+    SELECT gate_id, generation, $3::uuid, decided_at, $7::timestamptz
       FROM reservation
     RETURNING gate_id, generation, lease_holder, reserved_at, lease_until
   ), pruned AS (
@@ -726,7 +731,7 @@ export class PostgresGmgnAccountGateV1 implements GmgnAccountGateV1 {
             return null;
           }
           const holder = reservationHolder();
-          const leaseUntilMs = decidedAtMs + MAXIMUM_BLOCK_MS;
+          const leaseUntilMs = decidedAtMs + MAXIMUM_RESERVATION_LEASE_MS;
           const result = await client.query<GateReservationRowV1>(
             RESERVE_SLOT_SQL,
             [
@@ -797,7 +802,7 @@ export class PostgresGmgnAccountGateV1 implements GmgnAccountGateV1 {
     ) throw new TypeError("GMGN account gate block decision is invalid");
     const localNowMs = this.#nowMs();
     const requestedUntilMs = Math.min(
-      localNowMs + MAXIMUM_BLOCK_MS,
+      localNowMs + MAXIMUM_PROVIDER_COOLDOWN_MS,
       Math.max(localNowMs, Math.ceil(input.blockedUntilMs)),
     );
     await this.#assertReady();

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -3462,6 +3462,12 @@ export function evaluateReadModelOperationsSourceContracts(
     ) &&
     includesEverySourceFragment(gmgnAccountGate, [
       'const GATE_ID = "gmgn-openapi-v1" as const',
+      "const MAXIMUM_PROVIDER_COOLDOWN_MS = 5 * 60_000",
+      "const MAXIMUM_RESERVATION_LEASE_MS = 15_000",
+      "const leaseUntilMs = decidedAtMs + MAXIMUM_RESERVATION_LEASE_MS",
+      "localNowMs + MAXIMUM_PROVIDER_COOLDOWN_MS",
+      "lease_until = GREATEST(gate.lease_until, $7::timestamptz)",
+      "SELECT gate_id, generation, $3::uuid, decided_at, $7::timestamptz",
       "lease_holder = $3::uuid",
       "lease_until = authority.decided_at + INTERVAL '5 minutes'",
       "AND gate.generation = $4::bigint",

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -1255,6 +1255,24 @@ describe("read-model operations source contract", () => {
       "lease_until = authority.decided_at",
     ],
     [
+      "a reservation lease recoupled to provider cooldown",
+      "lib/market-data/gmgn-account-gate.server.ts",
+      "const leaseUntilMs = decidedAtMs + MAXIMUM_RESERVATION_LEASE_MS",
+      "const leaseUntilMs = decidedAtMs + MAXIMUM_PROVIDER_COOLDOWN_MS",
+    ],
+    [
+      "a mixed-version reservation that shortens the global marker",
+      "lib/market-data/gmgn-account-gate.server.ts",
+      "lease_until = GREATEST(gate.lease_until, $7::timestamptz)",
+      "lease_until = $7::timestamptz",
+    ],
+    [
+      "a short reservation that inherits a longer mixed-version marker",
+      "lib/market-data/gmgn-account-gate.server.ts",
+      "SELECT gate_id, generation, $3::uuid, decided_at, $7::timestamptz",
+      "SELECT gate_id, generation, $3::uuid, decided_at, lease_until",
+    ],
+    [
       "no generation-bound stale completion guard",
       "lib/market-data/gmgn-account-gate.server.ts",
       "AND gate.generation = $2::bigint",

--- a/tests/gmgn-account-gate.test.ts
+++ b/tests/gmgn-account-gate.test.ts
@@ -673,15 +673,137 @@ describe("GMGN account gate", () => {
       }
 
       await database.exec("RESET ROLE");
-      const active = await database.query<{ count: number }>(`
-        SELECT count(*) AS count
+      const active = await database.query<{
+        count: number;
+        lease_ms: number;
+      }>(`
+        SELECT count(*) AS count,
+               ROUND(MAX(EXTRACT(EPOCH FROM
+                 (lease_until - reserved_at))) * 1000)::integer AS lease_ms
           FROM programmable_website_projection_v1.gmgn_account_gate_leases_v1
          WHERE generation = ${lease.generation}
            AND lease_holder = '${lease.holder}'
       `);
-      expect(active.rows).toEqual([{ count: 1 }]);
+      expect(active.rows).toEqual([{ count: 1, lease_ms: 15_000 }]);
     },
   );
+
+  it("reclaims an expired orphan after a failed outcome write", async () => {
+    const { database, pool } = await migratedGate();
+    const failingGate = new PostgresGmgnAccountGateV1(
+      new OutcomeFailPool(pool, "completed"),
+    );
+    const orphan = await failingGate.reserveSlot({
+      requestsPerSecond: 20,
+      deadlineMs: Date.now() + 1_000,
+    });
+    if (orphan?.kind !== "reserved") throw new Error("test lease unavailable");
+    await expect(failingGate.complete(orphan)).rejects.toThrow(
+      "injected outcome write failure",
+    );
+
+    await database.exec(`
+      RESET ROLE;
+      UPDATE programmable_website_projection_v1.gmgn_account_gate_leases_v1
+         SET reserved_at = clock_timestamp() - INTERVAL '2 seconds',
+             lease_until = clock_timestamp() - INTERVAL '1 second'
+       WHERE generation = ${orphan.generation}
+         AND lease_holder = '${orphan.holder}';
+      UPDATE programmable_website_projection_v1.gmgn_account_gate_v1
+         SET next_slot_at = TIMESTAMPTZ 'epoch',
+             lease_until = clock_timestamp() - INTERVAL '1 millisecond'
+       WHERE gate_id = 'gmgn-openapi-v1';
+      SET ROLE programmable_website_projection_runtime;
+    `);
+
+    const gate = new PostgresGmgnAccountGateV1(pool);
+    const successor = await gate.reserveSlot({
+      requestsPerSecond: 20,
+      deadlineMs: Date.now() + 1_000,
+    });
+    expect(successor?.kind).toBe("reserved");
+    if (successor?.kind !== "reserved") {
+      throw new Error("successor lease unavailable");
+    }
+    expect(successor.generation).toBe(orphan.generation + 1);
+
+    await database.exec("RESET ROLE");
+    const state = await database.query<{
+      active: number;
+      orphaned: number;
+    }>(`
+      SELECT count(*) FILTER (
+               WHERE lease_until > clock_timestamp()
+             ) AS active,
+             count(*) FILTER (
+               WHERE generation = ${orphan.generation}
+                 AND lease_holder = '${orphan.holder}'
+             ) AS orphaned
+        FROM programmable_website_projection_v1.gmgn_account_gate_leases_v1
+    `);
+    expect(state.rows).toEqual([{ active: 1, orphaned: 0 }]);
+  });
+
+  it("preserves a longer marker across a mixed-version rollout", async () => {
+    const { database, pool } = await migratedGate();
+    const gate = new PostgresGmgnAccountGateV1(pool);
+    const legacyDurationLease = await gate.reserveSlot({
+      requestsPerSecond: 20,
+      deadlineMs: Date.now() + 1_000,
+    });
+    if (legacyDurationLease?.kind !== "reserved") {
+      throw new Error("legacy-duration lease unavailable");
+    }
+
+    await database.exec(`
+      RESET ROLE;
+      UPDATE programmable_website_projection_v1.gmgn_account_gate_leases_v1
+         SET lease_until = reserved_at + INTERVAL '5 minutes'
+       WHERE generation = ${legacyDurationLease.generation}
+         AND lease_holder = '${legacyDurationLease.holder}';
+      UPDATE programmable_website_projection_v1.gmgn_account_gate_v1 AS gate
+         SET next_slot_at = TIMESTAMPTZ 'epoch',
+             lease_until = lease.lease_until
+        FROM programmable_website_projection_v1.gmgn_account_gate_leases_v1
+          AS lease
+       WHERE gate.gate_id = lease.gate_id
+         AND lease.generation = ${legacyDurationLease.generation}
+         AND lease.lease_holder = '${legacyDurationLease.holder}';
+      SET ROLE programmable_website_projection_runtime;
+    `);
+
+    const firstShortLease = await gate.reserveSlot({
+      requestsPerSecond: 20,
+      deadlineMs: Date.now() + 1_000,
+    });
+    expect(firstShortLease?.kind).toBe("reserved");
+    const secondShortLease = await gate.reserveSlot({
+      requestsPerSecond: 20,
+      deadlineMs: Date.now() + 1_000,
+    });
+    expect(secondShortLease?.kind).toBe("reserved");
+    if (
+      firstShortLease?.kind !== "reserved"
+      || secondShortLease?.kind !== "reserved"
+    ) throw new Error("mixed-version successor lease unavailable");
+
+    await database.exec("RESET ROLE");
+    const leases = await database.query<{
+      generation: number;
+      lease_ms: number;
+    }>(`
+      SELECT generation,
+             ROUND(EXTRACT(EPOCH FROM
+               (lease_until - reserved_at)) * 1000)::integer AS lease_ms
+        FROM programmable_website_projection_v1.gmgn_account_gate_leases_v1
+       ORDER BY generation
+    `);
+    expect(leases.rows).toEqual([
+      { generation: legacyDurationLease.generation, lease_ms: 300_000 },
+      { generation: firstShortLease.generation, lease_ms: 15_000 },
+      { generation: secondShortLease.generation, lease_ms: 15_000 },
+    ]);
+  });
 
   it("rejects a stale generation release without clearing the active lease", async () => {
     const { database, pool } = await migratedGate();


### PR DESCRIPTION
## Summary

- separate the 15-second multiflight reservation lease from the five-minute provider cooldown
- preserve the longest global marker during mixed-version rollout while recording each new lease with the short expiry
- prove failed-outcome reclaim, rolling compatibility, and source-contract mutation resistance

## Release context

Stage Production Candidate run 33575501147 exposed account-gate starvation after failed GMGN token-info outcome writes. The candidate was not promoted.

## Validation

- 40 GMGN account-gate tests
- 333 read-model operations contract tests
- 50 read-model operations source gates
- TypeScript typecheck
- ESLint on all four changed files