### PR TITLE
Move chain selection into Explore

### DIFF
--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -10,8 +10,8 @@ import type {
   ExploreModelFilter,
 } from "@/components/explore-view";
 import { DEFAULT_EXPLORE_VIEW_SORT } from "@/lib/explore-defaults";
+import { resolveExploreChainId } from "@/lib/explore-chain";
 import {
-  parseViewChainId,
   VIEW_CHAIN_COOKIE_NAME,
   type ViewChainId,
 } from "@/lib/view-chain";
@@ -113,7 +113,7 @@ async function InitialExploreView({
       cookies(),
       searchParams,
     ]);
-  const viewChainId = parseViewChainId(
+  const viewChainId = resolveExploreChainId(
     requestCookies.get(VIEW_CHAIN_COOKIE_NAME)?.value,
   );
   const modelFilter = initialExploreModelFilter(resolvedSearchParams.model);

--- a/components/explore-chain-selector.module.css
+++ b/components/explore-chain-selector.module.css
@@ -1,0 +1,188 @@
+.selector {
+  flex: none;
+  position: relative;
+  z-index: 20;
+}
+
+.trigger {
+  align-items: center;
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-ink);
+  display: inline-flex;
+  font-family: var(--font-instrument), sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  gap: 9px;
+  min-height: 44px;
+  padding: 0 12px;
+  transition:
+    background-color 160ms cubic-bezier(0.32, 0.72, 0, 1),
+    border-color 160ms cubic-bezier(0.32, 0.72, 0, 1),
+    box-shadow 160ms cubic-bezier(0.32, 0.72, 0, 1);
+  white-space: nowrap;
+}
+
+.trigger:focus-visible {
+  outline: 2px solid var(--webde-ink);
+  outline-offset: 2px;
+}
+
+.selector[data-open="true"] .trigger {
+  background: var(--webde-surface-raised);
+  border-color: #595959;
+  box-shadow: 0 0 0 3px rgb(255 255 255 / 0.08);
+}
+
+.chevron {
+  color: var(--webde-dim);
+  flex: none;
+  transition: transform 160ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.selector[data-open="true"] .chevron {
+  transform: rotate(180deg);
+}
+
+.ethereumMark,
+.robinhoodMark,
+.baseMark {
+  color: currentColor;
+  display: block;
+  flex: none;
+  height: 18px;
+  width: 18px;
+}
+
+.robinhoodMark {
+  aspect-ratio: 32 / 42;
+  background: currentColor;
+  height: 19px;
+  mask: url("/brand/networks/robinhood-feather-white.svg") center / contain no-repeat;
+  width: auto;
+}
+
+.baseMark {
+  background: #0052ff;
+  border: 5px solid currentColor;
+  border-radius: 50%;
+  box-shadow: inset 0 0 0 1px #0052ff;
+}
+
+.menu {
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+  background: rgb(24 24 24 / 0.98);
+  border: 1px solid var(--webde-line);
+  border-radius: 12px;
+  box-shadow: 0 24px 64px rgb(0 0 0 / 0.58);
+  display: grid;
+  gap: 2px;
+  left: 0;
+  min-width: 232px;
+  padding: 8px;
+  position: absolute;
+  top: calc(100% + 8px);
+}
+
+.option {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 7px;
+  color: var(--webde-muted);
+  display: grid;
+  font: inherit;
+  grid-template-columns: 20px minmax(0, 1fr) 16px;
+  min-height: 48px;
+  padding: 7px 10px;
+  text-align: start;
+  width: 100%;
+}
+
+.option:focus-visible {
+  outline: 2px solid var(--webde-ink);
+  outline-offset: -2px;
+}
+
+.optionCurrent {
+  background: var(--webde-control);
+  color: var(--webde-ink);
+}
+
+.option[aria-disabled="true"] {
+  color: var(--webde-dim);
+}
+
+.optionCopy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.optionCopy > span:first-child {
+  font-family: var(--font-instrument), sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.optionStatus {
+  color: var(--webde-dim);
+  font-size: 11px;
+  line-height: 1.2;
+}
+
+.check {
+  color: var(--webde-ink);
+}
+
+.checkPlaceholder {
+  height: 16px;
+  width: 16px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .trigger:hover,
+  .option:hover:not([aria-disabled="true"]) {
+    background: var(--webde-surface-raised);
+    border-color: #505050;
+    color: var(--webde-ink);
+  }
+}
+
+@media (max-width: 700px) {
+  .menu {
+    left: auto;
+    max-width: calc(100vw - 32px);
+    min-width: min(232px, calc(100vw - 32px));
+    right: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .trigger,
+  .chevron {
+    transition-duration: 0.01ms;
+  }
+}
+
+@media (forced-colors: active) {
+  .trigger,
+  .menu,
+  .option {
+    border-color: CanvasText;
+    box-shadow: none;
+  }
+
+  .robinhoodMark,
+  .baseMark {
+    background: CanvasText;
+    forced-color-adjust: none;
+  }
+
+  .trigger:focus-visible,
+  .option:focus-visible {
+    outline-color: Highlight;
+  }
+}

--- a/components/explore-chain-selector.tsx
+++ b/components/explore-chain-selector.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { Check, ChevronDown } from "lucide-react";
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+
+import {
+  useViewChain,
+  type ViewChainId,
+} from "@/components/view-chain";
+import { resolveExploreChainId } from "@/lib/explore-chain";
+import styles from "@/components/explore-chain-selector.module.css";
+
+type ExploreChainOption = Readonly<{
+  id: number;
+  label: string;
+  mark: "ethereum" | "robinhood" | "base";
+  viewChainId?: ViewChainId;
+  available: boolean;
+}>;
+
+const EXPLORE_CHAIN_OPTIONS = [
+  {
+    id: 1,
+    label: "Ethereum",
+    mark: "ethereum",
+    viewChainId: 1,
+    available: true,
+  },
+  {
+    id: 4663,
+    label: "Robinhood",
+    mark: "robinhood",
+    viewChainId: 4663,
+    available: false,
+  },
+  {
+    id: 8453,
+    label: "Base",
+    mark: "base",
+    available: false,
+  },
+] as const satisfies readonly ExploreChainOption[];
+
+function ExploreChainMark({ mark }: Readonly<{ mark: ExploreChainOption["mark"] }>) {
+  if (mark === "ethereum") {
+    return (
+      <svg
+        className={styles.ethereumMark}
+        viewBox="0 0 24 24"
+        fill="none"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path d="M12 2 5.5 12.2 12 9.25l6.5 2.95L12 2Z" fill="currentColor" />
+        <path
+          d="m5.5 13.35 6.5 3.7 6.5-3.7L12 22 5.5 13.35Z"
+          fill="currentColor"
+        />
+        <path
+          d="m12 9.25-6.5 2.95L12 15.9l6.5-3.7L12 9.25Z"
+          fill="currentColor"
+        />
+      </svg>
+    );
+  }
+
+  return (
+    <span
+      className={mark === "robinhood" ? styles.robinhoodMark : styles.baseMark}
+      aria-hidden="true"
+    />
+  );
+}
+
+export function ExploreChainSelector() {
+  const { hydrated, viewChainId, setViewChainId } = useViewChain();
+  const [open, setOpen] = useState(false);
+  const selectedViewChainId = resolveExploreChainId(viewChainId);
+  const selectedIndex = Math.max(
+    0,
+    EXPLORE_CHAIN_OPTIONS.findIndex(
+      (option) => option.id === selectedViewChainId,
+    ),
+  );
+  const [activeIndex, setActiveIndex] = useState(selectedIndex);
+  const panelId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const selected = EXPLORE_CHAIN_OPTIONS[selectedIndex];
+
+  useEffect(() => {
+    if (!open) return;
+    const closeOnOutsidePress = (event: PointerEvent) => {
+      if (
+        event.target instanceof Node &&
+        !rootRef.current?.contains(event.target)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", closeOnOutsidePress);
+    return () => document.removeEventListener("pointerdown", closeOnOutsidePress);
+  }, [open]);
+
+  useEffect(() => {
+    if (open) optionRefs.current[activeIndex]?.focus();
+  }, [activeIndex, open]);
+
+  function openListbox(index = selectedIndex) {
+    setActiveIndex(index);
+    setOpen(true);
+  }
+
+  function closeListbox(restoreFocus = true) {
+    setOpen(false);
+    if (restoreFocus) {
+      window.requestAnimationFrame(() => triggerRef.current?.focus());
+    }
+  }
+
+  function selectChain(option: ExploreChainOption) {
+    if (!option.available || option.viewChainId === undefined) return;
+    setViewChainId(option.viewChainId);
+    closeListbox();
+  }
+
+  function handleOptionKeyDown(
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((index + 1) % EXPLORE_CHAIN_OPTIONS.length);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex(
+        (index - 1 + EXPLORE_CHAIN_OPTIONS.length) %
+          EXPLORE_CHAIN_OPTIONS.length,
+      );
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      setActiveIndex(0);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      setActiveIndex(EXPLORE_CHAIN_OPTIONS.length - 1);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      closeListbox();
+    } else if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      const option = EXPLORE_CHAIN_OPTIONS[index];
+      if (option) selectChain(option);
+    }
+  }
+
+  return (
+    <div
+      className={styles.selector}
+      data-open={open ? "true" : "false"}
+      ref={rootRef}
+      onBlurCapture={(event) => {
+        if (
+          event.relatedTarget instanceof Node &&
+          event.currentTarget.contains(event.relatedTarget)
+        ) {
+          return;
+        }
+        setOpen(false);
+      }}
+    >
+      <button
+        ref={triggerRef}
+        className={styles.trigger}
+        type="button"
+        aria-busy={!hydrated || undefined}
+        aria-controls={panelId}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-label={`Explore chain: ${selected.label}`}
+        onClick={() => {
+          if (open) closeListbox(false);
+          else openListbox();
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowDown") {
+            event.preventDefault();
+            openListbox(selectedIndex);
+          } else if (event.key === "ArrowUp") {
+            event.preventDefault();
+            openListbox(EXPLORE_CHAIN_OPTIONS.length - 1);
+          } else if (event.key === "Escape" && open) {
+            event.preventDefault();
+            closeListbox();
+          }
+        }}
+      >
+        <ExploreChainMark mark={selected.mark} />
+        <span>{selected.label}</span>
+        <ChevronDown className={styles.chevron} aria-hidden="true" size={15} />
+      </button>
+
+      {open ? (
+        <div
+          className={styles.menu}
+          id={panelId}
+          role="listbox"
+          aria-label="Explore chains"
+        >
+          {EXPLORE_CHAIN_OPTIONS.map((option, index) => {
+            const current = option.id === selectedViewChainId;
+            return (
+              <button
+                key={option.id}
+                ref={(element) => {
+                  optionRefs.current[index] = element;
+                }}
+                className={`${styles.option} ${
+                  current ? styles.optionCurrent : ""
+                }`}
+                type="button"
+                role="option"
+                aria-selected={current}
+                aria-disabled={!option.available || undefined}
+                data-active={activeIndex === index ? "true" : "false"}
+                tabIndex={activeIndex === index ? 0 : -1}
+                onClick={() => selectChain(option)}
+                onKeyDown={(event) => handleOptionKeyDown(event, index)}
+              >
+                <ExploreChainMark mark={option.mark} />
+                <span className={styles.optionCopy}>
+                  <span>{option.label}</span>
+                  {!option.available ? (
+                    <span className={styles.optionStatus}>Coming soon</span>
+                  ) : null}
+                </span>
+                {current ? (
+                  <Check className={styles.check} aria-hidden="true" size={16} />
+                ) : (
+                  <span className={styles.checkPlaceholder} aria-hidden="true" />
+                )}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -47,6 +47,15 @@
   text-wrap: balance;
 }
 
+.titleRow {
+  align-items: flex-end;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  justify-content: flex-start;
+  width: 100%;
+}
+
 .runnersSection {
   padding: 0 0 80px;
   position: relative;
@@ -1453,6 +1462,11 @@
   .pageHeading :is(h1, h2) {
     font-size: clamp(38px, 11vw, 48px);
     max-width: none;
+  }
+
+  .titleRow {
+    align-items: center;
+    gap: 12px;
   }
 
   .runnersIntro {

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -27,6 +27,7 @@ import {
   type MarketCapMetric,
 } from "@/components/animated-market-cap";
 import { XBrandIcon } from "@/components/brand-icons";
+import { ExploreChainSelector } from "@/components/explore-chain-selector";
 import { EXPLORE_PREVIEW_TOKENS } from "@/components/explore-preview-data";
 import {
   isInterfacePreviewHost,
@@ -50,6 +51,7 @@ import {
   type ExploreValuation,
   type ValuedExploreEntry,
 } from "@/lib/explore-financial-data";
+import { resolveExploreChainId } from "@/lib/explore-chain";
 import {
   CLASSIC_V4_PUBLIC_RELEASE_BINDING,
   isClassicV4AnchoredPublicReleaseBinding,
@@ -3376,11 +3378,20 @@ export function ExploreView({
   const {
     hydrated: viewChainReady,
     viewChainId: resolvedViewChainId,
+    setViewChainId,
   } = useViewChain();
-  const viewChainId =
+  const hydratedViewChainId =
     !viewChainReady && initialResponseChainId !== undefined
       ? initialResponseChainId
       : resolvedViewChainId;
+  const viewChainId = resolveExploreChainId(hydratedViewChainId);
+  useEffect(() => {
+    if (resolvedViewChainId === viewChainId) return;
+    const frame = window.requestAnimationFrame(() => {
+      setViewChainId(viewChainId);
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [resolvedViewChainId, setViewChainId, viewChainId, viewChainReady]);
   const activeInitialResponse =
     initialResponseChainId === undefined ||
       initialResponseChainId === viewChainId
@@ -4199,7 +4210,10 @@ export function ExploreView({
   return (
     <div className={`${styles.page} explore-page page-width`}>
         <header className={styles.pageHeading}>
-          <Heading data-explore-heading>Explore</Heading>
+          <div className={styles.titleRow}>
+            <Heading data-explore-heading>Explore</Heading>
+            {!embedded ? <ExploreChainSelector /> : null}
+          </div>
         </header>
 
         <section

--- a/components/site-navigation.module.css
+++ b/components/site-navigation.module.css
@@ -46,51 +46,6 @@
   outline-offset: 2px;
 }
 
-.chainTrigger {
-  align-items: center;
-  background: transparent;
-  border: 0;
-  border-radius: 12px;
-  color: #fff;
-  display: inline-flex;
-  flex: none;
-  height: 48px;
-  justify-content: center;
-  padding: 0;
-  transition:
-    opacity 180ms cubic-bezier(0.32, 0.72, 0, 1),
-    transform 180ms cubic-bezier(0.32, 0.72, 0, 1);
-  width: 48px;
-}
-
-.chainTrigger:active {
-  transform: scale(0.96);
-}
-
-.chainTrigger:disabled {
-  cursor: wait;
-}
-
-.chainTrigger:focus-visible {
-  outline: 2px solid var(--brand-ivory);
-  outline-offset: 2px;
-}
-
-.ethereumChainMark {
-  display: block;
-  height: 23px;
-  width: 23px;
-}
-
-/* Official Robinhood Chain feather, preserving its original 32:42 geometry. */
-.robinhoodChainMark {
-  aspect-ratio: 32 / 42;
-  background: currentColor;
-  display: block;
-  height: 24px;
-  mask: url("/brand/networks/robinhood-feather-white.svg") center / contain no-repeat;
-}
-
 .headerWalletButton {
   align-items: center;
   background: transparent;
@@ -117,13 +72,7 @@
   position: relative;
 }
 
-.headerChain {
-  display: flex;
-  flex: none;
-}
-
-.walletMenu,
-.chainFeedback {
+.walletMenu {
   background: rgb(14 15 18 / 0.98);
   border: 1px solid rgb(255 255 255 / 0.1);
   border-radius: 16px;
@@ -165,23 +114,12 @@
 
 .walletMenu > button[aria-disabled="true"] { opacity: 0.6; }
 
-.walletFeedback,
-.chainFeedback {
+.walletFeedback {
   font-size: 13px;
   line-height: 1.5;
   margin: 0;
   overflow-wrap: anywhere;
   padding: 8px 12px;
-}
-
-.chainFeedback {
-  inset-inline-end: 16px;
-  top: calc(100% + 4px);
-  width: min(320px, calc(100vw - 32px));
-}
-
-.siteHeader:has(.mobileSheetOpen, .walletMenu) .chainFeedback {
-  display: none;
 }
 
 .headerWalletButton:disabled {
@@ -368,8 +306,6 @@
     border-color: rgb(255 255 255 / 0.08);
   }
 
-  .chainTrigger:hover { opacity: 0.72; }
-
   .mobileSheet.mobileSheet :global(.mobile-nav a:hover) {
     background: rgb(255 255 255 / 0.055);
     color: var(--navigation-glass-ink);
@@ -432,7 +368,6 @@
 @media (prefers-reduced-motion: reduce) {
   .menuButton,
   .menuIcon svg,
-  .chainTrigger,
   .mobileSheet,
   .mobileSheet.mobileSheet :global(.mobile-nav a),
   .headerWalletButton {
@@ -443,24 +378,13 @@
 }
 
 @media (forced-colors: active) {
-  .chainTrigger {
-    color: CanvasText;
-  }
-
-  .robinhoodChainMark {
-    background: CanvasText;
-    forced-color-adjust: none;
-  }
-
   .menuButton,
-  .chainTrigger,
   .mobileSheetSurface {
     border-color: CanvasText;
     box-shadow: none;
   }
 
   .menuButton:focus-visible,
-  .chainTrigger:focus-visible,
   .mobileSheet.mobileSheet :global(.mobile-nav a:focus-visible),
   .headerWalletButton:focus-visible {
     outline-color: Highlight;

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -21,8 +21,6 @@ import {
   NavigationCloseIcon,
   NavigationMenuIcon,
 } from "@/components/navigation-icons";
-import { useViewChain, type ViewChainId } from "@/components/view-chain";
-import { isRobinhoodUnavailableRoute } from "@/components/view-chain-unavailable";
 import { useWallet } from "@/components/wallet-provider";
 import styles from "@/components/site-navigation.module.css";
 
@@ -275,111 +273,11 @@ function DesktopNavigation() {
   );
 }
 
-function ViewChainMark({ viewChainId }: { viewChainId: ViewChainId }) {
-  if (viewChainId === 4663) {
-    return (
-      <span className={styles.robinhoodChainMark} aria-hidden="true" />
-    );
-  }
-
-  return (
-    <svg
-      className={styles.ethereumChainMark}
-      viewBox="0 0 24 24"
-      fill="none"
-      aria-hidden="true"
-      focusable="false"
-    >
-      <path d="M12 2 5.5 12.2 12 9.25l6.5 2.95L12 2Z" fill="currentColor" />
-      <path
-        d="m5.5 13.35 6.5 3.7 6.5-3.7L12 22 5.5 13.35Z"
-        fill="currentColor"
-      />
-      <path
-        d="m12 9.25-6.5 2.95L12 15.9l6.5-3.7L12 9.25Z"
-        fill="currentColor"
-      />
-    </svg>
-  );
-}
-
-function viewChainLabel(viewChainId: ViewChainId) {
-  return viewChainId === 1 ? "Ethereum" : "Robinhood";
-}
-
-function HeaderChainToggle({
-  triggerRef,
-  onStart,
-  onSelect,
-}: Readonly<{
-  triggerRef: RefObject<HTMLButtonElement | null>;
-  onStart: () => void;
-  onSelect: (viewChainId: ViewChainId) => void;
-}>) {
-  const { hydrated, viewChainId, setViewChainId } = useViewChain();
-  const { wallet, authReady, hasSession, connecting, disconnecting, switchingNetwork, switchNetwork } = useWallet();
-  const pendingRef = useRef(false);
-  const accountRef = useRef(wallet?.account);
-  const [pending, setPending] = useState(false);
-  const [error, setError] = useState("");
-  useEffect(() => {
-    accountRef.current = wallet?.account;
-  }, [wallet?.account]);
-  const alternateViewChainId: ViewChainId = viewChainId === 1 ? 4663 : 1;
-  const currentLabel = viewChainLabel(viewChainId);
-  const alternateLabel = viewChainLabel(alternateViewChainId);
-
-  return (
-    <div className={styles.headerChain}>
-      <button
-        ref={triggerRef}
-        className={styles.chainTrigger}
-        type="button"
-        aria-busy={!hydrated || pending || switchingNetwork || undefined}
-        aria-label={`Viewing ${currentLabel}. Switch to ${alternateLabel}`}
-        disabled={!hydrated || (hasSession && !authReady) || connecting || disconnecting || pending || switchingNetwork}
-        title={`Switch to ${alternateLabel}`}
-        onClick={async () => {
-          if (pendingRef.current) return;
-          onStart();
-          setError("");
-          pendingRef.current = true;
-          setPending(true);
-          try {
-            if (wallet && !(await switchNetwork(String(alternateViewChainId)))) {
-              setError(`Network unchanged. Confirm ${alternateLabel} in your wallet and try again.`);
-              return;
-            }
-            if (accountRef.current !== wallet?.account) {
-              setError("Your wallet changed. Please try again.");
-              return;
-            }
-            setViewChainId(alternateViewChainId);
-            onSelect(alternateViewChainId);
-          } catch {
-            setError("Network unchanged. Please try again.");
-          } finally {
-            pendingRef.current = false;
-            setPending(false);
-          }
-        }}
-      >
-        <ViewChainMark viewChainId={viewChainId} />
-      </button>
-      <p className={error ? styles.chainFeedback : "sr-only"} role="status" aria-live="polite">
-        {error || (pending ? `Confirm ${alternateLabel} in your wallet` : "")}
-      </p>
-    </div>
-  );
-}
-
 export function SiteHeader() {
   const pathname = usePathname() ?? "/";
-  const router = useRouter();
   const menuId = useId();
   const headerRef = useRef<HTMLElement>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
-  const chainButtonRef = useRef<HTMLButtonElement>(null);
   const walletButtonRef = useRef<HTMLButtonElement>(null);
   const [menuPath, setMenuPath] = useState<string | null>(null);
   const [walletMenuPath, setWalletMenuPath] = useState<string | null>(null);
@@ -462,30 +360,6 @@ export function SiteHeader() {
         <DesktopNavigation />
 
         <div className={`header-actions ${styles.headerActions}`}>
-          <HeaderChainToggle
-            triggerRef={chainButtonRef}
-            onStart={() => {
-              setMenuPath(null);
-              setWalletMenuPath(null);
-            }}
-            onSelect={(selectedViewChainId) => {
-              setMenuPath(null);
-              if (pathname.startsWith("/token/")) {
-                const url = new URL(window.location.href);
-                url.searchParams.set("chain", String(selectedViewChainId));
-                const search = url.searchParams.toString();
-                router.replace(`${pathname}${search ? `?${search}` : ""}`);
-                window.requestAnimationFrame(() => {
-                  chainButtonRef.current?.focus({ preventScroll: true });
-                });
-                return;
-              }
-              if (isRobinhoodUnavailableRoute(pathname)) return;
-              window.requestAnimationFrame(() => {
-                chainButtonRef.current?.focus({ preventScroll: true });
-              });
-            }}
-          />
           <HeaderWalletButton
             triggerRef={walletButtonRef}
             open={walletMenuOpen}

--- a/lib/explore-chain.ts
+++ b/lib/explore-chain.ts
@@ -1,0 +1,13 @@
+import {
+  tryParseViewChainId,
+  type ViewChainId,
+} from "@/lib/view-chain";
+
+export const DEFAULT_EXPLORE_CHAIN_ID = 1 as const;
+
+export function resolveExploreChainId(value: unknown): ViewChainId {
+  const viewChainId = tryParseViewChainId(value);
+  return viewChainId === DEFAULT_EXPLORE_CHAIN_ID
+    ? viewChainId
+    : DEFAULT_EXPLORE_CHAIN_ID;
+}

--- a/tests/browser/fixtures/site-header-server.mjs
+++ b/tests/browser/fixtures/site-header-server.mjs
@@ -10,7 +10,7 @@ export async function createSiteHeaderServer() {
   const state = `
     import React, {createContext, useContext, useState} from 'react';
     const Context = createContext(null);
-    export function Fixture({children}) {
+    export function Fixture({children, selector}) {
       const [wallet, setWallet] = useState({account:'0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', chainId:'0x1'});
       const [viewChainId, setViewChainId] = useState(1);
       const [pending, setPending] = useState(false);
@@ -44,10 +44,12 @@ export async function createSiteHeaderServer() {
       };
       return <Context.Provider value={value}>{children}<main style={{padding:24}}>
         <h1>Header interaction fixture</h1><p>Deterministic test wallet. No real wallet requests.</p>
+        {selector}
         <button aria-pressed={reject} onClick={()=>setReject(!reject)}>Reject network switch</button>
         <button aria-pressed={failDisconnect} onClick={()=>setFailDisconnect(!failDisconnect)}>Fail disconnect</button>
         <button onClick={()=>setWallet(null)}>Use anonymous session</button>
         <p data-testid="requests">{requests.join(',')}</p>
+        <p data-testid="view-chain">{viewChainId}</p>
         <p data-testid="wallet-chain">{wallet?.chainId ?? 'disconnected'}</p>
         <p data-testid="disconnect-options">{disconnectOptions}</p>
         <a href="#outside">Outside control</a>
@@ -59,7 +61,7 @@ export async function createSiteHeaderServer() {
   `;
   const bundled = await build({
     stdin: {
-      contents: `import React from 'react'; import {createRoot} from 'react-dom/client'; import {SiteHeader} from './components/site-navigation'; import {Fixture} from 'fixture-state'; import './app/globals.css'; import './app/interface.css'; createRoot(document.getElementById('root')).render(<Fixture><SiteHeader/></Fixture>);`,
+      contents: `import React from 'react'; import {createRoot} from 'react-dom/client'; import {ExploreChainSelector} from './components/explore-chain-selector'; import {SiteHeader} from './components/site-navigation'; import {Fixture} from 'fixture-state'; import './app/globals.css'; import './app/interface.css'; createRoot(document.getElementById('root')).render(<Fixture selector={<ExploreChainSelector/>}><SiteHeader/></Fixture>);`,
       loader: "tsx", resolveDir: root,
     },
     bundle: true, format: "esm", platform: "browser", write: false,

--- a/tests/browser/site-header.spec.ts
+++ b/tests/browser/site-header.spec.ts
@@ -18,8 +18,6 @@ test.afterAll(async () => { server.close(); await once(server, "close"); });
 test.beforeEach(async ({ page }) => { await page.goto(origin); });
 
 const walletName = "Wallet 0xaaaa…aaaa";
-const toRobinhood = "Viewing Ethereum. Switch to Robinhood";
-const toEthereum = "Viewing Robinhood. Switch to Ethereum";
 
 test("wallet opens only its actions; copy, Escape, outside click and focus work", async ({page,context}) => {
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
@@ -58,39 +56,44 @@ test("disconnect failure stays inline and success returns to connect",async ({pa
   await expect(page.getByRole("group",{name:"Wallet actions",exact:true})).toHaveCount(0);
 });
 
-test("chain switch waits for wallet success and suppresses duplicate requests",async ({page})=>{
-  const toggle=page.getByRole("button",{name:toRobinhood,exact:true});
-  await toggle.evaluate((button:HTMLButtonElement)=>{button.click();button.click();});
-  await expect(toggle).toBeDisabled();
-  await expect(page.getByTestId("requests")).toHaveText("4663");
-  await expect(page.getByRole("button",{name:toEthereum,exact:true})).toBeEnabled();
-  await expect(page.getByTestId("wallet-chain")).toHaveText("0x1237");
-  await page.getByRole("button",{name:toEthereum,exact:true}).click();
-  await expect(page.getByRole("button",{name:toRobinhood,exact:true})).toBeEnabled();
-  await expect(page.getByTestId("wallet-chain")).toHaveText("0x1");
-  await expect(page.getByTestId("requests")).toHaveText("4663,1");
+test("keeps network selection out of the global header",async ({page})=>{
+  await expect(page.getByRole("button",{name:/Viewing .* Switch to/})).toHaveCount(0);
+  await expect(page.getByRole("button",{name:walletName,exact:true})).toBeVisible();
 });
 
-test("rejected network switch leaves the view and wallet unchanged",async ({page})=>{
-  await page.getByRole("button",{name:"Reject network switch"}).click();
-  await page.getByRole("button",{name:toRobinhood,exact:true}).click();
-  await expect(page.getByText("Network unchanged. Confirm Robinhood in your wallet and try again.")).toBeVisible();
-  await expect(page.getByRole("button",{name:toRobinhood,exact:true})).toBeEnabled();
-  await expect(page.getByTestId("wallet-chain")).toHaveText("0x1");
-});
-
-test("anonymous browsing can change chain without a wallet request",async ({page})=>{
-  await page.getByRole("button",{name:"Use anonymous session"}).click();
-  await page.getByRole("button",{name:toRobinhood,exact:true}).click();
-  await expect(page.getByRole("button",{name:toEthereum,exact:true})).toBeEnabled();
+test("Explore exposes one live chain and two truthful coming-soon choices",async ({page})=>{
+  const trigger=page.getByRole("button",{name:"Explore chain: Ethereum",exact:true});
+  await trigger.click();
+  const listbox=page.getByRole("listbox",{name:"Explore chains",exact:true});
+  await expect(listbox.getByRole("option")).toHaveText([
+    "Ethereum",
+    "RobinhoodComing soon",
+    "BaseComing soon",
+  ]);
+  await expect(listbox.getByRole("option",{name:"Robinhood Coming soon",exact:true})).toHaveAttribute("aria-disabled","true");
+  await expect(listbox.getByRole("option",{name:"Base Coming soon",exact:true})).toHaveAttribute("aria-disabled","true");
+  await page.keyboard.press("ArrowDown");
+  await expect(listbox.getByRole("option",{name:"Robinhood Coming soon",exact:true})).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("view-chain")).toHaveText("1");
   await expect(page.getByTestId("requests")).toBeEmpty();
+  await expect(listbox).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(listbox).toHaveCount(0);
+  await expect(trigger).toBeFocused();
 });
 
-test("session changes during a pending switch do not commit an outdated result",async ({page})=>{
-  await page.getByRole("button",{name:toRobinhood,exact:true}).click();
-  await page.getByRole("button",{name:"Use anonymous session"}).click();
-  await expect(page.getByText("Your wallet changed. Please try again.")).toBeVisible();
-  await expect(page.getByRole("button",{name:toRobinhood,exact:true})).toBeEnabled();
+test("Explore chain menu closes outside and stays inside the mobile viewport",async ({page})=>{
+  await page.setViewportSize({width:390,height:844});
+  const trigger=page.getByRole("button",{name:"Explore chain: Ethereum",exact:true});
+  await trigger.click();
+  const listbox=page.getByRole("listbox",{name:"Explore chains",exact:true});
+  const box=await listbox.boundingBox();
+  expect(box?.x).toBeGreaterThanOrEqual(0);
+  expect((box?.x??0)+(box?.width??0)).toBeLessThanOrEqual(390);
+  expect(await page.evaluate(()=>document.documentElement.scrollWidth)).toBe(390);
+  await page.getByRole("heading",{name:"Header interaction fixture",exact:true}).click();
+  await expect(listbox).toHaveCount(0);
 });
 
 test("anonymous Connect wallet closes navigation before opening login",async ({page})=>{

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -27,9 +27,12 @@ describe("Explore UI contract", () => {
     expect(page).toContain("initialResponseChainId={viewChainId}");
     expect(page).toContain("initialModelFilter={modelFilter}");
     expect(page).toContain("requestCookies.get(VIEW_CHAIN_COOKIE_NAME)");
+    expect(page).toContain("resolveExploreChainId(");
     expect(page).toContain("initialExploreQuery(modelFilter, viewChainId)");
     expect(source).toContain("hydrated: viewChainReady");
     expect(source).toContain("viewChainId: resolvedViewChainId");
+    expect(source).toContain("resolveExploreChainId(hydratedViewChainId)");
+    expect(source).toContain("setViewChainId(viewChainId)");
     expect(source).toContain(
       "!viewChainReady && initialResponseChainId !== undefined",
     );
@@ -60,6 +63,10 @@ describe("Explore UI contract", () => {
     expect(source).toContain("inert={loadingOnly ? true : undefined}");
     expect(source).toContain('const Heading = embedded ? "h2" : "h1"');
     expect(source).toContain("<Heading data-explore-heading>Explore</Heading>");
+    expect(source).toContain("!embedded ? <ExploreChainSelector /> : null");
+    expect(source.indexOf("<ExploreChainSelector />")).toBeLessThan(
+      source.indexOf('id="tokens"'),
+    );
     expect(source).not.toContain("ExploreModeSwitch");
     expect(source).toContain("const eagerImage = !embedded");
     expect(source).toContain("onPointerEnter={() => router.prefetch(href)}");

--- a/tests/view-chain-scope-gate.test.ts
+++ b/tests/view-chain-scope-gate.test.ts
@@ -28,6 +28,7 @@ describe("Robinhood view-chain scope gate", () => {
     const resolvedLayout = read("components/resolved-view-chain-layout.tsx");
     const transition = read("components/route-transition.tsx");
     const navigation = read("components/site-navigation.tsx");
+    const selector = read("components/explore-chain-selector.tsx");
     const tokenPage = read("app/token/[address]/page.tsx");
     const tokenSync = read("components/token-route-chain-sync.tsx");
     const styles = read("components/view-chain-unavailable.module.css");
@@ -40,8 +41,7 @@ describe("Robinhood view-chain scope gate", () => {
     expect(transition).not.toContain("<ViewChainPending />");
     expect(transition).not.toContain("<ViewChainUnavailable />");
     expect(transition).toContain("routeUsesChainBoundary");
-    expect(navigation).toContain('pathname.startsWith("/token/")');
-    expect(navigation).toContain('url.searchParams.set("chain"');
+    expect(navigation).not.toContain("HeaderChainToggle");
     expect(tokenPage).toContain("<TokenRouteChainSync");
     expect(tokenSync).toContain("synchronized.current = true");
     expect(transition).toContain(
@@ -54,9 +54,8 @@ describe("Robinhood view-chain scope gate", () => {
     expect(component).toContain("Ethereum remains live");
     expect(component).toContain("Your connected wallet stays connected");
     expect(component).not.toMatch(/useWallet|switchChain|switchNetwork|disconnect/);
-    expect(navigation).toContain(
-      "if (isRobinhoodUnavailableRoute(pathname)) return;",
-    );
+    expect(selector).toContain("setViewChainId(option.viewChainId)");
+    expect(selector).not.toMatch(/useWallet|switchChain|switchNetwork|disconnect/);
     expect(styles).toMatch(/\.action\s*\{[^}]*min-height:\s*44px;/s);
     expect(styles).toMatch(/\.action:focus-visible\s*\{/);
     expect(styles).toContain("@media (prefers-reduced-motion: reduce)");

--- a/tests/view-chain.test.ts
+++ b/tests/view-chain.test.ts
@@ -11,6 +11,7 @@ import {
   serializeViewChainCookie,
   tryParseViewChainId,
 } from "../lib/view-chain";
+import { resolveExploreChainId } from "../lib/explore-chain";
 
 const root = process.cwd();
 const read = (path: string) => readFileSync(join(root, path), "utf8");
@@ -23,6 +24,7 @@ describe("view chain", () => {
     expect(isViewChainId("4663")).toBe(false);
     expect(tryParseViewChainId("1")).toBe(1);
     expect(tryParseViewChainId("4663")).toBe(4663);
+    expect(tryParseViewChainId("8453")).toBeNull();
     expect(tryParseViewChainId("11155111")).toBeNull();
     expect(parseViewChainId(null)).toBe(1);
     expect(parseViewChainId("invalid")).toBe(1);
@@ -36,6 +38,13 @@ describe("view chain", () => {
     );
     expect(serializeViewChainCookie(4663)).toContain("Path=/");
     expect(serializeViewChainCookie(4663)).toContain("SameSite=Lax");
+  });
+
+  it("normalizes unavailable Explore preferences to Ethereum", () => {
+    expect(resolveExploreChainId(1)).toBe(1);
+    expect(resolveExploreChainId(4663)).toBe(1);
+    expect(resolveExploreChainId(8453)).toBe(1);
+    expect(resolveExploreChainId("invalid")).toBe(1);
   });
 
   it("resolves the server cookie only inside chain-bound product routes", () => {
@@ -91,30 +100,27 @@ describe("view chain", () => {
     expect(existsSync("app/token/layout.tsx")).toBe(false);
   });
 
-  it("switches directly between chains beside the header wallet action", () => {
+  it("scopes the truthful chain selector to Explore instead of the header", () => {
     const navigation = read("components/site-navigation.tsx");
-    const styles = read("components/site-navigation.module.css");
+    const explore = read("components/explore-view.tsx");
+    const selector = read("components/explore-chain-selector.tsx");
+    const styles = read("components/explore-chain-selector.module.css");
 
-    expect(navigation.indexOf("<HeaderChainToggle")).toBeLessThan(
-      navigation.indexOf("<HeaderWalletButton"),
-    );
-    expect(navigation.indexOf("<HeaderWalletButton")).toBeLessThan(
-      navigation.indexOf("ref={menuButtonRef}"),
-    );
-    expect(navigation).toContain("viewChainId === 1 ? 4663 : 1");
-    expect(navigation).toContain("setViewChainId(alternateViewChainId)");
-    expect(navigation).toContain("Switch to ${alternateLabel}");
+    expect(navigation).not.toContain("HeaderChainToggle");
+    expect(navigation).not.toContain("switchNetwork");
+    expect(explore).toContain("<ExploreChainSelector />");
+    expect(selector).toContain('aria-haspopup="listbox"');
+    expect(selector).toContain('role="listbox"');
+    expect(selector).toContain('role="option"');
+    expect(selector).toContain('label: "Ethereum"');
+    expect(selector).toContain('label: "Robinhood"');
+    expect(selector).toContain('label: "Base"');
+    expect(selector.match(/available: false/gu)).toHaveLength(2);
+    expect(selector).toContain("setViewChainId(option.viewChainId)");
+    expect(selector).not.toContain("useWallet");
+    expect(selector).not.toContain("switchNetwork");
     expect(styles).toContain("/brand/networks/robinhood-feather-white.svg");
-    expect(navigation).not.toContain("chainPopover");
-    expect(navigation).not.toContain("Choose network");
-    expect(navigation).not.toContain('role="menu"');
-    expect(navigation).toContain("inert={menuOpen ? undefined : true}");
-    expect(navigation).toContain('if (event.key !== "Escape") return;');
-    expect(styles).toMatch(
-      /\.chainTrigger\s*\{[^}]*height:\s*48px;[^}]*width:\s*48px;/s,
-    );
-    expect(styles).toMatch(
-      /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.chainTrigger,/,
-    );
+    expect(styles).toMatch(/\.trigger\s*\{[^}]*min-height:\s*44px;/s);
+    expect(styles).toContain("@media (prefers-reduced-motion: reduce)");
   });
 });


### PR DESCRIPTION
## Summary

- move the chain selector from the global header into the Explore heading
- expose Ethereum as live and Robinhood/Base as truthful coming-soon options
- keep Explore selection separate from wallet network prompts
- normalize unavailable persisted Explore choices to Ethereum

## Verification

- npm run build
- npm run typecheck
- targeted ESLint
- 21 targeted Vitest tests
- desktop 1440x900 and mobile 390x844 real-Chrome QA
- keyboard, disabled-option, outside-click, overflow and console checks