### PR TITLE
docs: make Robinhood terminal indexer guide publicly reachable

### DIFF
--- a/app/developer-reference/robinhood-terminal-indexer/page.tsx
+++ b/app/developer-reference/robinhood-terminal-indexer/page.tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  metadata,
+} from "@/app/docs/developers/robinhood-terminal-indexer/page";

--- a/app/docs/developers/robinhood-terminal-indexer/page.tsx
+++ b/app/docs/developers/robinhood-terminal-indexer/page.tsx
@@ -21,8 +21,7 @@ const CAPABILITIES_URL = `${API_ORIGIN}/v4/chains/4663/capabilities`;
 const READINESS_URL = `${API_ORIGIN}/v4/chains/4663/readiness`;
 const FINALIZED_FEED_URL = `${API_ORIGIN}/v4/chains/4663/finalized-custom-launches`;
 const OPENAPI_URL = "/openapi/custom-launch-v4.json";
-const ABI_URL =
-  "/contracts/robinhood/ProgrammableLaunchStampRouterV1.abi.json";
+const ABI_URL = "/contracts/robinhood/ProgrammableLaunchStampRouterV1.abi.json";
 const FIXTURE_URL = "/fixtures/robinhood-terminal-indexer-v1.json";
 
 const ROUTER = "0x34965F2A2ee9254522232C32F02056E92BE0C98a";
@@ -56,8 +55,7 @@ const events = [
   },
   {
     name: "ProgrammableComponentStampedV1",
-    signature:
-      "ProgrammableComponentStampedV1(bytes32,address,uint8,bytes32)",
+    signature: "ProgrammableComponentStampedV1(bytes32,address,uint8,bytes32)",
     topic0:
       "0x8147265e7396d6400cee8d049456a1f7438fdfbe2a7c81c976d51ba67e52ff4b",
     indexed: "launchId, component, kind",
@@ -293,11 +291,11 @@ export default function RobinhoodTerminalIndexerPage() {
         <div className={styles.sectionIntro}>
           <h2>Resolve activation from the live authority</h2>
           <p>
-            This contract targets public self-serve Robinhood Custom launches.
-            The Router and backend are deployed and ready. At this source
-            snapshot, public activation is{" "}
-            <code>pending-public-discovery-promotion</code>. Documentation and a
-            reachable route do not prove that production writes are active.
+            This contract covers public self-serve Robinhood Custom launches.
+            Resolve current availability from the live discovery and readiness
+            authorities before every create or ingestion session. Documentation
+            and a reachable route do not prove that production writes are
+            active.
           </p>
         </div>
 
@@ -314,9 +312,10 @@ export default function RobinhoodTerminalIndexerPage() {
             <dd>Public self-serve, with separate controller-wallet review</dd>
           </div>
           <div>
-            <dt>Public activation at this source snapshot</dt>
+            <dt>Public activation authority</dt>
             <dd>
-              <code>pending-public-discovery-promotion</code>
+              Live discovery <code>customLaunchApi.versions.v4</code> plus the
+              chain-bound readiness response
             </dd>
           </div>
           <div>
@@ -330,22 +329,24 @@ export default function RobinhoodTerminalIndexerPage() {
           <div>
             <dt>Indexer read path</dt>
             <dd>
-              Route and contract prepared; no public item is claimed until live
-              feed, finality and authoritative exact-source eligibility verify
+              Require a schema-valid feed response with{" "}
+              <code>quality.status: ready</code>; verify finality and
+              authoritative exact-source eligibility independently for every
+              item
             </dd>
           </div>
           <div>
-            <dt>Current public-item evidence</dt>
+            <dt>Public-item authority</dt>
             <dd>
-              No per-launch protected exact-source composite is yet proven and
-              persisted for public promotion at this source snapshot
+              The live finalized feed only, followed by the Router, finality and
+              exact-source verification steps in this guide
             </dd>
           </div>
           <div>
-            <dt>Clean-room release binding</dt>
+            <dt>Release binding</dt>
             <dd>
-              <code>V4_RELEASE_BINDING_NOT_READY</code> until the changed
-              OpenAPI bytes are closed into refreshed release hashes
+              Require the source commit, source tree, policy and deployment
+              evidence returned by the live readiness authority
             </dd>
           </div>
           <div>
@@ -364,10 +365,10 @@ export default function RobinhoodTerminalIndexerPage() {
           <div>
             <dt>Fixture feed example</dt>
             <dd>
-              <code>0</code> eligible V3-finalized, authoritatively source-verified
-              candidates / <code>0</code> published / <code>0</code> quarantined.
-              This is a schema-valid parser vector, not a production observation.
-              Always fetch the live feed.
+              <code>0</code> eligible V3-finalized, authoritatively
+              source-verified candidates / <code>0</code> published /{" "}
+              <code>0</code> quarantined. This is a schema-valid parser vector,
+              not a production observation. Always fetch the live feed.
             </dd>
           </div>
         </dl>
@@ -385,16 +386,17 @@ export default function RobinhoodTerminalIndexerPage() {
         </aside>
 
         <aside className={styles.callout}>
-          <strong>This is not a provider-outage claim</strong>
+          <strong>Source-verification authority</strong>
           <p>
-            Sourcify&apos;s provider-native match is a non-authoritative observation
-            with <code>releaseAuthority: false</code>. Public finalized eligibility
-            additionally requires a protected source closure, reproducible hosted
-            build and compiler settings, finalized creation transaction, and exact
-            creation/runtime bytecode binding for every launch component. Robinhood
-            Blockscout is optional and cannot satisfy or block that authority or
-            revise finality. Until that per-launch evidence is captured, persisted
-            and promoted, do not infer a public feed item.
+            Sourcify&apos;s provider-native match is a non-authoritative
+            observation with <code>releaseAuthority: false</code>. Public
+            finalized eligibility additionally requires a protected source
+            closure, reproducible hosted build and compiler settings, finalized
+            creation transaction, and exact creation/runtime bytecode binding
+            for every launch component. Robinhood Blockscout is optional and
+            cannot satisfy or block that authority or revise finality. Until
+            that per-launch evidence is captured, persisted and promoted, do not
+            infer a public feed item.
           </p>
         </aside>
       </section>
@@ -403,10 +405,10 @@ export default function RobinhoodTerminalIndexerPage() {
         <div className={styles.sectionIntro}>
           <h2>Use one chain-bound identity and label</h2>
           <p>
-            Require the server-authored <code>platformId: programmable</code> and{" "}
-            <code>category: custom</code>, then independently verify their Router
-            launch kind <code>1</code> binding. Names, symbols, factories and hook
-            addresses are not provenance by themselves.
+            Require the server-authored <code>platformId: programmable</code>{" "}
+            and <code>category: custom</code>, then independently verify their
+            Router launch kind <code>1</code> binding. Names, symbols, factories
+            and hook addresses are not provenance by themselves.
           </p>
         </div>
 
@@ -436,9 +438,7 @@ export default function RobinhoodTerminalIndexerPage() {
           <div>
             <dt>Durable key</dt>
             <dd className={styles.breakableValue}>
-              <code>
-                (eip155:4663, Router address, onchain.routerLaunchId)
-              </code>
+              <code>(eip155:4663, Router address, onchain.routerLaunchId)</code>
             </dd>
           </div>
         </dl>
@@ -544,15 +544,15 @@ export default function RobinhoodTerminalIndexerPage() {
         <p className={styles.bodyCopy}>
           Download the <a href={ABI_URL}>complete Router ABI</a> and hash its
           exact served bytes before decoding. The hosted-file digest covers
-          exact bytes. The profile digest hashes one compact{" "}
-          <code>jq -cS</code> serialization plus its trailing LF; the two
-          digests are intentionally not interchangeable. The fixture records
-          both. At <code>onchain.l2Inclusion.blockNumber</code>, also
-          match the Router runtime and immutable <code>CHAIN_ID</code>, permit
-          authority, Graph Factory and PoolManager getters to the live
-          capabilities document. Confirm the L2 receipt block hash and event
-          positions first. Do not use the deprecated flat checkpoint projection
-          for these chain-4663 reads.
+          exact bytes. The profile digest hashes one compact <code>jq -cS</code>{" "}
+          serialization plus its trailing LF; the two digests are intentionally
+          not interchangeable. The fixture records both. At{" "}
+          <code>onchain.l2Inclusion.blockNumber</code>, also match the Router
+          runtime and immutable <code>CHAIN_ID</code>, permit authority, Graph
+          Factory and PoolManager getters to the live capabilities document.
+          Confirm the L2 receipt block hash and event positions first. Do not
+          use the deprecated flat checkpoint projection for these chain-4663
+          reads.
         </p>
       </section>
 
@@ -633,12 +633,15 @@ export default function RobinhoodTerminalIndexerPage() {
           <li>
             <a href={WELL_KNOWN_URL}>Public release and activation discovery</a>
             <span>
-              Resolve the current V4 write and authorization gates before create.
+              Resolve the current V4 write and authorization gates before
+              create.
             </span>
           </li>
           <li>
             <a href={CAPABILITIES_URL}>Capabilities and chain bindings</a>
-            <span>Resolve routes, contracts, profile and current safety flags.</span>
+            <span>
+              Resolve routes, contracts, profile and current safety flags.
+            </span>
           </li>
           <li>
             <a href={READINESS_URL}>Runtime release identity</a>
@@ -654,7 +657,9 @@ export default function RobinhoodTerminalIndexerPage() {
           </li>
           <li>
             <a href={OPENAPI_URL}>Robinhood V4 OpenAPI</a>
-            <span>Validate the full response envelope and nested evidence.</span>
+            <span>
+              Validate the full response envelope and nested evidence.
+            </span>
           </li>
           <li>
             <a download href={FIXTURE_URL}>
@@ -669,8 +674,9 @@ export default function RobinhoodTerminalIndexerPage() {
 
         <ol className={styles.steps}>
           <li>
-            Fetch <code>?limit=25</code>. Do not cache beyond the response&apos;s
-            HTTP policy without preserving an explicit observed time.
+            Fetch <code>?limit=25</code>. Do not cache beyond the
+            response&apos;s HTTP policy without preserving an explicit observed
+            time.
           </li>
           <li>
             Require <code>chainId: &quot;4663&quot;</code> and{" "}
@@ -682,16 +688,16 @@ export default function RobinhoodTerminalIndexerPage() {
           </li>
           <li>
             Stop and return <code>UNAVAILABLE</code> when the endpoint request
-            fails. A malformed eligible V3 candidate must fail the whole request;
-            do not accept a row-wise quarantine or partial success.
+            fails. A malformed eligible V3 candidate must fail the whole
+            request; do not accept a row-wise quarantine or partial success.
           </li>
           <li>
-            Treat <code>sourceRowCount</code>, <code>publishedRowCount</code> and{" "}
-            <code>quarantinedRowCount</code> as global finalized-dataset totals,
-            not page lengths. A successful response must be <code>ready</code>,
-            with source equal to published and quarantined equal to zero. The
-            current <code>launches.length</code> may be smaller than published but
-            must never be larger.
+            Treat <code>sourceRowCount</code>, <code>publishedRowCount</code>{" "}
+            and <code>quarantinedRowCount</code> as global finalized-dataset
+            totals, not page lengths. A successful response must be{" "}
+            <code>ready</code>, with source equal to published and quarantined
+            equal to zero. The current <code>launches.length</code> may be
+            smaller than published but must never be larger.
           </li>
         </ol>
       </section>
@@ -700,9 +706,9 @@ export default function RobinhoodTerminalIndexerPage() {
         <div className={styles.sectionIntro}>
           <h2>Keep request status separate from finality</h2>
           <p>
-            Request history has a lifecycle <code>status</code>. A finalized-feed
-            item does not. Its route and schema establish the feed class; require{" "}
-            <code>onchain.terminal: true</code> and{" "}
+            Request history has a lifecycle <code>status</code>. A
+            finalized-feed item does not. Its route and schema establish the
+            feed class; require <code>onchain.terminal: true</code> and{" "}
             <code>onchain.checkpointType: ethereum_finalized</code>, plus
             non-null V3 <code>l2Inclusion</code>, <code>l1Posting</code> and{" "}
             <code>l1FinalizedCheckpoint</code> evidence on the item.
@@ -751,37 +757,38 @@ export default function RobinhoodTerminalIndexerPage() {
             Use <code>onchain.l2Inclusion</code> for the exact chain-4663
             transaction, block and Router event positions. Replay and match the
             receipt before reading the Router at that block; the route-event log
-            index must precede the launch-event log index in that receipt. Require
-            the top-level <code>onchain.transactionHash</code> to equal the nested
-            L2 transaction hash.
+            index must precede the launch-event log index in that receipt.
+            Require the top-level <code>onchain.transactionHash</code> to equal
+            the nested L2 transaction hash.
           </li>
           <li>
-            Use <code>onchain.l1Posting</code> only for the Ethereum batch-posting
-            event and <code>onchain.l1FinalizedCheckpoint</code> only for the
-            common finalized checkpoint. Require rollup{" "}
+            Use <code>onchain.l1Posting</code> only for the Ethereum
+            batch-posting event and <code>onchain.l1FinalizedCheckpoint</code>{" "}
+            only for the common finalized checkpoint. Require rollup{" "}
             <code>0x23A19d23e89166adedbDcB432518AB01e4272D94</code>,
             SequencerInbox{" "}
-            <code>0xBd0D173EEb87D57A09521c24388a12789F33ba96</code>,
-            and chain <code>eip155:1</code>. Its ordered provider readbacks are{" "}
+            <code>0xBd0D173EEb87D57A09521c24388a12789F33ba96</code>, and chain{" "}
+            <code>eip155:1</code>. Its ordered provider readbacks are{" "}
             <code>drpc / drpc.org</code> then{" "}
             <code>quicknode / quicknode.com</code>; bind them to the chain
             deployment&apos;s Ethereum-finality evidence and keep all L1
             coordinates separate from the L2 receipt.
           </li>
           <li>
-            The flat <code>onchain.blockNumber</code>, <code>blockHash</code> and{" "}
-            <code>logIndex</code> fields are a deprecated stage projection. They
-            are not a transaction locator; at the finalized stage the log index
-            belongs to <code>l1Posting</code>, not the finalized-checkpoint block.
-            Never combine them with the top-level L2 transaction hash.
+            The flat <code>onchain.blockNumber</code>, <code>blockHash</code>{" "}
+            and <code>logIndex</code> fields are a deprecated stage projection.
+            They are not a transaction locator; at the finalized stage the log
+            index belongs to <code>l1Posting</code>, not the
+            finalized-checkpoint block. Never combine them with the top-level L2
+            transaction hash.
           </li>
           <li>
             If any nested coordinate is missing or disagrees with its provider
-            readback, finality or provenance is <code>INDETERMINATE</code> on the
-            affected axis. Historical V2 evidence remains private authenticated
-            history and is never a finalized public-feed candidate. Only a
-            separate, fully revalidated canonical V3-finalized projection may
-            qualify on its own evidence.
+            readback, finality or provenance is <code>INDETERMINATE</code> on
+            the affected axis. Historical V2 evidence remains private
+            authenticated history and is never a finalized public-feed
+            candidate. Only a separate, fully revalidated canonical V3-finalized
+            projection may qualify on its own evidence.
           </li>
           <li>
             Require <code>sourceVerification.status: exact_match</code> and an{" "}
@@ -808,9 +815,9 @@ export default function RobinhoodTerminalIndexerPage() {
           <h2>Return explicit, independent result axes</h2>
           <p>
             Provenance, authoritative source verification, security, finality,
-            market support and fee behavior are separate facts. Feed availability
-            and write activation are separate again. One axis must never fill or
-            erase another.
+            market support and fee behavior are separate facts. Feed
+            availability and write activation are separate again. One axis must
+            never fill or erase another.
           </p>
         </div>
 
@@ -839,10 +846,10 @@ export default function RobinhoodTerminalIndexerPage() {
               <code>UNAVAILABLE</code>
             </dt>
             <dd>
-              Use on the affected availability, write-activation or fee axis.
-              It does not turn an independently proven stamp into unavailable
-              provenance. An explicit false create gate is{" "}
-              <code>INACTIVE</code>, not <code>UNAVAILABLE</code>.
+              Use on the affected availability, write-activation or fee axis. It
+              does not turn an independently proven stamp into unavailable
+              provenance. An explicit false create gate is <code>INACTIVE</code>
+              , not <code>UNAVAILABLE</code>.
             </dd>
           </div>
           <div>
@@ -852,8 +859,8 @@ export default function RobinhoodTerminalIndexerPage() {
             <dd>
               Use on provenance or finality when its runtime, ABI, provider,
               required V3 L2/L1 coordinate or finality evidence is missing or
-              disagrees. Do not use it as a synonym for{" "}
-              <code>NOT_STAMPED</code>.
+              disagrees. Do not use it as a synonym for <code>NOT_STAMPED</code>
+              .
             </dd>
           </div>
         </dl>
@@ -885,19 +892,19 @@ export default function RobinhoodTerminalIndexerPage() {
           <article>
             <h3>Platform fee</h3>
             <p className={styles.bodyCopy}>
-              The required policy and default configuration for new Robinhood
-              V4 API Custom launches is <code>20 bps</code> to{" "}
-              <code>0xD88539d3c4C460136a733A3Fd60cf6BF269079da</code>
-              . It does not change existing launches or Ethereum. Report actual
-              fee behavior as <code>UNAVAILABLE</code> unless separately proven:
+              The required policy and default configuration for new Robinhood V4
+              API Custom launches is <code>20 bps</code> to{" "}
+              <code>0xD88539d3c4C460136a733A3Fd60cf6BF269079da</code>. It does
+              not change existing launches or Ethereum. Report actual fee
+              behavior as <code>UNAVAILABLE</code> unless separately proven:
               basis, currency, accounting, rounding, accrual and claim mechanics
               remain null, while canonical onchain enforcement and revenue are
               not guaranteed. Do not copy this global new-launch default onto a
               finalized feed row: per-launch applicability remains{" "}
               <code>UNVERIFIED</code> unless the backend publishes an explicit
               launch binding. Do not infer that a direct Router transaction or
-              any path outside the V4 API carries the policy. Fee-path absence is
-              not a write-activation blocker.
+              any path outside the V4 API carries the policy. Fee-path absence
+              is not a write-activation blocker.
             </p>
           </article>
         </div>

--- a/app/docs/developers/robinhood-terminal-indexer/page.tsx
+++ b/app/docs/developers/robinhood-terminal-indexer/page.tsx
@@ -117,6 +117,26 @@ import {
  * Never replace that function with a kind-only launchStamp read.
  */
 const origin = "${API_ORIGIN}";
+const readinessResponse = await fetch("${READINESS_URL}", {
+  headers: { accept: "application/json" },
+});
+if (!readinessResponse.ok) throw new Error("UNAVAILABLE: release readiness");
+const readiness = await readinessResponse.json() as {
+  status?: string;
+  openApiSha256?: string;
+};
+if (readiness.status !== "ready") {
+  throw new Error("UNAVAILABLE: release readiness is not ready");
+}
+
+const openApiResponse = await fetch(new URL("${OPENAPI_URL}", "https://programmable.market"));
+if (!openApiResponse.ok) throw new Error("UNAVAILABLE: V4 OpenAPI");
+const openApiBytes = new Uint8Array(await openApiResponse.arrayBuffer());
+const openApiSha256 = "sha256:" + createHash("sha256").update(openApiBytes).digest("hex");
+if (readiness.openApiSha256 !== openApiSha256) {
+  throw new Error("UNAVAILABLE: V4 OpenAPI/readiness digest mismatch");
+}
+
 const abiUrl = new URL("${ABI_URL}", "https://programmable.market");
 const abiResponse = await fetch(abiUrl);
 if (!abiResponse.ok) throw new Error("UNAVAILABLE: Router ABI");
@@ -352,8 +372,8 @@ export default function RobinhoodTerminalIndexerPage() {
           <div>
             <dt>Required fee policy</dt>
             <dd>
-              <code>20 bps</code> · <code>2,000 ppm</code> · recipient{" "}
-              <code>0xD88539d3c4C460136a733A3Fd60cf6BF269079da</code>
+              Resolve the complete current value from live discovery at{" "}
+              <code>customLaunchApi.versions.v4.platformFeePolicy</code>
             </dd>
           </div>
           <div>
@@ -379,8 +399,8 @@ export default function RobinhoodTerminalIndexerPage() {
             Before creating, fetch{" "}
             <a href={WELL_KNOWN_URL}>the live discovery document</a> and the
             readiness authority. A <code>ready</code> runtime response proves
-            service composition, not write activation. The required 20 bps
-            default configuration is policy; it is not proof of canonical
+            service composition, not write activation. The current global fee
+            configuration comes from discovery; it is not proof of canonical
             onchain enforcement, a charged fee or platform revenue.
           </p>
         </aside>
@@ -658,7 +678,8 @@ export default function RobinhoodTerminalIndexerPage() {
           <li>
             <a href={OPENAPI_URL}>Robinhood V4 OpenAPI</a>
             <span>
-              Validate the full response envelope and nested evidence.
+              Hash the exact bytes, require equality with readiness{" "}
+              <code>openApiSha256</code>, then validate the full response.
             </span>
           </li>
           <li>
@@ -666,13 +687,20 @@ export default function RobinhoodTerminalIndexerPage() {
               Download the terminal integration fixture
             </a>
             <span>
-              Exact bindings, topics, lifecycle, activation gate, required fee
-              policy and a schema-valid empty-feed vector for fail-closed tests.
+              Exact bindings, topics, lifecycle, live-authority paths and a
+              schema-valid empty-feed vector for fail-closed tests. It carries
+              no production status or current fee values.
             </span>
           </li>
         </ul>
 
         <ol className={styles.steps}>
+          <li>
+            Before generating types or validating data, hash the exact hosted
+            OpenAPI bytes and require equality with the top-level{" "}
+            <code>openApiSha256</code> in a <code>ready</code> response. A
+            missing or mismatched digest is <code>UNAVAILABLE</code>.
+          </li>
           <li>
             Fetch <code>?limit=25</code>. Do not cache beyond the
             response&apos;s HTTP policy without preserving an explicit observed
@@ -892,19 +920,20 @@ export default function RobinhoodTerminalIndexerPage() {
           <article>
             <h3>Platform fee</h3>
             <p className={styles.bodyCopy}>
-              The required policy and default configuration for new Robinhood V4
-              API Custom launches is <code>20 bps</code> to{" "}
-              <code>0xD88539d3c4C460136a733A3Fd60cf6BF269079da</code>. It does
-              not change existing launches or Ethereum. Report actual fee
-              behavior as <code>UNAVAILABLE</code> unless separately proven:
-              basis, currency, accounting, rounding, accrual and claim mechanics
-              remain null, while canonical onchain enforcement and revenue are
-              not guaranteed. Do not copy this global new-launch default onto a
-              finalized feed row: per-launch applicability remains{" "}
-              <code>UNVERIFIED</code> unless the backend publishes an explicit
-              launch binding. Do not infer that a direct Router transaction or
-              any path outside the V4 API carries the policy. Fee-path absence
-              is not a write-activation blocker.
+              Do not hardcode a rate or recipient from this page or the fixture.
+              Resolve the current global requirement from live discovery at{" "}
+              <code>customLaunchApi.versions.v4.platformFeePolicy</code> and
+              preserve its rate, percentage, recipient, scope and enforcement
+              fields together. Report actual fee behavior as{" "}
+              <code>UNAVAILABLE</code> unless separately proven: basis,
+              currency, accounting, rounding, accrual and claim mechanics may
+              remain unknown, while canonical onchain enforcement and revenue
+              are not guaranteed. Do not copy the global policy onto a finalized
+              feed row: per-launch applicability remains <code>UNVERIFIED</code>{" "}
+              unless the backend publishes an explicit launch binding. Do not
+              infer that a direct Router transaction or any path outside the V4
+              API carries the policy. Fee-path absence is not a write-activation
+              blocker.
             </p>
           </article>
         </div>
@@ -949,10 +978,12 @@ export default function RobinhoodTerminalIndexerPage() {
         <aside className={styles.callout}>
           <strong>Production rule</strong>
           <p>
-            Validate the complete OpenAPI schema, not only the fields shown in
-            the short example. The current list and item schemas are closed:
-            reject unknown fields and regenerate your parser for a published
-            schema change. A missing required binding must fail closed.
+            First require the exact hosted OpenAPI byte digest to equal
+            readiness <code>openApiSha256</code>. Then validate the complete
+            schema, not only the fields shown in the short example. The current
+            list and item schemas are closed: reject unknown fields and
+            regenerate your parser for a published schema change. A missing
+            required binding must fail closed.
           </p>
         </aside>
       </section>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -24,6 +24,7 @@ const PUBLIC_ROUTES = [
   "/docs/developers/verify",
   "/docs/developers/indexing",
   "/docs/developers/machine-readable",
+  "/docs/developers/robinhood-terminal-indexer",
   "/docs/launch-stamps",
   "/docs/models/classic",
   "/docs/models/custom",

--- a/docs/public/SUMMARY.md
+++ b/docs/public/SUMMARY.md
@@ -19,5 +19,6 @@
   - [Custom Launch API](developers/custom-launch.md)
   - [Verify a launch](developers/verify.md)
   - [Index launches](developers/indexing.md)
+  - [Robinhood terminal indexer](developers/robinhood-terminal-indexer.md)
   - [API reference](developers/machine-readable.md)
 - [Official links](reference/official-links.md)

--- a/docs/public/developers/indexing.md
+++ b/docs/public/developers/indexing.md
@@ -18,9 +18,11 @@ The Ethereum public status endpoint reports feed freshness, chain head, scan cov
 
 ## Integrate Robinhood V4
 
-Robinhood Chain Mainnet uses `chainId: 4663` and `eip155:4663`. Generate types from the stable
-[V4 OpenAPI contract](https://programmable.market/openapi/custom-launch-v4.json), validate the fixture, and map the
-published ABI topics. Resolve current activation from
+Robinhood Chain Mainnet uses `chainId: 4663` and `eip155:4663`. Download the exact bytes of the
+[V4 OpenAPI contract](https://programmable.market/openapi/custom-launch-v4.json), compute their SHA-256 digest and
+require equality with the top-level `openApiSha256` in a ready chain response before generating types or validating
+data. A missing or mismatched digest must fail closed. Then validate the fixture and map the published ABI topics.
+Resolve current activation from
 [Programmable discovery](https://programmable.market/.well-known/programmable.json),
 `GET /v4/chains/4663/capabilities` and `GET /v4/chains/4663/readiness`; those are separate live authorities. Treat
 creation as active only when discovery reports `publicWrites: true`, `publicAuthorization: true` and

--- a/docs/public/developers/indexing.md
+++ b/docs/public/developers/indexing.md
@@ -5,8 +5,8 @@ description: Index Programmable launches with finality, cursor completeness and 
 # Index Programmable launches
 
 An Ethereum indexer can use the normalized v2 feed or reproduce Router records directly. Robinhood Chain V4 uses the
-separate deployed release-candidate feed described below. In every case, finality, cursor traversal and unknown data
-need explicit handling.
+separate chain-bound feed described below. In every case, finality, cursor traversal and unknown data need explicit
+handling.
 
 The normalized launch feed returns versioned records for Classic and Registry-verified Custom launches. Consumers should follow every cursor until completion, remove duplicate launch ids and retain records when optional price, chart or liquidity data is unavailable. A missing chart or quote is not permission to discard a valid launch record.
 
@@ -16,17 +16,17 @@ Price and liquidity data should carry its own source, timestamp, status and qual
 
 The Ethereum public status endpoint reports feed freshness, chain head, scan coverage and current counts. Production consumers should alert on lag and incomplete traversal instead of treating service availability as freshness.
 
-## Integrate Robinhood V4 before public discovery promotion
+## Integrate Robinhood V4
 
-Robinhood Chain Mainnet (`chainId: 4663`, `eip155:4663`) has a deployed Router, backend routes and stable
-[V4 OpenAPI contract](https://programmable.market/openapi/custom-launch-v4.json). You can generate types, validate
-feed fixtures, map ABI topics and build cursor, quality and reorg handling now. This release snapshot remains
-`pending-public-discovery-promotion` with `publicWrites: false`, `publicAuthorization: false` and
-`releaseReady: false`; deployed runtime and an HTTP `200` do not activate writes. Read
+Robinhood Chain Mainnet uses `chainId: 4663` and `eip155:4663`. Generate types from the stable
+[V4 OpenAPI contract](https://programmable.market/openapi/custom-launch-v4.json), validate the fixture, and map the
+published ABI topics. Resolve current activation from
 [Programmable discovery](https://programmable.market/.well-known/programmable.json),
-`GET /v4/chains/4663/capabilities` and `GET /v4/chains/4663/readiness` as separate live authorities. The fixture's
-empty response is a schema-valid parser vector, not a production observation. Always fetch the live feed. The public
-Developer API v2 remains an Ethereum-only surface.
+`GET /v4/chains/4663/capabilities` and `GET /v4/chains/4663/readiness`; those are separate live authorities. Treat
+creation as active only when discovery reports `publicWrites: true`, `publicAuthorization: true` and
+`releaseReady: true`, and readiness reports the matching ready release. A deployed route or HTTP `200` alone does not
+activate writes. The fixture's empty response is a schema-valid parser vector, not a production observation. Always
+fetch the live feed.
 
 For provenance discovery, read the public, keyless
 `GET /v4/chains/4663/finalized-custom-launches` feed. Validate every response and item against both chain identifiers,
@@ -66,11 +66,13 @@ then apply these rules:
   larger. A malformed eligible V3 candidate fails the entire endpoint request; consumers must not accept a row-wise
   quarantine or partial result.
 
-At this source snapshot, no per-launch protected exact-source composite is proven and persisted for public promotion,
-so this guide claims no existing public item. That is pending source-authority capture, persistence and promotion—not
-an RPC-provider outage. Sourcify's observation carries `releaseAuthority: false`; optional Robinhood Blockscout cannot
-satisfy or block the authority and cannot revise finality. Separately, the changed V4 OpenAPI bytes still leave the
-clean-room release binding at `V4_RELEASE_BINDING_NOT_READY` until refreshed release hashes close.
+Do not infer a public item from the empty fixture. An item exists only when the live feed returns it with the complete
+Router, finality and protected exact-source composite described here. A Sourcify observation with
+`releaseAuthority: false` is not publication authority; optional Robinhood Blockscout cannot satisfy or block that
+authority and cannot revise finality. The machine-contract hashes are already refreshed. Release readiness instead
+depends on six independent evidence gates: chain deployment, profile, release manifest, source closure, finality and
+backend release evidence. Resolve their current result from the live readiness authority rather than copied status
+text.
 
 The request accepts an optional `limit` from 1 to 25 and defaults to 10. The response returns an opaque `nextCursor`;
 pass each non-null value back unchanged as `cursor` and never decode or construct one. Declare traversal complete only

--- a/docs/public/developers/robinhood-terminal-indexer.md
+++ b/docs/public/developers/robinhood-terminal-indexer.md
@@ -22,14 +22,16 @@ transaction, Router log or fixture alone. Require the complete feed, finality, R
 | Robinhood deployment manifest | [`GET /v4/chains/4663/capabilities`](https://api.programmable.market/v4/chains/4663/capabilities)                                      | Read `chainDeployment` and `chainDeploymentDescriptorDigest`, including contracts, runtime hashes, deployment evidence and finality policy. |
 | Release readiness             | [`GET /v4/chains/4663/readiness`](https://api.programmable.market/v4/chains/4663/readiness)                                            | Verify the matching source commit, source tree, policy and deployment release identity.                                                     |
 | Finalized feed                | [`GET /v4/chains/4663/finalized-custom-launches`](https://api.programmable.market/v4/chains/4663/finalized-custom-launches)            | Discover only schema-valid, terminal, Ethereum-finalized candidates.                                                                        |
-| OpenAPI                       | [`custom-launch-v4.json`](https://programmable.market/openapi/custom-launch-v4.json)                                                   | Generate types and validate the complete list and item schemas.                                                                             |
+| OpenAPI                       | [`custom-launch-v4.json`](https://programmable.market/openapi/custom-launch-v4.json)                                                   | Hash the exact response bytes, require equality with readiness `openApiSha256`, then generate types and validate the complete schemas.      |
 | Integration fixture           | [`robinhood-terminal-indexer-v1.json`](https://programmable.market/fixtures/robinhood-terminal-indexer-v1.json)                        | Test exact constants, event topics, pagination, finality and fail-closed result states. It is not production data.                          |
 | Router ABI                    | [`ProgrammableLaunchStampRouterV1.abi.json`](https://programmable.market/contracts/robinhood/ProgrammableLaunchStampRouterV1.abi.json) | Decode logs and perform the canonical registry reads.                                                                                       |
 | Router explorer               | [`0x3496...C98a`](https://robinhoodchain.blockscout.com/address/0x34965F2A2ee9254522232C32F02056E92BE0C98a)                            | Inspect the address as supporting evidence. Explorer availability is not a release or source-verification authority.                        |
 
 The top-level `manifestUrl` in discovery belongs to the Ethereum V2 developer surface. It is not the Robinhood V4
 manifest. For chain 4663, use the `chainDeployment` object and its descriptor digest from the capabilities response,
-then require the same binding in readiness and in each finalized item.
+then require the same binding in readiness and in each finalized item. Download the V4 OpenAPI as exact bytes, compute
+`sha256:<lowercase hex>` and require equality with the top-level `openApiSha256` in the ready response before generating
+types or validating a feed. A missing or mismatched digest is `UNAVAILABLE`; do not silently trust either side.
 
 Resolve write activation independently from indexing. Report `ACTIVE` only when
 `customLaunchApi.versions.v4.publicWrites`, `publicAuthorization` and `releaseReady` are all exactly `true` in live
@@ -101,8 +103,9 @@ and stamp commitments. Graph Factory logs are execution diagnostics and cannot r
 
 The feed is public and keyless. Authentication-protected request history is not a terminal discovery feed.
 
-1. Validate the full response against `CustomLaunchFinalizedListV4` and every item against
-   `CustomLaunchFinalizedMetadataV4` in the [V4 OpenAPI](https://programmable.market/openapi/custom-launch-v4.json).
+1. Hash the exact hosted [V4 OpenAPI](https://programmable.market/openapi/custom-launch-v4.json) bytes and require the
+   digest to equal readiness `openApiSha256`. Then validate the full response against `CustomLaunchFinalizedListV4` and
+   every item against `CustomLaunchFinalizedMetadataV4` in that bound schema.
 2. Request `limit` from `1` to `25`. The default is `10`.
 3. Process the page, then pass each non-null `nextCursor` back unchanged as `cursor`. Never decode, construct or
    normalize a cursor. Track all non-null cursors and return `INDETERMINATE` if one repeats.
@@ -170,11 +173,12 @@ does not assert that such an item currently exists. Only the live feed can estab
 
 ## Fee policy is a separate fact
 
-The required default configuration for new Robinhood V4 API Custom launches is `20 bps` to
-`0xD88539d3c4C460136a733A3Fd60cf6BF269079da`. This requirement does not change older launches and is not, by itself,
-proof of immutable onchain enforcement, a charged fee or platform revenue. Do not copy the global default onto a
-terminal row. Report fee behavior only when the live record explicitly proves the applicable rate, basis, currency,
-recipient, accounting and claim path for that exact launch.
+Do not hardcode a rate or recipient from this guide or the fixture. Resolve the current global requirement from
+`customLaunchApi.versions.v4.platformFeePolicy` in live discovery and preserve its `rateBps`, `ratePpm`, `ratePercent`,
+`recipient`, scope and enforcement fields together. A global API requirement does not change older launches and is not,
+by itself, proof of immutable onchain enforcement, a charged fee or platform revenue. Do not copy it onto a terminal
+row. Report fee behavior only when the live record explicitly proves the applicable rate, basis, currency, recipient,
+accounting and claim path for that exact launch.
 
 ## Third-party indexing is not guaranteed
 
@@ -187,12 +191,14 @@ executable trade route.
 ## Integration sequence
 
 1. Fetch discovery, capabilities and readiness. Resolve live state and require one matching chain-deployment binding.
-2. Download and hash the ABI. Verify chain, Router, dependencies, runtime hashes and immutable getters.
-3. Fetch and OpenAPI-validate every finalized-feed page through a null cursor.
-4. Verify each item's nested finality coordinates, receipt, Router events, registry reads and exact-source components.
-5. Emit the **Programmable Custom** label only after provenance, finality and source verification pass. Preserve all
+2. Download the OpenAPI, hash its exact bytes and require equality with readiness `openApiSha256`. Fail closed on a
+   missing or mismatched digest.
+3. Download and hash the ABI. Verify chain, Router, dependencies, runtime hashes and immutable getters.
+4. Fetch and OpenAPI-validate every finalized-feed page through a null cursor.
+5. Verify each item's nested finality coordinates, receipt, Router events, registry reads and exact-source components.
+6. Emit the **Programmable Custom** label only after provenance, finality and source verification pass. Preserve all
    other result axes independently.
-6. Record the endpoint, UTC observation time, response status, manifest digest, Router, V3 coordinates and provider
+7. Record the endpoint, UTC observation time, response status, manifest digest, Router, V3 coordinates and provider
    identities for reproducibility. Never include an API key, signed transaction or private request body.
 
 For non-sensitive integration failures, [open a GitHub issue](https://github.com/programmablehq/PROGRAMMABLE/issues).

--- a/docs/public/developers/robinhood-terminal-indexer.md
+++ b/docs/public/developers/robinhood-terminal-indexer.md
@@ -1,0 +1,198 @@
+---
+description: Verify and index Programmable Custom launch provenance on Robinhood Chain
+---
+
+# Index Programmable Custom on Robinhood
+
+Use the chain-bound finalized feed and Launch Stamp Router V1 to identify Programmable Custom launches on Robinhood
+Chain Mainnet. This page is a verification recipe, not a status snapshot. It does not claim that public writes are
+active or that the feed currently contains a launch. Resolve those facts from the live authorities before every
+create or ingestion session.
+
+{% hint style="warning" %}
+Do not publish the **Programmable Custom** label from a project name, token symbol, hook, factory, deployment
+transaction, Router log or fixture alone. Require the complete feed, finality, Router and exact-source binding below.
+{% endhint %}
+
+## Start with the live authorities
+
+| Authority                     | URL                                                                                                                                    | Use                                                                                                                                         |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Discovery                     | [`.well-known/programmable.json`](https://programmable.market/.well-known/programmable.json)                                           | Resolve V4 paths, write gates, machine-contract links and the external-indexing guarantee field.                                            |
+| Robinhood deployment manifest | [`GET /v4/chains/4663/capabilities`](https://api.programmable.market/v4/chains/4663/capabilities)                                      | Read `chainDeployment` and `chainDeploymentDescriptorDigest`, including contracts, runtime hashes, deployment evidence and finality policy. |
+| Release readiness             | [`GET /v4/chains/4663/readiness`](https://api.programmable.market/v4/chains/4663/readiness)                                            | Verify the matching source commit, source tree, policy and deployment release identity.                                                     |
+| Finalized feed                | [`GET /v4/chains/4663/finalized-custom-launches`](https://api.programmable.market/v4/chains/4663/finalized-custom-launches)            | Discover only schema-valid, terminal, Ethereum-finalized candidates.                                                                        |
+| OpenAPI                       | [`custom-launch-v4.json`](https://programmable.market/openapi/custom-launch-v4.json)                                                   | Generate types and validate the complete list and item schemas.                                                                             |
+| Integration fixture           | [`robinhood-terminal-indexer-v1.json`](https://programmable.market/fixtures/robinhood-terminal-indexer-v1.json)                        | Test exact constants, event topics, pagination, finality and fail-closed result states. It is not production data.                          |
+| Router ABI                    | [`ProgrammableLaunchStampRouterV1.abi.json`](https://programmable.market/contracts/robinhood/ProgrammableLaunchStampRouterV1.abi.json) | Decode logs and perform the canonical registry reads.                                                                                       |
+| Router explorer               | [`0x3496...C98a`](https://robinhoodchain.blockscout.com/address/0x34965F2A2ee9254522232C32F02056E92BE0C98a)                            | Inspect the address as supporting evidence. Explorer availability is not a release or source-verification authority.                        |
+
+The top-level `manifestUrl` in discovery belongs to the Ethereum V2 developer surface. It is not the Robinhood V4
+manifest. For chain 4663, use the `chainDeployment` object and its descriptor digest from the capabilities response,
+then require the same binding in readiness and in each finalized item.
+
+Resolve write activation independently from indexing. Report `ACTIVE` only when
+`customLaunchApi.versions.v4.publicWrites`, `publicAuthorization` and `releaseReady` are all exactly `true` in live
+discovery and readiness returns the matching ready release. Any explicit false gate is `INACTIVE`. A missing,
+unreachable or malformed authority is `UNAVAILABLE`. A deployed Router, a reachable route or HTTP `200` does not
+activate writes.
+
+## Bind the exact identity
+
+The expected chain and stamp identity is fixed. Fail closed if the live manifest disagrees.
+
+| Field               | Required value                                          |
+| ------------------- | ------------------------------------------------------- |
+| Chain               | Robinhood Chain Mainnet                                 |
+| `chainId`           | `4663`                                                  |
+| `caip2`             | `eip155:4663`                                           |
+| `chainDeploymentId` | `robinhood-mainnet-custom-launch-v1`                    |
+| `platformId`        | `programmable`                                          |
+| `category`          | `custom`                                                |
+| Display label       | `Programmable Custom`                                   |
+| Stamp generation    | `programmable-launch-stamp-router-v1`                   |
+| Router launch kind  | `LaunchKindV1.CustomGraph = 1`                          |
+| Durable key         | `(eip155:4663, onchain.router, onchain.routerLaunchId)` |
+
+Keep the API request UUID in `launchId` separate from `onchain.routerLaunchId`. Treat `projectMetadata.token` as name
+and symbol metadata only. Resolve the token address from `launchStamp(onchain.routerLaunchId)` at the verified L2
+receipt block. Never merge an address with the same bytes on another chain.
+
+### Verify the Router binding
+
+Start provenance scans at block `50469365`. At the item's verified `onchain.l2Inclusion.blockNumber`, require these
+addresses and runtime hashes to match the live deployment manifest and independent provider reads.
+
+| Component              | Address                                                                                                                                  | Runtime Keccak-256                                                   |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Launch Stamp Router V1 | [`0x34965F2A2ee9254522232C32F02056E92BE0C98a`](https://robinhoodchain.blockscout.com/address/0x34965F2A2ee9254522232C32F02056E92BE0C98a) | `0x1dbbdaaad901ea3c6134dca0d4872a4789b3c071bf8ccfb44edd65d26d817388` |
+| Graph Factory          | [`0x0B6b3F40f84Df25D3bd69238f937096177DD09Bd`](https://robinhoodchain.blockscout.com/address/0x0B6b3F40f84Df25D3bd69238f937096177DD09Bd) | `0xd23692fae59331592048e71a96d4963e170ee56e449683dc9f7fa3f9470018b8` |
+| Permit authority       | [`0xeD617CE7f82e2AB589aDeFFD319D1D872Bc8De06`](https://robinhoodchain.blockscout.com/address/0xeD617CE7f82e2AB589aDeFFD319D1D872Bc8De06) | `0xd7d408ebcd99b2b70be43e20253d6d92a8ea8fab29bd3be7f55b10032331fb4c` |
+| PoolManager            | [`0x8366a39CC670B4001A1121B8F6A443A643e40951`](https://robinhoodchain.blockscout.com/address/0x8366a39CC670B4001A1121B8F6A443A643e40951) | `0xbd3881180b547f5fe817545743cfb4343e96b1bc6640dcd70c106b0066e95626` |
+
+Hash the exact hosted ABI bytes before decoding. Their SHA-256 is
+`bb4e728e9f9c850eb01f928e8a798ac206a82e241a8d93b3b3c686635c88ed86`. The profile-normalized ABI SHA-256 is
+`ab25262ce1cb907eba1cb820492754c0cd5d7278eb5fd6a024ba24c767323ac0`, calculated from one `jq -cS`
+serialization plus a trailing LF. These hashes cover different byte representations and are not interchangeable.
+
+Also verify the Router's `CHAIN_ID`, Graph Factory, permit authority and PoolManager getters. Then verify
+`launchIdByToken`, `launchIdByPool`, `launchIdByComponent`, `launchStamp`, `stampProof` and
+`componentRuntimeCodeHash` at the same canonical L2 block. Robinhood provenance uses this Router-embedded registry.
+There is no separate authoritative Custom Registry for this generation.
+
+## Decode the Router events
+
+Accept logs only from the exact Router at or after block `50469365`. The signatures are defined by the
+[hosted ABI](https://programmable.market/contracts/robinhood/ProgrammableLaunchStampRouterV1.abi.json).
+
+| Event and full signature                                                       | `topic0`                                                             | Indexed inputs                         | Role                |
+| ------------------------------------------------------------------------------ | -------------------------------------------------------------------- | -------------------------------------- | ------------------- |
+| `ProgrammableLaunchStampedV1(bytes32,address,address,address,bytes32,bytes32)` | `0x6cf479a102f1eebc9244f48f8d68f6aa52b4c5a4516318df58ba46614a5b14f2` | `launchId`, `token`, `hook`            | Discovery candidate |
+| `ProgrammableLaunchRouteStampedV1(bytes32,uint8,bytes32,bytes32,bytes32)`      | `0x45e7cc355b63ca67d6278a0d8d23470ce2a0741a9c60283d7dee712df7a877a5` | `launchId`, `kind`, `routePayloadHash` | Discovery candidate |
+| `ProgrammableComponentStampedV1(bytes32,address,uint8,bytes32)`                | `0x8147265e7396d6400cee8d049456a1f7438fdfbe2a7c81c976d51ba67e52ff4b` | `launchId`, `component`, `kind`        | Discovery candidate |
+| `EIP712DomainChanged()`                                                        | `0x0a6387c9ea3628b88a633bb4f3b151770f70085117a15f9bf3787cda53f13d31` | None                                   | Not a launch signal |
+
+Correlate the Component, Route and Launch events by indexed launch ID in the same successful receipt. Require the
+route-event log index to precede the launch-event log index. Then replay the registry getters at that receipt block and
+require launch kind `1`, the exact token, hook, PoolManager, pool ID, route launcher, component proofs, runtime hashes
+and stamp commitments. Graph Factory logs are execution diagnostics and cannot replace the Router stamp.
+
+## Traverse and validate the finalized feed
+
+The feed is public and keyless. Authentication-protected request history is not a terminal discovery feed.
+
+1. Validate the full response against `CustomLaunchFinalizedListV4` and every item against
+   `CustomLaunchFinalizedMetadataV4` in the [V4 OpenAPI](https://programmable.market/openapi/custom-launch-v4.json).
+2. Request `limit` from `1` to `25`. The default is `10`.
+3. Process the page, then pass each non-null `nextCursor` back unchanged as `cursor`. Never decode, construct or
+   normalize a cursor. Track all non-null cursors and return `INDETERMINATE` if one repeats.
+4. Traversal is complete only when `nextCursor` is `null` and every page remains schema-valid with
+   `quality.status: ready`.
+5. Treat `sourceRowCount`, `publishedRowCount` and `quarantinedRowCount` as global dataset totals, not page lengths.
+   A successful response requires source equal to published, quarantined equal to zero, and the current page length no
+   greater than published. A malformed eligible candidate must fail the endpoint. Do not accept partial output or
+   row-wise quarantine.
+6. On an HTTP, schema or quality failure, report feed availability as `UNAVAILABLE`. Do not infer a result from cached
+   metadata or the fixture.
+
+For every item, require `platformId: programmable`, `category: custom`, `chainId: "4663"`, `caip2: "eip155:4663"`,
+the expected Router and `onchain.schemaVersion: programmable.custom-launch-onchain-evidence.v3`. Deduplicate by the
+durable key, not the API request UUID.
+
+If you also index Router logs directly, retain an overlap window, compare canonical block hashes and rewind to the last
+common finalized checkpoint after a reorganization. Direct Router provenance indexing is independent of write
+activation, but a log alone is not eligible for the public finalized label.
+
+## Verify finality and source
+
+Request lifecycle states such as `sequencer_soft_confirmed` and `ethereum_posted` are not finality. A public candidate
+must have `onchain.terminal: true`, `onchain.checkpointType: ethereum_finalized` and all three non-null V3 evidence
+objects:
+
+1. `onchain.l2Inclusion` identifies the successful Robinhood transaction, block hash and exact Route and Launch event
+   positions. Require `onchain.transactionHash` to equal its nested transaction hash. Replay this receipt before all
+   Router reads.
+2. `onchain.l1Posting` identifies the distinct Ethereum batch-posting transaction and event. Require chain
+   `eip155:1`, rollup `0x23A19d23e89166adedbDcB432518AB01e4272D94` and SequencerInbox
+   `0xBd0D173EEb87D57A09521c24388a12789F33ba96`.
+3. `onchain.l1FinalizedCheckpoint` identifies the common Ethereum checkpoint with tag `finalized`. Require its ordered
+   provider readbacks to be `drpc` / `drpc.org`, then `quicknode` / `quicknode.com`, bound to the same provider
+   identities in the deployment manifest. Both block number and hash pairs must match the common checkpoint.
+
+The flat `onchain.blockNumber`, `blockHash` and `logIndex` fields are a deprecated stage projection, not a transaction
+locator. At the finalized stage, the block fields project the L1 finalized checkpoint while the log index belongs to
+the earlier L1 posting event. Never combine this trio with the L2 transaction hash. Historical V2 evidence is private
+history and is not a public-feed candidate unless a separate canonical V3 projection is fully revalidated.
+
+Require `sourceVerification.status: exact_match` and `exact_match` on every component, keeping each component keyed by
+both `targetId` and address. The authoritative binding includes protected source closure, reproducible hosted build,
+compiler and settings, finalized creation transaction, and exact creation and runtime bytecode. A provider-only
+Sourcify observation is not publication authority. Robinhood Blockscout is optional and cannot satisfy or block exact
+source authority or revise finality. Exact source verification is still not an audit or safety endorsement.
+
+## Return independent result axes
+
+Do not let one result fill in or erase another.
+
+| Axis                | Values and rule                                                                                                                                                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Provenance          | `STAMPED` only after every Router binding, canonical read and event correlation succeeds at the verified L2 block. `NOT_STAMPED` only after a canonical identity lookup succeeds and returns zero. Otherwise `INDETERMINATE`.      |
+| Feed availability   | `AVAILABLE` only for a complete schema-valid page with ready quality. Endpoint, schema or quality failure is `UNAVAILABLE`.                                                                                                        |
+| Finality            | `FINALIZED` only after all required V3 L2 inclusion, L1 posting and L1 finalized-checkpoint evidence agrees. Otherwise `INDETERMINATE`.                                                                                            |
+| Source verification | Publication requires aggregate and component `exact_match`. Any missing or conflicting authoritative binding is `INDETERMINATE` for publication.                                                                                   |
+| Write activation    | `ACTIVE` only when all three live discovery gates are true and readiness matches. An explicit false gate is `INACTIVE`; an unreadable authority is `UNAVAILABLE`.                                                                  |
+| Fee behavior        | Report `UNAVAILABLE` unless basis, currency, accounting, rounding, accrual, claim mechanics and canonical onchain enforcement are separately proven. Per-launch applicability is `UNVERIFIED` without an explicit backend binding. |
+| Security            | `UNVERIFIED`. A stamp and exact source prove identity, not safety.                                                                                                                                                                 |
+| Market support      | `UNVERIFIED`. A stamp does not prove price, liquidity, routability, venue support or trading compatibility.                                                                                                                        |
+
+An independently finalized `STAMPED` launch remains indexable when writes are inactive or unavailable. That statement
+does not assert that such an item currently exists. Only the live feed can establish item presence.
+
+## Fee policy is a separate fact
+
+The required default configuration for new Robinhood V4 API Custom launches is `20 bps` to
+`0xD88539d3c4C460136a733A3Fd60cf6BF269079da`. This requirement does not change older launches and is not, by itself,
+proof of immutable onchain enforcement, a charged fee or platform revenue. Do not copy the global default onto a
+terminal row. Report fee behavior only when the live record explicitly proves the applicable rate, basis, currency,
+recipient, accounting and claim path for that exact launch.
+
+## Third-party indexing is not guaranteed
+
+No third-party terminal, exchange, explorer, data provider or indexer is guaranteed to ingest, display or support a
+Programmable launch. The live discovery field `customLaunchApi.versions.v4.externalIndexingGuaranteed` is the machine
+authority for any advertised guarantee. If no explicit guarantee is available, report third-party indexing as
+`UNVERIFIED`. Never turn Router indexability into a claim about a named third party, price coverage, liquidity or an
+executable trade route.
+
+## Integration sequence
+
+1. Fetch discovery, capabilities and readiness. Resolve live state and require one matching chain-deployment binding.
+2. Download and hash the ABI. Verify chain, Router, dependencies, runtime hashes and immutable getters.
+3. Fetch and OpenAPI-validate every finalized-feed page through a null cursor.
+4. Verify each item's nested finality coordinates, receipt, Router events, registry reads and exact-source components.
+5. Emit the **Programmable Custom** label only after provenance, finality and source verification pass. Preserve all
+   other result axes independently.
+6. Record the endpoint, UTC observation time, response status, manifest digest, Router, V3 coordinates and provider
+   identities for reproducibility. Never include an API key, signed transaction or private request body.
+
+For non-sensitive integration failures, [open a GitHub issue](https://github.com/programmablehq/PROGRAMMABLE/issues).

--- a/public/fixtures/robinhood-terminal-indexer-v1.json
+++ b/public/fixtures/robinhood-terminal-indexer-v1.json
@@ -27,7 +27,8 @@
     },
     "feeBehaviorClaim": false,
     "marketSupportClaim": false,
-    "releaseBlockersSource": "live readiness reasonCodes only",
+    "releaseBlockersAuthority": "https://api.programmable.market/v4/chains/4663/capabilities",
+    "releaseBlockersPath": "readiness.reasonCodes",
     "publicItemPresenceSource": "live finalized feed only",
     "note": "This fixture is a parser and fail-closed test vector. It carries no production activation, runtime, blocker or item-presence status. Fetch every live authority URL before creating, ingesting or displaying a launch."
   },

--- a/public/fixtures/robinhood-terminal-indexer-v1.json
+++ b/public/fixtures/robinhood-terminal-indexer-v1.json
@@ -6,13 +6,16 @@
     "wellKnownUrl": "https://programmable.market/.well-known/programmable.json",
     "capabilitiesUrl": "https://api.programmable.market/v4/chains/4663/capabilities",
     "readinessUrl": "https://api.programmable.market/v4/chains/4663/readiness",
-    "finalizedLaunchesUrl": "https://api.programmable.market/v4/chains/4663/finalized-custom-launches"
+    "finalizedLaunchesUrl": "https://api.programmable.market/v4/chains/4663/finalized-custom-launches",
+    "openApiUrl": "https://programmable.market/openapi/custom-launch-v4.json"
   },
   "integrationBoundary": {
     "target": "public-self-serve",
-    "activationStatus": "pending-public-discovery-promotion",
-    "runtimeStatus": "deployed-ready",
+    "stateAuthority": "live-only",
+    "fixtureCarriesProductionState": false,
     "activationAuthority": "https://programmable.market/.well-known/programmable.json",
+    "runtimeAuthority": "https://api.programmable.market/v4/chains/4663/readiness",
+    "publicItemAuthority": "https://api.programmable.market/v4/chains/4663/finalized-custom-launches",
     "liveCreateGate": {
       "required": true,
       "paths": [
@@ -24,17 +27,9 @@
     },
     "feeBehaviorClaim": false,
     "marketSupportClaim": false,
-    "currentReleaseBlockers": {
-      "cleanRoomBinding": "V4_RELEASE_BINDING_NOT_READY",
-      "cleanRoomReason": "Machine-contract hashes are refreshed. The release binding remains incomplete until chain deployment, profile, release manifest, source closure, finality and backend release evidence are all present.",
-      "publicItemEvidence": "pending-per-launch-authoritative-exact-source-capture-persistence-promotion",
-      "existingPublicItemClaim": false,
-      "providerOutageClaim": false,
-      "sourcifyProviderReleaseAuthority": false,
-      "robinhoodBlockscoutRequired": false,
-      "note": "Public finalized eligibility requires a protected per-launch source closure, reproducible hosted build and compiler settings, finalized creation transaction, and exact creation/runtime bytecode binding for every component. Provider observation alone cannot promote an item or revise finality."
-    },
-    "note": "This fixture is a parser and fail-closed test vector, not proof that production writes are active. Fetch every live authority URL before creating, ingesting or displaying a launch."
+    "releaseBlockersSource": "live readiness reasonCodes only",
+    "publicItemPresenceSource": "live finalized feed only",
+    "note": "This fixture is a parser and fail-closed test vector. It carries no production activation, runtime, blocker or item-presence status. Fetch every live authority URL before creating, ingesting or displaying a launch."
   },
   "chain": {
     "chainId": "4663",
@@ -170,9 +165,12 @@
     },
     "openApiValidation": {
       "url": "https://programmable.market/openapi/custom-launch-v4.json",
+      "digestAuthorityUrl": "https://api.programmable.market/v4/chains/4663/readiness",
+      "digestAuthorityPath": "openApiSha256",
+      "digestAlgorithm": "sha256-exact-response-bytes",
       "responseSchema": "#/components/schemas/CustomLaunchFinalizedListV4",
       "itemSchema": "#/components/schemas/CustomLaunchFinalizedMetadataV4",
-      "rule": "Validate the complete response and every launches[] item against the authoritative OpenAPI schemas before using this minimum identity evidence. The list below is not the full DTO contract."
+      "rule": "Hash the exact hosted OpenAPI response bytes and require the sha256-prefixed digest to equal readiness.openApiSha256 before generating types or validating data. A missing or mismatched digest is UNAVAILABLE and must fail closed. Then validate the complete response and every launches[] item against the bound OpenAPI schemas before using this minimum identity evidence. The list below is not the full DTO contract."
     },
     "minimumIdentityEvidence": {
       "source": "minimum identity and finality paths from one OpenAPI-validated launches[] item",
@@ -299,20 +297,28 @@
     "terminalFinalityStage": "ethereum_finalized"
   },
   "feePolicy": {
-    "required": true,
-    "status": "required-default-configuration",
-    "scope": "new Robinhood V4 API Custom launches only",
-    "changesExistingLaunches": false,
-    "changesEthereumLaunches": false,
+    "authority": {
+      "url": "https://programmable.market/.well-known/programmable.json",
+      "path": "customLaunchApi.versions.v4.platformFeePolicy"
+    },
+    "currentValueSource": "live-discovery-only",
+    "fixtureCarriesCurrentValues": false,
+    "requiredFields": [
+      "required",
+      "status",
+      "appliesTo",
+      "rateBps",
+      "ratePpm",
+      "ratePercent",
+      "recipient",
+      "enforcement",
+      "canonicalOnchainEnforcementProven",
+      "guaranteedRevenue",
+      "feeBehaviorClaim",
+      "universalFeeBehaviorClaim"
+    ],
     "directRouterOrOutsideApiBindingClaim": false,
     "perLaunchApplicabilityWithoutExplicitBackendBinding": "UNVERIFIED",
-    "defaultConfiguration": {
-      "rateBps": 20,
-      "ratePpm": 2000,
-      "ratePercent": "0.20%",
-      "recipient": "0xD88539d3c4C460136a733A3Fd60cf6BF269079da"
-    },
-    "enforcement": "not-guaranteed-onchain",
     "feeBehaviorClaim": false,
     "universalFeeBehaviorClaim": false,
     "genericClaimingLive": false,
@@ -323,8 +329,7 @@
     "rounding": null,
     "accrual": null,
     "claimMechanism": null,
-    "canonicalOnchainEnforcementProven": false,
-    "guaranteedRevenue": false
+    "claimRule": "Do not copy the current global policy onto a launch row. Report per-launch fee behavior only from an explicit authoritative launch binding and separately proven execution and claim mechanics."
   },
   "resultAxes": {
     "provenance": {

--- a/public/fixtures/robinhood-terminal-indexer-v1.json
+++ b/public/fixtures/robinhood-terminal-indexer-v1.json
@@ -26,7 +26,7 @@
     "marketSupportClaim": false,
     "currentReleaseBlockers": {
       "cleanRoomBinding": "V4_RELEASE_BINDING_NOT_READY",
-      "cleanRoomReason": "The changed OpenAPI bytes are not yet closed into refreshed V4 release-binding hashes.",
+      "cleanRoomReason": "Machine-contract hashes are refreshed. The release binding remains incomplete until chain deployment, profile, release manifest, source closure, finality and backend release evidence are all present.",
       "publicItemEvidence": "pending-per-launch-authoritative-exact-source-capture-persistence-promotion",
       "existingPublicItemClaim": false,
       "providerOutageClaim": false,

--- a/tests/robinhood-terminal-indexer-docs.test.ts
+++ b/tests/robinhood-terminal-indexer-docs.test.ts
@@ -56,7 +56,8 @@ type TerminalFixture = {
     publicItemAuthority: string;
     liveCreateGate: { paths: string[]; expected: boolean[] };
     feeBehaviorClaim: boolean;
-    releaseBlockersSource: string;
+    releaseBlockersAuthority: string;
+    releaseBlockersPath: string;
     publicItemPresenceSource: string;
   };
   chain: { chainId: string; caip2: string; provenanceStartBlock: string };
@@ -213,7 +214,9 @@ describe("Robinhood terminal and indexer documentation", () => {
       publicItemAuthority:
         "https://api.programmable.market/v4/chains/4663/finalized-custom-launches",
       feeBehaviorClaim: false,
-      releaseBlockersSource: "live readiness reasonCodes only",
+      releaseBlockersAuthority:
+        "https://api.programmable.market/v4/chains/4663/capabilities",
+      releaseBlockersPath: "readiness.reasonCodes",
       publicItemPresenceSource: "live finalized feed only",
       liveCreateGate: {
         paths: [

--- a/tests/robinhood-terminal-indexer-docs.test.ts
+++ b/tests/robinhood-terminal-indexer-docs.test.ts
@@ -20,6 +20,31 @@ const pageSource = readFileSync(
   ),
   "utf8",
 );
+const aliasSource = readFileSync(
+  resolve(
+    process.cwd(),
+    "app/developer-reference/robinhood-terminal-indexer/page.tsx",
+  ),
+  "utf8",
+);
+const gitBookSource = readFileSync(
+  resolve(
+    process.cwd(),
+    "docs/public/developers/robinhood-terminal-indexer.md",
+  ),
+  "utf8",
+);
+const gitBookSummary = readFileSync(
+  resolve(process.cwd(), "docs/public/SUMMARY.md"),
+  "utf8",
+);
+const sitemapSource = readFileSync(
+  resolve(process.cwd(), "app/sitemap.ts"),
+  "utf8",
+);
+const vercelConfig = JSON.parse(
+  readFileSync(resolve(process.cwd(), "vercel.json"), "utf8"),
+) as { rewrites: Array<{ source: string; destination: string }> };
 
 type TerminalFixture = {
   integrationBoundary: {
@@ -30,6 +55,7 @@ type TerminalFixture = {
     feeBehaviorClaim: boolean;
     currentReleaseBlockers: {
       cleanRoomBinding: string;
+      cleanRoomReason: string;
       publicItemEvidence: string;
       existingPublicItemClaim: boolean;
       providerOutageClaim: boolean;
@@ -120,7 +146,9 @@ type TerminalFixture = {
   independenceRule: string;
 };
 
-const fixture = JSON.parse(readFileSync(fixturePath, "utf8")) as TerminalFixture;
+const fixture = JSON.parse(
+  readFileSync(fixturePath, "utf8"),
+) as TerminalFixture;
 const abiBytes = readFileSync(abiPath);
 const abi = JSON.parse(abiBytes.toString("utf8")) as Array<
   AbiEvent | Record<string, unknown>
@@ -139,6 +167,43 @@ function sortJsonKeys(value: unknown): unknown {
 }
 
 describe("Robinhood terminal and indexer documentation", () => {
+  it("serves the canonical guide before the GitBook catch-all", () => {
+    const exactRewriteIndex = vercelConfig.rewrites.findIndex(
+      ({ source }) => source === "/docs/developers/robinhood-terminal-indexer",
+    );
+    const gitBookCatchAllIndex = vercelConfig.rewrites.findIndex(
+      ({ source }) => source === "/docs/:match*",
+    );
+
+    expect(exactRewriteIndex).toBeGreaterThanOrEqual(0);
+    expect(gitBookCatchAllIndex).toBeGreaterThan(exactRewriteIndex);
+    expect(vercelConfig.rewrites[exactRewriteIndex]).toEqual({
+      source: "/docs/developers/robinhood-terminal-indexer",
+      destination: "/developer-reference/robinhood-terminal-indexer",
+    });
+    expect(aliasSource).toContain(
+      'from "@/app/docs/developers/robinhood-terminal-indexer/page"',
+    );
+    expect(sitemapSource).toContain(
+      '"/docs/developers/robinhood-terminal-indexer"',
+    );
+    expect(gitBookSummary).toContain(
+      "(developers/robinhood-terminal-indexer.md)",
+    );
+    for (const sentinel of [
+      "eip155:4663",
+      "0x34965F2A2ee9254522232C32F02056E92BE0C98a",
+      "platformId: programmable",
+      "category: custom",
+      "finalized-custom-launches",
+      "robinhood-terminal-indexer-v1.json",
+      "ProgrammableLaunchStampRouterV1.abi.json",
+      "Third-party indexing is not guaranteed",
+    ]) {
+      expect(gitBookSource).toContain(sentinel);
+    }
+  });
+
   it("pins the chain, Router identity, activation gate and fee policy boundary", () => {
     expect(fixture.integrationBoundary).toMatchObject({
       target: "public-self-serve",
@@ -147,6 +212,8 @@ describe("Robinhood terminal and indexer documentation", () => {
       feeBehaviorClaim: false,
       currentReleaseBlockers: {
         cleanRoomBinding: "V4_RELEASE_BINDING_NOT_READY",
+        cleanRoomReason:
+          "Machine-contract hashes are refreshed. The release binding remains incomplete until chain deployment, profile, release manifest, source closure, finality and backend release evidence are all present.",
         publicItemEvidence:
           "pending-per-launch-authoritative-exact-source-capture-persistence-promotion",
         existingPublicItemClaim: false,
@@ -225,7 +292,9 @@ describe("Robinhood terminal and indexer documentation", () => {
       expect(event, expected.name).toBeDefined();
       expect(toEventSelector(event!)).toBe(expected.topic0);
       expect(
-        event!.inputs.filter((input) => input.indexed).map((input) => input.name),
+        event!.inputs
+          .filter((input) => input.indexed)
+          .map((input) => input.name),
       ).toEqual(expected.indexedInputs);
     }
   });
@@ -241,7 +310,9 @@ describe("Robinhood terminal and indexer documentation", () => {
       },
       launches: [],
     });
-    expect(fixture.feed.exampleResponsePurpose).toMatch(/not a captured production/u);
+    expect(fixture.feed.exampleResponsePurpose).toMatch(
+      /not a captured production/u,
+    );
     expect(fixture.feed.requiredTerminalEvidence).toEqual({
       platformId: "programmable",
       category: "custom",
@@ -259,8 +330,7 @@ describe("Robinhood terminal and indexer documentation", () => {
         "programmable.custom-launch-l1-posting.v1",
       "onchain.l1Posting.chainId": "1",
       "onchain.l1Posting.caip2": "eip155:1",
-      "onchain.l1Posting.rollup":
-        "0x23A19d23e89166adedbDcB432518AB01e4272D94",
+      "onchain.l1Posting.rollup": "0x23A19d23e89166adedbDcB432518AB01e4272D94",
       "onchain.l1Posting.sequencerInbox":
         "0xBd0D173EEb87D57A09521c24388a12789F33ba96",
       "onchain.l1FinalizedCheckpoint": "required-object",
@@ -289,8 +359,7 @@ describe("Robinhood terminal and indexer documentation", () => {
       "onchain.terminal": true,
       "onchain.checkpointType": "ethereum_finalized",
       "onchain.router": "0x34965F2A2ee9254522232C32F02056E92BE0C98a",
-      "onchain.l1Posting.rollup":
-        "0x23A19d23e89166adedbDcB432518AB01e4272D94",
+      "onchain.l1Posting.rollup": "0x23A19d23e89166adedbDcB432518AB01e4272D94",
       "onchain.l1Posting.sequencerInbox":
         "0xBd0D173EEb87D57A09521c24388a12789F33ba96",
       "onchain.l1FinalizedCheckpoint.consensusCheckpointTag": "finalized",
@@ -345,9 +414,9 @@ describe("Robinhood terminal and indexer documentation", () => {
     expect(fixture.feed.coordinateSemantics.l1ProviderBindingRule).toMatch(
       /exact order.*ethereumFinalityEvidence/u,
     );
-    expect(fixture.feed.coordinateSemantics.directRouterVerificationRule).toMatch(
-      /Replay onchain\.l2Inclusion\.transactionHash/u,
-    );
+    expect(
+      fixture.feed.coordinateSemantics.directRouterVerificationRule,
+    ).toMatch(/Replay onchain\.l2Inclusion\.transactionHash/u);
     expect(fixture.feed.coordinateSemantics.l2EventOrderRule).toMatch(
       /routeEventLogIndex must be less than.*launchEventLogIndex/u,
     );
@@ -385,15 +454,11 @@ describe("Robinhood terminal and indexer documentation", () => {
     expect(pageSource).toContain(
       'l1SequencerInbox: "0xBd0D173EEb87D57A09521c24388a12789F33ba96"',
     );
-    expect(pageSource).toContain("V4_RELEASE_BINDING_NOT_READY");
-    expect(pageSource).toContain("This is not a provider-outage claim");
+    expect(pageSource).toContain("Source-verification authority");
+    expect(pageSource).toContain("Public activation authority");
     expect(pageSource).toContain("chainId !== 1");
-    expect(pageSource).toContain(
-      'page.quality.status !== "ready"',
-    );
-    expect(pageSource).toContain(
-      "sourceRowCount !== publishedRowCount",
-    );
+    expect(pageSource).toContain('page.quality.status !== "ready"');
+    expect(pageSource).toContain("sourceRowCount !== publishedRowCount");
     expect(pageSource).toContain("quarantinedRowCount !== 0");
     expect(pageSource).toContain("page.launches.length > publishedRowCount");
     expect(pageSource).toContain(
@@ -415,7 +480,9 @@ describe("Robinhood terminal and indexer documentation", () => {
     );
     expect(pageSource).toContain('feePolicyApplicability: "UNVERIFIED"');
     expect(pageSource).not.toContain("platformFeePolicy: {");
-    expect(pageSource).not.toMatch(/const stamp = await publicClient\.readContract/u);
+    expect(pageSource).not.toMatch(
+      /const stamp = await publicClient\.readContract/u,
+    );
   });
 
   it("keeps provenance independent from feed, activation and fee availability", () => {

--- a/tests/robinhood-terminal-indexer-docs.test.ts
+++ b/tests/robinhood-terminal-indexer-docs.test.ts
@@ -49,19 +49,15 @@ const vercelConfig = JSON.parse(
 type TerminalFixture = {
   integrationBoundary: {
     target: string;
-    activationStatus: string;
-    runtimeStatus: string;
+    stateAuthority: string;
+    fixtureCarriesProductionState: boolean;
+    activationAuthority: string;
+    runtimeAuthority: string;
+    publicItemAuthority: string;
     liveCreateGate: { paths: string[]; expected: boolean[] };
     feeBehaviorClaim: boolean;
-    currentReleaseBlockers: {
-      cleanRoomBinding: string;
-      cleanRoomReason: string;
-      publicItemEvidence: string;
-      existingPublicItemClaim: boolean;
-      providerOutageClaim: boolean;
-      sourcifyProviderReleaseAuthority: boolean;
-      robinhoodBlockscoutRequired: boolean;
-    };
+    releaseBlockersSource: string;
+    publicItemPresenceSource: string;
   };
   chain: { chainId: string; caip2: string; provenanceStartBlock: string };
   classification: {
@@ -87,6 +83,9 @@ type TerminalFixture = {
     requiredTerminalEvidence: Record<string, unknown>;
     openApiValidation: {
       url: string;
+      digestAuthorityUrl: string;
+      digestAuthorityPath: string;
+      digestAlgorithm: string;
       responseSchema: string;
       itemSchema: string;
       rule: string;
@@ -124,16 +123,14 @@ type TerminalFixture = {
     qualitySemantics: Record<string, string>;
   };
   feePolicy: {
-    required: boolean;
-    status: string;
-    defaultConfiguration: Record<string, unknown>;
-    enforcement: string;
+    authority: { url: string; path: string };
+    currentValueSource: string;
+    fixtureCarriesCurrentValues: boolean;
+    requiredFields: string[];
     feeBehaviorClaim: boolean;
     universalFeeBehaviorClaim: boolean;
     genericClaimingLive: boolean;
     chargedFeeResult: string;
-    canonicalOnchainEnforcementProven: boolean;
-    guaranteedRevenue: boolean;
     perLaunchApplicabilityWithoutExplicitBackendBinding: string;
   };
   resultAxes: {
@@ -204,23 +201,20 @@ describe("Robinhood terminal and indexer documentation", () => {
     }
   });
 
-  it("pins the chain, Router identity, activation gate and fee policy boundary", () => {
+  it("pins the chain and Router while resolving mutable state live", () => {
     expect(fixture.integrationBoundary).toMatchObject({
       target: "public-self-serve",
-      activationStatus: "pending-public-discovery-promotion",
-      runtimeStatus: "deployed-ready",
+      stateAuthority: "live-only",
+      fixtureCarriesProductionState: false,
+      activationAuthority:
+        "https://programmable.market/.well-known/programmable.json",
+      runtimeAuthority:
+        "https://api.programmable.market/v4/chains/4663/readiness",
+      publicItemAuthority:
+        "https://api.programmable.market/v4/chains/4663/finalized-custom-launches",
       feeBehaviorClaim: false,
-      currentReleaseBlockers: {
-        cleanRoomBinding: "V4_RELEASE_BINDING_NOT_READY",
-        cleanRoomReason:
-          "Machine-contract hashes are refreshed. The release binding remains incomplete until chain deployment, profile, release manifest, source closure, finality and backend release evidence are all present.",
-        publicItemEvidence:
-          "pending-per-launch-authoritative-exact-source-capture-persistence-promotion",
-        existingPublicItemClaim: false,
-        providerOutageClaim: false,
-        sourcifyProviderReleaseAuthority: false,
-        robinhoodBlockscoutRequired: false,
-      },
+      releaseBlockersSource: "live readiness reasonCodes only",
+      publicItemPresenceSource: "live finalized feed only",
       liveCreateGate: {
         paths: [
           "customLaunchApi.versions.v4.publicWrites",
@@ -248,23 +242,27 @@ describe("Robinhood terminal and indexer documentation", () => {
         "0x1dbbdaaad901ea3c6134dca0d4872a4789b3c071bf8ccfb44edd65d26d817388",
     });
     expect(fixture.feePolicy).toMatchObject({
-      required: true,
-      status: "required-default-configuration",
-      enforcement: "not-guaranteed-onchain",
+      authority: {
+        url: "https://programmable.market/.well-known/programmable.json",
+        path: "customLaunchApi.versions.v4.platformFeePolicy",
+      },
+      currentValueSource: "live-discovery-only",
+      fixtureCarriesCurrentValues: false,
       directRouterOrOutsideApiBindingClaim: false,
       perLaunchApplicabilityWithoutExplicitBackendBinding: "UNVERIFIED",
       feeBehaviorClaim: false,
       universalFeeBehaviorClaim: false,
       genericClaimingLive: false,
       chargedFeeResult: "UNAVAILABLE",
-      canonicalOnchainEnforcementProven: false,
-      guaranteedRevenue: false,
-      defaultConfiguration: {
-        rateBps: 20,
-        ratePpm: 2000,
-        recipient: "0xD88539d3c4C460136a733A3Fd60cf6BF269079da",
-      },
     });
+    expect(fixture.feePolicy.requiredFields).toEqual(
+      expect.arrayContaining([
+        "rateBps",
+        "ratePercent",
+        "recipient",
+        "enforcement",
+      ]),
+    );
   });
 
   it("hashes the exact downloadable ABI bytes and derives every event topic", () => {
@@ -344,11 +342,15 @@ describe("Robinhood terminal and indexer documentation", () => {
     });
     expect(fixture.feed.openApiValidation).toMatchObject({
       url: "https://programmable.market/openapi/custom-launch-v4.json",
+      digestAuthorityUrl:
+        "https://api.programmable.market/v4/chains/4663/readiness",
+      digestAuthorityPath: "openApiSha256",
+      digestAlgorithm: "sha256-exact-response-bytes",
       responseSchema: "#/components/schemas/CustomLaunchFinalizedListV4",
       itemSchema: "#/components/schemas/CustomLaunchFinalizedMetadataV4",
     });
     expect(fixture.feed.openApiValidation.rule).toMatch(
-      /complete response and every launches\[\] item/u,
+      /exact hosted OpenAPI response bytes.*readiness\.openApiSha256.*fail closed.*complete response.*launches\[\] item/u,
     );
     expect(fixture.feed.minimumIdentityEvidence.constantAssertions).toEqual({
       platformId: "programmable",
@@ -445,6 +447,7 @@ describe("Robinhood terminal and indexer documentation", () => {
       /successful response has status ready.*quarantinedRowCount equal to zero/u,
     );
     expect(pageSource).toContain("verifyCompleteRouterBinding");
+    expect(pageSource).toContain("readiness.openApiSha256 !== openApiSha256");
     expect(pageSource).toContain("await robinhoodClient.getChainId() !== 4663");
     expect(pageSource).toContain("ETHEREUM_DRPC_RPC_URL");
     expect(pageSource).toContain("ETHEREUM_QUICKNODE_RPC_URL");
@@ -479,6 +482,9 @@ describe("Robinhood terminal and indexer documentation", () => {
       'launch.sourceVerification.status !== "exact_match"',
     );
     expect(pageSource).toContain('feePolicyApplicability: "UNVERIFIED"');
+    expect(pageSource).not.toContain(
+      "0xD88539d3c4C460136a733A3Fd60cf6BF269079da",
+    );
     expect(pageSource).not.toContain("platformFeePolicy: {");
     expect(pageSource).not.toMatch(
       /const stamp = await publicClient\.readContract/u,

--- a/vercel.json
+++ b/vercel.json
@@ -51,6 +51,10 @@
       "destination": "/api/retired-prediction"
     },
     {
+      "source": "/docs/developers/robinhood-terminal-indexer",
+      "destination": "/developer-reference/robinhood-terminal-indexer"
+    },
+    {
       "source": "/docs",
       "destination": "https://proxy.gitbook.site/sites/site_V93gQ"
     },


### PR DESCRIPTION
## Summary

- publish a GitBook-native Robinhood terminal/indexer guide and add it to the public documentation table of contents
- make the advertised canonical guide URL bypass the stale GitBook catch-all through an exact first-match rewrite while preserving the browser URL
- keep activation state live-authority-driven and document exact Programmable stamp identity, Router events, finalized-feed pagination, L2/L1 finality, exact-source rules, independent result axes, and the third-party indexing boundary
- correct the stale explanation for the V4 release-binding blocker without claiming that public writes are active

## Verification

- targeted Robinhood documentation tests: 20 passed
- changed-file ESLint: passed
- GitBook/OpenAPI synchronization check: passed
- production build: passed, including candidate-neutrality and production-bundle scans

## Coordination

This PR owns only the public terminal-indexer guide, its route/TOC/sitemap, fixture explanation, and tests. Runtime activation, backend promotion, CLI release, finalized-feed performance, and Explore remain in the separate API release workstream.