### PR TITLE
Fix backend verifier timestamp canonicalization

### DIFF
--- a/contracts/scripts/finalize-robinhood-custom-launch-deployment.mjs
+++ b/contracts/scripts/finalize-robinhood-custom-launch-deployment.mjs
@@ -102,6 +102,13 @@ export function canonicalRobinhoodVerifierInstant(now = () => new Date(), label 
   return new Date(Math.floor(instant.getTime() / 1_000) * 1_000).toISOString();
 }
 
+export function canonicalRobinhoodBackendVerifierInstant(
+  now = () => new Date(),
+  label = "backend verifier clock",
+) {
+  return canonicalRobinhoodVerifierInstant(now, label).replace(/\.000Z$/u, "Z");
+}
+
 function usage() {
   return [
     "Usage:",
@@ -767,7 +774,7 @@ async function verifySigstoreBackendCaptureAttestation({
       || Buffer.byteLength(result.stderr) > 16 * 1024 * 1024) {
       throw new TypeError("Cosign backend verification diagnostics exceeded their bound");
     }
-    const verifiedAt = canonicalRobinhoodVerifierInstant(now, "backend verifier clock");
+    const verifiedAt = canonicalRobinhoodBackendVerifierInstant(now, "backend verifier clock");
     return {
       authorization: buildRobinhoodBackendCaptureAuthorization({
         schemaVersion: ROBINHOOD_BACKEND_CAPTURE_AUTHORIZATION_SCHEMA,

--- a/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
@@ -100,6 +100,7 @@ import {
   SIGSTORE_BUNDLE_V03_MEDIA_TYPE,
 } from "../robinhood-backend-promotion-v1.mjs";
 import {
+  canonicalRobinhoodBackendVerifierInstant,
   canonicalRobinhoodVerifierInstant,
   runRobinhoodPostdeploymentCli,
 } from "../finalize-robinhood-custom-launch-deployment.mjs";
@@ -977,6 +978,15 @@ test("focused backend evidence import verifies fresh exact public bytes without 
     await mkdir(path.dirname(backendPath), { recursive: true });
     await writeFile(backendPath, backend.inputBytes);
     await writeFile(attestationPath, backend.attestationBundleBytes);
+    const backendVerifiedAt = canonicalRobinhoodBackendVerifierInstant(
+      () => new Date("2026-08-29T12:01:00.987Z"),
+    );
+    assert.equal(backendVerifiedAt, "2026-08-29T12:01:00Z");
+    const backendCaptureAuthorization = buildRobinhoodBackendCaptureAuthorization({
+      ...structuredClone(backend.captureAuthorization),
+      verifiedAt: backendVerifiedAt,
+      verificationDigest: null,
+    });
     let verificationCalls = 0;
     const dependencies = {
       backendDependencies: backend.dependencies,
@@ -984,7 +994,7 @@ test("focused backend evidence import verifies fresh exact public bytes without 
         verificationCalls += 1;
         assert.equal(inputFile.bytes.equals(backend.inputBytes), true);
         assert.equal(attestationBundleFile.bytes.equals(backend.attestationBundleBytes), true);
-        return backend.captureAuthorization;
+        return backendCaptureAuthorization;
       },
     };
     const result = await runRobinhoodPostdeploymentCli([


### PR DESCRIPTION
## Summary

- preserve the shared Phase A millisecond timestamp canonicalization
- emit backend capture authorization timestamps in the schema-required whole-second `...ssZ` form
- regress the exact formatter output through the backend import authorization validator

## Evidence

- reproduces PR #660 Contracts failure: `backend capture authorization verifiedAt is invalid`
- `npm run contracts:robinhood:postdeploy:test` (26 passed)
- `npm run release:custom-launch:v4:test` (54 passed)
- exact commit gitleaks scan: no leaks

This PR intentionally contains no backend evidence files. A fresh capture and separately based exact-two-file evidence PR are required after this fix merges.