### PR TITLE
Fix Robinhood backend verifier timestamp format

### DIFF
--- a/contracts/scripts/finalize-robinhood-custom-launch-deployment.mjs
+++ b/contracts/scripts/finalize-robinhood-custom-launch-deployment.mjs
@@ -102,6 +102,13 @@ export function canonicalRobinhoodVerifierInstant(now = () => new Date(), label 
   return new Date(Math.floor(instant.getTime() / 1_000) * 1_000).toISOString();
 }
 
+export function canonicalRobinhoodBackendVerifierInstant(
+  now = () => new Date(),
+  label = "backend verifier clock",
+) {
+  return canonicalRobinhoodVerifierInstant(now, label).replace(/\.000Z$/u, "Z");
+}
+
 function usage() {
   return [
     "Usage:",
@@ -767,7 +774,7 @@ async function verifySigstoreBackendCaptureAttestation({
       || Buffer.byteLength(result.stderr) > 16 * 1024 * 1024) {
       throw new TypeError("Cosign backend verification diagnostics exceeded their bound");
     }
-    const verifiedAt = canonicalRobinhoodVerifierInstant(now, "backend verifier clock");
+    const verifiedAt = canonicalRobinhoodBackendVerifierInstant(now);
     return {
       authorization: buildRobinhoodBackendCaptureAuthorization({
         schemaVersion: ROBINHOOD_BACKEND_CAPTURE_AUTHORIZATION_SCHEMA,

--- a/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
@@ -100,6 +100,7 @@ import {
   SIGSTORE_BUNDLE_V03_MEDIA_TYPE,
 } from "../robinhood-backend-promotion-v1.mjs";
 import {
+  canonicalRobinhoodBackendVerifierInstant,
   canonicalRobinhoodVerifierInstant,
   runRobinhoodPostdeploymentCli,
 } from "../finalize-robinhood-custom-launch-deployment.mjs";
@@ -610,6 +611,19 @@ test("canonical verifier timestamps remain valid through Phase A stage assembly"
   } finally {
     await rm(fixture.root, { recursive: true, force: true });
   }
+});
+
+test("canonical backend verifier timestamps match the seconds-only authorization schema", () => {
+  assert.equal(
+    canonicalRobinhoodBackendVerifierInstant(
+      () => new Date("2026-08-29T18:00:00.987Z"),
+    ),
+    "2026-08-29T18:00:00Z",
+  );
+  assert.throws(
+    () => canonicalRobinhoodBackendVerifierInstant(() => new Date(Number.NaN)),
+    /backend verifier clock is invalid/u,
+  );
 });
 
 test("production capture builder binds the exact protected Git source closure", async () => {


### PR DESCRIPTION
## Summary
- keep the Phase A verifier timestamp in canonical millisecond form
- emit the seconds-only timestamp required by the backend capture authorization schema
- add a focused regression for the production failure and invalid clocks

## Evidence
- targeted postdeployment tests: 3/3
- `git diff --check`: clean
- signed commit: `846bed6e7c01b1cc175ca0eac08fdffaabf697f1`

## Production impact
This only repairs the public Phase B evidence verifier. It does not change API behavior, policies, contracts, transactions, indexing, signing, or production runtime state.

PR #660 remains the separate exact two-file Phase B producer and will be refreshed after this prerequisite lands.
