### PR TITLE
Collect chain and project details before agent launch preparation

### DIFF
--- a/components/developer-api-keys.module.css
+++ b/components/developer-api-keys.module.css
@@ -255,6 +255,44 @@
   gap: 8px;
 }
 
+.agentSetup {
+  align-items: center;
+  border-block: 1px solid var(--api-line);
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+  margin-bottom: 24px;
+  padding-block: 20px;
+}
+
+.agentSetupCopy {
+  min-width: 0;
+}
+
+.agentSetupCopy h2 {
+  color: var(--webde-ink);
+  font-size: 18px;
+  font-weight: 590;
+  line-height: 1.3;
+}
+
+.agentSetupCopy > p {
+  color: var(--webde-muted);
+  font-size: 14px;
+  line-height: 1.55;
+  margin-top: 8px;
+  max-width: 680px;
+  text-wrap: pretty;
+}
+
+.agentSetupActions {
+  flex: 0 0 180px;
+}
+
+.agentSetupActions > button {
+  width: 100%;
+}
+
 .setupNote {
   color: var(--webde-dim);
   font-size: 12px;
@@ -1081,6 +1119,16 @@
 
   .secretRow {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .agentSetup {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .agentSetupActions {
+    flex-basis: auto;
   }
 
   .secretRow .secondaryButton {

--- a/components/developer-api-keys.tsx
+++ b/components/developer-api-keys.tsx
@@ -621,7 +621,7 @@ export function DeveloperApiKeys({
   );
 }
 
-function DeveloperApiKeysView({
+export function DeveloperApiKeysView({
   account,
   authReady,
   connecting,
@@ -963,7 +963,6 @@ function DeveloperApiKeysView({
   };
 
   const copyAgentSetup = async () => {
-    if (mutationResult?.result.secretState !== "delivered-once") return;
     try {
       await copyToClipboard(PROGRAMMABLE_AGENT_SETUP_TEXT_V1);
       setSetupCopyState("copied");
@@ -1237,6 +1236,42 @@ function DeveloperApiKeysView({
         </div>
       </header>
 
+      {activeSection === "keys" ? (
+        <section
+          className={styles.agentSetup}
+          aria-labelledby="agent-setup-title"
+        >
+          <div className={styles.agentSetupCopy}>
+            <h2 id="agent-setup-title">Set up your agent</h2>
+            <p>
+              Your agent asks which chain to use and collects your complete
+              project details. Review the prepared launch on this website
+              before confirming it in your wallet.
+            </p>
+            <p className={styles.setupNote}>
+              Use these instructions with a new or existing key. They include
+              the <code>$PROGRAMMABLE_API_KEY</code> placeholder, never your secret.
+            </p>
+          </div>
+          <div className={styles.agentSetupActions}>
+            <button
+              className={styles.secondaryButton}
+              type="button"
+              onClick={() => void copyAgentSetup()}
+            >
+              {setupCopyState === "copied"
+                ? "Setup copied"
+                : "Copy agent setup"}
+            </button>
+            {setupCopyState === "error" ? (
+              <p className={styles.inlineError} role="alert">
+                Agent setup could not be copied. Try again.
+              </p>
+            ) : null}
+          </div>
+        </section>
+      ) : null}
+
       {activeSection === "launch" ? (
         <RobinhoodFeePolicyDisclosure />
       ) : null}
@@ -1346,30 +1381,11 @@ function DeveloperApiKeysView({
                       >
                         {keyCopyState === "copied" ? "Copied" : "Copy key"}
                       </button>
-                      <button
-                        className={styles.secondaryButton}
-                        type="button"
-                        onClick={() => void copyAgentSetup()}
-                      >
-                        {setupCopyState === "copied"
-                          ? "Setup copied"
-                          : "Copy agent setup"}
-                      </button>
                     </div>
                   </div>
-                  <p className={styles.setupNote}>
-                    Agent setup uses only the <code>$PROGRAMMABLE_API_KEY</code>
-                    placeholder and never includes this key. It links to the
-                    public CLI, guide and OpenAPI contract.
-                  </p>
                   {keyCopyState === "error" ? (
                     <p className={styles.inlineError} role="alert">
                       Copy failed. Select the key and copy it manually.
-                    </p>
-                  ) : null}
-                  {setupCopyState === "error" ? (
-                    <p className={styles.inlineError} role="alert">
-                      Agent setup could not be copied. Try again.
                     </p>
                   ) : null}
                   <button

--- a/components/developer-launch-history.module.css
+++ b/components/developer-launch-history.module.css
@@ -284,6 +284,15 @@
   padding-block: 10px;
 }
 
+.projectRequirements .projectChain {
+  grid-column: 1 / -1;
+}
+
+.projectRequirements .projectChain dd {
+  color: var(--webde-ink);
+  font-weight: 650;
+}
+
 .projectRequirements dt {
   color: var(--webde-dim);
   font-size: 10px;
@@ -379,8 +388,18 @@
   font-size: 12px;
   font-weight: 650;
   min-height: 44px;
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
   padding-inline: 11px;
   text-decoration: none;
+}
+
+.projectOptionalLinks {
+  color: var(--webde-dim);
+  font-size: 12px;
+  line-height: 16px;
+  margin-top: 8px;
 }
 
 .projectBinding {

--- a/components/developer-launch-history.tsx
+++ b/components/developer-launch-history.tsx
@@ -1287,6 +1287,19 @@ export function walletProjectMetadataRequirementsV1(
   });
 }
 
+function requiresCurrentProjectMetadata(launch: LaunchResource) {
+  return launch.routeId === "custom-launch:create:v4"
+    || launch.launchProfileVersion === "3.3.0"
+    || launch.launchProfileVersion === "3.4.0";
+}
+
+export function walletProjectMetadataReadyForReviewV1(launch: LaunchResource) {
+  const summary = walletProjectMetadataSummaryV1(launch);
+  return summary !== null
+    && (!requiresCurrentProjectMetadata(launch)
+      || walletProjectMetadataRequirementsV1(summary.projectMetadata).complete);
+}
+
 export function walletProjectMetadataSummaryV1(
   launch: LaunchResource,
 ): WalletProjectMetadataBindingV1 | null {
@@ -1796,8 +1809,7 @@ function projectMetadataLinkDisplayLabels(
   links: CustomLaunchProjectMetadataV1["presentation"]["links"],
 ) {
   const bases = links.map((link) => {
-    const hostname = new URL(link.uri).hostname.replace(/^www\./u, "");
-    return `${projectMetadataLinkLabels[link.kind]} · ${hostname}`;
+    return `${projectMetadataLinkLabels[link.kind]} · ${link.uri}`;
   });
   const totals = new Map<string, number>();
   for (const base of bases) totals.set(base, (totals.get(base) ?? 0) + 1);
@@ -1807,6 +1819,37 @@ function projectMetadataLinkDisplayLabels(
     seen.set(base, count);
     return (totals.get(base) ?? 0) > 1 ? `${base} ${count}` : base;
   });
+}
+
+export function DeveloperLaunchMetadataPreview({
+  launch,
+}: Readonly<{ launch: LaunchResource }>) {
+  const binding = walletProjectMetadataSummaryV1(launch);
+  if (binding) return <ProjectMetadataReview launch={launch} binding={binding} />;
+  const legacy = walletLegacyProjectBindingV1(launch);
+  if (legacy) {
+    return (
+      <div className={styles.metadataUnavailable} role="status">
+        <strong>Legacy launch identity</strong>
+        <p>
+          This immutable {legacy.launchProfileVersion}
+          {" request predates bound project metadata. Exact retries remain available, but no project name, symbol, image or links can be reviewed for this record."}
+        </p>
+      </div>
+    );
+  }
+  if (launch.routeId !== "custom-launch:create:v3"
+    && launch.routeId !== "custom-launch:create:v4") return null;
+  return (
+    <div className={styles.metadataUnavailable} role="status">
+      <strong>Bound project metadata unavailable</strong>
+      <p>
+        {launch.requestHash === null
+          ? "Load the exact wallet review to see the launch details supplied by your agent."
+          : "Ask your agent to provide the missing or corrected launch details, then repack and submit a new request. This record remains visible; its bound details cannot be edited here."}
+      </p>
+    </div>
+  );
 }
 
 function ProjectMetadataReview({
@@ -1822,12 +1865,13 @@ function ProjectMetadataReview({
   const imagePreview = useVerifiedProjectImageV1(presentation.image);
   const linkLabels = projectMetadataLinkDisplayLabels(presentation.links);
   const requirements = walletProjectMetadataRequirementsV1(projectMetadata);
-  const completeForProfile = !["3.3.0", "3.4.0"].includes(
-    launch.launchProfileVersion ?? "",
-  )
+  const completeForProfile = !requiresCurrentProjectMetadata(launch)
     || requirements.complete;
   const website = presentation.links.find((link) => link.kind === "website");
   const xLink = presentation.links.find((link) => link.kind === "x");
+  const chain = launch.routeId === "custom-launch:create:v4"
+    ? { name: "Robinhood Chain", id: "4663" }
+    : { name: "Ethereum Mainnet", id: "1" };
   const resourceIdentity = launchResourceIdentity(launch);
   return (
     <section
@@ -1857,8 +1901,7 @@ function ProjectMetadataReview({
       </div>
       <div className={styles.projectRequirementHeading}>
         <h5>
-          {launch.launchProfileVersion === "3.3.0"
-            || launch.launchProfileVersion === "3.4.0"
+          {requiresCurrentProjectMetadata(launch)
             ? "Required launch details"
             : "Bound legacy launch details"}
         </h5>
@@ -1867,6 +1910,10 @@ function ProjectMetadataReview({
         </span>
       </div>
       <dl className={styles.projectRequirements}>
+        <div className={styles.projectChain}>
+          <dt>Chain</dt>
+          <dd>{chain.name} · {chain.id}</dd>
+        </div>
         <div data-complete={requirements.name ? "true" : "false"}>
           <dt>Name</dt>
           <dd>{requirements.name ? token.name : "Missing"}</dd>
@@ -1876,7 +1923,7 @@ function ProjectMetadataReview({
           <dd>{requirements.symbol ? `$${token.symbol}` : "Missing"}</dd>
         </div>
         <div data-complete={requirements.description ? "true" : "false"}>
-          <dt>Coin description</dt>
+          <dt>Bio</dt>
           <dd>{requirements.description ? "Included below" : "Missing"}</dd>
         </div>
         <div data-complete={requirements.image ? "true" : "false"}>
@@ -1888,7 +1935,7 @@ function ProjectMetadataReview({
           <dd>
             {website ? (
               <a href={website.uri} rel="noreferrer" target="_blank">
-                {new URL(website.uri).hostname.replace(/^www\./u, "")}
+                {website.uri}
                 <span className={styles.visuallyHidden}>, opens in a new tab</span>
               </a>
             ) : "Missing"}
@@ -1899,7 +1946,7 @@ function ProjectMetadataReview({
           <dd>
             {xLink ? (
               <a href={xLink.uri} rel="noreferrer" target="_blank">
-                {new URL(xLink.uri).hostname.replace(/^www\./u, "")}
+                {xLink.uri}
                 <span className={styles.visuallyHidden}>, opens in a new tab</span>
               </a>
             ) : "Missing"}
@@ -1908,13 +1955,12 @@ function ProjectMetadataReview({
       </dl>
       {presentation.description ? (
         <div className={styles.projectDescription}>
-          <strong>Coin description</strong>
+          <strong>Bio</strong>
           <p>{presentation.description}</p>
         </div>
-      ) : launch.launchProfileVersion === "3.3.0"
-        || launch.launchProfileVersion === "3.4.0" ? (
+      ) : requiresCurrentProjectMetadata(launch) ? (
         <p className={styles.projectMissing} role="alert">
-          Add a coin description and repack this request before signing.
+          Ask your agent to add a bio, then repack and submit a new request.
         </p>
       ) : null}
       {presentation.image && imagePreview.state !== "verified" ? (
@@ -1945,6 +1991,15 @@ function ProjectMetadataReview({
           ))}
         </nav>
       ) : null}
+      {!presentation.links.some((link) => link.kind === "telegram")
+        || !presentation.links.some((link) => link.kind === "discord") ? (
+        <p className={styles.projectOptionalLinks}>
+          {!presentation.links.some((link) => link.kind === "telegram")
+            ? "Telegram: not supplied. " : ""}
+          {!presentation.links.some((link) => link.kind === "discord")
+            ? "Discord: not supplied." : ""}
+        </p>
+      ) : null}
       <dl className={styles.projectBinding}>
         <div>
           <dt>Metadata digest</dt>
@@ -1961,12 +2016,13 @@ function ProjectMetadataReview({
       {completeForProfile ? (
         <p className={styles.projectBoundary}>
           Review this immutable summary before either wallet step. Changing any
-          bound field requires a newly packed request.
+          bound field requires a newly packed request. Ask your agent to make
+          changes; this preview is read only.
         </p>
       ) : (
         <p className={styles.projectBoundary}>
-          Every required launch detail must be present in the immutable request
-          before a wallet signature or transaction can open.
+          Ask your agent to collect the missing launch details, then repack and
+          submit a new request before opening your wallet. This preview is read only.
         </p>
       )}
     </section>
@@ -3123,6 +3179,7 @@ export function DeveloperLaunchHistory({
     try {
       if (launch.routeId === "custom-launch:create:v4") {
         if (launch.rawResourceV4 === null
+          || !walletProjectMetadataReadyForReviewV1(launch)
           || !["wallet_action_required", "awaiting_wallet_signature"]
             .includes(launch.status)) {
           throw new Error(
@@ -3135,8 +3192,9 @@ export function DeveloperLaunchHistory({
           loadFreshResource: async () => {
             const current = await readLaunchResource(launch);
             updateLaunch(current);
-            if (current.rawResourceV4 === null) {
-              throw new Error("The API omitted the exact Robinhood Chain wallet resource.");
+            if (current.rawResourceV4 === null
+              || !walletProjectMetadataReadyForReviewV1(current)) {
+              throw new Error("The API omitted the exact Robinhood Chain wallet resource or its complete bound launch details.");
             }
             return current.rawResourceV4;
           },
@@ -3354,11 +3412,8 @@ export function DeveloperLaunchHistory({
             const projectMetadataBinding = walletProjectMetadataBindingV1(
               reviewLaunch,
             );
-            const projectMetadataReadyForProfile = projectMetadataSummary !== null
-              && (!["3.3.0", "3.4.0"].includes(
-                reviewLaunch.launchProfileVersion ?? "",
-              )
-                || projectMetadataRequirements?.complete === true);
+            const projectMetadataReadyForProfile =
+              walletProjectMetadataReadyForReviewV1(reviewLaunch);
             const projectRequestBinding = walletProjectRequestBindingV1(
               reviewLaunch,
             );
@@ -3439,42 +3494,17 @@ export function DeveloperLaunchHistory({
                     </div>
                   ) : null}
                 </dl>
-                {projectMetadataSummary ? (
-                  <ProjectMetadataReview
-                    binding={projectMetadataSummary}
-                    launch={reviewLaunch}
-                  />
-                ) : projectRequestBinding?.mode === "legacy-exact-retry" ? (
-                  <div className={styles.metadataUnavailable} role="status">
-                    <strong>Legacy launch identity</strong>
-                    <p>
-                      This immutable {projectRequestBinding.launchProfileVersion}
-                      {" request predates bound project metadata. Exact retries remain available, but no project name, symbol, image or links can be reviewed for this record."}
-                    </p>
-                  </div>
-                ) : reviewLaunch.routeId === "custom-launch:create:v3" ? (
-                  <div className={styles.metadataUnavailable} role="status">
-                    <strong>Bound project metadata unavailable</strong>
-                    <p>
-                      This record remains visible, but no funding signature or
-                      Router transaction can open until the current metadata,
-                      digest and immutable request binding are returned together.
-                      Repack this current-profile request with the latest CLI.
-                    </p>
-                  </div>
-                ) : null}
+                <DeveloperLaunchMetadataPreview launch={reviewLaunch} />
                 {projectMetadataSummary
                   && projectMetadataRequirements
-                  && (reviewLaunch.launchProfileVersion === "3.3.0"
-                    || reviewLaunch.launchProfileVersion === "3.4.0")
+                  && requiresCurrentProjectMetadata(reviewLaunch)
                   && !projectMetadataRequirements.complete ? (
                     <div className={styles.metadataUnavailable} role="alert">
                       <strong>Required launch details are missing</strong>
                       <p>
-                        Name, ticker, coin description, profile image, website
-                        and X must all be bound before signing. Repack this
-                        request with the missing details; no wallet action can
-                        open from this record.
+                        Ask your agent to include the name, ticker, bio, profile
+                        image, website and X, then repack and submit a new
+                        request. These details must be bound before signing.
                       </p>
                     </div>
                   ) : null}
@@ -3756,6 +3786,7 @@ export function DeveloperLaunchHistory({
                                 || checkingId !== null
                                 || Boolean(pollingIds[key])
                                 || handoffExpired
+                                || !projectMetadataReadyForProfile
                               }
                               type="button"
                               onClick={() => void submitWalletTransaction(reviewLaunch)}

--- a/lib/custom-launch/agent-setup-v1.ts
+++ b/lib/custom-launch/agent-setup-v1.ts
@@ -1,3 +1,56 @@
+export const PROGRAMMABLE_AGENT_INTAKE_V1 = Object.freeze({
+  schemaVersion: "programmable.custom-launch-agent-intake.v1" as const,
+  scope: "agent-preparation-not-server-authorization" as const,
+  chainSelection: Object.freeze({
+    requiredBefore: Object.freeze([
+      "chain-specific-implementation", "build", "pack", "submit",
+    ] as const),
+    authority: "explicit-user-choice" as const,
+    reuseExplicitPriorAnswer: true as const,
+    missingOrAmbiguous: "ask-user-before-proceeding" as const,
+    neverInferFrom: Object.freeze([
+      "api-key", "connected-wallet", "project-defaults", "uniswap-v4",
+    ] as const),
+    choices: Object.freeze([
+      Object.freeze({ chainId: 1, caip2: "eip155:1", name: "Ethereum Mainnet", apiVersion: "3" }),
+      Object.freeze({ chainId: 4663, caip2: "eip155:4663", name: "Robinhood Chain Mainnet", apiVersion: "4" }),
+    ] as const),
+  }),
+  metadata: Object.freeze({
+    requiredBefore: Object.freeze(["build", "pack", "submit"] as const),
+    required: Object.freeze([
+      "token.name", "token.symbol", "presentation.description",
+      "presentation.image.sourcePath", "presentation.image.uri",
+      "presentation.links.website", "presentation.links.x",
+    ] as const),
+    askIfAvailable: Object.freeze([
+      "telegram", "discord", "documentation", "github", "other",
+    ] as const),
+    additionalLinksRequired: false as const,
+    reuseExplicitPriorAnswers: true as const,
+    inventedValuesAllowed: false as const,
+    actualImageBytesRequired: true as const,
+    imagePolicy: "selected-chain-pack-config-schema" as const,
+  }),
+  review: Object.freeze({
+    beforeSubmit: "show-complete-user-summary-and-resolve-contradictions" as const,
+    website: "same-bound-read-only-metadata" as const,
+    changedMetadata: "repack-and-revalidate-a-new-request" as const,
+    walletAuthority: "separate-controller-review-and-sign" as const,
+  }),
+  instructions: Object.freeze([
+    "1. Confirm the project's intended chain: Ethereum Mainnet (1) or Robinhood Chain Mainnet (4663). Reuse an explicit earlier answer; ask if the choice is missing, ambiguous or contradictory. Uniswap V4 identifies a protocol, not a chain. Never infer the chain from the API key, connected wallet or project defaults, and never fall back to another chain when a gate fails.",
+    "2. Before building or packing, collect the token name, ticker/symbol, useful public bio/description, actual image file and its public URI, website and X profile. Reuse answers and assets already supplied by the user; ask only for missing or conflicting values. Ask whether Telegram, Discord, documentation, GitHub or other links are available; these additional links are optional. Never invent metadata, image bytes or public URLs. Use the selected chain's image rules.",
+    "3. Before submission, show the complete summary: chain, launch wallet, token name, ticker, bio, image preview and public URI, website, X and every additional link. Resolve contradictions with the user. The website shows the same bound metadata read-only before wallet authorization. To change metadata, repack and revalidate a new request. API access does not authorize the agent to sign or broadcast; the controller reviews and signs the exact wallet action separately.",
+    "Do not begin chain-specific implementation until the chain is explicit. Do not build, pack or submit while required intake values are missing or contradictory. Existing explicit user answers remain valid; do not ask for them again.",
+  ] as const),
+});
+
+export const PROGRAMMABLE_AGENT_INTAKE_TEXT_V1 = [
+  "Start with the launch details",
+  ...PROGRAMMABLE_AGENT_INTAKE_V1.instructions,
+].join("\n");
+
 export const PROGRAMMABLE_AGENT_SETUP_LINKS_V1 = Object.freeze({
   discovery: "https://programmable.market/.well-known/programmable.json",
   capabilities: "https://api.programmable.market/v3/capabilities",
@@ -31,11 +84,13 @@ export const PROGRAMMABLE_AGENT_SETUP_LINKS_V1 = Object.freeze({
 export const PROGRAMMABLE_AGENT_SETUP_TEXT_V1 = Object.freeze([
   "Programmable Custom Launch agent setup",
   "",
+  PROGRAMMABLE_AGENT_INTAKE_TEXT_V1,
+  "",
   "Use the preconfigured $PROGRAMMABLE_API_KEY from encrypted secrets or the environment. Never paste the key into chat, a prompt, source code, or command history.",
   "The API key grants API access only. It does not contain policy or integration instructions.",
   "",
   `Start here: ${PROGRAMMABLE_AGENT_SETUP_LINKS_V1.discovery}`,
-  "Select the project's intended chain before installing a CLI or preparing request bytes: Ethereum Mainnet (1, eip155:1) uses V3; Robinhood Chain Mainnet (4663, eip155:4663) uses V4. If the project does not identify its chain, ask for it. Never choose Ethereum merely because the key came from the shared API keys page, and never fall back to another chain when a gate fails.",
+  "Read customLaunchApi.intake in discovery and complete the launch details above before chain-specific implementation. Follow the user's explicit choice: Ethereum Mainnet (1, eip155:1) uses V3; Robinhood Chain Mainnet (4663, eip155:4663) uses V4.",
   "The same API-key entry point serves both chains. A key needs custom-launch:create and custom-launch:read plus server authorization for the selected chain; its presence does not prove a chain grant. A wallet key's launchWallet must equal its wallet binding. Keep credentials on https://api.programmable.market and follow only the selected chain's instructions below.",
   "",
   "Robinhood Chain Mainnet only (V4, chain 4663)",
@@ -51,8 +106,8 @@ export const PROGRAMMABLE_AGENT_SETUP_TEXT_V1 = Object.freeze([
   "After all public release gates pass: programmable-launch pack --config programmable-launch.config.json --output launch.json",
   "Then: programmable-launch validate launch.json --config programmable-launch.config.json --remote",
   "Follow the V4 preflight's server-authored disposition and typed remediation. Preflight is not admission or a wallet action. If ready for submission, submit the exact validated bytes with programmable-launch submit launch.json --config programmable-launch.config.json. Keep the CLI journal and Idempotency-Key unchanged for retries. An action_required resource requires its specified correction, rebuild and a new immutable request; never bypass a server decision.",
-  "programmable-launch status REQUEST_UUID --api-version 4 --chain-id 4663 --watch --until authorized",
-  "At authorized, awaiting_wallet_signature or wallet_action_required, open only the server-provided same-origin walletHandoffUrl and stop for the controller to review chain 4663, sender, Router, value, calldata and expiry. The API key and CLI never sign or broadcast. After the controller sends the exact transaction: programmable-launch status REQUEST_UUID --api-version 4 --chain-id 4663 --watch --until finalized. Source verification, indexing, trading and publication remain separate from finality. The following Ethereum instructions do not apply to this V4 request.",
+  "Use the returned launchId as LAUNCH_ID, not requestId: programmable-launch status LAUNCH_ID --api-version 4 --chain-id 4663 --watch --until authorized",
+  "At authorized, awaiting_wallet_signature or wallet_action_required, open only the server-provided same-origin walletHandoffUrl and stop for the controller to review the bound project metadata, chain 4663, sender, Router, value, calldata and expiry. The API key and CLI never sign or broadcast. After the controller sends the exact transaction: programmable-launch status LAUNCH_ID --api-version 4 --chain-id 4663 --watch --until finalized. Source verification, indexing, trading and publication remain separate from finality. The following Ethereum instructions do not apply to this V4 request.",
   "",
   "Ethereum Mainnet only (V3, chain 1)",
   `Public capabilities: ${PROGRAMMABLE_AGENT_SETUP_LINKS_V1.capabilities}`,

--- a/lib/server/custom-launch/well-known-v1.ts
+++ b/lib/server/custom-launch/well-known-v1.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { V4_API_DISCOVERY } from "../../custom-launch/v4-api-discovery";
+import { PROGRAMMABLE_AGENT_INTAKE_V1 } from "../../custom-launch/agent-setup-v1";
 
 import { resolveCustomRegistryPublicManifestV1 } from
   "./registry-manifest-v1";
@@ -36,6 +37,7 @@ export function programmableWellKnownDocumentV1(
     documentationUrl: "https://developers.programmable.family/",
     sourceUrl: "https://github.com/programmablehq/Developers",
     customLaunchApi: Object.freeze({
+      intake: PROGRAMMABLE_AGENT_INTAKE_V1,
       status: "live" as const,
       readStatus: "live" as const,
       apiVersion: "3" as const,
@@ -539,9 +541,9 @@ export function programmableWellKnownDocumentV1(
             actionRequiredMeaning:
               "server-authored-remediation-not-wallet-action" as const,
             walletStageStatusCommand:
-              "programmable-launch status REQUEST_UUID --api-version 4 --chain-id 4663 --watch --until authorized" as const,
+              "programmable-launch status LAUNCH_ID --api-version 4 --chain-id 4663 --watch --until authorized" as const,
             finalityStatusCommand:
-              "programmable-launch status REQUEST_UUID --api-version 4 --chain-id 4663 --watch --until finalized" as const,
+              "programmable-launch status LAUNCH_ID --api-version 4 --chain-id 4663 --watch --until finalized" as const,
             sourceVerificationStartsAfter: "finalized" as const,
             sourceVerificationIndependentFromFinality: true as const,
             indexingTradingAndPublicationIndependent: true as const,

--- a/public/developers/custom-launch-api-v1.md
+++ b/public/developers/custom-launch-api-v1.md
@@ -1,5 +1,21 @@
 # Programmable Custom Launch API
 
+## Start with the launch details
+
+The shared intake is published at `customLaunchApi.intake` in [live discovery](https://programmable.market/.well-known/programmable.json). Complete it before following either chain-specific guide.
+
+1. Confirm the project's intended chain: Ethereum Mainnet (1) or Robinhood Chain Mainnet (4663). Reuse an explicit earlier answer; ask if the choice is missing, ambiguous or contradictory. Uniswap V4 identifies a protocol, not a chain. Never infer the chain from the API key, connected wallet or project defaults, and never fall back to another chain when a gate fails.
+
+2. Before building or packing, collect the token name, ticker/symbol, useful public bio/description, actual image file and its public URI, website and X profile. Reuse answers and assets already supplied by the user; ask only for missing or conflicting values. Ask whether Telegram, Discord, documentation, GitHub or other links are available; these additional links are optional. Never invent metadata, image bytes or public URLs. Use the selected chain's image rules.
+
+3. Before submission, show the complete summary: chain, launch wallet, token name, ticker, bio, image preview and public URI, website, X and every additional link. Resolve contradictions with the user. The website shows the same bound metadata read-only before wallet authorization. To change metadata, repack and revalidate a new request. API access does not authorize the agent to sign or broadcast; the controller reviews and signs the exact wallet action separately.
+
+Do not begin chain-specific implementation until the chain is explicit. Do not build, pack or submit while required intake values are missing or contradictory. Existing explicit user answers remain valid; do not ask for them again.
+
+For the image, supply the actual local bytes and their matching public HTTPS, IPFS or Arweave URI. Ethereum V3 accepts PNG, JPEG, WebP or GIF; Robinhood V4 accepts PNG or single-frame GIF. A filename or invented image URL is not a supplied image.
+
+## API versions and release gates
+
 V3.3 is public and live: general custom-hook launch creation, list and single-resource reads are available at
 `https://api.programmable.market` for wallet keys, partner roots and bounded partner subkeys. V2 and V1 history remain
 available for existing requests, and their schemas remain published. Fresh authenticated `POST /v2/custom-launches`
@@ -38,8 +54,8 @@ capabilities and readiness. The authenticated API server selects `robinhood-laun
 `robinhood-production-launch` from the chain binding; callers cannot select a policy profile.
 
 Create one platform API key at <https://programmable.market/developers/api-keys> and provide it through
-`PROGRAMMABLE_API_KEY`. Select Ethereum V3 or Robinhood V4 using that chain's discovery contract and the grants
-reported for the key. The key authorizes API requests; the user separately reviews and signs their onchain launch
+`PROGRAMMABLE_API_KEY`. Follow the user's explicit Ethereum or Robinhood choice, then verify that chain's discovery
+contract and the grants reported for the key. A grant does not select the chain. The key authorizes API requests; the user separately reviews and signs their onchain launch
 transaction and pays gas.
 
 V4 contract pointers:
@@ -103,12 +119,12 @@ The V4 resource uses these exact statuses:
 | `failed` | Processing is terminal. Read the bound failure and remediation before creating a new request. |
 
 The CLI only prepares, validates, submits request bytes, polls status and displays the exact transaction. It never
-signs or broadcasts. Guard V4 polling with the explicit API version and chain:
+signs or broadcasts. Set `LAUNCH_ID` to the returned `launchId`, not `requestId`. Guard V4 polling with the explicit API version and chain:
 
 ```sh
-programmable-launch status REQUEST_UUID --api-version 4 --chain-id 4663 --watch --until authorized
+programmable-launch status LAUNCH_ID --api-version 4 --chain-id 4663 --watch --until authorized
 # Stop for separate controller-wallet review, signing and broadcast.
-programmable-launch status REQUEST_UUID --api-version 4 --chain-id 4663 --watch --until finalized
+programmable-launch status LAUNCH_ID --api-version 4 --chain-id 4663 --watch --until finalized
 ```
 
 Provider source verification starts after `finalized` and remains independent. Finality does not imply

--- a/tests/custom-launch-agent-intake.test.ts
+++ b/tests/custom-launch-agent-intake.test.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  PROGRAMMABLE_AGENT_INTAKE_TEXT_V1,
+  PROGRAMMABLE_AGENT_INTAKE_V1,
+  PROGRAMMABLE_AGENT_SETUP_TEXT_V1,
+} from "../lib/custom-launch/agent-setup-v1";
+import { PRELAUNCH_CUSTOM_REGISTRY_PUBLIC_MANIFEST_V1 } from "../lib/custom-launch/registry-public-manifest-v1";
+import { programmableWellKnownDocumentV1 } from "../lib/server/custom-launch/well-known-v1";
+
+const rawGuide = readFileSync(
+  new URL("../public/developers/custom-launch-api-v1.md", import.meta.url),
+  "utf8",
+);
+const document = programmableWellKnownDocumentV1(
+  PRELAUNCH_CUSTOM_REGISTRY_PUBLIC_MANIFEST_V1,
+);
+
+describe("chain-first Custom Launch intake", () => {
+  it("publishes the same preparation guidance before technical setup on every entry point", () => {
+    expect(document.customLaunchApi.intake).toBe(PROGRAMMABLE_AGENT_INTAKE_V1);
+    expect(document.customLaunchApi.intake.scope).toBe("agent-preparation-not-server-authorization");
+    expect(PROGRAMMABLE_AGENT_SETUP_TEXT_V1.indexOf(PROGRAMMABLE_AGENT_INTAKE_TEXT_V1))
+      .toBeGreaterThan(0);
+    expect(PROGRAMMABLE_AGENT_SETUP_TEXT_V1.indexOf(PROGRAMMABLE_AGENT_INTAKE_TEXT_V1))
+      .toBeLessThan(PROGRAMMABLE_AGENT_SETUP_TEXT_V1.indexOf("Use the preconfigured"));
+    const guideIntake = rawGuide.slice(0, rawGuide.indexOf("## API versions and release gates"));
+    for (const instruction of document.customLaunchApi.intake.instructions) {
+      expect(PROGRAMMABLE_AGENT_INTAKE_TEXT_V1).toContain(instruction);
+      expect(guideIntake).toContain(instruction);
+    }
+    expect(guideIntake).toContain("customLaunchApi.intake");
+  });
+
+  it("requires an explicit supported chain and preserves prior user answers", () => {
+    const selection = document.customLaunchApi.intake.chainSelection;
+    expect(selection.authority).toBe("explicit-user-choice");
+    expect(selection.missingOrAmbiguous).toBe("ask-user-before-proceeding");
+    expect(selection.reuseExplicitPriorAnswer).toBe(true);
+    expect(selection.requiredBefore).toEqual([
+      "chain-specific-implementation", "build", "pack", "submit",
+    ]);
+    expect(selection.choices).toEqual([
+      { chainId: 1, caip2: "eip155:1", name: "Ethereum Mainnet", apiVersion: "3" },
+      { chainId: 4663, caip2: "eip155:4663", name: "Robinhood Chain Mainnet", apiVersion: "4" },
+    ]);
+    for (const choice of selection.choices) {
+      expect(document.chains).toContainEqual(expect.objectContaining({
+        chainId: choice.chainId, caip2: choice.caip2, name: choice.name,
+      }));
+    }
+    expect(PROGRAMMABLE_AGENT_INTAKE_TEXT_V1).toContain("ask if the choice is missing, ambiguous or contradictory");
+    expect(PROGRAMMABLE_AGENT_INTAKE_TEXT_V1).toContain("Existing explicit user answers remain valid; do not ask for them again");
+  });
+
+  it.each([
+    ["a shared API key", "api-key"],
+    ["the connected wallet network", "connected-wallet"],
+    ["a project configuration default", "project-defaults"],
+    ["a request for Uniswap V4", "uniswap-v4"],
+  ] as const)("does not accept %s as the user's chain choice", (_scenario, source) => {
+    expect(document.customLaunchApi.intake.chainSelection.neverInferFrom).toContain(source);
+    expect(PROGRAMMABLE_AGENT_INTAKE_TEXT_V1).toContain("Uniswap V4 identifies a protocol, not a chain");
+    expect(PROGRAMMABLE_AGENT_INTAKE_TEXT_V1).toContain("Do not begin chain-specific implementation until the chain is explicit");
+  });
+
+  it("requires actual metadata before building and asks about optional channels without inventing them", () => {
+    const metadata = document.customLaunchApi.intake.metadata;
+    expect(metadata.requiredBefore).toEqual(["build", "pack", "submit"]);
+    expect(metadata.required).toEqual([
+      "token.name", "token.symbol", "presentation.description",
+      "presentation.image.sourcePath", "presentation.image.uri",
+      "presentation.links.website", "presentation.links.x",
+    ]);
+    expect(metadata.askIfAvailable).toEqual(["telegram", "discord", "documentation", "github", "other"]);
+    expect(metadata.additionalLinksRequired).toBe(false);
+    expect(metadata.actualImageBytesRequired).toBe(true);
+    expect(metadata.inventedValuesAllowed).toBe(false);
+    expect(metadata.reuseExplicitPriorAnswers).toBe(true);
+    expect(metadata.imagePolicy).toBe("selected-chain-pack-config-schema");
+    expect(PROGRAMMABLE_AGENT_INTAKE_TEXT_V1).toContain("Do not build, pack or submit while required intake values are missing or contradictory");
+    expect(rawGuide).toContain("Ethereum V3 accepts PNG, JPEG, WebP or GIF; Robinhood V4 accepts PNG or single-frame GIF");
+  });
+
+  it("keeps summary review distinct from immutable metadata and wallet authority", () => {
+    expect(document.customLaunchApi.intake.review).toEqual({
+      beforeSubmit: "show-complete-user-summary-and-resolve-contradictions",
+      website: "same-bound-read-only-metadata",
+      changedMetadata: "repack-and-revalidate-a-new-request",
+      walletAuthority: "separate-controller-review-and-sign",
+    });
+    expect(PROGRAMMABLE_AGENT_INTAKE_TEXT_V1).toContain("chain, launch wallet, token name, ticker, bio, image preview and public URI, website, X and every additional link");
+    expect(PROGRAMMABLE_AGENT_INTAKE_TEXT_V1).toContain("the controller reviews and signs the exact wallet action separately");
+    expect(document.customLaunchApi.versions.v4.decisionAuthority).toBe("api-server");
+    expect(document.customLaunchApi.versions.v4.localOrModelApprovalAccepted).toBe(false);
+  });
+
+  it("uses the V4 launchId for polling while retaining V3 request commands", () => {
+    const lifecycle = document.customLaunchApi.versions.v4.lifecycle;
+    for (const command of [lifecycle.walletStageStatusCommand, lifecycle.finalityStatusCommand]) {
+      expect(command).toContain("status LAUNCH_ID --api-version 4 --chain-id 4663");
+      expect(PROGRAMMABLE_AGENT_SETUP_TEXT_V1).toContain(command);
+      expect(rawGuide).toContain(command);
+    }
+    expect(PROGRAMMABLE_AGENT_SETUP_TEXT_V1).toContain("Use the returned launchId as LAUNCH_ID, not requestId");
+    expect(rawGuide).toContain("Set `LAUNCH_ID` to the returned `launchId`, not `requestId`");
+    for (const text of [PROGRAMMABLE_AGENT_SETUP_TEXT_V1, rawGuide]) {
+      expect(text).not.toContain("status REQUEST_UUID --api-version 4");
+      expect(text).toContain("status REQUEST_UUID --watch --until authorized");
+    }
+  });
+});

--- a/tests/custom-launch-robinhood-v4-discovery.test.ts
+++ b/tests/custom-launch-robinhood-v4-discovery.test.ts
@@ -94,9 +94,9 @@ describe("Robinhood Chain V4 public self-serve release discovery", () => {
         actionRequiredMeaning:
           "server-authored-remediation-not-wallet-action",
         walletStageStatusCommand:
-          "programmable-launch status REQUEST_UUID --api-version 4 --chain-id 4663 --watch --until authorized",
+          "programmable-launch status LAUNCH_ID --api-version 4 --chain-id 4663 --watch --until authorized",
         finalityStatusCommand:
-          "programmable-launch status REQUEST_UUID --api-version 4 --chain-id 4663 --watch --until finalized",
+          "programmable-launch status LAUNCH_ID --api-version 4 --chain-id 4663 --watch --until finalized",
         sourceVerificationStartsAfter: "finalized",
         sourceVerificationIndependentFromFinality: true,
         indexingTradingAndPublicationIndependent: true,
@@ -346,7 +346,7 @@ describe("Robinhood Chain V4 public self-serve release discovery", () => {
     expect(publicDocs).toContain("4.0.0");
     expect(publicDocs).toContain("releaseReady: false");
     expect(publicDocs).toContain(
-      "programmable-launch status REQUEST_UUID --api-version 4 --chain-id 4663",
+      "programmable-launch status LAUNCH_ID --api-version 4 --chain-id 4663",
     );
     for (const status of [
       "received",

--- a/tests/developer-api-keys-ui.test.ts
+++ b/tests/developer-api-keys-ui.test.ts
@@ -1,8 +1,11 @@
 import { readFileSync } from "node:fs";
 
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  DeveloperApiKeysView,
   applyApiKeyMutationResult,
   apiKeyLifetimeDays,
   mergeApiKeySummaries,
@@ -342,6 +345,57 @@ describe("developer API key interface", () => {
     expect(apiKeysStyles).not.toContain("appearance: auto");
   });
 
+  it.each([
+    { state: "returning wallet before any key mutation", authReady: true,
+      account: "0x0000000000000000000000000000000000000001" as const },
+    { state: "disconnected wallet", authReady: true, account: null },
+    { state: "loading wallet session", authReady: false, account: null },
+  ])("offers setup without exposing a key for $state", ({ authReady, account }) => {
+    const getToken = vi.fn(async () => null);
+    const walletAction = vi.fn(async (): Promise<`0x${string}`> => {
+      throw new Error("Setup must not request a wallet action");
+    });
+    const html = renderToStaticMarkup(createElement(DeveloperApiKeysView, {
+      account,
+      authReady,
+      connecting: false,
+      getAccessToken: getToken,
+      getIdentityToken: getToken,
+      initialSection: "keys",
+      openWallet: vi.fn(),
+      sendCustomLaunchWalletAction: walletAction,
+      sendCustomLaunchWalletActionV4: walletAction,
+      signCustomLaunchFundingAuthorization: walletAction,
+    }));
+
+    const setupButton = html.match(/<button\b[^>]*>Copy agent setup<\/button>/u)?.[0];
+    expect(setupButton).toBeDefined();
+    expect(setupButton).not.toContain("disabled");
+    expect(html).toContain('aria-labelledby="agent-setup-title"');
+    expect(html).toContain("new or existing key");
+    expect(html).not.toContain(">Copy key</button>");
+    expect(html).not.toContain("api-key-mutation-result-title");
+    expect(html).not.toMatch(/pm_live_[A-Za-z0-9_-]{22}_[A-Za-z0-9_-]{43}/u);
+    expect(getToken).not.toHaveBeenCalled();
+    expect(walletAction).not.toHaveBeenCalled();
+  });
+
+  it("keeps copying setup independent of the one-time key secret", () => {
+    const copyKeyStart = apiKeysSource.indexOf("const copyApiKey = async");
+    const copySetupStart = apiKeysSource.indexOf("const copyAgentSetup = async");
+    const dismissStart = apiKeysSource.indexOf("const dismissApiKeyResult =");
+    expect(copyKeyStart).toBeGreaterThan(-1);
+    expect(copySetupStart).toBeGreaterThan(copyKeyStart);
+    expect(dismissStart).toBeGreaterThan(copySetupStart);
+
+    const copyKey = apiKeysSource.slice(copyKeyStart, copySetupStart);
+    const copySetup = apiKeysSource.slice(copySetupStart, dismissStart);
+    expect(copyKey).toContain('secretState !== "delivered-once"');
+    expect(copySetup).toContain("copyToClipboard(PROGRAMMABLE_AGENT_SETUP_TEXT_V1)");
+    expect(copySetup).not.toContain("mutationResult");
+    expect(copySetup).not.toContain("apiKeySecret");
+  });
+
   it("preserves wallet authority and one-time secret handling", () => {
     expect(apiKeysSource).toContain(
       "API keys cannot sign or broadcast wallet transactions.",
@@ -355,12 +409,8 @@ describe("developer API key interface", () => {
     expect(apiKeysSource).toContain("Copy agent setup");
     expect(apiKeysSource).toContain("PROGRAMMABLE_AGENT_SETUP_TEXT_V1");
     expect(apiKeysSource).toContain(
-      "Agent setup uses only the <code>$PROGRAMMABLE_API_KEY</code>",
+      "the <code>$PROGRAMMABLE_API_KEY</code> placeholder, never your secret.",
     );
-    expect(apiKeysSource).toContain(
-      "public CLI, guide and OpenAPI contract.",
-    );
-    expect(apiKeysSource).toContain("never includes this key");
     expect(PROGRAMMABLE_AGENT_SETUP_TEXT_V1).toContain("$PROGRAMMABLE_API_KEY");
     expect(PROGRAMMABLE_AGENT_SETUP_TEXT_V1).toContain(
       PROGRAMMABLE_AGENT_SETUP_LINKS_V1.cli,

--- a/tests/developer-launch-metadata-preview.test.tsx
+++ b/tests/developer-launch-metadata-preview.test.tsx
@@ -1,0 +1,201 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  DeveloperLaunchMetadataPreview,
+  parseHistoryPage,
+  walletProjectMetadataReadyForReviewV1,
+  walletProjectRequestBindingV1,
+  type CustomLaunchProjectMetadataV1,
+  type LaunchResource,
+} from "../components/developer-launch-history";
+import { canonicalBrowserSha256V2 } from
+  "../lib/custom-launch/browser-authority-v2";
+
+const owner = "0x0000000000000000000000000000000000000001";
+const metadata: CustomLaunchProjectMetadataV1 = {
+  schemaVersion: "programmable.project-metadata.v1",
+  token: { name: "River Hook", symbol: "RIVER" },
+  presentation: {
+    schemaVersion: "programmable.launch-presentation-draft.v1",
+    description: "A community designed custom hook.\nPrepared entirely with an agent.",
+    image: {
+      uri: "https://assets.example.com/river.png",
+      contentSha256: `sha256:${"44".repeat(32)}`,
+      mediaType: "image/png",
+      byteLength: 4096,
+      width: 512,
+      height: 512,
+    },
+    links: [
+      { kind: "discord", uri: "https://discord.gg/riverhook" },
+      { kind: "documentation", uri: "https://docs.example.com/river" },
+      { kind: "github", uri: "https://github.com/example/river-hook" },
+      { kind: "other", uri: "https://example.com/river/community" },
+      { kind: "other", uri: "https://example.com/river/security" },
+      { kind: "telegram", uri: "https://t.me/river_hook" },
+      { kind: "website", uri: "https://example.com/river" },
+      { kind: "x", uri: "https://x.com/river_hook" },
+    ],
+  },
+  tokenMetadataBinding: {
+    schemaVersion: "programmable.project-token-metadata-binding.v1",
+    tokenTargetId: "token",
+    declarationBinding: "request-and-launch-id",
+    standardReadModel: { name: true, symbol: true },
+    name: { staticSource: "constructor-argument", argumentIndex: 0, argumentName: "name_" },
+    symbol: { staticSource: "constructor-argument", argumentIndex: 1, argumentName: "symbol_" },
+    postDeploymentReadback: "required",
+  },
+};
+
+function v4Resource(projectMetadata = metadata) {
+  return {
+    schemaVersion: "programmable.custom-launch.v4",
+    apiVersion: "v4",
+    routeId: "custom-launch:create:v4",
+    chainId: "4663",
+    caip2: "eip155:4663",
+    launchId: "90000000-0000-4000-8000-000000000009",
+    requestId: "a0000000-0000-4000-8000-00000000000a",
+    controller: { namespace: "eip155:4663", address: owner },
+    status: "wallet_action_required",
+    requestHash: `sha256:${"11".repeat(32)}`,
+    profile: { profileDigest: `sha256:${"22".repeat(32)}` },
+    commitments: { launchIntent: `sha256:${"33".repeat(32)}` },
+    metadataCommitment: canonicalBrowserSha256V2(
+      "programmable.project-metadata.v1", projectMetadata,
+    ),
+    projectMetadata,
+    walletTransaction: null,
+    preparedArtifact: null,
+    onchain: null,
+    failure: null,
+    createdAt: "2026-09-05T12:00:00.000Z",
+    updatedAt: "2026-09-05T12:00:01.000Z",
+  };
+}
+
+function readResource(raw = v4Resource()) {
+  return parseHistoryPage({
+    schemaVersion: "programmable.custom-launch-history.v1",
+    launches: [raw],
+    nextCursor: null,
+  }, owner);
+}
+
+function v4Launch(projectMetadata = metadata): LaunchResource {
+  const page = readResource(v4Resource(projectMetadata));
+  expect(page).not.toBeNull();
+  return page!.launches[0]!;
+}
+
+function render(launch: LaunchResource) {
+  return renderToStaticMarkup(<DeveloperLaunchMetadataPreview launch={launch} />);
+}
+
+describe("agent supplied launch metadata preview", () => {
+  it("shows chain, identity, bio, bound image reference and every full social destination without inputs", () => {
+    const launch = v4Launch();
+    const html = render(launch);
+    expect(html).toContain("Robinhood Chain · 4663");
+    expect(html).not.toContain("Ethereum Mainnet");
+    expect(html).toContain("Required launch details");
+    expect(html).not.toContain("Bound legacy launch details");
+    expect(html).toContain("River Hook");
+    expect(html).toContain("$RIVER");
+    expect(html).toContain(">Bio<");
+    expect(html).toContain(metadata.presentation.description);
+    expect(html).toContain(metadata.presentation.image!.uri);
+    expect(html).toContain(metadata.presentation.image!.contentSha256);
+    for (const link of metadata.presentation.links) {
+      expect(html).toContain(`href="${link.uri}"`);
+      expect(html).toContain(link.uri);
+    }
+    expect(html).toContain("Telegram");
+    expect(html).toContain("Discord");
+    expect(html).not.toMatch(/<(?:input|textarea|select)\b/u);
+    expect(html).not.toContain(`src="${metadata.presentation.image!.uri}"`);
+    expect(html).toContain("Verifying the bound image bytes before preview.");
+    expect(html).toContain("Ask your agent to make");
+    expect(walletProjectMetadataReadyForReviewV1(launch)).toBe(true);
+  });
+
+  it("does not preview tampered metadata or allow that changed summary at the wallet boundary", () => {
+    const launch = v4Launch();
+    const changed = {
+      ...launch,
+      projectMetadata: { ...metadata, token: { ...metadata.token, name: "Changed name" } },
+    };
+    expect(render(changed)).toContain("Bound project metadata unavailable");
+    expect(render(changed)).not.toContain("Changed name");
+    expect(walletProjectMetadataReadyForReviewV1(changed)).toBe(false);
+  });
+
+  it.each(["description", "image", "website", "x"] as const)(
+    "sends missing current V4 %s back to the agent without removing history",
+    (missing) => {
+      const changed = structuredClone(metadata);
+      const presentation = {
+        ...changed.presentation,
+        ...(missing === "description" ? { description: "" } : {}),
+        ...(missing === "image" ? { image: null } : {}),
+        links: changed.presentation.links.filter((link) => link.kind !== missing),
+      };
+      const launch = v4Launch({ ...changed, presentation });
+      const html = render(launch);
+      expect(html).toContain("River Hook");
+      expect(html).toContain("Action required");
+      expect(html).toContain("Ask your agent to collect the missing launch details");
+      expect(html).not.toMatch(/<(?:input|textarea|select)\b/u);
+      expect(walletProjectMetadataReadyForReviewV1(launch)).toBe(false);
+    },
+  );
+
+  it("keeps omitted optional Telegram and Discord optional and never fabricates destinations", () => {
+    const launch = v4Launch({
+      ...metadata,
+      presentation: {
+        ...metadata.presentation,
+        links: metadata.presentation.links.filter(
+          (link) => link.kind !== "telegram" && link.kind !== "discord",
+        ),
+      },
+    });
+    const html = render(launch);
+    expect(html).toContain("Telegram: not supplied.");
+    expect(html).toContain("Discord: not supplied.");
+    expect(html).not.toContain("https://t.me/");
+    expect(html).not.toContain("https://discord.gg/");
+    expect(walletProjectMetadataReadyForReviewV1(launch)).toBe(true);
+  });
+
+  it("takes chain from the validated launch resource and rejects contradictory V4 chain data", () => {
+    expect(readResource({ ...v4Resource(), chainId: "1" })).toBeNull();
+    expect(readResource({ ...v4Resource(), caip2: "eip155:1" })).toBeNull();
+    const ethereum: LaunchResource = {
+      ...v4Launch(),
+      schemaVersion: "programmable.custom-launch.v3",
+      routeId: "custom-launch:create:v3",
+      launchProfileVersion: "3.3.0",
+      rawResourceV4: null,
+    };
+    expect(render(ethereum)).toContain("Ethereum Mainnet · 1");
+    expect(render(ethereum)).not.toContain("Robinhood Chain");
+  });
+
+  it("preserves legacy history and its existing exact retry binding", () => {
+    const legacy: LaunchResource = {
+      ...v4Launch(),
+      schemaVersion: "programmable.custom-launch.v3",
+      routeId: "custom-launch:create:v3",
+      launchProfileVersion: "3.1.0",
+      projectMetadata: null,
+      projectMetadataHash: null,
+      rawResourceV4: null,
+    };
+    expect(render(legacy)).toContain("Legacy launch identity");
+    expect(render(legacy)).toContain("Exact retries remain available");
+    expect(walletProjectRequestBindingV1(legacy)?.mode).toBe("legacy-exact-retry");
+  });
+});


### PR DESCRIPTION
Agents could begin chain-specific launch work without first collecting the user's chain and project details, and returning API-key users could no longer copy the setup instructions. The shared setup and public discovery now require an explicit Ethereum or Robinhood choice and complete project metadata before preparation, with a persistent setup-copy action for existing keys.

The wallet preview shows the bound chain, name, ticker, bio, verified image and complete link destinations. Telegram, Discord and other links are asked about but optional. Missing or corrected metadata returns to the agent for a new packed request; the website remains read-only. V4 also checks complete metadata on the displayed and freshly fetched wallet resource. V4 status instructions use the returned launchId.

Validation: 52 focused intake, discovery and UI tests pass; TypeScript check passes; independent source review found no actionable defect. Local rendered desktop/mobile previews verify the image digest, full social destinations, no editable metadata, no horizontal overflow and no console errors. Setup clipboard contains the new intake and no API-key secret. Frozen request schemas, backend policy, CLI versions and LP/tax rules are unchanged.
