### PR TITLE
Align Robinhood backend promotion contract

### DIFF
--- a/contracts/scripts/robinhood-backend-promotion-v1.mjs
+++ b/contracts/scripts/robinhood-backend-promotion-v1.mjs
@@ -79,6 +79,13 @@ const HEX40 = /^(?!0{40}$)[0-9a-f]{40}$/u;
 const HEX32 = /^0x(?!0{64}$)[0-9a-f]{64}$/u;
 const ISO_SECOND = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/u;
 const CAPTURE_ID = /^[0-9a-f]{64}$/u;
+const FLY_RELEASE_ID = /^[A-Za-z0-9_-]{1,128}$/u;
+const FLY_MACHINE_RELEASE_ID = /^rel_[a-z0-9]{6,128}$/u;
+const FLY_V1_SCHEME = "FlyV1 ";
+const FLY_V1_SEGMENT = /^fm2_([A-Za-z0-9/+_-]+={0,2})$/u;
+const FLY_V1_MAXIMUM_SEGMENTS = 16;
+const FLY_V1_MINIMUM_SEGMENT_BYTES = 32;
+const FLY_V1_MAXIMUM_SEGMENT_BYTES = 12_288;
 const BACKEND_REPOSITORY = "programmablehq/programmable-open-hook-v2-internal";
 const BACKEND_REPOSITORY_ID = "1318883798";
 const PROGRAMMABLE_REPOSITORY = "programmablehq/PROGRAMMABLE";
@@ -95,7 +102,8 @@ const UNISWAP_REGISTRY = Object.freeze({
 });
 const COMPOSITION_KEYS = Object.freeze([
   "authoritativeChainRuntime",
-  "apiSignerObserverRoleAttestation",
+  "liveExactPrivyPolicyReadiness",
+  "apiSignerObserverVerifierRoleAttestation",
   "durableLedger",
   "exactCredentialScopeRecheck",
   "isolatedImageDecoder",
@@ -107,9 +115,65 @@ const COMPOSITION_KEYS = Object.freeze([
   "dualProviderSubmissionDiscovery",
   "finalityObserver",
   "finalityWorkerLifecycle",
+  "sourceVerificationWorkerConfigured",
+  "sourceVerificationWorkerStarted",
+  "sourceVerificationWorkerLifecycle",
 ]);
+
+function failFlyV1TokenWire() {
+  throw new TypeError("FLY_V1_TOKEN_WIRE_INVALID");
+}
+
+function canonicalFlyV1Segment(segment) {
+  const match = FLY_V1_SEGMENT.exec(segment);
+  if (match === null) failFlyV1TokenWire();
+  const encoded = match[1];
+  const unpadded = encoded.replace(/=+$/u, "");
+  const paddingLength = encoded.length - unpadded.length;
+  const remainder = unpadded.length % 4;
+  if (remainder === 1) failFlyV1TokenWire();
+  const requiredPadding = remainder === 0 ? 0 : 4 - remainder;
+  if (paddingLength !== 0 && paddingLength !== requiredPadding) failFlyV1TokenWire();
+  if (/[+/]/u.test(unpadded) && /[-_]/u.test(unpadded)) failFlyV1TokenWire();
+  const standardUnpadded = unpadded.replaceAll("-", "+").replaceAll("_", "/");
+  const standard = `${standardUnpadded}${"=".repeat(requiredPadding)}`;
+  const bytes = Buffer.from(standard, "base64");
+  if (bytes.byteLength < FLY_V1_MINIMUM_SEGMENT_BYTES
+    || bytes.byteLength > FLY_V1_MAXIMUM_SEGMENT_BYTES
+    || bytes.toString("base64") !== standard) {
+    bytes.fill(0);
+    failFlyV1TokenWire();
+  }
+  bytes.fill(0);
+  return `fm2_${standard}`;
+}
+
+function normalizeFlyV1TokenWireV1(value, { requireScheme = false } = {}) {
+  if (typeof value !== "string" || !/^[\x20-\x7e]+$/u.test(value)) failFlyV1TokenWire();
+  const hasScheme = value.startsWith(FLY_V1_SCHEME);
+  if (requireScheme && !hasScheme) failFlyV1TokenWire();
+  const raw = hasScheme ? value.slice(FLY_V1_SCHEME.length) : value;
+  const segments = raw.split(",");
+  if (segments.length < 1 || segments.length > FLY_V1_MAXIMUM_SEGMENTS) {
+    failFlyV1TokenWire();
+  }
+  const canonicalRaw = segments.map(canonicalFlyV1Segment).join(",");
+  return Object.freeze({
+    raw: canonicalRaw,
+    header: `${FLY_V1_SCHEME}${canonicalRaw}`,
+  });
+}
+
+function normalizeFlyV1Authorization(value) {
+  if (typeof value !== "string" || value.length < 16 || value.length > 16_384
+    || !/^[\x20-\x7e]+$/u.test(value)) {
+    failFlyV1TokenWire();
+  }
+  return normalizeFlyV1TokenWireV1(value);
+}
 const MAX_CAPTURE_AGE_MS = 15 * 60 * 1000;
 const MAX_FUTURE_SKEW_MS = 2 * 60 * 1000;
+const MAX_FLY_RELEASE_AGE_MS = 24 * 60 * 60 * 1000;
 const MAX_CAPTURE_AUTHORIZATION_DELAY_MS = 10 * 60 * 1000;
 const BACKEND_SAFE_RECEIPTS_DOMAIN =
   "programmable.robinhood-custom-launch.backend-safe-readback-receipts.v2";
@@ -144,12 +208,14 @@ const BACKEND_RESPONSE_BYTES = Object.freeze({
   metadata: 1 * 1024 * 1024,
 });
 const FLY_RELEASES_QUERY = "query ProgrammableRobinhoodRelease($appName: String!, $first: Int!) { app(name: $appName) { releasesUnprocessed(first: $first) { totalCount pageInfo { hasNextPage hasPreviousPage startCursor endCursor } nodes { id version status stable imageRef image { registry repository tag digest } createdAt } } } }";
-const BACKEND_MIGRATION_PATH = "migrations/0017_chain_aware_custom_launch_v4.sql";
+const BACKEND_MIGRATION_PATH = "migrations/0024_custom_launch_source_authority_v4.sql";
 const BACKEND_MIGRATION_SHA256 =
-  "sha256:40f0e2fb30af99e53649d0091a1571f88b9503aa7001c32dca11050b747f2eab";
+  "sha256:51efb50f6f59131042d4253ce485cf14c3d375ab639d8c7075eb22dc8a9d44a0";
 const BACKEND_API_CONTRACT_PATH = "release/custom-launch-api-contract.v4.json";
 const BACKEND_API_CONTRACT_SHA256 =
-  "sha256:ddf45b96ff5bc402951e009849924fda8796b8db8498521c6903f7b1a2c29e62";
+  "sha256:1c22711fa0516507d1e207ee7cb565d9ec95f59e042d869c0052a98a57d73634";
+const ROBINHOOD_PROVIDER_PROFILE_SHA256 =
+  "sha256:88daed906c2a142c57d2483099a6d18be31dbff2a282108657ec6f5e73f53132";
 
 export function validateSigstoreMessageBundleV03({ bundleBytes, subjectBytes }) {
   if (!Buffer.isBuffer(bundleBytes) || bundleBytes.byteLength < 1
@@ -411,9 +477,9 @@ function bindingMachineContract(stageBundle, name) {
 function exactReadinessIdentity(value, stageBundle, backendSource) {
   assertExactKeys(value, [
     "schemaVersion", "status", "service", "sourceCommit", "sourceTree", "chainId",
-    "chainDeploymentId", "chainDeploymentDescriptorDigest", "migration", "apiContract",
-    "openApiSha256", "finalityPolicy", "uniswapRegistrySnapshot", "policySource", "profile",
-    "providerQuorums", "composition",
+    "chainDeploymentId", "chainDeploymentDescriptorDigest", "providerProfileDigest",
+    "migration", "apiContract", "openApiSha256", "finalityPolicy",
+    "uniswapRegistrySnapshot", "policySource", "profile", "providerQuorums", "composition",
   ], "backend readiness release identity");
   const descriptorDigest = stageBundle.finalizedBindings.chainDeploymentDescriptorDigest;
   const releaseIdentity = stageBundle.artifacts.cliReleaseBinding.value.releaseIdentity;
@@ -421,7 +487,8 @@ function exactReadinessIdentity(value, stageBundle, backendSource) {
     || value.service !== "custom-launch-api-v1" || value.sourceCommit !== backendSource.sourceCommit
     || value.sourceTree !== backendSource.sourceTree || value.chainId !== CHAIN_ID
     || value.chainDeploymentId !== CHAIN_DEPLOYMENT_ID
-    || value.chainDeploymentDescriptorDigest !== descriptorDigest) {
+    || value.chainDeploymentDescriptorDigest !== descriptorDigest
+    || value.providerProfileDigest !== ROBINHOOD_PROVIDER_PROFILE_SHA256) {
     throw new TypeError("backend readiness release identity does not bind the staged deployment");
   }
   assertExactKeys(value.migration, ["path", "sha256"], "backend readiness migration");
@@ -444,21 +511,23 @@ function exactReadinessIdentity(value, stageBundle, backendSource) {
   }
   assertExactKeys(value.profile, [
     "structuralProfileId", "businessProfileId", "profileRevision", "profileVersion",
-    "profileDigest",
+    "profileDigest", "providerProfileDigest",
   ], "backend readiness profile");
   const expectedProfile = releaseIdentity.profile;
   if (value.profile.structuralProfileId !== expectedProfile.structuralProfileId
     || value.profile.businessProfileId !== expectedProfile.businessProfileId
     || value.profile.profileRevision !== expectedProfile.profileRevision
     || value.profile.profileVersion !== expectedProfile.profileVersion
-    || value.profile.profileDigest !== expectedProfile.profileDigest) {
+    || value.profile.profileDigest !== expectedProfile.profileDigest
+    || value.profile.providerProfileDigest !== ROBINHOOD_PROVIDER_PROFILE_SHA256
+    || value.profile.providerProfileDigest !== value.providerProfileDigest) {
     throw new TypeError("backend readiness profile differs");
   }
   assertExactKeys(value.providerQuorums, ["robinhood", "ethereum"],
     "backend readiness provider quorums");
   if (canonicalizeJson(value.providerQuorums) !== canonicalizeJson({
     robinhood: [
-      { providerId: "quicknode", trustDomain: "quicknode.com" },
+      { providerId: "drpc", trustDomain: "drpc.org" },
       { providerId: "alchemy", trustDomain: "alchemy.com" },
     ],
     ethereum: [
@@ -488,33 +557,61 @@ function normalizeFlyBodies(fly, backendSource, observedAt) {
     || typeof app.id !== "string" || app.id.length === 0) {
     throw new TypeError("Fly app identity/status differs");
   }
-  if (fly.releases.body?.errors !== undefined) {
+  const releasesBody = fly.releases.body;
+  if (Object.hasOwn(releasesBody, "errors")) {
     throw new TypeError("Fly releases GraphQL response contains errors");
   }
-  const releaseConnection = fly.releases.body?.data?.app?.releasesUnprocessed;
-  const releases = releaseConnection?.nodes;
-  if (!Array.isArray(releases) || releases.length < 1 || releases.length > 256) {
-    throw new TypeError("Fly releasesUnprocessed inventory is invalid");
+  assertExactKeys(releasesBody, ["data"], "Fly GraphQL response");
+  assertExactKeys(releasesBody.data, ["app"], "Fly GraphQL data");
+  assertExactKeys(releasesBody.data.app, ["releasesUnprocessed"], "Fly GraphQL app");
+  const releaseConnection = releasesBody.data.app.releasesUnprocessed;
+  assertExactKeys(releaseConnection, ["totalCount", "pageInfo", "nodes"],
+    "Fly releasesUnprocessed connection");
+  assertExactKeys(releaseConnection.pageInfo, [
+    "hasNextPage", "hasPreviousPage", "startCursor", "endCursor",
+  ], "Fly release pageInfo");
+  const pageInfo = releaseConnection.pageInfo;
+  if (pageInfo.hasNextPage !== false || pageInfo.hasPreviousPage !== false) {
+    throw new TypeError("Fly releasesUnprocessed inventory is paginated or incomplete");
   }
-  if (releaseConnection.totalCount !== releases.length
-    || releaseConnection.pageInfo?.hasNextPage !== false) {
-    throw new TypeError("Fly releasesUnprocessed inventory is incomplete or paginated");
+  if (typeof pageInfo.startCursor !== "string" || pageInfo.startCursor.length < 1
+    || pageInfo.startCursor.length > 2048 || typeof pageInfo.endCursor !== "string"
+    || pageInfo.endCursor.length < 1 || pageInfo.endCursor.length > 2048) {
+    throw new TypeError("Fly release inventory cursors are invalid");
+  }
+  const releases = releaseConnection.nodes;
+  if (!Array.isArray(releases) || releases.length < 1 || releases.length > 256
+    || !Number.isSafeInteger(releaseConnection.totalCount)
+    || releaseConnection.totalCount !== releases.length) {
+    throw new TypeError("Fly releasesUnprocessed inventory count is invalid or incomplete");
   }
   const versions = releases.map((entry) => entry?.version);
   const ids = releases.map((entry) => entry?.id);
+  for (const entry of releases) {
+    assertExactKeys(entry, [
+      "id", "version", "status", "stable", "imageRef", "image", "createdAt",
+    ], "Fly release node");
+  }
+  const observedTime = Date.parse(observedAt);
   if (versions.some((version) => !Number.isSafeInteger(version) || version < 1)
-    || ids.some((id) => typeof id !== "string" || !/^[A-Za-z0-9_-]{1,128}$/u.test(id))
+    || ids.some((id) => typeof id !== "string" || !FLY_RELEASE_ID.test(id))
     || new Set(versions).size !== versions.length || new Set(ids).size !== ids.length
-    || releases.some((entry) => typeof entry.createdAt !== "string"
+    || releases.some((entry) => typeof entry.status !== "string"
+      || typeof entry.stable !== "boolean" || !ISO_SECOND.test(entry.createdAt)
       || Number.isNaN(Date.parse(entry.createdAt))
-      || Date.parse(entry.createdAt) > Date.parse(observedAt) + MAX_FUTURE_SKEW_MS)) {
+      || Date.parse(entry.createdAt) > observedTime + MAX_FUTURE_SKEW_MS)) {
     throw new TypeError("Fly release identities/versions/timestamps are invalid");
   }
   const release = releases.reduce((latest, entry) => entry.version > latest.version
     ? entry : latest);
-  if (release.status !== "complete" || release.stable !== true) {
-    throw new TypeError("Fly absolute latest release is not complete and stable");
+  if (release.status !== "complete") {
+    throw new TypeError("The latest Fly release is not complete");
   }
+  if (observedTime - Date.parse(release.createdAt) > MAX_FLY_RELEASE_AGE_MS) {
+    throw new TypeError("The latest Fly release is stale or future-dated");
+  }
+  assertExactKeys(release.image, ["registry", "repository", "tag", "digest"],
+    "latest Fly release image");
   if (release.imageRef !== `registry.fly.io/${ROBINHOOD_FLY_APP}:${release.image?.tag}`
     || release.image?.registry !== "registry.fly.io"
     || release.image?.repository !== ROBINHOOD_FLY_APP
@@ -538,8 +635,7 @@ function normalizeFlyBodies(fly, backendSource, observedAt) {
     imageTag: release.image.tag,
     imageDigest: release.image.digest,
   });
-  const listedMachines = Array.isArray(fly.machineList.body)
-    ? fly.machineList.body : fly.machineList.body?.machines;
+  const listedMachines = fly.machineList.body;
   if (!Array.isArray(listedMachines) || listedMachines.length < 1
     || listedMachines.length > 8) {
     throw new TypeError("Fly machine inventory is invalid");
@@ -550,6 +646,7 @@ function normalizeFlyBodies(fly, backendSource, observedAt) {
     || canonicalizeJson(listedIds) !== canonicalizeJson([...fly.machines.keys()])) {
     throw new TypeError("Fly list/individual machine inventories differ");
   }
+  let machineReleaseId = null;
   const normalizedMachines = listedIds.map((id, index) => {
     const listed = listedMachines.find((entry) => entry?.id === id);
     const machine = fly.machines.get(id).body;
@@ -577,10 +674,17 @@ function normalizeFlyBodies(fly, backendSource, observedAt) {
       || listedImageRef.repository !== imageRef.repository
       || listedImageRef.tag !== imageRef.tag
       || listedImageRef.digest !== imageRef.digest
-      || listed.config.image !== machine.config.image
-      || metadata?.fly_release_id !== release.id
-      || metadata?.fly_release_version !== String(release.version)) {
+      || listed.config.image !== machine.config.image) {
       throw new TypeError("Fly machine identity/state/image differs");
+    }
+    if (typeof metadata?.fly_release_id !== "string"
+      || !FLY_MACHINE_RELEASE_ID.test(metadata.fly_release_id)
+      || metadata.fly_release_version !== String(release.version)) {
+      throw new TypeError("Fly machine metadata differs from the latest release");
+    }
+    if (machineReleaseId === null) machineReleaseId = metadata.fly_release_id;
+    else if (metadata.fly_release_id !== machineReleaseId) {
+      throw new TypeError("Fly machine release metadata inventories differ");
     }
     return Object.freeze({
       slot: String(index + 1),
@@ -1503,6 +1607,7 @@ export function buildRobinhoodBackendPromotionFixture(stageBundle) {
     chainDeploymentId: CHAIN_DEPLOYMENT_ID,
     chainDeploymentDescriptorDigest:
       stageBundle.finalizedBindings.chainDeploymentDescriptorDigest,
+    providerProfileDigest: ROBINHOOD_PROVIDER_PROFILE_SHA256,
     migration: {
       path: BACKEND_MIGRATION_PATH,
       sha256: BACKEND_MIGRATION_SHA256,
@@ -1521,10 +1626,11 @@ export function buildRobinhoodBackendPromotionFixture(stageBundle) {
       profileRevision: binding.releaseIdentity.profile.profileRevision,
       profileVersion: binding.releaseIdentity.profile.profileVersion,
       profileDigest: binding.releaseIdentity.profile.profileDigest,
+      providerProfileDigest: ROBINHOOD_PROVIDER_PROFILE_SHA256,
     },
     providerQuorums: {
       robinhood: [
-        { providerId: "quicknode", trustDomain: "quicknode.com" },
+        { providerId: "drpc", trustDomain: "drpc.org" },
         { providerId: "alchemy", trustDomain: "alchemy.com" },
       ],
       ethereum: [
@@ -1562,7 +1668,7 @@ export function buildRobinhoodBackendPromotionFixture(stageBundle) {
             id: "release_123",
             version: 123,
             status: "complete",
-            stable: true,
+            stable: false,
             imageRef,
             image: {
               registry: "registry.fly.io",
@@ -1602,7 +1708,7 @@ export function buildRobinhoodBackendPromotionFixture(stageBundle) {
       readback("metadata:abcdef123456", ROBINHOOD_FLY_MACHINES_HOSTNAME,
         `/v1/apps/${ROBINHOOD_FLY_APP}/machines/abcdef123456/metadata`,
         "fly-api-token-redacted", {
-          fly_release_id: "release_123",
+          fly_release_id: "rel_abcdef123456",
           fly_release_version: "123",
         }, 5),
     ],
@@ -1627,10 +1733,7 @@ async function fetchRawReadback({
   const headers = { accept: "application/json" };
   if (method === "POST") headers["content-type"] = "application/json";
   if (authentication === "fly-api-token-redacted") {
-    if (typeof token !== "string" || token.length < 16 || /[\r\n]/u.test(token)) {
-      throw new TypeError("fresh Fly readback requires a non-empty protected API token");
-    }
-    headers.authorization = `Bearer ${token}`;
+    headers.authorization = normalizeFlyV1TokenWireV1(token, { requireScheme: true }).header;
   }
   const response = await fetchImpl(`https://${hostname}${requestPath}`, {
     method,
@@ -1692,13 +1795,12 @@ export async function freshVerifyRobinhoodBackendPromotionInput({
   now = () => new Date(),
 }) {
   if (typeof fetchImpl !== "function") throw new TypeError("fresh backend fetch is unavailable");
+  const flyAuthorization = normalizeFlyV1Authorization(flyApiToken).header;
   const captured = validateRobinhoodBackendPromotionPublicInput({
     input: capturedInput,
     stageBundle,
     now: () => new Date(capturedInput.observedAt),
   });
-  const observedAt = canonicalRobinhoodFreshObservedAt(now);
-  const backendInputObservedAt = observedAt.replace(".000Z", "Z");
   const responseBudget = createRobinhoodResponseBudget(BACKEND_FRESH_AGGREGATE_BYTES);
   const readinessReadback = await fetchRawReadback({
     kind: "readiness",
@@ -1715,7 +1817,7 @@ export async function freshVerifyRobinhoodBackendPromotionInput({
     hostname: ROBINHOOD_FLY_GRAPHQL_HOSTNAME,
     requestPath: "/graphql",
     authentication: "fly-api-token-redacted",
-    token: flyApiToken,
+    token: flyAuthorization,
     fetchImpl,
     method: "POST",
     requestBody: {
@@ -1730,7 +1832,7 @@ export async function freshVerifyRobinhoodBackendPromotionInput({
     hostname: ROBINHOOD_FLY_MACHINES_HOSTNAME,
     requestPath: `/v1/apps/${ROBINHOOD_FLY_APP}`,
     authentication: "fly-api-token-redacted",
-    token: flyApiToken,
+    token: flyAuthorization,
     fetchImpl,
     maximumResponseBytes: BACKEND_RESPONSE_BYTES.app,
     responseBudget,
@@ -1740,7 +1842,7 @@ export async function freshVerifyRobinhoodBackendPromotionInput({
     hostname: ROBINHOOD_FLY_MACHINES_HOSTNAME,
     requestPath: `/v1/apps/${ROBINHOOD_FLY_APP}/machines`,
     authentication: "fly-api-token-redacted",
-    token: flyApiToken,
+    token: flyAuthorization,
     fetchImpl,
     maximumResponseBytes: BACKEND_RESPONSE_BYTES["machine-list"],
     responseBudget,
@@ -1750,7 +1852,7 @@ export async function freshVerifyRobinhoodBackendPromotionInput({
     "fresh Fly machine list",
     BACKEND_RESPONSE_BYTES["machine-list"],
   ).value;
-  const listed = Array.isArray(listValue) ? listValue : listValue?.machines;
+  const listed = listValue;
   if (!Array.isArray(listed)) throw new TypeError("fresh Fly machine list is invalid");
   const machineIds = listed.map(({ id } = {}) => id).sort();
   if (machineIds.length < 1 || machineIds.length > 8
@@ -1765,7 +1867,7 @@ export async function freshVerifyRobinhoodBackendPromotionInput({
       hostname: ROBINHOOD_FLY_MACHINES_HOSTNAME,
       requestPath: `/v1/apps/${ROBINHOOD_FLY_APP}/machines/${machineId}`,
       authentication: "fly-api-token-redacted",
-      token: flyApiToken,
+      token: flyAuthorization,
       fetchImpl,
       maximumResponseBytes: BACKEND_RESPONSE_BYTES.machine,
       responseBudget,
@@ -1775,7 +1877,7 @@ export async function freshVerifyRobinhoodBackendPromotionInput({
       hostname: ROBINHOOD_FLY_MACHINES_HOSTNAME,
       requestPath: `/v1/apps/${ROBINHOOD_FLY_APP}/machines/${machineId}/metadata`,
       authentication: "fly-api-token-redacted",
-      token: flyApiToken,
+      token: flyAuthorization,
       fetchImpl,
       maximumResponseBytes: BACKEND_RESPONSE_BYTES.metadata,
       responseBudget,
@@ -1784,6 +1886,8 @@ export async function freshVerifyRobinhoodBackendPromotionInput({
       throw new TypeError("fresh Fly machine inventory ordering differs");
     }
   }
+  const observedAt = canonicalRobinhoodFreshObservedAt(now);
+  const backendInputObservedAt = observedAt.replace(".000Z", "Z");
   const freshInput = buildRobinhoodBackendPromotionInput({
     schemaVersion: ROBINHOOD_BACKEND_PROMOTION_INPUT_SCHEMA,
     captureId: createHash("sha256")

--- a/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
@@ -111,6 +111,9 @@ import {
 
 const repositoryRoot = path.resolve(fileURLToPath(new URL("../../../", import.meta.url)));
 const bindingPath = "docs/operations/releases/custom-launch-v4/cli-release-binding.json";
+const FLY_V1_TEST_TOKEN =
+  "fm2_AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=";
+const FLY_V1_TEST_HEADER = `FlyV1 ${FLY_V1_TEST_TOKEN}`;
 const sourcePaths = [
   "contracts/spec/robinhood-custom-launch/standard-json/ProgrammableCreate2GraphDeployerV1.standard-input.json",
   "contracts/spec/robinhood-custom-launch/standard-json/ProgrammableLaunchStampRouterV1.standard-input.json",
@@ -181,6 +184,39 @@ const PHASE_A_TRANSACTION_INDEX = "9";
 const PHASE_A_DEPLOYER = "0x2Bb333d48DFAF1596D9036671d2E43168994249E";
 const OWNER_CALLDATA_HASH =
   "0x3ba04469085b17e12843a94c154a335c9c384837f8f6531f179cb4915fd237d9";
+const BACKEND_MAIN_2CA9D297_COMPOSITION = Object.freeze({
+  authoritativeChainRuntime: true,
+  liveExactPrivyPolicyReadiness: true,
+  apiSignerObserverVerifierRoleAttestation: true,
+  durableLedger: true,
+  exactCredentialScopeRecheck: true,
+  isolatedImageDecoder: true,
+  dualProviderSimulation: true,
+  exactExternalContractVerifier: true,
+  permitDigestSigner: true,
+  durableFinalityWriter: true,
+  canonicalFinalitySubjectReader: true,
+  dualProviderSubmissionDiscovery: true,
+  finalityObserver: true,
+  finalityWorkerLifecycle: true,
+  sourceVerificationWorkerConfigured: true,
+  sourceVerificationWorkerStarted: true,
+  sourceVerificationWorkerLifecycle: true,
+});
+const BACKEND_MAIN_2CA9D297_PROVIDER_PROFILE_DIGEST =
+  "sha256:88daed906c2a142c57d2483099a6d18be31dbff2a282108657ec6f5e73f53132";
+const BACKEND_MAIN_2CA9D297_MIGRATION = Object.freeze({
+  path: "migrations/0024_custom_launch_source_authority_v4.sql",
+  sha256: "sha256:51efb50f6f59131042d4253ce485cf14c3d375ab639d8c7075eb22dc8a9d44a0",
+});
+const BACKEND_MAIN_2CA9D297_API_CONTRACT = Object.freeze({
+  path: "release/custom-launch-api-contract.v4.json",
+  sha256: "sha256:1c22711fa0516507d1e207ee7cb565d9ec95f59e042d869c0052a98a57d73634",
+});
+const BACKEND_MAIN_2CA9D297_ROBINHOOD_PROVIDER_QUORUM = Object.freeze([
+  Object.freeze({ providerId: "drpc", trustDomain: "drpc.org" }),
+  Object.freeze({ providerId: "alchemy", trustDomain: "alchemy.com" }),
+]);
 const ROUTER_READ_ABI = [
   { type: "function", name: "PERMIT_AUTHORITY", stateMutability: "view", inputs: [], outputs: [{ type: "address" }] },
   { type: "function", name: "PERMIT_AUTHORITY_RUNTIME_CODE_HASH", stateMutability: "view", inputs: [], outputs: [{ type: "bytes32" }] },
@@ -1357,7 +1393,7 @@ test("backend raw promotion input rejects fake summaries, ref swaps, and incompl
       input: failedLatestInput,
       stageBundle: stage,
       now: baseline.dependencies.now,
-    }), /absolute latest release is not complete and stable/u);
+    }), /latest Fly release is not complete/u);
 
     assert.throws(() => validateRobinhoodBackendPromotionInput({
       input: baseline.privateInput,
@@ -1441,6 +1477,255 @@ test("backend raw promotion input rejects fake summaries, ref swaps, and incompl
   }
 });
 
+test("backend promotion accepts the exact main@2ca9d297 release identity and rejects drift", async () => {
+  const fixture = await fixtureRepository();
+  try {
+    const built = await buildInput(fixture);
+    const stage = await materialize(fixture, built);
+    const candidate = structuredClone(buildRobinhoodBackendPromotionFixture(stage));
+    const readiness = responseBody(candidate.readinessReadback);
+    readiness.providerProfileDigest = BACKEND_MAIN_2CA9D297_PROVIDER_PROFILE_DIGEST;
+    readiness.migration = structuredClone(BACKEND_MAIN_2CA9D297_MIGRATION);
+    readiness.apiContract = structuredClone(BACKEND_MAIN_2CA9D297_API_CONTRACT);
+    readiness.profile.providerProfileDigest = BACKEND_MAIN_2CA9D297_PROVIDER_PROFILE_DIGEST;
+    readiness.providerQuorums.robinhood =
+      structuredClone(BACKEND_MAIN_2CA9D297_ROBINHOOD_PROVIDER_QUORUM);
+    readiness.composition = structuredClone(BACKEND_MAIN_2CA9D297_COMPOSITION);
+    replaceResponseBody(candidate.readinessReadback, readiness);
+    const privateInput = buildRobinhoodBackendPromotionInput(candidate);
+    const privateInputBytes = Buffer.from(`${JSON.stringify(privateInput, null, 2)}\n`, "utf8");
+    const publicInput = buildRobinhoodBackendPromotionPublicInputFromPrivate({
+      privateInput,
+      privateInputBytes,
+      stageBundle: stage,
+      now: () => new Date("2026-08-29T12:01:00Z"),
+    });
+    const validated = validateRobinhoodBackendPromotionPublicInput({
+      input: publicInput,
+      stageBundle: stage,
+      now: () => new Date("2026-08-29T12:01:00Z"),
+    });
+    assert.deepEqual(
+      validated.releaseIdentity.composition,
+      BACKEND_MAIN_2CA9D297_COMPOSITION,
+    );
+    const validateBackend = postdeploymentAjv.getSchema(
+      "https://programmable.market/schemas/releases/custom-launch-v4/backend-promotion-public-input.schema.json",
+    );
+    assert.equal(validateBackend(publicInput), true, JSON.stringify(validateBackend.errors));
+
+    for (const [label, expectedError, mutate] of [
+      [
+        "missing capability",
+        /must contain exactly/u,
+        (composition) => { delete composition.sourceVerificationWorkerLifecycle; },
+      ],
+      [
+        "legacy renamed capability",
+        /must contain exactly/u,
+        (composition) => {
+          delete composition.apiSignerObserverVerifierRoleAttestation;
+          composition.apiSignerObserverRoleAttestation = true;
+        },
+      ],
+      [
+        "extra capability",
+        /must contain exactly/u,
+        (composition) => { composition.unreviewedCapability = true; },
+      ],
+      [
+        "false capability",
+        /production composition is incomplete/u,
+        (composition) => { composition.sourceVerificationWorkerStarted = false; },
+      ],
+    ]) {
+      const driftedPrivate = structuredClone(privateInput);
+      const driftedReadiness = responseBody(driftedPrivate.readinessReadback);
+      mutate(driftedReadiness.composition);
+      replaceResponseBody(driftedPrivate.readinessReadback, driftedReadiness);
+      const sealedPrivate = buildRobinhoodBackendPromotionInput(driftedPrivate);
+      assert.throws(() => validateRobinhoodBackendPromotionInput({
+        input: sealedPrivate,
+        stageBundle: stage,
+        now: () => new Date("2026-08-29T12:01:00Z"),
+      }), expectedError, `${label} raw readiness`);
+
+      const drifted = structuredClone(publicInput);
+      mutate(drifted.runtimeReadiness.releaseIdentity.composition);
+      const sealed = buildRobinhoodBackendPromotionPublicInput(drifted);
+      assert.throws(() => validateRobinhoodBackendPromotionPublicInput({
+        input: sealed,
+        stageBundle: stage,
+        now: () => new Date("2026-08-29T12:01:00Z"),
+      }), expectedError, label);
+      assert.equal(validateBackend(sealed), false, `${label} must fail the public schema`);
+    }
+
+    for (const [label, expectedError, schemaMustReject, mutate] of [
+      [
+        "missing provider-profile binding",
+        /must contain exactly/u,
+        true,
+        (identity) => { delete identity.providerProfileDigest; },
+      ],
+      [
+        "split provider-profile binding",
+        /profile differs|source\/deployment identity differs/u,
+        true,
+        (identity) => { identity.profile.providerProfileDigest = `sha256:${"f".repeat(64)}`; },
+      ],
+      [
+        "legacy Robinhood provider quorum",
+        /provider quorums differ/u,
+        true,
+        (identity) => {
+          identity.providerQuorums.robinhood[0] = {
+            providerId: "quicknode",
+            trustDomain: "quicknode.com",
+          };
+        },
+      ],
+      [
+        "legacy migration",
+        /artifact bindings are invalid/u,
+        true,
+        (identity) => {
+          identity.migration = {
+            path: "migrations/0017_chain_aware_custom_launch_v4.sql",
+            sha256: `sha256:${"2".repeat(64)}`,
+          };
+        },
+      ],
+      [
+        "unreviewed API contract bytes",
+        /artifact bindings are invalid/u,
+        false,
+        (identity) => { identity.apiContract.sha256 = `sha256:${"3".repeat(64)}`; },
+      ],
+    ]) {
+      const driftedPrivate = structuredClone(privateInput);
+      const driftedReadiness = responseBody(driftedPrivate.readinessReadback);
+      mutate(driftedReadiness);
+      replaceResponseBody(driftedPrivate.readinessReadback, driftedReadiness);
+      const sealedPrivate = buildRobinhoodBackendPromotionInput(driftedPrivate);
+      assert.throws(() => validateRobinhoodBackendPromotionInput({
+        input: sealedPrivate,
+        stageBundle: stage,
+        now: () => new Date("2026-08-29T12:01:00Z"),
+      }), expectedError, `${label} raw readiness`);
+
+      const drifted = structuredClone(publicInput);
+      mutate(drifted.runtimeReadiness.releaseIdentity);
+      const sealed = buildRobinhoodBackendPromotionPublicInput(drifted);
+      assert.throws(() => validateRobinhoodBackendPromotionPublicInput({
+        input: sealed,
+        stageBundle: stage,
+        now: () => new Date("2026-08-29T12:01:00Z"),
+      }), expectedError, label);
+      if (schemaMustReject) {
+        assert.equal(validateBackend(sealed), false, `${label} must fail the public schema`);
+      }
+    }
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("backend promotion mirrors complete Machines-backed Fly release semantics", async () => {
+  const fixture = await fixtureRepository();
+  try {
+    const built = await buildInput(fixture);
+    const stage = await materialize(fixture, built);
+    const candidate = structuredClone(buildRobinhoodBackendPromotionFixture(stage));
+    const releaseResponse = responseBody(candidate.flyReadbacks[0]);
+    releaseResponse.data.app.releasesUnprocessed.nodes[0].stable = false;
+    replaceResponseBody(candidate.flyReadbacks[0], releaseResponse);
+    const machineReleaseId = "rel_abcdef123456";
+    const firstMetadata = responseBody(candidate.flyReadbacks[4]);
+    firstMetadata.fly_release_id = machineReleaseId;
+    replaceResponseBody(candidate.flyReadbacks[4], firstMetadata);
+    addBackendFixtureMachine(candidate, {
+      machineId: "bcdefa123456",
+      machineReleaseId,
+    });
+    const privateInput = buildRobinhoodBackendPromotionInput(candidate);
+    const privateInputBytes = Buffer.from(`${JSON.stringify(privateInput, null, 2)}\n`, "utf8");
+    const publicInput = buildRobinhoodBackendPromotionPublicInputFromPrivate({
+      privateInput,
+      privateInputBytes,
+      stageBundle: stage,
+      now: () => new Date("2026-08-29T12:01:00Z"),
+    });
+    const validated = validateRobinhoodBackendPromotionPublicInput({
+      input: publicInput,
+      stageBundle: stage,
+      now: () => new Date("2026-08-29T12:01:00Z"),
+    });
+    assert.equal(validated.backendReleaseEvidence.flyControlPlane.machines.length, 2);
+    const fresh = await freshVerifyRobinhoodBackendPromotionInput({
+      stageBundle: stage,
+      capturedInput: publicInput,
+      fetch: freshBackendFetch(privateInput),
+      flyApiToken: FLY_V1_TEST_TOKEN,
+      now: () => new Date("2026-08-29T12:01:00Z"),
+    });
+    assert.equal(fresh.observedAt, "2026-08-29T12:01:00.000Z");
+
+    const rejectPrivateMutation = (label, expectedError, mutate) => {
+      const drifted = structuredClone(privateInput);
+      mutate(drifted);
+      const sealed = buildRobinhoodBackendPromotionInput(drifted);
+      assert.throws(() => validateRobinhoodBackendPromotionInput({
+        input: sealed,
+        stageBundle: stage,
+        now: () => new Date("2026-08-29T12:01:00Z"),
+      }), expectedError, label);
+    };
+    rejectPrivateMutation("stable type", /release identities\/versions/u, (drifted) => {
+      const releases = responseBody(drifted.flyReadbacks[0]);
+      releases.data.app.releasesUnprocessed.nodes[0].stable = "false";
+      replaceResponseBody(drifted.flyReadbacks[0], releases);
+    });
+    rejectPrivateMutation("incomplete latest release", /latest Fly release is not complete/u,
+      (drifted) => {
+        const releases = responseBody(drifted.flyReadbacks[0]);
+        releases.data.app.releasesUnprocessed.nodes[0].status = "pending";
+        replaceResponseBody(drifted.flyReadbacks[0], releases);
+      });
+    rejectPrivateMutation("paginated release inventory", /paginated or incomplete/u, (drifted) => {
+      const releases = responseBody(drifted.flyReadbacks[0]);
+      releases.data.app.releasesUnprocessed.pageInfo.hasPreviousPage = true;
+      replaceResponseBody(drifted.flyReadbacks[0], releases);
+    });
+    rejectPrivateMutation("stale latest release", /latest Fly release is stale/u, (drifted) => {
+      const releases = responseBody(drifted.flyReadbacks[0]);
+      releases.data.app.releasesUnprocessed.nodes[0].createdAt = "2026-08-28T11:00:00Z";
+      replaceResponseBody(drifted.flyReadbacks[0], releases);
+    });
+    rejectPrivateMutation("wrapped machine list", /machine inventory/u, (drifted) => {
+      const machines = responseBody(drifted.flyReadbacks[2]);
+      replaceResponseBody(drifted.flyReadbacks[2], { machines });
+    });
+    rejectPrivateMutation("non-Machines release id", /metadata differs/u, (drifted) => {
+      const metadata = responseBody(drifted.flyReadbacks[4]);
+      metadata.fly_release_id = "release_123";
+      replaceResponseBody(drifted.flyReadbacks[4], metadata);
+    });
+    rejectPrivateMutation("split Machines release ids", /metadata inventories differ/u, (drifted) => {
+      const metadata = responseBody(drifted.flyReadbacks[6]);
+      metadata.fly_release_id = "rel_bcdefa123456";
+      replaceResponseBody(drifted.flyReadbacks[6], metadata);
+    });
+    rejectPrivateMutation("Machines release version drift", /metadata differs/u, (drifted) => {
+      const metadata = responseBody(drifted.flyReadbacks[6]);
+      metadata.fly_release_version = "124";
+      replaceResponseBody(drifted.flyReadbacks[6], metadata);
+    });
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("fresh backend replay re-reads the full readiness and Fly inventory", async () => {
   const fixture = await fixtureRepository();
   try {
@@ -1453,7 +1738,7 @@ test("fresh backend replay re-reads the full readiness and Fly inventory", async
       fetch: freshBackendFetch(backend.privateInput, {
         responseDate: "Sat, 29 Aug 2026 18:00:00 GMT",
       }),
-      flyApiToken: "protected-test-token-value",
+      flyApiToken: FLY_V1_TEST_TOKEN,
       now: () => new Date("2026-08-29T18:00:00Z"),
     });
     assert.equal(fresh.observedAt, "2026-08-29T18:00:00.000Z");
@@ -1465,7 +1750,7 @@ test("fresh backend replay re-reads the full readiness and Fly inventory", async
         privateCanaries: true,
         responseDate: "Sat, 29 Aug 2026 18:00:00 GMT",
       }),
-      flyApiToken: "protected-test-token-value",
+      flyApiToken: FLY_V1_TEST_TOKEN,
       now: () => new Date("2026-08-29T18:00:00Z"),
     });
     assert.equal(
@@ -1474,14 +1759,20 @@ test("fresh backend replay re-reads the full readiness and Fly inventory", async
       "fresh backend output must expose the semantic public digest, never the raw-private digest",
     );
     assert.equal(privateCanary.freshBackendReadbackDigest, fresh.freshBackendReadbackDigest);
+    let replayClock = new Date("2026-08-29T18:00:00Z");
+    const laterFetch = freshBackendFetch(backend.privateInput, {
+      responseDate: "Sat, 29 Aug 2026 18:01:00 GMT",
+    });
     const later = await freshVerifyRobinhoodBackendPromotionInput({
       stageBundle: stage,
       capturedInput: backend.input,
-      fetch: freshBackendFetch(backend.privateInput, {
-        responseDate: "Sat, 29 Aug 2026 18:01:00 GMT",
-      }),
-      flyApiToken: "protected-test-token-value",
-      now: () => new Date("2026-08-29T18:01:00Z"),
+      fetch: async (...args) => {
+        const response = await laterFetch(...args);
+        replayClock = new Date("2026-08-29T18:01:00Z");
+        return response;
+      },
+      flyApiToken: FLY_V1_TEST_TOKEN,
+      now: () => replayClock,
     });
     assert.equal(later.observedAt, "2026-08-29T18:01:00.000Z");
     assert.notEqual(
@@ -1496,9 +1787,45 @@ test("fresh backend replay re-reads the full readiness and Fly inventory", async
         driftMachineImage: true,
         responseDate: "Sat, 29 Aug 2026 18:00:00 GMT",
       }),
-      flyApiToken: "protected-test-token-value",
+      flyApiToken: FLY_V1_TEST_TOKEN,
       now: () => new Date("2026-08-29T18:00:00Z"),
     }), /machine identity|fresh backend\/Fly readback differs/u);
+
+    const schemed = await freshVerifyRobinhoodBackendPromotionInput({
+      stageBundle: stage,
+      capturedInput: backend.input,
+      fetch: freshBackendFetch(backend.privateInput, {
+        responseDate: "Sat, 29 Aug 2026 18:00:00 GMT",
+      }),
+      flyApiToken: FLY_V1_TEST_HEADER,
+      now: () => new Date("2026-08-29T18:00:00Z"),
+    });
+    assert.equal(schemed.freshBackendReadbackDigest, fresh.freshBackendReadbackDigest);
+
+    const oversizedFlyV1Token =
+      `fm2_${Buffer.alloc(12_288, 1).toString("base64")}`;
+    for (const invalidToken of [
+      `Bearer ${FLY_V1_TEST_TOKEN}`,
+      "fm2_short",
+      oversizedFlyV1Token,
+    ]) {
+      let fetchCalls = 0;
+      await assert.rejects(() => freshVerifyRobinhoodBackendPromotionInput({
+        stageBundle: stage,
+        capturedInput: backend.input,
+        fetch: async () => {
+          fetchCalls += 1;
+          throw new Error("invalid Fly token reached the network");
+        },
+        flyApiToken: invalidToken,
+        now: () => new Date("2026-08-29T18:00:00Z"),
+      }), (error) => {
+        assert.equal(error.message, "FLY_V1_TOKEN_WIRE_INVALID");
+        assert.doesNotMatch(error.message, /fm2_|Bearer/u);
+        return true;
+      });
+      assert.equal(fetchCalls, 0, "an invalid Fly token must fail before any network request");
+    }
   } finally {
     await rm(fixture.root, { recursive: true, force: true });
   }
@@ -3286,6 +3613,53 @@ function replaceResponseBody(readback, value) {
   readback.response.bodySha256 = sha256Digest(bytes);
 }
 
+function replaceReadbackPathAndKind(readback, { kind, requestPath, requestId }) {
+  const requestBodyBytes = Buffer.from(readback.request.bodyBytesBase64, "base64");
+  const requestBytes = Buffer.from(
+    `${readback.request.method} https://${readback.request.hostname}${requestPath}\n`
+      + `accept: ${readback.request.accept}\n`
+      + `content-type: ${readback.request.contentType ?? "none"}\n`
+      + `authentication: ${readback.request.authentication}\n\n`
+      + requestBodyBytes.toString("utf8"),
+    "utf8",
+  );
+  readback.kind = kind;
+  readback.request.path = requestPath;
+  readback.request.sanitizedBytesBase64 = requestBytes.toString("base64");
+  readback.request.byteLength = String(requestBytes.byteLength);
+  readback.request.sha256 = sha256Digest(requestBytes);
+  readback.response.requestId = requestId;
+}
+
+function addBackendFixtureMachine(input, { machineId, machineReleaseId }) {
+  const listedMachines = responseBody(input.flyReadbacks[2]);
+  const listedMachine = structuredClone(listedMachines[0]);
+  listedMachine.id = machineId;
+  listedMachines.push(listedMachine);
+  replaceResponseBody(input.flyReadbacks[2], listedMachines);
+
+  const machineReadback = structuredClone(input.flyReadbacks[3]);
+  const machine = responseBody(machineReadback);
+  machine.id = machineId;
+  replaceResponseBody(machineReadback, machine);
+  replaceReadbackPathAndKind(machineReadback, {
+    kind: `machine:${machineId}`,
+    requestPath: `/v1/apps/programmable-custom-launch-api/machines/${machineId}`,
+    requestId: `fixture-machine-${machineId}`,
+  });
+
+  const metadataReadback = structuredClone(input.flyReadbacks[4]);
+  const metadata = responseBody(metadataReadback);
+  metadata.fly_release_id = machineReleaseId;
+  replaceResponseBody(metadataReadback, metadata);
+  replaceReadbackPathAndKind(metadataReadback, {
+    kind: `metadata:${machineId}`,
+    requestPath: `/v1/apps/programmable-custom-launch-api/machines/${machineId}/metadata`,
+    requestId: `fixture-metadata-${machineId}`,
+  });
+  input.flyReadbacks.push(machineReadback, metadataReadback);
+}
+
 function freshBackendFetch(input, {
   driftMachineImage = false,
   privateCanaries = false,
@@ -3304,7 +3678,7 @@ function freshBackendFetch(input, {
     if (readback === undefined) throw new Error(`unexpected fresh backend URL ${url}`);
     assert.equal(init.redirect, "error");
     if (readback.request.authentication === "fly-api-token-redacted") {
-      assert.equal(init.headers.authorization, "Bearer protected-test-token-value");
+      assert.equal(init.headers.authorization, FLY_V1_TEST_HEADER);
     } else {
       assert.equal(init.headers.authorization, undefined);
     }

--- a/docs/operations/releases/custom-launch-v4/backend-promotion-public-input.schema.json
+++ b/docs/operations/releases/custom-launch-v4/backend-promotion-public-input.schema.json
@@ -227,7 +227,8 @@
         "businessProfileId",
         "profileRevision",
         "profileVersion",
-        "profileDigest"
+        "profileDigest",
+        "providerProfileDigest"
       ],
       "properties": {
         "structuralProfileId": {
@@ -238,6 +239,9 @@
         "profileVersion": { "const": "4.0.0" },
         "profileDigest": {
           "const": "sha256:484b1dc6e9091804fabc230f2b3a7504940fa00264f8e66e82a66a951e71f1a0"
+        },
+        "providerProfileDigest": {
+          "const": "sha256:88daed906c2a142c57d2483099a6d18be31dbff2a282108657ec6f5e73f53132"
         }
       }
     },
@@ -249,7 +253,7 @@
         "robinhood": {
           "type": "array",
           "prefixItems": [
-            { "const": { "providerId": "quicknode", "trustDomain": "quicknode.com" } },
+            { "const": { "providerId": "drpc", "trustDomain": "drpc.org" } },
             { "const": { "providerId": "alchemy", "trustDomain": "alchemy.com" } }
           ],
           "items": false,
@@ -273,7 +277,8 @@
       "additionalProperties": false,
       "required": [
         "authoritativeChainRuntime",
-        "apiSignerObserverRoleAttestation",
+        "liveExactPrivyPolicyReadiness",
+        "apiSignerObserverVerifierRoleAttestation",
         "durableLedger",
         "exactCredentialScopeRecheck",
         "isolatedImageDecoder",
@@ -284,11 +289,15 @@
         "canonicalFinalitySubjectReader",
         "dualProviderSubmissionDiscovery",
         "finalityObserver",
-        "finalityWorkerLifecycle"
+        "finalityWorkerLifecycle",
+        "sourceVerificationWorkerConfigured",
+        "sourceVerificationWorkerStarted",
+        "sourceVerificationWorkerLifecycle"
       ],
       "properties": {
         "authoritativeChainRuntime": { "const": true },
-        "apiSignerObserverRoleAttestation": { "const": true },
+        "liveExactPrivyPolicyReadiness": { "const": true },
+        "apiSignerObserverVerifierRoleAttestation": { "const": true },
         "durableLedger": { "const": true },
         "exactCredentialScopeRecheck": { "const": true },
         "isolatedImageDecoder": { "const": true },
@@ -299,7 +308,10 @@
         "canonicalFinalitySubjectReader": { "const": true },
         "dualProviderSubmissionDiscovery": { "const": true },
         "finalityObserver": { "const": true },
-        "finalityWorkerLifecycle": { "const": true }
+        "finalityWorkerLifecycle": { "const": true },
+        "sourceVerificationWorkerConfigured": { "const": true },
+        "sourceVerificationWorkerStarted": { "const": true },
+        "sourceVerificationWorkerLifecycle": { "const": true }
       }
     },
     "releaseIdentity": {
@@ -314,6 +326,7 @@
         "chainId",
         "chainDeploymentId",
         "chainDeploymentDescriptorDigest",
+        "providerProfileDigest",
         "migration",
         "apiContract",
         "openApiSha256",
@@ -335,6 +348,9 @@
         "chainId": { "const": "4663" },
         "chainDeploymentId": { "const": "robinhood-mainnet-custom-launch-v1" },
         "chainDeploymentDescriptorDigest": { "$ref": "#/$defs/hex32" },
+        "providerProfileDigest": {
+          "const": "sha256:88daed906c2a142c57d2483099a6d18be31dbff2a282108657ec6f5e73f53132"
+        },
         "migration": {
           "allOf": [
             { "$ref": "#/$defs/artifactBinding" },
@@ -342,7 +358,7 @@
               "type": "object",
               "properties": {
                 "path": {
-                  "const": "migrations/0017_chain_aware_custom_launch_v4.sql"
+                  "const": "migrations/0024_custom_launch_source_authority_v4.sql"
                 }
               }
             }

--- a/scripts/programmable-launch-v4-release-binding.mjs
+++ b/scripts/programmable-launch-v4-release-binding.mjs
@@ -862,7 +862,7 @@ function auditBackend(value, deployment) {
   required(value.backendPromotionInputDigest, SHA256, "backend raw promotion input digest");
   artifactDigest(value.apiContract, "release/custom-launch-api-contract.v4.json",
     "backend API contract");
-  if (value.migration?.path !== "migrations/0017_chain_aware_custom_launch_v4.sql") {
+  if (value.migration?.path !== "migrations/0024_custom_launch_source_authority_v4.sql") {
     throw new Error("backend final migration path is invalid");
   }
   artifactDigest(value.migration, value.migration.path, "backend final migration");

--- a/scripts/test/programmable-launch-v4-release-binding.test.mjs
+++ b/scripts/test/programmable-launch-v4-release-binding.test.mjs
@@ -637,7 +637,7 @@ async function addCompleteEvidence(root, binding) {
       sha256: `sha256:${"1".repeat(64)}`,
     },
     migration: {
-      path: "migrations/0017_chain_aware_custom_launch_v4.sql",
+      path: "migrations/0024_custom_launch_source_authority_v4.sql",
       sha256: `sha256:${"2".repeat(64)}`,
     },
     openApiSha256: binding.machineContracts.find(({ name }) => name === "openapi").sha256,


### PR DESCRIPTION
## Outcome

Aligns the public Phase B backend-promotion consumer with the immutable backend `main` release at `2ca9d297a4127a0091deed0cd8e39a0c1a18a8f9` before a fresh Phase A capture is produced.

## Contract alignment

- requires the exact 17 backend composition capabilities and the exact provider-profile digest
- binds migration `0024_custom_launch_source_authority_v4.sql`, the current API-contract digest, and Robinhood dRPC + Alchemy quorum
- mirrors Fly Machines completion semantics: latest GraphQL release must be `complete`, while `stable:false` remains valid when the complete fleet binds exact version and image
- requires one common Machines `rel_*` release ID without falsely equating it to the distinct GraphQL release ID
- closes GraphQL key, pagination, cursor, timestamp, age, image, and array-only machine-inventory gaps
- canonicalizes raw or already-schemed protected Fly tokens to `Authorization: FlyV1 ...` and rejects malformed, Bearer, control-character, or oversized values before network access
- anchors fresh `observedAt` after all live reads, matching the backend producer

## Validation

- exact five-file diff SHA-256: `1475baf868e1509b852a98465d09ee72b86d11345a866881d40b96ca415b5238`
- `npm run release:custom-launch:v4:test` (54/54)
- focused independent review tests (38/38)
- `actionlint`, syntax/JSON checks, ESLint with 0 errors, and `git diff --check`
- independent exact-backend security/compatibility review: CLEAR, no P0/P1/P2

The tested diff was transplanted byte-identically onto protected-production commit `5be2782a63f31e95c5b20c7ea9725913337ba9ad`; the hosted required checks now provide the post-transplant verification.

Base: `5be2782a63f31e95c5b20c7ea9725913337ba9ad`
Head: `6d4e470d4dcffd288e610e39bf14192b3700f893`

This PR does not modify Phase A evidence, dispatch capture, deploy the backend, or publish release state.