### PR TITLE
fix: keep Robinhood indexer docs out of GitBook fallback

### DIFF
--- a/tests/robinhood-terminal-indexer-docs.test.ts
+++ b/tests/robinhood-terminal-indexer-docs.test.ts
@@ -165,12 +165,14 @@ function sortJsonKeys(value: unknown): unknown {
 }
 
 describe("Robinhood terminal and indexer documentation", () => {
-  it("serves the canonical guide before the GitBook catch-all", () => {
+  it("keeps the canonical guide out of the GitBook catch-all", () => {
     const exactRewriteIndex = vercelConfig.rewrites.findIndex(
       ({ source }) => source === "/docs/developers/robinhood-terminal-indexer",
     );
     const gitBookCatchAllIndex = vercelConfig.rewrites.findIndex(
-      ({ source }) => source === "/docs/:match*",
+      ({ source }) =>
+        source ===
+        "/docs/:match((?!developers/robinhood-terminal-indexer$).*)",
     );
 
     expect(exactRewriteIndex).toBeGreaterThanOrEqual(0);
@@ -178,6 +180,11 @@ describe("Robinhood terminal and indexer documentation", () => {
     expect(vercelConfig.rewrites[exactRewriteIndex]).toEqual({
       source: "/docs/developers/robinhood-terminal-indexer",
       destination: "/developer-reference/robinhood-terminal-indexer",
+    });
+    expect(vercelConfig.rewrites[gitBookCatchAllIndex]).toEqual({
+      source:
+        "/docs/:match((?!developers/robinhood-terminal-indexer$).*)",
+      destination: "https://proxy.gitbook.site/sites/site_V93gQ/:match*",
     });
     expect(aliasSource).toContain(
       'from "@/app/docs/developers/robinhood-terminal-indexer/page"',

--- a/vercel.json
+++ b/vercel.json
@@ -59,7 +59,7 @@
       "destination": "https://proxy.gitbook.site/sites/site_V93gQ"
     },
     {
-      "source": "/docs/:match*",
+      "source": "/docs/:match((?!developers/robinhood-terminal-indexer$).*)",
       "destination": "https://proxy.gitbook.site/sites/site_V93gQ/:match*"
     }
   ],


### PR DESCRIPTION
## Summary
- exclude the canonical Robinhood terminal indexer guide from the GitBook catch-all rewrite
- keep the public `/docs/developers/robinhood-terminal-indexer` URL on the in-app guide
- add a focused regression assertion for the Vercel route configuration

## Verification
- `npm exec -- vitest run tests/robinhood-terminal-indexer-docs.test.ts` (5 passed)
- live candidate verification follows the protected production workflow