### PR TITLE
fix(web): accept normalized MetaMask accounts

### DIFF
--- a/lib/custom-launch/wallet-handoff-v4.ts
+++ b/lib/custom-launch/wallet-handoff-v4.ts
@@ -2086,7 +2086,9 @@ async function assertProviderState(
     }
     for (const accounts of [accountsBefore, accountsFinal]) {
       if (!Array.isArray(accounts) || accounts.length === 0
-        || canonicalAddress(accounts[0]) !== expectedAccount) return invalid();
+        || typeof accounts[0] !== "string"
+        || !isAddress(accounts[0])
+        || getAddress(accounts[0]) !== expectedAccount) return invalid();
     }
     for (const code of [codeBefore, codeFinal]) {
       const runtime = exactHex(code, true);

--- a/tests/developer-api-keys-ui.test.ts
+++ b/tests/developer-api-keys-ui.test.ts
@@ -63,6 +63,10 @@ const walletProviderSource = readFileSync(
   new URL("../components/wallet-provider.tsx", import.meta.url),
   "utf8",
 );
+const walletHandoffV4Source = readFileSync(
+  new URL("../lib/custom-launch/wallet-handoff-v4.ts", import.meta.url),
+  "utf8",
+);
 
 const PROJECT_METADATA = Object.freeze({
   schemaVersion: "programmable.project-metadata.v1",
@@ -1476,6 +1480,17 @@ describe("developer launch history interface", () => {
   });
 
   it("keeps the V4 handoff owner-controlled and sends only its hash as a discovery hint", () => {
+    expect(walletHandoffV4Source).toContain(
+      'typeof accounts[0] !== "string"',
+    );
+    expect(walletHandoffV4Source).toContain("!isAddress(accounts[0])");
+    expect(walletHandoffV4Source).toContain(
+      "getAddress(accounts[0]) !== expectedAccount",
+    );
+    expect(walletHandoffV4Source).not.toContain(
+      "canonicalAddress(accounts[0]) !== expectedAccount",
+    );
+
     const walletStart = walletProviderSource.indexOf(
       "const sendCustomLaunchWalletActionV4 = useCallback",
     );


### PR DESCRIPTION
## Outcome

Accept EIP-1193 wallet account values regardless of address casing while preserving checksum-strict parsing for backend artifacts. This unblocks the Robinhood V4 wallet safety gate for MetaMask, which returns `eth_accounts` in lowercase.

## Evidence

- exact live resource/capabilities validation passed
- exact MetaMask trace: chain `0x1237`, current account, and pinned Router runtime hash all matched
- 28 targeted tests passed
- exact live-resource regression diagnostic passed
- ESLint: 0 errors
- diff check passed

No signing or broadcast is performed by this change.