### PR TITLE
Test completed V4 release binding without weakening gates

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -211,6 +211,8 @@ jobs:
       - name: Check out repository
         if: needs.scope.outputs.interface == 'true'
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         if: needs.scope.outputs.interface == 'true'
@@ -239,6 +241,16 @@ jobs:
           PROGRAMMABLE_CI_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           PROGRAMMABLE_CI_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: npm run verify:interface:ci
+
+      - name: Require complete Git history for the V4 release audit
+        if: needs.scope.outputs.interface == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$(git rev-parse --is-shallow-repository)" = true ]; then
+            git fetch --unshallow --no-tags origin
+          fi
+          test "$(git rev-parse --is-shallow-repository)" = false
 
       - name: Verify V4 clean-room no-broadcast release gate
         if: needs.scope.outputs.interface == 'true'

--- a/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-postdeploy.test.mjs
@@ -143,7 +143,11 @@ const FRESH_ROBINHOOD_RPC_COMMITMENTS = Object.freeze([
     rpcUrl: FRESH_PROVIDER_RPC_URLS.robinhood[1],
   }),
 ]);
-const template = JSON.parse(await readFile(path.join(repositoryRoot, bindingPath), "utf8"));
+const committedTemplate = JSON.parse(await readFile(
+  path.join(repositoryRoot, bindingPath),
+  "utf8",
+));
+const template = blockedBindingBaseline(committedTemplate);
 const postdeploymentSchemaNames = [
   "cli-release-binding", "stage-bundle", "backend-promotion-input",
   "backend-promotion-public-input", "backend-capture-authorization",
@@ -2494,6 +2498,11 @@ async function fixtureRepository() {
     await mkdir(path.dirname(destination), { recursive: true });
     await cp(path.join(repositoryRoot, relativePath), destination);
   }
+  await writeFile(
+    path.join(rootPath, bindingPath),
+    `${JSON.stringify(template, null, 2)}\n`,
+    "utf8",
+  );
   runGit(rootPath, ["init", "-b", "temporary-local-branch"]);
   runGit(rootPath, ["add", "-A"]);
   runGit(rootPath, [
@@ -2510,6 +2519,29 @@ async function fixtureRepository() {
     revision,
     tree: runGit(rootPath, ["rev-parse", "HEAD^{tree}"]),
   };
+}
+
+function blockedBindingBaseline(value) {
+  const binding = structuredClone(value);
+  binding.chain.chainDeploymentDescriptorDigest = null;
+  binding.evidence = {
+    chainDeployment: null,
+    profile: null,
+    manifest: null,
+    source: null,
+    finality: null,
+    backend: null,
+  };
+  binding.blockers = [
+    "chainDeploymentEvidence",
+    "profileEvidence",
+    "releaseManifestEvidence",
+    "sourceClosureEvidence",
+    "finalityEvidence",
+    "backendReleaseEvidence",
+  ];
+  binding.releaseReady = false;
+  return binding;
 }
 
 async function buildInput(fixture, options = {}) {

--- a/scripts/programmable-launch-v4-clean-room.mjs
+++ b/scripts/programmable-launch-v4-clean-room.mjs
@@ -360,6 +360,13 @@ export function validateReviewedReleaseCoordinate(value, bindingResult) {
   return value;
 }
 
+export function requireReviewedReleaseCoordinateReady(coordinate, bindingResult) {
+  requireValue(bindingResult.releaseReady === true, "V4_RELEASE_BINDING_NOT_READY");
+  requireValue(coordinate.releaseReady === true,
+    "REVIEWED_RELEASE_COORDINATE_BLOCKED");
+  return coordinate;
+}
+
 export function assertReleaseMatchesReviewedCoordinate(release, coordinate) {
   requireValue(coordinate.releaseReady === true,
     "REVIEWED_RELEASE_COORDINATE_BLOCKED");
@@ -397,9 +404,7 @@ async function loadReviewedReleaseCoordinate() {
   );
   requireValue(prettyCanonicalJsonBytes(coordinate).equals(bytes),
     "REVIEWED_RELEASE_COORDINATE_NOT_CANONICAL");
-  requireValue(binding.releaseReady === true, "V4_RELEASE_BINDING_NOT_READY");
-  requireValue(coordinate.releaseReady === true,
-    "REVIEWED_RELEASE_COORDINATE_BLOCKED");
+  requireReviewedReleaseCoordinateReady(coordinate, binding);
   return Object.freeze({
     coordinate: Object.freeze(structuredClone(coordinate)),
     coordinateSha256: sha256(bytes),

--- a/scripts/test/fixtures/isolated-protected-checkout.mjs
+++ b/scripts/test/fixtures/isolated-protected-checkout.mjs
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { lstat, mkdtemp, realpath, rm, symlink } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const CANONICAL_ORIGIN = "https://github.com/programmablehq/PROGRAMMABLE";
+const PROTECTED_ENVIRONMENT = Object.freeze({
+  GITHUB_ACTIONS: "true",
+  GITHUB_REPOSITORY: "programmablehq/PROGRAMMABLE",
+  GITHUB_REPOSITORY_ID: "1314365508",
+  GITHUB_REF: "refs/heads/production",
+  GITHUB_REF_PROTECTED: "true",
+});
+const SANITIZED_ENVIRONMENT = Object.freeze({
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_NOSYSTEM: "1",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+  GIT_NO_LAZY_FETCH: "1",
+  GIT_NO_REPLACE_OBJECTS: "1",
+  GIT_OPTIONAL_LOCKS: "0",
+  GIT_TERMINAL_PROMPT: "0",
+});
+const REMOVED_ENVIRONMENT = Object.freeze([
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_COMMON_DIR",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_DIR",
+  "GIT_INDEX_FILE",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_PREFIX",
+  "GIT_WORK_TREE",
+  "NODE_OPTIONS",
+  "NODE_PATH",
+  "PROGRAMMABLE_API_KEY",
+  "PROGRAMMABLE_PRODUCTION_VERIFY_PROOF",
+  "PROGRAMMABLE_ROBINHOOD_BACKEND_AUTHORIZATION",
+]);
+
+export async function withIsolatedProtectedCheckout({
+  repositoryRoot,
+  materialize = null,
+}, callback) {
+  assert.equal(runGit(repositoryRoot, ["rev-parse", "--is-shallow-repository"]), "false",
+    "protected-checkout fixture requires complete Git history");
+  const sourceRevision = runGit(repositoryRoot, ["rev-parse", "HEAD^{commit}"]);
+  const custodyRoot = await mkdtemp(path.join(os.tmpdir(), "programmable-v4-protected-"));
+  const isolatedRoot = path.join(custodyRoot, "repository");
+  try {
+    runGit(null, ["clone", "--shared", "--no-checkout", "--", repositoryRoot, isolatedRoot]);
+    runGit(isolatedRoot, ["checkout", "--detach", sourceRevision]);
+    runGit(isolatedRoot, ["remote", "set-url", "origin", CANONICAL_ORIGIN]);
+    await linkDependencies(repositoryRoot, isolatedRoot);
+
+    const changedPaths = materialize === null
+      ? []
+      : await materialize({ isolatedRoot, sourceRevision });
+    assert.ok(Array.isArray(changedPaths), "fixture materializer must return changed paths");
+    if (changedPaths.length > 0) {
+      for (const relativePath of changedPaths) assertSafeRelativePath(relativePath);
+      runGit(isolatedRoot, ["add", "--", ...changedPaths]);
+      if (runGitStatus(isolatedRoot, ["diff", "--cached", "--quiet"]) === 1) {
+        runGit(isolatedRoot, [
+          "-c", "commit.gpgsign=false",
+          "-c", "user.name=Programmable Release Test",
+          "-c", "user.email=release-test@programmable.invalid",
+          "commit", "-m", "materialize isolated protected-checkout fixture",
+        ]);
+      }
+    }
+
+    const revision = runGit(isolatedRoot, ["rev-parse", "HEAD^{commit}"]);
+    runGit(isolatedRoot, ["update-ref", "refs/remotes/origin/production", revision]);
+    assert.equal(runGit(isolatedRoot, ["remote", "get-url", "origin"]), CANONICAL_ORIGIN);
+    assert.equal(runGit(isolatedRoot, ["rev-parse", "refs/remotes/origin/production^{commit}"]),
+      revision);
+    assert.equal(runGit(isolatedRoot, ["rev-parse", "--is-shallow-repository"]), "false");
+    assert.equal(runGit(isolatedRoot, ["status", "--porcelain=v1", "--untracked-files=all"]),
+      "");
+    const symbolic = spawnGit(isolatedRoot, ["symbolic-ref", "-q", "HEAD"]);
+    assert.equal(symbolic.status, 1, "protected-checkout fixture must use detached HEAD");
+    assert.equal(symbolic.stdout, "");
+    assert.equal(symbolic.stderr, "");
+
+    return await withProtectedEnvironment(revision,
+      () => callback({ isolatedRoot, revision, sourceRevision }));
+  } finally {
+    await rm(custodyRoot, { recursive: true, force: true });
+  }
+}
+
+function assertSafeRelativePath(relativePath) {
+  assert.equal(typeof relativePath, "string");
+  assert.equal(path.isAbsolute(relativePath), false);
+  assert.ok(relativePath.length > 0
+    && !relativePath.split("/").some((segment) => segment === "" || segment === "."
+      || segment === ".."), `unsafe fixture path: ${relativePath}`);
+}
+
+async function linkDependencies(repositoryRoot, isolatedRoot) {
+  const source = await realpath(path.join(repositoryRoot, "node_modules"));
+  const info = await lstat(source);
+  assert.ok(info.isDirectory() && !info.isSymbolicLink(),
+    "protected-checkout fixture requires installed root dependencies");
+  await symlink(source, path.join(isolatedRoot, "node_modules"), "dir");
+}
+
+function runGit(root, args) {
+  const result = spawnGit(root, args);
+  if (result.status !== 0) {
+    throw new Error(`git ${args[0]} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+function runGitStatus(root, args) {
+  const result = spawnGit(root, args);
+  if (result.status !== 0 && result.status !== 1) {
+    throw new Error(`git ${args[0]} failed: ${result.stderr.trim()}`);
+  }
+  return result.status;
+}
+
+function spawnGit(root, args) {
+  const commandArgs = root === null ? args : ["-C", root, ...args];
+  return spawnSync("git", commandArgs, {
+    encoding: "utf8",
+    env: sanitizedEnvironment(),
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: 60_000,
+  });
+}
+
+function sanitizedEnvironment() {
+  const environment = { ...process.env, ...SANITIZED_ENVIRONMENT };
+  for (const name of REMOVED_ENVIRONMENT) delete environment[name];
+  return environment;
+}
+
+async function withProtectedEnvironment(revision, callback) {
+  const replacements = {
+    ...SANITIZED_ENVIRONMENT,
+    ...PROTECTED_ENVIRONMENT,
+    GITHUB_SHA: revision,
+  };
+  const names = new Set([...Object.keys(replacements), ...REMOVED_ENVIRONMENT]);
+  const previous = new Map([...names].map((name) => [name, process.env[name]]));
+  try {
+    for (const name of REMOVED_ENVIRONMENT) delete process.env[name];
+    Object.assign(process.env, replacements);
+    return await callback();
+  } finally {
+    for (const [name, value] of previous) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+}

--- a/scripts/test/programmable-launch-v4-clean-room.test.mjs
+++ b/scripts/test/programmable-launch-v4-clean-room.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
+import { cp, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
 import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import Ajv2020 from "ajv/dist/2020.js";
 
@@ -11,6 +14,7 @@ import {
   buildCleanRoomRecoveryReceipt,
   canonicalJsonBytes,
   prepareCleanRoom,
+  requireReviewedReleaseCoordinateReady,
   validateCleanRoomEvidence,
   validateCleanRoomRecoveryReceipt,
   validateCleanRoomImage,
@@ -20,6 +24,15 @@ import {
 import {
   validCleanRoomTranscript,
 } from "./fixtures/programmable-launch-v4-clean-room.mjs";
+import {
+  withIsolatedProtectedCheckout,
+} from "./fixtures/isolated-protected-checkout.mjs";
+
+const repositoryRoot = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const bindingPath = "docs/operations/releases/custom-launch-v4/cli-release-binding.json";
+const coordinatePath =
+  "docs/operations/releases/custom-launch-v4/clean-room-release-coordinate.json";
+const runnerPath = "scripts/programmable-launch-v4-clean-room.mjs";
 
 function hexSha(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
@@ -32,6 +45,37 @@ function prettyCanonical(value) {
     return Object.fromEntries(Object.keys(entry).sort().map((key) => [key, sort(entry[key])]));
   };
   return Buffer.from(`${JSON.stringify(sort(value), null, 2)}\n`, "utf8");
+}
+
+function blockedCoordinateBaseline(value) {
+  const coordinate = structuredClone(value);
+  coordinate.releaseReady = false;
+  coordinate.source.commitSha = null;
+  coordinate.source.treeSha = null;
+  coordinate.releaseBinding.sha256 = null;
+  coordinate.machineContractBinding.sha256 = null;
+  coordinate.manifestSha256 = null;
+  coordinate.assets = coordinate.assets.map((asset) => ({ ...asset, sha256: null }));
+  coordinate.blockers = [
+    "releaseBindingReady",
+    "releaseSourceCoordinate",
+    "releaseManifestDigest",
+    "releaseAssetDigests",
+    "machineContractBindingDigest",
+  ];
+  return coordinate;
+}
+
+function awaitingCliCoordinate(value, bindingSha256) {
+  const coordinate = blockedCoordinateBaseline(value);
+  coordinate.releaseBinding.sha256 = bindingSha256;
+  coordinate.machineContractBinding.sha256 = bindingSha256;
+  coordinate.blockers = [
+    "releaseSourceCoordinate",
+    "releaseManifestDigest",
+    "releaseAssetDigests",
+  ];
+  return coordinate;
 }
 
 function releaseFiles() {
@@ -337,20 +381,73 @@ test("prepare stage refuses to coexist with the production API credential", asyn
   }
 });
 
-test("prepare stage rejects the audited closed-but-not-release-ready binding", async () => {
-  const previous = process.env.PROGRAMMABLE_API_KEY;
-  delete process.env.PROGRAMMABLE_API_KEY;
-  try {
+test("reviewed release readiness distinguishes a blocked binding from an unpublished CLI", () => {
+  const committedCoordinate = JSON.parse(readFileSync(new URL(
+    "../../docs/operations/releases/custom-launch-v4/clean-room-release-coordinate.json",
+    import.meta.url,
+  ), "utf8"));
+  const coordinate = blockedCoordinateBaseline(committedCoordinate);
+  const bindingSha256 = `sha256:${"f".repeat(64)}`;
+  const blockedBinding = { releaseReady: false, bindingSha256 };
+  assert.equal(validateReviewedReleaseCoordinate(coordinate, blockedBinding), coordinate);
+  assert.throws(
+    () => requireReviewedReleaseCoordinateReady(coordinate, blockedBinding),
+    (error) => {
+      assert.equal(error?.code, "V4_RELEASE_BINDING_NOT_READY");
+      assert.equal(error.cause, undefined);
+      return true;
+    },
+  );
+
+  const awaitingCliRelease = awaitingCliCoordinate(committedCoordinate, bindingSha256);
+  const readyBinding = { releaseReady: true, bindingSha256 };
+  assert.equal(
+    validateReviewedReleaseCoordinate(awaitingCliRelease, readyBinding),
+    awaitingCliRelease,
+  );
+  assert.throws(
+    () => requireReviewedReleaseCoordinateReady(awaitingCliRelease, readyBinding),
+    (error) => {
+      assert.equal(error?.code, "REVIEWED_RELEASE_COORDINATE_BLOCKED");
+      assert.equal(error.cause, undefined);
+      return true;
+    },
+  );
+});
+
+test("prepare stage enforces the real binding-to-coordinate readiness wiring", async () => {
+  let expectedCode;
+  await withIsolatedProtectedCheckout({
+    repositoryRoot,
+    materialize: async ({ isolatedRoot }) => {
+      const bindingBytes = await readFile(path.join(isolatedRoot, bindingPath));
+      const binding = JSON.parse(bindingBytes.toString("utf8"));
+      const coordinate = JSON.parse(await readFile(
+        path.join(isolatedRoot, coordinatePath),
+        "utf8",
+      ));
+      const bindingSha256 = `sha256:${hexSha(bindingBytes)}`;
+      const blockedCoordinate = binding.releaseReady
+        ? awaitingCliCoordinate(coordinate, bindingSha256)
+        : blockedCoordinateBaseline(coordinate);
+      expectedCode = binding.releaseReady
+        ? "REVIEWED_RELEASE_COORDINATE_BLOCKED"
+        : "V4_RELEASE_BINDING_NOT_READY";
+      await cp(path.join(repositoryRoot, runnerPath), path.join(isolatedRoot, runnerPath));
+      await writeFile(path.join(isolatedRoot, coordinatePath), prettyCanonical(blockedCoordinate));
+      return [runnerPath, coordinatePath];
+    },
+  }, async ({ isolatedRoot, revision }) => {
+    const runner = await import(
+      `${pathToFileURL(path.join(isolatedRoot, runnerPath)).href}?fixture=${revision}`
+    );
     await assert.rejects(
-      prepareCleanRoom({}),
+      runner.prepareCleanRoom({}),
       (error) => {
-        assert.equal(error?.code, "V4_RELEASE_BINDING_NOT_READY");
+        assert.equal(error?.code, expectedCode);
         assert.equal(error.cause, undefined);
         return true;
       },
     );
-  } finally {
-    if (previous === undefined) delete process.env.PROGRAMMABLE_API_KEY;
-    else process.env.PROGRAMMABLE_API_KEY = previous;
-  }
+  });
 });

--- a/scripts/test/programmable-launch-v4-release-binding.test.mjs
+++ b/scripts/test/programmable-launch-v4-release-binding.test.mjs
@@ -9,6 +9,10 @@ import test from "node:test";
 import Ajv2020 from "ajv/dist/2020.js";
 
 import {
+  withIsolatedProtectedCheckout,
+} from "./fixtures/isolated-protected-checkout.mjs";
+
+import {
   V4_RELEASE_BINDING_SCHEMA,
   auditV4ReleaseCommitChain,
   auditV4ReleaseBindingTransition,
@@ -74,8 +78,9 @@ const expectedPolicySource = {
   },
 };
 
-test("committed V4 binding pins policy bytes and remains blocked on six evidence objects", () => {
-  const result = auditV4ReleaseBinding({ repositoryRoot });
+test("blocked V4 binding baseline pins policy bytes and all six evidence gates", () => {
+  const bindingBytes = Buffer.from(`${JSON.stringify(blockedBindingBaseline(), null, 2)}\n`);
+  const result = auditV4ReleaseBinding({ repositoryRoot, bindingBytes });
   assert.equal(result.binding.schemaVersion, V4_RELEASE_BINDING_SCHEMA);
   assert.equal(result.releaseReady, false);
   assert.deepEqual(result.blockers, expectedBlockers);
@@ -89,9 +94,26 @@ test("committed V4 binding pins policy bytes and remains blocked on six evidence
     backend: null,
   });
   assert.throws(
-    () => requireV4ReleaseReady({ repositoryRoot }),
+    () => requireV4ReleaseReady({ repositoryRoot, bindingBytes }),
     /blocked: chainDeploymentEvidence/u,
   );
+});
+
+test("committed V4 binding passes the semantic audit for its declared state", async () => {
+  const committedBytes = await readFile(path.join(releaseDirectory, "cli-release-binding.json"));
+  await withIsolatedProtectedCheckout({ repositoryRoot }, async ({ isolatedRoot }) => {
+    const isolatedBytes = await readFile(path.join(
+      isolatedRoot,
+      "docs/operations/releases/custom-launch-v4/cli-release-binding.json",
+    ));
+    assert.deepEqual(isolatedBytes, committedBytes,
+      "isolated audit must consume the exact committed release binding bytes");
+    const result = auditV4ReleaseBinding({ repositoryRoot: isolatedRoot });
+    assert.equal(result.bindingSha256, digest(committedBytes));
+    assert.equal(result.releaseReady, committedBinding.releaseReady);
+    assert.deepEqual(result.blockers, committedBinding.blockers);
+    assert.deepEqual(result.binding, committedBinding);
+  });
 });
 
 test("committed V4 binding validates against its local closed JSON Schema", () => {
@@ -543,7 +565,7 @@ async function materializeFixture({ complete = false } = {}) {
   await mkdir(path.join(root, "docs", "operations", "releases", "custom-launch-v4"), {
     recursive: true,
   });
-  const binding = structuredClone(committedBinding);
+  const binding = blockedBindingBaseline();
   for (const { path: relative } of binding.machineContracts) {
     await cp(path.join(repositoryRoot, relative), path.join(root, relative));
   }
@@ -552,6 +574,22 @@ async function materializeFixture({ complete = false } = {}) {
     ? await addCompleteEvidence(root, binding)
     : null;
   return { root, binding, commitChain };
+}
+
+function blockedBindingBaseline() {
+  const binding = structuredClone(committedBinding);
+  binding.chain.chainDeploymentDescriptorDigest = null;
+  binding.evidence = {
+    chainDeployment: null,
+    profile: null,
+    manifest: null,
+    source: null,
+    finality: null,
+    backend: null,
+  };
+  binding.blockers = [...expectedBlockers];
+  binding.releaseReady = false;
+  return binding;
 }
 
 async function addCompleteEvidence(root, binding) {


### PR DESCRIPTION
## Summary

- keep blocked-state fixtures explicit as the committed V4 binding transitions to release-ready
- preserve semantic auditing of the exact committed binding in an isolated protected-checkout fixture
- exercise the real prepareCleanRoom binding-to-coordinate wiring for both blocked and ready-binding states
- give the Interface release-gate test complete Git history without changing permissions or release authority

## Validation

- npm run lint (0 errors; existing warnings only)
- npm run release:custom-launch:v4:test (72/72)
- npm run contracts:robinhood:postdeploy:test (27/27)
- ready-state simulation against b5c7f5ae65a6b0d4ba827cb31840362080b3e092: clean-room 13/13 and semantic binding 13/13
- independent read-only review: GO