### PR TITLE
fix(web): preserve Robinhood V4 launch identity

### DIFF
--- a/components/developer-launch-history.tsx
+++ b/components/developer-launch-history.tsx
@@ -693,7 +693,7 @@ function parseV4Launch(
     || typeof value.launchId !== "string"
     || !requestIdPattern.test(value.launchId)
     || typeof value.requestId !== "string"
-    || value.requestId !== value.launchId
+    || !requestIdPattern.test(value.requestId)
     || !isRecord(value.controller)
     || value.controller.namespace !== "eip155:4663"
     || typeof value.controller.address !== "string"
@@ -1481,10 +1481,18 @@ function terminalStatus(status: LaunchStatus) {
   return status === "finalized" || status === "failed" || status === "cancelled";
 }
 
-function launchResourceKey(
-  launch: Pick<LaunchResource, "routeId" | "requestId">,
+export function launchResourceIdentity(
+  launch: Pick<LaunchResource, "routeId" | "launchId" | "requestId">,
 ) {
-  return `${launch.routeId}:${launch.requestId}`;
+  return launch.routeId === "custom-launch:create:v4"
+    ? launch.launchId
+    : launch.requestId;
+}
+
+function launchResourceKey(
+  launch: Pick<LaunchResource, "routeId" | "launchId" | "requestId">,
+) {
+  return `${launch.routeId}:${launchResourceIdentity(launch)}`;
 }
 
 function updatedAtTime(value: string) {
@@ -1820,10 +1828,11 @@ function ProjectMetadataReview({
     || requirements.complete;
   const website = presentation.links.find((link) => link.kind === "website");
   const xLink = presentation.links.find((link) => link.kind === "x");
+  const resourceIdentity = launchResourceIdentity(launch);
   return (
     <section
       className={styles.projectReview}
-      aria-labelledby={`project-metadata-${launch.requestId}`}
+      aria-labelledby={`project-metadata-${resourceIdentity}`}
     >
       <div className={styles.projectReviewHeading}>
         <div className={styles.projectArtwork}>
@@ -1842,7 +1851,7 @@ function ProjectMetadataReview({
         </div>
         <div className={styles.projectIdentity}>
           <span>Included in this launch</span>
-          <h4 id={`project-metadata-${launch.requestId}`}>{token.name}</h4>
+          <h4 id={`project-metadata-${resourceIdentity}`}>{token.name}</h4>
           <strong>${token.symbol}</strong>
         </div>
       </div>
@@ -1970,10 +1979,11 @@ function LaunchTruthLedger({ launch }: Readonly<{ launch: LaunchResource }>) {
     sourceVerification: launch.sourceVerification,
     liquidityIntent: launch.liquidityIntent,
   });
+  const resourceIdentity = launchResourceIdentity(launch);
   return (
-    <section className={styles.truthLedger} aria-labelledby={`truth-${launch.requestId}`}>
+    <section className={styles.truthLedger} aria-labelledby={`truth-${resourceIdentity}`}>
       <div className={styles.truthHeading}>
-        <h4 id={`truth-${launch.requestId}`}>What this record proves</h4>
+        <h4 id={`truth-${resourceIdentity}`}>What this record proves</h4>
         <span>Independent states</span>
       </div>
       <dl className={styles.truthGrid}>
@@ -2278,7 +2288,7 @@ export function DeveloperLaunchHistory({
   }, [account, getAuthHeaders]);
 
   const readLaunchResource = useCallback(async (
-    launch: Pick<LaunchResource, "requestId" | "routeId">,
+    launch: Pick<LaunchResource, "launchId" | "requestId" | "routeId">,
     signal?: AbortSignal,
   ) => {
     const version = launch.routeId === "custom-launch:create:v4"
@@ -2288,8 +2298,9 @@ export function DeveloperLaunchHistory({
       : launch.routeId === "custom-launch:create:v2"
         ? "v2"
         : "v1";
+    const resourceIdentity = launchResourceIdentity(launch);
     const response = await fetch(
-      `/api/developer/custom-launches/${encodeURIComponent(launch.requestId)}?walletAddress=${encodeURIComponent(account)}&version=${version}`,
+      `/api/developer/custom-launches/${encodeURIComponent(resourceIdentity)}?walletAddress=${encodeURIComponent(account)}&version=${version}`,
       {
         cache: "no-store",
         headers: await getAuthHeaders(),
@@ -2307,7 +2318,7 @@ export function DeveloperLaunchHistory({
     const updated = parseLaunch(body, account);
     if (
       !updated ||
-      updated.requestId !== launch.requestId ||
+      launchResourceIdentity(updated) !== resourceIdentity ||
       updated.routeId !== launch.routeId
     ) {
       throw new Error("The API returned an invalid launch status.");
@@ -2342,7 +2353,7 @@ export function DeveloperLaunchHistory({
     headers.set("Content-Type", "application/json");
     const response = await fetch(
       `/api/developer/custom-launches/${
-        encodeURIComponent(launch.requestId)
+        encodeURIComponent(launch.launchId)
       }/submission-hint?walletAddress=${
         encodeURIComponent(account)
       }&version=v4`,
@@ -2368,7 +2379,7 @@ export function DeveloperLaunchHistory({
       || !isRecord(body)
       || body.schemaVersion !== "programmable.custom-launch-submission-hint.v1"
       || body.apiVersion !== "v4"
-      || body.launchId !== launch.requestId
+      || body.launchId !== launch.launchId
       || body.chainId !== "4663"
       || body.chainDeploymentId !== "robinhood-mainnet-custom-launch-v1"
       || body.transactionHash !== transactionHash
@@ -2376,7 +2387,7 @@ export function DeveloperLaunchHistory({
       || body.authoritative !== false
       || typeof body.acceptedAt !== "string"
       || body.statusPath
-        !== `/v4/chains/4663/wallet-admin/custom-launches/${launch.requestId}`) {
+        !== `/v4/chains/4663/wallet-admin/custom-launches/${launch.launchId}`) {
       throw new Error("The API returned an invalid transaction discovery receipt.");
     }
     return body;
@@ -2406,7 +2417,7 @@ export function DeveloperLaunchHistory({
     const launch = parseLaunch(body, account);
     if (
       !launch
-      || launch.requestId !== launchId
+      || launchResourceIdentity(launch) !== launchId
       || launch.routeId !== `custom-launch:create:${version}`
     ) throw new Error("The API returned an invalid wallet handoff.");
     return launch;
@@ -2473,7 +2484,7 @@ export function DeveloperLaunchHistory({
             ? "Wallet handoff loaded. Review every field before opening your wallet."
             : "Launch loaded. Its current status does not request a wallet action.",
         );
-        focusLaunchCard(launch.requestId);
+        focusLaunchCard(launchResourceIdentity(launch));
       })
       .catch((cause) => {
         if (cause instanceof DOMException && cause.name === "AbortError") return;
@@ -2578,7 +2589,7 @@ export function DeveloperLaunchHistory({
           ? "Exact remediation loaded. Fix every listed item before creating a new request."
           : "Exact launch evidence loaded.",
       );
-      focusLaunchCard(current.requestId);
+      focusLaunchCard(launchResourceIdentity(current));
     } catch (cause) {
       reportLaunchError(key, cause, "Unable to load the exact launch details.");
     } finally {
@@ -3327,6 +3338,7 @@ export function DeveloperLaunchHistory({
         <ul className={styles.launchList}>
           {launches.map((launch) => {
             const key = launchResourceKey(launch);
+            const resourceIdentity = launchResourceIdentity(launch);
             const reviewLaunch = reviewResourceForLaunch(
               launch,
               hydratedReviews[key],
@@ -3378,17 +3390,17 @@ export function DeveloperLaunchHistory({
               );
             return (
               <li
-                id={`custom-launch-${launch.requestId}`}
+                id={`custom-launch-${resourceIdentity}`}
                 className={styles.launchItem}
                 data-highlighted={
-                  highlightedLaunchId === launch.requestId ? "true" : "false"
+                  highlightedLaunchId === resourceIdentity ? "true" : "false"
                 }
                 key={key}
                 tabIndex={-1}
               >
                 <div className={styles.launchTopline}>
                   <div>
-                    <h3>Launch {shortId(launch.requestId)}</h3>
+                    <h3>Launch {shortId(resourceIdentity)}</h3>
                   </div>
                   <span className={styles.status} data-status={launch.status}>
                     {statusCopy(launch.status)}

--- a/lib/server/custom-launch/launch-history-bridge-v1.ts
+++ b/lib/server/custom-launch/launch-history-bridge-v1.ts
@@ -555,7 +555,10 @@ export function createDeveloperLaunchHistoryBridgeV1(input: Readonly<{
             ?? await readVersion("v4");
         }
         if (!launch) throw new BrowserRequestErrorV1(404, "launch_not_found");
-        if (launch.requestId !== launchId.toLowerCase()) {
+        const resourceId = launch.routeId === "custom-launch:create:v4"
+          ? launch.launchId
+          : launch.requestId;
+        if (resourceId !== launchId.toLowerCase()) {
           throw new BackendContractErrorV1();
         }
         return jsonResponse(200, { ...launch });
@@ -1531,6 +1534,7 @@ function parseLaunchV4(
     "expiresAt",
     "secondsRemaining",
     "partnerAttribution",
+    "sourceVerification",
   ].filter((key) => Object.hasOwn(record, key));
   exactProjectKeys(record, [
     "schemaVersion", "apiVersion", "launchId", "requestId", "routeId",
@@ -1551,7 +1555,6 @@ function parseLaunchV4(
     || !UUID.test(record.launchId)
     || typeof record.requestId !== "string"
     || !UUID.test(record.requestId)
-    || record.launchId.toLowerCase() !== record.requestId.toLowerCase()
     || record.routeId !== "custom-launch:create:v4"
     || record.chainId !== "4663"
     || record.caip2 !== "eip155:4663"
@@ -1579,7 +1582,9 @@ function parseLaunchV4(
         || !REQUEST_HASH.test(record.walletTransactionPreimageHash)))
     || parseProjectMetadataV1(record.projectMetadata) === null
     || requiredTimestamp(record.createdAt) !== record.createdAt
-    || requiredTimestamp(record.updatedAt) !== record.updatedAt) {
+    || requiredTimestamp(record.updatedAt) !== record.updatedAt
+    || (Object.hasOwn(record, "sourceVerification")
+      && record.sourceVerification !== null)) {
     throw new BackendContractErrorV1();
   }
   const unevaluated = record.status === "received" || record.status === "validating";

--- a/tests/custom-launch-history-bridge-v1.test.ts
+++ b/tests/custom-launch-history-bridge-v1.test.ts
@@ -25,6 +25,7 @@ const V3_LAUNCH_ID = "60000000-0000-4000-8000-000000000006";
 const V3_NATIVE_LAUNCH_ID = "70000000-0000-4000-8000-000000000007";
 const V3_ACTION_REQUIRED_LAUNCH_ID = "80000000-0000-4000-8000-000000000008";
 const V4_LAUNCH_ID = "90000000-0000-4000-8000-000000000009";
+const V4_REQUEST_ID = "a0000000-0000-4000-8000-00000000000a";
 const V4_CHAIN_DEPLOYMENT_ID = "robinhood-mainnet-custom-launch-v1";
 const V4_CHAIN_DEPLOYMENT_DIGEST = `0x${"aa".repeat(32)}` as const;
 const V4_TRANSACTION_HASH = `0x${"bb".repeat(32)}` as const;
@@ -321,7 +322,7 @@ function launchV4(ownerWallet: string = WALLET) {
     schemaVersion: "programmable.custom-launch.v4",
     apiVersion: "v4",
     launchId: V4_LAUNCH_ID,
-    requestId: V4_LAUNCH_ID,
+    requestId: V4_REQUEST_ID,
     routeId: "custom-launch:create:v4",
     chainId: "4663",
     caip2: "eip155:4663",
@@ -816,6 +817,49 @@ describe("developer launch history same-origin bridge", () => {
       .toBe(`Bearer ${WEBSITE_TOKEN}`);
     expect(new Headers(init.headers).get("x-programmable-wallet-address"))
       .toBe(WALLET);
+  });
+
+  it("accepts only null source verification on a non-finalized V4 wallet resource", async () => {
+    const resource = {
+      ...launchV4(),
+      status: "wallet_action_required",
+      walletTransaction: {},
+      preparedArtifact: {},
+      admissionReceipt: {},
+      simulationReceipt: {},
+      externalContractEvidenceReceipt: {},
+      sourceVerification: null,
+    };
+    fetchBackend.mockResolvedValueOnce(new Response(JSON.stringify(resource), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }));
+
+    const response = await bridge().get(new Request(
+      `https://programmable.market/api/developer/custom-launches/${V4_LAUNCH_ID}?walletAddress=${WALLET}&version=v4`,
+      { headers: { authorization: "Bearer browser-privy-token" } },
+    ), V4_LAUNCH_ID);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(resource);
+
+    fetchBackend.mockResolvedValueOnce(new Response(JSON.stringify({
+      ...resource,
+      sourceVerification: SOURCE_VERIFICATION,
+    }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }));
+
+    const rejected = await bridge().get(new Request(
+      `https://programmable.market/api/developer/custom-launches/${V4_LAUNCH_ID}?walletAddress=${WALLET}&version=v4`,
+      { headers: { authorization: "Bearer browser-privy-token" } },
+    ), V4_LAUNCH_ID);
+
+    expect(rejected.status).toBe(503);
+    expect((await rejected.json()).error.code).toBe(
+      "launch_history_unavailable",
+    );
   });
 
   it("proxies only the chain-scoped V4 capabilities document", async () => {

--- a/tests/developer-api-keys-ui.test.ts
+++ b/tests/developer-api-keys-ui.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   launchPollingRetryAfterMs,
   fetchVerifiedProjectImageV1,
+  launchResourceIdentity,
   mergeLaunchResources,
   parseCustomLaunchProjectMetadataV1,
   parseHistoryPage,
@@ -571,7 +572,7 @@ describe("developer launch history interface", () => {
     expect(historySource).toContain('? "v3"');
     expect(historySource).toContain('? "v2"');
     expect(historySource).toContain(
-      "encodeURIComponent(launch.requestId)",
+      "encodeURIComponent(resourceIdentity)",
     );
     expect(historySource).toContain("PROGRAMMABLE_AGENT_SETUP_LINKS_V1.remediation");
     expect(historySource).toContain("Read the remediation catalog");
@@ -1381,8 +1382,97 @@ describe("developer launch history interface", () => {
       "readLaunchById(initialLaunchId, version, controller.signal)",
     );
     expect(historySource).toContain("Loading the exact wallet handoff.");
-    expect(historySource).toContain("focusLaunchCard(launch.requestId)");
+    expect(historySource).toContain(
+      "focusLaunchCard(launchResourceIdentity(launch))",
+    );
     expect(historySource).toContain("tabIndex={-1}");
+  });
+
+  it("keeps distinct V4 request and launch IDs on one launch-addressed card", () => {
+    const account = "0x0000000000000000000000000000000000000001";
+    const launchId = "90000000-0000-4000-8000-000000000009";
+    const requestId = "a0000000-0000-4000-8000-00000000000a";
+    const summary = {
+      schemaVersion: "programmable.custom-launch-summary.v4",
+      apiVersion: "v4",
+      launchId,
+      requestId: launchId,
+      routeId: "custom-launch:create:v4",
+      chainId: "4663",
+      caip2: "eip155:4663",
+      chainDeploymentId: "robinhood-mainnet-custom-launch-v1",
+      chainDeploymentDescriptorDigest: `0x${"aa".repeat(32)}`,
+      controller: { namespace: "eip155:4663", address: account },
+      status: "wallet_action_required",
+      walletHandoffUrl: null,
+      expiresAt: null,
+      createdAt: "2026-09-02T22:00:00.000Z",
+      updatedAt: "2026-09-02T22:00:01.000Z",
+    };
+    const resource = {
+      schemaVersion: "programmable.custom-launch.v4",
+      apiVersion: "v4",
+      launchId,
+      requestId,
+      routeId: "custom-launch:create:v4",
+      chainId: "4663",
+      caip2: "eip155:4663",
+      controller: { namespace: "eip155:4663", address: account },
+      status: "wallet_action_required",
+      requestHash: `sha256:${"11".repeat(32)}`,
+      profile: { profileDigest: `sha256:${"22".repeat(32)}` },
+      commitments: { launchIntent: `sha256:${"33".repeat(32)}` },
+      metadataCommitment: `sha256:${"44".repeat(32)}`,
+      projectMetadata: PROJECT_METADATA,
+      walletTransaction: {},
+      preparedArtifact: {},
+      sourceVerification: null,
+      onchain: null,
+      failure: null,
+      createdAt: "2026-09-02T22:00:00.000Z",
+      updatedAt: "2026-09-02T22:00:02.000Z",
+    };
+    const summaryPage = parseHistoryPage({
+      schemaVersion: "programmable.custom-launch-history.v1",
+      launches: [summary],
+      nextCursor: null,
+    }, account);
+    const resourcePage = parseHistoryPage({
+      schemaVersion: "programmable.custom-launch-history.v1",
+      launches: [resource],
+      nextCursor: null,
+    }, account);
+
+    expect(summaryPage).not.toBeNull();
+    expect(resourcePage).not.toBeNull();
+    expect(resourcePage!.launches[0]).toMatchObject({ launchId, requestId });
+    expect(launchResourceIdentity(resourcePage!.launches[0]!)).toBe(launchId);
+    expect(launchResourceIdentity(launch("legacy-request", "authorized",
+      "2026-09-02T22:00:00.000Z"))).toBe("legacy-request");
+    const merged = mergeLaunchResources(
+      summaryPage!.launches,
+      resourcePage!.launches,
+      false,
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({ launchId, requestId });
+    expect(merged[0]?.rawResourceV4).not.toBeNull();
+
+    const readStart = historySource.indexOf(
+      "const readLaunchResource = useCallback",
+    );
+    const readEnd = historySource.indexOf(
+      "const readV4Capabilities = useCallback",
+      readStart,
+    );
+    const readBoundary = historySource.slice(readStart, readEnd);
+    expect(readBoundary).toContain(
+      "const resourceIdentity = launchResourceIdentity(launch)",
+    );
+    expect(readBoundary).toContain("encodeURIComponent(resourceIdentity)");
+    expect(readBoundary).toContain(
+      "launchResourceIdentity(updated) !== resourceIdentity",
+    );
   });
 
   it("keeps the V4 handoff owner-controlled and sends only its hash as a discovery hint", () => {
@@ -1433,6 +1523,12 @@ describe("developer launch history interface", () => {
     expect(hintBoundary).not.toContain("signedTransaction");
     expect(hintBoundary).not.toContain("evidence:");
     expect(hintBoundary).toContain("body.authoritative !== false");
+    expect(hintBoundary).toContain("encodeURIComponent(launch.launchId)");
+    expect(hintBoundary).toContain("body.launchId !== launch.launchId");
+    expect(hintBoundary).toContain(
+      "custom-launches/${launch.launchId}",
+    );
+    expect(hintBoundary).not.toContain("launch.requestId");
 
     const sendStart = historySource.indexOf(
       "const submitWalletTransaction = async",


### PR DESCRIPTION
## Outcome

Unblocks the production Robinhood Custom Launch wallet review for V4 resources with distinct `launchId` and `requestId`.

## Fix

- address V4 wallet resources, deep links, card state, and submission hints by `launchId`
- preserve `requestId` as its separate correlation identity
- accept the backend wallet projection’s explicit `sourceVerification: null` while remaining fail-closed on unparsed structured values
- leave V1–V3 request identity unchanged

## Production evidence

Vercel request IDs `4a16e70e-0420-44b0-a393-2ae5088941b4` and `eba58681-85e3-486f-9cd9-657620c5798f` failed with `BackendContractErrorV1`. The prepared launch exists and its wallet artifact is already stored; only the website contract bridge was rejecting the valid V4 identity pair.

## Verification

- `npx vitest run tests/custom-launch-history-bridge-v1.test.ts tests/developer-api-keys-ui.test.ts --reporter=dot` — 107 passed
- `npm run typecheck` — passed
- targeted ESLint on all four changed files — passed
- `git diff --check` — passed