### PR TITLE
Fix immutable PoolManager binding in the V4 agent example

### DIFF
--- a/packages/launch/examples/robinhood-v4-no-broadcast/README.md
+++ b/packages/launch/examples/robinhood-v4-no-broadcast/README.md
@@ -7,7 +7,8 @@ chain-deployment descriptor and integer-revision profile reference into the gene
 that route, any required trust root, the finality digest, or the production profile digest is unavailable.
 
 The request declares funding mode `none`, value `0`, an uninitialized empty pool, and no liquidity action. The hook
-authenticates `beforeSwap` calls against the capabilities-bound PoolManager. This fixture does not claim a fee,
+authenticates `beforeSwap` calls against the capabilities-bound immutable PoolManager. The build binds the compiler's
+exact immutable reference to the same address passed to the constructor. This fixture does not claim a fee,
 claiming, liquidity, deployment, or launched-token outcome. A successful local build, pack, or validation is not API
 admission, wallet approval, onchain deployment, or public availability.
 
@@ -29,12 +30,14 @@ pre-release source candidate supports local preparation only.
 stop. This conditional procedure does not assert today's release state; this example still never submits,
 signs or broadcasts.
 
-Set `PACKAGE_ROOT` to that verified package directory, or the reviewed checkout's `packages/launch` directory for
-local preparation, then copy the project and install its exact compiler lock:
+Use the verified CLI with the project from the current reviewed protected checkout. The immutable `4.0.0` release
+contains an older example with a mutable PoolManager; that example is rejected by production admission. The CLI
+itself supports the corrected immutable binding. Set `PROJECT_SOURCE_ROOT` to the reviewed checkout, then copy
+the corrected project and install its exact compiler lock:
 
 ```sh
-PACKAGE_ROOT="/absolute/path/to/package-root"
-cp -R "$PACKAGE_ROOT/examples/robinhood-v4-no-broadcast/project" ./robinhood-v4-clean-room
+PROJECT_SOURCE_ROOT="/absolute/path/to/reviewed-programmable-checkout"
+cp -R "$PROJECT_SOURCE_ROOT/packages/launch/examples/robinhood-v4-no-broadcast/project" ./robinhood-v4-clean-room
 cd ./robinhood-v4-clean-room
 npm ci --ignore-scripts --no-audit --no-fund
 mkdir -p assets

--- a/packages/launch/examples/robinhood-v4-no-broadcast/project/build-and-configure.mjs
+++ b/packages/launch/examples/robinhood-v4-no-broadcast/project/build-and-configure.mjs
@@ -131,6 +131,11 @@ try {
   throw new TypeError("V4 capabilities response is not JSON");
 }
 const now = Math.floor(Date.now() / 1_000);
+const hookImmutableIds = Object.keys(output.contracts["src/RobinhoodCleanRoomHook.sol"]
+  .RobinhoodCleanRoomHook.evm.deployedBytecode.immutableReferences ?? {});
+if (hookImmutableIds.length !== 1) {
+  throw new TypeError("the hook must contain exactly one immutable PoolManager binding");
+}
 const config = createPackConfigFromCapabilities({
   capabilities,
   launchWallet,
@@ -144,6 +149,7 @@ const config = createPackConfigFromCapabilities({
   tokenSupply,
   projectMetadata,
   checkedAt,
+  hookImmutableId: hookImmutableIds[0],
 });
 const canonicalCapabilitiesBytes = Buffer.from(`${JSON.stringify(capabilities, null, 2)}\n`, "utf8");
 await writeFile(path.join(root, "evidence", "capabilities.json"), canonicalCapabilitiesBytes);

--- a/packages/launch/examples/robinhood-v4-no-broadcast/project/config-from-capabilities.mjs
+++ b/packages/launch/examples/robinhood-v4-no-broadcast/project/config-from-capabilities.mjs
@@ -23,8 +23,12 @@ export function createPackConfigFromCapabilities({
   tokenSupply,
   projectMetadata,
   checkedAt,
+  hookImmutableId,
 }) {
   assertProductionV4Capabilities(capabilities);
+  if (typeof hookImmutableId !== "string" || !/^(?:0|[1-9][0-9]*)$/u.test(hookImmutableId)) {
+    throw new TypeError("the compiled hook PoolManager immutable ID is required");
+  }
   if (!ADDRESS.test(launchWallet)
     || /^0x0{40}$/u.test(launchWallet)
     || !/^0x(?!0{64}$)[0-9a-f]{64}$/u.test(nonce)
@@ -96,7 +100,7 @@ export function createPackConfigFromCapabilities({
         initializerValueWei: "0",
         componentKind: "hook",
         declaredHookPermissions: ["beforeSwap"],
-        runtimeImmutables: [],
+        runtimeImmutables: [{ immutableId: hookImmutableId, abiType: "address", literal: poolManager }],
       },
       {
         targetId: "initializer",

--- a/packages/launch/examples/robinhood-v4-no-broadcast/project/src/RobinhoodCleanRoomHook.sol
+++ b/packages/launch/examples/robinhood-v4-no-broadcast/project/src/RobinhoodCleanRoomHook.sol
@@ -21,7 +21,7 @@ struct SwapParams {
 contract RobinhoodCleanRoomHook {
     error NotPoolManager();
 
-    address public poolManager;
+    address public immutable poolManager;
 
     constructor(address poolManager_) {
         require(poolManager_ != address(0), "zero PoolManager");

--- a/packages/launch/test/example-v4.test.mjs
+++ b/packages/launch/test/example-v4.test.mjs
@@ -70,12 +70,17 @@ test("Robinhood V4 example materializes a schema-valid funding-none config from 
       },
     },
     checkedAt: "2026-08-29T12:00:00.000Z",
+    hookImmutableId: "7",
   });
 
   assert.equal(validate(config), true, JSON.stringify(validate.errors));
   assert.equal(config.funding.mode, "none");
   assert.equal(config.funding.valueWei, "0");
   assert.equal(config.targets.length, 3);
+  const hook = config.targets.find(target => target.targetId === "hook");
+  assert.deepEqual(hook.runtimeImmutables, [{ immutableId: "7", abiType: "address",
+    literal: capabilities.chainDeployment.contracts.poolManager.address }]);
+  assert.equal(hook.constructorArguments[0], hook.runtimeImmutables[0].literal);
   assert.equal(config.profile.profileRevision, 1);
   assert.equal(config.chainDeployment,
     capabilities.chainDeployment,

--- a/scripts/programmable-launch-v4-clean-room.mjs
+++ b/scripts/programmable-launch-v4-clean-room.mjs
@@ -593,7 +593,11 @@ export async function prepareCleanRoom(options) {
     stage: "INSTALLED_CLI_VERSION", requireSilentStderr: true, cwd: workspace,
   })).trim();
   requireValue(installedVersion === RELEASE_VERSION, "INSTALLED_CLI_VERSION_INVALID");
-  await cp(path.join(packageRoot, "examples", "robinhood-v4-no-broadcast", "project"),
+  const projectSourceRevision = (await runCommand("git", ["-C", REPOSITORY_ROOT, "rev-parse", "HEAD"],
+    { stage: "PROJECT_SOURCE_REVISION", requireSilentStderr: true })).trim();
+  requireValue(COMMIT.test(projectSourceRevision) && projectSourceRevision === process.env.GITHUB_SHA,
+    "PROJECT_SOURCE_REVISION_INVALID");
+  await cp(path.join(REPOSITORY_ROOT, "packages", "launch", "examples", "robinhood-v4-no-broadcast", "project"),
     projectDirectory, { recursive: true, errorOnExist: true, force: false, dereference: false });
   const imagePath = path.resolve(options.image);
   await assertRegularFile(imagePath, "PROJECT_IMAGE", MAX_IMAGE_BYTES);
@@ -626,7 +630,7 @@ export async function prepareCleanRoom(options) {
       ).href,
       PROGRAMMABLE_PROJECT_IMAGE_URI: imageUri,
       PROGRAMMABLE_SOURCE_ORIGIN: "https://github.com/programmablehq/PROGRAMMABLE",
-      PROGRAMMABLE_SOURCE_REVISION: release.source.commitSha,
+      PROGRAMMABLE_SOURCE_REVISION: projectSourceRevision,
       PROGRAMMABLE_WEBSITE_URL: websiteUrl,
       PROGRAMMABLE_X_URL: options.xUrl,
     }),


### PR DESCRIPTION
The protected production agent test reached authenticated V4 intake, but admission rejected the example hook with `V4_CALLBACK_AUTHENTICATION_MISSING`: its PoolManager authority was stored in mutable state. Make that authority immutable and bind the compiler's exact immutable reference to the same capabilities-derived address supplied to the constructor.

The runner continues to install and verify immutable CLI 4.0.0. It now builds the corrected project from its exact protected producer checkout and records that checkout revision as the project source. The existing prepared project tree hash and producer provenance remain enforced. The README identifies the old bundled sample and points to the corrected source; no published release assets or admission gates are changed.

Validation: the four focused example tests pass; the corrected project builds and packs with the independently verified public 4.0.0 tarball; the deployed backend's exact compiler-binding verifier passes and its static scanner returns `no_static_finding` with no findings. The real protected API-key test will run again after this change reaches production. No wallet signing or transaction broadcast occurred.
