### PR TITLE
feat(web): launch Robinhood custom hooks with API keys

### DIFF
--- a/components/developer-api-keys.module.css
+++ b/components/developer-api-keys.module.css
@@ -148,7 +148,7 @@
   border-radius: var(--webde-radius-control);
   display: inline-grid;
   gap: 4px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   margin-bottom: 16px;
   padding: 4px;
 }

--- a/components/developer-api-keys.tsx
+++ b/components/developer-api-keys.tsx
@@ -21,6 +21,8 @@ import {
 
 import styles from "@/components/developer-api-keys.module.css";
 import { DeveloperLaunchHistory } from "@/components/developer-launch-history";
+import { DeveloperRobinhoodLaunch } from
+  "@/components/developer-robinhood-launch";
 import {
   useWallet,
   type CustomLaunchWalletActionInputV4,
@@ -74,7 +76,7 @@ type ApiKeyMutationState =
   | Readonly<{ kind: "rotate"; credentialId: string }>;
 
 type ListState = "idle" | "loading" | "ready" | "error";
-type ActiveSection = "keys" | "history";
+type ActiveSection = "keys" | "launch" | "history";
 type ApiKeyLoadMode = "initial" | "refresh" | "mutation";
 type DeveloperApiKeysViewProps = Readonly<{
   account: `0x${string}` | null;
@@ -810,6 +812,16 @@ function DeveloperApiKeysView({
 
   useEffect(() => {
     const url = new URL(window.location.href);
+    if (
+      url.searchParams.get("start") === "custom"
+      && url.searchParams.get("chainId") === "4663"
+    ) {
+      const update = window.setTimeout(() => {
+        setActiveSection("launch");
+        setStatusMessage("Opening Robinhood Custom launch.");
+      }, 0);
+      return () => window.clearTimeout(update);
+    }
     const candidate = url.searchParams.get("launchId");
     if (!candidate || !launchRequestIdPattern.test(candidate)) return;
     const chainId = url.searchParams.get("chainId");
@@ -969,16 +981,43 @@ function DeveloperApiKeysView({
   const showSection = (section: ActiveSection) => {
     setActiveSection(section);
     const url = new URL(window.location.href);
-    if (section === "keys") {
+    if (section === "launch") {
+      url.searchParams.set("start", "custom");
+      url.searchParams.set("chainId", "4663");
       url.searchParams.delete("launchId");
-      url.searchParams.delete("chainId");
       setInitialLaunchId(null);
       setInitialLaunchChainId(null);
+    } else {
+      url.searchParams.delete("start");
+      if (section === "keys") {
+        url.searchParams.delete("launchId");
+        url.searchParams.delete("chainId");
+        setInitialLaunchId(null);
+        setInitialLaunchChainId(null);
+      } else if (!url.searchParams.has("launchId")) {
+        url.searchParams.delete("chainId");
+      }
     }
     window.history.replaceState(null, "", `${url.pathname}${url.search}`);
     setStatusMessage(
-      section === "keys" ? "Showing API keys." : "Showing launch history.",
+      section === "keys"
+        ? "Showing API keys."
+        : section === "launch"
+          ? "Showing Robinhood Custom launch."
+          : "Showing launch history.",
     );
+  };
+
+  const openRobinhoodLaunchHistory = (launchId: string) => {
+    setInitialLaunchId(launchId);
+    setInitialLaunchChainId("4663");
+    setActiveSection("history");
+    const url = new URL(window.location.href);
+    url.searchParams.delete("start");
+    url.searchParams.set("launchId", launchId);
+    url.searchParams.set("chainId", "4663");
+    window.history.replaceState(null, "", `${url.pathname}${url.search}`);
+    setStatusMessage("Opening the new Robinhood launch in history.");
   };
 
   const beginRevoke = (apiKeyId: string, trigger: HTMLButtonElement) => {
@@ -1354,6 +1393,13 @@ function DeveloperApiKeysView({
               onClick={() => showSection("keys")}
             >
               API keys
+            </button>
+            <button
+              aria-pressed={activeSection === "launch"}
+              type="button"
+              onClick={() => showSection("launch")}
+            >
+              Launch
             </button>
             <button
               aria-pressed={activeSection === "history"}
@@ -1758,6 +1804,10 @@ function DeveloperApiKeysView({
                 ) : null}
               </section>
             </div>
+          ) : activeSection === "launch" ? (
+            <DeveloperRobinhoodLaunch
+              onOpenLaunch={openRobinhoodLaunchHistory}
+            />
           ) : (
             <DeveloperLaunchHistory
               account={account}

--- a/components/developer-robinhood-launch.module.css
+++ b/components/developer-robinhood-launch.module.css
@@ -1,0 +1,329 @@
+.launchPanel {
+  gap: 0;
+  max-width: 900px;
+}
+
+.launchHeader {
+  align-items: flex-start;
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+}
+
+.launchHeader > div {
+  min-width: 0;
+}
+
+.launchHeader h2 {
+  color: var(--webde-ink);
+  font-size: clamp(26px, 4vw, 36px);
+  font-weight: 590;
+  letter-spacing: -0.04em;
+  line-height: 1.08;
+  margin-top: 5px;
+  text-wrap: balance;
+}
+
+.launchHeader p:last-child {
+  color: var(--webde-muted);
+  font-size: 14px;
+  line-height: 1.55;
+  margin-top: 10px;
+  max-width: 640px;
+  text-wrap: pretty;
+}
+
+.launchHeader code,
+.preflightResult code,
+.createdResult code {
+  font-family: var(--font-plex-mono), monospace;
+}
+
+.readinessBadge {
+  align-items: center;
+  background: var(--webde-control);
+  border: 1px solid var(--webde-line);
+  border-radius: 999px;
+  color: var(--webde-muted);
+  display: inline-flex;
+  flex: none;
+  font-size: 12px;
+  font-weight: 650;
+  gap: 6px;
+  min-height: 32px;
+  padding-inline: 11px;
+  white-space: nowrap;
+}
+
+.readinessBadge[data-state="ready"],
+.readinessBadge[data-state="created"] {
+  border-color: color-mix(in srgb, var(--success) 42%, var(--webde-line));
+  color: var(--success);
+}
+
+.readinessBadge[data-state="blocked"],
+.readinessBadge[data-state="error"] {
+  border-color: color-mix(in srgb, var(--danger) 42%, var(--webde-line));
+  color: var(--danger);
+}
+
+.launchForm {
+  border-top: 1px solid var(--webde-line);
+  display: grid;
+  gap: 14px;
+  margin-top: 22px;
+  padding-top: 22px;
+}
+
+.secretField,
+.idempotencyField {
+  align-items: end;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.secretField > label,
+.idempotencyField > label {
+  min-width: 0;
+}
+
+.secretField > button,
+.idempotencyField > button {
+  gap: 7px;
+  min-width: 116px;
+}
+
+.fieldNote,
+.safetyNote {
+  color: var(--webde-dim);
+  font-size: 12px;
+  line-height: 1.5;
+  margin-top: -6px;
+  max-width: 680px;
+  text-wrap: pretty;
+}
+
+.fileField {
+  display: grid;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.fileField > span:first-child {
+  color: var(--webde-ink);
+  font-size: 14px;
+  font-weight: 620;
+}
+
+.fileControl {
+  align-items: center;
+  background: var(--webde-control);
+  border: 1px dashed var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-muted);
+  display: flex;
+  gap: 10px;
+  min-height: 52px;
+  padding: 8px 12px;
+}
+
+.fileControl > svg {
+  flex: none;
+}
+
+.fileControl input {
+  color: var(--webde-muted);
+  font: inherit;
+  font-size: 13px;
+  min-width: 0;
+  width: 100%;
+}
+
+.fileControl input::file-selector-button {
+  background: var(--webde-surface-raised);
+  border: 1px solid var(--webde-line);
+  border-radius: calc(var(--webde-radius-control) - 2px);
+  color: var(--webde-ink);
+  font: inherit;
+  font-weight: 620;
+  margin-inline-end: 10px;
+  min-height: 36px;
+  padding-inline: 10px;
+}
+
+.selectedFile {
+  align-items: center;
+  color: var(--webde-muted);
+  display: flex;
+  font-size: 12px;
+  gap: 12px;
+  justify-content: space-between;
+  margin-top: -6px;
+  min-width: 0;
+}
+
+.selectedFile strong {
+  color: var(--webde-ink);
+  font-weight: 590;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.selectedFile span {
+  flex: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.preflightResult,
+.createdResult {
+  background: var(--webde-surface-raised);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  padding: 14px;
+}
+
+.preflightResult[data-deployable="true"],
+.createdResult {
+  border-color: color-mix(in srgb, var(--success) 40%, var(--webde-line));
+}
+
+.preflightResult[data-deployable="false"] {
+  border-color: color-mix(in srgb, var(--danger) 40%, var(--webde-line));
+}
+
+.preflightResult > div:first-child {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  justify-content: space-between;
+}
+
+.preflightResult strong,
+.createdResult strong {
+  color: var(--webde-ink);
+  font-size: 14px;
+  font-weight: 620;
+}
+
+.preflightResult > div:first-child > span,
+.createdResult span {
+  color: var(--webde-dim);
+  font-size: 12px;
+  text-transform: capitalize;
+}
+
+.preflightResult dl {
+  display: grid;
+  gap: 9px;
+  margin-top: 12px;
+}
+
+.preflightResult dt {
+  color: var(--webde-dim);
+  font-size: 11px;
+  font-weight: 620;
+}
+
+.preflightResult dd {
+  color: var(--webde-muted);
+  font-size: 11px;
+  line-height: 1.45;
+  margin: 3px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.preflightResult > p {
+  color: var(--webde-muted);
+  font-size: 12px;
+  line-height: 1.5;
+  margin-top: 10px;
+  overflow-wrap: anywhere;
+}
+
+.actions {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 4px;
+}
+
+.createdResult {
+  align-items: center;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.createdResult > div {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.createdResult code {
+  color: var(--webde-muted);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.createdResult > button {
+  flex: none;
+}
+
+.safetyNote {
+  border-top: 1px solid var(--webde-line);
+  margin-top: 20px;
+  max-width: none;
+  padding-top: 14px;
+}
+
+.fileControl:has(input:focus-visible) {
+  outline: 2px solid var(--focus);
+  outline-offset: 3px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .fileControl:has(input:not(:disabled)):hover {
+    border-color: color-mix(in srgb, var(--focus) 50%, var(--webde-line));
+  }
+}
+
+@media (max-width: 680px) {
+  .launchHeader,
+  .createdResult {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .secretField,
+  .idempotencyField,
+  .actions {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .secretField > button,
+  .idempotencyField > button,
+  .actions > button,
+  .createdResult > button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fileControl,
+  .fileControl input::file-selector-button {
+    transition: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .readinessBadge,
+  .fileControl,
+  .preflightResult,
+  .createdResult {
+    border: 1px solid CanvasText;
+  }
+}

--- a/components/developer-robinhood-launch.tsx
+++ b/components/developer-robinhood-launch.tsx
@@ -1,0 +1,691 @@
+"use client";
+
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+} from "react";
+import { Check, FileJson, RefreshCw, Trash2 } from "lucide-react";
+
+import sharedStyles from "@/components/developer-api-keys.module.css";
+import styles from "@/components/developer-robinhood-launch.module.css";
+
+export const ROBINHOOD_PREFLIGHT_URL =
+  "https://api.programmable.market/v4/chains/4663/custom-launches/preflight";
+export const ROBINHOOD_CREATE_URL =
+  "https://api.programmable.market/v4/chains/4663/custom-launches";
+export const MAX_ROBINHOOD_LAUNCH_BYTES = 16 * 1024 * 1024;
+
+const apiKeyPattern =
+  /^pm_(?:live|partner|partner_root)_[A-Za-z0-9_-]{22}_[A-Za-z0-9_-]{43}$/u;
+const idempotencyKeyPattern = /^[A-Za-z0-9._:-]{16,128}$/u;
+const sha256Pattern = /^sha256:[0-9a-f]{64}$/u;
+const launchIdPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+
+const dispositions = new Set([
+  "supported",
+  "supported_with_warnings",
+  "needs_evidence",
+  "unsupported",
+  "system_blocked",
+]);
+
+type Fetcher = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+type PackedLaunch = Readonly<{
+  bytes: ArrayBuffer;
+  fileName: string;
+}>;
+
+export type RobinhoodPreflightProof = Readonly<{
+  deployable: boolean;
+  disposition: string;
+  hardBlockFindingCodes: readonly string[];
+  needsEvidenceFindingCodes: readonly string[];
+  rawRequestSha256: string;
+  requestBytes: ArrayBuffer;
+  requestHash: string;
+  warningFindingCodes: readonly string[];
+}>;
+
+export type RobinhoodLaunchCreated = Readonly<{
+  launchId: string;
+  requestId: string;
+  status: string;
+}>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringArray(value: unknown): readonly string[] | null {
+  return Array.isArray(value)
+    && value.every((candidate) => typeof candidate === "string")
+    ? value
+    : null;
+}
+
+function parsePreflight(
+  value: unknown,
+  requestBytes: ArrayBuffer,
+): RobinhoodPreflightProof | null {
+  if (
+    !isRecord(value)
+    || value.schemaVersion !== "programmable.custom-launch-preflight.v2"
+    || value.apiVersion !== "v4"
+    || value.chainId !== "4663"
+    || value.caip2 !== "eip155:4663"
+    || typeof value.disposition !== "string"
+    || !dispositions.has(value.disposition)
+    || typeof value.requestHash !== "string"
+    || !sha256Pattern.test(value.requestHash)
+    || typeof value.rawRequestSha256 !== "string"
+    || !sha256Pattern.test(value.rawRequestSha256)
+    || !isRecord(value.launchEligibility)
+    || typeof value.launchEligibility.deployable !== "boolean"
+    || value.quotaConsumed !== false
+    || value.nonceAllocated !== false
+    || value.persisted !== false
+    || value.walletSignatureRequiredLater !== true
+    || value.walletBroadcastByService !== false
+  ) return null;
+
+  const hardBlockFindingCodes = stringArray(value.hardBlockFindingCodes);
+  const needsEvidenceFindingCodes = stringArray(
+    value.needsEvidenceFindingCodes,
+  );
+  const warningFindingCodes = stringArray(value.warningFindingCodes);
+  if (
+    !hardBlockFindingCodes
+    || !needsEvidenceFindingCodes
+    || !warningFindingCodes
+  ) return null;
+
+  return Object.freeze({
+    deployable: value.launchEligibility.deployable,
+    disposition: value.disposition,
+    hardBlockFindingCodes,
+    needsEvidenceFindingCodes,
+    rawRequestSha256: value.rawRequestSha256,
+    requestBytes,
+    requestHash: value.requestHash,
+    warningFindingCodes,
+  });
+}
+
+function parseCreated(value: unknown): RobinhoodLaunchCreated | null {
+  if (
+    !isRecord(value)
+    || value.schemaVersion !== "programmable.custom-launch.v4"
+    || value.apiVersion !== "v4"
+    || value.chainId !== "4663"
+    || value.caip2 !== "eip155:4663"
+    || value.routeId !== "custom-launch:create:v4"
+    || typeof value.launchId !== "string"
+    || !launchIdPattern.test(value.launchId)
+    || typeof value.requestId !== "string"
+    || !launchIdPattern.test(value.requestId)
+    || typeof value.status !== "string"
+    || value.status.length === 0
+  ) return null;
+
+  return Object.freeze({
+    launchId: value.launchId,
+    requestId: value.requestId,
+    status: value.status,
+  });
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  return response.json().catch(() => null);
+}
+
+function apiError(
+  response: Response,
+  value: unknown,
+  fallback: string,
+) {
+  if (!isRecord(value) || !isRecord(value.error)) return fallback;
+  const message = typeof value.error.message === "string"
+    && value.error.message.trim().length > 0
+    ? value.error.message.trim()
+    : fallback;
+  const requestId = typeof value.error.requestId === "string"
+    && launchIdPattern.test(value.error.requestId)
+    ? ` Request ID: ${value.error.requestId}.`
+    : "";
+  const retryAfter = response.headers.get("retry-after");
+  const retry = retryAfter && /^[1-9][0-9]{0,4}$/u.test(retryAfter)
+    ? ` Try again in ${retryAfter} seconds.`
+    : "";
+  return `${message}${retry}${requestId}`;
+}
+
+function requestHeaders(apiKey: string) {
+  return new Headers({
+    Accept: "application/json",
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  });
+}
+
+function directRequestInit(
+  apiKey: string,
+  requestBytes: ArrayBuffer,
+  signal?: AbortSignal,
+): RequestInit {
+  return {
+    body: requestBytes,
+    cache: "no-store",
+    credentials: "omit",
+    headers: requestHeaders(apiKey),
+    method: "POST",
+    mode: "cors",
+    redirect: "error",
+    referrerPolicy: "no-referrer",
+    signal,
+  };
+}
+
+export function isRobinhoodApiKey(value: string) {
+  return apiKeyPattern.test(value);
+}
+
+export function isRobinhoodIdempotencyKey(value: string) {
+  return idempotencyKeyPattern.test(value);
+}
+
+export async function preflightRobinhoodLaunch(
+  fetcher: Fetcher,
+  apiKey: string,
+  requestBytes: ArrayBuffer,
+  signal?: AbortSignal,
+) {
+  if (!isRobinhoodApiKey(apiKey)) {
+    throw new TypeError("Enter a valid Programmable API key.");
+  }
+  if (
+    requestBytes.byteLength === 0
+    || requestBytes.byteLength > MAX_ROBINHOOD_LAUNCH_BYTES
+  ) {
+    throw new TypeError(
+      "Select a non-empty packed launch.json file no larger than 16 MiB.",
+    );
+  }
+
+  let response: Response;
+  try {
+    response = await fetcher(
+      ROBINHOOD_PREFLIGHT_URL,
+      directRequestInit(apiKey, requestBytes, signal),
+    );
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw error;
+    }
+    throw new Error(
+      "The browser could not reach Robinhood preflight. The API may be unavailable or browser access may not be enabled.",
+    );
+  }
+  const body = await readJson(response);
+  if (!response.ok || response.status !== 200) {
+    throw new Error(apiError(
+      response,
+      body,
+      "Robinhood preflight is unavailable or rejected this request.",
+    ));
+  }
+  const proof = parsePreflight(body, requestBytes);
+  if (!proof) {
+    throw new Error(
+      "The Robinhood preflight response could not be verified.",
+    );
+  }
+  return proof;
+}
+
+export async function createRobinhoodLaunch(
+  fetcher: Fetcher,
+  apiKey: string,
+  idempotencyKey: string,
+  proof: RobinhoodPreflightProof,
+  signal?: AbortSignal,
+) {
+  if (!isRobinhoodApiKey(apiKey)) {
+    throw new TypeError("Enter a valid Programmable API key.");
+  }
+  if (!isRobinhoodIdempotencyKey(idempotencyKey)) {
+    throw new TypeError(
+      "Use a 16–128 character Idempotency-Key with letters, numbers, dots, underscores, colons or hyphens.",
+    );
+  }
+  if (!proof.deployable) {
+    throw new TypeError(
+      "This exact launch.json did not pass a deployable preflight.",
+    );
+  }
+
+  const headers = requestHeaders(apiKey);
+  headers.set("Idempotency-Key", idempotencyKey);
+  let response: Response;
+  try {
+    response = await fetcher(ROBINHOOD_CREATE_URL, {
+      ...directRequestInit(apiKey, proof.requestBytes, signal),
+      headers,
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw error;
+    }
+    throw new Error(
+      "The create result is unknown. Keep this exact file and Idempotency-Key, then retry when the API is reachable.",
+    );
+  }
+  const body = await readJson(response);
+  if (!response.ok || (response.status !== 200 && response.status !== 202)) {
+    throw new Error(apiError(
+      response,
+      body,
+      "The Robinhood launch request was not created.",
+    ));
+  }
+  const created = parseCreated(body);
+  if (!created) {
+    throw new Error(
+      "The launch may have been created, but the response could not be verified. Retry with the same file and Idempotency-Key.",
+    );
+  }
+  return created;
+}
+
+function createIdempotencyKey() {
+  return globalThis.crypto.randomUUID();
+}
+
+function formatBytes(byteLength: number) {
+  if (byteLength < 1_000) return `${byteLength} B`;
+  if (byteLength < 1_000_000) return `${(byteLength / 1_000).toFixed(1)} KB`;
+  return `${(byteLength / 1_000_000).toFixed(1)} MB`;
+}
+
+type LaunchState =
+  | "idle"
+  | "checking"
+  | "ready"
+  | "blocked"
+  | "creating"
+  | "created"
+  | "error";
+
+export function DeveloperRobinhoodLaunch({
+  onOpenLaunch,
+}: Readonly<{
+  onOpenLaunch: (launchId: string) => void;
+}>) {
+  const [apiKey, setApiKey] = useState("");
+  const [idempotencyKey, setIdempotencyKey] = useState("");
+  const [packedLaunch, setPackedLaunch] = useState<PackedLaunch | null>(null);
+  const [proof, setProof] = useState<RobinhoodPreflightProof | null>(null);
+  const [created, setCreated] = useState<RobinhoodLaunchCreated | null>(null);
+  const [idempotencyLocked, setIdempotencyLocked] = useState(false);
+  const [state, setState] = useState<LaunchState>("idle");
+  const [error, setError] = useState("");
+  const apiKeyRef = useRef<HTMLInputElement>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+  const fileGenerationRef = useRef(0);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => controllerRef.current?.abort();
+  }, []);
+
+  const busy = state === "checking" || state === "creating";
+  const createEnabled = state === "ready"
+    && packedLaunch !== null
+    && proof !== null
+    && proof.requestBytes === packedLaunch.bytes
+    && proof.deployable
+    && isRobinhoodApiKey(apiKey)
+    && isRobinhoodIdempotencyKey(idempotencyKey);
+
+  const resetVerification = () => {
+    controllerRef.current?.abort();
+    controllerRef.current = null;
+    setProof(null);
+    setCreated(null);
+    setError("");
+    setState("idle");
+  };
+
+  const changeFile = async (event: ChangeEvent<HTMLInputElement>) => {
+    const generation = ++fileGenerationRef.current;
+    const file = event.target.files?.[0] ?? null;
+    resetVerification();
+    setPackedLaunch(null);
+    setIdempotencyLocked(false);
+    setIdempotencyKey(createIdempotencyKey());
+    if (!file) return;
+    if (file.size === 0 || file.size > MAX_ROBINHOOD_LAUNCH_BYTES) {
+      setError(
+        "Select a non-empty packed launch.json file no larger than 16 MiB.",
+      );
+      setState("error");
+      return;
+    }
+    try {
+      const bytes = await file.arrayBuffer();
+      if (generation !== fileGenerationRef.current) return;
+      if (bytes.byteLength > MAX_ROBINHOOD_LAUNCH_BYTES) {
+        throw new Error("The selected file exceeds 16 MiB.");
+      }
+      setPackedLaunch(Object.freeze({ bytes, fileName: file.name }));
+    } catch (caught) {
+      if (generation !== fileGenerationRef.current) return;
+      setError(caught instanceof Error
+        ? caught.message
+        : "The selected launch.json could not be read.");
+      setState("error");
+    }
+  };
+
+  const changeApiKey = (value: string) => {
+    resetVerification();
+    setApiKey(value.trim());
+  };
+
+  const clearApiKey = () => {
+    resetVerification();
+    setApiKey("");
+    window.requestAnimationFrame(() => apiKeyRef.current?.focus());
+  };
+
+  const runPreflight = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (busy || !packedLaunch) return;
+    if (!isRobinhoodApiKey(apiKey)) {
+      setError("Enter a valid Programmable API key.");
+      setState("error");
+      apiKeyRef.current?.focus();
+      return;
+    }
+
+    const controller = new AbortController();
+    controllerRef.current?.abort();
+    controllerRef.current = controller;
+    setProof(null);
+    setCreated(null);
+    setError("");
+    setState("checking");
+    try {
+      const nextProof = await preflightRobinhoodLaunch(
+        fetch,
+        apiKey,
+        packedLaunch.bytes,
+        controller.signal,
+      );
+      setProof(nextProof);
+      setState(nextProof.deployable ? "ready" : "blocked");
+    } catch (caught) {
+      if (caught instanceof DOMException && caught.name === "AbortError") return;
+      setError(caught instanceof Error
+        ? caught.message
+        : "Robinhood preflight failed.");
+      setState("error");
+    } finally {
+      if (controllerRef.current === controller) controllerRef.current = null;
+    }
+  };
+
+  const submitLaunch = async () => {
+    if (!createEnabled || !proof) return;
+    const controller = new AbortController();
+    controllerRef.current?.abort();
+    controllerRef.current = controller;
+    setIdempotencyLocked(true);
+    setError("");
+    setState("creating");
+    try {
+      const result = await createRobinhoodLaunch(
+        fetch,
+        apiKey,
+        idempotencyKey,
+        proof,
+        controller.signal,
+      );
+      setCreated(result);
+      setApiKey("");
+      setProof(null);
+      setPackedLaunch(null);
+      if (fileRef.current) fileRef.current.value = "";
+      setState("created");
+    } catch (caught) {
+      if (caught instanceof DOMException && caught.name === "AbortError") return;
+      setError(caught instanceof Error
+        ? caught.message
+        : "The Robinhood launch request was not created.");
+      setState("ready");
+    } finally {
+      if (controllerRef.current === controller) controllerRef.current = null;
+    }
+  };
+
+  const findingCodes = proof
+    ? [
+        ...proof.hardBlockFindingCodes,
+        ...proof.needsEvidenceFindingCodes,
+        ...proof.warningFindingCodes,
+      ]
+    : [];
+
+  const readinessLabel = state === "checking"
+    ? "Checking exact bytes"
+    : state === "ready"
+      ? "Ready to create"
+      : state === "blocked"
+        ? "Not deployable"
+        : state === "creating"
+          ? "Creating request"
+          : state === "created"
+            ? "Request created"
+            : state === "error"
+              ? "Not ready"
+              : "Preflight required";
+
+  return (
+    <section
+      className={`${sharedStyles.panel} ${styles.launchPanel}`}
+      aria-labelledby="robinhood-launch-title"
+      aria-busy={busy}
+    >
+      <div className={styles.launchHeader}>
+        <div>
+          <p className={sharedStyles.kicker}>Robinhood Chain · 4663</p>
+          <h2 id="robinhood-launch-title">Launch a Custom v4 hook</h2>
+          <p>
+            Send the exact packed <code>launch.json</code> directly to the
+            Programmable API. Preflight is side-effect free; creating a request
+            never signs or broadcasts a wallet transaction.
+          </p>
+        </div>
+        <span
+          className={styles.readinessBadge}
+          data-state={state}
+          role="status"
+          aria-live="polite"
+        >
+          {state === "ready" || state === "created" ? (
+            <Check aria-hidden="true" size={14} strokeWidth={2.2} />
+          ) : null}
+          {readinessLabel}
+        </span>
+      </div>
+
+      <form className={styles.launchForm} onSubmit={runPreflight}>
+        <div className={styles.secretField}>
+          <label className={sharedStyles.field} htmlFor="robinhood-api-key">
+            <span>Programmable API key</span>
+            <input
+              ref={apiKeyRef}
+              id="robinhood-api-key"
+              aria-describedby="robinhood-api-key-note"
+              aria-invalid={apiKey.length > 0 && !isRobinhoodApiKey(apiKey)}
+              autoCapitalize="none"
+              autoComplete="off"
+              disabled={busy}
+              inputMode="text"
+              spellCheck={false}
+              type="password"
+              value={apiKey}
+              onChange={(event) => changeApiKey(event.target.value)}
+            />
+          </label>
+          <button
+            className={sharedStyles.secondaryButton}
+            disabled={busy || apiKey.length === 0}
+            type="button"
+            onClick={clearApiKey}
+          >
+            <Trash2 aria-hidden="true" size={16} strokeWidth={1.9} />
+            Clear key
+          </button>
+        </div>
+        <p className={styles.fieldNote} id="robinhood-api-key-note">
+          This page does not store or log the key. Your browser sends it only
+          to <code>api.programmable.market</code> for these direct requests.
+        </p>
+
+        <label className={styles.fileField} htmlFor="robinhood-launch-file">
+          <span>Packed launch.json</span>
+          <span className={styles.fileControl}>
+            <FileJson aria-hidden="true" size={19} strokeWidth={1.8} />
+            <input
+              ref={fileRef}
+              id="robinhood-launch-file"
+              accept=".json,application/json"
+              disabled={busy}
+              type="file"
+              onChange={(event) => void changeFile(event)}
+            />
+          </span>
+        </label>
+        {packedLaunch ? (
+          <p className={styles.selectedFile}>
+            <strong>{packedLaunch.fileName}</strong>
+            <span>{formatBytes(packedLaunch.bytes.byteLength)}</span>
+          </p>
+        ) : null}
+
+        <div className={styles.idempotencyField}>
+          <label className={sharedStyles.field} htmlFor="robinhood-idempotency-key">
+            <span>Idempotency-Key</span>
+            <input
+              id="robinhood-idempotency-key"
+              aria-describedby="robinhood-idempotency-note"
+              aria-invalid={
+                idempotencyKey.length > 0
+                && !isRobinhoodIdempotencyKey(idempotencyKey)
+              }
+              autoCapitalize="none"
+              autoComplete="off"
+              disabled={busy || idempotencyLocked}
+              maxLength={128}
+              minLength={16}
+              spellCheck={false}
+              type="text"
+              value={idempotencyKey}
+              onChange={(event) => setIdempotencyKey(event.target.value)}
+            />
+          </label>
+          <button
+            className={sharedStyles.secondaryButton}
+            disabled={busy || idempotencyLocked}
+            type="button"
+            onClick={() => setIdempotencyKey(createIdempotencyKey())}
+          >
+            <RefreshCw aria-hidden="true" size={16} strokeWidth={1.9} />
+            New key
+          </button>
+        </div>
+        <p className={styles.fieldNote} id="robinhood-idempotency-note">
+          Keep this value unchanged if a create request needs to be retried.
+        </p>
+
+        {proof ? (
+          <div className={styles.preflightResult} data-deployable={proof.deployable}>
+            <div>
+              <strong>
+                {proof.deployable
+                  ? "Exact request bytes passed preflight"
+                  : "Exact request bytes are not deployable"}
+              </strong>
+              <span>{proof.disposition.replaceAll("_", " ")}</span>
+            </div>
+            <dl>
+              <div>
+                <dt>Raw request SHA-256</dt>
+                <dd><code>{proof.rawRequestSha256}</code></dd>
+              </div>
+              <div>
+                <dt>Request hash</dt>
+                <dd><code>{proof.requestHash}</code></dd>
+              </div>
+            </dl>
+            {findingCodes.length > 0 ? (
+              <p>Findings: {findingCodes.join(", ")}</p>
+            ) : null}
+          </div>
+        ) : null}
+
+        {error ? (
+          <p className={sharedStyles.inlineError} role="alert">{error}</p>
+        ) : null}
+
+        {created ? (
+          <div className={styles.createdResult} role="status">
+            <div>
+              <strong>Launch request created</strong>
+              <code>{created.launchId}</code>
+              <span>Status: {created.status.replaceAll("_", " ")}</span>
+            </div>
+            <button
+              className={sharedStyles.primaryButton}
+              type="button"
+              onClick={() => onOpenLaunch(created.launchId)}
+            >
+              Open launch history
+            </button>
+          </div>
+        ) : (
+          <div className={styles.actions}>
+            <button
+              className={sharedStyles.secondaryButton}
+              disabled={busy || !packedLaunch || !isRobinhoodApiKey(apiKey)}
+              type="submit"
+            >
+              {state === "checking" ? "Running preflight" : "Run preflight"}
+            </button>
+            <button
+              className={sharedStyles.primaryButton}
+              disabled={!createEnabled}
+              type="button"
+              onClick={() => void submitLaunch()}
+            >
+              {state === "creating" ? "Creating request" : "Create launch request"}
+            </button>
+          </div>
+        )}
+      </form>
+
+      <p className={styles.safetyNote}>
+        The API can prepare the launch, but your wallet remains the only signing
+        and broadcast authority.
+      </p>
+    </section>
+  );
+}

--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -137,19 +137,19 @@ export function LaunchModelPicker({
           className={`launch-model-card-heading ${launchExperience.modelHeading}`}
         >
           <strong id="launch-model-custom-title">Custom</strong>
-          <small data-status="live">Live API</small>
+          <small data-status="pending">Preflight required</small>
         </span>
         <span
           className={`launch-model-description ${launchExperience.modelDescription}`}
           id="launch-model-custom-description"
         >
-          Package, validate and submit a deterministic Custom launch through
-          the public V3 API. Your connected wallet reviews and signs separately.
+          Upload an exact packed Custom launch, preflight it against Robinhood
+          Chain, then create the request. Your wallet reviews and signs later.
         </span>
         <span
           className={`launch-model-action ${launchExperience.modelAction}`}
         >
-          Open API launch guide
+          Open Custom launch
           <ArrowRight aria-hidden="true" size={16} />
         </span>
       </span>
@@ -244,9 +244,9 @@ export function LaunchModelPicker({
           className={`launch-model-card ${launchExperience.modelCard} liquid-glass-surface`}
           data-launch-model-option="custom"
           data-launch-model-available="true"
-          data-launch-model-entry="public-api"
+          data-launch-model-entry="api-key-launch"
           data-launch-model-launchable="false"
-          href="/docs/developers/custom-launch"
+          href="/developers/api-keys?start=custom&chainId=4663"
           aria-labelledby="launch-model-custom-title"
           aria-describedby="launch-model-custom-description"
         >

--- a/tests/developer-robinhood-launch.test.tsx
+++ b/tests/developer-robinhood-launch.test.tsx
@@ -1,0 +1,245 @@
+import { readFileSync } from "node:fs";
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DeveloperRobinhoodLaunch,
+  MAX_ROBINHOOD_LAUNCH_BYTES,
+  ROBINHOOD_CREATE_URL,
+  ROBINHOOD_PREFLIGHT_URL,
+  createRobinhoodLaunch,
+  isRobinhoodIdempotencyKey,
+  preflightRobinhoodLaunch,
+} from "../components/developer-robinhood-launch";
+
+const componentSource = readFileSync(
+  new URL("../components/developer-robinhood-launch.tsx", import.meta.url),
+  "utf8",
+);
+const apiKeysSource = readFileSync(
+  new URL("../components/developer-api-keys.tsx", import.meta.url),
+  "utf8",
+);
+const launchEntrySource = readFileSync(
+  new URL("../components/launch-entry.tsx", import.meta.url),
+  "utf8",
+);
+
+const apiKey = `pm_live_${"A".repeat(22)}_${"B".repeat(43)}`;
+const idempotencyKey = ["test", "robinhood", "replay", "0001"].join("-");
+const launchId = "018f3e2a-7b4c-7d5e-8f90-123456789abc";
+
+function json(value: unknown, status = 200) {
+  return new Response(JSON.stringify(value), {
+    headers: { "content-type": "application/json" },
+    status,
+  });
+}
+
+function preflightResponse(deployable = true) {
+  return {
+    schemaVersion: "programmable.custom-launch-preflight.v2",
+    apiVersion: "v4",
+    chainId: "4663",
+    caip2: "eip155:4663",
+    requestHash: `sha256:${"1".repeat(64)}`,
+    rawRequestSha256: `sha256:${"2".repeat(64)}`,
+    disposition: deployable ? "supported" : "needs_evidence",
+    launchEligibility: {
+      deployable,
+      routable: false,
+      featured: false,
+    },
+    hardBlockFindingCodes: [],
+    needsEvidenceFindingCodes: deployable ? [] : ["SOURCE_EVIDENCE_REQUIRED"],
+    warningFindingCodes: [],
+    quotaConsumed: false,
+    nonceAllocated: false,
+    persisted: false,
+    walletSignatureRequiredLater: true,
+    walletBroadcastByService: false,
+  };
+}
+
+function createdResponse(status = "accepted") {
+  return {
+    schemaVersion: "programmable.custom-launch.v4",
+    apiVersion: "v4",
+    chainId: "4663",
+    caip2: "eip155:4663",
+    routeId: "custom-launch:create:v4",
+    launchId,
+    requestId: launchId,
+    status,
+  };
+}
+
+describe("Robinhood Custom launch website flow", () => {
+  it("sends the same exact ArrayBuffer directly to preflight and create", async () => {
+    const requestBytes = new TextEncoder().encode('{"exact":true}\n').buffer;
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(json(preflightResponse()))
+      .mockResolvedValueOnce(json(createdResponse(), 202));
+
+    const proof = await preflightRobinhoodLaunch(
+      fetcher,
+      apiKey,
+      requestBytes,
+    );
+    const created = await createRobinhoodLaunch(
+      fetcher,
+      apiKey,
+      idempotencyKey,
+      proof,
+    );
+
+    expect(created.launchId).toBe(launchId);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher.mock.calls[0]?.[0]).toBe(ROBINHOOD_PREFLIGHT_URL);
+    expect(fetcher.mock.calls[1]?.[0]).toBe(ROBINHOOD_CREATE_URL);
+    const preflightInit = fetcher.mock.calls[0]?.[1] as RequestInit;
+    const createInit = fetcher.mock.calls[1]?.[1] as RequestInit;
+    expect(preflightInit.body).toBe(requestBytes);
+    expect(createInit.body).toBe(requestBytes);
+    expect(createInit.body).toBe(preflightInit.body);
+    for (const init of [preflightInit, createInit]) {
+      expect(init.credentials).toBe("omit");
+      expect(init.referrerPolicy).toBe("no-referrer");
+      expect(init.redirect).toBe("error");
+      expect(init.method).toBe("POST");
+      expect(new Headers(init.headers).get("authorization"))
+        .toBe(`Bearer ${apiKey}`);
+    }
+    expect(new Headers(preflightInit.headers).has("idempotency-key"))
+      .toBe(false);
+    expect(new Headers(createInit.headers).get("idempotency-key"))
+      .toBe(idempotencyKey);
+  });
+
+  it.each([200, 202])(
+    "accepts the verified create resource for HTTP %i",
+    async (status) => {
+      const requestBytes = new TextEncoder().encode("{}").buffer;
+      const preflightFetcher = vi.fn().mockResolvedValue(
+        json(preflightResponse()),
+      );
+      const proof = await preflightRobinhoodLaunch(
+        preflightFetcher,
+        apiKey,
+        requestBytes,
+      );
+      const createFetcher = vi.fn().mockResolvedValue(
+        json(createdResponse(status === 200 ? "replayed" : "accepted"), status),
+      );
+
+      await expect(createRobinhoodLaunch(
+        createFetcher,
+        apiKey,
+        idempotencyKey,
+        proof,
+      )).resolves.toMatchObject({ launchId });
+    },
+  );
+
+  it("retries an ambiguous create with the same body and Idempotency-Key", async () => {
+    const requestBytes = new TextEncoder().encode("{}").buffer;
+    const proof = await preflightRobinhoodLaunch(
+      vi.fn().mockResolvedValue(json(preflightResponse())),
+      apiKey,
+      requestBytes,
+    );
+    const fetcher = vi.fn()
+      .mockRejectedValueOnce(new TypeError("network unavailable"))
+      .mockResolvedValueOnce(json(createdResponse("replayed"), 200));
+
+    await expect(createRobinhoodLaunch(
+      fetcher,
+      apiKey,
+      idempotencyKey,
+      proof,
+    )).rejects.toThrow("create result is unknown");
+    await expect(createRobinhoodLaunch(
+      fetcher,
+      apiKey,
+      idempotencyKey,
+      proof,
+    )).resolves.toMatchObject({ status: "replayed" });
+
+    const first = fetcher.mock.calls[0]?.[1] as RequestInit;
+    const retry = fetcher.mock.calls[1]?.[1] as RequestInit;
+    expect(first.body).toBe(requestBytes);
+    expect(retry.body).toBe(requestBytes);
+    expect(new Headers(first.headers).get("idempotency-key"))
+      .toBe(idempotencyKey);
+    expect(new Headers(retry.headers).get("idempotency-key"))
+      .toBe(idempotencyKey);
+  });
+
+  it("enforces the exact 16 MiB body limit before any network request", async () => {
+    const fetcher = vi.fn();
+    expect(MAX_ROBINHOOD_LAUNCH_BYTES).toBe(16 * 1024 * 1024);
+
+    await expect(preflightRobinhoodLaunch(
+      fetcher,
+      apiKey,
+      new ArrayBuffer(MAX_ROBINHOOD_LAUNCH_BYTES + 1),
+    )).rejects.toThrow("no larger than 16 MiB");
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("keeps blocked preflight honest and refuses create", async () => {
+    const requestBytes = new TextEncoder().encode("{}").buffer;
+    const proof = await preflightRobinhoodLaunch(
+      vi.fn().mockResolvedValue(json(preflightResponse(false))),
+      apiKey,
+      requestBytes,
+    );
+
+    expect(proof.deployable).toBe(false);
+    await expect(createRobinhoodLaunch(
+      vi.fn(),
+      apiKey,
+      idempotencyKey,
+      proof,
+    )).rejects.toThrow("did not pass a deployable preflight");
+  });
+
+  it("renders secret-safe, accessible controls and locks replay identity", () => {
+    const html = renderToStaticMarkup(
+      <DeveloperRobinhoodLaunch onOpenLaunch={() => undefined} />,
+    );
+
+    expect(html).toContain('type="password"');
+    expect(html).toContain('id="robinhood-launch-file"');
+    expect(html).toContain('accept=".json,application/json"');
+    expect(html).toContain("Preflight required");
+    expect(html).toContain("Create launch request");
+    expect(html).toContain("never signs or broadcasts");
+    expect(html).not.toContain(apiKey);
+    expect(componentSource).not.toContain("localStorage");
+    expect(componentSource).not.toContain("sessionStorage");
+    expect(componentSource).not.toContain("console.");
+    expect(componentSource).toContain("setIdempotencyLocked(true)");
+    expect(componentSource).toContain("disabled={busy || idempotencyLocked}");
+    expect(isRobinhoodIdempotencyKey(idempotencyKey)).toBe(true);
+    expect(isRobinhoodIdempotencyKey("too-short")).toBe(false);
+  });
+
+  it("routes the Custom card into the chain-bound launch section", () => {
+    expect(launchEntrySource).toContain(
+      'href="/developers/api-keys?start=custom&chainId=4663"',
+    );
+    expect(launchEntrySource).toContain(
+      'data-status="pending">Preflight required</small>',
+    );
+    expect(launchEntrySource).not.toContain("Live API");
+    expect(apiKeysSource).toContain(
+      'url.searchParams.get("start") === "custom"',
+    );
+    expect(apiKeysSource).toContain(
+      'url.searchParams.get("chainId") === "4663"',
+    );
+    expect(apiKeysSource).toContain('setActiveSection("launch")');
+  });
+});

--- a/tests/launch-model-gating.test.ts
+++ b/tests/launch-model-gating.test.ts
@@ -192,19 +192,23 @@ describe("unreleased launch model gating", () => {
       /<a[^>]*data-launch-model-option="custom"[^>]*>/,
     )?.[0];
     expect(customCard).toContain('data-launch-model-available="true"');
-    expect(customCard).toContain('data-launch-model-entry="public-api"');
+    expect(customCard).toContain('data-launch-model-entry="api-key-launch"');
     expect(customCard).toContain('data-launch-model-launchable="false"');
-    expect(customCard).toContain('href="/docs/developers/custom-launch"');
+    expect(customCard).toContain(
+      'href="/developers/api-keys?start=custom&amp;chainId=4663"',
+    );
     expect(customCard).not.toContain("disabled");
     expect(html).toContain(
       'id="launch-model-custom-title">Custom</strong>',
     );
     expect(html).toContain("Create a Classic coin");
-    expect(html).toContain('data-status="live">Live API</small>');
     expect(html).toContain(
-      "Package, validate and submit a deterministic Custom launch through the public V3 API. Your connected wallet reviews and signs separately.",
+      'data-status="pending">Preflight required</small>',
     );
-    expect(html).toContain("Open API launch guide");
+    expect(html).toContain(
+      "Upload an exact packed Custom launch, preflight it against Robinhood Chain, then create the request. Your wallet reviews and signs later.",
+    );
+    expect(html).toContain("Open Custom launch");
     expect(html).not.toContain("approved GitHub revision");
     expect(html.indexOf('data-launch-model-option="classic"')).toBeLessThan(
       html.indexOf('data-launch-model-option="custom"'),
@@ -226,7 +230,7 @@ describe("unreleased launch model gating", () => {
     expect(html).not.toContain("Liquidity Growth");
   });
 
-  it("keeps the public Custom API entry independent of the legacy gate", () => {
+  it("keeps the Robinhood Custom entry independent of the legacy gate", () => {
     const html = renderToStaticMarkup(
       createElement(LaunchModelPicker, {
         onChoose: () => undefined,
@@ -237,11 +241,15 @@ describe("unreleased launch model gating", () => {
     expect(html).toContain('data-launch-model-option="custom"');
     expect(html).toContain('id="launch-model-custom-title"');
     expect(html).toContain('data-launch-model-available="true"');
-    expect(html).toContain('data-launch-model-entry="public-api"');
+    expect(html).toContain('data-launch-model-entry="api-key-launch"');
     expect(html).toContain('data-launch-model-launchable="false"');
-    expect(html).toContain('data-status="live">Live API</small>');
-    expect(html).toContain('href="/docs/developers/custom-launch"');
-    expect(html).toContain("Open API launch guide");
+    expect(html).toContain(
+      'data-status="pending">Preflight required</small>',
+    );
+    expect(html).toContain(
+      'href="/developers/api-keys?start=custom&amp;chainId=4663"',
+    );
+    expect(html).toContain("Open Custom launch");
     expect(html).not.toContain("approved GitHub revision");
     expect(html).not.toContain("Build or resume");
   });

--- a/tests/launch-model-motion.test.ts
+++ b/tests/launch-model-motion.test.ts
@@ -64,8 +64,10 @@ describe("launch model artwork", () => {
     );
     expect(source).toContain('data-launch-model-option="custom"');
     expect(source).toContain('data-launch-model-available="true"');
-    expect(source).toContain('data-launch-model-entry="public-api"');
-    expect(source).toContain('href="/docs/developers/custom-launch"');
+    expect(source).toContain('data-launch-model-entry="api-key-launch"');
+    expect(source).toContain(
+      'href="/developers/api-keys?start=custom&chainId=4663"',
+    );
     expect(source).not.toContain('onChoose("custom")');
     expect(source).not.toContain("customLaunchPublicEnabled");
     expect(source).not.toContain("custom-launch-experience");


### PR DESCRIPTION
## Outcome

Adds the missing first-party website path from connected wallet and API key to exact Robinhood Custom Launch preflight/create, then into the existing launch history and wallet handoff.

## Security boundary

- API key remains only in password-component memory and is clearable
- browser calls only `api.programmable.market` V4 chain-4663 preflight/create
- exact same `ArrayBuffer` for preflight and create
- no website BFF, persistence, logging, signing, or broadcast
- `credentials: omit`, `no-referrer`, redirects fail closed
- 16 MiB V4 limit and stable idempotency identity for ambiguous retries

## Verification

- typecheck pass
- focused ESLint pass
- focused tests 62/62
- production build and Custom Launch production-bundle verification pass

Backend CORS is tracked separately in programmablehq/programmable-open-hook-v2-internal#186.