### PR TITLE
Make the V4 example compatible with finalized Router simulation

### DIFF
--- a/packages/launch/examples/robinhood-v4-no-broadcast/README.md
+++ b/packages/launch/examples/robinhood-v4-no-broadcast/README.md
@@ -6,6 +6,11 @@ addresses. At build time it fetches the unauthenticated production V4 capabiliti
 chain-deployment descriptor and integer-revision profile reference into the generated config. It fails closed while
 that route, any required trust root, the finality digest, or the production profile digest is unavailable.
 
+The builder reads the finalized Robinhood block from the official public RPC and includes that checkpoint in the
+permit window. Finalized blocks can trail the current API clock by many minutes. The permit still lasts at most
+one hour, and the build stops unless at least five minutes remain for submission. The backend independently
+checks finality and the exact transaction; the public RPC read does not authorize a launch.
+
 The request declares funding mode `none`, value `0`, an uninitialized empty pool, and no liquidity action. The hook
 authenticates `beforeSwap` calls against the capabilities-bound immutable PoolManager. The build binds the compiler's
 exact immutable reference to the same address passed to the constructor. This fixture does not claim a fee,
@@ -75,7 +80,7 @@ programmable-launch validate launch.json \
   --config programmable-launch.config.json
 ```
 
-Run `build` again if the one-hour permit window expires or the public capabilities binding changes. Do not edit the
+Run `build` again if the generated permit expires or the public capabilities binding changes. Do not edit the
 generated chain deployment or profile to bypass that change; generate a new config and pack new bytes.
 
 The four public CLI commands are `pack`, `validate`, `submit`, and `status`. This example stops after local validation.

--- a/packages/launch/examples/robinhood-v4-no-broadcast/README.md
+++ b/packages/launch/examples/robinhood-v4-no-broadcast/README.md
@@ -11,7 +11,9 @@ permit window. Finalized blocks can trail the current API clock by many minutes.
 one hour, and the build stops unless at least five minutes remain for submission. The backend independently
 checks finality and the exact transaction; the public RPC read does not authorize a launch.
 
-The request declares funding mode `none`, value `0`, an uninitialized empty pool, and no liquidity action. The hook
+The request declares funding mode `none`, value `0`, an initialized empty pool, and no liquidity action. The
+initializer's constructor initializes the PoolManager pool after the token and hook are deployed; the Router
+requires an initialized pool before issuing its stamp. It adds no liquidity or funds. The hook
 authenticates `beforeSwap` calls against the capabilities-bound immutable PoolManager. The build binds the compiler's
 exact immutable reference to the same address passed to the constructor. This fixture does not claim a fee,
 claiming, liquidity, deployment, or launched-token outcome. A successful local build, pack, or validation is not API

--- a/packages/launch/examples/robinhood-v4-no-broadcast/project/build-and-configure.mjs
+++ b/packages/launch/examples/robinhood-v4-no-broadcast/project/build-and-configure.mjs
@@ -7,11 +7,12 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 import solc from "solc";
 
-import { createPackConfigFromCapabilities } from "./config-from-capabilities.mjs";
+import { createPackConfigFromCapabilities, createPermitWindowFromFinalizedBlock } from "./config-from-capabilities.mjs";
 import { assertExactProjectImageV4 } from "./image-precheck.mjs";
 
 const CAPABILITIES_URL =
   "https://api.programmable.market/v4/chains/4663/capabilities";
+const ROBINHOOD_RPC_URL = "https://rpc.mainnet.chain.robinhood.com";
 const EXPECTED_SOLC = "0.8.26+commit.8a97fa7a.Emscripten.clang";
 const SOURCE_TARGETS = Object.freeze([
   ["src/RobinhoodCleanRoomToken.sol", "RobinhoodCleanRoomToken", "token"],
@@ -130,7 +131,15 @@ try {
 } catch {
   throw new TypeError("V4 capabilities response is not JSON");
 }
-const now = Math.floor(Date.now() / 1_000);
+const [rpcChainId, finalizedBlock] = await Promise.all([
+  rpc("eth_chainId", []),
+  rpc("eth_getBlockByNumber", ["finalized", false]),
+]);
+const permitWindow = createPermitWindowFromFinalizedBlock({
+  rpcChainId,
+  block: finalizedBlock,
+  nowSeconds: Math.floor(Date.parse(capabilities.serverTime) / 1_000),
+});
 const hookImmutableIds = Object.keys(output.contracts["src/RobinhoodCleanRoomHook.sol"]
   .RobinhoodCleanRoomHook.evm.deployedBytecode.immutableReferences ?? {});
 if (hookImmutableIds.length !== 1) {
@@ -140,10 +149,7 @@ const config = createPackConfigFromCapabilities({
   capabilities,
   launchWallet,
   nonce,
-  permitWindow: {
-    validAfter: String(Math.max(0, now - 60)),
-    deadline: String(now + 3_540),
-  },
+  permitWindow,
   sourceRevision,
   sourceOrigin,
   tokenSupply,
@@ -160,6 +166,12 @@ await writeFile(path.join(root, "evidence", "build.json"), `${JSON.stringify({
   artifactDigests,
   capabilitiesUrl: CAPABILITIES_URL,
   capabilitiesSha256: sha256(canonicalCapabilitiesBytes),
+  permitWindowCheckpoint: {
+    rpcUrl: ROBINHOOD_RPC_URL,
+    blockNumber: BigInt(finalizedBlock.number).toString(),
+    blockHash: finalizedBlock.hash,
+    timestamp: BigInt(finalizedBlock.timestamp).toString(),
+  },
   fundingMode: "none",
   signing: false,
   broadcast: false,
@@ -171,6 +183,22 @@ await writeFile(
   "utf8",
 );
 process.stdout.write("Wrote capability-bound programmable-launch.config.json; no signing or broadcast performed.\n");
+
+async function rpc(method, params) {
+  const response = await fetch(ROBINHOOD_RPC_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    redirect: "error",
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) throw new TypeError(`Robinhood finalized checkpoint unavailable: HTTP ${response.status}`);
+  const result = await response.json();
+  if (result.jsonrpc !== "2.0" || result.id !== 1 || result.error || result.result == null) {
+    throw new TypeError("Robinhood finalized checkpoint RPC response is invalid");
+  }
+  return result.result;
+}
 
 function required(name) {
   const value = process.env[name];

--- a/packages/launch/examples/robinhood-v4-no-broadcast/project/config-from-capabilities.mjs
+++ b/packages/launch/examples/robinhood-v4-no-broadcast/project/config-from-capabilities.mjs
@@ -13,6 +13,26 @@ const TRUST_ROOTS = Object.freeze([
   "universalRouter",
 ]);
 
+export function createPermitWindowFromFinalizedBlock({ rpcChainId, block, nowSeconds }) {
+  const quantity = /^0x(?:0|[1-9a-f][0-9a-f]*)$/u;
+  if (!quantity.test(rpcChainId ?? "") || BigInt(rpcChainId) !== 4_663n
+    || !quantity.test(block?.number ?? "") || !quantity.test(block?.timestamp ?? "")
+    || !/^0x[0-9a-f]{64}$/u.test(block?.hash ?? "")
+    || !Number.isSafeInteger(nowSeconds) || nowSeconds <= 0) {
+    throw new TypeError("a Robinhood finalized block and current API time are required");
+  }
+  const timestamp = BigInt(block.timestamp);
+  const now = BigInt(nowSeconds);
+  // The production simulator uses an independently agreed finalized checkpoint.
+  // Leave one minute for provider skew while retaining the existing one-hour cap.
+  const validAfter = timestamp - 60n;
+  const deadline = validAfter + 3_600n;
+  if (timestamp > now || validAfter < now - 3_600n || deadline < now + 300n) {
+    throw new TypeError("the finalized checkpoint cannot provide a fresh one-hour permit with five minutes remaining");
+  }
+  return { validAfter: validAfter.toString(), deadline: deadline.toString() };
+}
+
 export function createPackConfigFromCapabilities({
   capabilities,
   launchWallet,

--- a/packages/launch/examples/robinhood-v4-no-broadcast/project/config-from-capabilities.mjs
+++ b/packages/launch/examples/robinhood-v4-no-broadcast/project/config-from-capabilities.mjs
@@ -127,7 +127,7 @@ export function createPackConfigFromCapabilities({
         compilationUnitId: "robinhood-v4-clean-room",
         artifact: "out/initializer.json",
         applicantSalt: `0x${"03".repeat(32)}`,
-        constructorArguments: [],
+        constructorArguments: [poolManager, { target: "token" }, { target: "hook" }],
         initializer: null,
         deploymentValueWei: "0",
         initializerValueWei: "0",
@@ -152,7 +152,7 @@ export function createPackConfigFromCapabilities({
     liquidityModel: {
       schemaVersion: "programmable.custom-launch-liquidity-model.v1",
       model: "none-empty-pool",
-      declaredLaunchState: "pool-not-initialized",
+      declaredLaunchState: "pool-initialized-empty",
       targetIds: [],
     },
     agentAttestation: {

--- a/packages/launch/examples/robinhood-v4-no-broadcast/project/src/RobinhoodCleanRoomInitializer.sol
+++ b/packages/launch/examples/robinhood-v4-no-broadcast/project/src/RobinhoodCleanRoomInitializer.sol
@@ -1,7 +1,26 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
+import {PoolKey} from "./RobinhoodCleanRoomHook.sol";
+
+interface ICleanRoomPoolManager {
+    function initialize(PoolKey memory key, uint160 sqrtPriceX96) external returns (int24);
+}
+
 contract RobinhoodCleanRoomInitializer {
+    constructor(address poolManager, address token, address hook) {
+        ICleanRoomPoolManager(poolManager).initialize(
+            PoolKey({
+                currency0: address(0),
+                currency1: token,
+                fee: 3000,
+                tickSpacing: 60,
+                hooks: hook
+            }),
+            uint160(1 << 96)
+        );
+    }
+
     function noLiquidityAction() external pure returns (bytes4) {
         return this.noLiquidityAction.selector;
     }

--- a/packages/launch/examples/robinhood-v4-no-broadcast/project/src/RobinhoodCleanRoomInitializer.sol
+++ b/packages/launch/examples/robinhood-v4-no-broadcast/project/src/RobinhoodCleanRoomInitializer.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import {PoolKey} from "./RobinhoodCleanRoomHook.sol";
+import {Currency, PoolKey} from "./RobinhoodCleanRoomHook.sol";
 
 interface ICleanRoomPoolManager {
     function initialize(PoolKey memory key, uint160 sqrtPriceX96) external returns (int24);
@@ -11,8 +11,8 @@ contract RobinhoodCleanRoomInitializer {
     constructor(address poolManager, address token, address hook) {
         ICleanRoomPoolManager(poolManager).initialize(
             PoolKey({
-                currency0: address(0),
-                currency1: token,
+                currency0: Currency.wrap(address(0)),
+                currency1: Currency.wrap(token),
                 fee: 3000,
                 tickSpacing: 60,
                 hooks: hook

--- a/packages/launch/test/example-v4.test.mjs
+++ b/packages/launch/test/example-v4.test.mjs
@@ -7,6 +7,7 @@ import Ajv2020 from "ajv/dist/2020.js";
 import {
   assertProductionV4Capabilities,
   createPackConfigFromCapabilities,
+  createPermitWindowFromFinalizedBlock,
 } from "../examples/robinhood-v4-no-broadcast/project/config-from-capabilities.mjs";
 import { assertExactProjectImageV4 } from
   "../examples/robinhood-v4-no-broadcast/project/image-precheck.mjs";
@@ -43,6 +44,23 @@ ajv.addKeyword({
   validate: (minimum, value) => [...value.matchAll(/[\p{L}\p{N}]/gu)].length >= minimum,
 });
 const validate = ajv.compile(schema);
+
+test("Robinhood permit includes a finalized checkpoint fifteen minutes behind the API clock", () => {
+  const nowSeconds = 1_800_000_000;
+  const block = { number: "0x123", hash: `0x${"44".repeat(32)}`,
+    timestamp: `0x${(nowSeconds - 900).toString(16)}` };
+  const permit = createPermitWindowFromFinalizedBlock({ rpcChainId: "0x1237", block, nowSeconds });
+  assert.ok(BigInt(permit.validAfter) <= BigInt(block.timestamp));
+  assert.equal(BigInt(permit.deadline) - BigInt(permit.validAfter), 3_600n);
+  assert.ok(BigInt(permit.deadline) >= BigInt(nowSeconds + 300));
+  for (const [rpcChainId, timestamp] of [
+    ["0x1", nowSeconds - 900],
+    ["0x1237", nowSeconds - 3_600],
+    ["0x1237", nowSeconds + 1],
+  ]) assert.throws(() => createPermitWindowFromFinalizedBlock({
+    rpcChainId, block: { ...block, timestamp: `0x${timestamp.toString(16)}` }, nowSeconds,
+  }), /Robinhood|finalized/u);
+});
 
 test("Robinhood V4 example materializes a schema-valid funding-none config from capabilities", () => {
   const capabilities = validV4Capabilities();

--- a/packages/launch/test/example-v4.test.mjs
+++ b/packages/launch/test/example-v4.test.mjs
@@ -99,6 +99,10 @@ test("Robinhood V4 example materializes a schema-valid funding-none config from 
   assert.deepEqual(hook.runtimeImmutables, [{ immutableId: "7", abiType: "address",
     literal: capabilities.chainDeployment.contracts.poolManager.address }]);
   assert.equal(hook.constructorArguments[0], hook.runtimeImmutables[0].literal);
+  assert.deepEqual(config.targets.find(target => target.targetId === "initializer").constructorArguments,
+    [capabilities.chainDeployment.contracts.poolManager.address, { target: "token" }, { target: "hook" }]);
+  assert.equal(config.liquidityModel.declaredLaunchState, "pool-initialized-empty");
+  assert.deepEqual(config.liquidityModel.targetIds, []);
   assert.equal(config.profile.profileRevision, 1);
   assert.equal(config.chainDeployment,
     capabilities.chainDeployment,

--- a/scripts/programmable-launch-v4-clean-room.mjs
+++ b/scripts/programmable-launch-v4-clean-room.mjs
@@ -930,7 +930,7 @@ export function buildCleanRoomEvidence(input) {
   requireValue(request.funding?.mode === "none" && request.funding.valueWei === "0",
     "REQUEST_FUNDING_INVALID");
   requireValue(request.liquidityModel?.model === "none-empty-pool"
-    && request.liquidityModel.declaredLaunchState === "pool-not-initialized"
+    && request.liquidityModel.declaredLaunchState === "pool-initialized-empty"
     && Array.isArray(request.liquidityModel.targetIds)
     && request.liquidityModel.targetIds.length === 0,
   "REQUEST_LIQUIDITY_INVALID");

--- a/scripts/test/fixtures/programmable-launch-v4-clean-room.mjs
+++ b/scripts/test/fixtures/programmable-launch-v4-clean-room.mjs
@@ -23,7 +23,7 @@ export function validCleanRoomTranscript() {
     liquidityModel: {
       schemaVersion: "programmable.custom-launch-liquidity-model.v1",
       model: "none-empty-pool",
-      declaredLaunchState: "pool-not-initialized",
+      declaredLaunchState: "pool-initialized-empty",
       targetIds: [],
     },
   });


### PR DESCRIPTION
Production accepts the corrected hook, but the example cannot complete the Router simulation for two reasons: its permit starts after the finalized checkpoint, and its no-op initializer leaves the pool uninitialized even though the deployed Router requires an initialized pool before stamping.

Read the finalized block from the official Robinhood RPC, verify its chain and block fields, and derive the request's existing one-hour permit from that checkpoint with one minute of provider skew. Require at least five minutes remaining and record the observed checkpoint in build evidence. The backend continues to enforce its independent two-provider simulation and all existing permit limits.

The initializer now initializes the empty pool in its constructor, with dependencies on the predicted token and hook and the capabilities-bound PoolManager. It supplies no funds or liquidity. The request and clean-room verifier both require `pool-initialized-empty`, preserving zero ETH and the no-liquidity boundary.

Validation: focused example and clean-room evidence tests pass, including the fifteen-minute finality-lag regression and wrong-chain, stale-checkpoint, future-time, funding, replay, and wallet boundaries. The corrected project built and packed with the immutable public CLI 4.0.0. Direct production API validation now returns supported admission, a successful exact Router simulation, and `wallet_action_required` with zero ETH. The temporary diagnostic key was revoked after verification. No wallet signing or broadcast is performed. The protected production agent test still must pass before public activation.
