### PR TITLE
perf(web): speed up landing reveal and profile entry

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 
 import {
-  ProfileSessionLoadingState,
-  ProfileView,
-} from "@/components/profile-view";
+  ProfileEntry,
+  ProfileEntryLoadingState,
+} from "@/components/profile-entry";
 
 export const metadata: Metadata = {
   title: "Profile · Programmable",
@@ -16,8 +16,8 @@ export const metadata: Metadata = {
 
 export default function ProfilePage() {
   return (
-    <Suspense fallback={<ProfileSessionLoadingState />}>
-      <ProfileView />
+    <Suspense fallback={<ProfileEntryLoadingState />}>
+      <ProfileEntry />
     </Suspense>
   );
 }

--- a/components/landing-page.module.css
+++ b/components/landing-page.module.css
@@ -458,27 +458,27 @@
   .hero h1,
   .heroContent > p,
   .migrationCta {
-    animation: hero-reveal 1700ms cubic-bezier(0.23, 1, 0.32, 1) both;
+    animation: hero-reveal 760ms cubic-bezier(0.23, 1, 0.32, 1) both;
   }
 
   .heroLogo {
-    animation-delay: 160ms;
+    animation-delay: 40ms;
   }
 
   .hero h1 {
-    animation-delay: 340ms;
+    animation-delay: 100ms;
   }
 
   .heroContent > p {
-    animation-delay: 520ms;
+    animation-delay: 160ms;
   }
 
   .migrationCta {
-    animation-delay: 680ms;
+    animation-delay: 220ms;
   }
 
   .scrollCue {
-    animation: cue-reveal 1400ms cubic-bezier(0.23, 1, 0.32, 1) 900ms both;
+    animation: cue-reveal 760ms cubic-bezier(0.23, 1, 0.32, 1) 300ms both;
   }
 
   .heroTwinkles i {

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -138,7 +138,6 @@ export function LandingPage() {
               fetchPriority="high"
               loading="eager"
               sizes="100vw"
-              unoptimized
             />
           </picture>
           <span className={styles.heroTwinkles}>

--- a/components/profile-entry.module.css
+++ b/components/profile-entry.module.css
@@ -1,0 +1,121 @@
+.page {
+  max-width: 1280px;
+  min-height: calc(100svh - 88px);
+  min-width: 0;
+  overflow-x: clip;
+  padding-block: 22px 56px;
+}
+
+.card {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0 auto;
+  max-width: 540px;
+  min-height: min(520px, calc(100svh - var(--header-height) - 88px));
+  min-width: 0;
+  padding: 42px 18px 54px;
+  text-align: center;
+}
+
+.mark {
+  filter: grayscale(1) brightness(0) invert(1);
+  height: clamp(62px, 7vw, 78px);
+  margin-block-end: 22px;
+  object-fit: contain;
+  width: clamp(62px, 7vw, 78px);
+}
+
+.card h1 {
+  font-size: clamp(46px, 5.4vw, 60px);
+  font-weight: 565;
+  letter-spacing: -0.052em;
+  line-height: 0.94;
+}
+
+.button {
+  align-items: center;
+  background: var(--webde-control);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-ink);
+  display: inline-flex;
+  font-size: 13px;
+  font-weight: 650;
+  justify-content: center;
+  margin-block-start: 24px;
+  min-height: 46px;
+  padding-inline: 19px;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease,
+    opacity 150ms ease,
+    transform 120ms var(--ease-out);
+}
+
+.button:disabled {
+  cursor: progress;
+  opacity: 0.64;
+}
+
+.button:active:not(:disabled) {
+  transform: scale(0.96);
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.visuallyHidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .button:not(:disabled):hover {
+    background: #333;
+    border-color: #555;
+    color: #fff;
+  }
+}
+
+@media (max-width: 820px) {
+  .page {
+    min-height: calc(100svh - 72px);
+    padding-block: 16px 42px;
+  }
+}
+
+@media (max-width: 620px) {
+  .card {
+    min-height: 0;
+    padding: 48px 8px 54px;
+  }
+
+  .card h1 {
+    font-size: 44px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .button {
+    transition: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .button {
+    border-color: ButtonText;
+  }
+}

--- a/components/profile-entry.tsx
+++ b/components/profile-entry.tsx
@@ -9,12 +9,15 @@ import { useWallet } from "@/components/wallet-provider";
 import styles from "./profile-entry.module.css";
 
 const ethereumAddressPattern = /^0x[0-9a-f]{40}$/;
-const loadProfileView = () =>
-  import("@/components/profile-view").then((module) => module.ProfileView);
-const ProfileView = dynamic(loadProfileView, {
-  loading: () => <ProfileEntryLoadingState />,
-  ssr: false,
-});
+const ProfileView = dynamic(
+  () =>
+    import("@/components/profile-view").then((module) => module.ProfileView),
+  { loading: () => <ProfileEntryLoadingState /> },
+);
+
+function preloadProfileView() {
+  void import("@/components/profile-view");
+}
 
 export function profileEntryHasPublicAccount(
   queryAccounts: readonly string[],
@@ -38,9 +41,11 @@ export function shouldLoadProfileEntryView({
 function ProfileEntryFrame({
   loading,
   onConnect,
+  onPrepareProfile,
 }: Readonly<{
   loading: boolean;
   onConnect?: () => void;
+  onPrepareProfile?: () => void;
 }>) {
   const titleId = loading
     ? "profile-entry-loading-title"
@@ -85,7 +90,13 @@ function ProfileEntryFrame({
             <span className={styles.visuallyHidden} id={descriptionId}>
               Connect to manage your profile, launches and rewards.
             </span>
-            <button className={styles.button} type="button" onClick={onConnect}>
+            <button
+              className={styles.button}
+              type="button"
+              onClick={onConnect}
+              onFocus={onPrepareProfile}
+              onPointerEnter={onPrepareProfile}
+            >
               Connect wallet
             </button>
           </>
@@ -115,5 +126,16 @@ export function ProfileEntry() {
 
   if (connecting) return <ProfileEntryLoadingState />;
 
-  return <ProfileEntryFrame loading={false} onConnect={openWallet} />;
+  function connectWallet() {
+    preloadProfileView();
+    openWallet();
+  }
+
+  return (
+    <ProfileEntryFrame
+      loading={false}
+      onConnect={connectWallet}
+      onPrepareProfile={preloadProfileView}
+    />
+  );
 }

--- a/components/profile-entry.tsx
+++ b/components/profile-entry.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import Image from "next/image";
+import { useSearchParams } from "next/navigation";
+
+import { useWallet } from "@/components/wallet-provider";
+
+import styles from "./profile-entry.module.css";
+
+const ethereumAddressPattern = /^0x[0-9a-f]{40}$/;
+const loadProfileView = () =>
+  import("@/components/profile-view").then((module) => module.ProfileView);
+const ProfileView = dynamic(loadProfileView, {
+  loading: () => <ProfileEntryLoadingState />,
+  ssr: false,
+});
+
+export function profileEntryHasPublicAccount(
+  queryAccounts: readonly string[],
+) {
+  if (queryAccounts.length !== 1) return false;
+  return ethereumAddressPattern.test(
+    (queryAccounts[0] ?? "").trim().toLowerCase(),
+  );
+}
+
+export function shouldLoadProfileEntryView({
+  account,
+  publicProfileRequested,
+}: Readonly<{
+  account?: string;
+  publicProfileRequested: boolean;
+}>) {
+  return Boolean(account) || publicProfileRequested;
+}
+
+function ProfileEntryFrame({
+  loading,
+  onConnect,
+}: Readonly<{
+  loading: boolean;
+  onConnect?: () => void;
+}>) {
+  const titleId = loading
+    ? "profile-entry-loading-title"
+    : "profile-entry-connect-title";
+  const descriptionId = loading
+    ? "profile-entry-loading-description"
+    : "profile-entry-connect-description";
+
+  return (
+    <div className={`${styles.page} page-width`}>
+      <section
+        className={styles.card}
+        aria-busy={loading ? "true" : undefined}
+        aria-describedby={descriptionId}
+        aria-labelledby={titleId}
+      >
+        <Image
+          className={styles.mark}
+          src="/brand/loop/programmable-loop-mark-warm-ivory-v1-1536.png"
+          alt=""
+          width={512}
+          height={512}
+          sizes="(max-width: 700px) 72px, 188px"
+          priority
+        />
+        <h1 id={titleId}>Profile</h1>
+        {loading ? (
+          <>
+            <span
+              className={styles.visuallyHidden}
+              id={descriptionId}
+              role="status"
+            >
+              Loading profile…
+            </span>
+            <button className={styles.button} type="button" disabled>
+              Loading
+            </button>
+          </>
+        ) : (
+          <>
+            <span className={styles.visuallyHidden} id={descriptionId}>
+              Connect to manage your profile, launches and rewards.
+            </span>
+            <button className={styles.button} type="button" onClick={onConnect}>
+              Connect wallet
+            </button>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export function ProfileEntryLoadingState() {
+  return <ProfileEntryFrame loading />;
+}
+
+export function ProfileEntry() {
+  const searchParams = useSearchParams();
+  const { connecting, openWallet, wallet } = useWallet();
+  const publicProfileRequested = profileEntryHasPublicAccount(
+    searchParams?.getAll("account") ?? [],
+  );
+
+  if (shouldLoadProfileEntryView({
+    account: wallet?.account,
+    publicProfileRequested,
+  })) {
+    return <ProfileView />;
+  }
+
+  if (connecting) return <ProfileEntryLoadingState />;
+
+  return <ProfileEntryFrame loading={false} onConnect={openWallet} />;
+}

--- a/components/profile-entry.tsx
+++ b/components/profile-entry.tsx
@@ -9,14 +9,14 @@ import { useWallet } from "@/components/wallet-provider";
 import styles from "./profile-entry.module.css";
 
 const ethereumAddressPattern = /^0x[0-9a-f]{40}$/;
-const ProfileView = dynamic(
-  () =>
-    import("@/components/profile-view").then((module) => module.ProfileView),
-  { loading: () => <ProfileEntryLoadingState /> },
-);
+const loadProfileView = () =>
+  import("@/components/profile-view").then((module) => module.ProfileView);
+const ProfileView = dynamic(loadProfileView, {
+  loading: () => <ProfileEntryLoadingState />,
+});
 
 function preloadProfileView() {
-  void import("@/components/profile-view");
+  void loadProfileView().catch(() => undefined);
 }
 
 export function profileEntryHasPublicAccount(

--- a/tests/profile-entry.test.ts
+++ b/tests/profile-entry.test.ts
@@ -53,10 +53,10 @@ describe("profile entry", () => {
       'from "@/components/profile-view"',
     );
     expect(profileEntrySource).toContain('import dynamic from "next/dynamic"');
-    expect(profileEntrySource).toContain(
-      'import("@/components/profile-view")',
+    expect(profileEntrySource).toMatch(
+      /dynamic\(\s*\(\) =>\s*import\("@\/components\/profile-view"\)/u,
     );
-    expect(profileEntrySource).toMatch(/ssr:\s*false/u);
+    expect(profileEntrySource).not.toMatch(/ssr:\s*false/u);
     expect(profileEntrySource).toContain("useSearchParams");
     expect(profileEntrySource).not.toMatch(
       /from\s+["']@\/components\/profile-view["']/u,
@@ -64,5 +64,7 @@ describe("profile entry", () => {
     expect(profileEntrySource).toMatch(
       /if \(shouldLoadProfileEntryView\([\s\S]*?return <ProfileView \/>;/u,
     );
+    expect(profileEntrySource).toContain("preloadProfileView();");
+    expect(profileEntrySource).toContain("onPointerEnter={onPrepareProfile}");
   });
 });

--- a/tests/profile-entry.test.ts
+++ b/tests/profile-entry.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  profileEntryHasPublicAccount,
+  shouldLoadProfileEntryView,
+} from "../components/profile-entry";
+
+const profilePageSource = readFileSync(
+  new URL("../app/profile/page.tsx", import.meta.url),
+  "utf8",
+);
+const profileEntrySource = readFileSync(
+  new URL("../components/profile-entry.tsx", import.meta.url),
+  "utf8",
+);
+
+describe("profile entry", () => {
+  it("loads the full profile only for a connected or public profile", () => {
+    expect(shouldLoadProfileEntryView({
+      publicProfileRequested: false,
+    })).toBe(false);
+    expect(shouldLoadProfileEntryView({
+      account: "0x1111111111111111111111111111111111111111",
+      publicProfileRequested: false,
+    })).toBe(true);
+    expect(shouldLoadProfileEntryView({
+      publicProfileRequested: true,
+    })).toBe(true);
+  });
+
+  it("recognizes only one valid public account query", () => {
+    expect(profileEntryHasPublicAccount([
+      "0x1111111111111111111111111111111111111111",
+    ])).toBe(true);
+    expect(profileEntryHasPublicAccount([
+      "  0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA  ",
+    ])).toBe(true);
+    expect(profileEntryHasPublicAccount([])).toBe(false);
+    expect(profileEntryHasPublicAccount(["not-an-address"])).toBe(false);
+    expect(profileEntryHasPublicAccount([
+      "0x1111111111111111111111111111111111111111",
+      "0x2222222222222222222222222222222222222222",
+    ])).toBe(false);
+  });
+
+  it("keeps the heavy profile view behind a conditional dynamic import", () => {
+    expect(profilePageSource).toContain(
+      'from "@/components/profile-entry"',
+    );
+    expect(profilePageSource).not.toContain(
+      'from "@/components/profile-view"',
+    );
+    expect(profileEntrySource).toContain('import dynamic from "next/dynamic"');
+    expect(profileEntrySource).toContain(
+      'import("@/components/profile-view")',
+    );
+    expect(profileEntrySource).toMatch(/ssr:\s*false/u);
+    expect(profileEntrySource).toContain("useSearchParams");
+    expect(profileEntrySource).not.toMatch(
+      /from\s+["']@\/components\/profile-view["']/u,
+    );
+    expect(profileEntrySource).toMatch(
+      /if \(shouldLoadProfileEntryView\([\s\S]*?return <ProfileView \/>;/u,
+    );
+  });
+});

--- a/tests/profile-entry.test.ts
+++ b/tests/profile-entry.test.ts
@@ -53,9 +53,10 @@ describe("profile entry", () => {
       'from "@/components/profile-view"',
     );
     expect(profileEntrySource).toContain('import dynamic from "next/dynamic"');
-    expect(profileEntrySource).toMatch(
-      /dynamic\(\s*\(\) =>\s*import\("@\/components\/profile-view"\)/u,
+    expect(profileEntrySource).toContain(
+      'import("@/components/profile-view")',
     );
+    expect(profileEntrySource).toContain("dynamic(loadProfileView");
     expect(profileEntrySource).not.toMatch(/ssr:\s*false/u);
     expect(profileEntrySource).toContain("useSearchParams");
     expect(profileEntrySource).not.toMatch(
@@ -64,7 +65,9 @@ describe("profile entry", () => {
     expect(profileEntrySource).toMatch(
       /if \(shouldLoadProfileEntryView\([\s\S]*?return <ProfileView \/>;/u,
     );
-    expect(profileEntrySource).toContain("preloadProfileView();");
+    expect(profileEntrySource).toContain(
+      "loadProfileView().catch(() => undefined)",
+    );
     expect(profileEntrySource).toContain("onPointerEnter={onPrepareProfile}");
   });
 });


### PR DESCRIPTION
## Outcome

- optimize the desktop landing hero through Next Image
- shorten the first-view reveal while preserving the existing visual direction
- keep the heavy profile dashboard behind a conditional client boundary until a wallet or public account is requested
- preserve the existing disconnected profile UI with mobile, focus, reduced-motion, and forced-colors handling

## Evidence

- production hero transfer: 943 KB live to 499 KB candidate
- 450 ms title opacity: 35% live to 97% candidate
- disconnected production profile: 868 KB JS; public profile after demand: 1,240 KB JS
- desktop 1440x900 and mobile 390x844 Chrome QA; no horizontal overflow or console exceptions on landing and disconnected profile
- 18 focused tests passed
- scoped ESLint passed
- TypeScript passed
- full production build passed