### PR TITLE
Update Dexscreener link for Robinhood

### DIFF
--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -22,7 +22,7 @@ const resourceLinks = [
     external: true,
   },
   {
-    href: "https://dexscreener.com/ethereum/0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0",
+    href: "https://dexscreener.com/robinhood/0x3df16f271060e4941c0386047def159f42e629dc0455db623c5b363eeacbcc1d",
     label: "DEX Screener",
     external: true,
   },

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -76,7 +76,7 @@ function HeaderSocialLinks({ mobile = false }: { mobile?: boolean }) {
       </a>
       <a
         className="header-social-link"
-        href="https://dexscreener.com/ethereum/0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0"
+        href="https://dexscreener.com/robinhood/0x3df16f271060e4941c0386047def159f42e629dc0455db623c5b363eeacbcc1d"
         target="_blank"
         rel="noreferrer"
         aria-label="Programmable on DEX Screener"

--- a/docs/public/reference/official-links.md
+++ b/docs/public/reference/official-links.md
@@ -28,7 +28,7 @@ description: Official Programmable product, source, community and analytics link
 | X                       | [x.com/ProgrammableHQ](https://x.com/ProgrammableHQ)                                                               |
 | Discord                 | [discord.com/invite/programmable](https://discord.com/invite/programmable)                                         |
 | Dune                    | [Programmable analytics](https://dune.com/0xprogrammable6098/programmable-analytics)                               |
-| V4 token                | [Dexscreener](https://dexscreener.com/ethereum/0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0) |
+| V4 token                | [Dexscreener](https://dexscreener.com/robinhood/0x3df16f271060e4941c0386047def159f42e629dc0455db623c5b363eeacbcc1d) |
 
 Use `api.programmable.market` for authenticated public V3 general-hook creation and exact-credential-principal lifecycle reads with wallet keys, partner roots or bounded partner subkeys. The
 default profile is revision 3 with `profileVersion: 3.3.0`; it requires and binds canonical project metadata, including

--- a/docs/public/v4-token.md
+++ b/docs/public/v4-token.md
@@ -17,4 +17,4 @@ The published allocation assigns 80% of attributable net protocol revenue to V4 
 
 Holding V4 does not represent equity in Programmable and does not create a claim on protocol revenue. Purchases do not guarantee price, liquidity or returns, and a new revenue source is not processed until its source profile is verified and activated.
 
-The official token page on [Dexscreener](https://dexscreener.com/ethereum/0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0) can be useful for price and liquidity context, while the contract address remains the identity.
+The official token page on [Dexscreener](https://dexscreener.com/robinhood/0x3df16f271060e4941c0386047def159f42e629dc0455db623c5b363eeacbcc1d) can be useful for price and liquidity context, while the contract address remains the identity.

--- a/tests/topbar-hero-polish.test.ts
+++ b/tests/topbar-hero-polish.test.ts
@@ -49,7 +49,7 @@ describe("topbar and Explore hero polish", () => {
     const navigationCss = read("components/site-navigation.module.css");
 
     expect(navigation).toContain(
-      "https://dexscreener.com/ethereum/0xd9ca22573437a06a12d5c757b151aa1a76265c1dfdde4b76507233d7ad2b6df0",
+      "https://dexscreener.com/robinhood/0x3df16f271060e4941c0386047def159f42e629dc0455db623c5b363eeacbcc1d",
     );
     expect(navigation).toContain(
       'src="/brand/platforms/dexscreener-mark-warm-ivory-v1.png"',


### PR DESCRIPTION
Replace the legacy Ethereum Dexscreener URL with the current Robinhood Chain pool URL across the site navigation, footer, public token documentation, official links, and the exact UI expectation.\n\nTargeted validation: 13/13 tests passed in tests/topbar-hero-polish.test.ts and tests/site-footer.test.ts.