### PR TITLE
fix(web): show Robinhood fee policy before wallet

### DIFF
--- a/app/developers/api-keys/page.tsx
+++ b/app/developers/api-keys/page.tsx
@@ -11,6 +11,26 @@ export const metadata: Metadata = {
   },
 };
 
-export default function DeveloperApiKeysPage() {
-  return <DeveloperApiKeys />;
+type DeveloperApiKeysSearchParams = Promise<
+  Record<string, string | string[] | undefined>
+>;
+
+export function developerApiKeysInitialSection(
+  searchParams: Record<string, string | string[] | undefined>,
+) {
+  return searchParams.start === "custom"
+    && searchParams.chainId === "4663"
+    ? "launch" as const
+    : "keys" as const;
+}
+
+export default async function DeveloperApiKeysPage({
+  searchParams,
+}: Readonly<{ searchParams: DeveloperApiKeysSearchParams }>) {
+  const resolvedSearchParams = await searchParams;
+  return (
+    <DeveloperApiKeys
+      initialSection={developerApiKeysInitialSection(resolvedSearchParams)}
+    />
+  );
 }

--- a/components/developer-api-keys.tsx
+++ b/components/developer-api-keys.tsx
@@ -21,7 +21,10 @@ import {
 
 import styles from "@/components/developer-api-keys.module.css";
 import { DeveloperLaunchHistory } from "@/components/developer-launch-history";
-import { DeveloperRobinhoodLaunch } from
+import {
+  DeveloperRobinhoodLaunch,
+  RobinhoodFeePolicyDisclosure,
+} from
   "@/components/developer-robinhood-launch";
 import {
   useWallet,
@@ -78,12 +81,16 @@ type ApiKeyMutationState =
 type ListState = "idle" | "loading" | "ready" | "error";
 type ActiveSection = "keys" | "launch" | "history";
 type ApiKeyLoadMode = "initial" | "refresh" | "mutation";
+type DeveloperApiKeysProps = Readonly<{
+  initialSection?: ActiveSection;
+}>;
 type DeveloperApiKeysViewProps = Readonly<{
   account: `0x${string}` | null;
   authReady: boolean;
   connecting: boolean;
   getAccessToken: () => Promise<string | null>;
   getIdentityToken: () => Promise<string | null>;
+  initialSection: ActiveSection;
   openWallet: () => void;
   sendCustomLaunchWalletAction: (
     input: CustomLaunchWalletActionV1,
@@ -578,7 +585,9 @@ function ExpirySelect({
   );
 }
 
-export function DeveloperApiKeys() {
+export function DeveloperApiKeys({
+  initialSection = "keys",
+}: DeveloperApiKeysProps) {
   const {
     authReady,
     connecting,
@@ -601,6 +610,7 @@ export function DeveloperApiKeys() {
       connecting={connecting}
       getAccessToken={getAccessToken}
       getIdentityToken={getIdentityToken}
+      initialSection={initialSection}
       openWallet={openWallet}
       sendCustomLaunchWalletAction={sendCustomLaunchWalletAction}
       sendCustomLaunchWalletActionV4={sendCustomLaunchWalletActionV4}
@@ -617,6 +627,7 @@ function DeveloperApiKeysView({
   connecting,
   getAccessToken,
   getIdentityToken,
+  initialSection,
   openWallet,
   sendCustomLaunchWalletAction,
   sendCustomLaunchWalletActionV4,
@@ -654,7 +665,9 @@ function DeveloperApiKeysView({
   const [revokeError, setRevokeError] = useState("");
   const [rotateError, setRotateError] = useState("");
   const [statusMessage, setStatusMessage] = useState("");
-  const [activeSection, setActiveSection] = useState<ActiveSection>("keys");
+  const [activeSection, setActiveSection] = useState<ActiveSection>(
+    initialSection,
+  );
   const [initialLaunchId, setInitialLaunchId] = useState<string | null>(null);
   const [initialLaunchChainId, setInitialLaunchChainId] = useState<"4663" | null>(null);
   const [refreshingKeys, setRefreshingKeys] = useState(false);
@@ -1223,6 +1236,10 @@ function DeveloperApiKeysView({
           </p>
         </div>
       </header>
+
+      {activeSection === "launch" ? (
+        <RobinhoodFeePolicyDisclosure />
+      ) : null}
 
       {!authReady ? (
         walletSessionTimedOut ? (

--- a/components/developer-robinhood-launch.module.css
+++ b/components/developer-robinhood-launch.module.css
@@ -190,10 +190,12 @@
   border-radius: var(--webde-radius-control);
   display: grid;
   gap: 6px;
+  margin-bottom: 16px;
+  max-width: 900px;
   padding: 12px 14px;
 }
 
-.policyDisclosure h3 {
+.policyDisclosure h2 {
   color: var(--webde-ink);
   font-size: 13px;
   font-weight: 620;

--- a/components/developer-robinhood-launch.tsx
+++ b/components/developer-robinhood-launch.tsx
@@ -201,6 +201,28 @@ export function isRobinhoodIdempotencyKey(value: string) {
   return idempotencyKeyPattern.test(value);
 }
 
+export function RobinhoodFeePolicyDisclosure() {
+  return (
+    <section
+      className={styles.policyDisclosure}
+      aria-labelledby="robinhood-fee-policy-title"
+    >
+      <h2 id="robinhood-fee-policy-title">Robinhood fee policy</h2>
+      <p>
+        Programmable policy for new Robinhood V4 API Custom launch requests is
+        0.20% (2,000 ppm), recipient{" "}
+        <code>0xD88539d3c4C460136a733A3Fd60cf6BF269079da</code>. Existing
+        launches are unchanged.
+      </p>
+      <p>
+        The current V4 runtime does not claim immutable onchain fee
+        enforcement, fee behavior, claiming, or guaranteed revenue. The
+        Launch Stamp proves provenance only.
+      </p>
+    </section>
+  );
+}
+
 export async function preflightRobinhoodLaunch(
   fetcher: Fetcher,
   apiKey: string,
@@ -615,23 +637,6 @@ export function DeveloperRobinhoodLaunch({
         <p className={styles.fieldNote} id="robinhood-idempotency-note">
           Keep this value unchanged if a create request needs to be retried.
         </p>
-
-        <section
-          className={styles.policyDisclosure}
-          aria-labelledby="robinhood-fee-policy-title"
-        >
-          <h3 id="robinhood-fee-policy-title">Robinhood fee policy</h3>
-          <p>
-            Programmable policy for new Robinhood Custom launches is 0.20%
-            (2,000 ppm), recipient{" "}
-            <code>0xD88539d3c4C460136a733A3Fd60cf6BF269079da</code>.
-          </p>
-          <p>
-            The current V4 runtime does not claim immutable onchain fee
-            enforcement, fee behavior, claiming, or guaranteed revenue. The
-            Launch Stamp proves provenance only.
-          </p>
-        </section>
 
         {proof ? (
           <div className={styles.preflightResult} data-deployable={proof.deployable}>

--- a/tests/developer-robinhood-launch.test.tsx
+++ b/tests/developer-robinhood-launch.test.tsx
@@ -3,11 +3,14 @@ import { readFileSync } from "node:fs";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
+import { developerApiKeysInitialSection } from
+  "../app/developers/api-keys/page";
 import {
   DeveloperRobinhoodLaunch,
   MAX_ROBINHOOD_LAUNCH_BYTES,
   ROBINHOOD_CREATE_URL,
   ROBINHOOD_PREFLIGHT_URL,
+  RobinhoodFeePolicyDisclosure,
   createRobinhoodLaunch,
   isRobinhoodIdempotencyKey,
   preflightRobinhoodLaunch,
@@ -216,12 +219,8 @@ describe("Robinhood Custom launch website flow", () => {
     expect(html).toContain("Preflight required");
     expect(html).toContain("Create launch request");
     expect(html).toContain("never signs or broadcasts");
-    expect(html).toContain(
-      "Programmable policy for new Robinhood Custom launches is 0.20% (2,000 ppm), recipient <code>0xD88539d3c4C460136a733A3Fd60cf6BF269079da</code>.",
-    );
-    expect(html).toContain(
-      "The current V4 runtime does not claim immutable onchain fee enforcement, fee behavior, claiming, or guaranteed revenue. The Launch Stamp proves provenance only.",
-    );
+    expect(html).not.toContain("Robinhood fee policy");
+    expect(html).not.toContain("0xD88539d3c4C460136a733A3Fd60cf6BF269079da");
     expect(html).not.toContain("fee-policy-pending");
     expect(html).not.toContain(apiKey);
     expect(componentSource).not.toContain("localStorage");
@@ -231,6 +230,26 @@ describe("Robinhood Custom launch website flow", () => {
     expect(componentSource).toContain("disabled={busy || idempotencyLocked}");
     expect(isRobinhoodIdempotencyKey(idempotencyKey)).toBe(true);
     expect(isRobinhoodIdempotencyKey("too-short")).toBe(false);
+  });
+
+  it("renders one static, labelled fee policy disclosure outside the private launch form", () => {
+    const html = renderToStaticMarkup(<RobinhoodFeePolicyDisclosure />);
+
+    expect(html).toContain(
+      'aria-labelledby="robinhood-fee-policy-title"',
+    );
+    expect(html).toContain(
+      '<h2 id="robinhood-fee-policy-title">Robinhood fee policy</h2>',
+    );
+    expect(html).toContain(
+      "Programmable policy for new Robinhood V4 API Custom launch requests is 0.20% (2,000 ppm), recipient <code>0xD88539d3c4C460136a733A3Fd60cf6BF269079da</code>. Existing launches are unchanged.",
+    );
+    expect(html).toContain(
+      "The current V4 runtime does not claim immutable onchain fee enforcement, fee behavior, claiming, or guaranteed revenue. The Launch Stamp proves provenance only.",
+    );
+    expect(html).not.toContain('role="status"');
+    expect(html).not.toContain("aria-live");
+    expect(html).not.toContain("fee-policy-pending");
   });
 
   it("routes the Custom card into the chain-bound launch section", () => {
@@ -248,5 +267,20 @@ describe("Robinhood Custom launch website flow", () => {
       'url.searchParams.get("chainId") === "4663"',
     );
     expect(apiKeysSource).toContain('setActiveSection("launch")');
+    expect(apiKeysSource.match(/<RobinhoodFeePolicyDisclosure \/>/gu))
+      .toHaveLength(1);
+    expect(apiKeysSource.indexOf("<RobinhoodFeePolicyDisclosure />"))
+      .toBeLessThan(apiKeysSource.indexOf("{!authReady ? ("));
+    expect(apiKeysSource.indexOf("<DeveloperRobinhoodLaunch"))
+      .toBeGreaterThan(apiKeysSource.indexOf(") : !account ? ("));
+    expect(developerApiKeysInitialSection({
+      start: "custom",
+      chainId: "4663",
+    })).toBe("launch");
+    expect(developerApiKeysInitialSection({
+      start: "custom",
+      chainId: "1",
+    })).toBe("keys");
+    expect(developerApiKeysInitialSection({ chainId: "4663" })).toBe("keys");
   });
 });


### PR DESCRIPTION
## Summary

- server-select the Robinhood Custom launch view for start=custom&chainId=4663, so its fee policy is public before wallet initialization or connection
- disclose that Programmable policy for new Robinhood V4 API Custom launch requests is 0.20% (2,000 ppm), recipient 0xD88539d3c4C460136a733A3Fd60cf6BF269079da, while existing launches remain unchanged
- state that the current V4 runtime does not claim immutable onchain fee enforcement, fee behavior, claiming, or guaranteed revenue; the Launch Stamp proves provenance only
- render the disclosure once as a labelled static section while keeping API key ownership, preflight, creation, history handoff, signing, and broadcast controls behind the existing wallet gate

## Verification

- git diff --check origin/production...HEAD
- focused Vitest: 5 files, 66/66 passed
- focused ESLint: passed
- npm run typecheck: passed
- npm run build: passed
- local headed browser checks at desktop and 390x844: exact disclosure visible once before the wallet gate, gated actions absent, generic API keys route unchanged, 0 console errors

No deployment was triggered.