### PR TITLE
Point Fomo holders to the Discord tutorial

### DIFF
--- a/components/late-migration-claim.module.css
+++ b/components/late-migration-claim.module.css
@@ -23,7 +23,7 @@
 .page a { color: inherit; }
 .page button { font: inherit; cursor: pointer; }
 .page button:disabled { cursor: default; }
-.page a:focus-visible, .page button:focus-visible, .page summary:focus-visible {
+.page a:focus-visible, .page button:focus-visible {
   outline: 2px solid #e1efb6;
   outline-offset: 4px;
 }
@@ -43,15 +43,8 @@
 .cardHeading p { color: var(--intake-muted); margin: 16px 0 0; text-wrap: pretty; }
 .cardHeading .eyebrow { color: var(--intake-text); font-size: 12px; line-height: 16px; letter-spacing: .1em; text-transform: uppercase; margin: 0 0 12px; }
 .cardHeading h1 { font-size: 36px; line-height: 40px; font-weight: 500; letter-spacing: -.035em; margin: 0; text-wrap: balance; }
-.fomoHelp { margin: -16px 0 24px; font-size: 14px; line-height: 20px; }
-.fomoHelp summary { width: fit-content; min-height: 44px; padding: 12px 0; color: var(--intake-muted); cursor: pointer; }
-.fomoHelp[open] summary { color: var(--intake-text); }
-.fomoHelpContent { color: var(--intake-muted); text-wrap: pretty; overflow-wrap: anywhere; }
-.fomoHelpContent p { margin: 0 0 12px; }
-.fomoHelpContent ol { padding-left: 24px; margin: 0 0 16px; }
-.fomoHelpContent li + li { margin-top: 12px; }
-.fomoHelpContent a { color: var(--intake-text); text-decoration: underline; text-underline-offset: 4px; }
-.fomoHelpContent strong, .fomoHelpContent .fomoSafety { color: var(--intake-text); font-weight: 500; }
+.fomoHelp { margin: -16px 0 24px; color: var(--intake-muted); font-size: 14px; line-height: 20px; text-wrap: pretty; }
+.fomoHelp a { color: var(--intake-text); text-decoration: underline; text-underline-offset: 4px; }
 .walletLine { display: flex; gap: 12px; align-items: center; justify-content: space-between; margin-bottom: 16px; font-size: 14px; line-height: 20px; }
 .walletLine > span { font-family: var(--font-plex-mono, monospace); }
 .walletButton { color: var(--intake-muted); background: transparent; border: 0; border-radius: 4px; padding: 8px 0 8px 12px; min-height: 44px; text-decoration: underline; text-underline-offset: 4px; }
@@ -88,7 +81,7 @@
   .primaryAction:not(:disabled):hover { background: #fff; border-color: #fff; }
   .maxButton:not(:disabled):hover { background: #313131; }
   .walletButton:hover { color: var(--intake-text); }
-  .fomoHelp summary:hover { color: var(--intake-text); }
+  .fomoHelp a:hover { color: #fff; }
 }
 .page button:not(:disabled):active { transform: translateY(1px); }
 @media (max-width: 600px) {

--- a/components/late-migration-claim.tsx
+++ b/components/late-migration-claim.tsx
@@ -764,36 +764,10 @@ function LateMigrationClaimSession({
             <p>Connect the wallet that held V4 at the snapshot.</p>
           </div>
 
-          <details className={styles.fomoHelp}>
-            <summary>Using Fomo?</summary>
-            <div className={styles.fomoHelpContent}>
-              <p>
-                Connect your existing Fomo Ethereum account through an external
-                wallet. Signing in here with the same email does not connect
-                your Fomo wallet.
-              </p>
-              <ol>
-                <li>
-                  Open <a href="https://fomo.family/export-key" target="_blank" rel="noopener noreferrer">Fomo’s official export page</a>,
-                  sign in to Fomo, and select <strong>Export EVM wallet</strong>.
-                </li>
-                <li>
-                  Import that EVM account into MetaMask using its <a href="https://support.metamask.io/start/use-an-existing-wallet/" target="_blank" rel="noopener noreferrer">official account import guide</a>.
-                </li>
-                <li>
-                  Check that the imported Ethereum address matches your snapshot
-                  wallet, then connect that account here.
-                </li>
-              </ol>
-              <p>
-                Importing moves no tokens. You do not need ETH for this deposit;
-                Programmable pays the gas.
-              </p>
-              <p className={styles.fomoSafety}>
-                Never paste private keys on this site or send them to support.
-              </p>
-            </div>
-          </details>
+          <p className={styles.fomoHelp}>
+            Using Fomo? We have a tutorial in our{" "}
+            <a href="https://discord.com/invite/programmable" target="_blank" rel="noopener noreferrer">Discord chat</a>.
+          </p>
 
           {account ? (
             <div className={styles.walletLine}>

--- a/tests/browser/late-migration.spec.ts
+++ b/tests/browser/late-migration.spec.ts
@@ -44,50 +44,38 @@ test.afterEach(async ({ page }) => {
   expect(browserErrors.get(page)).toEqual([]);
 });
 
-test("Fomo help is available before connecting and only opens Fomo after an explicit link click", async ({ page, context }) => {
-  const fomoRequests: string[] = [];
+test("Fomo Discord tutorial is available before connecting and opens only after an explicit link click", async ({ page, context }) => {
+  const discordRequests: string[] = [];
   context.on("request", request => {
-    if (new URL(request.url()).hostname === "fomo.family") fomoRequests.push(request.url());
+    if (new URL(request.url()).hostname === "discord.com") discordRequests.push(request.url());
   });
-  // Exercise the real link navigation without contacting a real export service.
-  await context.route("https://fomo.family/**", route => route.fulfill({
-    contentType: "text/html", body: "<!doctype html><title>Official-link navigation fixture</title>",
+  // Exercise link navigation without contacting the real Discord service.
+  await context.route("https://discord.com/**", route => route.fulfill({
+    contentType: "text/html", body: "<!doctype html><title>Discord navigation fixture</title>",
   }));
   await page.goto(origin);
-  const help = page.locator("details").filter({ has: page.locator("summary", { hasText: "Using Fomo?" }) });
-  const summary = help.locator("summary");
-  const exportLink = help.getByRole("link", { name: "Fomo’s official export page", exact: true });
-  await expect(summary).toBeVisible();
-  await expect(exportLink).not.toBeVisible();
+  const help = page.getByText("Using Fomo? We have a tutorial in our Discord chat.", { exact: true });
+  const discordLink = help.getByRole("link", { name: "Discord chat", exact: true });
+  await expect(help).toBeVisible();
+  await expect(discordLink).toBeVisible();
   await expect(page.getByRole("button", { name: "Connect wallet", exact: true })).toBeVisible();
-  expect(fomoRequests).toEqual([]);
+  await expect(page.locator("details")).toHaveCount(0);
+  expect(discordRequests).toEqual([]);
 
-  await summary.focus();
-  await expect(summary).toBeFocused();
-  expect(await summary.evaluate(element => getComputedStyle(element).outlineStyle)).toBe("solid");
-  await page.keyboard.press("Enter");
-  await expect(help).toHaveAttribute("open", "");
-  await expect(exportLink).toBeVisible();
-  await expect(exportLink).toHaveAttribute("href", "https://fomo.family/export-key");
-  await expect(exportLink).toHaveAttribute("rel", "noopener noreferrer");
-  expect(await exportLink.evaluate(element => getComputedStyle(element).textDecorationLine)).toContain("underline");
-  await expect(help.getByRole("link", { name: "official account import guide", exact: true })).toHaveAttribute("href", "https://support.metamask.io/start/use-an-existing-wallet/");
-  await expect(help).toContainText("Export EVM wallet");
-  await expect(help).toContainText("same email does not connect your Fomo wallet");
-  await expect(help).toContainText("matches your snapshot wallet");
-  await expect(help).toContainText("Importing moves no tokens");
-  await expect(help).toContainText("You do not need ETH for this deposit");
-  await expect(help).toContainText("Never paste private keys on this site or send them to support");
-  await expect(help.locator("input, textarea, form")).toHaveCount(0);
-  expect(fomoRequests).toEqual([]);
+  await discordLink.focus();
+  await expect(discordLink).toBeFocused();
+  expect(await discordLink.evaluate(element => getComputedStyle(element).outlineStyle)).toBe("solid");
+  await expect(discordLink).toHaveAttribute("href", "https://discord.com/invite/programmable");
+  await expect(discordLink).toHaveAttribute("rel", "noopener noreferrer");
+  expect(await discordLink.evaluate(element => getComputedStyle(element).textDecorationLine)).toContain("underline");
   const beforeNavigation = await snapshot(page);
   expect(beforeNavigation.connects).toBe(0);
   expect(beforeNavigation.signatures).toEqual([]);
   expect(beforeNavigation.requests).toEqual([]);
 
-  const [popup] = await Promise.all([page.waitForEvent("popup"), exportLink.click()]);
-  await popup.waitForURL("https://fomo.family/export-key");
-  expect(fomoRequests).toEqual(["https://fomo.family/export-key"]);
+  const [popup] = await Promise.all([page.waitForEvent("popup"), page.keyboard.press("Enter")]);
+  await popup.waitForURL("https://discord.com/invite/programmable");
+  expect(discordRequests).toEqual(["https://discord.com/invite/programmable"]);
   expect(page.url()).toBe(origin + "/");
   expect((await snapshot(page)).signatures).toEqual([]);
   expect(posts(await snapshot(page))).toEqual([]);
@@ -95,11 +83,10 @@ test("Fomo help is available before connecting and only opens Fomo after an expl
 });
 
 for (const width of [1440, 390, 320]) {
-  test(`expanded Fomo help fits at ${width}px before wallet connection`, async ({ page }) => {
+  test(`Fomo Discord hint fits at ${width}px before wallet connection`, async ({ page }) => {
     await page.setViewportSize({ width, height: width === 1440 ? 900 : 844 });
     await page.goto(origin);
-    await page.locator("summary", { hasText: "Using Fomo?" }).click();
-    const help = page.locator("details[open]");
+    const help = page.getByText("Using Fomo? We have a tutorial in our Discord chat.", { exact: true });
     await expect(help).toBeVisible();
     expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(width);
     const box = await help.boundingBox();
@@ -107,22 +94,21 @@ for (const width of [1440, 390, 320]) {
     expect((box?.x ?? 0) + (box?.width ?? 0)).toBeLessThanOrEqual(width);
     expect((await snapshot(page)).connects).toBe(0);
     expect((await snapshot(page)).signatures).toEqual([]);
-    await page.screenshot({ path: `output/playwright/late-migration-fomo-${width}-expanded.png`, fullPage: true });
+    await page.screenshot({ path: `output/playwright/late-migration-fomo-discord-${width}.png`, fullPage: true });
   });
 }
 
-test("Fomo help preserves exact MAX and manual payout at 200% zoom", async ({ page }) => {
+test("Fomo Discord hint preserves exact MAX and manual payout at 200% zoom", async ({ page }) => {
   await page.setViewportSize({ width: 780, height: 1000 });
   await ready(page); await selectMax(page);
-  await page.locator("summary", { hasText: "Using Fomo?" }).click();
   await page.evaluate(() => { document.documentElement.style.zoom = "2"; });
   await expect(page.locator("#late-migration-amount")).toHaveText(exactAmount);
   await expect(page.getByText("Manual payout · 80%", { exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Sign and send", exact: true })).toBeEnabled();
-  expect(await page.locator("details[open]").evaluate(element => element.scrollWidth <= element.clientWidth)).toBe(true);
+  expect(await page.getByText("Using Fomo? We have a tutorial in our Discord chat.", { exact: true }).evaluate(element => element.scrollWidth <= element.clientWidth)).toBe(true);
   expect((await snapshot(page)).signatures).toEqual([]);
   expect(posts(await snapshot(page))).toEqual([]);
-  await page.screenshot({ path: "output/playwright/late-migration-fomo-zoom-200.png", fullPage: true });
+  await page.screenshot({ path: "output/playwright/late-migration-fomo-discord-zoom-200.png", fullPage: true });
 });
 
 


### PR DESCRIPTION
The late-migration page now shows “Using Fomo? We have a tutorial in our Discord chat.” with the existing official Programmable Discord invite. This replaces the expandable export/import instructions with a visible, keyboard-accessible link before wallet connection.

Validation: all 24 existing late-migration browser checks pass, including keyboard link navigation, 1440/390/320 px layouts, 200% zoom and the deposit-flow fixtures. Desktop and mobile screenshots were inspected; targeted ESLint and git diff --check pass. Discord’s public invite API confirms the link belongs to Programmable.
