### PR TITLE
Fix Phase B Verify coordinate parsing

### DIFF
--- a/.github/workflows/finalize-robinhood-custom-launch-promotion.yml
+++ b/.github/workflows/finalize-robinhood-custom-launch-promotion.yml
@@ -273,10 +273,16 @@ jobs:
         run: |
           set -euo pipefail
           coordinates="$PHASE_A_DIR/production-verify-coordinates.json"
-          echo "run_id=$(jq -er '.runId | select(test(\"^[1-9][0-9]*$\"))' "$coordinates")" >> "$GITHUB_OUTPUT"
-          echo "run_attempt=$(jq -er '.runAttempt | select(test(\"^[1-9][0-9]*$\"))' "$coordinates")" >> "$GITHUB_OUTPUT"
-          echo "artifact_id=$(jq -er '.artifactId | select(test(\"^[1-9][0-9]*$\"))' "$coordinates")" >> "$GITHUB_OUTPUT"
-          echo "artifact_digest=$(jq -er '.artifactDigest | select(test(\"^sha256:[0-9a-f]{64}$\"))' "$coordinates")" >> "$GITHUB_OUTPUT"
+          run_id="$(jq -er '.runId | select(test("^[1-9][0-9]*$"))' "$coordinates")"
+          run_attempt="$(jq -er '.runAttempt | select(test("^[1-9][0-9]*$"))' "$coordinates")"
+          artifact_id="$(jq -er '.artifactId | select(test("^[1-9][0-9]*$"))' "$coordinates")"
+          artifact_digest="$(jq -er '.artifactDigest | select(test("^sha256:[0-9a-f]{64}$"))' "$coordinates")"
+          {
+            printf 'run_id=%s\n' "$run_id"
+            printf 'run_attempt=%s\n' "$run_attempt"
+            printf 'artifact_id=%s\n' "$artifact_id"
+            printf 'artifact_digest=%s\n' "$artifact_digest"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Emit canonical protected backend authorization
         id: authorize-backend

--- a/scripts/test/programmable-launch-release-workflow.test.mjs
+++ b/scripts/test/programmable-launch-release-workflow.test.mjs
@@ -590,6 +590,14 @@ function robinhoodPromotionFailures(value) {
     ".github/workflows/verify.yml",
     ".github/workflows/capture-robinhood-custom-launch-postdeployment.yml",
     ".github/workflows/capture-programmable-robinhood-promotion.yml",
+    "run_id=\"$(jq -er '.runId | select(test(\"^[1-9][0-9]*$\"))' \"$coordinates\")\"",
+    "run_attempt=\"$(jq -er '.runAttempt | select(test(\"^[1-9][0-9]*$\"))' \"$coordinates\")\"",
+    "artifact_id=\"$(jq -er '.artifactId | select(test(\"^[1-9][0-9]*$\"))' \"$coordinates\")\"",
+    "artifact_digest=\"$(jq -er '.artifactDigest | select(test(\"^sha256:[0-9a-f]{64}$\"))' \"$coordinates\")\"",
+    "printf 'run_id=%s\\n' \"$run_id\"",
+    "printf 'run_attempt=%s\\n' \"$run_attempt\"",
+    "printf 'artifact_id=%s\\n' \"$artifact_id\"",
+    "printf 'artifact_digest=%s\\n' \"$artifact_digest\"",
     "finalize-robinhood-custom-launch-deployment.mjs authorize-backend",
     "--capture-attestation-bundle",
     "--stage-attestation-bundle",
@@ -656,6 +664,7 @@ test("Robinhood Phase B workflow accepts only portable public-safe producer evid
   assert.equal(robinhoodPromotionSource.includes("inputs.backend_artifact"), false);
   assert.equal(robinhoodPromotionSource.includes("pull_request:"), false);
   assert.equal(robinhoodPromotionSource.includes("create-storage-record: false"), false);
+  assert.equal(robinhoodPromotionSource.includes('test(\\"'), false);
 });
 
 test("Robinhood Phase B workflow contract mutations fail closed", () => {


### PR DESCRIPTION
## Summary
- parse the four historical Verify coordinates with valid jq programs
- bind each value before writing GitHub job outputs so `set -e` fails closed
- extend the workflow contract test to require all four exact parsers and reject the escaped spelling

## Evidence
- exact coordinate parser against tracked receipt: green (`33839208790`, attempt `3`, artifact `9936456321`)
- release workflow contract tests: 7/7
- shell syntax and `git diff --check`: green
- signed commit: `202f8181081535f2d70bd8a872849aac9e87920e`
- failed finalizer evidence: run `33906942253`, attempt `2`, where malformed jq programs produced four empty outputs

## Scope
Workflow and its contract test only. No API runtime, policies, contracts, evidence bytes, indexing, signing, transactions, or deployment state changes.
