### PR TITLE
docs(web): disclose Robinhood fee policy boundary

### DIFF
--- a/components/developer-robinhood-launch.module.css
+++ b/components/developer-robinhood-launch.module.css
@@ -184,6 +184,35 @@
   padding: 14px;
 }
 
+.policyDisclosure {
+  background: var(--webde-surface-raised);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  display: grid;
+  gap: 6px;
+  padding: 12px 14px;
+}
+
+.policyDisclosure h3 {
+  color: var(--webde-ink);
+  font-size: 13px;
+  font-weight: 620;
+  margin: 0;
+}
+
+.policyDisclosure p {
+  color: var(--webde-muted);
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 0;
+  text-wrap: pretty;
+}
+
+.policyDisclosure code {
+  font-family: var(--font-plex-mono), monospace;
+  overflow-wrap: anywhere;
+}
+
 .preflightResult[data-deployable="true"],
 .createdResult {
   border-color: color-mix(in srgb, var(--success) 40%, var(--webde-line));
@@ -322,6 +351,7 @@
 @media (forced-colors: active) {
   .readinessBadge,
   .fileControl,
+  .policyDisclosure,
   .preflightResult,
   .createdResult {
     border: 1px solid CanvasText;

--- a/components/developer-robinhood-launch.tsx
+++ b/components/developer-robinhood-launch.tsx
@@ -616,6 +616,23 @@ export function DeveloperRobinhoodLaunch({
           Keep this value unchanged if a create request needs to be retried.
         </p>
 
+        <section
+          className={styles.policyDisclosure}
+          aria-labelledby="robinhood-fee-policy-title"
+        >
+          <h3 id="robinhood-fee-policy-title">Robinhood fee policy</h3>
+          <p>
+            Programmable policy for new Robinhood Custom launches is 0.20%
+            (2,000 ppm), recipient{" "}
+            <code>0xD88539d3c4C460136a733A3Fd60cf6BF269079da</code>.
+          </p>
+          <p>
+            The current V4 runtime does not claim immutable onchain fee
+            enforcement, fee behavior, claiming, or guaranteed revenue. The
+            Launch Stamp proves provenance only.
+          </p>
+        </section>
+
         {proof ? (
           <div className={styles.preflightResult} data-deployable={proof.deployable}>
             <div>

--- a/tests/developer-robinhood-launch.test.tsx
+++ b/tests/developer-robinhood-launch.test.tsx
@@ -216,6 +216,13 @@ describe("Robinhood Custom launch website flow", () => {
     expect(html).toContain("Preflight required");
     expect(html).toContain("Create launch request");
     expect(html).toContain("never signs or broadcasts");
+    expect(html).toContain(
+      "Programmable policy for new Robinhood Custom launches is 0.20% (2,000 ppm), recipient <code>0xD88539d3c4C460136a733A3Fd60cf6BF269079da</code>.",
+    );
+    expect(html).toContain(
+      "The current V4 runtime does not claim immutable onchain fee enforcement, fee behavior, claiming, or guaranteed revenue. The Launch Stamp proves provenance only.",
+    );
+    expect(html).not.toContain("fee-policy-pending");
     expect(html).not.toContain(apiKey);
     expect(componentSource).not.toContain("localStorage");
     expect(componentSource).not.toContain("sessionStorage");


### PR DESCRIPTION
## Summary

- disclose the Robinhood Custom policy rate and recipient without claiming immutable onchain fee enforcement or guaranteed revenue
- clarify that the Launch Stamp proves provenance only
- keep the public self-serve entry, preflight, create, and wallet handoff behavior unchanged

## Verification

- `git diff --check origin/production...HEAD`
- `npm exec vitest run -- tests/developer-robinhood-launch.test.tsx tests/launch-model-gating.test.ts tests/launch-model-motion.test.ts tests/custom-launch-wallet-handoff-v4.test.ts tests/developer-api-keys-ui.test.ts` — 65/65 passed
- `npm run typecheck`