### PR TITLE
fix: harden GMGN analytics release gate

### DIFF
--- a/lib/market-data/gmgn.server.ts
+++ b/lib/market-data/gmgn.server.ts
@@ -38,6 +38,7 @@ const GMGN_MARKET_CACHE_TTL_MS = 30_000;
 const GMGN_MAXIMUM_CACHE_ENTRIES = 512;
 const GMGN_VISIBLE_MAXIMUM_ENTRY_COUNT = 100;
 const GMGN_VISIBLE_CHUNK_SIZE = 20;
+const GMGN_ACCOUNT_MAXIMUM_CONCURRENT_LEASES = 20;
 // Reserve eight account-wide leases for ranking, search, chart, and analytics
 // reads. A timed-out visible token-info fanout can otherwise occupy the entire
 // shared provider gate after its Explore response has already returned.
@@ -66,9 +67,12 @@ type GmgnProviderReadWaitV1 = Readonly<{
   fetchImpl: FetchImplementation | undefined;
   now: () => Date;
   accountGate: GmgnAccountGateV1 | undefined;
+  maximumConcurrentLeases: number;
   deadlineMs: number;
   signal: AbortSignal;
 }>;
+
+type GmgnMarketReadClassV1 = "foreground" | "visible";
 
 type ProviderOperationV1 = Pick<
   GmgnProviderReadWaitV1,
@@ -115,7 +119,7 @@ export async function readGmgnExploreSnapshotsV1(
         try {
           return [
             entry.id,
-            await readGmgnMarketSnapshotV1(entry, wait),
+            await readGmgnMarketSnapshotWithClassV1(entry, wait, "visible"),
           ] as const;
         } catch {
           return [entry.id, null] as const;
@@ -153,6 +157,14 @@ export async function readGmgnMarketSnapshotV1(
   entry: ExploreEntry,
   wait: GmgnReadWaitV1 = {},
 ): Promise<GmgnMarketSnapshotV1 | null> {
+  return readGmgnMarketSnapshotWithClassV1(entry, wait, "foreground");
+}
+
+async function readGmgnMarketSnapshotWithClassV1(
+  entry: ExploreEntry,
+  wait: GmgnReadWaitV1,
+  readClass: GmgnMarketReadClassV1,
+): Promise<GmgnMarketSnapshotV1 | null> {
   const apiKey = readApiKey();
   const canonicalSupply = canonicalSupplyV1(entry);
   const identities = exploreEntryMarketIdentitiesV1(entry);
@@ -173,10 +185,22 @@ export async function readGmgnMarketSnapshotV1(
   if (!callerCanAwaitSharedRead(wait, nowMs)) return null;
   const cached = currentCacheValue(snapshotCache, cacheKey, nowMs);
   if (cached !== undefined) return cached;
-  const active = snapshotInFlight.get(cacheKey);
+  const inFlightKey = `${readClass}:${cacheKey}`;
+  // Foreground work must never inherit the lower visible ceiling. Visible
+  // callers may safely join an already-running foreground read for the same
+  // exact identity, avoiding an unnecessary second provider lease.
+  const active = snapshotInFlight.get(inFlightKey) ??
+    (readClass === "visible"
+      ? snapshotInFlight.get(`foreground:${cacheKey}`)
+      : undefined);
   if (active) return awaitSharedReadForCaller(active, wait);
 
-  const providerWait = sharedProviderWait(wait);
+  const providerWait = sharedProviderWait(
+    wait,
+    readClass === "visible"
+      ? GMGN_VISIBLE_MAXIMUM_CONCURRENT_LEASES
+      : GMGN_ACCOUNT_MAXIMUM_CONCURRENT_LEASES,
+  );
   const providerRead = (async () => {
     const value = await gmgnJsonRequest(
       "/v1/token/info",
@@ -199,7 +223,14 @@ export async function readGmgnMarketSnapshotV1(
     (settled) => {
       if (settled === PROVIDER_OPERATION_TIMED_OUT) return null;
       const snapshot = settled;
-      if (snapshot !== null) {
+      // A visible read that started first may finish after a foreground read.
+      // Keep the foreground success already in the shared cache in that race.
+      const current = currentCacheValue(
+        snapshotCache,
+        cacheKey,
+        providerWait.now().getTime(),
+      );
+      if (snapshot !== null && (readClass === "foreground" || current === undefined)) {
         setCacheValue(
           snapshotCache,
           cacheKey,
@@ -210,11 +241,11 @@ export async function readGmgnMarketSnapshotV1(
       return snapshot;
     },
   ).catch(() => null).finally(() => {
-    if (snapshotInFlight.get(cacheKey) === promise) {
-      snapshotInFlight.delete(cacheKey);
+    if (snapshotInFlight.get(inFlightKey) === promise) {
+      snapshotInFlight.delete(inFlightKey);
     }
   });
-  snapshotInFlight.set(cacheKey, promise);
+  snapshotInFlight.set(inFlightKey, promise);
   return awaitSharedReadForCaller(promise, wait);
 }
 
@@ -414,7 +445,7 @@ async function gmgnJsonRequest(
     if (accountGate !== null) {
       const decision = await reserveProviderSlot(accountGate, {
         requestsPerSecond: gmgnEffectiveRequestsPerSecondV1(),
-        maximumConcurrentLeases: GMGN_VISIBLE_MAXIMUM_CONCURRENT_LEASES,
+        maximumConcurrentLeases: wait.maximumConcurrentLeases,
         deadlineMs: gateDeadlineMs,
         signal: gateSignal,
       }, gateOperation);
@@ -633,13 +664,17 @@ function currentTimestampMs(now: () => Date, minimumMs: number): number {
   return Number.isFinite(value) ? Math.max(minimumMs, value) : minimumMs;
 }
 
-function sharedProviderWait(wait: GmgnReadWaitV1): GmgnProviderReadWaitV1 {
+function sharedProviderWait(
+  wait: GmgnReadWaitV1,
+  maximumConcurrentLeases: number,
+): GmgnProviderReadWaitV1 {
   const now = wait.now ?? (() => new Date());
   const startedAtMs = now().getTime();
   return {
     fetchImpl: wait.fetchImpl,
     now,
     accountGate: wait.accountGate,
+    maximumConcurrentLeases,
     deadlineMs: Number.isFinite(startedAtMs)
       ? startedAtMs + GMGN_PROVIDER_WORK_TIMEOUT_MS
       : Date.now() + GMGN_PROVIDER_WORK_TIMEOUT_MS,

--- a/scripts/perf/read-model-ops-source-contracts.mjs
+++ b/scripts/perf/read-model-ops-source-contracts.mjs
@@ -3368,11 +3368,38 @@ export function evaluateReadModelOperationsSourceContracts(
       "const GMGN_RESPONSE_MAXIMUM_BYTES = 1_000_000",
       "const GMGN_VISIBLE_MAXIMUM_ENTRY_COUNT = 100",
       "const GMGN_VISIBLE_CHUNK_SIZE = 20",
+      "const GMGN_ACCOUNT_MAXIMUM_CONCURRENT_LEASES = 20",
       "const GMGN_VISIBLE_MAXIMUM_CONCURRENT_LEASES = 12",
+      'type GmgnMarketReadClassV1 = "foreground" | "visible"',
       "entries.slice(0, GMGN_VISIBLE_MAXIMUM_ENTRY_COUNT)",
       "offset += GMGN_VISIBLE_CHUNK_SIZE",
       "boundedEntries.slice(offset, offset + GMGN_VISIBLE_CHUNK_SIZE)",
       "gmgnVisibleMarketConcurrencyV1(chunk.length)",
+      'await readGmgnMarketSnapshotWithClassV1(entry, wait, "visible")',
+      'return readGmgnMarketSnapshotWithClassV1(entry, wait, "foreground")',
+      "const cached = currentCacheValue(snapshotCache, cacheKey, nowMs)",
+      'const inFlightKey = `${readClass}:${cacheKey}`',
+      "const active = snapshotInFlight.get(inFlightKey) ??",
+      'readClass === "visible"\n' +
+        '      ? snapshotInFlight.get(`foreground:${cacheKey}`)\n' +
+        "      : undefined",
+      'readClass === "visible"\n' +
+        "      ? GMGN_VISIBLE_MAXIMUM_CONCURRENT_LEASES\n" +
+        "      : GMGN_ACCOUNT_MAXIMUM_CONCURRENT_LEASES",
+      "maximumConcurrentLeases: wait.maximumConcurrentLeases",
+      "const current = currentCacheValue(\n" +
+        "        snapshotCache,\n" +
+        "        cacheKey,\n" +
+        "        providerWait.now().getTime(),\n" +
+        "      )",
+      'snapshot !== null && (readClass === "foreground" || current === undefined)',
+      "setCacheValue(\n" +
+        "          snapshotCache,\n" +
+        "          cacheKey,\n" +
+        "          snapshot,",
+      "snapshotInFlight.get(inFlightKey) === promise",
+      "snapshotInFlight.delete(inFlightKey)",
+      "snapshotInFlight.set(inFlightKey, promise)",
       "gmgnEffectiveRequestsPerSecondV1()",
       "gmgnVisibleMarketEntryEligibleV1(",
       "canonicalIdentities?.length === 1",
@@ -3410,7 +3437,6 @@ export function evaluateReadModelOperationsSourceContracts(
       "return settled !== PROVIDER_OPERATION_TIMED_OUT;",
       "if (!callerCanAwaitSharedRead(wait, nowMs)) return null;",
       "if (active) return awaitSharedReadForCaller(active, wait);",
-      "if (snapshot !== null) {",
       "!hasExactOptionalEthereumChain(response)",
       "!hasExactOptionalEthereumChain(data)",
       "return value;",
@@ -4509,6 +4535,10 @@ export function evaluateReadModelOperationsSourceContracts(
         'targetKind === "staged" ? waitForStagedRetryAfter : null',
         "const EXPLORE_SNAPSHOT_ATTEMPTS = 3",
         "const EXPLORE_SNAPSHOT_RETRY_DELAY_MS = 16_000",
+        "const GMGN_ANALYTICS_ATTEMPTS = 2",
+        "const GMGN_ANALYTICS_RECOVERY_DELAY_MS = 16_000",
+        "const GMGN_ANALYTICS_PARTIAL_SUMMARY_RECOVERY_DELAY_MS = 46_000",
+        'const ANALYTICS_STATUSES = new Set(["ready", "partial", "unavailable"])',
         "class ExploreCatalogBoundaryDriftError extends Error",
         "class ExploreMarketCapSnapshotDriftError extends Error",
         "snapshotAttempt < EXPLORE_SNAPSHOT_ATTEMPTS",
@@ -4593,10 +4623,57 @@ export function evaluateReadModelOperationsSourceContracts(
         "!matchedIdentities.includes(targetIdentity)",
         "async function readRequiredGmgnAnalytics({",
         'for (const section of ["summary", "holders", "traders"])',
+        "function acceptableAnalyticsIdentity(value, expected, status)",
+        "if (sameAnalyticsIdentity(value, expected)) return true",
+        'return status === "unavailable" && value === null',
+        "function exactSummaryAnalyticsProjection(body, identity, nowMs)",
+        'const expectedCount = body.status === "ready"\n' +
+          "    ? 2\n" +
+          '    : body.status === "partial"\n' +
+          "      ? 1\n" +
+          "      : 0",
+        "count === expectedCount",
+        "function exactRankingAnalyticsProjection(body, nowMs)",
+        'if (body.status === "unavailable") return ranking === null',
+        'if (body.status !== "ready") return false',
+        'const unavailable = status === "unavailable"',
+        'const expectedCache = unavailable\n    ? new Set(["no-store"])',
+        'const launchSources = new Set(launchSource.split("+"))',
+        "const operationalReadStatusesAreValid =",
+        '(launchSources.has("envio-classic-v3")\n' +
+          "      ? CATALOG_STATUSES.has(canonicalReadStatus)\n" +
+          '      : canonicalReadStatus === "unavailable")',
+        '(launchSources.has("canonical-launch-stamp-router")\n' +
+          "      ? CATALOG_STATUSES.has(routerReadStatus)\n" +
+          '      : routerReadStatus === "unavailable")',
+        "operationalReadStatusesAreValid",
+        "exactIsoTimestamp(lastIndexedAt)",
+        "exactIsoTimestamp(minimumLastIndexedAt)",
+        "Date.parse(lastIndexedAt) >= Date.parse(minimumLastIndexedAt)",
+        'response.headers.get("x-programmable-analytics-read-status") === status',
+        'response.headers.get("x-programmable-market-source") ===\n      (unavailable ? null : "gmgn")',
+        "!ANALYTICS_STATUSES.has(body.status)",
+        "!acceptableAnalyticsIdentity(body.identity, identity, body.status)",
+        "let minimumAnalyticsLastIndexedAt = lastIndexedAt",
+        "minimumAnalyticsLastIndexedAt,",
+        'minimumAnalyticsLastIndexedAt = response.headers.get(\n' +
+          '        "x-programmable-identity-last-indexed-at",\n' +
+          "      )",
+        "!exactSummaryAnalyticsProjection(body, identity, now().getTime())",
+        "!exactRankingAnalyticsProjection(body, now().getTime())",
+        'if (body.status === "ready") break',
+        "attempt === GMGN_ANALYTICS_ATTEMPTS - 1",
+        'const recoveryDelayMs = section === "summary" && body.status === "partial"',
+        "? GMGN_ANALYTICS_PARTIAL_SUMMARY_RECOVERY_DELAY_MS\n" +
+          "        : GMGN_ANALYTICS_RECOVERY_DELAY_MS",
+        "await waitForGmgnAnalyticsRecovery(recoveryDelayMs)",
+        'body === null || body.status !== "ready"',
+        "input.waitForGmgnAnalyticsRecovery ?? sleep",
+        'throw new Error("GMGN analytics recovery wait is invalid")',
         '"private, max-age=0, no-store"',
         "ANALYTICS_WALLET_KEYS",
-        "canonicalMarketAddress(wallet.address) !== wallet.address",
-        'pool.exchange !== "uniswap_v4"',
+        "canonicalMarketAddress(wallet.address) === wallet.address",
+        'pool.exchange === "uniswap_v4"',
         "analyticsSummaryStatus = analytics.summary",
         "`discovery_ranking_commitment=${trendingDiscovery.rankingCommitment}`",
         "`discovery_consistency=${trendingDiscoveryConsistency}`",

--- a/scripts/smoke-static-dexscreener-public-apis.mjs
+++ b/scripts/smoke-static-dexscreener-public-apis.mjs
@@ -50,6 +50,13 @@ const EXPLORE_MARKET_PROVIDERS = new Set([
 const EXPLORE_SNAPSHOT_ATTEMPTS = 3;
 const EXPLORE_SNAPSHOT_RETRY_DELAY_MS = 16_000;
 const STAGED_503_RETRY_AFTER_MAXIMUM_MS = 5_000;
+const GMGN_ANALYTICS_ATTEMPTS = 2;
+// New multiflight reservations expire after 15 seconds. The extra second keeps
+// the retry beyond the lease boundary even with timer and scheduling skew.
+const GMGN_ANALYTICS_RECOVERY_DELAY_MS = 16_000;
+// A partial summary may be served for 15 seconds and stale-revalidated for a
+// further 30 seconds. Retry only after that entire public cache window.
+const GMGN_ANALYTICS_PARTIAL_SUMMARY_RECOVERY_DELAY_MS = 46_000;
 const VISIBLE_EXPLORE_PAGE_SIZE = 9;
 const TRENDING_EXPLORE_PAGE_SIZE = 100;
 const TRENDING_EXPLORE_MAXIMUM_PAGES = 100;
@@ -64,6 +71,7 @@ const MARKET_CAP_RANKING_SEPARATE_KEYS = new Set([
 const GMGN_CANONICAL_SCAN_MAXIMUM_PAGES = 8;
 const PROVIDER_RECENT_MAXIMUM_AGE_MS = 5 * 60_000;
 const MINIMUM_FDV_LIQUIDITY_USD_WAD = 10_000n * 10n ** 18n;
+const ANALYTICS_STATUSES = new Set(["ready", "partial", "unavailable"]);
 
 class ExploreCatalogBoundaryDriftError extends Error {
   constructor(message) {
@@ -1976,27 +1984,51 @@ function sameAnalyticsIdentity(value, expected) {
     value.quoteAddress === expected.quoteAddress;
 }
 
+function acceptableAnalyticsIdentity(value, expected, status) {
+  if (sameAnalyticsIdentity(value, expected)) return true;
+  return status === "unavailable" && value === null;
+}
+
 function exactAnalyticsHeaders(
-  response, status, section, launchSource, lastIndexedAt, referenceHeaders,
+  response, status, section, launchSource, minimumLastIndexedAt,
 ) {
   const cache = response.headers.get("cache-control");
-  const expectedCache = section === "summary"
-    ? new Set([
-        "public, max-age=0, s-maxage=15, stale-while-revalidate=30",
-        "public, max-age=0",
-      ])
-    : new Set(["private, max-age=0, no-store"]);
+  const unavailable = status === "unavailable";
+  const expectedCache = unavailable
+    ? new Set(["no-store"])
+    : section === "summary"
+      ? new Set([
+          "public, max-age=0, s-maxage=15, stale-while-revalidate=30",
+          "public, max-age=0",
+        ])
+      : new Set(["private, max-age=0, no-store"]);
+  const lastIndexedAt = response.headers.get(
+    "x-programmable-identity-last-indexed-at",
+  );
+  const canonicalReadStatus = response.headers.get(
+    "x-programmable-canonical-read-status",
+  );
+  const routerReadStatus = response.headers.get(
+    "x-programmable-router-read-status",
+  );
+  const launchSources = new Set(launchSource.split("+"));
+  const operationalReadStatusesAreValid =
+    (launchSources.has("envio-classic-v3")
+      ? CATALOG_STATUSES.has(canonicalReadStatus)
+      : canonicalReadStatus === "unavailable") &&
+    (launchSources.has("canonical-launch-stamp-router")
+      ? CATALOG_STATUSES.has(routerReadStatus)
+      : routerReadStatus === "unavailable");
   return expectedCache.has(cache) &&
     response.headers.get("x-content-type-options") === "nosniff" &&
     response.headers.get("referrer-policy") === "no-referrer" &&
     response.headers.get("x-programmable-chain-id") === "1" &&
     response.headers.get("x-programmable-launch-source") === launchSource &&
     response.headers.get("x-programmable-read-source") === `${launchSource}+gmgn` &&
-    response.headers.get("x-programmable-identity-last-indexed-at") === lastIndexedAt &&
-    response.headers.get("x-programmable-canonical-read-status") ===
-      referenceHeaders.get("x-programmable-canonical-read-status") &&
-    response.headers.get("x-programmable-router-read-status") ===
-      referenceHeaders.get("x-programmable-router-read-status") &&
+    exactIsoTimestamp(lastIndexedAt) &&
+    exactIsoTimestamp(minimumLastIndexedAt) &&
+    Date.parse(lastIndexedAt) >= Date.parse(minimumLastIndexedAt) &&
+    operationalReadStatusesAreValid &&
     response.headers.get("x-programmable-analytics-provider") === "gmgn" &&
     response.headers.get("x-programmable-analytics-scope") === "token" &&
     response.headers.get("x-programmable-analytics-pool-attribution") ===
@@ -2007,7 +2039,8 @@ function exactAnalyticsHeaders(
       (status === "ready" ? "complete" : status) &&
     response.headers.get("x-programmable-data-quality") ===
       (status === "ready" ? "current" : status) &&
-    response.headers.get("x-programmable-market-source") === "gmgn" &&
+    response.headers.get("x-programmable-market-source") ===
+      (unavailable ? null : "gmgn") &&
     response.headers.get("x-programmable-market-as-of") === null &&
     response.headers.get("x-programmable-price-source") === null &&
     response.headers.get("x-programmable-valuation-block") === null &&
@@ -2072,120 +2105,151 @@ function exactPublicSecurityTypes(security) {
     );
 }
 
+function exactSummaryAnalyticsProjection(body, identity, nowMs) {
+  const security = body.analytics?.security;
+  const pool = body.analytics?.pool;
+  const count = Number(security !== null) + Number(pool !== null);
+  const expectedCount = body.status === "ready"
+    ? 2
+    : body.status === "partial"
+      ? 1
+      : 0;
+  return exactObjectKeys(body.analytics, ["pool", "security"]) &&
+    count === expectedCount &&
+    (security === null || (
+      exactObjectKeys(security, ANALYTICS_SECURITY_KEYS) &&
+      security.schemaVersion === "programmable.gmgn-token-security.v1" &&
+      security.source === "gmgn" &&
+      currentProviderTimestamp(security.fetchedAt, nowMs) &&
+      canonicalMarketAddress(security.tokenAddress) === security.tokenAddress &&
+      security.tokenAddress === identity.tokenAddress &&
+      sameAnalyticsIdentity(security.identity, identity) &&
+      Array.isArray(security.flags) && security.flags.length <= 64 &&
+      exactPublicSecurityTypes(security) &&
+      (security.lockSummary === null || (
+        exactObjectKeys(security.lockSummary, [
+          "details", "isLocked", "lockRatio", "remainingLockRatio",
+        ]) && Array.isArray(security.lockSummary.details) &&
+        typeof security.lockSummary.isLocked === "boolean" &&
+        publicRatio(security.lockSummary.lockRatio) &&
+        publicRatio(security.lockSummary.remainingLockRatio) &&
+        security.lockSummary.details.length <= 256 &&
+        security.lockSummary.details.every((detail) =>
+          exactObjectKeys(detail, ["isBlackhole", "poolAddress", "ratio"]) &&
+          typeof detail.isBlackhole === "boolean" &&
+          canonicalMarketAddress(detail.poolAddress) === detail.poolAddress &&
+          publicRatio(detail.ratio)
+        )
+      ))
+    )) &&
+    (pool === null || (
+      exactObjectKeys(pool, ANALYTICS_POOL_KEYS) &&
+      pool.schemaVersion === "programmable.gmgn-token-pool-info.v1" &&
+      pool.source === "gmgn" && pool.currency === "USD" &&
+      pool.marketScope === "token" &&
+      pool.poolAttribution === "unavailable" &&
+      currentProviderTimestamp(pool.fetchedAt, nowMs) &&
+      sameAnalyticsIdentity(pool.identity, identity) &&
+      canonicalMarketAddress(pool.tokenAddress) === pool.tokenAddress &&
+      pool.tokenAddress === identity.tokenAddress &&
+      canonicalMarketAddress(pool.providerAddress) === pool.providerAddress &&
+      pool.providerAddress === identity.tokenAddress &&
+      canonicalMarketAddress(pool.baseAddress) === pool.baseAddress &&
+      pool.baseAddress === identity.tokenAddress &&
+      canonicalMarketAddress(pool.quoteAddress) === pool.quoteAddress &&
+      pool.quoteAddress === identity.quoteAddress &&
+      pool.exchange === "uniswap_v4" &&
+      [pool.token0Address, pool.token1Address].every((value) =>
+        canonicalMarketAddress(value) === value
+      ) &&
+      new Set([pool.token0Address, pool.token1Address]).size === 2 &&
+      [pool.token0Address, pool.token1Address].includes(identity.tokenAddress) &&
+      [pool.token0Address, pool.token1Address].includes(identity.quoteAddress) &&
+      [pool.liquidityUsd, pool.baseReserve, pool.quoteReserve].every(publicDecimal) &&
+      [
+        pool.baseReserveValueUsd, pool.quoteReserveValueUsd,
+        pool.initialLiquidityUsd, pool.initialBaseReserve,
+        pool.initialQuoteReserve, pool.priceUsd,
+      ].every(nullablePublicDecimal) &&
+      nullablePublicRatio(pool.feeRatio) &&
+      Number.isSafeInteger(pool.creationTimestamp) &&
+      pool.creationTimestamp >= 0 &&
+      (pool.quoteSymbol === null ||
+        (typeof pool.quoteSymbol === "string" && pool.quoteSymbol.length <= 64))
+    ));
+}
+
+function exactRankingAnalyticsProjection(body, nowMs) {
+  if (!exactObjectKeys(body.analytics, ["ranking"])) return false;
+  const ranking = body.analytics.ranking;
+  if (body.status === "unavailable") return ranking === null;
+  if (body.status !== "ready") return false;
+  return exactObjectKeys(ranking, ["fetchedAt", "wallets"]) &&
+    currentProviderTimestamp(ranking.fetchedAt, nowMs) &&
+    Array.isArray(ranking.wallets) && ranking.wallets.length <= 20 &&
+    ranking.wallets.every((wallet) =>
+      exactObjectKeys(wallet, ANALYTICS_WALLET_KEYS) &&
+      canonicalMarketAddress(wallet.address) === wallet.address &&
+      Object.entries(wallet).every(([key, value]) =>
+        key === "address" || finiteNullable(value)
+      )
+    );
+}
+
 async function readRequiredGmgnAnalytics({
   request, tokenAddress, identity, catalogBoundary, lastIndexedAt,
-  referenceHeaders, now,
+  waitForGmgnAnalyticsRecovery, now,
 }) {
   const reads = {};
+  let minimumAnalyticsLastIndexedAt = lastIndexedAt;
   for (const section of ["summary", "holders", "traders"]) {
     const suffix = section === "summary" ? "" : "&limit=20";
-    const response = await request(
-      `/api/explore/token/analytics?chain=1&address=${encodeURIComponent(tokenAddress)}` +
-        `&section=${section}${suffix}`,
-    );
-    const body = response.body;
-    if (
-      response.status !== 200 ||
-      !exactObjectKeys(body, [
-        "analytics", "analyticsScope", "identity", "poolAttribution",
-        "provider", "schemaVersion", "section", "status",
-      ]) ||
-      body.schemaVersion !== "programmable.token-analytics.v1" ||
-      body.provider !== "gmgn" || body.analyticsScope !== "token" ||
-      body.poolAttribution !== "unavailable" || body.section !== section ||
-      !sameAnalyticsIdentity(body.identity, identity) ||
-      !exactAnalyticsHeaders(
-        response, body.status, section, catalogBoundary.launchSource,
-        lastIndexedAt, referenceHeaders,
-      )
-    ) throw new Error(`GMGN ${section} analytics envelope is invalid`);
-
-    if (section === "summary") {
-      const security = body.analytics?.security;
-      const pool = body.analytics?.pool;
-      const count = Number(security !== null) + Number(pool !== null);
+    let body = null;
+    for (let attempt = 0; attempt < GMGN_ANALYTICS_ATTEMPTS; attempt += 1) {
+      const response = await request(
+        `/api/explore/token/analytics?chain=1&address=${encodeURIComponent(tokenAddress)}` +
+          `&section=${section}${suffix}`,
+      );
+      body = response.body;
       if (
-        !exactObjectKeys(body.analytics, ["pool", "security"]) ||
-        body.status !== "ready" || count !== 2 ||
-        (security !== null && (
-          !exactObjectKeys(security, ANALYTICS_SECURITY_KEYS) ||
-          security.schemaVersion !== "programmable.gmgn-token-security.v1" ||
-          security.source !== "gmgn" ||
-          !currentProviderTimestamp(security.fetchedAt, now().getTime()) ||
-          canonicalMarketAddress(security.tokenAddress) !== security.tokenAddress ||
-          security.tokenAddress !== identity.tokenAddress ||
-          !sameAnalyticsIdentity(security.identity, identity) ||
-          !Array.isArray(security.flags) || security.flags.length > 64 ||
-          !exactPublicSecurityTypes(security) ||
-          (security.lockSummary !== null && (
-            !exactObjectKeys(security.lockSummary, [
-              "details", "isLocked", "lockRatio", "remainingLockRatio",
-            ]) || !Array.isArray(security.lockSummary.details) ||
-            typeof security.lockSummary.isLocked !== "boolean" ||
-            !publicRatio(security.lockSummary.lockRatio) ||
-            !publicRatio(security.lockSummary.remainingLockRatio) ||
-            security.lockSummary.details.length > 256 ||
-            security.lockSummary.details.some((detail) =>
-              !exactObjectKeys(detail, ["isBlackhole", "poolAddress", "ratio"]) ||
-              typeof detail.isBlackhole !== "boolean" ||
-              canonicalMarketAddress(detail.poolAddress) !== detail.poolAddress ||
-              !publicRatio(detail.ratio)
-            )
-          ))
-        )) ||
-        (pool !== null && (
-          !exactObjectKeys(pool, ANALYTICS_POOL_KEYS) ||
-          pool.schemaVersion !== "programmable.gmgn-token-pool-info.v1" ||
-          pool.source !== "gmgn" || pool.currency !== "USD" ||
-          pool.marketScope !== "token" ||
-          pool.poolAttribution !== "unavailable" ||
-          !currentProviderTimestamp(pool.fetchedAt, now().getTime()) ||
-          !sameAnalyticsIdentity(pool.identity, identity) ||
-          canonicalMarketAddress(pool.tokenAddress) !== pool.tokenAddress ||
-          pool.tokenAddress !== identity.tokenAddress ||
-          canonicalMarketAddress(pool.providerAddress) !==
-            pool.providerAddress ||
-          pool.providerAddress !== identity.tokenAddress ||
-          canonicalMarketAddress(pool.baseAddress) !== pool.baseAddress ||
-          pool.baseAddress !== identity.tokenAddress ||
-          canonicalMarketAddress(pool.quoteAddress) !== pool.quoteAddress ||
-          pool.quoteAddress !== identity.quoteAddress ||
-          pool.exchange !== "uniswap_v4" ||
-          ![pool.token0Address, pool.token1Address].every((value) =>
-            canonicalMarketAddress(value) === value
-          ) ||
-          new Set([pool.token0Address, pool.token1Address]).size !== 2 ||
-          ![pool.token0Address, pool.token1Address].includes(identity.tokenAddress) ||
-          ![pool.token0Address, pool.token1Address].includes(identity.quoteAddress) ||
-          ![pool.liquidityUsd, pool.baseReserve, pool.quoteReserve].every(publicDecimal) ||
-          ![
-            pool.baseReserveValueUsd, pool.quoteReserveValueUsd,
-            pool.initialLiquidityUsd, pool.initialBaseReserve,
-            pool.initialQuoteReserve, pool.priceUsd,
-          ].every(nullablePublicDecimal) ||
-          !nullablePublicRatio(pool.feeRatio) ||
-          !Number.isSafeInteger(pool.creationTimestamp) || pool.creationTimestamp < 0 ||
-          !(pool.quoteSymbol === null ||
-            (typeof pool.quoteSymbol === "string" && pool.quoteSymbol.length <= 64))
-        ))
-      ) throw new Error("GMGN summary analytics projection is invalid");
-    } else {
-      const ranking = body.analytics?.ranking;
-      if (
-        body.status !== "ready" ||
-        !exactObjectKeys(body.analytics, ["ranking"]) ||
-        !exactObjectKeys(ranking, ["fetchedAt", "wallets"]) ||
-        !currentProviderTimestamp(ranking.fetchedAt, now().getTime()) ||
-        !Array.isArray(ranking.wallets) || ranking.wallets.length > 20 ||
-        ranking.wallets.some((wallet) =>
-          !exactObjectKeys(wallet, ANALYTICS_WALLET_KEYS) ||
-          canonicalMarketAddress(wallet.address) !== wallet.address ||
-          Object.entries(wallet).some(([key, value]) =>
-            key !== "address" && !finiteNullable(value)
-          )
+        response.status !== 200 ||
+        !exactObjectKeys(body, [
+          "analytics", "analyticsScope", "identity", "poolAttribution",
+          "provider", "schemaVersion", "section", "status",
+        ]) ||
+        body.schemaVersion !== "programmable.token-analytics.v1" ||
+        body.provider !== "gmgn" || body.analyticsScope !== "token" ||
+        body.poolAttribution !== "unavailable" || body.section !== section ||
+        !ANALYTICS_STATUSES.has(body.status) ||
+        !acceptableAnalyticsIdentity(body.identity, identity, body.status) ||
+        !exactAnalyticsHeaders(
+          response, body.status, section, catalogBoundary.launchSource,
+          minimumAnalyticsLastIndexedAt,
         )
-      ) throw new Error(`GMGN ${section} ranking projection is invalid`);
+      ) throw new Error(`GMGN ${section} analytics envelope is invalid`);
+      minimumAnalyticsLastIndexedAt = response.headers.get(
+        "x-programmable-identity-last-indexed-at",
+      );
+      if (section === "summary") {
+        if (!exactSummaryAnalyticsProjection(body, identity, now().getTime())) {
+          throw new Error("GMGN summary analytics projection is invalid");
+        }
+      } else if (!exactRankingAnalyticsProjection(body, now().getTime())) {
+        throw new Error(`GMGN ${section} ranking projection is invalid`);
+      }
+      if (body.status === "ready") break;
+      if (attempt === GMGN_ANALYTICS_ATTEMPTS - 1) {
+        throw new Error(`GMGN ${section} analytics is required`);
+      }
+      const recoveryDelayMs = section === "summary" && body.status === "partial"
+        ? GMGN_ANALYTICS_PARTIAL_SUMMARY_RECOVERY_DELAY_MS
+        : GMGN_ANALYTICS_RECOVERY_DELAY_MS;
+      await waitForGmgnAnalyticsRecovery(recoveryDelayMs);
     }
+    if (body === null || body.status !== "ready") {
+      throw new Error(`GMGN ${section} analytics retry contract is unreachable`);
+    }
+
     reads[section] = body.status;
   }
   return reads;
@@ -2197,12 +2261,17 @@ export async function runStagedStaticDexscreenerSmokeV1(input = {}) {
   const appendOutput = input.appendOutput ?? appendFileSync;
   const waitForCatalogConvergence = input.waitForCatalogConvergence ?? sleep;
   const waitForStagedRetryAfter = input.waitForStagedRetryAfter ?? sleep;
+  const waitForGmgnAnalyticsRecovery =
+    input.waitForGmgnAnalyticsRecovery ?? sleep;
   const now = input.now ?? (() => new Date());
   if (typeof waitForCatalogConvergence !== "function") {
     throw new Error("Explore catalog convergence wait is invalid");
   }
   if (typeof waitForStagedRetryAfter !== "function") {
     throw new Error("Public API staged Retry-After wait is invalid");
+  }
+  if (typeof waitForGmgnAnalyticsRecovery !== "function") {
+    throw new Error("GMGN analytics recovery wait is invalid");
   }
   if (typeof now !== "function" || !Number.isFinite(now().getTime())) {
     throw new Error("Public API smoke clock is invalid");
@@ -2858,7 +2927,7 @@ export async function runStagedStaticDexscreenerSmokeV1(input = {}) {
       identity: chartIdentity,
       catalogBoundary,
       lastIndexedAt: highest.body.catalog.lastIndexedAt,
-      referenceHeaders: highest.headers,
+      waitForGmgnAnalyticsRecovery,
       now,
     });
     analyticsSummaryStatus = analytics.summary;

--- a/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
+++ b/scripts/test/smoke-static-dexscreener-public-apis.test.mjs
@@ -1028,8 +1028,61 @@ function gmgnStagedFetch(options = {}) {
   const visibleNewestFetchedAt = options.visibleNewestFetchedAt ?? NOW;
   const visibleFallbackObservedCount =
     options.visibleFallbackObservedCount ?? 0;
+  const catalogBoundary = options.catalogBoundary;
+  const fixtureCatalog = catalogBoundary?.catalog;
+  const catalogLaunchSource = fixtureCatalog?.launchSource ??
+    "envio-classic-v3";
+  const catalogCanonicalReadStatus = fixtureCatalog?.completeness?.classic ??
+    "last-known-good";
+  const catalogRouterReadStatus = fixtureCatalog?.completeness?.routerCustom ??
+    "unavailable";
+  const catalogLastIndexedAt = fixtureCatalog?.lastIndexedAt ?? NOW;
+  const withCatalogBoundary = (body, url) => {
+    if (catalogBoundary === undefined || body?.catalog === undefined) {
+      return body;
+    }
+    return {
+      ...body,
+      ...(url.pathname === "/api/explore" &&
+          catalogBoundary.launchIdentity !== undefined
+        ? {
+            dataQuality: {
+              ...body.dataQuality,
+              launchIdentity: catalogBoundary.launchIdentity,
+            },
+          }
+        : {}),
+      catalog: fixtureCatalog,
+    };
+  };
+  const withCatalogHeaders = (
+    extraHeaders,
+    readSource,
+    lastIndexedAt = catalogLastIndexedAt,
+  ) => ({
+    ...extraHeaders,
+    "x-programmable-launch-source": catalogLaunchSource,
+    "x-programmable-read-source": readSource,
+    "x-programmable-canonical-read-status": catalogCanonicalReadStatus,
+    "x-programmable-router-read-status": catalogRouterReadStatus,
+    "x-programmable-identity-last-indexed-at": lastIndexedAt,
+  });
+  const analyticsResponseCounts = new Map();
+  const analyticsStatusAt = (section, responseIndex) => {
+    const sequence = options.analyticsStatusSequence?.[section];
+    return Array.isArray(sequence) && sequence.length > 0
+      ? sequence[Math.min(responseIndex, sequence.length - 1)]
+      : "ready";
+  };
+  const analyticsLastIndexedAtAt = (section, responseIndex) => {
+    const sequence = options.analyticsLastIndexedAtSequence?.[section];
+    return Array.isArray(sequence) && sequence.length > 0
+      ? sequence[Math.min(responseIndex, sequence.length - 1)]
+      : options.analyticsLastIndexedAt ?? NOW;
+  };
   return stagedFetch(
-    ({ body, url }) => {
+    ({ body: initialBody, url }) => {
+      const body = withCatalogBoundary(initialBody, url);
       if (
         url.pathname === "/api/explore" &&
         url.searchParams.get("sort") === "trending"
@@ -1125,11 +1178,26 @@ function gmgnStagedFetch(options = {}) {
       }
       if (url.pathname === "/api/explore/token/analytics") {
         const section = url.searchParams.get("section") ?? "summary";
+        const responseIndex = analyticsResponseCounts.get(section) ?? 0;
+        analyticsResponseCounts.set(section, responseIndex + 1);
+        const status = analyticsStatusAt(section, responseIndex);
         const identity = body.identity;
+        if (status === "unavailable") {
+          const value = {
+            ...body,
+            status,
+            ...(Object.hasOwn(options, "analyticsUnavailableIdentity")
+              ? { identity: options.analyticsUnavailableIdentity }
+              : {}),
+          };
+          return typeof options.mutateGmgnAnalytics === "function"
+            ? options.mutateGmgnAnalytics(value, section, responseIndex)
+            : value;
+        }
         if (section !== "summary") {
           const value = {
             ...body,
-            status: "ready",
+            status,
             analytics: {
               ranking: {
                 fetchedAt: NOW,
@@ -1146,12 +1214,12 @@ function gmgnStagedFetch(options = {}) {
             },
           };
           return typeof options.mutateGmgnAnalytics === "function"
-            ? options.mutateGmgnAnalytics(value, section)
+            ? options.mutateGmgnAnalytics(value, section, responseIndex)
             : value;
         }
         const value = {
           ...body,
-          status: "ready",
+          status,
           analytics: {
             security: {
               schemaVersion: "programmable.gmgn-token-security.v1",
@@ -1189,9 +1257,19 @@ function gmgnStagedFetch(options = {}) {
             },
           },
         };
-        return typeof options.mutateGmgnAnalytics === "function"
-          ? options.mutateGmgnAnalytics(value, section)
+        const projectedValue = status === "partial"
+          ? {
+              ...value,
+              analytics: { ...value.analytics, pool: null },
+            }
           : value;
+        return typeof options.mutateGmgnAnalytics === "function"
+          ? options.mutateGmgnAnalytics(
+              projectedValue,
+              section,
+              responseIndex,
+            )
+          : projectedValue;
       }
       if (
         url.pathname === "/api/explore/token/chart" &&
@@ -1259,19 +1337,21 @@ function gmgnStagedFetch(options = {}) {
         options.gmgnChart !== false;
       if (chart) {
         return {
-          extraHeaders: {
-            ...extraHeaders,
-            "cache-control": "public, max-age=0",
-            "x-programmable-data-quality": "current",
-            "x-programmable-read-source": "envio-classic-v3+gmgn",
-            "x-programmable-market-provider": "gmgn",
-            "x-programmable-market-read-status": "live",
-            "x-programmable-chart-scope": "token",
-            "x-programmable-chart-pool-attribution": chartPoolAttribution,
-            "x-programmable-market-source": "gmgn",
-            "x-programmable-price-source": "gmgn",
-            "x-programmable-market-as-of": NOW,
-          },
+          extraHeaders: withCatalogHeaders(
+            {
+              ...extraHeaders,
+              "cache-control": "public, max-age=0",
+              "x-programmable-data-quality": "current",
+              "x-programmable-market-provider": "gmgn",
+              "x-programmable-market-read-status": "live",
+              "x-programmable-chart-scope": "token",
+              "x-programmable-chart-pool-attribution": chartPoolAttribution,
+              "x-programmable-market-source": "gmgn",
+              "x-programmable-price-source": "gmgn",
+              "x-programmable-market-as-of": NOW,
+            },
+            `${catalogLaunchSource}+gmgn`,
+          ),
           omittedHeaders: omittedHeaders.filter((name) => ![
             "x-programmable-market-source",
             "x-programmable-price-source",
@@ -1281,29 +1361,44 @@ function gmgnStagedFetch(options = {}) {
       }
       if (analytics) {
         const section = url.searchParams.get("section") ?? "summary";
+        const responseIndex = (analyticsResponseCounts.get(section) ?? 1) - 1;
+        const status = analyticsStatusAt(section, responseIndex);
+        const unavailable = status === "unavailable";
         return {
-          extraHeaders: {
-            ...extraHeaders,
-            "cache-control": section === "summary"
-              ? "public, max-age=0"
-              : "private, max-age=0, no-store",
-            "x-content-type-options": "nosniff",
-            "referrer-policy": "no-referrer",
-            "x-programmable-chain-id": "1",
-            "x-programmable-canonical-read-status": "last-known-good",
-            "x-programmable-router-read-status": "unavailable",
-            "x-programmable-read-source": "envio-classic-v3+gmgn",
-            "x-programmable-analytics-provider": "gmgn",
-            "x-programmable-analytics-scope": "token",
-            "x-programmable-analytics-pool-attribution": "unavailable",
-            "x-programmable-analytics-read-status": "ready",
-            "x-programmable-market-provider": "gmgn",
-            "x-programmable-market-read-status": "complete",
-            "x-programmable-data-quality": "current",
-            "x-programmable-market-source": "gmgn",
-          },
+          extraHeaders: withCatalogHeaders(
+            {
+              ...extraHeaders,
+              "cache-control": unavailable
+                ? "no-store"
+                : status === "partial" && section === "summary"
+                  ? "public, max-age=0, s-maxage=15, stale-while-revalidate=30"
+                  : section === "summary"
+                    ? "public, max-age=0"
+                    : "private, max-age=0, no-store",
+              "x-content-type-options": "nosniff",
+              "referrer-policy": "no-referrer",
+              "x-programmable-chain-id": "1",
+              "x-programmable-analytics-provider": "gmgn",
+              "x-programmable-analytics-scope": "token",
+              "x-programmable-analytics-pool-attribution": "unavailable",
+              "x-programmable-analytics-read-status": status,
+              "x-programmable-market-provider": "gmgn",
+              "x-programmable-market-read-status": status === "ready"
+                ? "complete"
+                : status,
+              "x-programmable-data-quality": status === "ready"
+                ? "current"
+                : status,
+              ...(unavailable
+                ? {}
+                : { "x-programmable-market-source": "gmgn" }),
+            },
+            `${catalogLaunchSource}+gmgn`,
+            analyticsLastIndexedAtAt(section, responseIndex),
+          ),
           omittedHeaders: [
             ...omittedHeaders,
+            ...(unavailable ? ["x-programmable-market-source"] : []),
             "x-programmable-price-source",
             "x-programmable-market-as-of",
             "x-programmable-valuation-block",
@@ -1312,39 +1407,64 @@ function gmgnStagedFetch(options = {}) {
       }
       if (trending) {
         if (options.discoveryUnavailable) {
-          return { extraHeaders, omittedHeaders };
+          return {
+            extraHeaders: withCatalogHeaders(
+              extraHeaders,
+              `${catalogLaunchSource}+dexscreener`,
+            ),
+            omittedHeaders,
+          };
         }
         return {
-          extraHeaders: {
-            ...extraHeaders,
-            "x-programmable-read-source":
-              "envio-classic-v3+dexscreener+gmgn-discovery",
-          },
+          extraHeaders: withCatalogHeaders(
+            extraHeaders,
+            `${catalogLaunchSource}+dexscreener+gmgn-discovery`,
+          ),
           omittedHeaders,
         };
       }
-      if (!newest && !detail) return { extraHeaders, omittedHeaders };
+      if (!newest && !detail) {
+        if (![
+          "/api/explore",
+          "/api/explore/token/chart",
+        ].includes(url.pathname)) return { extraHeaders, omittedHeaders };
+        const defaultReadSource = url.pathname.endsWith("/chart")
+          ? "envio-classic-v3+bitquery"
+          : "envio-classic-v3+dexscreener";
+        const inheritedReadSource =
+          extraHeaders["x-programmable-read-source"] ?? defaultReadSource;
+        const readSource = inheritedReadSource.replace(
+          /^envio-classic-v3/u,
+          catalogLaunchSource,
+        );
+        return {
+          extraHeaders: withCatalogHeaders(extraHeaders, readSource),
+          omittedHeaders,
+        };
+      }
       const provider = newest ? "gmgn+dexscreener" : detailProvider;
       const detailUsesGmgn = newest || detailProvider === "gmgn";
       return {
-        extraHeaders: {
-          ...extraHeaders,
-          "x-programmable-read-source": `envio-classic-v3+${provider}`,
-          "x-programmable-market-provider": provider,
-          "x-programmable-market-read-status": newest
-            ? "partial"
-            : detailReadStatus,
-          ...(detailUsesGmgn
-            ? {
-                "x-programmable-market-source": newest &&
-                    visibleFallbackObservedCount > 0
-                  ? "gmgn+dexscreener"
-                  : "gmgn",
-                "x-programmable-price-source": "gmgn",
-              }
-            : {}),
-          "x-programmable-market-as-of": NOW,
-        },
+        extraHeaders: withCatalogHeaders(
+          {
+            ...extraHeaders,
+            "x-programmable-market-provider": provider,
+            "x-programmable-market-read-status": newest
+              ? "partial"
+              : detailReadStatus,
+            ...(detailUsesGmgn
+              ? {
+                  "x-programmable-market-source": newest &&
+                      visibleFallbackObservedCount > 0
+                    ? "gmgn+dexscreener"
+                    : "gmgn",
+                  "x-programmable-price-source": "gmgn",
+                }
+              : {}),
+            "x-programmable-market-as-of": NOW,
+          },
+          `${catalogLaunchSource}+${provider}`,
+        ),
         omittedHeaders: detailUsesGmgn
           ? omittedHeaders
           : [
@@ -2417,6 +2537,389 @@ test("staged smoke binds an observed unqualified fallback to GMGN market sources
   assert.equal(result.marketProvider, "gmgn+dexscreener");
   assert.equal(result.marketReadStatus, "partial");
   assert.equal(result.detailMarketProvider, "gmgn");
+});
+
+test("staged smoke accepts required GMGN analytics on a Router-only catalog", async () => {
+  for (const routerReadStatus of ["current", "last-known-good"]) {
+    const routerCatalog = {
+      source: "envio-classic-v3",
+      launchSource: "canonical-launch-stamp-router",
+      status: "last-known-good",
+      lastIndexedAt: NOW,
+      asOfBlock: "25740001",
+      asOfBlockHash: `0x${"ab".repeat(32)}`,
+      identityCount: 2,
+      identityCommitment: `sha256:${"de".repeat(32)}`,
+      completeness: {
+        classic: "unavailable",
+        stock: "excluded",
+        custom: "unavailable",
+        registryCustom: "unavailable",
+        routerCustom: routerReadStatus,
+      },
+      scope: {
+        included: ["canonical-launch-stamp-router"],
+        excluded: [
+          "classic-v1",
+          "classic-v2",
+          "stock-paired-v1",
+          "stock-paired-v2",
+          "stock-paired-v3",
+        ],
+        publicCategories: ["classic", "custom"],
+      },
+      routerStamp: {
+        source: "canonical-launch-stamp-router",
+        status: routerReadStatus,
+        finalityConfirmations: 64,
+        verifiedIdentityCount: 2,
+        projectedIdentityCount: 2,
+        generatedAt: NOW,
+        asOfBlock: "25740001",
+        asOfBlockHash: `0x${"ab".repeat(32)}`,
+        identityCommitment: `sha256:${"ac".repeat(32)}`,
+      },
+    };
+    const result = await runStagedStaticDexscreenerSmokeV1({
+      environment: {
+        STAGED_TARGET_URL: "https://candidate.vercel.app/",
+        VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+        PROGRAMMABLE_REQUIRE_GMGN_MARKET: "true",
+        GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+      },
+      fetchImpl: gmgnStagedFetch({
+        catalogBoundary: {
+          catalog: routerCatalog,
+          launchIdentity: {
+            status: "partial",
+            canonical: "unavailable",
+            custom: "unavailable",
+            ageMs: 1_000,
+          },
+        },
+        analyticsLastIndexedAtSequence: {
+          summary: [new Date(Date.parse(NOW) + 1_000).toISOString()],
+          holders: [new Date(Date.parse(NOW) + 2_000).toISOString()],
+          traders: [new Date(Date.parse(NOW) + 3_000).toISOString()],
+        },
+      }),
+      appendOutput: () => undefined,
+    });
+
+    assert.equal(result.catalogSource, "envio-classic-v3");
+    assert.equal(result.analyticsSummaryStatus, "ready");
+    assert.equal(result.analyticsHoldersStatus, "ready");
+    assert.equal(result.analyticsTradersStatus, "ready");
+  }
+});
+
+test("staged smoke accepts a newer monotonic GMGN analytics identity timestamp", async () => {
+  const summaryLastIndexedAt = new Date(Date.parse(NOW) + 1_000).toISOString();
+  const holdersLastIndexedAt = new Date(Date.parse(NOW) + 2_000).toISOString();
+  const tradersLastIndexedAt = new Date(Date.parse(NOW) + 3_000).toISOString();
+  const result = await runStagedStaticDexscreenerSmokeV1({
+    environment: {
+      STAGED_TARGET_URL: "https://candidate.vercel.app/",
+      VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+      PROGRAMMABLE_REQUIRE_GMGN_MARKET: "true",
+      GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+    },
+    fetchImpl: gmgnStagedFetch({
+      analyticsLastIndexedAtSequence: {
+        summary: [summaryLastIndexedAt],
+        holders: [holdersLastIndexedAt],
+        traders: [tradersLastIndexedAt],
+      },
+    }),
+    appendOutput: () => undefined,
+  });
+
+  assert.equal(result.analyticsSummaryStatus, "ready");
+  assert.equal(result.analyticsHoldersStatus, "ready");
+  assert.equal(result.analyticsTradersStatus, "ready");
+});
+
+test("staged smoke rejects a cross-section GMGN analytics timestamp regression", async () => {
+  const summaryLastIndexedAt = new Date(Date.parse(NOW) + 2_000).toISOString();
+  const holdersLastIndexedAt = new Date(Date.parse(NOW) + 1_000).toISOString();
+  const waits = [];
+  await assert.rejects(
+    runStagedStaticDexscreenerSmokeV1({
+      environment: {
+        STAGED_TARGET_URL: "https://candidate.vercel.app/",
+        VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+        PROGRAMMABLE_REQUIRE_GMGN_MARKET: "true",
+        GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+      },
+      fetchImpl: gmgnStagedFetch({
+        analyticsLastIndexedAtSequence: {
+          summary: [summaryLastIndexedAt],
+          holders: [holdersLastIndexedAt],
+        },
+      }),
+      waitForGmgnAnalyticsRecovery: async (milliseconds) => {
+        waits.push(milliseconds);
+      },
+      appendOutput: () => undefined,
+    }),
+    /GMGN holders analytics envelope is invalid/u,
+  );
+  assert.deepEqual(waits, []);
+});
+
+test("staged smoke retries one self-consistent unavailable GMGN analytics read", async () => {
+  const waits = [];
+  const analyticsResponses = [];
+  const fixtureFetch = gmgnStagedFetch({
+    analyticsStatusSequence: { summary: ["unavailable", "ready"] },
+    analyticsUnavailableIdentity: null,
+  });
+  const result = await runStagedStaticDexscreenerSmokeV1({
+    environment: {
+      STAGED_TARGET_URL: "https://candidate.vercel.app/",
+      VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+      PROGRAMMABLE_REQUIRE_GMGN_MARKET: "true",
+      GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+    },
+    fetchImpl: async (url, init) => {
+      const response = await fixtureFetch(url, init);
+      if (
+        url.pathname === "/api/explore/token/analytics" &&
+        url.searchParams.get("section") === "summary"
+      ) {
+        analyticsResponses.push({
+          status: (await response.clone().json()).status,
+          cacheControl: response.headers.get("cache-control"),
+          marketSource: response.headers.get("x-programmable-market-source"),
+        });
+      }
+      return response;
+    },
+    waitForGmgnAnalyticsRecovery: async (milliseconds) => {
+      waits.push(milliseconds);
+    },
+    appendOutput: () => undefined,
+  });
+
+  assert.equal(result.analyticsSummaryStatus, "ready");
+  assert.deepEqual(waits, [16_000]);
+  assert.deepEqual(analyticsResponses, [
+    {
+      status: "unavailable",
+      cacheControl: "no-store",
+      marketSource: null,
+    },
+    {
+      status: "ready",
+      cacheControl: "public, max-age=0",
+      marketSource: "gmgn",
+    },
+  ]);
+});
+
+test("staged smoke rejects drifted non-null unavailable GMGN identities without waiting", async () => {
+  const cases = [
+    ["wrong pool", (identity) => ({
+      ...identity,
+      poolId: `0x${"44".repeat(32)}`,
+    })],
+    ["null pool", (identity) => ({ ...identity, poolId: null })],
+    ["wrong quote", (identity) => ({
+      ...identity,
+      quoteAddress: "0x5555555555555555555555555555555555555555",
+    })],
+    ["null quote", (identity) => ({ ...identity, quoteAddress: null })],
+  ];
+  for (const [label, mutateIdentity] of cases) {
+    const waits = [];
+    let summaryRequests = 0;
+    const fixtureFetch = gmgnStagedFetch({
+      analyticsStatusSequence: { summary: ["unavailable", "ready"] },
+      mutateGmgnAnalytics: (value, section, responseIndex) =>
+        section === "summary" && responseIndex === 0
+          ? { ...value, identity: mutateIdentity(value.identity) }
+          : value,
+    });
+    await assert.rejects(
+      runStagedStaticDexscreenerSmokeV1({
+        environment: {
+          STAGED_TARGET_URL: "https://candidate.vercel.app/",
+          VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+          PROGRAMMABLE_REQUIRE_GMGN_MARKET: "true",
+          GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+        },
+        fetchImpl: async (url, init) => {
+          if (
+            url.pathname === "/api/explore/token/analytics" &&
+            url.searchParams.get("section") === "summary"
+          ) summaryRequests += 1;
+          return fixtureFetch(url, init);
+        },
+        waitForGmgnAnalyticsRecovery: async (milliseconds) => {
+          waits.push(milliseconds);
+        },
+        appendOutput: () => undefined,
+      }),
+      /GMGN summary analytics envelope is invalid/u,
+    );
+    assert.equal(summaryRequests, 1, label);
+    assert.deepEqual(waits, [], label);
+  }
+});
+
+test("staged smoke waits beyond a partial summary cache before retrying GMGN analytics", async () => {
+  const waits = [];
+  const summaryResponses = [];
+  const fixtureFetch = gmgnStagedFetch({
+    analyticsStatusSequence: { summary: ["partial", "ready"] },
+  });
+  const result = await runStagedStaticDexscreenerSmokeV1({
+    environment: {
+      STAGED_TARGET_URL: "https://candidate.vercel.app/",
+      VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+      PROGRAMMABLE_REQUIRE_GMGN_MARKET: "true",
+      GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+    },
+    fetchImpl: async (url, init) => {
+      const response = await fixtureFetch(url, init);
+      if (
+        url.pathname === "/api/explore/token/analytics" &&
+        url.searchParams.get("section") === "summary"
+      ) {
+        summaryResponses.push({
+          status: (await response.clone().json()).status,
+          cacheControl: response.headers.get("cache-control"),
+        });
+      }
+      return response;
+    },
+    waitForGmgnAnalyticsRecovery: async (milliseconds) => {
+      waits.push(milliseconds);
+    },
+    appendOutput: () => undefined,
+  });
+
+  assert.equal(result.analyticsSummaryStatus, "ready");
+  assert.deepEqual(waits, [46_000]);
+  assert.deepEqual(summaryResponses, [
+    {
+      status: "partial",
+      cacheControl:
+        "public, max-age=0, s-maxage=15, stale-while-revalidate=30",
+    },
+    { status: "ready", cacheControl: "public, max-age=0" },
+  ]);
+});
+
+test("staged smoke fails a persistently unavailable GMGN analytics read after one retry", async () => {
+  const waits = [];
+  let summaryRequests = 0;
+  const fixtureFetch = gmgnStagedFetch({
+    analyticsStatusSequence: { summary: ["unavailable"] },
+  });
+  await assert.rejects(
+    runStagedStaticDexscreenerSmokeV1({
+      environment: {
+        STAGED_TARGET_URL: "https://candidate.vercel.app/",
+        VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+        PROGRAMMABLE_REQUIRE_GMGN_MARKET: "true",
+        GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+      },
+      fetchImpl: async (url, init) => {
+        if (
+          url.pathname === "/api/explore/token/analytics" &&
+          url.searchParams.get("section") === "summary"
+        ) summaryRequests += 1;
+        return fixtureFetch(url, init);
+      },
+      waitForGmgnAnalyticsRecovery: async (milliseconds) => {
+        waits.push(milliseconds);
+      },
+      appendOutput: () => undefined,
+    }),
+    /GMGN summary analytics is required/u,
+  );
+  assert.equal(summaryRequests, 2);
+  assert.deepEqual(waits, [16_000]);
+});
+
+test("staged smoke rejects a malformed unavailable GMGN envelope without retrying", async () => {
+  const waits = [];
+  let summaryRequests = 0;
+  const fixtureFetch = gmgnStagedFetch({
+    analyticsStatusSequence: { summary: ["unavailable", "ready"] },
+    mutateGmgnAnalytics: (value, section, responseIndex) => {
+      if (section !== "summary" || responseIndex !== 0) return value;
+      const malformed = structuredClone(value);
+      delete malformed.provider;
+      return malformed;
+    },
+  });
+  await assert.rejects(
+    runStagedStaticDexscreenerSmokeV1({
+      environment: {
+        STAGED_TARGET_URL: "https://candidate.vercel.app/",
+        VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+        PROGRAMMABLE_REQUIRE_GMGN_MARKET: "true",
+        GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+      },
+      fetchImpl: async (url, init) => {
+        if (
+          url.pathname === "/api/explore/token/analytics" &&
+          url.searchParams.get("section") === "summary"
+        ) summaryRequests += 1;
+        return fixtureFetch(url, init);
+      },
+      waitForGmgnAnalyticsRecovery: async (milliseconds) => {
+        waits.push(milliseconds);
+      },
+      appendOutput: () => undefined,
+    }),
+    /GMGN summary analytics envelope is invalid/u,
+  );
+  assert.equal(summaryRequests, 1);
+  assert.deepEqual(waits, []);
+});
+
+test("staged smoke rejects malformed retryable GMGN projections without waiting", async () => {
+  for (const status of ["unavailable", "partial"]) {
+    const waits = [];
+    let summaryRequests = 0;
+    const fixtureFetch = gmgnStagedFetch({
+      analyticsStatusSequence: { summary: [status, "ready"] },
+      mutateGmgnAnalytics: (value, section, responseIndex) =>
+        section === "summary" && responseIndex === 0
+          ? {
+              ...value,
+              analytics: { ...value.analytics, pool: {} },
+            }
+          : value,
+    });
+    await assert.rejects(
+      runStagedStaticDexscreenerSmokeV1({
+        environment: {
+          STAGED_TARGET_URL: "https://candidate.vercel.app/",
+          VERCEL_AUTOMATION_BYPASS_SECRET: "0123456789abcdef",
+          PROGRAMMABLE_REQUIRE_GMGN_MARKET: "true",
+          GITHUB_OUTPUT: "/tmp/unused-public-smoke-output",
+        },
+        fetchImpl: async (url, init) => {
+          if (
+            url.pathname === "/api/explore/token/analytics" &&
+            url.searchParams.get("section") === "summary"
+          ) summaryRequests += 1;
+          return fixtureFetch(url, init);
+        },
+        waitForGmgnAnalyticsRecovery: async (milliseconds) => {
+          waits.push(milliseconds);
+        },
+        appendOutput: () => undefined,
+      }),
+      /GMGN summary analytics projection is invalid/u,
+    );
+    assert.equal(summaryRequests, 1, status);
+    assert.deepEqual(waits, [], status);
+  }
 });
 
 test("staged smoke rejects malformed public GMGN analytics projections", async () => {

--- a/tests/data-pipeline/read-model-ops-contract.test.ts
+++ b/tests/data-pipeline/read-model-ops-contract.test.ts
@@ -1491,6 +1491,84 @@ describe("read-model operations source contract", () => {
     );
   });
 
+  it.each([
+    [
+      "visible bulk reads above the 12-lease ceiling",
+      "const GMGN_VISIBLE_MAXIMUM_CONCURRENT_LEASES = 12",
+      "const GMGN_VISIBLE_MAXIMUM_CONCURRENT_LEASES = 13",
+    ],
+    [
+      "foreground direct reads above the 20-lease ceiling",
+      "const GMGN_ACCOUNT_MAXIMUM_CONCURRENT_LEASES = 20",
+      "const GMGN_ACCOUNT_MAXIMUM_CONCURRENT_LEASES = 21",
+    ],
+    [
+      "visible bulk reads routed through the foreground lane",
+      'await readGmgnMarketSnapshotWithClassV1(entry, wait, "visible")',
+      'await readGmgnMarketSnapshotWithClassV1(entry, wait, "foreground")',
+    ],
+    [
+      "foreground direct reads routed through the visible lane",
+      'return readGmgnMarketSnapshotWithClassV1(entry, wait, "foreground")',
+      'return readGmgnMarketSnapshotWithClassV1(entry, wait, "visible")',
+    ],
+    [
+      "cross-lane in-flight deduplication",
+      'const inFlightKey = `${readClass}:${cacheKey}`;',
+      "const inFlightKey = cacheKey;",
+    ],
+    [
+      "visible reads unable to join matching foreground work",
+      "const active = snapshotInFlight.get(inFlightKey) ??\n" +
+        '    (readClass === "visible"\n' +
+        '      ? snapshotInFlight.get(`foreground:${cacheKey}`)\n' +
+        "      : undefined);",
+      "const active = snapshotInFlight.get(inFlightKey);",
+    ],
+    [
+      "foreground reads joining lower-ceiling visible work",
+      'readClass === "visible"\n' +
+        '      ? snapshotInFlight.get(`foreground:${cacheKey}`)',
+      'readClass === "foreground"\n' +
+        '      ? snapshotInFlight.get(`visible:${cacheKey}`)',
+    ],
+    [
+      "lane-separated successful snapshot caching",
+      "setCacheValue(\n" +
+        "          snapshotCache,\n" +
+        "          cacheKey,\n" +
+        "          snapshot,",
+      "setCacheValue(\n" +
+        "          snapshotCache,\n" +
+        "          inFlightKey,\n" +
+        "          snapshot,",
+    ],
+    [
+      "a late visible result overwriting a foreground cache success",
+      'if (snapshot !== null && (readClass === "foreground" || current === undefined)) {',
+      "if (snapshot !== null) {",
+    ],
+    [
+      "a provider gate that ignores the selected lane ceiling",
+      "maximumConcurrentLeases: wait.maximumConcurrentLeases,",
+      "maximumConcurrentLeases: GMGN_VISIBLE_MAXIMUM_CONCURRENT_LEASES,",
+    ],
+  ])("rejects the GMGN market read-lane contract with %s", (
+    _label,
+    needle,
+    replacement,
+  ) => {
+    const path = "lib/market-data/gmgn.server.ts";
+    const source = readFileSync(resolve(ROOT, path), "utf8");
+    expect(source).toContain(needle);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: { [path]: source.replace(needle, replacement) },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-public-provider-split-source-contract",
+    );
+  });
+
   it("rejects a staged descending GMGN gate detached from token_info", () => {
     const path = "scripts/smoke-static-dexscreener-public-apis.mjs";
     const source = readFileSync(resolve(ROOT, path), "utf8");
@@ -2100,6 +2178,157 @@ describe("read-model operations source contract", () => {
     });
     expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
       "ops-profile-claim-trade-provider-boundary",
+    );
+  });
+
+  it.each([
+    [
+      "an unavailable response omitted from accepted analytics statuses",
+      'const ANALYTICS_STATUSES = new Set(["ready", "partial", "unavailable"])',
+      'const ANALYTICS_STATUSES = new Set(["ready", "partial"])',
+    ],
+    [
+      "cacheable headers on an unavailable analytics envelope",
+      'const expectedCache = unavailable\n    ? new Set(["no-store"])',
+      'const expectedCache = unavailable\n    ? new Set(["public, max-age=0"])',
+    ],
+    [
+      "GMGN market-source provenance on an unavailable analytics envelope",
+      'response.headers.get("x-programmable-market-source") ===\n' +
+        '      (unavailable ? null : "gmgn")',
+      'response.headers.get("x-programmable-market-source") === "gmgn"',
+    ],
+    [
+      "an arbitrary identity on an unavailable analytics envelope",
+      'return status === "unavailable" && value === null;',
+      'return status === "unavailable";',
+    ],
+    [
+      "one populated summary projection while analytics are unavailable",
+      'const expectedCount = body.status === "ready"\n' +
+        "    ? 2\n" +
+        '    : body.status === "partial"\n' +
+        "      ? 1\n" +
+        "      : 0;",
+      'const expectedCount = body.status === "ready"\n' +
+        "    ? 2\n" +
+        '    : body.status === "partial"\n' +
+        "      ? 1\n" +
+        "      : 1;",
+    ],
+    [
+      "a non-null ranking projection while analytics are unavailable",
+      'if (body.status === "unavailable") return ranking === null;',
+      'if (body.status === "unavailable") return true;',
+    ],
+    [
+      "summary analytics accepted without status-aware projection validation",
+      "!exactSummaryAnalyticsProjection(body, identity, now().getTime())",
+      "false",
+    ],
+    [
+      "ranking analytics accepted without status-aware projection validation",
+      "!exactRankingAnalyticsProjection(body, now().getTime())",
+      "false",
+    ],
+    [
+      "more than one analytics recovery retry",
+      "const GMGN_ANALYTICS_ATTEMPTS = 2",
+      "const GMGN_ANALYTICS_ATTEMPTS = 3",
+    ],
+    [
+      "an analytics recovery wait inside the 15-second lease",
+      "const GMGN_ANALYTICS_RECOVERY_DELAY_MS = 16_000",
+      "const GMGN_ANALYTICS_RECOVERY_DELAY_MS = 15_000",
+    ],
+    [
+      "an analytics recovery wait beyond the 16-second bound",
+      "const GMGN_ANALYTICS_RECOVERY_DELAY_MS = 16_000",
+      "const GMGN_ANALYTICS_RECOVERY_DELAY_MS = 17_000",
+    ],
+    [
+      "a partial-summary recovery wait inside its public cache window",
+      "const GMGN_ANALYTICS_PARTIAL_SUMMARY_RECOVERY_DELAY_MS = 46_000",
+      "const GMGN_ANALYTICS_PARTIAL_SUMMARY_RECOVERY_DELAY_MS = 45_000",
+    ],
+    [
+      "a partial summary using only the lease-recovery delay",
+      'const recoveryDelayMs = section === "summary" && body.status === "partial"\n' +
+        "        ? GMGN_ANALYTICS_PARTIAL_SUMMARY_RECOVERY_DELAY_MS\n" +
+        "        : GMGN_ANALYTICS_RECOVERY_DELAY_MS;",
+      "const recoveryDelayMs = GMGN_ANALYTICS_RECOVERY_DELAY_MS;",
+    ],
+    [
+      "a skipped analytics recovery wait",
+      "await waitForGmgnAnalyticsRecovery(recoveryDelayMs);",
+      "await Promise.resolve();",
+    ],
+    [
+      "status coherence without exact launch-source segments",
+      'const launchSources = new Set(launchSource.split("+"));',
+      "const launchSources = new Set([launchSource]);",
+    ],
+    [
+      "an Envio source with unavailable canonical status",
+      'launchSources.has("envio-classic-v3")\n' +
+        "      ? CATALOG_STATUSES.has(canonicalReadStatus)",
+      'launchSources.has("envio-classic-v3")\n' +
+        '      ? canonicalReadStatus === "unavailable"',
+    ],
+    [
+      "current canonical status without an Envio source segment",
+      ': canonicalReadStatus === "unavailable")',
+      ": CATALOG_STATUSES.has(canonicalReadStatus))",
+    ],
+    [
+      "a Router source with unavailable router status",
+      'launchSources.has("canonical-launch-stamp-router")\n' +
+        "      ? CATALOG_STATUSES.has(routerReadStatus)",
+      'launchSources.has("canonical-launch-stamp-router")\n' +
+        '      ? routerReadStatus === "unavailable"',
+    ],
+    [
+      "current router status without a Router source segment",
+      ': routerReadStatus === "unavailable");',
+      ": CATALOG_STATUSES.has(routerReadStatus));",
+    ],
+    [
+      "regressing analytics identity freshness",
+      "Date.parse(lastIndexedAt) >= Date.parse(minimumLastIndexedAt)",
+      "Date.parse(lastIndexedAt) <= Date.parse(minimumLastIndexedAt)",
+    ],
+    [
+      "analytics responses compared only to the initial freshness floor",
+      "response, body.status, section, catalogBoundary.launchSource,\n" +
+        "          minimumAnalyticsLastIndexedAt,",
+      "response, body.status, section, catalogBoundary.launchSource,\n" +
+        "          lastIndexedAt,",
+    ],
+    [
+      "a freshness high-water mark that does not advance",
+      'minimumAnalyticsLastIndexedAt = response.headers.get(\n' +
+        '        "x-programmable-identity-last-indexed-at",\n' +
+        "      );",
+      "minimumAnalyticsLastIndexedAt = lastIndexedAt;",
+    ],
+    [
+      "analytics header status detached from the response envelope",
+      'response.headers.get("x-programmable-analytics-read-status") === status',
+      'response.headers.get("x-programmable-analytics-read-status") === "ready"',
+    ],
+  ])("rejects a staged GMGN analytics recovery contract with %s", (
+    _label,
+    needle,
+    replacement,
+  ) => {
+    const path = "scripts/smoke-static-dexscreener-public-apis.mjs";
+    const source = readFileSync(resolve(ROOT, path), "utf8");
+    expect(source).toContain(needle);
+    const result = evaluateReadModelOperationsSourceContracts(ROOT, {
+      sourceOverrides: { [path]: source.replace(needle, replacement) },
+    });
+    expect(result.failures.map(({ id }: { id: string }) => id)).toContain(
+      "ops-protected-public-provider-stage-smoke",
     );
   });
 

--- a/tests/gmgn-market-data.test.ts
+++ b/tests/gmgn-market-data.test.ts
@@ -273,7 +273,7 @@ describe("GMGN canonical market enrichment", () => {
     });
     expect(reserveSlot).toHaveBeenCalledWith({
       requestsPerSecond: 1,
-      maximumConcurrentLeases: 12,
+      maximumConcurrentLeases: 20,
       deadlineMs: NOW.getTime() + 5_000,
       signal: expect.any(AbortSignal),
     });
@@ -643,7 +643,137 @@ describe("GMGN canonical market enrichment", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(100);
     expect(maximumActive).toBe(12);
     expect(accountGate.reserveSlot).toHaveBeenCalledTimes(100);
+    for (const [reservation] of vi.mocked(accountGate.reserveSlot).mock.calls) {
+      expect(reservation.maximumConcurrentLeases).toBe(12);
+    }
     expect(accountGate.complete).toHaveBeenCalledTimes(100);
+  });
+
+  it("keeps foreground token-info admission separate from a matching visible read", async () => {
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    vi.stubEnv("GMGN_MAX_REQUESTS_PER_SECOND", "20");
+    const entry = token(134);
+    let generation = 0;
+    const accountGate: GmgnAccountGateV1 = {
+      reserveSlot: vi.fn(async () => ({
+        ...GATE_RESERVATION,
+        generation: ++generation,
+      })),
+      blockUntil: vi.fn(),
+      complete: vi.fn(async () => {}),
+    };
+    const resolvers: Array<(response: Response) => void> = [];
+    const fetchImpl = vi.fn(() => new Promise<Response>((resolve) => {
+      resolvers.push(resolve);
+    }));
+    const wait = {
+      fetchImpl: fetchImpl as typeof fetch,
+      accountGate,
+      now: () => NOW,
+      deadlineMs: NOW.getTime() + 8_000,
+    };
+
+    const visible = readGmgnExploreSnapshotsV1([entry], wait);
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+    const foreground = readGmgnMarketSnapshotV1(entry, wait);
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
+
+    expect(vi.mocked(accountGate.reserveSlot).mock.calls.map(
+      ([reservation]) => reservation.maximumConcurrentLeases,
+    )).toEqual([12, 20]);
+    resolvers[1]?.(new Response(JSON.stringify({
+      code: 0,
+      data: providerData(entry),
+    }), { status: 200 }));
+    await expect(foreground).resolves.toMatchObject({
+      identity: identity(entry),
+    });
+    const lateVisibleData = providerData(entry);
+    lateVisibleData.price.price = "1.0000000";
+    resolvers[0]?.(new Response(JSON.stringify({
+      code: 0,
+      data: lateVisibleData,
+    }), { status: 200 }));
+    await expect(visible).resolves.toEqual(new Map([[entry.id, expect.objectContaining({
+      identity: identity(entry),
+      priceUsdWad: "1000000000000000000",
+    })]]));
+    await expect(readGmgnMarketSnapshotV1(entry, wait)).resolves.toMatchObject({
+      identity: identity(entry),
+      priceUsdWad: "3311169800000000000",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(accountGate.complete).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares a completed token-info success across foreground and visible lanes", async () => {
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    const entry = token(135);
+    const accountGate: GmgnAccountGateV1 = {
+      reserveSlot: vi.fn(async () => GATE_RESERVATION),
+      blockUntil: vi.fn(),
+      complete: vi.fn(async () => {}),
+    };
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      code: 0,
+      data: providerData(entry),
+    }), { status: 200 }));
+    const wait = {
+      fetchImpl: fetchImpl as typeof fetch,
+      accountGate,
+      now: () => NOW,
+      deadlineMs: NOW.getTime() + 8_000,
+    };
+
+    const foreground = await readGmgnMarketSnapshotV1(entry, wait);
+    const visible = await readGmgnExploreSnapshotsV1([entry], wait);
+
+    expect(foreground).not.toBeNull();
+    expect(visible.get(entry.id)).toEqual(foreground);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(accountGate.reserveSlot).toHaveBeenCalledTimes(1);
+    expect(accountGate.reserveSlot).toHaveBeenCalledWith(
+      expect.objectContaining({ maximumConcurrentLeases: 20 }),
+    );
+  });
+
+  it("lets a visible caller join matching foreground token-info work", async () => {
+    vi.stubEnv("GMGN_API_KEY", "test-server-key");
+    const entry = token(136);
+    const accountGate: GmgnAccountGateV1 = {
+      reserveSlot: vi.fn(async () => GATE_RESERVATION),
+      blockUntil: vi.fn(),
+      complete: vi.fn(async () => {}),
+    };
+    let resolveProvider: ((response: Response) => void) | undefined;
+    const fetchImpl = vi.fn(() => new Promise<Response>((resolve) => {
+      resolveProvider = resolve;
+    }));
+    const wait = {
+      fetchImpl: fetchImpl as typeof fetch,
+      accountGate,
+      now: () => NOW,
+      deadlineMs: NOW.getTime() + 8_000,
+    };
+
+    const foreground = readGmgnMarketSnapshotV1(entry, wait);
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+    const visible = readGmgnExploreSnapshotsV1([entry], wait);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(accountGate.reserveSlot).toHaveBeenCalledTimes(1);
+    expect(accountGate.reserveSlot).toHaveBeenCalledWith(
+      expect.objectContaining({ maximumConcurrentLeases: 20 }),
+    );
+    resolveProvider?.(new Response(JSON.stringify({
+      code: 0,
+      data: providerData(entry),
+    }), { status: 200 }));
+    const foregroundSnapshot = await foreground;
+    await expect(visible).resolves.toEqual(new Map([
+      [entry.id, foregroundSnapshot],
+    ]));
   });
 
   it("rejects a foreign chain on the raw provider envelope", async () => {
@@ -718,7 +848,7 @@ describe("GMGN canonical market enrichment", () => {
       })).resolves.not.toBeNull();
       expect(reserveSlot).toHaveBeenCalledWith({
         requestsPerSecond: expected,
-        maximumConcurrentLeases: 12,
+        maximumConcurrentLeases: 20,
         deadlineMs: NOW.getTime() + 5_000,
         signal: expect.any(AbortSignal),
       });


### PR DESCRIPTION
## Summary

- reserve the full 20-flight GMGN account capacity for foreground token-info admission while keeping visible Explore hydration capped at 12
- keep foreground and visible in-flight work priority-safe with asymmetric coalescing and a shared success cache
- make the required-GMGN analytics gate status-aware, freshness-monotonic, and bounded across unavailable and cacheable-partial recovery
- fail malformed analytics immediately and preserve exact launch-source, identity, projection, and provider bindings

## Release failure addressed

The staged Custom V2 release candidate returned a valid fail-soft analytics response after bulk Explore hydration and was classified as an invalid envelope. The gate also compared volatile canonical timestamps/statuses to an earlier Explore response byte-for-byte. This patch keeps `ready` mandatory while removing those false classifications and restoring foreground admission headroom.

## Verification

- `tests/gmgn-market-data.test.ts`: 59 passed
- `scripts/test/smoke-static-dexscreener-public-apis.test.mjs`: 118 passed
- `tests/data-pipeline/read-model-ops-contract.test.ts`: 366 passed
- `npm run perf:read-model:ops-gate`: passed
- `npm run typecheck`: passed
- ESLint: 0 errors (one pre-existing unused-function warning)
- `git diff --check`: passed