### PR TITLE
Remove expired migration entry points

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,7 @@ PRIVY_APP_SECRET=
 # The checked-in activation manifest remains the authority for the timer,
 # official address, wallet actions and production transfers.
 PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_ENABLED=false
+NEXT_PUBLIC_PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_VISIBLE=false
 PROGRAMMABLE_MAIN_TOKEN_MIGRATION_LOCAL_PREVIEW=false
 
 # Optional, server-only V4 migration gas sponsor for the reviewed 72-hour

--- a/.env.example
+++ b/.env.example
@@ -56,7 +56,6 @@ PRIVY_APP_SECRET=
 # The checked-in activation manifest remains the authority for the timer,
 # official address, wallet actions and production transfers.
 PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_ENABLED=false
-NEXT_PUBLIC_PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_VISIBLE=false
 PROGRAMMABLE_MAIN_TOKEN_MIGRATION_LOCAL_PREVIEW=false
 
 # Optional, server-only V4 migration gas sponsor for the reviewed 72-hour

--- a/components/landing-page.module.css
+++ b/components/landing-page.module.css
@@ -142,41 +142,6 @@
   margin: 24px 0 0;
 }
 
-.migrationCta {
-  align-items: center;
-  background: rgb(0 0 0 / 0.56);
-  border: 1px solid rgb(255 255 255 / 0.22);
-  border-radius: 16px;
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.12),
-    0 20px 56px rgb(0 0 0 / 0.28);
-  color: #fff;
-  display: flex;
-  flex-direction: column;
-  margin-top: 36px;
-  min-height: 92px;
-  min-width: min(460px, calc(100vw - 40px));
-  padding: 17px 30px;
-  transition:
-    background 700ms var(--webde-ease),
-    border-color 700ms var(--webde-ease),
-    transform 700ms var(--webde-ease);
-}
-
-.migrationCta span {
-  font-size: clamp(21px, 2vw, 27px);
-  font-weight: 650;
-  line-height: 1.35;
-}
-
-.migrationCta small {
-  color: #c9c9c6;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 13px;
-  line-height: 1.4;
-  margin-top: 4px;
-}
-
 .scrollCue {
   align-items: center;
   bottom: 25px;
@@ -439,12 +404,6 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .migrationCta:hover {
-    background: rgb(20 20 20 / 0.78);
-    border-color: rgb(255 255 255 / 0.42);
-    transform: translateY(-2px);
-  }
-
   .scrollCue:hover,
   .docsLink:hover,
   .inlineLink:hover {
@@ -456,8 +415,7 @@
 @media (prefers-reduced-motion: no-preference) {
   .heroLogo,
   .hero h1,
-  .heroContent > p,
-  .migrationCta {
+  .heroContent > p {
     animation: hero-reveal 760ms cubic-bezier(0.23, 1, 0.32, 1) both;
   }
 
@@ -471,10 +429,6 @@
 
   .heroContent > p {
     animation-delay: 160ms;
-  }
-
-  .migrationCta {
-    animation-delay: 220ms;
   }
 
   .scrollCue {

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -6,14 +6,9 @@ import Link from "next/link";
 
 import { LandingExploreGate } from "@/components/landing-explore-gate";
 import styles from "@/components/landing-page.module.css";
-import migrationActivationManifest from "@/config/main-token-migration-activation.v1.json";
 
 const loopMark = "/brand/loop/programmable-loop-mark-header-white-v1-1536.png";
 const HERO_TWINKLE_COUNT = 120;
-const migrationAnnouncementVisible =
-  process.env.NEXT_PUBLIC_PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_VISIBLE ===
-  "true";
-const migrationWindowActive = migrationActivationManifest.enabled === true;
 
 type HeroStarStyle = CSSProperties & {
   "--hero-star-delay": string;
@@ -159,19 +154,6 @@ export function LandingPage() {
           />
           <h1 id="landing-title">Programmable</h1>
           <p>Build and launch custom Uniswap v4 hooks</p>
-          {migrationAnnouncementVisible ? (
-            <Link
-              className={styles.migrationCta}
-              href="/migration"
-            >
-              <span>V4 is moving to Robinhood</span>
-              <small>
-                {migrationWindowActive
-                  ? "Migration window open · View details"
-                  : "Migration opens soon · View details"}
-              </small>
-            </Link>
-          ) : null}
         </div>
 
         <a className={styles.scrollCue} href="#what-is-programmable">

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -27,7 +27,6 @@ import styles from "@/components/site-navigation.module.css";
 const desktopNavItems = [
   { href: "/explore", label: "Explore" },
   { href: "/launch", label: "Create" },
-  { href: "/migration", label: "Migrate" },
 ];
 
 const menuNavItems = [

--- a/tests/interaction-accessibility.test.ts
+++ b/tests/interaction-accessibility.test.ts
@@ -260,7 +260,7 @@ describe("interaction accessibility", () => {
 
     expect(source).toContain("const mobileNavItems = [...desktopNavItems, ...menuNavItems];");
     expect(source).toContain('{ href: "/profile", label: "Profile" },');
-    expect(source).toContain('{ href: "/migration", label: "Migrate" },');
+    expect(source).not.toContain('{ href: "/migration", label: "Migrate" },');
     expect(source).not.toContain("/hookathon");
     expect(source).toContain(
       '<nav className="mobile-nav" aria-label="Menu navigation">',

--- a/tests/main-token-migration.test.ts
+++ b/tests/main-token-migration.test.ts
@@ -539,12 +539,12 @@ describe("main token migration page contract", () => {
     expect(route).toContain("PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_ENABLED");
     expect(route).toContain("PROGRAMMABLE_MAIN_TOKEN_MIGRATION_LOCAL_PREVIEW");
     expect(route).toContain("notFound()");
-    expect(landing).toContain('href="/migration"');
-    expect(landing).toContain("V4 is moving to Robinhood");
-    expect(landing).toContain(
+    expect(landing).not.toContain('href="/migration"');
+    expect(landing).not.toContain("V4 is moving to Robinhood");
+    expect(landing).not.toContain(
       "NEXT_PUBLIC_PROGRAMMABLE_MAIN_TOKEN_MIGRATION_PAGE_VISIBLE",
     );
-    expect(landing).toContain("migrationWindowActive");
+    expect(landing).not.toContain("migrationWindowActive");
     expect(read("app/api/main-token-migration/window-time/route.ts")).toContain(
       "programmable-main-token-migration-window-time/v1",
     );

--- a/tests/topbar-hero-polish.test.ts
+++ b/tests/topbar-hero-polish.test.ts
@@ -87,14 +87,15 @@ describe("topbar and Explore hero polish", () => {
     for (const label of [
       "Explore",
       "Create",
-      "Migrate",
       "Docs",
       "API keys",
       "Profile",
     ]) {
       expect(navigation).toContain(`label: "${label}"`);
     }
-    expect(navigation).toContain('{ href: "/migration", label: "Migrate" }');
+    expect(navigation).not.toContain(
+      '{ href: "/migration", label: "Migrate" }',
+    );
     expect(navigationCss).toContain("@media (max-width: 60rem)");
     expect(navigationCss).toContain("grid-template-columns: 1fr");
     expect(navigation).toContain("<HeaderSocialLinks mobile />");


### PR DESCRIPTION
Removes the expired migration banner from the landing page and the Migrate item from desktop/mobile navigation.

Keeps the feature-gated /migration recovery route and APIs intact for existing requests.

Verified locally:
- targeted tests: 40 passed
- TypeScript
- ESLint
- desktop/mobile browser QA with zero migration links and zero console errors