### PR TITLE
feat: publish finalized Robinhood custom launches

### DIFF
--- a/app/api/explore/route.ts
+++ b/app/api/explore/route.ts
@@ -73,6 +73,10 @@ import { safeOperationalRpcError } from
   "../../../lib/onchain/operational-rpc-failover.server";
 import { readProductionCustomExploreDirectoryV1 } from
   "../../../lib/server/custom-launch/explore-directory-v1";
+import {
+  readRobinhoodFinalizedExploreSnapshotV1,
+} from
+  "../../../lib/server/custom-launch/robinhood-finalized-explore-feed-v1";
 import { isCustomLaunchRegistryPublicReadEnabled } from
   "../../../lib/server/custom-launch/public-readiness";
 import type { ExploreSort } from "../../../lib/onchain/types";
@@ -1979,6 +1983,16 @@ export async function GET(request: NextRequest) {
     );
   }
   const requestedSort = parseExploreSort(search.get("sort"));
+  if (chain === 4663 && requestedSort !== "newest") {
+    return NextResponse.json(
+      {
+        error: requestedSort === "trending"
+          ? "Trending discovery is available on Ethereum only"
+          : "Robinhood Explore supports newest sort only",
+      },
+      { status: 400, headers: { "Cache-Control": "no-store" } },
+    );
+  }
   const requestedPage = integerQuery(search.get("page"), 1);
   const requestedRankingCommitment = search.get("rankingCommitment");
   const ethereumMarketCapSort = chain === 1 &&
@@ -2013,6 +2027,84 @@ export async function GET(request: NextRequest) {
       9,
       100,
     );
+    try {
+      const snapshot = await readRobinhoodFinalizedExploreSnapshotV1({
+        signal: readSignal,
+      });
+      const paginated = paginateExploreEntriesV1(snapshot.entries, {
+        query,
+        sort: requestedSort,
+        page: requestedPage,
+        pageSize,
+        socials,
+        model,
+      });
+      const tokens = paginated.tokens.map((entry) => publicExploreEntryV1({
+        ...entry,
+        valuation: { status: "unavailable" as const, reason: "source-unavailable" as const },
+      }));
+      return NextResponse.json(
+        {
+          status: "ready" as const,
+          chainId: chain,
+          ...paginated,
+          tokens,
+          sort: requestedSort,
+          query,
+          catalog: {
+            source: snapshot.source,
+            launchSource: snapshot.launchSource,
+            status: "current" as const,
+            lastIndexedAt: snapshot.generatedAt,
+            asOfBlock: snapshot.asOfBlock,
+            asOfBlockHash: snapshot.asOfBlockHash,
+            identityCount: snapshot.entries.length,
+            identityCommitment: snapshot.identityCommitment,
+            completeness: {
+              classic: "unavailable" as const,
+              stock: "excluded" as const,
+              custom: "current" as const,
+              registryCustom: "unavailable" as const,
+              routerCustom: "current" as const,
+            },
+            scope: {
+              included: ["canonical-launch-stamp-router"] as const,
+              excluded: CLASSIC_EXCLUSIONS,
+              publicCategories: ["classic", "custom"] as const,
+            },
+            routerStamp: {
+              source: ROUTER_CUSTOM_LAUNCH_SOURCE,
+              status: "current" as const,
+              finalityConfirmations: Number(ROUTER_CUSTOM_FINALITY_CONFIRMATIONS),
+              verifiedIdentityCount: snapshot.entries.length,
+              projectedIdentityCount: snapshot.entries.length,
+              generatedAt: snapshot.generatedAt,
+              asOfBlock: snapshot.asOfBlock,
+              asOfBlockHash: snapshot.asOfBlockHash,
+              identityCommitment: snapshot.identityCommitment,
+            },
+          },
+        },
+        {
+          headers: {
+            "Cache-Control":
+              "public, max-age=0, s-maxage=15, stale-while-revalidate=45",
+            "X-Programmable-Chain-Id": String(chain),
+            "X-Programmable-Launch-Source": snapshot.launchSource,
+            "X-Programmable-Read-Source": snapshot.launchSource,
+            "X-Programmable-Canonical-Read-Status": "unavailable",
+            "X-Programmable-Router-Read-Status": "current",
+            "X-Programmable-Identity-Last-Indexed-At": snapshot.generatedAt,
+          },
+        },
+      );
+    } catch (error) {
+      console.warn("Robinhood finalized Explore feed unavailable", {
+        name: error instanceof Error
+          ? error.name
+          : "RobinhoodFinalizedExploreFeedError",
+      });
+    }
     return NextResponse.json(
       {
         status: "not-deployed" as const,

--- a/app/api/explore/token/route.ts
+++ b/app/api/explore/token/route.ts
@@ -29,6 +29,10 @@ import { readProductionCustomExploreDirectoryV1 } from
   "../../../../lib/server/custom-launch/explore-directory-v1";
 import { readProductionSourceVerificationDisplayV1 } from
   "../../../../lib/server/custom-launch/source-verification-display-v1";
+import {
+  readRobinhoodFinalizedExploreSnapshotV1,
+} from
+  "../../../../lib/server/custom-launch/robinhood-finalized-explore-feed-v1";
 import { routerTradeProjectForServerBoundEntryV1 } from
   "../../../../lib/server/custom-launch/router-trade-descriptor-v1";
 import {
@@ -170,6 +174,112 @@ export async function GET(request: NextRequest) {
   const requestedTokenAddress = getAddress(input);
   const address = requestedTokenAddress.toLowerCase();
   if (chain === 4663) {
+    try {
+      const robinhood = await readRobinhoodFinalizedExploreSnapshotV1({
+        signal: readSignal,
+      });
+      const entry = robinhood.entries.find(
+        (candidate) => candidate.tokenAddress.toLowerCase() === address,
+      ) ?? null;
+      const catalog = {
+        source: robinhood.source,
+        launchSource: robinhood.launchSource,
+        status: "current" as const,
+        lastIndexedAt: robinhood.generatedAt,
+        asOfBlock: robinhood.asOfBlock,
+        asOfBlockHash: robinhood.asOfBlockHash,
+        identityCount: robinhood.entries.length,
+        identityCommitment: robinhood.identityCommitment,
+        completeness: {
+          classic: "unavailable" as const,
+          stock: "excluded" as const,
+          custom: "current" as const,
+          registryCustom: "unavailable" as const,
+          routerCustom: "current" as const,
+        },
+        scope: {
+          included: ["canonical-launch-stamp-router"] as const,
+          excluded: [
+            "classic-v1", "classic-v2", "stock-paired-v1",
+            "stock-paired-v2", "stock-paired-v3",
+          ] as const,
+          publicCategories: ["classic", "custom"] as const,
+        },
+        routerStamp: {
+          source: ROUTER_CUSTOM_LAUNCH_SOURCE,
+          status: "current" as const,
+          finalityConfirmations: Number(ROUTER_CUSTOM_FINALITY_CONFIRMATIONS),
+          verifiedIdentityCount: robinhood.entries.length,
+          projectedIdentityCount: robinhood.entries.length,
+          generatedAt: robinhood.generatedAt,
+          asOfBlock: robinhood.asOfBlock,
+          asOfBlockHash: robinhood.asOfBlockHash,
+          identityCommitment: robinhood.identityCommitment,
+        },
+      };
+      const headers = {
+        "Cache-Control": SUCCESS_CACHE_CONTROL,
+        "X-Programmable-Chain-Id": String(chain),
+        "X-Programmable-Launch-Source": robinhood.launchSource,
+        "X-Programmable-Read-Source": robinhood.launchSource,
+        "X-Programmable-Canonical-Read-Status": "unavailable",
+        "X-Programmable-Router-Read-Status": "current",
+        "X-Programmable-Identity-Last-Indexed-At": robinhood.generatedAt,
+      };
+      if (entry === null) {
+        return NextResponse.json(
+          {
+            status: "ready" as const,
+            token: null,
+            customProject: null,
+            routerTradeProject: null,
+            platformFeeCertification: null,
+            sourceVerification: null,
+            creatorArticle: null,
+            snapshot: null,
+            catalog,
+          },
+          { status: 404, headers },
+        );
+      }
+      const publicToken = publicExploreEntryV1(
+        publicExplorePresentationEntryV1({
+          ...entry,
+          valuation: {
+            status: "unavailable" as const,
+            reason: "source-unavailable" as const,
+          },
+        }),
+      );
+      const sourceUpdatedAt = robinhood.sourceVerification.find(
+        (candidate) => candidate.tokenAddress.toLowerCase() === address,
+      )?.updatedAt ?? null;
+      return NextResponse.json(
+        {
+          status: "ready" as const,
+          token: publicToken,
+          customProject: null,
+          routerTradeProject: null,
+          platformFeeCertification: null,
+          sourceVerification: {
+            schemaVersion: "programmable.source-verification-display.v1" as const,
+            status: "verified" as const,
+            label: "Source verified" as const,
+            updatedAt: sourceUpdatedAt,
+          },
+          creatorArticle: null,
+          snapshot: { chainId: 4663 },
+          catalog,
+        },
+        { headers },
+      );
+    } catch (error) {
+      console.warn("Robinhood finalized token feed unavailable", {
+        name: error instanceof Error
+          ? error.name
+          : "RobinhoodFinalizedExploreFeedError",
+      });
+    }
     return NextResponse.json(
       {
         status: "not-deployed" as const,

--- a/components/explore-chain-selector.tsx
+++ b/components/explore-chain-selector.tsx
@@ -13,7 +13,10 @@ import {
   useViewChain,
   type ViewChainId,
 } from "@/components/view-chain";
-import { resolveExploreChainId } from "@/lib/explore-chain";
+import {
+  isRobinhoodExploreAvailableResponse,
+  resolveExploreChainId,
+} from "@/lib/explore-chain";
 import styles from "@/components/explore-chain-selector.module.css";
 
 type ExploreChainOption = Readonly<{
@@ -81,10 +84,16 @@ function ExploreChainMark({ mark }: Readonly<{ mark: ExploreChainOption["mark"] 
 export function ExploreChainSelector() {
   const { hydrated, viewChainId, setViewChainId } = useViewChain();
   const [open, setOpen] = useState(false);
+  const [robinhoodAvailable, setRobinhoodAvailable] = useState(false);
+  const exploreChainOptions = EXPLORE_CHAIN_OPTIONS.map((option) =>
+    option.id === 4663
+      ? { ...option, available: robinhoodAvailable }
+      : option
+  ) satisfies readonly ExploreChainOption[];
   const selectedViewChainId = resolveExploreChainId(viewChainId);
   const selectedIndex = Math.max(
     0,
-    EXPLORE_CHAIN_OPTIONS.findIndex(
+    exploreChainOptions.findIndex(
       (option) => option.id === selectedViewChainId,
     ),
   );
@@ -93,7 +102,24 @@ export function ExploreChainSelector() {
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const selected = EXPLORE_CHAIN_OPTIONS[selectedIndex];
+  const selected = exploreChainOptions[selectedIndex]!;
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 5_000);
+    void fetch("/api/explore?chain=4663&limit=1&page=1&q=&sort=newest", {
+      cache: "no-store",
+      credentials: "same-origin",
+      signal: controller.signal,
+    }).then(async (response) => {
+      if (!response.ok) return false;
+      return isRobinhoodExploreAvailableResponse(await response.json());
+    }).then(setRobinhoodAvailable).catch(() => setRobinhoodAvailable(false));
+    return () => {
+      window.clearTimeout(timeout);
+      controller.abort();
+    };
+  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -137,25 +163,25 @@ export function ExploreChainSelector() {
   ) {
     if (event.key === "ArrowDown") {
       event.preventDefault();
-      setActiveIndex((index + 1) % EXPLORE_CHAIN_OPTIONS.length);
+      setActiveIndex((index + 1) % exploreChainOptions.length);
     } else if (event.key === "ArrowUp") {
       event.preventDefault();
       setActiveIndex(
-        (index - 1 + EXPLORE_CHAIN_OPTIONS.length) %
-          EXPLORE_CHAIN_OPTIONS.length,
+        (index - 1 + exploreChainOptions.length) %
+          exploreChainOptions.length,
       );
     } else if (event.key === "Home") {
       event.preventDefault();
       setActiveIndex(0);
     } else if (event.key === "End") {
       event.preventDefault();
-      setActiveIndex(EXPLORE_CHAIN_OPTIONS.length - 1);
+      setActiveIndex(exploreChainOptions.length - 1);
     } else if (event.key === "Escape") {
       event.preventDefault();
       closeListbox();
     } else if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
-      const option = EXPLORE_CHAIN_OPTIONS[index];
+      const option = exploreChainOptions[index];
       if (option) selectChain(option);
     }
   }
@@ -194,7 +220,7 @@ export function ExploreChainSelector() {
             openListbox(selectedIndex);
           } else if (event.key === "ArrowUp") {
             event.preventDefault();
-            openListbox(EXPLORE_CHAIN_OPTIONS.length - 1);
+            openListbox(exploreChainOptions.length - 1);
           } else if (event.key === "Escape" && open) {
             event.preventDefault();
             closeListbox();
@@ -213,7 +239,7 @@ export function ExploreChainSelector() {
           role="listbox"
           aria-label="Explore chains"
         >
-          {EXPLORE_CHAIN_OPTIONS.map((option, index) => {
+          {exploreChainOptions.map((option, index) => {
             const current = option.id === selectedViewChainId;
             return (
               <button

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -150,6 +150,23 @@ export type ExploreDiscoverySort = "none" | "trending";
 export type ExploreSocialFilter = "all" | "yes" | "no";
 export type ExploreModelFilter = "all" | "classic" | "custom-hook";
 
+export function resolveExploreSortSelectionsForChain(
+  viewChainId: ViewChainId,
+  valuationSort: ExploreValuationSort,
+  ageSort: ExploreAgeSort,
+  discoverySort: ExploreDiscoverySort,
+) {
+  if (viewChainId !== 4663) {
+    return { valuationSort, ageSort, discoverySort } as const;
+  }
+
+  return {
+    valuationSort: "none",
+    ageSort: ageSort === "oldest" ? "none" : ageSort,
+    discoverySort: "none",
+  } as const;
+}
+
 type DexscreenerExploreMarketRead = Readonly<{
   provider: "dexscreener";
   status: "complete" | "partial" | "unavailable";
@@ -308,7 +325,10 @@ type ExploreSearchRanking = Readonly<{
 }>;
 
 type ExploreCatalogBoundary = Readonly<{
-  source: "envio-classic-v3" | "durable-blob";
+  source:
+    | "envio-classic-v3"
+    | "durable-blob"
+    | "robinhood-finalized-custom-launch-feed-v4";
   launchSource:
     | "durable-blob"
     | "durable-blob+registry.custom-launched"
@@ -320,7 +340,8 @@ type ExploreCatalogBoundary = Readonly<{
     | "envio-classic-v3"
     | "envio-classic-v3+registry.custom-launched"
     | "envio-classic-v3+canonical-launch-stamp-router"
-    | "envio-classic-v3+registry.custom-launched+canonical-launch-stamp-router";
+    | "envio-classic-v3+registry.custom-launched+canonical-launch-stamp-router"
+    | "robinhood-finalized-custom-launch-feed-v4+canonical-launch-stamp-router";
   status: "current" | "last-known-good";
   lastIndexedAt: string;
   asOfBlock: string;
@@ -1842,6 +1863,45 @@ function parseExploreCatalog(value: unknown): ExploreCatalogBoundary | null {
     : null;
   if (evidence !== null && envioEvidence === null && durableEvidence === null) {
     return null;
+  }
+  if (value.source === "robinhood-finalized-custom-launch-feed-v4") {
+    const routerStamp = value.routerStamp;
+    return value.launchSource ===
+        "robinhood-finalized-custom-launch-feed-v4+canonical-launch-stamp-router" &&
+      value.status === "current" &&
+      exactIsoTimestamp(value.lastIndexedAt) &&
+      typeof value.asOfBlock === "string" &&
+      /^[1-9][0-9]*$/u.test(value.asOfBlock) &&
+      typeof value.asOfBlockHash === "string" &&
+      /^0x[0-9a-f]{64}$/u.test(value.asOfBlockHash) &&
+      Number.isSafeInteger(value.identityCount) &&
+      Number(value.identityCount) > 0 &&
+      typeof value.identityCommitment === "string" &&
+      /^sha256:[0-9a-f]{64}$/u.test(value.identityCommitment) &&
+      value.completeness.classic === "unavailable" &&
+      value.completeness.stock === "excluded" &&
+      value.completeness.custom === "current" &&
+      value.completeness.registryCustom === "unavailable" &&
+      value.completeness.routerCustom === "current" &&
+      evidence === null && scope !== null &&
+      exactStringArray(scope.included, ["canonical-launch-stamp-router"]) &&
+      exactStringArray(scope.excluded, [
+        "classic-v1", "classic-v2", "stock-paired-v1", "stock-paired-v2",
+        "stock-paired-v3",
+      ]) &&
+      exactStringArray(scope.publicCategories, ["classic", "custom"]) &&
+      isRecord(routerStamp) &&
+      routerStamp.source === "canonical-launch-stamp-router" &&
+      routerStamp.status === "current" &&
+      routerStamp.finalityConfirmations === 64 &&
+      routerStamp.verifiedIdentityCount === value.identityCount &&
+      routerStamp.projectedIdentityCount === value.identityCount &&
+      routerStamp.generatedAt === value.lastIndexedAt &&
+      routerStamp.asOfBlock === value.asOfBlock &&
+      routerStamp.asOfBlockHash === value.asOfBlockHash &&
+      routerStamp.identityCommitment === value.identityCommitment
+      ? value as ExploreCatalogBoundary
+      : null;
   }
   const durableSource = value.source === "durable-blob";
   const envioSource = value.source === "envio-classic-v3";
@@ -3457,21 +3517,30 @@ export function ExploreView({
     updatedAt: number;
   } | null>(null);
   const filterRef = useRef<HTMLDetailsElement>(null);
-  const discoverySortForChain = viewChainId === 1 ? discoverySort : "none";
-  const sort = resolveExploreServerSort(
+  const {
+    valuationSort: valuationSortForChain,
+    ageSort: ageSortForChain,
+    discoverySort: discoverySortForChain,
+  } = resolveExploreSortSelectionsForChain(
+    viewChainId,
     valuationSort,
     ageSort,
+    discoverySort,
+  );
+  const sort = resolveExploreServerSort(
+    valuationSortForChain,
+    ageSortForChain,
     discoverySortForChain,
   );
   const requiresCompleteDataset = requiresCompleteExploreDataset(
-    valuationSort,
-    ageSort,
+    valuationSortForChain,
+    ageSortForChain,
     discoverySortForChain,
   );
   const chainContentKey = `${viewChainId}`;
-  const contentKey = `${chainContentKey}\u0000${debouncedQuery}\u0000${valuationSort}\u0000${ageSort}\u0000${discoverySortForChain}\u0000${socialFilter}\u0000${modelFilter}\u0000${currentPage}\u0000${pageSize}`;
+  const contentKey = `${chainContentKey}\u0000${debouncedQuery}\u0000${valuationSortForChain}\u0000${ageSortForChain}\u0000${discoverySortForChain}\u0000${socialFilter}\u0000${modelFilter}\u0000${currentPage}\u0000${pageSize}`;
   const requestKey = `${contentKey}\u0000${retryKey}`;
-  const modelDatasetKey = `${chainContentKey}\u0000${debouncedQuery}\u0000${valuationSort}\u0000${ageSort}\u0000${discoverySortForChain}\u0000${socialFilter}\u0000${modelFilter}\u0000${retryKey}`;
+  const modelDatasetKey = `${chainContentKey}\u0000${debouncedQuery}\u0000${valuationSortForChain}\u0000${ageSortForChain}\u0000${discoverySortForChain}\u0000${socialFilter}\u0000${modelFilter}\u0000${retryKey}`;
   const activeRequestContentKey =
     requiresCompleteDataset ? modelDatasetKey : contentKey;
   const [initialState] = useState(() =>
@@ -3652,8 +3721,8 @@ export function ExploreView({
     const initialValuationSort = DEFAULT_EXPLORE_VALUATION_SORT;
     const isInitialRequest =
       debouncedQuery === "" &&
-      valuationSort === initialValuationSort &&
-      ageSort === "none" &&
+      valuationSortForChain === initialValuationSort &&
+      ageSortForChain === "none" &&
       discoverySortForChain === "none" &&
       socialFilter === "all" &&
       modelFilter === initialModelFilter &&
@@ -3737,8 +3806,8 @@ export function ExploreView({
             modelFilter,
             currentPage,
             pageSize,
-            valuationSort,
-            ageSort,
+            valuationSortForChain,
+            ageSortForChain,
             socialFilter,
           );
         }
@@ -3800,9 +3869,9 @@ export function ExploreView({
     socialFilter,
     sort,
     setCurrentPage,
-    valuationSort,
+    valuationSortForChain,
     viewChainId,
-    ageSort,
+    ageSortForChain,
     discoverySortForChain,
   ]);
 
@@ -3822,8 +3891,8 @@ export function ExploreView({
       })),
       socialFilter,
       modelFilter,
-      valuationSort,
-      ageSort,
+      valuationSortForChain,
+      ageSortForChain,
       currentPage,
       pageSize,
     );
@@ -3833,13 +3902,13 @@ export function ExploreView({
       ...paginated,
     };
   }, [
-    ageSort,
+    ageSortForChain,
     currentPage,
     debouncedQuery,
     modelFilter,
     pageSize,
     socialFilter,
-    valuationSort,
+    valuationSortForChain,
   ]);
 
   const activeChainState: ExploreState =
@@ -3890,8 +3959,8 @@ export function ExploreView({
     count: activeFilterCount,
     summary: activeSelectionSummary,
   } = exploreActiveSelectionState({
-    valuationSort,
-    ageSort,
+    valuationSort: valuationSortForChain,
+    ageSort: ageSortForChain,
     discoverySort: discoverySortForChain,
     socialFilter,
     modelFilter,
@@ -4389,10 +4458,16 @@ export function ExploreView({
                           <button
                             key={option.id}
                             className={
-                              valuationSort === option.id ? "active" : undefined
+                              valuationSortForChain === option.id
+                                ? "active"
+                                : undefined
                             }
                             type="button"
-                            aria-pressed={valuationSort === option.id}
+                            aria-label={viewChainId === 4663
+                              ? `${option.label} market cap is available on Ethereum only`
+                              : `${option.label} market cap`}
+                            aria-pressed={valuationSortForChain === option.id}
+                            disabled={viewChainId === 4663}
                             onClick={() => {
                               setValuationSort((current) =>
                                 current === option.id ? "none" : option.id,
@@ -4402,7 +4477,7 @@ export function ExploreView({
                             }}
                           >
                             <span>{option.label}</span>
-                            {valuationSort === option.id ? (
+                            {valuationSortForChain === option.id ? (
                               <Check aria-hidden="true" size={15} />
                             ) : null}
                           </button>
@@ -4421,20 +4496,30 @@ export function ExploreView({
                           <button
                             key={option.id}
                             className={
-                              ageSort === option.id ? "active" : undefined
+                              ageSortForChain === option.id
+                                ? "active"
+                                : undefined
                             }
                             type="button"
-                            aria-pressed={ageSort === option.id}
+                            aria-label={viewChainId === 4663 &&
+                                option.id === "oldest"
+                              ? "Oldest is available on Ethereum only"
+                              : option.label}
+                            aria-pressed={ageSortForChain === option.id}
+                            disabled={viewChainId === 4663 &&
+                              option.id === "oldest"}
                             onClick={() => {
                               setAgeSort((current) =>
                                 current === option.id ? "none" : option.id,
                               );
-                              setDiscoverySort("none");
+                              if (viewChainId === 1) {
+                                setDiscoverySort("none");
+                              }
                               setCurrentPage(1);
                             }}
                           >
                             <span>{option.label}</span>
-                            {ageSort === option.id ? (
+                            {ageSortForChain === option.id ? (
                               <Check aria-hidden="true" size={15} />
                             ) : null}
                           </button>

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -2189,15 +2189,17 @@ function TokenDetailContent({
           </div>
 
           <div className={styles.marketChart}>
-            <TokenPriceChart
-              tokenAddress={token.tokenAddress}
-              tokenName={token.name}
-              launchModel={classicTradeLaunchModel}
-              totalSupply={chartTotalSupply(token)}
-              currentMarketCapUsd={chartCurrentMarketCapUsd(token)}
-              preview={preview}
-              onVolumeChange={setChartVolume}
-            />
+            {chainId === 1 ? (
+              <TokenPriceChart
+                tokenAddress={token.tokenAddress}
+                tokenName={token.name}
+                launchModel={classicTradeLaunchModel}
+                totalSupply={chartTotalSupply(token)}
+                currentMarketCapUsd={chartCurrentMarketCapUsd(token)}
+                preview={preview}
+                onVolumeChange={setChartVolume}
+              />
+            ) : null}
             <MetricGrid metrics={metrics} />
           </div>
         </section>

--- a/lib/explore-chain.ts
+++ b/lib/explore-chain.ts
@@ -7,7 +7,25 @@ export const DEFAULT_EXPLORE_CHAIN_ID = 1 as const;
 
 export function resolveExploreChainId(value: unknown): ViewChainId {
   const viewChainId = tryParseViewChainId(value);
-  return viewChainId === DEFAULT_EXPLORE_CHAIN_ID
-    ? viewChainId
-    : DEFAULT_EXPLORE_CHAIN_ID;
+  return viewChainId ?? DEFAULT_EXPLORE_CHAIN_ID;
+}
+
+export function isRobinhoodExploreAvailableResponse(value: unknown): boolean {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const response = value as Record<string, unknown>;
+  const catalog = response.catalog;
+  return response.status === "ready" &&
+    response.chainId === 4663 &&
+    typeof response.total === "number" &&
+    Number.isSafeInteger(response.total) &&
+    response.total > 0 &&
+    typeof catalog === "object" && catalog !== null && !Array.isArray(catalog) &&
+    (catalog as Record<string, unknown>).source ===
+      "robinhood-finalized-custom-launch-feed-v4" &&
+    typeof (catalog as Record<string, unknown>).completeness === "object" &&
+    (catalog as Record<string, unknown>).completeness !== null &&
+    ((catalog as Record<string, unknown>).completeness as Record<string, unknown>)
+      .custom === "current";
 }

--- a/lib/public-openapi.ts
+++ b/lib/public-openapi.ts
@@ -281,7 +281,7 @@ export const programmablePublicOpenApi = {
             name: "chain",
             in: "query",
             description:
-              "Chain-scoped Explore discovery. Ethereum Mainnet is live; the Robinhood Explore read-model lane currently returns an honest planned-not-deployed response with no catalog or tokens. This does not describe Router or Custom API deployment.",
+              "Chain-scoped Explore discovery. Ethereum Mainnet retains its existing market-enriched response. Robinhood returns a newest-only ready projection only when the finalized Programmable backend feed and direct chain verification succeed; otherwise it returns the honest planned-not-deployed response.",
             schema: { type: "integer", enum: [1, 4663], default: 1 },
           },
           {
@@ -319,7 +319,7 @@ export const programmablePublicOpenApi = {
             name: "sort",
             in: "query",
             description:
-              "Canonical launch order, GMGN Trending, or GMGN-primary market-cap ordering. trending is accepted only with chain=1. Market-cap sorts place qualified canonical GMGN rank matches first in the requested direction, then sort only the unobserved canonical remainder by exact-identity Dexscreener FDV; this is deliberately not a cross-provider numeric merge. Every mode retains the complete filtered canonical catalog.",
+              "Canonical launch order, GMGN Trending, or GMGN-primary market-cap ordering. chain=4663 accepts only newest. trending and every market-cap sort are accepted only with chain=1. Market-cap sorts place qualified canonical GMGN rank matches first in the requested direction, then sort only the unobserved canonical remainder by exact-identity Dexscreener FDV; this is deliberately not a cross-provider numeric merge. Every mode retains the complete filtered canonical catalog.",
             schema: {
               type: "string",
               enum: [
@@ -349,7 +349,7 @@ export const programmablePublicOpenApi = {
           "200": {
             ...jsonResponse(
               component("ExploreListResponse"),
-              "Verified launch page or an honest planned-not-deployed Explore-lane response.",
+              "Verified chain-scoped launch page or an honest planned-not-deployed Robinhood response.",
             ),
             headers: {
               ...exploreIdentityResponseHeaders,
@@ -376,7 +376,7 @@ export const programmablePublicOpenApi = {
         operationId: "getVerifiedToken",
         summary: "Look up one verified token",
         description:
-          "Looks up an exact token identity on the selected chain. Ethereum Mainnet is live. The Robinhood Explore read-model lane currently returns an honest planned-not-deployed response without reading chain 4663; this does not describe Router or Custom API deployment. A 404 response is a completed verified lookup with no public identity, not a provider timeout.",
+          "Looks up an exact token identity on the selected chain. Ethereum Mainnet retains its existing market-enriched response. Robinhood returns a ready identity only when the finalized Programmable backend feed and direct chain verification succeed; otherwise it returns the honest planned-not-deployed response. A 404 response is a completed verified lookup with no public identity, not a provider timeout.",
         tags: ["Discovery"],
         security: [],
         parameters: [
@@ -400,7 +400,7 @@ export const programmablePublicOpenApi = {
           "200": {
             ...jsonResponse(
               component("TokenDetailResponse"),
-              "Verified token, Registry-verified Custom project, or honest planned-not-deployed Explore-lane response.",
+              "Verified chain-scoped token, Registry-verified Custom project, or honest planned-not-deployed Robinhood response.",
             ),
             headers: {
               ...exploreIdentityResponseHeaders,
@@ -410,7 +410,7 @@ export const programmablePublicOpenApi = {
           "400": jsonResponse(component("ApiError"), "Invalid address or query shape."),
           "404": {
             ...jsonResponse(
-              component("TokenDetailReadyResponse"),
+              component("TokenDetailLookupReadyResponse"),
               "Verified lookup completed but no public token identity matched. No market provider is read for this response.",
             ),
             headers: exploreIdentityResponseHeaders,
@@ -3232,9 +3232,36 @@ export const programmablePublicOpenApi = {
         },
         additionalProperties: true,
       },
+      RobinhoodFinalizedCatalogBoundary: {
+        type: "object",
+        description:
+          "Finalized Robinhood Custom launch identities admitted from the Programmable V4 backend and reverified against the canonical launch-stamp Router before publication.",
+        required: [
+          "source",
+          "launchSource",
+          "status",
+          "lastIndexedAt",
+          "identityCount",
+        ],
+        properties: {
+          source: { const: "robinhood-finalized-custom-launch-feed-v4" },
+          launchSource: {
+            const:
+              "robinhood-finalized-custom-launch-feed-v4+canonical-launch-stamp-router",
+          },
+          status: { const: "current" },
+          lastIndexedAt: { type: "string", format: "date-time" },
+          asOfBlock: { type: "string", pattern: "^[1-9][0-9]*$" },
+          asOfBlockHash: component("Hex32"),
+          identityCount: { type: "integer", minimum: 1 },
+          identityCommitment: component("Sha256Digest"),
+        },
+        additionalProperties: true,
+      },
       ExploreListResponse: {
         oneOf: [
           component("ExploreReadyListResponse"),
+          component("RobinhoodExploreReadyListResponse"),
           component("ExplorePlannedListResponse"),
         ],
       },
@@ -3289,6 +3316,41 @@ export const programmablePublicOpenApi = {
         },
         additionalProperties: true,
       },
+      RobinhoodExploreReadyListResponse: {
+        type: "object",
+        description:
+          "Newest-first Robinhood Custom launches from the finalized Programmable backend feed after direct Router, L2 inclusion and Ethereum-finality verification. Market enrichment is unavailable and marketRead is omitted (or null).",
+        required: [
+          "status",
+          "chainId",
+          "tokens",
+          "page",
+          "pageSize",
+          "total",
+          "totalPages",
+          "sort",
+          "query",
+          "catalog",
+        ],
+        properties: {
+          status: { const: "ready" },
+          chainId: { const: 4663 },
+          tokens: { type: "array", items: component("ExploreEntry") },
+          page: { type: "integer", minimum: 1 },
+          pageSize: { type: "integer", minimum: 1, maximum: 100 },
+          total: { type: "integer", minimum: 0 },
+          totalPages: { type: "integer", minimum: 0 },
+          sort: { const: "newest" },
+          query: { type: "string" },
+          catalog: component("RobinhoodFinalizedCatalogBoundary"),
+          marketRead: {
+            type: "null",
+            description:
+              "Robinhood Explore currently performs no market-data provider read.",
+          },
+        },
+        additionalProperties: false,
+      },
       ExplorePlannedListResponse: {
         type: "object",
         required: [
@@ -3316,10 +3378,7 @@ export const programmablePublicOpenApi = {
           pageSize: { type: "integer", minimum: 1, maximum: 100 },
           total: { const: 0 },
           totalPages: { const: 0 },
-          sort: {
-            type: "string",
-            enum: ["newest", "oldest", "market-cap", "market-cap-asc"],
-          },
+          sort: { const: "newest" },
           query: { type: "string" },
         },
         additionalProperties: false,
@@ -3327,7 +3386,14 @@ export const programmablePublicOpenApi = {
       TokenDetailResponse: {
         oneOf: [
           component("TokenDetailReadyResponse"),
+          component("RobinhoodTokenDetailReadyResponse"),
           component("TokenDetailPlannedResponse"),
+        ],
+      },
+      TokenDetailLookupReadyResponse: {
+        oneOf: [
+          component("TokenDetailReadyResponse"),
+          component("RobinhoodTokenDetailReadyResponse"),
         ],
       },
       TokenDetailReadyResponse: {
@@ -3344,6 +3410,29 @@ export const programmablePublicOpenApi = {
           creatorArticle: { type: ["object", "null"], additionalProperties: true },
           snapshot: { type: ["object", "null"], additionalProperties: true },
           catalog: component("CatalogBoundary"),
+        },
+        additionalProperties: true,
+      },
+      RobinhoodTokenDetailReadyResponse: {
+        type: "object",
+        description:
+          "A Robinhood token lookup completed against the finalized Programmable feed and direct chain verification boundary. token is null only for a verified 404.",
+        required: ["status", "token", "customProject", "creatorArticle", "catalog"],
+        properties: {
+          status: { const: "ready" },
+          token: {
+            oneOf: [component("ExploreEntry"), { type: "null" }],
+          },
+          customProject: { type: "null" },
+          routerTradeProject: { type: "null" },
+          platformFeeCertification: { type: "null" },
+          sourceVerification: {
+            type: ["object", "null"],
+            additionalProperties: true,
+          },
+          creatorArticle: { type: "null" },
+          snapshot: { type: ["object", "null"], additionalProperties: true },
+          catalog: component("RobinhoodFinalizedCatalogBoundary"),
         },
         additionalProperties: true,
       },

--- a/lib/server/custom-launch/robinhood-finalized-explore-feed-v1.ts
+++ b/lib/server/custom-launch/robinhood-finalized-explore-feed-v1.ts
@@ -1,0 +1,1358 @@
+import "server-only";
+
+import {
+  createPublicClient,
+  decodeEventLog,
+  formatUnits,
+  getAddress,
+  http,
+  isAddressEqual,
+  keccak256,
+  parseAbi,
+  parseAbiItem,
+  toEventSelector,
+  type Address,
+  type Hex,
+  type Log,
+  type PublicClient,
+  type TransactionReceipt,
+} from "viem";
+import { mainnet } from "viem/chains";
+
+// The public launch package is the canonical runtime validator for the closed
+// V4 request shapes. It intentionally ships as ESM JavaScript today.
+// @ts-expect-error -- packages/launch does not publish TypeScript declarations.
+import { hashProjectMetadata, validateProjectMetadata } from "../../../packages/launch/src/project-metadata.mjs";
+// @ts-expect-error -- packages/launch does not publish TypeScript declarations.
+import { hashV4ChainDeployment, normalizeV4ChainDeployment, normalizeV4FundingIntent, normalizeV4LiquidityModel, normalizeV4ProfileRef } from "../../../packages/launch/src/v4-contract.mjs";
+
+import {
+  ROBINHOOD_MAINNET_RPC_URL,
+  robinhoodChain,
+} from "../../chains";
+import {
+  CUSTOM_LAUNCH_ROBINHOOD_TRUST_ROOTS_V4,
+} from "../../custom-launch/wallet-handoff-v4";
+import { canonicalTokenExploreEntryV1 } from "../../explore-entry-v1";
+import { uerc20ReadAbi } from "../../onchain/abis";
+import { productionMainnetRpcPair } from
+  "../../onchain/website-rpc-providers.server";
+import {
+  canonicalizeJson,
+  parseStrictJson,
+  type JsonValue,
+} from "../projection-target/canonical-json";
+import { canonicalSha256 } from "../projection-target/hashing";
+import {
+  computeOfficialV4PoolId,
+} from "../../uniswap/liquidity-launcher-sdk";
+import type {
+  CanonicalTokenExploreEntry,
+  LaunchStampProvenanceV1,
+  LauncherToken,
+  ProjectMetadataLink,
+  TokenLink,
+} from "../../tokens";
+
+export const ROBINHOOD_FINALIZED_EXPLORE_FEED_URL_V1 =
+  "https://api.programmable.market/v4/chains/4663/finalized-custom-launches" as const;
+export const ROBINHOOD_FINALIZED_EXPLORE_SOURCE_V1 =
+  "robinhood-finalized-custom-launch-feed-v4" as const;
+export const ROBINHOOD_FINALIZED_EXPLORE_LAUNCH_SOURCE_V1 =
+  "robinhood-finalized-custom-launch-feed-v4+canonical-launch-stamp-router" as const;
+
+const PAGE_LIMIT = 25;
+const MAXIMUM_PAGES = 40;
+const MAXIMUM_RECORDS = 1_000;
+const MAXIMUM_PAGE_BYTES = 4 * 1_024 * 1_024;
+const REQUEST_TIMEOUT_MS = 1_500;
+const VERIFICATION_TIMEOUT_MS = 8_000;
+const MAXIMUM_GENERATED_AGE_MS = 5 * 60_000;
+const MAXIMUM_FUTURE_SKEW_MS = 60_000;
+const FINALITY_CONFIRMATIONS = 64n;
+const ROUTER_START_BLOCK = 50_469_365n;
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const BYTES32 = /^0x(?!0{64}$)[0-9a-f]{64}$/u;
+const UNSIGNED_DECIMAL = /^(?:0|[1-9][0-9]*)$/u;
+const CURSOR = /^[A-Za-z0-9_-]{16,512}$/u;
+const TARGET_ID = /^[A-Za-z0-9][A-Za-z0-9._:@/+\-]{0,255}$/u;
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const ZERO_HASH = `0x${"00".repeat(32)}`;
+const L1_ROLLUP = "0x23A19d23e89166adedbDcB432518AB01e4272D94";
+const L1_SEQUENCER_INBOX =
+  "0xBd0D173EEb87D57A09521c24388a12789F33ba96";
+const SEQUENCER_BATCH_DELIVERED_TOPIC =
+  "0x7394f4a19a13c7b92b5bb71033245305946ef78452f7b4986ac1390b5df4ebd7";
+const TRUSTED_IPFS_PROJECT_IMAGE_GATEWAY_V1 =
+  "https://ipfs.io/ipfs/" as const;
+const TRUSTED_ARWEAVE_PROJECT_IMAGE_GATEWAY_V1 =
+  "https://arweave.net/" as const;
+const SOURCE_AUTHORITY =
+  "protected-hosted-build-finalized-transaction-bytecode";
+const SOURCE_BINDING_SCHEMA =
+  "programmable.robinhood-custom-launch.exact-byte-source-build-transaction-binding.v1";
+const SOURCE_COVERED_EVIDENCE = Object.freeze([
+  "protected-source-tree",
+  "source-closure",
+  "hosted-build-artifact",
+  "standard-json-input",
+  "compiler-binary",
+  "compiler-settings",
+  "finalized-creation-transaction",
+  "creation-bytecode",
+  "runtime-bytecode",
+] as const);
+
+const componentEvent = parseAbiItem(
+  "event ProgrammableComponentStampedV1(bytes32 indexed launchId,address indexed component,uint8 indexed kind,bytes32 runtimeCodeHash)",
+);
+const routeEvent = parseAbiItem(
+  "event ProgrammableLaunchRouteStampedV1(bytes32 indexed launchId,uint8 indexed kind,bytes32 indexed routePayloadHash,bytes32 expectedResultHash,bytes32 permitDigest)",
+);
+const launchEvent = parseAbiItem(
+  "event ProgrammableLaunchStampedV1(bytes32 indexed launchId,address indexed token,address indexed hook,address poolManager,bytes32 poolId,bytes32 stampHash)",
+);
+const initializeEvent = parseAbiItem(
+  "event Initialize(bytes32 indexed id,address indexed currency0,address indexed currency1,uint24 fee,int24 tickSpacing,address hooks,uint160 sqrtPriceX96,int24 tick)",
+);
+const sequencerBatchEvent = Object.freeze({
+  type: "event",
+  name: "SequencerBatchDelivered",
+  inputs: Object.freeze([
+    Object.freeze({ indexed: true, name: "batchSequenceNumber", type: "uint256" }),
+    Object.freeze({ indexed: true, name: "beforeAcc", type: "bytes32" }),
+    Object.freeze({ indexed: true, name: "afterAcc", type: "bytes32" }),
+    Object.freeze({ indexed: false, name: "delayedAcc", type: "bytes32" }),
+    Object.freeze({ indexed: false, name: "afterDelayedMessagesRead", type: "uint256" }),
+    Object.freeze({
+      indexed: false,
+      name: "timeBounds",
+      type: "tuple",
+      components: Object.freeze([
+        Object.freeze({ name: "delayBlocks", type: "uint64" }),
+        Object.freeze({ name: "futureBlocks", type: "uint64" }),
+        Object.freeze({ name: "delaySeconds", type: "uint64" }),
+        Object.freeze({ name: "futureSeconds", type: "uint64" }),
+      ]),
+    }),
+    Object.freeze({ indexed: false, name: "dataLocation", type: "uint8" }),
+  ]),
+} as const);
+const componentTopic = toEventSelector(componentEvent);
+const routeTopic = toEventSelector(routeEvent);
+const launchTopic = toEventSelector(launchEvent);
+const initializeTopic = toEventSelector(initializeEvent);
+const routerReadAbi = parseAbi([
+  "function CHAIN_ID() view returns (uint256)",
+  "function POOL_MANAGER() view returns (address)",
+  "function POOL_MANAGER_RUNTIME_CODE_HASH() view returns (bytes32)",
+  "function GRAPH_FACTORY() view returns (address)",
+  "function GRAPH_FACTORY_RUNTIME_CODE_HASH() view returns (bytes32)",
+  "function PERMIT_AUTHORITY() view returns (address)",
+  "function PERMIT_AUTHORITY_RUNTIME_CODE_HASH() view returns (bytes32)",
+  "function launchStamp(bytes32 launchId) view returns ((uint8 kind,address launchWallet,address token,address hook,address poolManager,bytes32 poolId,bytes32 poolKeyHash,bytes32 componentSetHash,bytes32 routePayloadHash,address routeLauncher,bytes32 routeLauncherRuntimeCodeHash,bytes32 expectedResultHash,bytes32 permitDigest,bytes32 stampHash) record)",
+  "function launchIdByToken(address token) view returns (bytes32 launchId)",
+  "function launchIdByPool(address poolManager,bytes32 poolId) view returns (bytes32 launchId)",
+  "function launchIdByComponent(address component) view returns (bytes32 launchId)",
+  "function componentRuntimeCodeHash(address component) view returns (bytes32 runtimeCodeHash)",
+  "function stampProof(address component) view returns (bytes32 launchId,bytes32 stampHash)",
+  "function computePoolKeyHash((address currency0,address currency1,uint24 fee,int24 tickSpacing,address hooks) poolKey) pure returns (bytes32)",
+]);
+
+type FeedQualityV1 = Readonly<{
+  status: "ready";
+  sourceRowCount: number;
+  publishedRowCount: number;
+  quarantinedRowCount: 0;
+}>;
+
+type SourceComponentV1 = Readonly<{
+  targetId: string;
+  address: Address;
+  updatedAt: string;
+}>;
+
+type ParsedLaunchV1 = Readonly<{
+  launchId: string;
+  routerLaunchId: Hex;
+  projectMetadata: Readonly<{
+    token: Readonly<{ name: string; symbol: string }>;
+    description: string;
+    imageUrl: string;
+    links: readonly TokenLink[];
+    projectMetadataLinks: readonly ProjectMetadataLink[];
+    tokenTargetId: string;
+  }>;
+  l2: Readonly<{
+    transactionHash: Hex;
+    blockNumber: bigint;
+    blockHash: Hex;
+    blockTimestamp: bigint;
+    routeLogIndex: number;
+    launchLogIndex: number;
+  }>;
+  l1: Readonly<{
+    posting: Readonly<{
+      transactionHash: Hex;
+      blockNumber: bigint;
+      blockHash: Hex;
+      logIndex: number;
+      sequencerInbox: Address;
+      batchNumber: bigint;
+    }>;
+    finalized: Readonly<{
+      blockNumber: bigint;
+      blockHash: Hex;
+    }>;
+  }>;
+  evidenceDigest: `sha256:${string}`;
+  finalizedAt: string;
+  sourceUpdatedAt: string;
+  sourceComponents: readonly SourceComponentV1[];
+}>;
+
+export type RobinhoodFinalizedExploreSnapshotV1 = Readonly<{
+  source: typeof ROBINHOOD_FINALIZED_EXPLORE_SOURCE_V1;
+  launchSource: typeof ROBINHOOD_FINALIZED_EXPLORE_LAUNCH_SOURCE_V1;
+  generatedAt: string;
+  asOfBlock: string;
+  asOfBlockHash: Hex;
+  identityCommitment: `sha256:${string}`;
+  entries: readonly CanonicalTokenExploreEntry[];
+  quality: FeedQualityV1;
+  sourceVerification: readonly Readonly<{
+    tokenAddress: Address;
+    updatedAt: string;
+  }>[];
+}>;
+
+export type RobinhoodFinalizedExploreReaderClientV1 = PublicClient;
+export type RobinhoodFinalizedExploreEthereumClientV1 = PublicClient;
+
+type ReaderDependenciesV1 = Readonly<{
+  fetchFeed?: typeof fetch;
+  client?: RobinhoodFinalizedExploreReaderClientV1;
+  ethereumClients?: readonly [
+    RobinhoodFinalizedExploreEthereumClientV1,
+    RobinhoodFinalizedExploreEthereumClientV1,
+  ];
+  now?: () => number;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  maximumPages?: number;
+  verifyLaunch?: (
+    launch: ParsedLaunchV1,
+    context: Readonly<{
+      client: RobinhoodFinalizedExploreReaderClientV1;
+      latestBlock: Readonly<{ number: bigint; hash: Hex }>;
+    }>,
+  ) => Promise<CanonicalTokenExploreEntry>;
+  verifyEthereumFinality?: (
+    launch: ParsedLaunchV1,
+    clients: readonly [
+      RobinhoodFinalizedExploreEthereumClientV1,
+      RobinhoodFinalizedExploreEthereumClientV1,
+    ],
+  ) => Promise<void>;
+}>;
+
+export async function readRobinhoodFinalizedExploreSnapshotV1(
+  dependencies: ReaderDependenciesV1 = {},
+): Promise<RobinhoodFinalizedExploreSnapshotV1> {
+  const fetchFeed = dependencies.fetchFeed ?? fetch;
+  const now = dependencies.now ?? Date.now;
+  const timeoutMs = dependencies.timeoutMs ?? REQUEST_TIMEOUT_MS;
+  const maximumPages = dependencies.maximumPages ?? MAXIMUM_PAGES;
+  if (
+    !Number.isSafeInteger(timeoutMs) || timeoutMs < 10 || timeoutMs > 5_000 ||
+    !Number.isSafeInteger(maximumPages) || maximumPages < 1 ||
+    maximumPages > MAXIMUM_PAGES
+  ) throw new TypeError("Robinhood finalized feed bounds are invalid");
+
+  const verificationSignal = dependencies.signal ??
+    AbortSignal.timeout(VERIFICATION_TIMEOUT_MS);
+  const feedSignal = AbortSignal.any([
+    ...(dependencies.signal ? [dependencies.signal] : []),
+    AbortSignal.timeout(timeoutMs),
+  ]);
+  const launches: ParsedLaunchV1[] = [];
+  const cursors = new Set<string>();
+  const launchIds = new Set<string>();
+  let cursor: string | null = null;
+  let generatedAt: string | null = null;
+  let quality: FeedQualityV1 | null = null;
+
+  for (let page = 0; page < maximumPages; page += 1) {
+    const url = new URL(ROBINHOOD_FINALIZED_EXPLORE_FEED_URL_V1);
+    url.searchParams.set("limit", String(PAGE_LIMIT));
+    if (cursor !== null) url.searchParams.set("cursor", cursor);
+    const response = await fetchFeed(url, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+      credentials: "omit",
+      redirect: "error",
+      referrerPolicy: "no-referrer",
+      signal: feedSignal,
+    });
+    if (response.status !== 200) {
+      throw new Error("Robinhood finalized feed is unavailable");
+    }
+    const parsed = parsePage(await readBoundedJson(response), now());
+    // The backend timestamps each HTTP page independently. The first page is
+    // the catalog timestamp; the keyset cursor and global quality totals bind
+    // the compatible cross-page read instead of generatedAt equality.
+    generatedAt ??= parsed.generatedAt;
+    if (quality === null) quality = parsed.quality;
+    else if (canonicalizeJson(quality) !== canonicalizeJson(parsed.quality)) {
+      throw new Error("Robinhood finalized feed quality changed while paging");
+    }
+    for (const launch of parsed.launches) {
+      const identity = launch.routerLaunchId.toLowerCase();
+      if (launchIds.has(identity)) {
+        throw new Error("Robinhood finalized feed contains duplicate launches");
+      }
+      launchIds.add(identity);
+      launches.push(launch);
+      if (launches.length > MAXIMUM_RECORDS) {
+        throw new Error("Robinhood finalized feed exceeds its record bound");
+      }
+    }
+    if (parsed.nextCursor === null) break;
+    if (parsed.launches.length === 0 || cursors.has(parsed.nextCursor)) {
+      throw new Error("Robinhood finalized feed cursor is invalid");
+    }
+    cursors.add(parsed.nextCursor);
+    cursor = parsed.nextCursor;
+    if (page === maximumPages - 1) {
+      throw new Error("Robinhood finalized feed exceeds its page bound");
+    }
+  }
+
+  if (
+    quality === null || generatedAt === null ||
+    quality.publishedRowCount === 0 ||
+    launches.length !== quality.publishedRowCount
+  ) throw new Error("Robinhood finalized feed is not publishable");
+
+  const client = dependencies.client ?? createPublicClient({
+    chain: robinhoodChain,
+    transport: http(
+      process.env.ROBINHOOD_RPC_URL?.trim() || ROBINHOOD_MAINNET_RPC_URL,
+      { retryCount: 1, timeout: 2_500 },
+    ),
+  });
+  const ethereumClients = dependencies.ethereumClients ??
+    productionEthereumClientsV1();
+  verificationSignal.throwIfAborted();
+  const [robinhoodChainId, primaryEthereumChainId,
+    secondaryEthereumChainId, latestNumber] = await Promise.all([
+    client.getChainId(),
+    ethereumClients[0].getChainId(),
+    ethereumClients[1].getChainId(),
+    client.getBlockNumber(),
+  ]);
+  if (robinhoodChainId !== 4663) {
+    throw new Error("Robinhood Explore RPC is on the wrong chain");
+  }
+  if (primaryEthereumChainId !== 1 || secondaryEthereumChainId !== 1) {
+    throw new Error("Robinhood finality RPC is on the wrong chain");
+  }
+  const latest = await canonicalBlock(client, latestNumber);
+  const verifyLaunch = dependencies.verifyLaunch ?? verifyLaunchV1;
+  const verifyEthereumFinality = dependencies.verifyEthereumFinality ??
+    verifyEthereumFinalityV1;
+  const finalityReads = new Map<string, Promise<void>>();
+  const entries: CanonicalTokenExploreEntry[] = [];
+  for (let offset = 0; offset < launches.length; offset += 3) {
+    verificationSignal.throwIfAborted();
+    entries.push(...await Promise.all(
+      launches.slice(offset, offset + 3).map(async (launch) => {
+        const finalityKey = [
+          launch.l1.posting.transactionHash,
+          launch.l1.posting.blockNumber.toString(),
+          launch.l1.posting.blockHash,
+          String(launch.l1.posting.logIndex),
+          launch.l1.posting.batchNumber.toString(),
+          launch.l1.finalized.blockNumber.toString(),
+          launch.l1.finalized.blockHash,
+        ].join("\0");
+        let finalityRead = finalityReads.get(finalityKey);
+        if (finalityRead === undefined) {
+          finalityRead = verifyEthereumFinality(launch, ethereumClients);
+          finalityReads.set(finalityKey, finalityRead);
+        }
+        const [entry] = await Promise.all([
+          verifyLaunch(launch, { client, latestBlock: latest }),
+          finalityRead,
+        ]);
+        return entry;
+      }),
+    ));
+    verificationSignal.throwIfAborted();
+  }
+  const tokenAddresses = new Set<string>();
+  for (const entry of entries) {
+    const address = entry.tokenAddress.toLowerCase();
+    if (tokenAddresses.has(address)) {
+      throw new Error("Robinhood finalized feed resolves duplicate tokens");
+    }
+    tokenAddresses.add(address);
+  }
+  const frozenEntries = Object.freeze(entries);
+  return Object.freeze({
+    source: ROBINHOOD_FINALIZED_EXPLORE_SOURCE_V1,
+    launchSource: ROBINHOOD_FINALIZED_EXPLORE_LAUNCH_SOURCE_V1,
+    generatedAt,
+    asOfBlock: latest.number.toString(),
+    asOfBlockHash: latest.hash,
+    identityCommitment: canonicalSha256(
+      "programmable.robinhood-finalized-explore-snapshot.v1",
+      {
+        chainId: 4663,
+        generatedAt,
+        asOfBlock: latest.number.toString(),
+        asOfBlockHash: latest.hash,
+        entries: frozenEntries,
+        finalizedEvidence: launches.map((launch) => ({
+          routerLaunchId: launch.routerLaunchId,
+          evidenceDigest: launch.evidenceDigest,
+          l1: {
+            posting: {
+              ...launch.l1.posting,
+              blockNumber: launch.l1.posting.blockNumber.toString(),
+              batchNumber: launch.l1.posting.batchNumber.toString(),
+            },
+            finalized: {
+              ...launch.l1.finalized,
+              blockNumber: launch.l1.finalized.blockNumber.toString(),
+            },
+          },
+        })),
+      },
+    ),
+    entries: frozenEntries,
+    quality,
+    sourceVerification: Object.freeze(entries.map((entry, index) => ({
+      tokenAddress: entry.tokenAddress,
+      updatedAt: launches[index]!.sourceUpdatedAt,
+    }))),
+  });
+}
+
+async function verifyLaunchV1(
+  launch: ParsedLaunchV1,
+  context: Readonly<{
+    client: RobinhoodFinalizedExploreReaderClientV1;
+    latestBlock: Readonly<{ number: bigint; hash: Hex }>;
+  }>,
+) {
+  if (context.latestBlock.number < launch.l2.blockNumber + FINALITY_CONFIRMATIONS) {
+    throw new Error("Robinhood launch is outside the Explore confirmation boundary");
+  }
+  const [receipt, launchBlock] = await Promise.all([
+    context.client.getTransactionReceipt({ hash: launch.l2.transactionHash }),
+    canonicalBlock(context.client, launch.l2.blockNumber),
+  ]);
+  if (
+    !sameHex(launchBlock.hash, launch.l2.blockHash) ||
+    launchBlock.timestamp !== launch.l2.blockTimestamp
+  ) throw new Error("Robinhood launch block evidence mismatch");
+  const parsed = parseReceipt(launch, receipt);
+  const roots = CUSTOM_LAUNCH_ROBINHOOD_TRUST_ROOTS_V4;
+  const router = roots.programmableLaunchStampRouter.address;
+  const blockNumber = launch.l2.blockNumber;
+  const [routerCode, poolCode, graphCode, permitCode, chainId, poolManager,
+    poolManagerCodeHash, graphFactory, graphFactoryCodeHash, permitAuthority,
+    permitAuthorityCodeHash, record, tokenLaunchId, poolLaunchId,
+    computedPoolKeyHash, tokenName, tokenSymbol, tokenDecimals,
+    tokenTotalSupply] = await Promise.all([
+    context.client.getCode({ address: router, blockNumber }),
+    context.client.getCode({ address: roots.poolManager.address, blockNumber }),
+    context.client.getCode({ address: roots.graphFactory.address, blockNumber }),
+    context.client.getCode({ address: roots.permitAuthority.address, blockNumber }),
+    context.client.readContract({ address: router, abi: routerReadAbi, functionName: "CHAIN_ID", blockNumber }),
+    context.client.readContract({ address: router, abi: routerReadAbi, functionName: "POOL_MANAGER", blockNumber }),
+    context.client.readContract({ address: router, abi: routerReadAbi, functionName: "POOL_MANAGER_RUNTIME_CODE_HASH", blockNumber }),
+    context.client.readContract({ address: router, abi: routerReadAbi, functionName: "GRAPH_FACTORY", blockNumber }),
+    context.client.readContract({ address: router, abi: routerReadAbi, functionName: "GRAPH_FACTORY_RUNTIME_CODE_HASH", blockNumber }),
+    context.client.readContract({ address: router, abi: routerReadAbi, functionName: "PERMIT_AUTHORITY", blockNumber }),
+    context.client.readContract({ address: router, abi: routerReadAbi, functionName: "PERMIT_AUTHORITY_RUNTIME_CODE_HASH", blockNumber }),
+    context.client.readContract({ address: router, abi: routerReadAbi, functionName: "launchStamp", args: [launch.routerLaunchId], blockNumber }),
+    context.client.readContract({ address: router, abi: routerReadAbi, functionName: "launchIdByToken", args: [parsed.token], blockNumber }),
+    context.client.readContract({ address: router, abi: routerReadAbi, functionName: "launchIdByPool", args: [roots.poolManager.address, parsed.poolId], blockNumber }),
+    context.client.readContract({ address: router, abi: routerReadAbi, functionName: "computePoolKeyHash", args: [parsed.poolKey], blockNumber }),
+    context.client.readContract({ address: parsed.token, abi: uerc20ReadAbi, functionName: "name", blockNumber }),
+    context.client.readContract({ address: parsed.token, abi: uerc20ReadAbi, functionName: "symbol", blockNumber }),
+    optionalRead(() => context.client.readContract({ address: parsed.token, abi: uerc20ReadAbi, functionName: "decimals", blockNumber })),
+    optionalRead(() => context.client.readContract({ address: parsed.token, abi: uerc20ReadAbi, functionName: "totalSupply", blockNumber })),
+  ]);
+  assertCodeHash(routerCode, roots.programmableLaunchStampRouter.runtimeCodeHash, "Router");
+  assertCodeHash(poolCode, roots.poolManager.runtimeCodeHash, "PoolManager");
+  assertCodeHash(graphCode, roots.graphFactory.runtimeCodeHash, "Graph Factory");
+  assertCodeHash(permitCode, roots.permitAuthority.runtimeCodeHash, "permit authority");
+  if (
+    chainId !== 4663n ||
+    !isAddressEqual(poolManager, roots.poolManager.address) ||
+    !sameHex(poolManagerCodeHash, roots.poolManager.runtimeCodeHash) ||
+    !isAddressEqual(graphFactory, roots.graphFactory.address) ||
+    !sameHex(graphFactoryCodeHash, roots.graphFactory.runtimeCodeHash) ||
+    !isAddressEqual(permitAuthority, roots.permitAuthority.address) ||
+    !sameHex(permitAuthorityCodeHash, roots.permitAuthority.runtimeCodeHash) ||
+    !sameHex(tokenLaunchId, launch.routerLaunchId) ||
+    !sameHex(poolLaunchId, launch.routerLaunchId) ||
+    !sameHex(computedPoolKeyHash, record.poolKeyHash) ||
+    record.kind !== 1 ||
+    !isAddressEqual(record.token, parsed.token) ||
+    !isAddressEqual(record.hook, parsed.hook) ||
+    !isAddressEqual(record.poolManager, roots.poolManager.address) ||
+    !sameHex(record.poolId, parsed.poolId) ||
+    !sameHex(record.routePayloadHash, parsed.routePayloadHash) ||
+    !sameHex(record.expectedResultHash, parsed.expectedResultHash) ||
+    !sameHex(record.permitDigest, parsed.permitDigest) ||
+    !sameHex(record.stampHash, parsed.stampHash) ||
+    !isAddressEqual(record.routeLauncher, roots.graphFactory.address) ||
+    !sameHex(record.routeLauncherRuntimeCodeHash, roots.graphFactory.runtimeCodeHash) ||
+    sameHex(record.componentSetHash, ZERO_HASH) ||
+    sameHex(record.poolKeyHash, ZERO_HASH) ||
+    isAddressEqual(record.launchWallet, ZERO_ADDRESS)
+  ) throw new Error("Robinhood Router binding does not match the finalized feed");
+
+  const componentProofs = await Promise.all(parsed.components.map(async (component) => {
+    const [code, launchId, runtimeCodeHash, proof] = await Promise.all([
+      context.client.getCode({ address: component.address, blockNumber }),
+      context.client.readContract({ address: router, abi: routerReadAbi, functionName: "launchIdByComponent", args: [component.address], blockNumber }),
+      context.client.readContract({ address: router, abi: routerReadAbi, functionName: "componentRuntimeCodeHash", args: [component.address], blockNumber }),
+      context.client.readContract({ address: router, abi: routerReadAbi, functionName: "stampProof", args: [component.address], blockNumber }),
+    ]);
+    assertCodeHash(code, component.runtimeCodeHash, `component ${component.address}`);
+    if (
+      !sameHex(launchId, launch.routerLaunchId) ||
+      !sameHex(runtimeCodeHash, component.runtimeCodeHash) ||
+      !sameHex(proof[0], launch.routerLaunchId) ||
+      !sameHex(proof[1], parsed.stampHash)
+    ) throw new Error("Robinhood component proof mismatch");
+    return {
+      address: component.address,
+      kind: component.kind,
+      scope: "exclusive" as const,
+      runtimeCodeHash: component.runtimeCodeHash,
+      logIndex: component.logIndex,
+      exclusiveProof: {
+        launchId: proof[0],
+        stampHash: proof[1],
+      },
+    };
+  }));
+  const sourceAddresses = [...launch.sourceComponents]
+    .map((component) => component.address.toLowerCase()).sort();
+  const routerAddresses = componentProofs
+    .map((component) => component.address.toLowerCase()).sort();
+  const tokenSource = launch.sourceComponents.find(
+    (component) => component.targetId === launch.projectMetadata.tokenTargetId,
+  );
+  if (
+    canonicalizeJson(sourceAddresses) !== canonicalizeJson(routerAddresses) ||
+    !tokenSource || !isAddressEqual(tokenSource.address, parsed.token) ||
+    tokenName !== launch.projectMetadata.token.name ||
+    tokenSymbol !== launch.projectMetadata.token.symbol
+  ) throw new Error("Robinhood source or token metadata binding mismatch");
+
+  const provenance: LaunchStampProvenanceV1 = {
+    schemaVersion: "programmable.launch-stamp-provenance.v1",
+    chainId: 4663,
+    routerAddress: router,
+    routerRuntimeCodeHash: roots.programmableLaunchStampRouter.runtimeCodeHash,
+    routerStartBlock: ROUTER_START_BLOCK.toString(),
+    finalityConfirmations: Number(FINALITY_CONFIRMATIONS),
+    kind: "custom-graph",
+    launchId: launch.routerLaunchId,
+    stampHash: parsed.stampHash,
+    launchWallet: record.launchWallet,
+    transactionHash: launch.l2.transactionHash,
+    blockNumber: launch.l2.blockNumber.toString(),
+    blockHash: launch.l2.blockHash,
+    transactionIndex: receipt.transactionIndex,
+    routeLogIndex: launch.l2.routeLogIndex,
+    launchLogIndex: launch.l2.launchLogIndex,
+    finalizedAtBlockNumber: context.latestBlock.number.toString(),
+    finalizedAtBlockHash: context.latestBlock.hash,
+    poolManagerAddress: roots.poolManager.address,
+    poolId: parsed.poolId,
+    poolKey: parsed.poolKey,
+    poolKeyHash: record.poolKeyHash,
+    componentSetHash: record.componentSetHash,
+    routePayloadHash: parsed.routePayloadHash,
+    routeLauncherAddress: record.routeLauncher,
+    routeLauncherRuntimeCodeHash: record.routeLauncherRuntimeCodeHash,
+    expectedResultHash: parsed.expectedResultHash,
+    permitDigest: parsed.permitDigest,
+    components: componentProofs,
+    tokenProof: {
+      tokenAddress: parsed.token,
+      launchId: launch.routerLaunchId,
+      stampHash: parsed.stampHash,
+    },
+    poolProof: {
+      poolManagerAddress: roots.poolManager.address,
+      poolId: parsed.poolId,
+      launchId: launch.routerLaunchId,
+      stampHash: parsed.stampHash,
+    },
+  };
+  const decimals = typeof tokenDecimals === "number" ? tokenDecimals : null;
+  const supply = typeof tokenTotalSupply === "bigint" ? tokenTotalSupply : null;
+  const token: LauncherToken = {
+    id: `4663:${parsed.token.toLowerCase()}`,
+    name: launch.projectMetadata.token.name,
+    symbol: launch.projectMetadata.token.symbol,
+    ...(launch.projectMetadata.description
+      ? { description: launch.projectMetadata.description }
+      : {}),
+    imageUrl: launch.projectMetadata.imageUrl,
+    ...(launch.projectMetadata.links.length
+      ? { links: [...launch.projectMetadata.links] }
+      : {}),
+    projectMetadataLinks: [...launch.projectMetadata.projectMetadataLinks],
+    projectMetadataStatus: "current",
+    tokenAddress: parsed.token,
+    hookAddress: parsed.hook,
+    poolId: parsed.poolId,
+    creatorAddress: record.launchWallet,
+    launchBlockNumber: launch.l2.blockNumber.toString(),
+    launchTransactionHash: launch.l2.transactionHash,
+    launchTransactionIndex: receipt.transactionIndex,
+    launchLogIndex: launch.l2.launchLogIndex,
+    launchedAt: new Date(Number(launch.l2.blockTimestamp) * 1_000).toISOString(),
+    ...(decimals === null ? {} : { tokenDecimals: decimals }),
+    ...(supply === null ? {} : { totalSupplyRaw: supply.toString() }),
+    ...(decimals === null || supply === null
+      ? {}
+      : { totalSupply: formatUnits(supply, decimals) }),
+    totalSwapFeeBps: null,
+    launchModel: "custom-graph",
+    launchModelVersion: "programmable-launch-stamp-router-v1",
+    liquidityPath: "programmable-v4",
+    launchStampProvenance: provenance,
+  };
+  return canonicalTokenExploreEntryV1(token);
+}
+
+function productionEthereumClientsV1(): readonly [
+  RobinhoodFinalizedExploreEthereumClientV1,
+  RobinhoodFinalizedExploreEthereumClientV1,
+] {
+  const pair = productionMainnetRpcPair();
+  return Object.freeze([
+    createPublicClient({
+      chain: mainnet,
+      transport: http(pair.primary.url, { retryCount: 1, timeout: 2_500 }),
+    }),
+    createPublicClient({
+      chain: mainnet,
+      transport: http(pair.secondary.url, { retryCount: 1, timeout: 2_500 }),
+    }),
+  ]);
+}
+
+async function verifyEthereumFinalityV1(
+  launch: ParsedLaunchV1,
+  clients: readonly [
+    RobinhoodFinalizedExploreEthereumClientV1,
+    RobinhoodFinalizedExploreEthereumClientV1,
+  ],
+) {
+  const posting = launch.l1.posting;
+  const finalized = launch.l1.finalized;
+  const observations = await Promise.all(clients.map(async (client) => {
+    const [receipt, postingBlock, finalizedBlock, finalizedHead] =
+      await Promise.all([
+        client.getTransactionReceipt({ hash: posting.transactionHash }),
+        ethereumBlockV1(client, posting.blockNumber),
+        ethereumBlockV1(client, finalized.blockNumber),
+        client.getBlock({ blockTag: "finalized" }),
+      ]);
+    if (
+      receipt.status !== "success" ||
+      !sameHex(receipt.transactionHash, posting.transactionHash) ||
+      receipt.blockNumber !== posting.blockNumber ||
+      !sameHex(receipt.blockHash, posting.blockHash)
+    ) throw new Error("Robinhood L1 posting receipt is inconsistent");
+    const postingLog = receipt.logs.find(
+      (log) => logNumber(log.logIndex) && log.logIndex === posting.logIndex,
+    );
+    if (
+      !postingLog ||
+      !isAddressEqual(postingLog.address, posting.sequencerInbox) ||
+      !isSequencerBatchDeliveredLogV1(postingLog, posting.batchNumber) ||
+      postingLog.blockNumber !== posting.blockNumber ||
+      !sameHex(postingLog.blockHash, posting.blockHash) ||
+      !sameHex(postingBlock.hash, posting.blockHash) ||
+      !sameHex(finalizedBlock.hash, finalized.blockHash) ||
+      finalizedHead.number === null || finalizedHead.number < finalized.blockNumber ||
+      !finalizedHead.hash ||
+      (finalizedHead.number === finalized.blockNumber &&
+        !sameHex(finalizedHead.hash, finalized.blockHash))
+    ) throw new Error("Robinhood L1 finalized checkpoint is inconsistent");
+    return true;
+  }));
+  if (observations.length !== 2 || observations.some((value) => value !== true)) {
+    throw new Error("Robinhood L1 finality quorum is unavailable");
+  }
+}
+
+function isSequencerBatchDeliveredLogV1(log: Log, batchNumber: bigint) {
+  if (
+    log.topics.length !== 4 ||
+    !sameHex(log.topics[0], SEQUENCER_BATCH_DELIVERED_TOPIC) ||
+    typeof log.topics[1] !== "string"
+  ) return false;
+  try {
+    if (BigInt(log.topics[1]) !== batchNumber) return false;
+    const decoded = decodeEventLog({
+      abi: [sequencerBatchEvent],
+      eventName: "SequencerBatchDelivered",
+      data: log.data,
+      topics: log.topics,
+      strict: true,
+    });
+    return (decoded.args as { batchSequenceNumber: bigint })
+      .batchSequenceNumber === batchNumber;
+  } catch {
+    return false;
+  }
+}
+
+async function ethereumBlockV1(
+  client: RobinhoodFinalizedExploreEthereumClientV1,
+  number: bigint,
+) {
+  const block = await client.getBlock({ blockNumber: number });
+  if (block.number !== number || !block.hash || !isBytes32(block.hash)) {
+    throw new Error("Robinhood L1 RPC returned an invalid canonical block");
+  }
+  return { number, hash: block.hash };
+}
+
+function parseReceipt(launch: ParsedLaunchV1, receipt: TransactionReceipt) {
+  if (
+    receipt.status !== "success" ||
+    !sameHex(receipt.transactionHash, launch.l2.transactionHash) ||
+    receipt.blockNumber !== launch.l2.blockNumber ||
+    !sameHex(receipt.blockHash, launch.l2.blockHash) ||
+    !Number.isSafeInteger(receipt.transactionIndex) ||
+    receipt.transactionIndex < 0
+  ) throw new Error("Robinhood receipt does not match the finalized feed");
+  const roots = CUSTOM_LAUNCH_ROBINHOOD_TRUST_ROOTS_V4;
+  const ordered = [...receipt.logs].sort((left, right) =>
+    logIndex(left) - logIndex(right)
+  );
+  const launchLog = ordered.find((log) =>
+    logIndex(log) === launch.l2.launchLogIndex
+  );
+  const routeLog = ordered.find((log) =>
+    logIndex(log) === launch.l2.routeLogIndex
+  );
+  if (
+    !launchLog || !routeLog ||
+    launch.l2.launchLogIndex !== launch.l2.routeLogIndex + 1 ||
+    !isAddressEqual(launchLog.address, roots.programmableLaunchStampRouter.address) ||
+    !isAddressEqual(routeLog.address, roots.programmableLaunchStampRouter.address) ||
+    !sameHex(launchLog.topics[0] ?? "", launchTopic) ||
+    !sameHex(routeLog.topics[0] ?? "", routeTopic)
+  ) throw new Error("Robinhood Router event coordinates are invalid");
+  const decodedLaunch = decodeEventLog({
+    abi: [launchEvent], data: launchLog.data, topics: launchLog.topics, strict: true,
+  }).args;
+  const decodedRoute = decodeEventLog({
+    abi: [routeEvent], data: routeLog.data, topics: routeLog.topics, strict: true,
+  }).args;
+  if (
+    !sameHex(decodedLaunch.launchId, launch.routerLaunchId) ||
+    !sameHex(decodedRoute.launchId, launch.routerLaunchId) ||
+    Number(decodedRoute.kind) !== 1 ||
+    !isAddressEqual(decodedLaunch.poolManager, roots.poolManager.address)
+  ) throw new Error("Robinhood Router event identity is invalid");
+
+  const components: Array<Readonly<{
+    address: Address;
+    kind: "token" | "hook" | "other";
+    runtimeCodeHash: Hex;
+    logIndex: number;
+  }>> = [];
+  for (let index = ordered.indexOf(routeLog) - 1; index >= 0; index -= 1) {
+    const log = ordered[index]!;
+    if (
+      logIndex(log) !== launch.l2.routeLogIndex - components.length - 1 ||
+      !isAddressEqual(log.address, roots.programmableLaunchStampRouter.address) ||
+      !sameHex(log.topics[0] ?? "", componentTopic)
+    ) break;
+    const decoded = decodeEventLog({
+      abi: [componentEvent], data: log.data, topics: log.topics, strict: true,
+    }).args;
+    if (!sameHex(decoded.launchId, launch.routerLaunchId)) {
+      throw new Error("Robinhood Router component launch identity is invalid");
+    }
+    const kind = Number(decoded.kind);
+    if (kind !== 0 && kind !== 1 && kind !== 2) {
+      throw new Error("Robinhood Router component kind is invalid");
+    }
+    components.unshift({
+      address: getAddress(decoded.component),
+      kind: kind === 1 ? "token" : kind === 2 ? "hook" : "other",
+      runtimeCodeHash: decoded.runtimeCodeHash,
+      logIndex: logIndex(log),
+    });
+  }
+  if (
+    components.length < 2 || components.length > 16 ||
+    components.filter((component) => component.kind === "token" &&
+      isAddressEqual(component.address, decodedLaunch.token)).length !== 1 ||
+    components.filter((component) => component.kind === "hook" &&
+      isAddressEqual(component.address, decodedLaunch.hook)).length !== 1
+  ) throw new Error("Robinhood Router component group is incomplete");
+
+  const initializeLogs = ordered.filter((log) =>
+    logIndex(log) < components[0]!.logIndex &&
+    isAddressEqual(log.address, roots.poolManager.address) &&
+    sameHex(log.topics[0] ?? "", initializeTopic) &&
+    sameHex(log.topics[1] ?? "", decodedLaunch.poolId)
+  );
+  if (initializeLogs.length !== 1) {
+    throw new Error("Robinhood pool initialization is unavailable");
+  }
+  const initialized = decodeEventLog({
+    abi: [initializeEvent], data: initializeLogs[0]!.data,
+    topics: initializeLogs[0]!.topics, strict: true,
+  }).args;
+  const poolKey = {
+    currency0: getAddress(initialized.currency0),
+    currency1: getAddress(initialized.currency1),
+    fee: Number(initialized.fee),
+    tickSpacing: Number(initialized.tickSpacing),
+    hooks: getAddress(initialized.hooks),
+  };
+  if (
+    !sameHex(computeOfficialV4PoolId(poolKey), decodedLaunch.poolId) ||
+    !isAddressEqual(poolKey.hooks, decodedLaunch.hook)
+  ) throw new Error("Robinhood PoolKey binding is invalid");
+  return {
+    token: getAddress(decodedLaunch.token),
+    hook: getAddress(decodedLaunch.hook),
+    poolId: decodedLaunch.poolId,
+    stampHash: decodedLaunch.stampHash,
+    poolKey,
+    routePayloadHash: decodedRoute.routePayloadHash,
+    expectedResultHash: decodedRoute.expectedResultHash,
+    permitDigest: decodedRoute.permitDigest,
+    components,
+  };
+}
+
+function parsePage(value: JsonValue, now: number) {
+  const page = exactRecord(value, [
+    "schemaVersion", "apiVersion", "chainId", "caip2", "generatedAt",
+    "quality", "launches", "nextCursor",
+  ], "Robinhood finalized feed page");
+  if (
+    page.schemaVersion !== "programmable.custom-launch-list.v4" ||
+    page.apiVersion !== "v4" || page.chainId !== "4663" ||
+    page.caip2 !== "eip155:4663" || !Array.isArray(page.launches) ||
+    page.launches.length > PAGE_LIMIT ||
+    (page.nextCursor !== null &&
+      (typeof page.nextCursor !== "string" || !CURSOR.test(page.nextCursor)))
+  ) throw new Error("Robinhood finalized feed page is invalid");
+  const generatedAt = timestamp(page.generatedAt, "feed generatedAt");
+  const generatedMs = Date.parse(generatedAt);
+  if (
+    generatedMs > now + MAXIMUM_FUTURE_SKEW_MS ||
+    now - generatedMs > MAXIMUM_GENERATED_AGE_MS
+  ) throw new Error("Robinhood finalized feed page is stale");
+  const qualityRecord = exactRecord(page.quality, [
+    "status", "sourceRowCount", "publishedRowCount", "quarantinedRowCount",
+  ], "Robinhood finalized feed quality");
+  if (
+    qualityRecord.status !== "ready" ||
+    !count(qualityRecord.sourceRowCount) ||
+    !count(qualityRecord.publishedRowCount) ||
+    !count(qualityRecord.quarantinedRowCount) ||
+    qualityRecord.sourceRowCount !== qualityRecord.publishedRowCount ||
+    qualityRecord.quarantinedRowCount !== 0 ||
+    page.launches.length > qualityRecord.publishedRowCount
+  ) throw new Error("Robinhood finalized feed quality is not publishable");
+  return {
+    generatedAt,
+    quality: qualityRecord as unknown as FeedQualityV1,
+    launches: page.launches.map(parseLaunch),
+    nextCursor: page.nextCursor as string | null,
+  };
+}
+
+function parseLaunch(value: JsonValue): ParsedLaunchV1 {
+  const launch = exactRecord(value, [
+    "schemaVersion", "apiVersion", "launchId", "chainId", "caip2",
+    "chainDeploymentId", "chainDeploymentDescriptorDigest", "chainDeployment",
+    "profile", "platformId", "category", "projectMetadata", "funding",
+    "liquidityModel", "commitments", "onchain", "sourceVerification",
+    "createdAt", "finalizedAt",
+  ], "Robinhood finalized launch");
+  if (
+    launch.schemaVersion !== "programmable.finalized-custom-launch-metadata.v4" ||
+    launch.apiVersion !== "v4" || typeof launch.launchId !== "string" ||
+    !UUID.test(launch.launchId) || launch.chainId !== "4663" ||
+    launch.caip2 !== "eip155:4663" ||
+    launch.chainDeploymentId !== "robinhood-mainnet-custom-launch-v1" ||
+    launch.platformId !== "programmable" || launch.category !== "custom" ||
+    !isBytes32(launch.chainDeploymentDescriptorDigest)
+  ) throw new Error("Robinhood finalized launch identity is invalid");
+  const chainDeployment = normalizeV4ChainDeployment(launch.chainDeployment);
+  if (
+    canonicalizeJson(chainDeployment) !== canonicalizeJson(launch.chainDeployment) ||
+    hashV4ChainDeployment(chainDeployment) !==
+      launch.chainDeploymentDescriptorDigest
+  ) throw new Error("Robinhood chain deployment binding is invalid");
+  const profile = normalizeV4ProfileRef(launch.profile);
+  const funding = normalizeV4FundingIntent(launch.funding);
+  const liquidityModel = normalizeV4LiquidityModel(launch.liquidityModel);
+  if (
+    canonicalizeJson(profile) !== canonicalizeJson(launch.profile) ||
+    canonicalizeJson(funding) !== canonicalizeJson(launch.funding) ||
+    canonicalizeJson(liquidityModel) !== canonicalizeJson(launch.liquidityModel)
+  ) throw new Error("Robinhood finalized launch contract is noncanonical");
+  const commitments = parseCommitments(launch.commitments);
+  const projectMetadata = parseProjectMetadata(
+    launch.projectMetadata,
+    commitments.metadata,
+  );
+  const onchain = parseOnchain(launch.onchain, {
+    chainDeploymentId: launch.chainDeploymentId,
+    chainDeploymentDescriptorDigest: launch.chainDeploymentDescriptorDigest,
+    chainDeployment,
+    profile,
+    commitments,
+  });
+  const source = parseSourceVerification(
+    launch.sourceVerification,
+    projectMetadata.tokenTargetId,
+  );
+  const createdAt = timestamp(launch.createdAt, "launch createdAt");
+  const finalizedAt = timestamp(launch.finalizedAt, "launch finalizedAt");
+  if (Date.parse(createdAt) > Date.parse(finalizedAt)) {
+    throw new Error("Robinhood finalized launch timestamps are invalid");
+  }
+  return {
+    launchId: launch.launchId,
+    routerLaunchId: onchain.routerLaunchId,
+    projectMetadata,
+    l2: onchain.l2,
+    l1: onchain.l1,
+    evidenceDigest: onchain.evidenceDigest,
+    finalizedAt,
+    sourceUpdatedAt: source.updatedAt,
+    sourceComponents: source.components,
+  };
+}
+
+function parseOnchain(
+  value: JsonValue,
+  launch: Readonly<{
+    chainDeploymentId: JsonValue;
+    chainDeploymentDescriptorDigest: JsonValue;
+    chainDeployment: JsonValue;
+    profile: JsonValue;
+    commitments: JsonValue;
+  }>,
+) {
+  const onchain = exactRecord(value, [
+    "schemaVersion", "apiVersion", "chainId", "caip2", "chainDeploymentId",
+    "chainDeploymentDescriptorDigest", "chainDeployment", "profile", "router",
+    "routerRuntimeCodeHash", "routerLaunchId", "transactionHash", "blockNumber",
+    "blockHash", "logIndex", "checkpointType", "l2Inclusion", "l1Posting",
+    "l1FinalizedCheckpoint", "finalityPolicy", "commitments", "evidenceDigest",
+    "terminal", "observedAt",
+  ], "Robinhood onchain evidence");
+  const roots = CUSTOM_LAUNCH_ROBINHOOD_TRUST_ROOTS_V4;
+  const deployment = record(launch.chainDeployment, "Robinhood chain deployment");
+  if (
+    onchain.schemaVersion !== "programmable.custom-launch-onchain-evidence.v3" ||
+    onchain.apiVersion !== "v4" || onchain.chainId !== "4663" ||
+    onchain.caip2 !== "eip155:4663" ||
+    onchain.chainDeploymentId !== launch.chainDeploymentId ||
+    onchain.chainDeploymentDescriptorDigest !== launch.chainDeploymentDescriptorDigest ||
+    canonicalizeJson(onchain.chainDeployment) !==
+      canonicalizeJson(launch.chainDeployment) ||
+    canonicalizeJson(onchain.profile) !== canonicalizeJson(launch.profile) ||
+    canonicalizeJson(onchain.commitments) !== canonicalizeJson(launch.commitments) ||
+    canonicalizeJson(onchain.finalityPolicy) !==
+      canonicalizeJson(deployment.finality) ||
+    !sameHex(onchain.router, roots.programmableLaunchStampRouter.address) ||
+    !sameHex(onchain.routerRuntimeCodeHash,
+      roots.programmableLaunchStampRouter.runtimeCodeHash) ||
+    !isBytes32(onchain.routerLaunchId) || !isBytes32(onchain.transactionHash) ||
+    // The backend verifies this digest before removing its private wallet
+    // preimage hash. Public consumers can require and snapshot-bind it, but
+    // cannot honestly recompute the intentionally redacted preimage.
+    !isSha256(onchain.evidenceDigest) ||
+    onchain.checkpointType !== "ethereum_finalized" || onchain.terminal !== true
+  ) throw new Error("Robinhood onchain evidence identity is invalid");
+  timestamp(onchain.observedAt, "onchain observedAt");
+  const l2 = exactRecord(onchain.l2Inclusion, [
+    "schemaVersion", "chainId", "caip2", "transactionHash", "blockNumber",
+    "blockHash", "blockTimestamp", "receiptStatus", "launchEventLogIndex",
+    "routeEventLogIndex",
+  ], "Robinhood L2 inclusion");
+  const blockNumber = positiveDecimal(l2.blockNumber, "L2 block number");
+  const blockTimestamp = positiveDecimal(l2.blockTimestamp, "L2 block timestamp");
+  if (
+    l2.schemaVersion !== "programmable.custom-launch-l2-inclusion.v1" ||
+    l2.chainId !== "4663" || l2.caip2 !== "eip155:4663" ||
+    l2.receiptStatus !== "success" || !isBytes32(l2.transactionHash) ||
+    !sameHex(onchain.transactionHash, l2.transactionHash) ||
+    !isBytes32(l2.blockHash) || blockNumber < ROUTER_START_BLOCK ||
+    !logNumber(l2.routeEventLogIndex) || !logNumber(l2.launchEventLogIndex) ||
+    l2.launchEventLogIndex !== l2.routeEventLogIndex + 1
+  ) throw new Error("Robinhood L2 inclusion is invalid");
+  const l1Posting = exactRecord(onchain.l1Posting, [
+    "schemaVersion", "chainId", "caip2", "rollup", "sequencerInbox",
+    "batchNumber", "transactionHash", "blockNumber", "blockHash", "logIndex",
+  ], "Robinhood L1 posting");
+  const postingBlock = positiveDecimal(l1Posting.blockNumber, "L1 posting block");
+  if (
+    l1Posting.schemaVersion !== "programmable.custom-launch-l1-posting.v1" ||
+    l1Posting.chainId !== "1" || l1Posting.caip2 !== "eip155:1" ||
+    !sameHex(l1Posting.rollup, L1_ROLLUP) ||
+    !sameHex(l1Posting.sequencerInbox, L1_SEQUENCER_INBOX) ||
+    !isDecimal(l1Posting.batchNumber) || !isBytes32(l1Posting.transactionHash) ||
+    !isBytes32(l1Posting.blockHash) || !logNumber(l1Posting.logIndex)
+  ) throw new Error("Robinhood L1 posting is invalid");
+  const finalized = exactRecord(onchain.l1FinalizedCheckpoint, [
+    "schemaVersion", "chainId", "caip2", "consensusCheckpointTag",
+    "blockNumber", "blockHash", "providerReadbacks",
+  ], "Robinhood L1 finalized checkpoint");
+  const finalizedBlock = positiveDecimal(finalized.blockNumber,
+    "L1 finalized block");
+  if (
+    finalized.schemaVersion !==
+      "programmable.custom-launch-l1-finalized-checkpoint.v1" ||
+    finalized.chainId !== "1" || finalized.caip2 !== "eip155:1" ||
+    finalized.consensusCheckpointTag !== "finalized" ||
+    finalizedBlock < postingBlock || !isBytes32(finalized.blockHash) ||
+    !Array.isArray(finalized.providerReadbacks) ||
+    finalized.providerReadbacks.length !== 2
+  ) throw new Error("Robinhood L1 finalized checkpoint is invalid");
+  const expectedProviders = [
+    ["drpc", "drpc.org"], ["quicknode", "quicknode.com"],
+  ] as const;
+  finalized.providerReadbacks.forEach((candidate, index) => {
+    const readback = exactRecord(candidate, [
+      "providerId", "trustDomain", "blockNumber", "blockHash",
+    ], "Robinhood L1 provider readback");
+    if (
+      readback.providerId !== expectedProviders[index]![0] ||
+      readback.trustDomain !== expectedProviders[index]![1] ||
+      readback.blockNumber !== finalized.blockNumber ||
+      !sameHex(readback.blockHash, finalized.blockHash)
+    ) throw new Error("Robinhood L1 provider quorum is invalid");
+  });
+  if (
+    onchain.blockNumber !== finalized.blockNumber ||
+    !sameHex(onchain.blockHash, finalized.blockHash) ||
+    onchain.logIndex !== l1Posting.logIndex
+  ) throw new Error("Robinhood deprecated finality aliases are inconsistent");
+  return {
+    routerLaunchId: onchain.routerLaunchId as Hex,
+    l2: {
+      transactionHash: l2.transactionHash as Hex,
+      blockNumber,
+      blockHash: l2.blockHash as Hex,
+      blockTimestamp,
+      routeLogIndex: l2.routeEventLogIndex as number,
+      launchLogIndex: l2.launchEventLogIndex as number,
+    },
+    l1: {
+      posting: {
+        transactionHash: l1Posting.transactionHash as Hex,
+        blockNumber: postingBlock,
+        blockHash: l1Posting.blockHash as Hex,
+        logIndex: l1Posting.logIndex as number,
+        sequencerInbox: getAddress(l1Posting.sequencerInbox as string),
+        batchNumber: BigInt(l1Posting.batchNumber as string),
+      },
+      finalized: {
+        blockNumber: finalizedBlock,
+        blockHash: finalized.blockHash as Hex,
+      },
+    },
+    evidenceDigest: onchain.evidenceDigest as `sha256:${string}`,
+  };
+}
+
+function parseProjectMetadata(value: JsonValue, metadataCommitment: JsonValue) {
+  const metadata = validateProjectMetadata(value, { requireComplete: true });
+  if (
+    canonicalizeJson(metadata) !== canonicalizeJson(value) ||
+    hashProjectMetadata(metadata, { requireComplete: true }) !==
+      metadataCommitment
+  ) {
+    throw new Error("Robinhood project metadata is noncanonical");
+  }
+  const presentation = metadata.presentation as Readonly<{
+    description: string;
+    image: Readonly<{ uri: string }>;
+    links: readonly Readonly<{
+      kind: ProjectMetadataLink["kind"];
+      uri: string;
+    }>[];
+  }>;
+  const projectMetadataLinks = presentation.links.map((link) => ({
+    kind: link.kind,
+    url: link.uri,
+  }));
+  const links = projectMetadataLinks.flatMap((link): TokenLink[] =>
+    link.kind === "website" || link.kind === "x" || link.kind === "telegram"
+      ? [{ kind: link.kind, url: link.url }]
+      : []
+  );
+  return {
+    token: {
+      name: metadata.token.name as string,
+      symbol: metadata.token.symbol as string,
+    },
+    description: presentation.description,
+    imageUrl: projectImageUrl(presentation.image.uri),
+    links,
+    projectMetadataLinks,
+    tokenTargetId: metadata.tokenMetadataBinding.tokenTargetId as string,
+  };
+}
+
+function parseCommitments(value: JsonValue | undefined) {
+  const commitments = exactRecord(value, [
+    "sourceBuild", "graph", "metadata", "verification", "fundingPermit",
+    "launchIntent",
+  ], "Robinhood launch commitments");
+  if (Object.values(commitments).some((digest) => !isSha256(digest))) {
+    throw new Error("Robinhood launch commitments are invalid");
+  }
+  return commitments;
+}
+
+function parseSourceVerification(value: JsonValue, tokenTargetId: string) {
+  const source = exactRecord(value, [
+    "schemaVersion", "chainId", "caip2", "chainDeploymentId", "status",
+    "components", "updatedAt",
+  ], "Robinhood source verification");
+  if (
+    source.schemaVersion !== "programmable.source-verification-status.v4" ||
+    source.chainId !== "4663" || source.caip2 !== "eip155:4663" ||
+    source.chainDeploymentId !== "robinhood-mainnet-custom-launch-v1" ||
+    source.status !== "exact_match" || !Array.isArray(source.components) ||
+    source.components.length < 1 || source.components.length > 16
+  ) throw new Error("Robinhood source verification is incomplete");
+  const updatedAt = timestamp(source.updatedAt, "source verification updatedAt");
+  let previousTarget = "";
+  const components = source.components.map((candidate) => {
+    const component = exactRecord(candidate, [
+      "targetId", "address", "status", "providerObservation",
+      "exactSourceAuthority", "exactSourceBinding", "updatedAt",
+    ], "Robinhood source component");
+    if (
+      typeof component.targetId !== "string" ||
+      !TARGET_ID.test(component.targetId) ||
+      component.targetId <= previousTarget || component.status !== "exact_match" ||
+      typeof component.address !== "string" ||
+      !/^0x[0-9a-f]{40}$/u.test(component.address) ||
+      component.exactSourceAuthority !== SOURCE_AUTHORITY
+    ) throw new Error("Robinhood source component is incomplete");
+    previousTarget = component.targetId;
+    const observation = exactRecord(component.providerObservation, [
+      "provider", "classification", "match", "creationMatch", "runtimeMatch",
+      "releaseAuthority", "evidenceDigest",
+    ], "Robinhood source provider observation");
+    const binding = exactRecord(component.exactSourceBinding, [
+      "schemaVersion", "authority", "coveredEvidence", "bindingDigest",
+    ], "Robinhood exact-source binding");
+    if (
+      observation.provider !== "sourcify-v2" ||
+      observation.classification !== "PARTIAL_NO_CBOR_EXACT_BYTES" ||
+      observation.match !== "match" || observation.creationMatch !== "match" ||
+      observation.runtimeMatch !== "match" || observation.releaseAuthority !== false ||
+      !isSha256(observation.evidenceDigest) ||
+      binding.schemaVersion !== SOURCE_BINDING_SCHEMA ||
+      binding.authority !== SOURCE_AUTHORITY ||
+      canonicalizeJson(binding.coveredEvidence) !==
+        canonicalizeJson(SOURCE_COVERED_EVIDENCE) ||
+      !isSha256(binding.bindingDigest)
+    ) throw new Error("Robinhood exact-source binding is incomplete");
+    const componentUpdatedAt = timestamp(
+      component.updatedAt,
+      "source component updatedAt",
+    );
+    return {
+      targetId: component.targetId,
+      address: getAddress(component.address),
+      updatedAt: componentUpdatedAt,
+    };
+  });
+  if (components.at(-1) === undefined ||
+    components.reduce((latest, component) =>
+      component.updatedAt > latest ? component.updatedAt : latest,
+    components[0]!.updatedAt) !== updatedAt) {
+    throw new Error("Robinhood source verification timestamp is inconsistent");
+  }
+  if (!components.some((component) => component.targetId === tokenTargetId)) {
+    throw new Error("Robinhood token source component is missing");
+  }
+  return { updatedAt, components };
+}
+
+async function canonicalBlock(client: RobinhoodFinalizedExploreReaderClientV1,
+  number: bigint) {
+  const block = await client.getBlock({ blockNumber: number });
+  if (block.number !== number || !block.hash || !isBytes32(block.hash)) {
+    throw new Error("Robinhood RPC returned an invalid canonical block");
+  }
+  return { number, hash: block.hash, timestamp: block.timestamp };
+}
+
+async function readBoundedJson(response: Response): Promise<JsonValue> {
+  const contentType = response.headers.get("content-type")?.split(";", 1)[0]
+    ?.trim().toLowerCase();
+  const cacheControl = response.headers.get("cache-control")?.trim().toLowerCase();
+  if (
+    contentType !== "application/json" ||
+    cacheControl !== "public, max-age=15, stale-while-revalidate=300"
+  ) {
+    throw new Error("Robinhood finalized feed response headers are invalid");
+  }
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null) {
+    const declaredLength = Number(contentLength);
+    if (
+      !Number.isSafeInteger(declaredLength) || declaredLength < 1 ||
+      declaredLength > MAXIMUM_PAGE_BYTES
+    ) throw new Error("Robinhood finalized feed page has an invalid size");
+  }
+  if (!response.body) throw new Error("Robinhood finalized feed page is empty");
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let totalBytes = 0;
+  let text = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > MAXIMUM_PAGE_BYTES) {
+        await reader.cancel();
+        throw new Error("Robinhood finalized feed page is too large");
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Robinhood finalized")) {
+      throw error;
+    }
+    throw new Error("Robinhood finalized feed page is invalid");
+  }
+  if (!text) throw new Error("Robinhood finalized feed page is empty");
+  return parseStrictJson(text, { maximumBytes: MAXIMUM_PAGE_BYTES, maximumDepth: 64 });
+}
+
+function exactRecord(value: JsonValue | undefined, keys: readonly string[], label: string) {
+  const candidate = record(value, label);
+  const actual = Object.keys(candidate).sort();
+  const expected = [...keys].sort();
+  if (
+    actual.length !== expected.length ||
+    actual.some((key, index) => key !== expected[index])
+  ) throw new Error(`${label} has unknown or missing fields`);
+  return candidate;
+}
+
+function record(value: JsonValue | undefined, label: string) {
+  if (value === null || value === undefined || Array.isArray(value) ||
+    typeof value !== "object") throw new Error(`${label} must be an object`);
+  return value as Readonly<Record<string, JsonValue>>;
+}
+
+function timestamp(value: JsonValue | undefined, label: string) {
+  if (
+    typeof value !== "string" || !Number.isFinite(Date.parse(value)) ||
+    new Date(value).toISOString() !== value
+  ) throw new Error(`${label} is invalid`);
+  return value;
+}
+
+function safeHttpsUrl(value: string) {
+  const url = new URL(value);
+  if (
+    url.protocol !== "https:" || url.username || url.password || !url.hostname ||
+    url.hash || url.hostname === "localhost" || url.hostname.endsWith(".local")
+  ) throw new Error("Robinhood presentation URL is unsafe");
+  return url.toString();
+}
+
+function projectImageUrl(value: string) {
+  const url = new URL(value);
+  if (url.protocol === "https:") return safeHttpsUrl(value);
+  if (url.protocol === "ipfs:") {
+    return `${TRUSTED_IPFS_PROJECT_IMAGE_GATEWAY_V1}${url.hostname}`;
+  }
+  if (url.protocol === "ar:") {
+    return `${TRUSTED_ARWEAVE_PROJECT_IMAGE_GATEWAY_V1}${url.hostname}`;
+  }
+  throw new Error("Robinhood project image URL is invalid");
+}
+
+function isBytes32(value: unknown): value is Hex {
+  return typeof value === "string" && BYTES32.test(value);
+}
+
+function isSha256(value: unknown) {
+  return typeof value === "string" && /^sha256:[0-9a-f]{64}$/u.test(value);
+}
+
+function isDecimal(value: unknown): value is string {
+  return typeof value === "string" && UNSIGNED_DECIMAL.test(value);
+}
+
+function positiveDecimal(value: unknown, label: string) {
+  if (!isDecimal(value) || value === "0") throw new Error(`${label} is invalid`);
+  return BigInt(value);
+}
+
+function count(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function logNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 &&
+    value <= 2_147_483_647;
+}
+
+function logIndex(log: Log) {
+  if (!logNumber(log.logIndex)) throw new Error("Robinhood receipt log index is invalid");
+  return log.logIndex;
+}
+
+function sameHex(left: unknown, right: unknown) {
+  return typeof left === "string" && typeof right === "string" &&
+    left.toLowerCase() === right.toLowerCase();
+}
+
+function assertCodeHash(code: Hex | undefined, expected: Hex, label: string) {
+  if (!code || code === "0x" || !sameHex(keccak256(code), expected)) {
+    throw new Error(`Robinhood ${label} runtime code hash mismatch`);
+  }
+}
+
+async function optionalRead<T>(read: () => Promise<T>) {
+  try {
+    return await read();
+  } catch {
+    return null;
+  }
+}

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -173,6 +173,16 @@ export const CANONICAL_LAUNCH_STAMP_V1 = Object.freeze({
   poolManagerAddress: "0x000000000004444c5dc75cB358380D2e3dE08A90",
 } as const);
 
+export const CANONICAL_ROBINHOOD_LAUNCH_STAMP_V1 = Object.freeze({
+  chainId: 4663,
+  routerAddress: "0x34965F2A2ee9254522232C32F02056E92BE0C98a",
+  routerRuntimeCodeHash:
+    "0x1dbbdaaad901ea3c6134dca0d4872a4789b3c071bf8ccfb44edd65d26d817388",
+  routerStartBlock: "50469365",
+  finalityConfirmations: 64,
+  poolManagerAddress: "0x8366a39CC670B4001A1121B8F6A443A643e40951",
+} as const);
+
 type LaunchStampExpectedIdentity = Readonly<{
   chainId?: number;
   tokenAddress?: `0x${string}`;
@@ -378,26 +388,33 @@ export function isLaunchStampProvenanceV1(
   value: unknown,
   expected: LaunchStampExpectedIdentity = {},
 ): value is LaunchStampProvenanceV1 {
+  const canonical = isRecord(value)
+    ? value.chainId === CANONICAL_LAUNCH_STAMP_V1.chainId
+      ? CANONICAL_LAUNCH_STAMP_V1
+      : value.chainId === CANONICAL_ROBINHOOD_LAUNCH_STAMP_V1.chainId
+        ? CANONICAL_ROBINHOOD_LAUNCH_STAMP_V1
+        : null
+    : null;
   if (
     !isRecord(value) ||
     value.schemaVersion !== "programmable.launch-stamp-provenance.v1" ||
     !Number.isSafeInteger(value.chainId) ||
-    value.chainId !== CANONICAL_LAUNCH_STAMP_V1.chainId ||
+    canonical === null ||
     !isAddress(value.routerAddress) ||
     !sameHex(
       value.routerAddress,
-      CANONICAL_LAUNCH_STAMP_V1.routerAddress,
+      canonical.routerAddress,
     ) ||
     !isBytes32(value.routerRuntimeCodeHash) ||
     !sameHex(
       value.routerRuntimeCodeHash,
-      CANONICAL_LAUNCH_STAMP_V1.routerRuntimeCodeHash,
+      canonical.routerRuntimeCodeHash,
     ) ||
     !isUnsignedDecimal(value.routerStartBlock) ||
-    value.routerStartBlock !== CANONICAL_LAUNCH_STAMP_V1.routerStartBlock ||
+    value.routerStartBlock !== canonical.routerStartBlock ||
     !Number.isSafeInteger(value.finalityConfirmations) ||
     value.finalityConfirmations !==
-      CANONICAL_LAUNCH_STAMP_V1.finalityConfirmations ||
+      canonical.finalityConfirmations ||
     (value.kind !== "custom-graph" && value.kind !== "classic") ||
     !isBytes32(value.launchId) ||
     !isBytes32(value.stampHash) ||
@@ -416,7 +433,7 @@ export function isLaunchStampProvenanceV1(
     !isAddress(value.poolManagerAddress) ||
     !sameHex(
       value.poolManagerAddress,
-      CANONICAL_LAUNCH_STAMP_V1.poolManagerAddress,
+      canonical.poolManagerAddress,
     ) ||
     !isBytes32(value.poolId) ||
     !areCanonicalCurrencies(value.poolKey) ||

--- a/packages/launch/schemas/programmable-launch-pack-config-v4.json
+++ b/packages/launch/schemas/programmable-launch-pack-config-v4.json
@@ -15,7 +15,29 @@
       "none",
       "wallet-transaction-value"
     ],
-    "walletSigning": "separate-owner-action"
+    "walletSigning": "separate-owner-action",
+    "platformFeePolicy": {
+      "required": true,
+      "status": "required-default-configuration",
+      "appliesTo": "new-robinhood-v4-api-custom-launches-only",
+      "changesExistingLaunches": false,
+      "changesEthereumLaunches": false,
+      "rateBps": 20,
+      "ratePpm": 2000,
+      "ratePercent": "0.20%",
+      "recipient": "0xD88539d3c4C460136a733A3Fd60cf6BF269079da",
+      "basis": null,
+      "feeCurrency": null,
+      "accountingMode": null,
+      "rounding": null,
+      "accrual": null,
+      "claimMechanism": null,
+      "enforcement": "not-guaranteed-onchain",
+      "canonicalOnchainEnforcementProven": false,
+      "guaranteedRevenue": false,
+      "feeBehaviorClaim": false,
+      "universalFeeBehaviorClaim": false
+    }
   },
   "type": "object",
   "additionalProperties": false,
@@ -1115,155 +1137,6 @@
                   }
                 }
               ]
-            }
-          }
-        }
-      ]
-    },
-    "launchProfile": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "schemaVersion",
-        "profileId",
-        "profileRevision",
-        "targetRoles",
-        "liquidityModel",
-        "fundingMode",
-        "accountingMode",
-        "assessmentBase",
-        "feeCurrency",
-        "claimMode",
-        "applicantSelectedBuyHundredthsOfBip",
-        "applicantSelectedSellHundredthsOfBip"
-      ],
-      "properties": {
-        "schemaVersion": {
-          "const": "programmable.direct-native-hook-graph-profile-selection.v3"
-        },
-        "profileId": {
-          "const": "programmable.direct-native-hook-graph.v1"
-        },
-        "profileRevision": {
-          "const": 3
-        },
-        "targetRoles": {
-          "$ref": "#/$defs/targetRoles"
-        },
-        "liquidityModel": {
-          "$ref": "#/$defs/liquidityModel"
-        },
-        "fundingMode": {
-          "enum": [
-            "none",
-            "wallet-transaction-value",
-            "eip-3009-receive-with-authorization"
-          ]
-        },
-        "accountingMode": {
-          "enum": [
-            "additive-platform-share",
-            "inclusive-selected-total"
-          ]
-        },
-        "assessmentBase": {
-          "enum": [
-            "executed-gross-declared-quote",
-            "settled-input-before-platform-fee"
-          ]
-        },
-        "feeCurrency": {
-          "enum": [
-            "declared-quote-currency",
-            "input-currency"
-          ]
-        },
-        "claimMode": {
-          "enum": [
-            "immutable-payout-recipient",
-            "claim-authority-selected-recipient"
-          ]
-        },
-        "payoutRecipient": {
-          "const": "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c"
-        },
-        "applicantSelectedBuyHundredthsOfBip": {
-          "$ref": "#/$defs/feeUintString"
-        },
-        "applicantSelectedSellHundredthsOfBip": {
-          "$ref": "#/$defs/feeUintString"
-        }
-      },
-      "allOf": [
-        {
-          "if": {
-            "type": "object",
-            "properties": {
-              "claimMode": {
-                "const": "immutable-payout-recipient"
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "payoutRecipient": {}
-            },
-            "required": [
-              "payoutRecipient"
-            ]
-          },
-          "else": {
-            "not": {
-              "properties": {
-                "payoutRecipient": {}
-              },
-              "required": [
-                "payoutRecipient"
-              ]
-            }
-          }
-        },
-        {
-          "if": {
-            "type": "object",
-            "properties": {
-              "assessmentBase": {
-                "const": "executed-gross-declared-quote"
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "feeCurrency": {
-                "const": "declared-quote-currency"
-              }
-            }
-          },
-          "else": {
-            "properties": {
-              "feeCurrency": {
-                "const": "input-currency"
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "type": "object",
-            "properties": {
-              "accountingMode": {
-                "const": "additive-platform-share"
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "applicantSelectedBuyHundredthsOfBip": {
-                "$ref": "#/$defs/additiveFeeUintString"
-              },
-              "applicantSelectedSellHundredthsOfBip": {
-                "$ref": "#/$defs/additiveFeeUintString"
-              }
             }
           }
         }

--- a/packages/launch/scripts/sync-v4-machine-contracts.mjs
+++ b/packages/launch/scripts/sync-v4-machine-contracts.mjs
@@ -21,6 +21,29 @@ const documents = new Map(await Promise.all([1, 2, 3].map(async (version) => {
 const openapi = await readJson(openApiPath);
 documents.set("custom-launch-v4.json", openapi);
 
+const robinhoodV4PlatformFeePolicy = Object.freeze({
+  required: true,
+  status: "required-default-configuration",
+  appliesTo: "new-robinhood-v4-api-custom-launches-only",
+  changesExistingLaunches: false,
+  changesEthereumLaunches: false,
+  rateBps: 20,
+  ratePpm: 2_000,
+  ratePercent: "0.20%",
+  recipient: "0xD88539d3c4C460136a733A3Fd60cf6BF269079da",
+  basis: null,
+  feeCurrency: null,
+  accountingMode: null,
+  rounding: null,
+  accrual: null,
+  claimMechanism: null,
+  enforcement: "not-guaranteed-onchain",
+  canonicalOnchainEnforcementProven: false,
+  guaranteedRevenue: false,
+  feeBehaviorClaim: false,
+  universalFeeBehaviorClaim: false,
+});
+
 const clone = (value) => structuredClone(value);
 const closed = (required, properties, rest = {}) => ({
   type: "object",
@@ -2200,6 +2223,10 @@ for (const [name, schema] of standalone) {
 }
 
 const packConfig = await readJson(packagedPackConfigPath);
+packConfig["x-programmable-contract"].platformFeePolicy = clone(
+  robinhoodV4PlatformFeePolicy,
+);
+delete packConfig.$defs.launchProfile;
 packConfig.$defs.chainDeployment = clone(chainDeployment);
 const packagedPackConfigSource = `${JSON.stringify(packConfig, null, 2)}\n`;
 await writeFile(packagedPackConfigPath, packagedPackConfigSource);

--- a/packages/launch/scripts/verify-public-machine-contracts.mjs
+++ b/packages/launch/scripts/verify-public-machine-contracts.mjs
@@ -32,6 +32,28 @@ const API_SERVER_BY_DOCUMENT = Object.freeze({
   "custom-launch-v3.json": "https://api.programmable.market",
   "custom-launch-v4.json": "https://api.programmable.market",
 });
+const ROBINHOOD_V4_PLATFORM_FEE_POLICY = Object.freeze({
+  required: true,
+  status: "required-default-configuration",
+  appliesTo: "new-robinhood-v4-api-custom-launches-only",
+  changesExistingLaunches: false,
+  changesEthereumLaunches: false,
+  rateBps: 20,
+  ratePpm: 2_000,
+  ratePercent: "0.20%",
+  recipient: "0xD88539d3c4C460136a733A3Fd60cf6BF269079da",
+  basis: null,
+  feeCurrency: null,
+  accountingMode: null,
+  rounding: null,
+  accrual: null,
+  claimMechanism: null,
+  enforcement: "not-guaranteed-onchain",
+  canonicalOnchainEnforcementProven: false,
+  guaranteedRevenue: false,
+  feeBehaviorClaim: false,
+  universalFeeBehaviorClaim: false,
+});
 
 const documents = new Map();
 for (const [name, filePath] of Object.entries(documentPaths)) {
@@ -296,6 +318,27 @@ assert.deepEqual(
   packageV4PackBytes,
   "Public and packaged V4 pack-config schemas must be byte-identical",
 );
+const packageV4Schema = parseStrictJson(packageV4PackBytes.toString("utf8"), {
+  maximumBytes: 10_000_000,
+  maximumDepth: 256,
+});
+assertJsonEqual(
+  packageV4Schema["x-programmable-contract"].platformFeePolicy,
+  ROBINHOOD_V4_PLATFORM_FEE_POLICY,
+  "V4 pack annotation must pin the Robinhood API platform fee policy",
+);
+assert.equal(
+  Object.hasOwn(packageV4Schema.$defs, "launchProfile"),
+  false,
+  "V4 pack schema must not retain the unreachable Ethereum V3 launch profile",
+);
+assert.equal(
+  JSON.stringify(packageV4Schema).includes(
+    "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c",
+  ),
+  false,
+  "V4 pack schema must not retain the Ethereum V3 payout recipient",
+);
 const v4StandaloneComponents = Object.freeze({
   "pack-config.json": "PackConfigV4",
   "custom-launch-create-request.json": "CustomLaunchCreateRequestV4",
@@ -339,6 +382,19 @@ assert.equal(
     .properties.walletHandoff.properties.walletHandoffBaseUrl.const,
   "https://programmable.market/developers/api-keys",
   "V4 wallet handoff must publish the exact owner-action base URL",
+);
+assertJsonEqual(
+  v4.components.schemas.CustomLaunchCapabilitiesV2.properties.safety.properties,
+  {
+    serverAuthoritative: { const: true },
+    clientBypassAccepted: { const: false },
+    walletSignatureProduced: { const: false },
+    transactionBroadcast: { const: false },
+    feeBehaviorClaim: { const: false },
+    universalFeeBehaviorClaim: { const: false },
+    genericClaimingLive: { const: false },
+  },
+  "V4 capabilities must preserve the non-claiming safety contract",
 );
 const packagedExternalContract = v4.components.schemas.PackConfigV4.$defs.externalContract;
 assert.equal(

--- a/packages/launch/test/v4-machine-contracts.test.mjs
+++ b/packages/launch/test/v4-machine-contracts.test.mjs
@@ -58,6 +58,28 @@ const publicSchemas = new Map(await Promise.all(
     )),
   ]),
 ));
+const robinhoodV4PlatformFeePolicy = Object.freeze({
+  required: true,
+  status: "required-default-configuration",
+  appliesTo: "new-robinhood-v4-api-custom-launches-only",
+  changesExistingLaunches: false,
+  changesEthereumLaunches: false,
+  rateBps: 20,
+  ratePpm: 2_000,
+  ratePercent: "0.20%",
+  recipient: "0xD88539d3c4C460136a733A3Fd60cf6BF269079da",
+  basis: null,
+  feeCurrency: null,
+  accountingMode: null,
+  rounding: null,
+  accrual: null,
+  claimMechanism: null,
+  enforcement: "not-guaranteed-onchain",
+  canonicalOnchainEnforcementProven: false,
+  guaranteedRevenue: false,
+  feeBehaviorClaim: false,
+  universalFeeBehaviorClaim: false,
+});
 const ajv = new Ajv2020({
   allErrors: true,
   strict: true,
@@ -142,7 +164,25 @@ test("public and packaged V4 pack schemas are byte-for-byte equivalent JSON cont
     maximumTargets: 16,
     fundingModes: ["none", "wallet-transaction-value"],
     walletSigning: "separate-owner-action",
+    platformFeePolicy: robinhoodV4PlatformFeePolicy,
   });
+  assert.equal(Object.hasOwn(packageSchema.$defs, "launchProfile"), false);
+  assert.doesNotMatch(
+    JSON.stringify(packageSchema),
+    /0x4957f49620AFf3Adbbe8195a4f633E49cc93376c/u,
+  );
+  assert.deepEqual(
+    openapi.components.schemas.CustomLaunchCapabilitiesV2.properties.safety.properties,
+    {
+      serverAuthoritative: { const: true },
+      clientBypassAccepted: { const: false },
+      walletSignatureProduced: { const: false },
+      transactionBroadcast: { const: false },
+      feeBehaviorClaim: { const: false },
+      universalFeeBehaviorClaim: { const: false },
+      genericClaimingLive: { const: false },
+    },
+  );
 });
 
 test("V4 Safe source commitment is recomputed from the exact non-Sourcify source subject", () => {

--- a/public/openapi/custom-launch-v4.json
+++ b/public/openapi/custom-launch-v4.json
@@ -34092,7 +34092,29 @@
             "none",
             "wallet-transaction-value"
           ],
-          "walletSigning": "separate-owner-action"
+          "walletSigning": "separate-owner-action",
+          "platformFeePolicy": {
+            "required": true,
+            "status": "required-default-configuration",
+            "appliesTo": "new-robinhood-v4-api-custom-launches-only",
+            "changesExistingLaunches": false,
+            "changesEthereumLaunches": false,
+            "rateBps": 20,
+            "ratePpm": 2000,
+            "ratePercent": "0.20%",
+            "recipient": "0xD88539d3c4C460136a733A3Fd60cf6BF269079da",
+            "basis": null,
+            "feeCurrency": null,
+            "accountingMode": null,
+            "rounding": null,
+            "accrual": null,
+            "claimMechanism": null,
+            "enforcement": "not-guaranteed-onchain",
+            "canonicalOnchainEnforcementProven": false,
+            "guaranteedRevenue": false,
+            "feeBehaviorClaim": false,
+            "universalFeeBehaviorClaim": false
+          }
         },
         "type": "object",
         "additionalProperties": false,
@@ -35192,155 +35214,6 @@
                         }
                       }
                     ]
-                  }
-                }
-              }
-            ]
-          },
-          "launchProfile": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "schemaVersion",
-              "profileId",
-              "profileRevision",
-              "targetRoles",
-              "liquidityModel",
-              "fundingMode",
-              "accountingMode",
-              "assessmentBase",
-              "feeCurrency",
-              "claimMode",
-              "applicantSelectedBuyHundredthsOfBip",
-              "applicantSelectedSellHundredthsOfBip"
-            ],
-            "properties": {
-              "schemaVersion": {
-                "const": "programmable.direct-native-hook-graph-profile-selection.v3"
-              },
-              "profileId": {
-                "const": "programmable.direct-native-hook-graph.v1"
-              },
-              "profileRevision": {
-                "const": 3
-              },
-              "targetRoles": {
-                "$ref": "#/$defs/targetRoles"
-              },
-              "liquidityModel": {
-                "$ref": "#/$defs/liquidityModel"
-              },
-              "fundingMode": {
-                "enum": [
-                  "none",
-                  "wallet-transaction-value",
-                  "eip-3009-receive-with-authorization"
-                ]
-              },
-              "accountingMode": {
-                "enum": [
-                  "additive-platform-share",
-                  "inclusive-selected-total"
-                ]
-              },
-              "assessmentBase": {
-                "enum": [
-                  "executed-gross-declared-quote",
-                  "settled-input-before-platform-fee"
-                ]
-              },
-              "feeCurrency": {
-                "enum": [
-                  "declared-quote-currency",
-                  "input-currency"
-                ]
-              },
-              "claimMode": {
-                "enum": [
-                  "immutable-payout-recipient",
-                  "claim-authority-selected-recipient"
-                ]
-              },
-              "payoutRecipient": {
-                "const": "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c"
-              },
-              "applicantSelectedBuyHundredthsOfBip": {
-                "$ref": "#/$defs/feeUintString"
-              },
-              "applicantSelectedSellHundredthsOfBip": {
-                "$ref": "#/$defs/feeUintString"
-              }
-            },
-            "allOf": [
-              {
-                "if": {
-                  "type": "object",
-                  "properties": {
-                    "claimMode": {
-                      "const": "immutable-payout-recipient"
-                    }
-                  }
-                },
-                "then": {
-                  "properties": {
-                    "payoutRecipient": {}
-                  },
-                  "required": [
-                    "payoutRecipient"
-                  ]
-                },
-                "else": {
-                  "not": {
-                    "properties": {
-                      "payoutRecipient": {}
-                    },
-                    "required": [
-                      "payoutRecipient"
-                    ]
-                  }
-                }
-              },
-              {
-                "if": {
-                  "type": "object",
-                  "properties": {
-                    "assessmentBase": {
-                      "const": "executed-gross-declared-quote"
-                    }
-                  }
-                },
-                "then": {
-                  "properties": {
-                    "feeCurrency": {
-                      "const": "declared-quote-currency"
-                    }
-                  }
-                },
-                "else": {
-                  "properties": {
-                    "feeCurrency": {
-                      "const": "input-currency"
-                    }
-                  }
-                }
-              },
-              {
-                "if": {
-                  "type": "object",
-                  "properties": {
-                    "accountingMode": {
-                      "const": "additive-platform-share"
-                    }
-                  }
-                },
-                "then": {
-                  "properties": {
-                    "applicantSelectedBuyHundredthsOfBip": {
-                      "$ref": "#/$defs/additiveFeeUintString"
-                    },
-                    "applicantSelectedSellHundredthsOfBip": {
-                      "$ref": "#/$defs/additiveFeeUintString"
-                    }
                   }
                 }
               }
@@ -77786,155 +77659,6 @@
                   }
                 }
               ]
-            }
-          }
-        }
-      ]
-    },
-    "launchProfile": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "schemaVersion",
-        "profileId",
-        "profileRevision",
-        "targetRoles",
-        "liquidityModel",
-        "fundingMode",
-        "accountingMode",
-        "assessmentBase",
-        "feeCurrency",
-        "claimMode",
-        "applicantSelectedBuyHundredthsOfBip",
-        "applicantSelectedSellHundredthsOfBip"
-      ],
-      "properties": {
-        "schemaVersion": {
-          "const": "programmable.direct-native-hook-graph-profile-selection.v3"
-        },
-        "profileId": {
-          "const": "programmable.direct-native-hook-graph.v1"
-        },
-        "profileRevision": {
-          "const": 3
-        },
-        "targetRoles": {
-          "$ref": "#/$defs/targetRoles"
-        },
-        "liquidityModel": {
-          "$ref": "#/$defs/liquidityModel"
-        },
-        "fundingMode": {
-          "enum": [
-            "none",
-            "wallet-transaction-value",
-            "eip-3009-receive-with-authorization"
-          ]
-        },
-        "accountingMode": {
-          "enum": [
-            "additive-platform-share",
-            "inclusive-selected-total"
-          ]
-        },
-        "assessmentBase": {
-          "enum": [
-            "executed-gross-declared-quote",
-            "settled-input-before-platform-fee"
-          ]
-        },
-        "feeCurrency": {
-          "enum": [
-            "declared-quote-currency",
-            "input-currency"
-          ]
-        },
-        "claimMode": {
-          "enum": [
-            "immutable-payout-recipient",
-            "claim-authority-selected-recipient"
-          ]
-        },
-        "payoutRecipient": {
-          "const": "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c"
-        },
-        "applicantSelectedBuyHundredthsOfBip": {
-          "$ref": "#/$defs/feeUintString"
-        },
-        "applicantSelectedSellHundredthsOfBip": {
-          "$ref": "#/$defs/feeUintString"
-        }
-      },
-      "allOf": [
-        {
-          "if": {
-            "type": "object",
-            "properties": {
-              "claimMode": {
-                "const": "immutable-payout-recipient"
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "payoutRecipient": {}
-            },
-            "required": [
-              "payoutRecipient"
-            ]
-          },
-          "else": {
-            "not": {
-              "properties": {
-                "payoutRecipient": {}
-              },
-              "required": [
-                "payoutRecipient"
-              ]
-            }
-          }
-        },
-        {
-          "if": {
-            "type": "object",
-            "properties": {
-              "assessmentBase": {
-                "const": "executed-gross-declared-quote"
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "feeCurrency": {
-                "const": "declared-quote-currency"
-              }
-            }
-          },
-          "else": {
-            "properties": {
-              "feeCurrency": {
-                "const": "input-currency"
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "type": "object",
-            "properties": {
-              "accountingMode": {
-                "const": "additive-platform-share"
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "applicantSelectedBuyHundredthsOfBip": {
-                "$ref": "#/$defs/additiveFeeUintString"
-              },
-              "applicantSelectedSellHundredthsOfBip": {
-                "$ref": "#/$defs/additiveFeeUintString"
-              }
             }
           }
         }

--- a/public/schemas/custom-launch/v4/pack-config.json
+++ b/public/schemas/custom-launch/v4/pack-config.json
@@ -15,7 +15,29 @@
       "none",
       "wallet-transaction-value"
     ],
-    "walletSigning": "separate-owner-action"
+    "walletSigning": "separate-owner-action",
+    "platformFeePolicy": {
+      "required": true,
+      "status": "required-default-configuration",
+      "appliesTo": "new-robinhood-v4-api-custom-launches-only",
+      "changesExistingLaunches": false,
+      "changesEthereumLaunches": false,
+      "rateBps": 20,
+      "ratePpm": 2000,
+      "ratePercent": "0.20%",
+      "recipient": "0xD88539d3c4C460136a733A3Fd60cf6BF269079da",
+      "basis": null,
+      "feeCurrency": null,
+      "accountingMode": null,
+      "rounding": null,
+      "accrual": null,
+      "claimMechanism": null,
+      "enforcement": "not-guaranteed-onchain",
+      "canonicalOnchainEnforcementProven": false,
+      "guaranteedRevenue": false,
+      "feeBehaviorClaim": false,
+      "universalFeeBehaviorClaim": false
+    }
   },
   "type": "object",
   "additionalProperties": false,
@@ -1115,155 +1137,6 @@
                   }
                 }
               ]
-            }
-          }
-        }
-      ]
-    },
-    "launchProfile": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "schemaVersion",
-        "profileId",
-        "profileRevision",
-        "targetRoles",
-        "liquidityModel",
-        "fundingMode",
-        "accountingMode",
-        "assessmentBase",
-        "feeCurrency",
-        "claimMode",
-        "applicantSelectedBuyHundredthsOfBip",
-        "applicantSelectedSellHundredthsOfBip"
-      ],
-      "properties": {
-        "schemaVersion": {
-          "const": "programmable.direct-native-hook-graph-profile-selection.v3"
-        },
-        "profileId": {
-          "const": "programmable.direct-native-hook-graph.v1"
-        },
-        "profileRevision": {
-          "const": 3
-        },
-        "targetRoles": {
-          "$ref": "#/$defs/targetRoles"
-        },
-        "liquidityModel": {
-          "$ref": "#/$defs/liquidityModel"
-        },
-        "fundingMode": {
-          "enum": [
-            "none",
-            "wallet-transaction-value",
-            "eip-3009-receive-with-authorization"
-          ]
-        },
-        "accountingMode": {
-          "enum": [
-            "additive-platform-share",
-            "inclusive-selected-total"
-          ]
-        },
-        "assessmentBase": {
-          "enum": [
-            "executed-gross-declared-quote",
-            "settled-input-before-platform-fee"
-          ]
-        },
-        "feeCurrency": {
-          "enum": [
-            "declared-quote-currency",
-            "input-currency"
-          ]
-        },
-        "claimMode": {
-          "enum": [
-            "immutable-payout-recipient",
-            "claim-authority-selected-recipient"
-          ]
-        },
-        "payoutRecipient": {
-          "const": "0x4957f49620AFf3Adbbe8195a4f633E49cc93376c"
-        },
-        "applicantSelectedBuyHundredthsOfBip": {
-          "$ref": "#/$defs/feeUintString"
-        },
-        "applicantSelectedSellHundredthsOfBip": {
-          "$ref": "#/$defs/feeUintString"
-        }
-      },
-      "allOf": [
-        {
-          "if": {
-            "type": "object",
-            "properties": {
-              "claimMode": {
-                "const": "immutable-payout-recipient"
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "payoutRecipient": {}
-            },
-            "required": [
-              "payoutRecipient"
-            ]
-          },
-          "else": {
-            "not": {
-              "properties": {
-                "payoutRecipient": {}
-              },
-              "required": [
-                "payoutRecipient"
-              ]
-            }
-          }
-        },
-        {
-          "if": {
-            "type": "object",
-            "properties": {
-              "assessmentBase": {
-                "const": "executed-gross-declared-quote"
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "feeCurrency": {
-                "const": "declared-quote-currency"
-              }
-            }
-          },
-          "else": {
-            "properties": {
-              "feeCurrency": {
-                "const": "input-currency"
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "type": "object",
-            "properties": {
-              "accountingMode": {
-                "const": "additive-platform-share"
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "applicantSelectedBuyHundredthsOfBip": {
-                "$ref": "#/$defs/additiveFeeUintString"
-              },
-              "applicantSelectedSellHundredthsOfBip": {
-                "$ref": "#/$defs/additiveFeeUintString"
-              }
             }
           }
         }

--- a/tests/explore-api.test.ts
+++ b/tests/explore-api.test.ts
@@ -115,6 +115,7 @@ const mocks = vi.hoisted(() => ({
   customEnabled: vi.fn(() => false),
   readCustom: vi.fn(),
   readRouter: vi.fn(),
+  readRobinhood: vi.fn(),
   routerStatus: vi.fn((): "current" | "last-known-good" => "current"),
   gmgnConfigured: vi.fn(() => false),
   gmgnEligible: vi.fn<(entry: ExploreEntry) => boolean>(),
@@ -176,6 +177,9 @@ vi.mock("../lib/server/custom-launch/public-readiness", () => ({
 vi.mock("../lib/server/custom-launch/explore-directory-v1", () => ({
   readProductionCustomExploreDirectoryV1: mocks.readCustom,
 }));
+vi.mock("../lib/server/custom-launch/robinhood-finalized-explore-feed-v1", () => ({
+  readRobinhoodFinalizedExploreSnapshotV1: mocks.readRobinhood,
+}));
 vi.mock("../lib/alchemy/router-custom-public.server", () => ({
   ROUTER_CUSTOM_FINALITY_CONFIRMATIONS: 64,
   ROUTER_CUSTOM_LAUNCH_SOURCE: "canonical-launch-stamp-router",
@@ -221,6 +225,30 @@ import { customGraphExploreEntry } from "./launch-stamp-surface-fixture";
 
 const NOW = "2026-08-16T08:00:00.000Z";
 const TOKEN_COUNT = 36;
+
+function robinhoodSnapshot() {
+  const tokenAddress = customGraphExploreEntry.tokenAddress;
+  return {
+    source: "robinhood-finalized-custom-launch-feed-v4",
+    launchSource:
+      "robinhood-finalized-custom-launch-feed-v4+canonical-launch-stamp-router",
+    generatedAt: NOW,
+    asOfBlock: "50470000",
+    asOfBlockHash: `0x${"ab".repeat(32)}`,
+    identityCommitment: `sha256:${"cd".repeat(32)}`,
+    entries: [{
+      ...customGraphExploreEntry,
+      id: `4663:${tokenAddress.toLowerCase()}`,
+    }],
+    quality: {
+      status: "ready",
+      sourceRowCount: 1,
+      publishedRowCount: 1,
+      quarantinedRowCount: 0,
+    },
+    sourceVerification: [{ tokenAddress, updatedAt: NOW }],
+  } as const;
+}
 
 function token(index: number): ExploreEntry {
   const tokenAddress = `0x${index.toString(16).padStart(40, "0")}` as const;
@@ -779,6 +807,7 @@ describe("Explore static identity and Dexscreener market contract", () => {
     mocks.customEnabled.mockReturnValue(false);
     mocks.readCustom.mockResolvedValue([]);
     mocks.readRouter.mockResolvedValue([]);
+    mocks.readRobinhood.mockRejectedValue(new Error("feed not publishable"));
     mocks.routerStatus.mockReturnValue("current");
     mocks.gmgnConfigured.mockReturnValue(false);
     mocks.gmgnEligible.mockReturnValue(false);
@@ -1013,6 +1042,38 @@ describe("Explore static identity and Dexscreener market contract", () => {
     expect(mocks.readDex).not.toHaveBeenCalled();
   });
 
+  it("serves finalized Robinhood launches once the backend feed is publishable", async () => {
+    mocks.readRobinhood.mockResolvedValue(robinhoodSnapshot());
+
+    const response = await GET(
+      request("chain=4663&sort=newest&page=1&limit=9"),
+    );
+    const body = await json(response);
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ready");
+    expect(body.chainId).toBe(4663);
+    expect(body.total).toBe(1);
+    expect(body.tokens[0]).toMatchObject({
+      id: `4663:${customGraphExploreEntry.tokenAddress.toLowerCase()}`,
+      symbol: "GRAPH",
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+    });
+    expect(body.catalog).toMatchObject({
+      source: "robinhood-finalized-custom-launch-feed-v4",
+      launchSource:
+        "robinhood-finalized-custom-launch-feed-v4+canonical-launch-stamp-router",
+      identityCount: 1,
+      completeness: { custom: "current", routerCustom: "current" },
+    });
+    expect(response.headers.get("x-programmable-chain-id")).toBe("4663");
+    expect(response.headers.get("x-programmable-identity-last-indexed-at"))
+      .toBe(NOW);
+    expect(mocks.readCatalog).not.toHaveBeenCalled();
+    expect(mocks.readRouter).not.toHaveBeenCalled();
+    expect(mocks.readDex).not.toHaveBeenCalled();
+  });
+
   it("rejects Trending on Robinhood before reading either discovery provider", async () => {
     const response = await GET(
       request("chain=4663&sort=trending&page=1&limit=9"),
@@ -1026,6 +1087,23 @@ describe("Explore static identity and Dexscreener market contract", () => {
     expect(mocks.readHotSearches).not.toHaveBeenCalled();
     expect(mocks.readCatalog).not.toHaveBeenCalled();
   });
+
+  it.each(["oldest", "market-cap", "market-cap-asc"])(
+    "rejects %s on Robinhood before reading the finalized feed",
+    async (sort) => {
+      const response = await GET(
+        request(`chain=4663&sort=${sort}&page=1&limit=9`),
+      );
+
+      expect(response.status).toBe(400);
+      expect(await json(response)).toEqual({
+        error: "Robinhood Explore supports newest sort only",
+      });
+      expect(mocks.readRobinhood).not.toHaveBeenCalled();
+      expect(mocks.readCatalog).not.toHaveBeenCalled();
+      expect(mocks.readDex).not.toHaveBeenCalled();
+    },
+  );
 
   it("ranks only filtered canonical Ethereum launches and retains the stable tail", async () => {
     const foreign = "0xffffffffffffffffffffffffffffffffffffffff" as const;

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -185,6 +185,24 @@ describe("Explore UI contract", () => {
     );
     expect(source).toContain("valuationSortOptions.map((option) => (");
     expect(source).toContain("ageSortOptions.map((option) => (");
+    expect(source).toContain("resolveExploreSortSelectionsForChain(");
+    expect(source).toContain(
+      "aria-pressed={valuationSortForChain === option.id}",
+    );
+    expect(source).toContain(
+      "aria-pressed={ageSortForChain === option.id}",
+    );
+    expect(source).toMatch(/disabled=\{viewChainId === 4663\}/u);
+    expect(source).toMatch(
+      /disabled=\{viewChainId === 4663 &&\s+option\.id === "oldest"\}/u,
+    );
+    expect(source).toContain(
+      "valuationSort: valuationSortForChain",
+    );
+    expect(source).toContain("ageSort: ageSortForChain");
+    expect(source).toContain(
+      "if (viewChainId === 1) {\n                                setDiscoverySort(\"none\");",
+    );
     expect(source).toContain("setValuationSort((current) =>");
     expect(source).toContain("setAgeSort((current) =>");
     expect(source).toContain('search.set(\n        "model",');

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -32,6 +32,7 @@ import {
   preserveExplorePayloadOnRefreshFailure,
   requiresCompleteExploreDataset,
   resolveExploreServerSort,
+  resolveExploreSortSelectionsForChain,
   sortExploreEntriesBySelections,
   stabilizeExploreRevalidationPayload,
   tokenHasSocialLinks,
@@ -1492,6 +1493,55 @@ describe("Explore refresh state", () => {
         expect.objectContaining({ id: highNew.id }),
         expect.objectContaining({ id: highOld.id }),
       ],
+    });
+  });
+
+  it("derives Robinhood sort choices without clearing the Ethereum selections", () => {
+    expect(
+      resolveExploreSortSelectionsForChain(
+        1,
+        "highest",
+        "oldest",
+        "trending",
+      ),
+    ).toEqual({
+      valuationSort: "highest",
+      ageSort: "oldest",
+      discoverySort: "trending",
+    });
+
+    const robinhoodSelections = resolveExploreSortSelectionsForChain(
+      4663,
+      "highest",
+      "oldest",
+      "trending",
+    );
+    expect(robinhoodSelections).toEqual({
+      valuationSort: "none",
+      ageSort: "none",
+      discoverySort: "none",
+    });
+    expect(resolveExploreServerSort(
+      robinhoodSelections.valuationSort,
+      robinhoodSelections.ageSort,
+      robinhoodSelections.discoverySort,
+    )).toBe("newest");
+    expect(requiresCompleteExploreDataset(
+      robinhoodSelections.valuationSort,
+      robinhoodSelections.ageSort,
+      robinhoodSelections.discoverySort,
+    )).toBe(false);
+    expect(
+      resolveExploreSortSelectionsForChain(
+        4663,
+        "lowest",
+        "newest",
+        "trending",
+      ),
+    ).toEqual({
+      valuationSort: "none",
+      ageSort: "newest",
+      discoverySort: "none",
     });
   });
 

--- a/tests/public-explore-openapi-contract.test.ts
+++ b/tests/public-explore-openapi-contract.test.ts
@@ -4,6 +4,73 @@ import { describe, expect, it } from "vitest";
 
 import { programmablePublicOpenApi } from "../lib/public-openapi";
 
+const robinhoodEntry = {
+  exploreKind: "token",
+  id: "4663:0x1111111111111111111111111111111111111111",
+  name: "Robinhood Custom Release",
+  symbol: "RHCR",
+  description: "A finalized Programmable Custom launch on Robinhood Chain.",
+  imageUrl: "https://ipfs.io/ipfs/bafybeigdyrzt5sfp7udm7hu76br3m5pnpytwhq",
+  links: [
+    { kind: "website", url: "https://programmable.market" },
+    { kind: "x", url: "https://x.com/programmable" },
+  ],
+  tokenAddress: "0x1111111111111111111111111111111111111111",
+  hookAddress: "0xa3b48907aCDD42A1Ec74E1D9208122eC34af4A88",
+  poolId: `0x${"11".repeat(32)}`,
+  launchedAt: "2026-09-02T18:30:00.000Z",
+  launchModel: "custom-graph",
+  launchModelVersion: "programmable-launch-stamp-router-v1",
+  liquidityPath: "programmable-v4",
+  totalSwapFeeBps: null,
+  valuation: { status: "unavailable", reason: "source-unavailable" },
+  launchCategoryProvenance: {
+    category: "custom",
+    source: "canonical-launch-stamp-router",
+  },
+};
+
+const robinhoodCatalog = {
+  source: "robinhood-finalized-custom-launch-feed-v4",
+  launchSource:
+    "robinhood-finalized-custom-launch-feed-v4+canonical-launch-stamp-router",
+  status: "current",
+  lastIndexedAt: "2026-09-03T07:30:00.000Z",
+  asOfBlock: "52929919",
+  asOfBlockHash: `0x${"22".repeat(32)}`,
+  identityCount: 1,
+  identityCommitment: `sha256:${"33".repeat(32)}`,
+  completeness: {
+    classic: "unavailable",
+    stock: "excluded",
+    custom: "current",
+    registryCustom: "unavailable",
+    routerCustom: "current",
+  },
+  scope: {
+    included: ["canonical-launch-stamp-router"],
+    excluded: [
+      "classic-v1",
+      "classic-v2",
+      "stock-paired-v1",
+      "stock-paired-v2",
+      "stock-paired-v3",
+    ],
+    publicCategories: ["classic", "custom"],
+  },
+  routerStamp: {
+    source: "canonical-launch-stamp-router",
+    status: "current",
+    finalityConfirmations: 64,
+    verifiedIdentityCount: 1,
+    projectedIdentityCount: 1,
+    generatedAt: "2026-09-03T07:30:00.000Z",
+    asOfBlock: "52929919",
+    asOfBlockHash: `0x${"22".repeat(32)}`,
+    identityCommitment: `sha256:${"33".repeat(32)}`,
+  },
+};
+
 function responseValidator(name: "ExploreListResponse" | "TokenDetailResponse") {
   const ajv = new Ajv2020({ allErrors: true, strict: false });
   addFormats(ajv);
@@ -245,6 +312,27 @@ describe("public Explore OpenAPI contract", () => {
     expect(validate({ ...ready, marketRead: incompleteGmgn })).toBe(false);
   });
 
+  it("validates the finalized Robinhood ready list without a market read", () => {
+    const validate = responseValidator("ExploreListResponse");
+    const ready = {
+      status: "ready",
+      chainId: 4663,
+      tokens: [robinhoodEntry],
+      page: 1,
+      pageSize: 9,
+      total: 1,
+      totalPages: 1,
+      sort: "newest",
+      query: "",
+      catalog: robinhoodCatalog,
+    };
+
+    expect(validate(ready), JSON.stringify(validate.errors)).toBe(true);
+    expect(ready).not.toHaveProperty("marketRead");
+    expect(validate({ ...ready, marketRead: null })).toBe(true);
+    expect(validate({ ...ready, sort: "oldest" })).toBe(false);
+  });
+
   it("documents the market response headers emitted by ready Explore reads", () => {
     const response = programmablePublicOpenApi.paths["/api/explore"].get
       .responses["200"];
@@ -377,6 +465,7 @@ describe("public Explore OpenAPI contract", () => {
 
     expect(validate(planned), JSON.stringify(validate.errors)).toBe(true);
     expect(validate({ ...planned, catalog: {} })).toBe(false);
+    expect(validate({ ...planned, sort: "oldest" })).toBe(false);
   });
 
   it("documents chain-scoped token reads and their planned response", () => {
@@ -406,6 +495,48 @@ describe("public Explore OpenAPI contract", () => {
     };
     expect(validate(planned), JSON.stringify(validate.errors)).toBe(true);
     expect(validate({ ...planned, catalog: {} })).toBe(false);
+  });
+
+  it("validates a finalized Robinhood ready token detail", () => {
+    const validate = responseValidator("TokenDetailResponse");
+    const detail = {
+      status: "ready",
+      token: robinhoodEntry,
+      customProject: null,
+      routerTradeProject: null,
+      platformFeeCertification: null,
+      sourceVerification: {
+        schemaVersion: "programmable.source-verification-display.v1",
+        status: "verified",
+        label: "Source verified",
+        updatedAt: "2026-09-03T07:29:00.000Z",
+      },
+      creatorArticle: null,
+      snapshot: { chainId: 4663 },
+      catalog: robinhoodCatalog,
+    };
+
+    expect(validate(detail), JSON.stringify(validate.errors)).toBe(true);
+    expect(validate({
+      ...detail,
+      token: null,
+      sourceVerification: null,
+      snapshot: null,
+    }), JSON.stringify(validate.errors)).toBe(true);
+    expect(
+      programmablePublicOpenApi.paths["/api/explore/token"].get
+        .responses["404"].content["application/json"].schema,
+    ).toEqual({
+      $ref: "#/components/schemas/TokenDetailLookupReadyResponse",
+    });
+    expect(programmablePublicOpenApi.components.schemas.TokenDetailReadyResponse
+      .properties.catalog).toEqual({
+        $ref: "#/components/schemas/CatalogBoundary",
+      });
+    expect(validate({
+      ...detail,
+      catalog: { ...robinhoodCatalog, source: "unverified" },
+    })).toBe(false);
   });
 
   it("documents token market headers only where a market read can occur", () => {

--- a/tests/robinhood-finalized-explore-feed-v1.test.ts
+++ b/tests/robinhood-finalized-explore-feed-v1.test.ts
@@ -1,0 +1,379 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  encodeAbiParameters,
+  padHex,
+  parseAbiParameters,
+  toHex,
+  type Hex,
+} from "viem";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  readRobinhoodFinalizedExploreSnapshotV1,
+  type RobinhoodFinalizedExploreEthereumClientV1,
+  type RobinhoodFinalizedExploreReaderClientV1,
+} from "../lib/server/custom-launch/robinhood-finalized-explore-feed-v1";
+import { customGraphExploreEntry } from "./launch-stamp-surface-fixture";
+
+// @ts-expect-error -- the canonical package fixtures intentionally ship as ESM JS.
+import { validV4OnchainEvidenceV3, validV4ProjectMetadata, validV4Resource, validV4SourceVerificationStatus } from "../packages/launch/test/fixtures/v4.mjs";
+// @ts-expect-error -- the canonical package runtime intentionally ships as ESM JS.
+import { hashProjectMetadata } from "../packages/launch/src/project-metadata.mjs";
+
+const NOW = Date.parse("2026-09-03T07:00:00.000Z");
+
+function publicCacheHeaders() {
+  return {
+    "cache-control": "public, max-age=15, stale-while-revalidate=300",
+    "content-type": "application/json; charset=utf-8",
+  };
+}
+
+function page(quality: Readonly<{
+  status: string;
+  sourceRowCount: number;
+  publishedRowCount: number;
+  quarantinedRowCount: number;
+}>) {
+  return new Response(JSON.stringify({
+    schemaVersion: "programmable.custom-launch-list.v4",
+    apiVersion: "v4",
+    chainId: "4663",
+    caip2: "eip155:4663",
+    generatedAt: new Date(NOW).toISOString(),
+    quality,
+    launches: [],
+    nextCursor: null,
+  }), {
+    status: 200,
+    headers: publicCacheHeaders(),
+  });
+}
+
+function finalizedLaunchFixture() {
+  const initialProjectMetadata = validV4ProjectMetadata();
+  const projectMetadata = {
+    ...initialProjectMetadata,
+    presentation: {
+      ...initialProjectMetadata.presentation,
+      links: [
+        { kind: "documentation", uri: "https://example.com/docs" },
+        ...initialProjectMetadata.presentation.links,
+      ],
+    },
+  };
+  const initial = validV4Resource();
+  const resource = {
+    ...initial,
+    projectMetadata,
+    commitments: {
+      ...initial.commitments,
+      metadata: hashProjectMetadata(projectMetadata, { requireComplete: true }),
+    },
+  };
+  const initialOnchain = validV4OnchainEvidenceV3(resource);
+  const onchain = {
+    ...initialOnchain,
+    l2Inclusion: {
+      ...initialOnchain.l2Inclusion,
+      blockNumber: "50470000",
+      launchEventLogIndex: 6,
+    },
+  };
+  const publicOnchain = structuredClone(onchain);
+  Reflect.deleteProperty(publicOnchain, "walletTransactionPreimageHash");
+  const exactEvidence = (providerDigit: string, bindingDigit: string) => ({
+    providerObservation: {
+      provider: "sourcify-v2",
+      classification: "PARTIAL_NO_CBOR_EXACT_BYTES",
+      match: "match",
+      creationMatch: "match",
+      runtimeMatch: "match",
+      releaseAuthority: false,
+      evidenceDigest: `sha256:${providerDigit.repeat(64)}`,
+    },
+    exactSourceAuthority:
+      "protected-hosted-build-finalized-transaction-bytecode",
+    exactSourceBinding: {
+      schemaVersion:
+        "programmable.robinhood-custom-launch.exact-byte-source-build-transaction-binding.v1",
+      authority: "protected-hosted-build-finalized-transaction-bytecode",
+      coveredEvidence: [
+        "protected-source-tree",
+        "source-closure",
+        "hosted-build-artifact",
+        "standard-json-input",
+        "compiler-binary",
+        "compiler-settings",
+        "finalized-creation-transaction",
+        "creation-bytecode",
+        "runtime-bytecode",
+      ],
+      bindingDigest: `sha256:${bindingDigit.repeat(64)}`,
+    },
+  });
+  const sourceVerification = validV4SourceVerificationStatus({
+    components: [
+      {
+        targetId: "hook",
+        address: "0x2222222222222222222222222222222222222222",
+        status: "exact_match",
+        ...exactEvidence("8", "a"),
+        updatedAt: "2026-09-03T06:59:58.000Z",
+      },
+      {
+        targetId: "token",
+        address: "0x1111111111111111111111111111111111111111",
+        status: "exact_match",
+        ...exactEvidence("9", "b"),
+        updatedAt: "2026-09-03T06:59:59.000Z",
+      },
+    ],
+  });
+  return {
+    schemaVersion: "programmable.finalized-custom-launch-metadata.v4",
+    apiVersion: "v4",
+    launchId: resource.launchId,
+    chainId: resource.chainId,
+    caip2: resource.caip2,
+    chainDeploymentId: resource.chainDeploymentId,
+    chainDeploymentDescriptorDigest: resource.chainDeploymentDescriptorDigest,
+    chainDeployment: resource.chainDeployment,
+    profile: resource.profile,
+    platformId: "programmable",
+    category: "custom",
+    projectMetadata,
+    funding: resource.funding,
+    liquidityModel: resource.liquidityModel,
+    commitments: resource.commitments,
+    onchain: publicOnchain,
+    sourceVerification,
+    createdAt: resource.createdAt,
+    finalizedAt: "2026-09-03T06:59:59.000Z",
+  };
+}
+
+function ethereumPostingLog(launch: ReturnType<typeof finalizedLaunchFixture>) {
+  const posting = launch.onchain.l1Posting;
+  return {
+    address: posting.sequencerInbox,
+    blockHash: posting.blockHash,
+    blockNumber: BigInt(posting.blockNumber),
+    data: encodeAbiParameters(
+      parseAbiParameters(
+        "bytes32 delayedAcc,uint256 afterDelayedMessagesRead,(uint64 delayBlocks,uint64 futureBlocks,uint64 delaySeconds,uint64 futureSeconds) timeBounds,uint8 dataLocation",
+      ),
+      [
+        `0x${"c".repeat(64)}`,
+        1n,
+        {
+          delayBlocks: 1n,
+          futureBlocks: 2n,
+          delaySeconds: 3n,
+          futureSeconds: 4n,
+        },
+        0,
+      ],
+    ),
+    logIndex: posting.logIndex,
+    removed: false,
+    topics: [
+      "0x7394f4a19a13c7b92b5bb71033245305946ef78452f7b4986ac1390b5df4ebd7",
+      padHex(toHex(BigInt(posting.batchNumber)), { size: 32 }),
+      `0x${"a".repeat(64)}`,
+      `0x${"b".repeat(64)}`,
+    ],
+    transactionHash: posting.transactionHash,
+    transactionIndex: 0,
+  };
+}
+
+function ethereumClient(launch: ReturnType<typeof finalizedLaunchFixture>) {
+  const posting = launch.onchain.l1Posting;
+  const checkpoint = launch.onchain.l1FinalizedCheckpoint;
+  const log = ethereumPostingLog(launch);
+  return {
+    getChainId: vi.fn(async () => 1),
+    getTransactionReceipt: vi.fn(async () => ({
+      status: "success",
+      transactionHash: posting.transactionHash,
+      blockNumber: BigInt(posting.blockNumber),
+      blockHash: posting.blockHash,
+      logs: [log],
+    })),
+    getBlock: vi.fn(async (input: Readonly<{
+      blockNumber?: bigint;
+      blockTag?: string;
+    }>) => {
+      if (input.blockTag === "finalized") {
+        return {
+          number: BigInt(checkpoint.blockNumber) + 1n,
+          hash: `0x${"d".repeat(64)}` as Hex,
+        };
+      }
+      if (input.blockNumber === BigInt(posting.blockNumber)) {
+        return { number: input.blockNumber, hash: posting.blockHash };
+      }
+      return {
+        number: BigInt(checkpoint.blockNumber),
+        hash: checkpoint.blockHash,
+      };
+    }),
+  } as unknown as RobinhoodFinalizedExploreEthereumClientV1;
+}
+
+describe("Robinhood finalized Explore feed", () => {
+  it.each([
+    {
+      name: "quarantined backend rows",
+      quality: {
+        status: "ready",
+        sourceRowCount: 3,
+        publishedRowCount: 0,
+        quarantinedRowCount: 3,
+      },
+    },
+    {
+      name: "empty backend dataset",
+      quality: {
+        status: "ready",
+        sourceRowCount: 0,
+        publishedRowCount: 0,
+        quarantinedRowCount: 0,
+      },
+    },
+    {
+      name: "non-ready backend status",
+      quality: {
+        status: "partial",
+        sourceRowCount: 1,
+        publishedRowCount: 1,
+        quarantinedRowCount: 0,
+      },
+    },
+  ])("fails closed before RPC verification for $name", async ({ quality }) => {
+    const getChainId = vi.fn();
+    const client = { getChainId } as unknown as
+      RobinhoodFinalizedExploreReaderClientV1;
+
+    await expect(readRobinhoodFinalizedExploreSnapshotV1({
+      fetchFeed: (async () => page(quality)) as typeof fetch,
+      client,
+      now: () => NOW,
+      timeoutMs: 50,
+    })).rejects.toThrow(/not publishable/u);
+    expect(getChainId).not.toHaveBeenCalled();
+  });
+
+  it("accepts a complete V4 item and projects full metadata after both L1 providers agree", async () => {
+    const launch = finalizedLaunchFixture();
+    const feed = new Response(JSON.stringify({
+      schemaVersion: "programmable.custom-launch-list.v4",
+      apiVersion: "v4",
+      chainId: "4663",
+      caip2: "eip155:4663",
+      generatedAt: new Date(NOW).toISOString(),
+      quality: {
+        status: "ready",
+        sourceRowCount: 1,
+        publishedRowCount: 1,
+        quarantinedRowCount: 0,
+      },
+      launches: [launch],
+      nextCursor: null,
+    }), { status: 200, headers: publicCacheHeaders() });
+    const client = {
+      getChainId: vi.fn(async () => 4663),
+      getBlockNumber: vi.fn(async () => 50_470_100n),
+      getBlock: vi.fn(async () => ({
+        number: 50_470_100n,
+        hash: `0x${"e".repeat(64)}` as Hex,
+        timestamp: 1_788_006_700n,
+      })),
+    } as unknown as RobinhoodFinalizedExploreReaderClientV1;
+    const primary = ethereumClient(launch);
+    const secondary = ethereumClient(launch);
+    const projected = {
+      ...customGraphExploreEntry,
+      id: `4663:${customGraphExploreEntry.tokenAddress.toLowerCase()}`,
+      name: "Robinhood V4 Test",
+      symbol: "RHV4",
+      description:
+        "Deterministic Robinhood Chain V4 launch metadata fixture",
+      imageUrl: "https://example.com/token.png",
+      projectMetadataLinks: [
+        { kind: "documentation" as const, url: "https://example.com/docs" },
+        { kind: "website" as const, url: "https://example.com/" },
+        { kind: "x" as const, url: "https://x.com/programmable" },
+      ],
+      projectMetadataStatus: "current" as const,
+    };
+    const verifyLaunch = vi.fn(async (parsed) => {
+      expect(parsed.projectMetadata).toMatchObject({
+        imageUrl: "https://example.com/token.png",
+        projectMetadataLinks: projected.projectMetadataLinks,
+        links: [
+          { kind: "website", url: "https://example.com/" },
+          { kind: "x", url: "https://x.com/programmable" },
+        ],
+      });
+      expect(parsed.evidenceDigest).toMatch(/^sha256:[0-9a-f]{64}$/u);
+      return projected;
+    });
+
+    const snapshot = await readRobinhoodFinalizedExploreSnapshotV1({
+      fetchFeed: (async () => feed) as typeof fetch,
+      client,
+      ethereumClients: [primary, secondary],
+      verifyLaunch,
+      now: () => NOW,
+      timeoutMs: 50,
+    });
+
+    expect(snapshot.entries).toEqual([projected]);
+    expect(snapshot.quality).toEqual({
+      status: "ready",
+      sourceRowCount: 1,
+      publishedRowCount: 1,
+      quarantinedRowCount: 0,
+    });
+    expect(verifyLaunch).toHaveBeenCalledOnce();
+    for (const ethereum of [primary, secondary]) {
+      expect(ethereum.getTransactionReceipt).toHaveBeenCalledOnce();
+      expect(ethereum.getBlock).toHaveBeenCalledTimes(3);
+    }
+  });
+
+  it("rejects a complete item whose public onchain evidence omits evidenceDigest", async () => {
+    const launch = finalizedLaunchFixture();
+    const onchain = structuredClone(launch.onchain);
+    Reflect.deleteProperty(onchain, "evidenceDigest");
+    const feed = new Response(JSON.stringify({
+      schemaVersion: "programmable.custom-launch-list.v4",
+      apiVersion: "v4",
+      chainId: "4663",
+      caip2: "eip155:4663",
+      generatedAt: new Date(NOW).toISOString(),
+      quality: {
+        status: "ready",
+        sourceRowCount: 1,
+        publishedRowCount: 1,
+        quarantinedRowCount: 0,
+      },
+      launches: [{ ...launch, onchain }],
+      nextCursor: null,
+    }), { status: 200, headers: publicCacheHeaders() });
+    const getChainId = vi.fn();
+
+    await expect(readRobinhoodFinalizedExploreSnapshotV1({
+      fetchFeed: (async () => feed) as typeof fetch,
+      client: { getChainId } as unknown as
+        RobinhoodFinalizedExploreReaderClientV1,
+      now: () => NOW,
+      timeoutMs: 50,
+    })).rejects.toThrow(/unknown or missing fields/u);
+    expect(getChainId).not.toHaveBeenCalled();
+  });
+
+});

--- a/tests/token-detail-api.test.ts
+++ b/tests/token-detail-api.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   customEnabled: vi.fn(() => false),
   readCustom: vi.fn(),
   readRouter: vi.fn(),
+  readRobinhood: vi.fn(),
   mergeRouter: vi.fn((existing: readonly unknown[], router: readonly unknown[]) => [
     ...existing,
     ...router,
@@ -37,6 +38,9 @@ vi.mock("../lib/server/custom-launch/public-readiness", () => ({
 }));
 vi.mock("../lib/server/custom-launch/explore-directory-v1", () => ({
   readProductionCustomExploreDirectoryV1: mocks.readCustom,
+}));
+vi.mock("../lib/server/custom-launch/robinhood-finalized-explore-feed-v1", () => ({
+  readRobinhoodFinalizedExploreSnapshotV1: mocks.readRobinhood,
 }));
 vi.mock("../lib/server/custom-launch/source-verification-display-v1", () => ({
   readProductionSourceVerificationDisplayV1: mocks.readSourceVerification,
@@ -85,6 +89,30 @@ import { confirmedPlatformFeePolicyV2 } from
 import { shardRouterTradeEntry } from "./shard-router-trade-fixture";
 
 const NOW = "2026-08-16T08:00:00.000Z";
+
+function robinhoodSnapshot() {
+  const tokenAddress = customGraphExploreEntry.tokenAddress;
+  return {
+    source: "robinhood-finalized-custom-launch-feed-v4",
+    launchSource:
+      "robinhood-finalized-custom-launch-feed-v4+canonical-launch-stamp-router",
+    generatedAt: NOW,
+    asOfBlock: "50470000",
+    asOfBlockHash: `0x${"ab".repeat(32)}`,
+    identityCommitment: `sha256:${"cd".repeat(32)}`,
+    entries: [{
+      ...customGraphExploreEntry,
+      id: `4663:${tokenAddress.toLowerCase()}`,
+    }],
+    quality: {
+      status: "ready",
+      sourceRowCount: 1,
+      publishedRowCount: 1,
+      quarantinedRowCount: 0,
+    },
+    sourceVerification: [{ tokenAddress, updatedAt: NOW }],
+  } as const;
+}
 
 function token(): ExploreEntry {
   const value = {
@@ -216,6 +244,7 @@ describe("Token detail static identity and Dexscreener market contract", () => {
     mocks.customEnabled.mockReturnValue(false);
     mocks.readCustom.mockResolvedValue([]);
     mocks.readRouter.mockResolvedValue([]);
+    mocks.readRobinhood.mockRejectedValue(new Error("feed not publishable"));
     mocks.mergeRouter.mockImplementation(
       (existing: readonly unknown[], router: readonly unknown[]) => [
         ...existing,
@@ -269,6 +298,38 @@ describe("Token detail static identity and Dexscreener market contract", () => {
     );
     expect(mocks.readCatalog).not.toHaveBeenCalled();
     expect(mocks.readCustom).not.toHaveBeenCalled();
+    expect(mocks.readRouter).not.toHaveBeenCalled();
+    expect(mocks.readDex).not.toHaveBeenCalled();
+  });
+
+  it("serves finalized Robinhood token details from the publishable feed", async () => {
+    mocks.readRobinhood.mockResolvedValue(robinhoodSnapshot());
+
+    const response = await GET(request(
+      customGraphExploreEntry.tokenAddress,
+      "&chain=4663",
+    ));
+    const body = await json(response);
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ready");
+    expect(body.token).toMatchObject({
+      id: `4663:${customGraphExploreEntry.tokenAddress.toLowerCase()}`,
+      symbol: "GRAPH",
+      valuation: { status: "unavailable", reason: "source-unavailable" },
+    });
+    expect(body.sourceVerification).toEqual({
+      schemaVersion: "programmable.source-verification-display.v1",
+      status: "verified",
+      label: "Source verified",
+      updatedAt: NOW,
+    });
+    expect(body.snapshot).toEqual({ chainId: 4663 });
+    expect(body.catalog).toMatchObject({
+      source: "robinhood-finalized-custom-launch-feed-v4",
+      identityCount: 1,
+    });
+    expect(mocks.readCatalog).not.toHaveBeenCalled();
     expect(mocks.readRouter).not.toHaveBeenCalled();
     expect(mocks.readDex).not.toHaveBeenCalled();
   });

--- a/tests/token-detail-layout.test.ts
+++ b/tests/token-detail-layout.test.ts
@@ -90,6 +90,9 @@ describe("token detail layout", () => {
     expect(detailSource).toMatch(
       /<div className=\{styles\.marketChart\}>[\s\S]*?<TokenPriceChart[\s\S]*?<MetricGrid metrics=\{metrics\} \/>[\s\S]*?<\/div>/s,
     );
+    expect(detailSource).toMatch(
+      /\{chainId === 1 \? \([\s\S]*?<TokenPriceChart[\s\S]*?\) : null\}/s,
+    );
     expect(detailSource).not.toContain("<VerifiedLaunchRecord");
     expect(detailSource).not.toContain("<TokenCommunityChat");
     expect(detailStyles).toMatch(

--- a/tests/view-chain.test.ts
+++ b/tests/view-chain.test.ts
@@ -11,7 +11,10 @@ import {
   serializeViewChainCookie,
   tryParseViewChainId,
 } from "../lib/view-chain";
-import { resolveExploreChainId } from "../lib/explore-chain";
+import {
+  isRobinhoodExploreAvailableResponse,
+  resolveExploreChainId,
+} from "../lib/explore-chain";
 
 const root = process.cwd();
 const read = (path: string) => readFileSync(join(root, path), "utf8");
@@ -40,11 +43,33 @@ describe("view chain", () => {
     expect(serializeViewChainCookie(4663)).toContain("SameSite=Lax");
   });
 
-  it("normalizes unavailable Explore preferences to Ethereum", () => {
+  it("accepts supported Explore preferences and normalizes invalid chains", () => {
     expect(resolveExploreChainId(1)).toBe(1);
-    expect(resolveExploreChainId(4663)).toBe(1);
+    expect(resolveExploreChainId(4663)).toBe(4663);
     expect(resolveExploreChainId(8453)).toBe(1);
     expect(resolveExploreChainId("invalid")).toBe(1);
+  });
+
+  it("derives Robinhood availability only from a non-empty ready server response", () => {
+    const ready = {
+      status: "ready",
+      chainId: 4663,
+      total: 1,
+      catalog: {
+        source: "robinhood-finalized-custom-launch-feed-v4",
+        completeness: { custom: "current" },
+      },
+    };
+    expect(isRobinhoodExploreAvailableResponse(ready)).toBe(true);
+    expect(isRobinhoodExploreAvailableResponse({ ...ready, total: 0 })).toBe(false);
+    expect(isRobinhoodExploreAvailableResponse({
+      ...ready,
+      status: "not-deployed",
+    })).toBe(false);
+    expect(isRobinhoodExploreAvailableResponse({
+      ...ready,
+      catalog: { ...ready.catalog, completeness: { custom: "unavailable" } },
+    })).toBe(false);
   });
 
   it("resolves the server cookie only inside chain-bound product routes", () => {


### PR DESCRIPTION
Publishes finalized Robinhood Chain custom launches through the existing Explore API and UI, with complete V4 item validation, independent L2/L1 finality checks, strict newest-only Robinhood sorting, and explicit chain-4663 OpenAPI responses. Aligns the public Robinhood V4 launch policy annotation to 20 BPS / 2000 ppm at 0xD88539d3c4C460136a733A3Fd60cf6BF269079da without claiming immutable onchain enforcement. Ethereum behavior is unchanged. The Robinhood path remains fail-closed until the backend catalog reports publishable finalized rows with zero quarantine. Verification: focused Explore suite 177/177, V4 machine-contract suite 17/17, public machine-contract verifier, typecheck on the final Explorer tree, and diff checks.