### PR TITLE
Clean up website Explore and launch UI

### DIFF
--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -11,6 +11,7 @@ import type {
 } from "@/components/explore-view";
 import { DEFAULT_EXPLORE_VIEW_SORT } from "@/lib/explore-defaults";
 import { resolveExploreChainId } from "@/lib/explore-chain";
+import { websiteExploreIndexEnabledV1 } from "@/lib/website-explore-index";
 import {
   VIEW_CHAIN_COOKIE_NAME,
   type ViewChainId,
@@ -104,7 +105,7 @@ function isLocalPreviewHost(host: string | null) {
   );
 }
 
-async function InitialExploreView({
+export async function InitialExploreView({
   searchParams,
 }: Readonly<{ searchParams: ExplorePageSearchParams }>) {
   const [requestHeaders, requestCookies, resolvedSearchParams] =
@@ -117,6 +118,15 @@ async function InitialExploreView({
     requestCookies.get(VIEW_CHAIN_COOKIE_NAME)?.value,
   );
   const modelFilter = initialExploreModelFilter(resolvedSearchParams.model);
+  if (!websiteExploreIndexEnabledV1()) {
+    return (
+      <ExploreView
+        indexRebuilding
+        initialResponseChainId={viewChainId}
+        initialModelFilter={modelFilter}
+      />
+    );
+  }
   if (isLocalPreviewHost(requestHeaders.get("host"))) {
     return <ExploreView initialModelFilter={modelFilter} />;
   }

--- a/components/explore-chain-selector.module.css
+++ b/components/explore-chain-selector.module.css
@@ -11,17 +11,16 @@
   border-radius: var(--webde-radius-control);
   color: var(--webde-ink);
   display: inline-flex;
-  font-family: var(--font-instrument), sans-serif;
-  font-size: 14px;
-  font-weight: 600;
-  gap: 9px;
+  height: 44px;
+  justify-content: center;
   min-height: 44px;
-  padding: 0 12px;
+  padding: 0;
   transition:
     background-color 160ms cubic-bezier(0.32, 0.72, 0, 1),
     border-color 160ms cubic-bezier(0.32, 0.72, 0, 1),
     box-shadow 160ms cubic-bezier(0.32, 0.72, 0, 1);
   white-space: nowrap;
+  width: 44px;
 }
 
 .trigger:focus-visible {
@@ -35,19 +34,8 @@
   box-shadow: 0 0 0 3px rgb(255 255 255 / 0.08);
 }
 
-.chevron {
-  color: var(--webde-dim);
-  flex: none;
-  transition: transform 160ms cubic-bezier(0.32, 0.72, 0, 1);
-}
-
-.selector[data-open="true"] .chevron {
-  transform: rotate(180deg);
-}
-
 .ethereumMark,
-.robinhoodMark,
-.baseMark {
+.robinhoodMark {
   color: currentColor;
   display: block;
   flex: none;
@@ -63,13 +51,6 @@
   width: auto;
 }
 
-.baseMark {
-  background: #0052ff;
-  border: 5px solid currentColor;
-  border-radius: 50%;
-  box-shadow: inset 0 0 0 1px #0052ff;
-}
-
 .menu {
   -webkit-backdrop-filter: blur(20px);
   backdrop-filter: blur(20px);
@@ -80,8 +61,8 @@
   display: grid;
   gap: 2px;
   left: 0;
-  min-width: 232px;
-  padding: 8px;
+  min-width: 52px;
+  padding: 4px;
   position: absolute;
   top: calc(100% + 8px);
 }
@@ -93,12 +74,11 @@
   border-radius: 7px;
   color: var(--webde-muted);
   display: grid;
-  font: inherit;
-  grid-template-columns: 20px minmax(0, 1fr) 16px;
-  min-height: 48px;
-  padding: 7px 10px;
-  text-align: start;
-  width: 100%;
+  height: 44px;
+  min-height: 44px;
+  padding: 0;
+  place-items: center;
+  width: 44px;
 }
 
 .option:focus-visible {
@@ -106,40 +86,8 @@
   outline-offset: -2px;
 }
 
-.optionCurrent {
-  background: var(--webde-control);
-  color: var(--webde-ink);
-}
-
 .option[aria-disabled="true"] {
   color: var(--webde-dim);
-}
-
-.optionCopy {
-  display: grid;
-  gap: 2px;
-  min-width: 0;
-}
-
-.optionCopy > span:first-child {
-  font-family: var(--font-instrument), sans-serif;
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.optionStatus {
-  color: var(--webde-dim);
-  font-size: 11px;
-  line-height: 1.2;
-}
-
-.check {
-  color: var(--webde-ink);
-}
-
-.checkPlaceholder {
-  height: 16px;
-  width: 16px;
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -155,14 +103,14 @@
   .menu {
     left: auto;
     max-width: calc(100vw - 32px);
-    min-width: min(232px, calc(100vw - 32px));
+    min-width: 52px;
     right: 0;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .trigger,
-  .chevron {
+  .option {
     transition-duration: 0.01ms;
   }
 }
@@ -175,8 +123,7 @@
     box-shadow: none;
   }
 
-  .robinhoodMark,
-  .baseMark {
+  .robinhoodMark {
     background: CanvasText;
     forced-color-adjust: none;
   }

--- a/components/explore-chain-selector.tsx
+++ b/components/explore-chain-selector.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Check, ChevronDown } from "lucide-react";
 import {
   useEffect,
   useId,
@@ -22,7 +21,7 @@ import styles from "@/components/explore-chain-selector.module.css";
 type ExploreChainOption = Readonly<{
   id: number;
   label: string;
-  mark: "ethereum" | "robinhood" | "base";
+  mark: "ethereum" | "robinhood";
   viewChainId?: ViewChainId;
   available: boolean;
 }>;
@@ -40,12 +39,6 @@ const EXPLORE_CHAIN_OPTIONS = [
     label: "Robinhood",
     mark: "robinhood",
     viewChainId: 4663,
-    available: false,
-  },
-  {
-    id: 8453,
-    label: "Base",
-    mark: "base",
     available: false,
   },
 ] as const satisfies readonly ExploreChainOption[];
@@ -73,21 +66,18 @@ function ExploreChainMark({ mark }: Readonly<{ mark: ExploreChainOption["mark"] 
     );
   }
 
-  return (
-    <span
-      className={mark === "robinhood" ? styles.robinhoodMark : styles.baseMark}
-      aria-hidden="true"
-    />
-  );
+  return <span className={styles.robinhoodMark} aria-hidden="true" />;
 }
 
-export function ExploreChainSelector() {
+export function ExploreChainSelector({
+  probeAvailability = true,
+}: Readonly<{ probeAvailability?: boolean }> = {}) {
   const { hydrated, viewChainId, setViewChainId } = useViewChain();
   const [open, setOpen] = useState(false);
   const [robinhoodAvailable, setRobinhoodAvailable] = useState(false);
   const exploreChainOptions = EXPLORE_CHAIN_OPTIONS.map((option) =>
     option.id === 4663
-      ? { ...option, available: robinhoodAvailable }
+      ? { ...option, available: probeAvailability && robinhoodAvailable }
       : option
   ) satisfies readonly ExploreChainOption[];
   const selectedViewChainId = resolveExploreChainId(viewChainId);
@@ -103,8 +93,12 @@ export function ExploreChainSelector() {
   const triggerRef = useRef<HTMLButtonElement>(null);
   const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const selected = exploreChainOptions[selectedIndex]!;
+  const alternateOptions = exploreChainOptions.filter(
+    (option) => option.id !== selected.id,
+  );
 
   useEffect(() => {
+    if (!probeAvailability) return;
     const controller = new AbortController();
     const timeout = window.setTimeout(() => controller.abort(), 5_000);
     void fetch("/api/explore?chain=4663&limit=1&page=1&q=&sort=newest", {
@@ -119,7 +113,7 @@ export function ExploreChainSelector() {
       window.clearTimeout(timeout);
       controller.abort();
     };
-  }, []);
+  }, [probeAvailability]);
 
   useEffect(() => {
     if (!open) return;
@@ -139,7 +133,7 @@ export function ExploreChainSelector() {
     if (open) optionRefs.current[activeIndex]?.focus();
   }, [activeIndex, open]);
 
-  function openListbox(index = selectedIndex) {
+  function openListbox(index = 0) {
     setActiveIndex(index);
     setOpen(true);
   }
@@ -163,25 +157,24 @@ export function ExploreChainSelector() {
   ) {
     if (event.key === "ArrowDown") {
       event.preventDefault();
-      setActiveIndex((index + 1) % exploreChainOptions.length);
+      setActiveIndex((index + 1) % alternateOptions.length);
     } else if (event.key === "ArrowUp") {
       event.preventDefault();
       setActiveIndex(
-        (index - 1 + exploreChainOptions.length) %
-          exploreChainOptions.length,
+        (index - 1 + alternateOptions.length) % alternateOptions.length,
       );
     } else if (event.key === "Home") {
       event.preventDefault();
       setActiveIndex(0);
     } else if (event.key === "End") {
       event.preventDefault();
-      setActiveIndex(exploreChainOptions.length - 1);
+      setActiveIndex(alternateOptions.length - 1);
     } else if (event.key === "Escape") {
       event.preventDefault();
       closeListbox();
     } else if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
-      const option = exploreChainOptions[index];
+      const option = alternateOptions[index];
       if (option) selectChain(option);
     }
   }
@@ -217,10 +210,10 @@ export function ExploreChainSelector() {
         onKeyDown={(event) => {
           if (event.key === "ArrowDown") {
             event.preventDefault();
-            openListbox(selectedIndex);
+            openListbox();
           } else if (event.key === "ArrowUp") {
             event.preventDefault();
-            openListbox(exploreChainOptions.length - 1);
+            openListbox(alternateOptions.length - 1);
           } else if (event.key === "Escape" && open) {
             event.preventDefault();
             closeListbox();
@@ -228,8 +221,6 @@ export function ExploreChainSelector() {
         }}
       >
         <ExploreChainMark mark={selected.mark} />
-        <span>{selected.label}</span>
-        <ChevronDown className={styles.chevron} aria-hidden="true" size={15} />
       </button>
 
       {open ? (
@@ -239,41 +230,31 @@ export function ExploreChainSelector() {
           role="listbox"
           aria-label="Explore chains"
         >
-          {exploreChainOptions.map((option, index) => {
-            const current = option.id === selectedViewChainId;
-            return (
+          {alternateOptions.map((option, index) => (
               <button
                 key={option.id}
                 ref={(element) => {
                   optionRefs.current[index] = element;
                 }}
-                className={`${styles.option} ${
-                  current ? styles.optionCurrent : ""
-                }`}
+                className={styles.option}
                 type="button"
                 role="option"
-                aria-selected={current}
+                aria-selected={false}
                 aria-disabled={!option.available || undefined}
+                aria-label={option.available
+                  ? `Switch Explore to ${option.label}`
+                  : `${option.label} coming soon`}
+                title={option.available
+                  ? option.label
+                  : `${option.label} · Coming soon`}
                 data-active={activeIndex === index ? "true" : "false"}
                 tabIndex={activeIndex === index ? 0 : -1}
                 onClick={() => selectChain(option)}
                 onKeyDown={(event) => handleOptionKeyDown(event, index)}
               >
                 <ExploreChainMark mark={option.mark} />
-                <span className={styles.optionCopy}>
-                  <span>{option.label}</span>
-                  {!option.available ? (
-                    <span className={styles.optionStatus}>Coming soon</span>
-                  ) : null}
-                </span>
-                {current ? (
-                  <Check className={styles.check} aria-hidden="true" size={16} />
-                ) : (
-                  <span className={styles.checkPlaceholder} aria-hidden="true" />
-                )}
               </button>
-            );
-          })}
+          ))}
         </div>
       ) : null}
     </div>

--- a/components/explore-experience.module.css
+++ b/components/explore-experience.module.css
@@ -1106,6 +1106,10 @@
   gap: 10px;
 }
 
+.chainControl {
+  flex: none;
+}
+
 .runnersIntro :global(.token-search),
 .runnersIntro :global(.token-filter summary),
 .runnersIntro :global(.token-pagination) {
@@ -1249,7 +1253,7 @@
 }
 
 .runnerBody {
-  min-height: 118px;
+  min-height: 82px;
   padding: 18px 18px 14px;
 }
 
@@ -1478,9 +1482,9 @@
     display: grid;
     gap: 8px;
     grid-template-areas:
-      "search search"
-      "pages sort";
-    grid-template-columns: minmax(0, 1fr) auto;
+      "search search search"
+      "pages chain sort";
+    grid-template-columns: minmax(0, 1fr) auto auto;
   }
 
   .runnersIntro :global(.token-search) {
@@ -1491,6 +1495,11 @@
 
   .runnersIntro :global(.token-filter) {
     grid-area: sort;
+    justify-self: end;
+  }
+
+  .chainControl {
+    grid-area: chain;
     justify-self: end;
   }
 
@@ -1653,7 +1662,7 @@
   }
 
   .runnersIntro :global(.token-toolbar) {
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr) auto auto;
   }
 
   .runnersIntro :global(.token-filter summary) {

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -22,10 +22,7 @@ import {
   useSyncExternalStore,
 } from "react";
 
-import {
-  AnimatedMarketCap,
-  type MarketCapMetric,
-} from "@/components/animated-market-cap";
+import type { MarketCapMetric } from "@/components/animated-market-cap";
 import { XBrandIcon } from "@/components/brand-icons";
 import { ExploreChainSelector } from "@/components/explore-chain-selector";
 import { EXPLORE_PREVIEW_TOKENS } from "@/components/explore-preview-data";
@@ -100,7 +97,7 @@ type TokenCard = {
   marketStatus?: ExploreMarketStatus;
   usesFallbackImage: boolean;
   tokenAddress?: `0x${string}`;
-  launchCategory: "Classic" | "Custom";
+  launchCategory: "Classic" | "Custom V4 Hook";
   partnerAttribution?: LaunchPartnerAttributionV1;
 };
 
@@ -795,13 +792,6 @@ const fallbackTokenImages = [
   "/brand/programmable-token-card-fallback-night-garden-05.webp",
   "/brand/programmable-token-card-fallback-night-garden-06.webp",
 ] as const;
-const valuationSortOptions: {
-  id: Exclude<ExploreValuationSort, "none">;
-  label: string;
-}[] = [
-  { id: "highest", label: "Highest" },
-  { id: "lowest", label: "Lowest" },
-];
 const ageSortOptions: {
   id: Exclude<ExploreAgeSort, "none">;
   label: string;
@@ -821,7 +811,7 @@ const modelFilterOptions: {
   label: string;
 }[] = [
   { id: "classic", label: "Classic" },
-  { id: "custom-hook", label: "Custom" },
+  { id: "custom-hook", label: "Custom V4 Hook" },
 ];
 
 export function exploreActiveSelectionState({
@@ -847,7 +837,7 @@ export function exploreActiveSelectionState({
     modelFilter === "classic"
       ? "Classic"
       : modelFilter === "custom-hook"
-        ? "Custom"
+        ? "Custom V4 Hook"
         : null,
     discoverySort === "trending" ? "Trending" : null,
     valuationSort !== "none" &&
@@ -3313,7 +3303,7 @@ export function getTokenCards(
       launchCategory:
         token.launchCategoryProvenance.category === "classic"
           ? "Classic"
-          : "Custom",
+          : "Custom V4 Hook",
       ...(token.partnerAttribution
         ? { partnerAttribution: token.partnerAttribution }
         : {}),
@@ -3410,7 +3400,7 @@ function ExploreGridSkeleton({ count }: Readonly<{ count: number }>) {
 
 function resultRangeLabel(payload: ExplorePayload | null) {
   if (!payload) return "Loading launch index";
-  if (payload.status === "not-deployed") return "Explore unavailable";
+  if (payload.status === "not-deployed") return "Launch index rebuilding";
   if (payload.total === 0) return "0 launches";
 
   const start = (payload.page - 1) * payload.pageSize + 1;
@@ -3424,12 +3414,14 @@ export function ExploreView({
   initialResponse,
   initialResponseChainId,
   initialModelFilter = "all",
+  indexRebuilding = false,
   loadingOnly = false,
   embedded = false,
 }: Readonly<{
   initialResponse?: ExploreInitialResponse;
   initialResponseChainId?: ViewChainId;
   initialModelFilter?: ExploreModelFilter;
+  indexRebuilding?: boolean;
   loadingOnly?: boolean;
   embedded?: boolean;
 }> = {}) {
@@ -3640,6 +3632,7 @@ export function ExploreView({
 
   useEffect(() => {
     if (
+      indexRebuilding ||
       preview ||
       loadingOnly ||
       isInterfacePreviewHost(window.location.hostname)
@@ -3682,10 +3675,11 @@ export function ExploreView({
       window.removeEventListener("online", syncScheduler);
       window.removeEventListener("offline", syncScheduler);
     };
-  }, [activeRequestContentKey, loadingOnly, pageSize, preview]);
+  }, [activeRequestContentKey, indexRebuilding, loadingOnly, pageSize, preview]);
 
   useEffect(() => {
     if (
+      indexRebuilding ||
       preview ||
       loadingOnly ||
       (typeof window !== "undefined" &&
@@ -3860,6 +3854,7 @@ export function ExploreView({
     activeInitialResponse,
     initialModelFilter,
     initialState,
+    indexRebuilding,
     loadingOnly,
     preview,
     revalidationKey,
@@ -3916,14 +3911,28 @@ export function ExploreView({
       state.contentKey.startsWith(`${chainContentKey}\u0000`)
       ? state
       : { phase: "loading" };
-  const displayState: ExploreState = preview
+  const displayState: ExploreState = indexRebuilding
     ? {
+        phase: "ready",
+        payload: {
+          status: "not-deployed",
+          tokens: [],
+          page: 1,
+          pageSize,
+          total: 0,
+          totalPages: 0,
+        },
+        requestKey,
+        contentKey,
+      }
+    : preview
+      ? {
         phase: "ready",
         payload: previewPayload,
         requestKey,
         contentKey,
       }
-    : activeChainState;
+      : activeChainState;
 
   const payload = displayState.phase === "ready" ? displayState.payload : null;
   const cards = useMemo(
@@ -3952,7 +3961,7 @@ export function ExploreView({
   const resultLabel =
     displayState.phase === "error" ? "" : resultRangeLabel(payload);
   const busy =
-    !preview &&
+    !preview && !indexRebuilding &&
     (displayState.phase === "loading" ||
       displayState.requestKey !== requestKey);
   const {
@@ -4027,12 +4036,12 @@ export function ExploreView({
             <h2>
               {viewChainId === 4663
                 ? "Robinhood Explore is not active yet"
-                : "Explore is getting ready"}
+                : "Launch indexing is being rebuilt"}
             </h2>
             <p>
               {viewChainId === 4663
                 ? "The Robinhood Explore and indexing lane is not available yet."
-                : "The launch index is not available in this environment yet."}
+                : "Programmable launches will return here after the new index is ready."}
             </p>
           </div>
         </div>
@@ -4156,27 +4165,6 @@ export function ExploreView({
                   <h3 title={token.name}>{token.name}</h3>
                   {token.symbol ? <span>${token.symbol}</span> : null}
                 </header>
-                <div className={styles.runnerData}>
-                  <span>
-                    <small
-                      title={token.valuationProvider
-                        ? `Fully diluted valuation from ${token.valuationProvider}`
-                        : "Fully diluted valuation"}
-                    >
-                      FDV{token.valuationProvider
-                        ? ` · ${token.valuationProvider}`
-                        : ""}
-                    </small>
-                    {token.valuation ? (
-                      <AnimatedMarketCap
-                        metric={token.valuation}
-                        replayKey={token.id}
-                      />
-                    ) : (
-                      <strong>{token.marketStatus ?? "Unavailable"}</strong>
-                    )}
-                  </span>
-                </div>
               </div>
             </>
           );
@@ -4281,7 +4269,6 @@ export function ExploreView({
         <header className={styles.pageHeading}>
           <div className={styles.titleRow}>
             <Heading data-explore-heading>Explore</Heading>
-            {!embedded ? <ExploreChainSelector /> : null}
           </div>
         </header>
 
@@ -4291,7 +4278,7 @@ export function ExploreView({
           aria-busy={busy}
         >
           <div className={styles.runnersIntro}>
-            {hasPublicTokens ? (
+            {hasPublicTokens || !embedded ? (
               <div className="token-section-heading">
                 <ResultsHeading className="sr-only">Launches</ResultsHeading>
                 <div
@@ -4331,6 +4318,14 @@ export function ExploreView({
                       </button>
                     ) : null}
                   </div>
+
+                  {!embedded ? (
+                    <div className={styles.chainControl}>
+                      <ExploreChainSelector
+                        probeAvailability={!indexRebuilding}
+                      />
+                    </div>
+                  ) : null}
 
                   <details
                     className="token-filter"
@@ -4397,87 +4392,6 @@ export function ExploreView({
                           >
                             <span>{option.label}</span>
                             {modelFilter === option.id ? (
-                              <Check aria-hidden="true" size={15} />
-                            ) : null}
-                          </button>
-                        ))}
-                      </div>
-
-                      <div
-                        className={styles.filterGroup}
-                        role="group"
-                        aria-labelledby="explore-discovery-label"
-                      >
-                        <p
-                          className={styles.filterLabel}
-                          id="explore-discovery-label"
-                        >
-                          Discovery
-                        </p>
-                        <button
-                          className={
-                            discoverySortForChain === "trending"
-                              ? "active"
-                              : undefined
-                          }
-                          type="button"
-                          aria-label={viewChainId === 1
-                            ? "Rank launches by GMGN Trending"
-                            : "Trending is available on Ethereum only"}
-                          aria-pressed={discoverySortForChain === "trending"}
-                          disabled={viewChainId !== 1}
-                          onClick={() => {
-                            setDiscoverySort((current) =>
-                              current === "trending" ? "none" : "trending"
-                            );
-                            setValuationSort(DEFAULT_EXPLORE_VALUATION_SORT);
-                            setAgeSort("none");
-                            setCurrentPage(1);
-                          }}
-                        >
-                          <span>Trending</span>
-                          {discoverySortForChain === "trending" ? (
-                            <Check aria-hidden="true" size={15} />
-                          ) : null}
-                        </button>
-                      </div>
-
-                      <div
-                        className={styles.filterGroup}
-                        role="group"
-                        aria-labelledby="explore-valuation-label"
-                      >
-                        <p
-                          className={styles.filterLabel}
-                          id="explore-valuation-label"
-                          title="GMGN market cap with FDV fallback for unmatched launches"
-                        >
-                          Market cap
-                        </p>
-                        {valuationSortOptions.map((option) => (
-                          <button
-                            key={option.id}
-                            className={
-                              valuationSortForChain === option.id
-                                ? "active"
-                                : undefined
-                            }
-                            type="button"
-                            aria-label={viewChainId === 4663
-                              ? `${option.label} market cap is available on Ethereum only`
-                              : `${option.label} market cap`}
-                            aria-pressed={valuationSortForChain === option.id}
-                            disabled={viewChainId === 4663}
-                            onClick={() => {
-                              setValuationSort((current) =>
-                                current === option.id ? "none" : option.id,
-                              );
-                              setDiscoverySort("none");
-                              setCurrentPage(1);
-                            }}
-                          >
-                            <span>{option.label}</span>
-                            {valuationSortForChain === option.id ? (
                               <Check aria-hidden="true" size={15} />
                             ) : null}
                           </button>

--- a/components/explore-view.tsx
+++ b/components/explore-view.tsx
@@ -3353,18 +3353,6 @@ function ExploreCardSkeleton() {
               data-skeleton="true"
             />
           </div>
-          <div className={styles.runnerData}>
-            <span>
-              <span
-                className={`${styles.skeletonLine} ${styles.skeletonLabel}`}
-                data-skeleton="true"
-              />
-              <span
-                className={`${styles.skeletonLine} ${styles.skeletonValue}`}
-                data-skeleton="true"
-              />
-            </span>
-          </div>
         </div>
       </div>
       <div className={styles.runnerMeta}>

--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -136,7 +136,7 @@ export function LaunchModelPicker({
         <span
           className={`launch-model-card-heading ${launchExperience.modelHeading}`}
         >
-          <strong id="launch-model-custom-title">Custom</strong>
+          <strong id="launch-model-custom-title">Custom V4 Hook</strong>
           <small data-status="pending">Preflight required</small>
         </span>
         <span
@@ -149,7 +149,7 @@ export function LaunchModelPicker({
         <span
           className={`launch-model-action ${launchExperience.modelAction}`}
         >
-          Open Custom launch
+          Open Custom V4 Hook
           <ArrowRight aria-hidden="true" size={16} />
         </span>
       </span>
@@ -176,7 +176,7 @@ export function LaunchModelPicker({
           disabled={!classicV3LaunchAvailable || preparingModel !== null}
           aria-busy={preparingModel === "classic-v3"}
           aria-labelledby="launch-model-classic-title"
-          aria-describedby="launch-model-classic-description"
+          aria-describedby="launch-model-classic-description launch-model-classic-status"
           onPointerEnter={
             classicV3LaunchAvailable ? preloadAvailableForm : undefined
           }
@@ -215,9 +215,12 @@ export function LaunchModelPicker({
               className={`launch-model-card-heading ${launchExperience.modelHeading}`}
             >
               <strong id="launch-model-classic-title">Classic</strong>
-              {!classicV3LaunchAvailable ? (
-                <small data-status="pending">Unavailable</small>
-              ) : null}
+              <small
+                id="launch-model-classic-status"
+                data-status={classicV3LaunchAvailable ? "ready" : "pending"}
+              >
+                {classicV3LaunchAvailable ? "Ethereum only" : "Unavailable"}
+              </small>
             </span>
             <span
               className={`launch-model-description ${launchExperience.modelDescription}`}

--- a/components/token-detail-view.tsx
+++ b/components/token-detail-view.tsx
@@ -1412,7 +1412,7 @@ export function buildTokenDetailMetrics(
       label: "Category",
       value:
         token.launchStampProvenance?.kind === "custom-graph"
-          ? "Custom"
+          ? "Custom V4 Hook"
           : "Classic",
     },
     marketProvider
@@ -2660,7 +2660,7 @@ function CustomProjectDetailContent({
           <div className={styles.identityCopy}>
             <div className={styles.tokenSymbolRow}>
               {project.symbol ? <span className={styles.symbol}>${project.symbol}</span> : null}
-              <span className={styles.categoryBadge}>Custom</span>
+              <span className={styles.categoryBadge}>Custom V4 Hook</span>
             </div>
             <h1 className={styles.name}>{project.name}</h1>
             {project.links.length > 0 ? (
@@ -2722,10 +2722,10 @@ function CustomProjectDetailContent({
               <span>Market details</span>
               <h2 id="custom-market-heading">{customMarketStatus(project)}</h2>
             </div>
-            <span className={styles.categoryBadge}>Custom</span>
+            <span className={styles.categoryBadge}>Custom V4 Hook</span>
           </div>
           <dl className={styles.customFacts}>
-            <div><dt>Type</dt><dd>Custom</dd></div>
+            <div><dt>Type</dt><dd>Custom V4 Hook</dd></div>
             <div><dt>Launch model</dt><dd>{project.modelId}</dd></div>
             <div><dt>Chain</dt><dd>{getNetworkLabel(chainId)}</dd></div>
             <div><dt>Markets</dt><dd>{project.markets.length}</dd></div>

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -358,6 +358,14 @@ export function getWalletSessionAction(ready: boolean, authenticated: boolean) {
   return "login" as const;
 }
 
+export function getWalletOpenAction(
+  sessionAction: ReturnType<typeof getWalletSessionAction>,
+  hasWallet: boolean,
+) {
+  if (sessionAction !== "manage") return sessionAction;
+  return hasWallet ? "manage" as const : "link" as const;
+}
+
 export function isWalletProviderSettled(
   privyReady: boolean,
   walletsReady: boolean,
@@ -1683,10 +1691,20 @@ function PrivyWalletBridge({
     });
   }, [activeAuthenticated, githubConnected, linkGithub, login, ready]);
 
+  const addWallet = useCallback(() => {
+    setDialogOpen(false);
+    linkWallet({
+      description: "Add an Ethereum wallet to Programmable",
+      walletChainType: "ethereum-only",
+    });
+  }, [linkWallet]);
+
   const openWallet = useCallback(() => {
     setError("");
 
-    if (sessionAction === "wait") {
+    const action = getWalletOpenAction(sessionAction, wallet !== null);
+
+    if (action === "wait") {
       if (providerTimedOut) {
         setError(
           "Wallet access is taking longer than expected. Reload the page and try again.",
@@ -1695,13 +1713,18 @@ function PrivyWalletBridge({
       }
       return;
     }
-    if (sessionAction === "manage") {
+    if (action === "manage") {
       setDialogOpen(true);
       return;
     }
 
+    if (action === "link") {
+      addWallet();
+      return;
+    }
+
     startLogin();
-  }, [providerTimedOut, sessionAction, startLogin]);
+  }, [addWallet, providerTimedOut, sessionAction, startLogin, wallet]);
 
   const openWalletWithError = useCallback((message: string) => {
     setError(message);
@@ -1815,14 +1838,6 @@ function PrivyWalletBridge({
       setSwitchingNetwork(false);
     }
   }, [connectedWallet]);
-
-  const addWallet = useCallback(() => {
-    setDialogOpen(false);
-    linkWallet({
-      description: "Add an Ethereum wallet to Programmable",
-      walletChainType: "ethereum-only",
-    });
-  }, [linkWallet]);
 
   const sendTransaction = useCallback(
     async (transaction: PreparedTransaction) => {

--- a/lib/website-explore-index.ts
+++ b/lib/website-explore-index.ts
@@ -1,0 +1,19 @@
+const WEBSITE_EXPLORE_INDEX_FLAG =
+  "PROGRAMMABLE_WEBSITE_EXPLORE_INDEX_ENABLED" as const;
+
+type WebsiteExploreEnvironment = Readonly<{
+  PROGRAMMABLE_WEBSITE_EXPLORE_INDEX_ENABLED?: string;
+}>;
+
+/**
+ * Temporary website-only boundary while the public Explore experience is
+ * rebuilt. The public APIs and provider adapters remain unchanged.
+ */
+export function websiteExploreIndexEnabledV1(
+  environment: WebsiteExploreEnvironment = {
+    [WEBSITE_EXPLORE_INDEX_FLAG]: process.env[WEBSITE_EXPLORE_INDEX_FLAG],
+  },
+) {
+  return environment[WEBSITE_EXPLORE_INDEX_FLAG]?.trim().toLowerCase() ===
+    "true";
+}

--- a/tests/browser/site-header.spec.ts
+++ b/tests/browser/site-header.spec.ts
@@ -61,19 +61,16 @@ test("keeps network selection out of the global header",async ({page})=>{
   await expect(page.getByRole("button",{name:walletName,exact:true})).toBeVisible();
 });
 
-test("Explore exposes one live chain and two truthful coming-soon choices",async ({page})=>{
+test("Explore exposes an icon-only Ethereum trigger and Robinhood choice",async ({page})=>{
   const trigger=page.getByRole("button",{name:"Explore chain: Ethereum",exact:true});
+  await expect(trigger).toHaveText("");
   await trigger.click();
   const listbox=page.getByRole("listbox",{name:"Explore chains",exact:true});
-  await expect(listbox.getByRole("option")).toHaveText([
-    "Ethereum",
-    "RobinhoodComing soon",
-    "BaseComing soon",
-  ]);
-  await expect(listbox.getByRole("option",{name:"Robinhood Coming soon",exact:true})).toHaveAttribute("aria-disabled","true");
-  await expect(listbox.getByRole("option",{name:"Base Coming soon",exact:true})).toHaveAttribute("aria-disabled","true");
+  await expect(listbox.getByRole("option")).toHaveCount(1);
+  await expect(listbox.getByRole("option",{name:"Robinhood coming soon",exact:true})).toHaveAttribute("aria-disabled","true");
+  await expect(listbox).not.toContainText("Base");
   await page.keyboard.press("ArrowDown");
-  await expect(listbox.getByRole("option",{name:"Robinhood Coming soon",exact:true})).toBeFocused();
+  await expect(listbox.getByRole("option",{name:"Robinhood coming soon",exact:true})).toBeFocused();
   await page.keyboard.press("Enter");
   await expect(page.getByTestId("view-chain")).toHaveText("1");
   await expect(page.getByTestId("requests")).toBeEmpty();

--- a/tests/explore-page-ssr.test.ts
+++ b/tests/explore-page-ssr.test.ts
@@ -7,17 +7,43 @@ vi.mock("next/headers", () => ({ cookies: vi.fn(), headers: vi.fn() }));
 import {
   INITIAL_EXPLORE_TIMEOUT_MS,
   INITIAL_EXPLORE_QUERY,
+  InitialExploreView,
   initialExploreModelFilter,
   initialExploreQuery,
   readInitialExploreWithinDeadline,
 } from "../app/explore/page";
+import { GET as readExploreResponse } from "@/app/api/explore/route";
+import { cookies, headers } from "next/headers";
 import { DEFAULT_EXPLORE_VIEW_SORT } from "../lib/explore-defaults";
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe("Explore initial server read", () => {
+  it("retires only the website surface without reading the public Explore API", async () => {
+    vi.stubEnv("PROGRAMMABLE_WEBSITE_EXPLORE_INDEX_ENABLED", "false");
+    vi.mocked(headers).mockResolvedValue({
+      get: () => "programmable.market",
+    } as never);
+    vi.mocked(cookies).mockResolvedValue({
+      get: () => undefined,
+    } as never);
+
+    const element = await InitialExploreView({
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(readExploreResponse).not.toHaveBeenCalled();
+    expect(element.props).toMatchObject({
+      indexRebuilding: true,
+      initialResponseChainId: 1,
+      initialModelFilter: "all",
+    });
+  });
+
   it("covers the API provider budget without allowing an unbounded render", () => {
     expect(INITIAL_EXPLORE_TIMEOUT_MS).toBeGreaterThan(8_000);
     expect(INITIAL_EXPLORE_TIMEOUT_MS).toBeLessThanOrEqual(9_000);

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -29,6 +29,8 @@ describe("Explore UI contract", () => {
     expect(page).toContain("requestCookies.get(VIEW_CHAIN_COOKIE_NAME)");
     expect(page).toContain("resolveExploreChainId(");
     expect(page).toContain("initialExploreQuery(modelFilter, viewChainId)");
+    expect(page).toContain("if (!websiteExploreIndexEnabledV1())");
+    expect(page).toContain("indexRebuilding");
     expect(source).toContain("hydrated: viewChainReady");
     expect(source).toContain("viewChainId: resolvedViewChainId");
     expect(source).toContain("resolveExploreChainId(hydratedViewChainId)");
@@ -63,10 +65,16 @@ describe("Explore UI contract", () => {
     expect(source).toContain("inert={loadingOnly ? true : undefined}");
     expect(source).toContain('const Heading = embedded ? "h2" : "h1"');
     expect(source).toContain("<Heading data-explore-heading>Explore</Heading>");
-    expect(source).toContain("!embedded ? <ExploreChainSelector /> : null");
-    expect(source.indexOf("<ExploreChainSelector />")).toBeLessThan(
-      source.indexOf('id="tokens"'),
+    expect(source).toContain("<ExploreChainSelector");
+    expect(source).toContain("probeAvailability={!indexRebuilding}");
+    expect(source.indexOf("<ExploreChainSelector")).toBeGreaterThan(
+      source.indexOf('className="token-search liquid-glass-control"'),
     );
+    expect(source.indexOf("<ExploreChainSelector")).toBeLessThan(
+      source.indexOf("<details"),
+    );
+    expect(source).toContain("indexRebuilding ||\n      preview ||");
+    expect(source).toContain("const displayState: ExploreState = indexRebuilding");
     expect(source).not.toContain("ExploreModeSwitch");
     expect(source).toContain("const eagerImage = !embedded");
     expect(source).toContain("onPointerEnter={() => router.prefetch(href)}");
@@ -158,15 +166,15 @@ describe("Explore UI contract", () => {
     );
 
     expect(source).toContain('id="explore-model-label"');
-    expect(source).toContain('id="explore-discovery-label"');
-    expect(source).toContain('id="explore-valuation-label"');
+    expect(source).not.toContain('id="explore-discovery-label"');
+    expect(source).not.toContain('id="explore-valuation-label"');
     expect(source).toContain('id="explore-age-label"');
     expect(source).toContain('id="explore-socials-label"');
     expect(source).toContain('{ id: "classic", label: "Classic" }');
-    expect(source).toContain('{ id: "custom-hook", label: "Custom" }');
-    expect(source).toContain('>Trending</span>');
+    expect(source).toContain(
+      '{ id: "custom-hook", label: "Custom V4 Hook" }',
+    );
     expect(source).toContain('sort,\n      page: String(currentPage)');
-    expect(source).toContain('aria-label={viewChainId === 1');
     expect(source).toContain(
       'valuationSort !== DEFAULT_EXPLORE_VALUATION_SORT',
     );
@@ -175,24 +183,17 @@ describe("Explore UI contract", () => {
     expect(source).toContain("<span>Filters</span>");
     expect(source).toContain("activeFilterCount > 0");
     expect(source.indexOf('id="explore-model-label"')).toBeLessThan(
-      source.indexOf('id="explore-valuation-label"'),
-    );
-    expect(source.indexOf('id="explore-valuation-label"')).toBeLessThan(
       source.indexOf('id="explore-age-label"'),
     );
     expect(source.indexOf('id="explore-age-label"')).toBeLessThan(
       source.indexOf('id="explore-socials-label"'),
     );
-    expect(source).toContain("valuationSortOptions.map((option) => (");
+    expect(source).not.toContain("valuationSortOptions.map((option) => (");
     expect(source).toContain("ageSortOptions.map((option) => (");
     expect(source).toContain("resolveExploreSortSelectionsForChain(");
     expect(source).toContain(
-      "aria-pressed={valuationSortForChain === option.id}",
-    );
-    expect(source).toContain(
       "aria-pressed={ageSortForChain === option.id}",
     );
-    expect(source).toMatch(/disabled=\{viewChainId === 4663\}/u);
     expect(source).toMatch(
       /disabled=\{viewChainId === 4663 &&\s+option\.id === "oldest"\}/u,
     );
@@ -203,7 +204,6 @@ describe("Explore UI contract", () => {
     expect(source).toContain(
       "if (viewChainId === 1) {\n                                setDiscoverySort(\"none\");",
     );
-    expect(source).toContain("setValuationSort((current) =>");
     expect(source).toContain("setAgeSort((current) =>");
     expect(source).toContain('search.set(\n        "model",');
     expect(source).toContain(
@@ -262,7 +262,7 @@ describe("Explore UI contract", () => {
     );
     expect(styles).toMatch(/\.runnerMeta\s*\{[^}]*gap:\s*4px;/s);
     expect(styles).toMatch(
-      /@media \(max-width: 700px\)[\s\S]*?grid-template-areas:[\s\S]*?"search search"[\s\S]*?"pages sort";/s,
+      /@media \(max-width: 700px\)[\s\S]*?grid-template-areas:[\s\S]*?"search search search"[\s\S]*?"pages chain sort";/s,
     );
     expect(styles).toMatch(
       /@media \(max-width: 700px\)[\s\S]*?\.runnerGrid\s*\{[^}]*grid-template-columns:\s*repeat\(2, minmax\(0, 1fr\)\);/s,
@@ -303,12 +303,8 @@ describe("Explore UI contract", () => {
       /\.runnerImagePreserved\s*\{[^}]*object-fit:\s*contain;[^}]*object-position:\s*center;/s,
     );
     expect(source).not.toContain("<small>CA</small>");
-    expect(source).toContain("title={token.valuationProvider");
-    expect(source).toContain(
-      "`Fully diluted valuation from ${token.valuationProvider}`",
-    );
-    expect(source).toContain("FDV{token.valuationProvider");
-    expect(source).toContain("` · ${token.valuationProvider}`");
+    expect(source).not.toContain("<AnimatedMarketCap");
+    expect(source).not.toContain("FDV{token.valuationProvider");
     expect(source).toContain("formatExploreContractAddress(token.tokenAddress)");
     expect(source).toContain(
       '`/token/${token.tokenAddress}?chain=${viewChainId}`',
@@ -318,9 +314,6 @@ describe("Explore UI contract", () => {
     );
     expect(styles).toMatch(
       /@media \(max-width: 700px\)[\s\S]*?\.runnerHeading > span\s*\{[^}]*font-size:\s*12px;[\s\S]*?\.runnerData small\s*\{[^}]*font-size:\s*12px;[\s\S]*?\.runnerCategory,[\s\S]*?font-size:\s*12px;[\s\S]*?\.runnerContract code\s*\{[^}]*font-size:\s*12px;/s,
-    );
-    expect(source).toMatch(
-      /<small[\s\S]*?title=\{token\.valuationProvider[\s\S]*?FDV\{token\.valuationProvider[\s\S]*?<\/small>[\s\S]*?<AnimatedMarketCap[\s\S]*?replayKey=\{token\.id\}[\s\S]*?token\.marketStatus \?\? "Unavailable"/,
     );
     expect(source).not.toContain(
       "exploreUnavailableFdvLabel(token.marketStatus)",
@@ -375,7 +368,7 @@ describe("Explore UI contract", () => {
     );
     expect(source).toContain('className="sr-only"');
     expect(styles).not.toContain(".resultLabel");
-    expect(source).toContain('return "Explore unavailable"');
+    expect(source).toContain('return "Launch index rebuilding"');
     expect(source).not.toContain("Market data is temporarily unavailable");
     expect(source).not.toContain("Loading tokens");
     expect(source).not.toContain("Updating tokens");

--- a/tests/explore-view-state.test.ts
+++ b/tests/explore-view-state.test.ts
@@ -1395,7 +1395,7 @@ describe("Explore refresh state", () => {
     expect(getTokenCards([project])).toEqual([
       expect.objectContaining({
         id: project.id,
-        launchCategory: "Custom",
+        launchCategory: "Custom V4 Hook",
         marketStatus: "No market",
       }),
     ]);

--- a/tests/interaction-state-regressions.test.ts
+++ b/tests/interaction-state-regressions.test.ts
@@ -200,7 +200,7 @@ describe("interaction state regressions", () => {
     );
   });
 
-  it("keeps Explore project-first with compact market metadata", () => {
+  it("keeps Explore project-first without interim market metadata", () => {
     const exploreSource = readFileSync(
       join(root, "components/explore-view.tsx"),
       "utf8",
@@ -218,17 +218,16 @@ describe("interaction state regressions", () => {
     expect(exploreSource).not.toContain("V4 model");
     expect(exploreSource).not.toContain("<dt>Market cap</dt>");
     expect(exploreSource).toContain("runnerMeta");
-    expect(exploreSource).toContain("runnerData");
-    expect(exploreSource).toContain("title={token.valuationProvider");
-    expect(exploreSource).toContain(
+    expect(exploreSource).not.toContain("styles.runnerData");
+    expect(exploreSource).not.toContain("title={token.valuationProvider");
+    expect(exploreSource).not.toContain(
       "`Fully diluted valuation from ${token.valuationProvider}`",
     );
-    expect(exploreSource).toContain("FDV{token.valuationProvider");
-    expect(exploreSource).toContain("` · ${token.valuationProvider}`");
-    expect(exploreSource).toContain("token.valuation ? (");
-    expect(exploreSource).toContain("<AnimatedMarketCap");
-    expect(exploreSource).toContain("metric={token.valuation}");
-    expect(exploreSource).toContain(
+    expect(exploreSource).not.toContain("FDV{token.valuationProvider");
+    expect(exploreSource).not.toContain("` · ${token.valuationProvider}`");
+    expect(exploreSource).not.toContain("<AnimatedMarketCap");
+    expect(exploreSource).not.toContain("metric={token.valuation}");
+    expect(exploreSource).not.toContain(
       '<strong>{token.marketStatus ?? "Unavailable"}</strong>',
     );
     expect(exploreSource).not.toContain(

--- a/tests/launch-model-gating.test.ts
+++ b/tests/launch-model-gating.test.ts
@@ -187,6 +187,11 @@ describe("unreleased launch model gating", () => {
     expect(html).toContain(
       'id="launch-model-classic-title">Classic</strong>',
     );
+    expect(html).toContain('data-status="ready">Ethereum only</small>');
+    expect(html).toContain('id="launch-model-classic-status"');
+    expect(html).toContain(
+      'aria-describedby="launch-model-classic-description launch-model-classic-status"',
+    );
     expect(html).toContain('data-launch-model-option="custom"');
     const customCard = html.match(
       /<a[^>]*data-launch-model-option="custom"[^>]*>/,
@@ -199,7 +204,7 @@ describe("unreleased launch model gating", () => {
     );
     expect(customCard).not.toContain("disabled");
     expect(html).toContain(
-      'id="launch-model-custom-title">Custom</strong>',
+      'id="launch-model-custom-title">Custom V4 Hook</strong>',
     );
     expect(html).toContain("Create a Classic coin");
     expect(html).toContain(
@@ -208,7 +213,7 @@ describe("unreleased launch model gating", () => {
     expect(html).toContain(
       "Upload an exact packed Custom launch, preflight it against Robinhood Chain, then create the request. Your wallet reviews and signs later.",
     );
-    expect(html).toContain("Open Custom launch");
+    expect(html).toContain("Open Custom V4 Hook");
     expect(html).not.toContain("approved GitHub revision");
     expect(html.indexOf('data-launch-model-option="classic"')).toBeLessThan(
       html.indexOf('data-launch-model-option="custom"'),
@@ -249,7 +254,7 @@ describe("unreleased launch model gating", () => {
     expect(html).toContain(
       'href="/developers/api-keys?start=custom&amp;chainId=4663"',
     );
-    expect(html).toContain("Open Custom launch");
+    expect(html).toContain("Open Custom V4 Hook");
     expect(html).not.toContain("approved GitHub revision");
     expect(html).not.toContain("Build or resume");
   });

--- a/tests/launch-model-motion.test.ts
+++ b/tests/launch-model-motion.test.ts
@@ -54,7 +54,7 @@ describe("launch model artwork", () => {
       'aria-labelledby="launch-model-classic-title"',
     );
     expect(source).toContain(
-      'aria-describedby="launch-model-classic-description"',
+      'aria-describedby="launch-model-classic-description launch-model-classic-status"',
     );
     expect(source).toContain(
       'aria-labelledby="launch-model-custom-title"',

--- a/tests/launch-stamp-surfaces.test.ts
+++ b/tests/launch-stamp-surfaces.test.ts
@@ -260,7 +260,7 @@ describe("canonical Router stamp surfaces", () => {
       "classic",
     ]);
     expect(getTokenCards(payload.tokens).map((card) => card.launchCategory))
-      .toEqual(["Custom", "Classic"]);
+      .toEqual(["Custom V4 Hook", "Classic"]);
     expect(payload.tokens[0]).toMatchObject({
       launchStampProvenance: { kind: "custom-graph" },
     });
@@ -281,7 +281,7 @@ describe("canonical Router stamp surfaces", () => {
     ]);
 
     expect(cards[0]).toMatchObject({
-      launchCategory: "Custom",
+      launchCategory: "Custom V4 Hook",
       description:
         "Canonical Router stamp. v4 pool initialized.",
       valuation: undefined,

--- a/tests/token-detail-layout.test.ts
+++ b/tests/token-detail-layout.test.ts
@@ -200,6 +200,7 @@ describe("token detail layout", () => {
     );
     expect(detailSource).toContain("totalSupplyRaw?: string;");
     expect(detailSource).toContain("return formatUnits(BigInt(rawSupply)");
+    expect(customContent).toContain("Custom V4 Hook");
   });
 
   it("keeps canonical detail valuation independent from chart history", () => {

--- a/tests/view-chain.test.ts
+++ b/tests/view-chain.test.ts
@@ -133,19 +133,25 @@ describe("view chain", () => {
 
     expect(navigation).not.toContain("HeaderChainToggle");
     expect(navigation).not.toContain("switchNetwork");
-    expect(explore).toContain("<ExploreChainSelector />");
+    expect(explore).toContain("<ExploreChainSelector");
+    expect(explore).toContain("probeAvailability={!indexRebuilding}");
     expect(selector).toContain('aria-haspopup="listbox"');
     expect(selector).toContain('role="listbox"');
     expect(selector).toContain('role="option"');
     expect(selector).toContain('label: "Ethereum"');
     expect(selector).toContain('label: "Robinhood"');
-    expect(selector).toContain('label: "Base"');
-    expect(selector.match(/available: false/gu)).toHaveLength(2);
+    expect(selector).not.toContain('label: "Base"');
+    expect(selector.match(/available: false/gu)).toHaveLength(1);
+    expect(selector).toContain("alternateOptions.map");
+    expect(selector).toContain("if (!probeAvailability) return;");
+    expect(selector).not.toContain("<span>{selected.label}</span>");
     expect(selector).toContain("setViewChainId(option.viewChainId)");
     expect(selector).not.toContain("useWallet");
     expect(selector).not.toContain("switchNetwork");
     expect(styles).toContain("/brand/networks/robinhood-feather-white.svg");
-    expect(styles).toMatch(/\.trigger\s*\{[^}]*min-height:\s*44px;/s);
+    expect(styles).toMatch(
+      /\.trigger\s*\{[^}]*min-height:\s*44px;[^}]*width:\s*44px;/s,
+    );
     expect(styles).toContain("@media (prefers-reduced-motion: reduce)");
   });
 });

--- a/tests/wallet-state.test.ts
+++ b/tests/wallet-state.test.ts
@@ -23,6 +23,10 @@ type WalletProviderContract = {
     ready: boolean,
     authenticated: boolean,
   ) => "wait" | "login" | "manage";
+  getWalletOpenAction: (
+    sessionAction: "wait" | "login" | "manage",
+    hasWallet: boolean,
+  ) => "wait" | "login" | "link" | "manage";
   isWalletProviderSettled: (
     privyReady: boolean,
     walletsReady: boolean,
@@ -612,6 +616,14 @@ describe("wallet recovery state", () => {
     expect(subject.getWalletSessionAction(false, false)).toBe("wait");
     expect(subject.getWalletSessionAction(true, false)).toBe("login");
     expect(subject.getWalletSessionAction(true, true)).toBe("manage");
+  });
+
+  it("opens Privy directly when an authenticated session still needs a wallet", () => {
+    expect(subject.getWalletOpenAction).toBeTypeOf("function");
+    expect(subject.getWalletOpenAction("wait", false)).toBe("wait");
+    expect(subject.getWalletOpenAction("login", false)).toBe("login");
+    expect(subject.getWalletOpenAction("manage", false)).toBe("link");
+    expect(subject.getWalletOpenAction("manage", true)).toBe("manage");
   });
 
   it("does not block login while the unauthenticated wallet list is still loading", () => {

--- a/tests/website-explore-index.test.ts
+++ b/tests/website-explore-index.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { websiteExploreIndexEnabledV1 } from
+  "../lib/website-explore-index";
+
+describe("website Explore index", () => {
+  it("keeps the website coin index fail-closed by default", () => {
+    expect(websiteExploreIndexEnabledV1({})).toBe(false);
+  });
+
+  it("requires an exact explicit opt-in for the later replacement", () => {
+    expect(websiteExploreIndexEnabledV1({
+      PROGRAMMABLE_WEBSITE_EXPLORE_INDEX_ENABLED: "TRUE",
+    })).toBe(true);
+    expect(websiteExploreIndexEnabledV1({
+      PROGRAMMABLE_WEBSITE_EXPLORE_INDEX_ENABLED: "1",
+    })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Outcome

- pauses the current website Explore index and renders a clean rebuilding state without requesting `/api/explore`
- moves the icon-only Ethereum chain control beside search and filters; the menu exposes only the Robinhood icon and removes Base
- removes market-cap, trending, GMGN, Dexscreener, and FDV presentation from the Explore website
- labels Classic as Ethereum only and renames Custom to Custom V4 Hook
- sends Wallet Connect directly to the Privy login or link flow instead of the intermediate wallet panel

## Scope boundary

Website surfaces only. Public APIs, provider adapters, API keys, Devdocs, contracts, release workflows, and onchain state are unchanged.

## Verification

- 188 targeted Vitest tests
- TypeScript typecheck
- changed-file ESLint
- production build including OpenAPI and candidate-neutrality checks
- Playwright header/wallet regression: 9/9
- desktop 1440x900 and mobile 390x844 rendered-browser QA
- no `/api/explore` requests on reload or search while the website index is paused
- browser console clean for application errors and warnings