### PR TITLE
Fix owner proof for protected CLI tag rules

### DIFF
--- a/.github/workflows/release-programmable-launch.yml
+++ b/.github/workflows/release-programmable-launch.yml
@@ -216,6 +216,8 @@ jobs:
       - name: Require protected CLI tags and a fresh release identity
         env:
           GH_TOKEN: ${{ github.token }}
+          IMMUTABLE_RELEASES_PREFLIGHT_RECORD_BASE64: ${{ vars.PROGRAMMABLE_IMMUTABLE_RELEASES_PREFLIGHT_RECORD_BASE64 }}
+          IMMUTABLE_RELEASES_PREFLIGHT_SIGNATURE_BASE64: ${{ vars.PROGRAMMABLE_IMMUTABLE_RELEASES_PREFLIGHT_SIGNATURE_BASE64 }}
           TAG: ${{ steps.identity.outputs.tag }}
         run: |
           set -euo pipefail
@@ -234,7 +236,7 @@ jobs:
             --header "X-GitHub-Api-Version: 2026-03-10" \
             "https://api.github.com/repos/$GITHUB_REPOSITORY/rulesets/$ruleset_id" \
             --output "$rulesets"
-          node scripts/verify-programmable-launch-tag-ruleset.mjs "$rulesets"
+          node scripts/verify-programmable-launch-tag-ruleset.mjs "$rulesets" --owner-preflight
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "Release already exists and will not be changed." >&2
             exit 1
@@ -313,6 +315,12 @@ jobs:
             --environment "production" \
             --actor-id "$GITHUB_ACTOR_ID" \
             --actor-login "$GITHUB_ACTOR"
+          rulesets="$RUNNER_TEMP/programmable-launch-tag-ruleset-before-publication.json"
+          gh api \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/$GITHUB_REPOSITORY/rulesets/21679403" > "$rulesets"
+          node scripts/verify-programmable-launch-tag-ruleset.mjs "$rulesets" --owner-preflight
           test "$GITHUB_REF_PROTECTED" = "true"
           test "$(gh api \
             --header "Accept: application/vnd.github+json" \

--- a/docs/operations/programmable-launch-cli-release.md
+++ b/docs/operations/programmable-launch-cli-release.md
@@ -50,7 +50,7 @@ node scripts/capture-immutable-release-owner-preflight.mjs \
 
 The helper refuses to run when `GITHUB_ACTIONS` is present. It validates
 `gh api /user` as the exact login and numeric owner, validates the live `production` ref
-as the requested SHA, and makes one owner-authenticated request to the
+as the requested SHA, and makes owner-authenticated requests to the
 [immutable release setting endpoint](https://docs.github.com/en/rest/repos/repos#check-if-immutable-releases-are-enabled-for-a-repository).
 It retains that response's exact body bytes, SHA-256, canonical HTTP `Date`,
 `X-GitHub-Request-Id`, status `200`, and the exact parsed two-key body
@@ -59,12 +59,14 @@ It retains that response's exact body bytes, SHA-256, canonical HTTP `Date`,
 signs the record locally and verifies the result against
 the checked-in trust root before emitting the capture JSON.
 
+The same signature also binds the complete response for tag ruleset `21679403`, including an explicit empty `bypass_actors` array. GitHub [omits this field for callers without ruleset write access](https://docs.github.com/en/rest/repos/rules#get-a-repository-ruleset), including the ordinary workflow token. The workflow requires the signed owner response and compares every public protection field and the normalized `updated_at` timestamp against a fresh workflow read before building and before publication. Missing owner permissions, any bypass actor, changed protection, or changed update timestamp fails closed. Both signed endpoint observations must be fresh and within 30 seconds of each other. No owner API token is passed to Actions.
+
 The signed record uses schema
-`programmable.github-immutable-release-owner-preflight.v2`. Its UTF-8 bytes are
+`programmable.github-immutable-release-owner-preflight.v3`. Its UTF-8 bytes are
 RFC 8785/JCS JSON followed by exactly one LF. The record has exactly these fields:
 
 ```json
-{"actorId":"258789013","actorLogin":"hazarxyz","apiVersion":"2026-03-10","environment":"production","observedAt":"YYYY-MM-DDTHH:MM:SSZ","repository":"programmablehq/PROGRAMMABLE","repositoryId":"1314365508","response":{"bodyBase64":"RAW_ENDPOINT_BODY_BASE64","bodySha256":"sha256:...","date":"HTTP_DATE","enabled":true,"enforcedByOwner":false,"requestId":"X_GITHUB_REQUEST_ID","status":200},"revision":"EXACT_PRODUCTION_SHA","schemaVersion":"programmable.github-immutable-release-owner-preflight.v2","url":"https://api.github.com/repos/programmablehq/PROGRAMMABLE/immutable-releases"}
+{"actorId":"258789013","actorLogin":"hazarxyz","apiVersion":"2026-03-10","environment":"production","observedAt":"YYYY-MM-DDTHH:MM:SSZ","repository":"programmablehq/PROGRAMMABLE","repositoryId":"1314365508","response":{"bodyBase64":"RAW_ENDPOINT_BODY_BASE64","bodySha256":"sha256:...","date":"HTTP_DATE","enabled":true,"enforcedByOwner":false,"requestId":"X_GITHUB_REQUEST_ID","status":200},"revision":"EXACT_PRODUCTION_SHA","schemaVersion":"programmable.github-immutable-release-owner-preflight.v3","tagRuleset":{"response":{"bodyBase64":"RAW_RULESET_BODY_BASE64","bodySha256":"sha256:...","date":"HTTP_DATE","requestId":"X_GITHUB_REQUEST_ID","status":200},"url":"https://api.github.com/repos/programmablehq/PROGRAMMABLE/rulesets/21679403"},"url":"https://api.github.com/repos/programmablehq/PROGRAMMABLE/immutable-releases"}
 ```
 
 Both the LF-terminated record and the complete armored OpenSSH signature are

--- a/scripts/capture-immutable-release-owner-preflight.mjs
+++ b/scripts/capture-immutable-release-owner-preflight.mjs
@@ -5,6 +5,7 @@ import { createHash } from "node:crypto";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { TextDecoder } from "node:util";
 import { canonicalizeJson, parseStrictJson } from "../packages/launch/src/canonical-json.mjs";
+import { assertProgrammableLaunchTagRuleset } from "./verify-programmable-launch-tag-ruleset.mjs";
 import {
   canonicalImmutableReleaseOwnerPreflightBytes,
   IMMUTABLE_RELEASE_PREFLIGHT_ALLOWED_SIGNERS_PATH,
@@ -100,7 +101,7 @@ function headerSeparator(bytes) {
   throw new TypeError("GitHub immutable-release response headers are missing");
 }
 
-export function parseIncludedGitHubResponse(bytes) {
+export function parseIncludedGitHubResponse(bytes, { tagRuleset = false } = {}) {
   if (!Buffer.isBuffer(bytes) || bytes.length === 0
     || bytes.length > MAXIMUM_ENDPOINT_RESPONSE_BYTES) {
     throw new TypeError("GitHub immutable-release response is invalid");
@@ -139,8 +140,12 @@ export function parseIncludedGitHubResponse(bytes) {
   }
   const body = parseStrictJson(decodeUtf8(bodyBytes, "GitHub immutable-release response body"), {
     maximumBytes: 4_096,
-    maximumDepth: 4,
+    maximumDepth: 8,
   });
+  if (tagRuleset) {
+    assertProgrammableLaunchTagRuleset(body);
+    return Object.freeze({ bodyBytes: Buffer.from(bodyBytes), date, requestId });
+  }
   if (body === null || typeof body !== "object" || Array.isArray(body)
     || Object.keys(body).sort().join(",") !== "enabled,enforced_by_owner"
     || body.enabled !== true || typeof body.enforced_by_owner !== "boolean") {
@@ -160,6 +165,7 @@ export function buildImmutableReleaseOwnerPreflightRecord({
   date,
   enforcedByOwner,
   requestId,
+  tagRuleset,
 }) {
   const dateMilliseconds = Date.parse(date);
   if (typeof revision !== "string" || !COMMIT.test(revision)
@@ -190,6 +196,16 @@ export function buildImmutableReleaseOwnerPreflightRecord({
     },
     revision,
     schemaVersion: IMMUTABLE_RELEASE_PREFLIGHT_SCHEMA,
+    tagRuleset: {
+      url: `https://api.github.com/repos/${REPOSITORY}/rulesets/21679403`,
+      response: {
+        bodyBase64: tagRuleset.bodyBytes.toString("base64"),
+        bodySha256: sha256(tagRuleset.bodyBytes),
+        date: tagRuleset.date,
+        requestId: tagRuleset.requestId,
+        status: 200,
+      },
+    },
     url: `https://api.github.com/repos/${REPOSITORY}/immutable-releases`,
   });
 }
@@ -255,12 +271,16 @@ export function captureImmutableReleaseOwnerPreflight({
     { maximumBytes: MAXIMUM_ENDPOINT_RESPONSE_BYTES },
   );
   const endpoint = parseIncludedGitHubResponse(included);
+  const tagRuleset = parseIncludedGitHubResponse(runCommand(GH,
+    ghArguments(`/repos/${REPOSITORY}/rulesets/21679403`, { include: true }),
+    { maximumBytes: MAXIMUM_ENDPOINT_RESPONSE_BYTES }), { tagRuleset: true });
   const record = buildImmutableReleaseOwnerPreflightRecord({
     revision,
     bodyBytes: endpoint.bodyBytes,
     date: endpoint.date,
     enforcedByOwner: endpoint.enforcedByOwner,
     requestId: endpoint.requestId,
+    tagRuleset,
   });
   const recordBytes = canonicalImmutableReleaseOwnerPreflightBytes(record);
   const signatureBytes = runCommand(SSH_KEYGEN, [
@@ -293,7 +313,7 @@ export function captureImmutableReleaseOwnerPreflight({
     namespace: trustPolicy.namespace,
     recordBase64,
     recordSha256: sha256(recordBytes),
-    schemaVersion: "programmable.github-immutable-release-owner-preflight-capture.v2",
+    schemaVersion: "programmable.github-immutable-release-owner-preflight-capture.v3",
     signatureBase64,
     signer: trustPolicy.principal,
   });

--- a/scripts/test/immutable-release-owner-preflight-v2.test.mjs
+++ b/scripts/test/immutable-release-owner-preflight-v2.test.mjs
@@ -26,6 +26,7 @@ import {
   IMMUTABLE_RELEASE_PREFLIGHT_TRUST_POLICY,
   verifyImmutableReleaseOwnerPreflight,
 } from "../verify-immutable-release-owner-preflight.mjs";
+import { assertOwnerBoundProgrammableLaunchTagRuleset } from "../verify-programmable-launch-tag-ruleset.mjs";
 
 const SSH_KEYGEN = "/usr/bin/ssh-keygen";
 const REVISION = "1".repeat(40);
@@ -99,6 +100,16 @@ function endpointBody(enforcedByOwner = false) {
   );
 }
 
+function tagRuleset() {
+  return {
+    id: 21679403, name: "Protect Programmable Launch CLI release tags", target: "tag",
+    enforcement: "active", bypass_actors: [],
+    conditions: { ref_name: { include: ["refs/tags/programmable-launch-v*"], exclude: [] } },
+    rules: [{ type: "update" }, { type: "deletion" }],
+    updated_at: "2026-08-27T20:27:05.716Z",
+  };
+}
+
 function record({
   revision = REVISION,
   bodyBytes = endpointBody(false),
@@ -112,6 +123,7 @@ function record({
     date,
     enforcedByOwner,
     requestId,
+    tagRuleset: { bodyBytes: Buffer.from(JSON.stringify(tagRuleset())), date, requestId },
   });
 }
 
@@ -277,6 +289,58 @@ test("record and signature transports require canonical bounded base64", (t) => 
     }),
     /canonical base64/u,
   );
+});
+
+test("signed owner tag policy proves an omitted list only while live protection is unchanged", (t) => {
+  const trust = makeTrust(t);
+  const verified = verifyImmutableReleaseOwnerPreflight(verificationInput(trust));
+  const live = tagRuleset();
+  delete live.bypass_actors;
+  assert.doesNotThrow(() => assertOwnerBoundProgrammableLaunchTagRuleset(live, verified.tagRuleset));
+  assert.doesNotThrow(() => assertOwnerBoundProgrammableLaunchTagRuleset({
+    ...live, updated_at: "2026-08-27T22:27:05.716+02:00",
+  }, verified.tagRuleset));
+  for (const changed of [
+    { ...live, updated_at: "2026-08-29T12:00:00Z" },
+    { ...live, updated_at: undefined },
+    { ...live, enforcement: "disabled" },
+    { ...live, rules: [{ type: "update" }] },
+    { ...live, bypass_actors: null },
+    { ...live, bypass_actors: [{ actor_type: "OrganizationAdmin" }] },
+  ]) assert.throws(() => assertOwnerBoundProgrammableLaunchTagRuleset(changed, verified.tagRuleset));
+  assert.throws(() => assertOwnerBoundProgrammableLaunchTagRuleset(live, live));
+});
+
+test("owner tag proof rejects signed missing permissions, bypass actors, stale provenance and substitution", (t) => {
+  const trust = makeTrust(t);
+  const base = record();
+  for (const mutate of [
+    value => { delete value.tagRuleset; },
+    value => { value.schemaVersion = "programmable.github-immutable-release-owner-preflight.v2"; },
+    value => { value.tagRuleset.url += "0"; },
+    value => { value.tagRuleset.response.bodySha256 = `sha256:${"0".repeat(64)}`; },
+    value => { value.tagRuleset.response.date = "Sat, 29 Aug 2026 11:59:00 GMT"; },
+    value => { value.tagRuleset.response.requestId = "missing"; },
+    value => { value.tagRuleset.response.status = 404; },
+    ...[undefined, [{ actor_type: "OrganizationAdmin" }]].map(actors => value => {
+      const rules = tagRuleset();
+      if (actors === undefined) delete rules.bypass_actors;
+      else rules.bypass_actors = actors;
+      const bytes = Buffer.from(JSON.stringify(rules));
+      value.tagRuleset.response.bodyBase64 = bytes.toString("base64");
+      value.tagRuleset.response.bodySha256 = sha256(bytes);
+    }),
+  ]) {
+    const value = structuredClone(base);
+    mutate(value);
+    assert.throws(() => verifyImmutableReleaseOwnerPreflight(verificationInput(trust, value)));
+  }
+  const signed = verificationInput(trust, base);
+  const changed = structuredClone(base);
+  changed.tagRuleset.response.requestId = "ABCD:EF01:2345:6789:EEEE";
+  assert.throws(() => verifyImmutableReleaseOwnerPreflight({
+    ...signed, recordBase64: canonicalImmutableReleaseOwnerPreflightBytes(changed).toString("base64"),
+  }), /signature/u);
 });
 
 test("the signature covers exact canonical JSON plus one LF", (t) => {
@@ -477,6 +541,7 @@ function captureRunner({
       return Buffer.from(JSON.stringify(ref));
     }
     if (endpoint.endsWith("/immutable-releases")) return includedResponse(body);
+    if (endpoint.endsWith("/rulesets/21679403")) return includedResponse(JSON.stringify(tagRuleset()));
     assert.fail(`unexpected endpoint ${endpoint}`);
   };
 }
@@ -527,7 +592,7 @@ test("local capture refuses Actions and validates gh owner, production ref, and 
     runCommand: captureRunner(),
     trustPolicy: trust.policy,
   });
-  assert.equal(captured.schemaVersion, "programmable.github-immutable-release-owner-preflight-capture.v2");
+  assert.equal(captured.schemaVersion, "programmable.github-immutable-release-owner-preflight-capture.v3");
   assert.equal(captured.signer, trust.policy.principal);
   assert.doesNotMatch(JSON.stringify(captured), /PRIVATE KEY|id_ed25519/u);
   assert.doesNotThrow(() => verifyImmutableReleaseOwnerPreflight({

--- a/scripts/test/programmable-launch-release-workflow.test.mjs
+++ b/scripts/test/programmable-launch-release-workflow.test.mjs
@@ -186,7 +186,7 @@ function failures(value) {
     "--environment \"production\"",
     "--actor-id \"$GITHUB_ACTOR_ID\"",
     "--actor-login \"$GITHUB_ACTOR\"",
-    "programmable.github-immutable-release-owner-preflight.v2",
+    "programmable.github-immutable-release-owner-preflight.v3",
     "258789013+hazarxyz@users.noreply.github.com",
     "SHA256:RTXVJ3XspKUc+Qmj/daOWwU2WyT+qbRBtsJJwNpItdI",
     "immutable-release-preflight@programmable.xyz",
@@ -216,9 +216,13 @@ function failures(value) {
     'test -n "$IMMUTABLE_RELEASES_PREFLIGHT_SIGNATURE_BASE64"',
     "--allowed-signers \"$GITHUB_WORKSPACE/.github/release-trust/programmable-launch-immutable-release-owner.allowed_signers\"",
   ]) {
-    if (value.split(item).length - 1 !== 2) {
-      missing.push(`${item} must appear in both immutable preflight checks`);
+    const expectedCount = item.startsWith("PROGRAMMABLE_") ? 3 : 2;
+    if (value.split(item).length - 1 !== expectedCount) {
+      missing.push(`${item} must appear in all required owner preflight checks`);
     }
+  }
+  if (value.split('node scripts/verify-programmable-launch-tag-ruleset.mjs "$rulesets" --owner-preflight').length - 1 !== 2) {
+    missing.push("owner-bound tag protection must be verified before build and publication");
   }
   return missing;
 }
@@ -357,6 +361,7 @@ test("release workflow contract mutations fail closed", () => {
     ),
     source.replaceAll('--actor-id "$GITHUB_ACTOR_ID"', '--actor-id "0"'),
     source.replaceAll('--actor-login "$GITHUB_ACTOR"', '--actor-login "someone-else"'),
+    source.replaceAll("--owner-preflight", ""),
     source.replaceAll('--repository-id "1314365508"', '--repository-id "0"'),
     replaceLast(
       source,

--- a/scripts/test/programmable-launch-v4-clean-room.test.mjs
+++ b/scripts/test/programmable-launch-v4-clean-room.test.mjs
@@ -220,16 +220,25 @@ test("V4 release contract binds canonical manifest, checksum, assets, and produc
   assert.throws(() => validateReleaseFiles(extra), /RELEASE_FILES_SHAPE_INVALID/u);
 });
 
-test("reviewed release coordinate blocks the current unreleased state and binds every future byte", () => {
+test("reviewed release coordinate preserves the blocked baseline and binds every released byte", () => {
   const coordinateSchema = JSON.parse(readFileSync(new URL(
     "../../docs/operations/releases/custom-launch-v4/clean-room-release-coordinate.schema.json",
     import.meta.url,
   ), "utf8"));
   const validateCoordinateSchema = new Ajv2020({ strict: true }).compile(coordinateSchema);
-  const blocked = JSON.parse(readFileSync(new URL(
+  const committed = JSON.parse(readFileSync(new URL(
     "../../docs/operations/releases/custom-launch-v4/clean-room-release-coordinate.json",
     import.meta.url,
   ), "utf8"));
+  assert.equal(validateCoordinateSchema(committed), true, JSON.stringify(validateCoordinateSchema.errors));
+  if (committed.releaseReady) {
+    const bindingBytes = readFileSync(path.join(repositoryRoot, bindingPath));
+    validateReviewedReleaseCoordinate(committed, {
+      releaseReady: JSON.parse(bindingBytes).releaseReady,
+      bindingSha256: `sha256:${hexSha(bindingBytes)}`,
+    });
+  }
+  const blocked = blockedCoordinateBaseline(committed);
   assert.equal(validateCoordinateSchema(blocked), true, JSON.stringify(validateCoordinateSchema.errors));
   assert.equal(validateReviewedReleaseCoordinate(blocked, {
     releaseReady: false,

--- a/scripts/verify-immutable-release-owner-preflight.mjs
+++ b/scripts/verify-immutable-release-owner-preflight.mjs
@@ -18,9 +18,10 @@ import {
   canonicalizeJson,
   parseStrictJson,
 } from "../packages/launch/src/canonical-json.mjs";
+import { assertProgrammableLaunchTagRuleset } from "./verify-programmable-launch-tag-ruleset.mjs";
 
 export const IMMUTABLE_RELEASE_PREFLIGHT_SCHEMA =
-  "programmable.github-immutable-release-owner-preflight.v2";
+  "programmable.github-immutable-release-owner-preflight.v3";
 export const IMMUTABLE_RELEASE_PREFLIGHT_API_VERSION = "2026-03-10";
 export const IMMUTABLE_RELEASE_PREFLIGHT_SIGNER =
   "258789013+hazarxyz@users.noreply.github.com";
@@ -73,6 +74,7 @@ const RECORD_KEYS = Object.freeze([
   "response",
   "revision",
   "schemaVersion",
+  "tagRuleset",
   "url",
 ]);
 const RESPONSE_KEYS = Object.freeze([
@@ -333,6 +335,28 @@ export function verifyImmutableReleaseOwnerPreflight({
     throw new TypeError("immutable-release owner preflight is stale or differs");
   }
 
+  const tag = exactKeys(value.tagRuleset, ["url", "response"], "owner tag ruleset");
+  const tagResponse = exactKeys(tag.response,
+    ["bodyBase64", "bodySha256", "date", "requestId", "status"], "owner tag ruleset response");
+  const tagBytes = decodeCanonicalBase64(tagResponse.bodyBase64, "owner tag ruleset body", MAXIMUM_RESPONSE_BODY_BYTES);
+  const tagRuleset = parseStrictJson(decodeUtf8(tagBytes, "owner tag ruleset body"),
+    { maximumBytes: MAXIMUM_RESPONSE_BODY_BYTES, maximumDepth: 8 });
+  assertProgrammableLaunchTagRuleset(tagRuleset);
+  const tagDate = Date.parse(tagResponse.date);
+  const tagUpdated = Date.parse(tagRuleset.updated_at);
+  if (tag.url !== `https://api.github.com/repos/${repository}/rulesets/21679403`
+    || tagResponse.status !== 200 || tagResponse.bodySha256 !== sha256(tagBytes)
+    || typeof tagResponse.requestId !== "string" || !GITHUB_REQUEST_ID.test(tagResponse.requestId)
+    || typeof tagResponse.date !== "string" || !Number.isFinite(tagDate)
+    || new Date(tagDate).toUTCString() !== tagResponse.date
+    || tagDate > nowMilliseconds + MAXIMUM_FUTURE_SKEW_MS
+    || nowMilliseconds - tagDate > MAXIMUM_AGE_MS
+    || Math.abs(tagDate - observedAtMilliseconds) > MAXIMUM_FUTURE_SKEW_MS
+    || typeof tagRuleset.updated_at !== "string" || !Number.isFinite(tagUpdated)
+    || tagUpdated > tagDate + MAXIMUM_FUTURE_SKEW_MS) {
+    throw new TypeError("owner tag ruleset preflight is stale or differs");
+  }
+
   return Object.freeze({
     actorId,
     actorLogin,
@@ -350,6 +374,7 @@ export function verifyImmutableReleaseOwnerPreflight({
     revision,
     schemaVersion: IMMUTABLE_RELEASE_PREFLIGHT_SCHEMA,
     signer: policy.principal,
+    tagRuleset,
     url: expectedUrl,
   });
 }

--- a/scripts/verify-programmable-launch-tag-ruleset.mjs
+++ b/scripts/verify-programmable-launch-tag-ruleset.mjs
@@ -2,6 +2,7 @@
 
 import { readFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
+import { canonicalizeJson } from "../packages/launch/src/canonical-json.mjs";
 
 export const PROGRAMMABLE_LAUNCH_TAG_RULESET = Object.freeze({
   id: 21679403,
@@ -86,12 +87,45 @@ export function assertProgrammableLaunchTagRuleset(ruleset) {
   return ruleset;
 }
 
+// GitHub omits bypass_actors unless the caller can write the ruleset. Never
+// infer an empty list from omission: use the freshly verified owner signature.
+export function assertOwnerBoundProgrammableLaunchTagRuleset(live, owner) {
+  assertProgrammableLaunchTagRuleset(owner);
+  if (!isRecord(live)) fail("live response must be an object");
+  if (Object.hasOwn(live, "bypass_actors")) assertProgrammableLaunchTagRuleset(live);
+  for (const field of ["id", "name", "target", "enforcement", "conditions", "rules"]) {
+    if (canonicalizeJson(live[field]) !== canonicalizeJson(owner[field])) {
+      fail(`live ${field} differs from the signed owner observation`);
+    }
+  }
+  const observedUpdate = Date.parse(owner.updated_at);
+  if (typeof owner.updated_at !== "string" || !Number.isFinite(observedUpdate)
+    || typeof live.updated_at !== "string" || Date.parse(live.updated_at) !== observedUpdate) {
+    fail("live updated_at differs from the signed owner observation");
+  }
+  return owner;
+}
+
 async function main(argv) {
-  if (argv.length !== 1) {
+  if (argv.length !== 1 && !(argv.length === 2 && argv[1] === "--owner-preflight")) {
     throw new Error("Usage: verify-programmable-launch-tag-ruleset.mjs <ruleset.json>");
   }
   const ruleset = JSON.parse(await readFile(argv[0], "utf8"));
-  assertProgrammableLaunchTagRuleset(ruleset);
+  if (argv.length === 1) return assertProgrammableLaunchTagRuleset(ruleset);
+  const { verifyImmutableReleaseOwnerPreflight, IMMUTABLE_RELEASE_PREFLIGHT_ALLOWED_SIGNERS_PATH } =
+    await import("./verify-immutable-release-owner-preflight.mjs");
+  const verified = verifyImmutableReleaseOwnerPreflight({
+    recordBase64: process.env.IMMUTABLE_RELEASES_PREFLIGHT_RECORD_BASE64,
+    signatureBase64: process.env.IMMUTABLE_RELEASES_PREFLIGHT_SIGNATURE_BASE64,
+    allowedSignersPath: IMMUTABLE_RELEASE_PREFLIGHT_ALLOWED_SIGNERS_PATH,
+    repository: process.env.GITHUB_REPOSITORY,
+    repositoryId: process.env.GITHUB_REPOSITORY_ID,
+    revision: process.env.GITHUB_SHA,
+    environment: "production",
+    actorId: process.env.GITHUB_ACTOR_ID,
+    actorLogin: process.env.GITHUB_ACTOR,
+  });
+  return assertOwnerBoundProgrammableLaunchTagRuleset(ruleset, verified.tagRuleset);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {


### PR DESCRIPTION
The official CLI release stopped because GitHub omits `bypass_actors` from ruleset responses made with the Actions token. An owner read confirms that the protected tag ruleset has no bypass actors; treating the omitted field as an empty list would discard that check.

Bind the complete owner-authenticated ruleset response into preflight schema v3, covered by the existing Ed25519 trust root, exact production revision and ten-minute expiry. Verify explicit empty bypass actors in the signed response, then compare the live protection fields and normalized update timestamp both before building and before publication. The workflow keeps its existing permissions and receives no owner API token.

Keep the clean-room blocked-coordinate test explicit so publishing the actual release coordinate does not invalidate its negative fixture.

Validation: 29 focused preflight, workflow and clean-room tests passed; five external operator checks passed. A current anonymous GitHub response (bypass field omitted) matched the owner response (explicit empty list). Mutation tests reject omitted owner authority, nonempty bypass actors, stale or substituted signatures, and changed live protection. Existing release and production CI remain required.
