### PR TITLE
Add Robinhood coin cards and shared multichain profiles

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -302,3 +302,28 @@ condition = "AND"
 regexTarget = "match"
 paths = ['''contracts/test/late-migration/mocks/IntakeV3Mocks\.sol''']
 regexes = ['''^PinnedPermitTokenMockV3 is IERC20, IERC20Permit\s+$''']
+
+[[allowlists]]
+description = "Robinhood website and tests pin the public Programmable token address"
+targetRules = ["generic-api-key"]
+condition = "AND"
+regexTarget = "secret"
+paths = [
+  '''^lib/robinhood-explore-policy\.ts$''',
+  '''^lib/server/robinhood-presentation\.ts$''',
+  '''^tests/robinhood-website-index\.test\.ts$''',
+  '''^tests/robinhood-presentation\.test\.ts$''',
+  '''^tests/robinhood-profile\.test\.ts$''',
+]
+regexes = ['''(?i)^0xc60ba256b44334a0cd2c7242e98b88f031abb006$''']
+
+[[allowlists]]
+description = "Robinhood visibility tests pin the public Clean Room token address"
+targetRules = ["generic-api-key"]
+condition = "AND"
+regexTarget = "secret"
+paths = [
+  '''^tests/robinhood-website-index\.test\.ts$''',
+  '''^tests/robinhood-explore-read\.test\.ts$''',
+]
+regexes = ['''(?i)^0x15fca474b23cafe775120b1fafbcff0e7a827af2$''']

--- a/app/api/explore/robinhood/presentation/route.ts
+++ b/app/api/explore/robinhood/presentation/route.ts
@@ -14,10 +14,9 @@ export async function GET(request: Request) {
     || [...query.keys()].some((key) => key !== "token" || query.getAll(key).length !== 1)) {
     return Response.json({ error: "invalid_query" }, { status: 400, headers: { "cache-control": "no-store" } });
   }
-  const tokens = listQuery
-    ? (await readRobinhoodLaunches(listQuery.page, listQuery.q, listQuery.filters)).items
-    : [(await readRobinhoodToken(token!)).token].filter((row) => row !== null);
-  const items = await readRobinhoodPresentations(tokens);
+  const items = listQuery
+    ? (await readRobinhoodLaunches(listQuery.page, listQuery.q, listQuery.filters)).presentations
+    : await readRobinhoodPresentations([(await readRobinhoodToken(token!)).token].filter((row) => row !== null));
   return Response.json({ items }, { headers: {
     "cache-control": "public, max-age=0, s-maxage=60, stale-while-revalidate=60",
     "x-content-type-options": "nosniff",

--- a/app/api/explore/robinhood/presentation/route.ts
+++ b/app/api/explore/robinhood/presentation/route.ts
@@ -1,0 +1,26 @@
+import { isAddress } from "viem";
+import { readRobinhoodLaunches, readRobinhoodToken } from "@/lib/server/robinhood-index/read";
+import { readRobinhoodPresentations } from "@/lib/server/robinhood-presentation";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const query = new URL(request.url).searchParams;
+  const token = query.get("token");
+  const page = query.get("page") ?? "1";
+  const search = query.get("q") ?? "";
+  const allowed = token === null ? ["page", "q"] : ["token"];
+  if ([...query.keys()].some((key) => !allowed.includes(key) || query.getAll(key).length !== 1)
+    || (token !== null && !isAddress(token)) || !/^[1-9]\d{0,5}$/.test(page) || search.length > 128) {
+    return Response.json({ error: "invalid_query" }, { status: 400, headers: { "cache-control": "no-store" } });
+  }
+  const tokens = token === null
+    ? (await readRobinhoodLaunches(Number(page), search)).items
+    : [(await readRobinhoodToken(token)).token].filter((row) => row !== null);
+  const items = await readRobinhoodPresentations(tokens);
+  return Response.json({ items }, { headers: {
+    "cache-control": "public, max-age=0, s-maxage=60, stale-while-revalidate=60",
+    "x-content-type-options": "nosniff",
+  } });
+}

--- a/app/api/explore/robinhood/presentation/route.ts
+++ b/app/api/explore/robinhood/presentation/route.ts
@@ -1,6 +1,7 @@
 import { isAddress } from "viem";
 import { readRobinhoodLaunches, readRobinhoodToken } from "@/lib/server/robinhood-index/read";
 import { readRobinhoodPresentations } from "@/lib/server/robinhood-presentation";
+import { parseRobinhoodExploreQuery } from "@/lib/robinhood-explore-filters";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -8,16 +9,14 @@ export const dynamic = "force-dynamic";
 export async function GET(request: Request) {
   const query = new URL(request.url).searchParams;
   const token = query.get("token");
-  const page = query.get("page") ?? "1";
-  const search = query.get("q") ?? "";
-  const allowed = token === null ? ["page", "q"] : ["token"];
-  if ([...query.keys()].some((key) => !allowed.includes(key) || query.getAll(key).length !== 1)
-    || (token !== null && !isAddress(token)) || !/^[1-9]\d{0,5}$/.test(page) || search.length > 128) {
+  const listQuery = token === null ? parseRobinhoodExploreQuery(query) : null;
+  if (token === null ? !listQuery : !isAddress(token)
+    || [...query.keys()].some((key) => key !== "token" || query.getAll(key).length !== 1)) {
     return Response.json({ error: "invalid_query" }, { status: 400, headers: { "cache-control": "no-store" } });
   }
-  const tokens = token === null
-    ? (await readRobinhoodLaunches(Number(page), search)).items
-    : [(await readRobinhoodToken(token)).token].filter((row) => row !== null);
+  const tokens = listQuery
+    ? (await readRobinhoodLaunches(listQuery.page, listQuery.q, listQuery.filters)).items
+    : [(await readRobinhoodToken(token!)).token].filter((row) => row !== null);
   const items = await readRobinhoodPresentations(tokens);
   return Response.json({ items }, { headers: {
     "cache-control": "public, max-age=0, s-maxage=60, stale-while-revalidate=60",

--- a/app/api/explore/robinhood/presentation/route.ts
+++ b/app/api/explore/robinhood/presentation/route.ts
@@ -1,5 +1,5 @@
 import { isAddress } from "viem";
-import { readRobinhoodLaunches, readRobinhoodToken } from "@/lib/server/robinhood-index/read";
+import { readRobinhoodLaunches, readRobinhoodProfileLaunches, readRobinhoodToken } from "@/lib/server/robinhood-index/read";
 import { readRobinhoodPresentations } from "@/lib/server/robinhood-presentation";
 import { parseRobinhoodExploreQuery } from "@/lib/robinhood-explore-filters";
 
@@ -8,6 +8,20 @@ export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
   const query = new URL(request.url).searchParams;
+  const account = query.get("account");
+  if (account !== null) {
+    const page = query.get("page") ?? "1";
+    if (!isAddress(account) || !/^[1-9]\d{0,5}$/.test(page)
+      || [...query.keys()].some((key) => !["account", "page"].includes(key) || query.getAll(key).length !== 1)) {
+      return Response.json({ error: "invalid_query" }, { status: 400, headers: { "cache-control": "no-store" } });
+    }
+    const profile = await readRobinhoodProfileLaunches(account.toLowerCase(), Number(page));
+    const items = await readRobinhoodPresentations(profile.items);
+    return Response.json({ items }, { headers: {
+      "cache-control": "public, max-age=0, s-maxage=60, stale-while-revalidate=60",
+      "x-content-type-options": "nosniff",
+    } });
+  }
   const token = query.get("token");
   const listQuery = token === null ? parseRobinhoodExploreQuery(query) : null;
   if (token === null ? !listQuery : !isAddress(token)

--- a/app/api/explore/robinhood/route.ts
+++ b/app/api/explore/robinhood/route.ts
@@ -1,17 +1,15 @@
 import { readRobinhoodLaunches } from "@/lib/server/robinhood-index/read";
+import { parseRobinhoodExploreQuery } from "@/lib/robinhood-explore-filters";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
-  const query = new URL(request.url).searchParams;
-  const page = query.get("page") ?? "1";
-  const search = query.get("q") ?? "";
-  if ([...query.keys()].some((key) => !["page", "q"].includes(key) || query.getAll(key).length !== 1)
-    || !/^[1-9]\d{0,5}$/.test(page) || search.length > 128) {
+  const query = parseRobinhoodExploreQuery(new URL(request.url).searchParams);
+  if (!query) {
     return Response.json({ error: "invalid_query" }, { status: 400, headers: { "cache-control": "no-store" } });
   }
-  return Response.json(await readRobinhoodLaunches(Number(page), search), { headers: {
+  return Response.json(await readRobinhoodLaunches(query.page, query.q, query.filters), { headers: {
     "cache-control": "public, max-age=0, s-maxage=15, stale-while-revalidate=30",
     "x-content-type-options": "nosniff",
   } });

--- a/app/api/profile/robinhood/route.ts
+++ b/app/api/profile/robinhood/route.ts
@@ -1,0 +1,27 @@
+import { isAddress } from "viem";
+
+import { readRobinhoodProfileLaunches } from "@/lib/server/robinhood-index/read";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  if (request.method !== "GET") {
+    return Response.json({ error: "method_not_allowed" }, { status: 405, headers: {
+      "allow": "GET", "cache-control": "no-store", "x-content-type-options": "nosniff",
+    } });
+  }
+  const query = new URL(request.url).searchParams;
+  const account = query.get("account");
+  const page = query.get("page") ?? "1";
+  if ([...query.keys()].some((key) => !["account", "page"].includes(key) || query.getAll(key).length !== 1)
+    || account === null || !isAddress(account) || !/^[1-9]\d{0,5}$/.test(page)) {
+    return Response.json({ error: "invalid_query" }, { status: 400, headers: {
+      "cache-control": "no-store", "x-content-type-options": "nosniff",
+    } });
+  }
+  return Response.json(await readRobinhoodProfileLaunches(account.toLowerCase(), Number(page)), { headers: {
+    "cache-control": "public, max-age=0, s-maxage=15, stale-while-revalidate=30",
+    "x-content-type-options": "nosniff",
+  } });
+}

--- a/app/launch/layout.tsx
+++ b/app/launch/layout.tsx
@@ -1,2 +1,0 @@
-export { ResolvedViewChainLayout as default } from
-  "@/components/resolved-view-chain-layout";

--- a/app/launch/page.tsx
+++ b/app/launch/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 
 import { LaunchExperience } from "@/components/launch-entry";
+import { parseViewChainId, VIEW_CHAIN_COOKIE_NAME } from "@/lib/view-chain";
 
 export const dynamic = "force-dynamic";
 
@@ -13,6 +15,10 @@ export const metadata: Metadata = {
   },
 };
 
-export default function LaunchPage() {
-  return <LaunchExperience />;
+export default async function LaunchPage() {
+  const requestCookies = await cookies();
+  const initialViewChainId = parseViewChainId(
+    requestCookies.get(VIEW_CHAIN_COOKIE_NAME)?.value,
+  );
+  return <LaunchExperience initialViewChainId={initialViewChainId} />;
 }

--- a/app/profile/layout.tsx
+++ b/app/profile/layout.tsx
@@ -1,2 +1,5 @@
-export { ResolvedViewChainLayout as default } from
-  "@/components/resolved-view-chain-layout";
+import type { ReactNode } from "react";
+
+export default function ProfileLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/components/developer-api-keys.tsx
+++ b/components/developer-api-keys.tsx
@@ -1219,9 +1219,9 @@ export function DeveloperApiKeysView({
         {statusMessage}
       </p>
 
-      <Link className={styles.backLink} href="/profile">
+      <Link className={styles.backLink} href="/launch">
         <ArrowLeft aria-hidden="true" size={16} strokeWidth={1.9} />
-        <span>Back to profile</span>
+        <span>Back</span>
       </Link>
 
       <header className={styles.hero}>

--- a/components/explore-chain-selector.module.css
+++ b/components/explore-chain-selector.module.css
@@ -52,27 +52,21 @@
 }
 
 .menu {
-  -webkit-backdrop-filter: blur(20px);
-  backdrop-filter: blur(20px);
-  background: rgb(24 24 24 / 0.98);
-  border: 1px solid var(--webde-line);
-  border-radius: 12px;
-  box-shadow: 0 24px 64px rgb(0 0 0 / 0.58);
   display: grid;
-  gap: 2px;
+  gap: 8px;
   left: 0;
-  min-width: 52px;
-  padding: 4px;
+  padding: 0;
   position: absolute;
   top: calc(100% + 8px);
+  width: 44px;
 }
 
 .option {
   align-items: center;
-  background: transparent;
-  border: 0;
-  border-radius: 7px;
-  color: var(--webde-muted);
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-ink);
   display: grid;
   height: 44px;
   min-height: 44px;
@@ -83,7 +77,7 @@
 
 .option:focus-visible {
   outline: 2px solid var(--webde-ink);
-  outline-offset: -2px;
+  outline-offset: 2px;
 }
 
 .option[aria-disabled="true"] {
@@ -103,7 +97,6 @@
   .menu {
     left: auto;
     max-width: calc(100vw - 32px);
-    min-width: 52px;
     right: 0;
   }
 }

--- a/components/explore-chain-selector.tsx
+++ b/components/explore-chain-selector.tsx
@@ -113,8 +113,13 @@ export function ExploreChainSelector() {
 
   function selectChain(option: ExploreChainOption) {
     if (!option.available || option.viewChainId === undefined) return;
+    const main = rootRef.current?.closest("main");
     setViewChainId(option.viewChainId);
-    closeListbox();
+    closeListbox(false);
+    window.requestAnimationFrame(() => {
+      const trigger = triggerRef.current ?? main?.querySelector<HTMLButtonElement>(`button[aria-label="Explore chain: ${option.label}"]`);
+      trigger?.focus();
+    });
   }
 
   function handleOptionKeyDown(

--- a/components/explore-filters.module.css
+++ b/components/explore-filters.module.css
@@ -1,5 +1,5 @@
 .root { flex: none; position: relative; z-index: 21; }
-.trigger, .panel button, .field select {
+.trigger, .panel button {
   background: var(--webde-surface);
   border: 1px solid var(--webde-line);
   border-radius: var(--webde-radius-control);
@@ -22,9 +22,10 @@
 .trigger[data-active="true"] { border-color: var(--webde-muted); }
 .count {
   align-items: center;
-  background: var(--webde-ink);
+  background: var(--webde-surface-raised);
+  border: 1px solid var(--webde-muted);
   border-radius: 50%;
-  color: var(--webde-canvas);
+  color: var(--webde-ink);
   display: flex;
   font-size: 10px;
   height: 16px;
@@ -51,13 +52,19 @@
 .heading { align-items: center; display: flex; justify-content: space-between; margin: -8px -8px -4px 0; }
 .heading h2 { font-size: 16px; font-weight: 500; line-height: 24px; margin: 0; }
 .panel .close { background: transparent; border: 0; display: grid; padding: 0; place-items: center; width: 44px; }
-.field { display: grid; gap: 8px; min-width: 0; }
-.field > span { color: var(--webde-muted); font-size: 13px; line-height: 20px; }
-.field select { background: var(--webde-surface-raised); cursor: pointer; padding: 8px 12px; width: 100%; }
+.field { border: 0; margin: 0; min-inline-size: 0; padding: 0; }
+.field legend { color: var(--webde-muted); font-size: 13px; line-height: 20px; margin-bottom: 8px; padding: 0; }
+.choices { display: grid; gap: 8px; grid-template-columns: 1fr 1fr; }
+.choices button { color: var(--webde-muted); }
+.choices button[aria-pressed="true"] {
+  background: var(--webde-surface-raised);
+  border-color: color-mix(in srgb, var(--webde-ink) 35%, transparent);
+  color: var(--webde-ink);
+}
 .actions { display: grid; gap: 8px; grid-template-columns: 1fr 1fr; margin-top: 4px; }
 .panel button { cursor: pointer; padding: 8px 12px; }
-.panel .apply { background: var(--webde-ink); border-color: var(--webde-ink); color: var(--webde-canvas); }
-.trigger:focus-visible, .panel button:focus-visible, .field select:focus-visible { outline: 2px solid var(--webde-ink); outline-offset: 2px; }
+.panel .apply { background: var(--webde-surface-raised); border-color: var(--webde-muted); }
+.trigger:focus-visible, .panel button:focus-visible { outline: 2px solid var(--webde-muted); outline-offset: 2px; }
 @media (hover: hover) and (pointer: fine) {
   .trigger:hover:not(:disabled), .panel button:hover:not(.apply) { background: var(--webde-surface-raised); }
   .panel .apply:hover { opacity: .9; }
@@ -65,9 +72,9 @@
 @media (max-width: 700px) {
   .trigger { min-width: 44px; padding: 0; width: 44px; }
   .label { display: none; }
-  .field select { font-size: 16px; }
 }
 @media (forced-colors: active) {
-  .trigger, .panel, .panel button, .field select { border-color: CanvasText; }
-  .trigger:focus-visible, .panel button:focus-visible, .field select:focus-visible { outline-color: Highlight; }
+  .trigger, .panel, .panel button { border-color: CanvasText; }
+  .choices button[aria-pressed="true"] { background: Highlight; color: HighlightText; }
+  .trigger:focus-visible, .panel button:focus-visible { outline-color: Highlight; }
 }

--- a/components/explore-filters.module.css
+++ b/components/explore-filters.module.css
@@ -1,0 +1,73 @@
+.root { flex: none; position: relative; z-index: 21; }
+.trigger, .panel button, .field select {
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-ink);
+  font: inherit;
+  font-size: 14px;
+  min-height: 44px;
+}
+.trigger {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  min-width: 104px;
+  padding: 0 14px;
+  position: relative;
+}
+.trigger:disabled { cursor: not-allowed; opacity: .58; }
+.trigger[data-active="true"] { border-color: var(--webde-muted); }
+.count {
+  align-items: center;
+  background: var(--webde-ink);
+  border-radius: 50%;
+  color: var(--webde-canvas);
+  display: flex;
+  font-size: 10px;
+  height: 16px;
+  justify-content: center;
+  position: absolute;
+  right: -5px;
+  top: -5px;
+  width: 16px;
+}
+.panel {
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: 12px;
+  box-shadow: 0 12px 36px rgb(0 0 0 / .3);
+  display: grid;
+  gap: 16px;
+  max-width: calc(100vw - 32px);
+  padding: 16px;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  width: 288px;
+}
+.heading { align-items: center; display: flex; justify-content: space-between; margin: -8px -8px -4px 0; }
+.heading h2 { font-size: 16px; font-weight: 500; line-height: 24px; margin: 0; }
+.panel .close { background: transparent; border: 0; display: grid; padding: 0; place-items: center; width: 44px; }
+.field { display: grid; gap: 8px; min-width: 0; }
+.field > span { color: var(--webde-muted); font-size: 13px; line-height: 20px; }
+.field select { background: var(--webde-surface-raised); cursor: pointer; padding: 8px 12px; width: 100%; }
+.actions { display: grid; gap: 8px; grid-template-columns: 1fr 1fr; margin-top: 4px; }
+.panel button { cursor: pointer; padding: 8px 12px; }
+.panel .apply { background: var(--webde-ink); border-color: var(--webde-ink); color: var(--webde-canvas); }
+.trigger:focus-visible, .panel button:focus-visible, .field select:focus-visible { outline: 2px solid var(--webde-ink); outline-offset: 2px; }
+@media (hover: hover) and (pointer: fine) {
+  .trigger:hover:not(:disabled), .panel button:hover:not(.apply) { background: var(--webde-surface-raised); }
+  .panel .apply:hover { opacity: .9; }
+}
+@media (max-width: 700px) {
+  .trigger { min-width: 44px; padding: 0; width: 44px; }
+  .label { display: none; }
+  .field select { font-size: 16px; }
+}
+@media (forced-colors: active) {
+  .trigger, .panel, .panel button, .field select { border-color: CanvasText; }
+  .trigger:focus-visible, .panel button:focus-visible, .field select:focus-visible { outline-color: Highlight; }
+}

--- a/components/explore-filters.tsx
+++ b/components/explore-filters.tsx
@@ -3,7 +3,7 @@
 import { SlidersHorizontal, X } from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
 import {
-  activeExploreFilterCount, DEFAULT_EXPLORE_FILTERS, LAUNCH_AGE_OPTIONS, LAUNCH_SORT_OPTIONS,
+  activeExploreFilterCount, DEFAULT_EXPLORE_FILTERS, LAUNCH_SORT_OPTIONS,
   type RobinhoodExploreFilters,
 } from "@/lib/robinhood-explore-filters";
 import styles from "./explore-filters.module.css";
@@ -63,15 +63,8 @@ export function ExploreFilters({ value = DEFAULT_EXPLORE_FILTERS, onApply, disab
         <button className={styles.close} type="button" aria-label="Close filters" onClick={() => close(true)}><X size={18} aria-hidden="true" /></button>
       </div>
       <label className={styles.field}>
-        <span>Launched</span>
-        <select ref={firstFieldRef} name="age" value={draft.age}
-          onChange={(event) => setDraft((current) => ({ ...current, age: event.target.value as RobinhoodExploreFilters["age"] }))}>
-          {LAUNCH_AGE_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
-        </select>
-      </label>
-      <label className={styles.field}>
         <span>Sort by</span>
-        <select name="sort" value={draft.sort}
+        <select ref={firstFieldRef} name="sort" value={draft.sort}
           onChange={(event) => setDraft((current) => ({ ...current, sort: event.target.value as RobinhoodExploreFilters["sort"] }))}>
           {LAUNCH_SORT_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
         </select>

--- a/components/explore-filters.tsx
+++ b/components/explore-filters.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { SlidersHorizontal, X } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+import {
+  activeExploreFilterCount, DEFAULT_EXPLORE_FILTERS, LAUNCH_AGE_OPTIONS, LAUNCH_SORT_OPTIONS,
+  type RobinhoodExploreFilters,
+} from "@/lib/robinhood-explore-filters";
+import styles from "./explore-filters.module.css";
+
+export function ExploreFilters({ value = DEFAULT_EXPLORE_FILTERS, onApply, disabled = false }: {
+  value?: RobinhoodExploreFilters;
+  onApply?: (filters: RobinhoodExploreFilters) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const firstFieldRef = useRef<HTMLSelectElement>(null);
+  const panelId = useId();
+  const count = activeExploreFilterCount(value);
+
+  function close(restoreFocus = false) {
+    setOpen(false);
+    if (restoreFocus) triggerRef.current?.focus();
+  }
+
+  useEffect(() => {
+    if (!open) return;
+    firstFieldRef.current?.focus();
+    function outside(event: PointerEvent) {
+      if (event.target instanceof Node && !rootRef.current?.contains(event.target)) setOpen(false);
+    }
+    document.addEventListener("pointerdown", outside);
+    return () => document.removeEventListener("pointerdown", outside);
+  }, [open]);
+
+  return <div className={styles.root} ref={rootRef}
+    onKeyDown={(event) => {
+      if (open && event.key === "Escape") { event.preventDefault(); event.stopPropagation(); close(true); }
+    }}
+    onBlurCapture={(event) => {
+      if (event.relatedTarget instanceof Node && !event.currentTarget.contains(event.relatedTarget)) close();
+    }}
+  >
+    <button className={styles.trigger} ref={triggerRef} type="button" disabled={disabled}
+      aria-label={count ? `Filters, ${count} active` : "Filters"}
+      aria-expanded={open} aria-controls={panelId} aria-haspopup="dialog"
+      title={disabled ? "Filters are unavailable while Ethereum indexing is rebuilt" : undefined}
+      data-active={count > 0}
+      onClick={() => { if (open) close(); else { setDraft(value); setOpen(true); } }}
+    >
+      <SlidersHorizontal size={16} aria-hidden="true" />
+      <span className={styles.label}>Filters</span>
+      {count > 0 ? <span className={styles.count} aria-hidden="true">{count}</span> : null}
+    </button>
+    {open ? <form className={styles.panel} id={panelId} role="dialog" aria-label="Launch filters"
+      onSubmit={(event) => { event.preventDefault(); onApply?.(draft); close(true); }}
+    >
+      <div className={styles.heading}>
+        <h2>Filters</h2>
+        <button className={styles.close} type="button" aria-label="Close filters" onClick={() => close(true)}><X size={18} aria-hidden="true" /></button>
+      </div>
+      <label className={styles.field}>
+        <span>Launched</span>
+        <select ref={firstFieldRef} name="age" value={draft.age}
+          onChange={(event) => setDraft((current) => ({ ...current, age: event.target.value as RobinhoodExploreFilters["age"] }))}>
+          {LAUNCH_AGE_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+        </select>
+      </label>
+      <label className={styles.field}>
+        <span>Sort by</span>
+        <select name="sort" value={draft.sort}
+          onChange={(event) => setDraft((current) => ({ ...current, sort: event.target.value as RobinhoodExploreFilters["sort"] }))}>
+          {LAUNCH_SORT_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+        </select>
+      </label>
+      <div className={styles.actions}>
+        <button type="button" onClick={() => { onApply?.(DEFAULT_EXPLORE_FILTERS); close(true); }}>Reset</button>
+        <button className={styles.apply} type="submit">Apply</button>
+      </div>
+    </form> : null}
+  </div>;
+}

--- a/components/explore-filters.tsx
+++ b/components/explore-filters.tsx
@@ -3,7 +3,7 @@
 import { SlidersHorizontal, X } from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
 import {
-  activeExploreFilterCount, DEFAULT_EXPLORE_FILTERS, LAUNCH_SORT_OPTIONS,
+  activeExploreFilterCount, DEFAULT_EXPLORE_FILTERS,
   type RobinhoodExploreFilters,
 } from "@/lib/robinhood-explore-filters";
 import styles from "./explore-filters.module.css";
@@ -17,7 +17,7 @@ export function ExploreFilters({ value = DEFAULT_EXPLORE_FILTERS, onApply, disab
   const [draft, setDraft] = useState(value);
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const firstFieldRef = useRef<HTMLSelectElement>(null);
+  const keyboardOpenRef = useRef(false);
   const panelId = useId();
   const count = activeExploreFilterCount(value);
 
@@ -28,7 +28,7 @@ export function ExploreFilters({ value = DEFAULT_EXPLORE_FILTERS, onApply, disab
 
   useEffect(() => {
     if (!open) return;
-    firstFieldRef.current?.focus();
+    if (keyboardOpenRef.current) rootRef.current?.querySelector<HTMLButtonElement>('[aria-pressed="true"]')?.focus();
     function outside(event: PointerEvent) {
       if (event.target instanceof Node && !rootRef.current?.contains(event.target)) setOpen(false);
     }
@@ -49,7 +49,10 @@ export function ExploreFilters({ value = DEFAULT_EXPLORE_FILTERS, onApply, disab
       aria-expanded={open} aria-controls={panelId} aria-haspopup="dialog"
       title={disabled ? "Filters are unavailable while Ethereum indexing is rebuilt" : undefined}
       data-active={count > 0}
-      onClick={() => { if (open) close(); else { setDraft(value); setOpen(true); } }}
+      onClick={(event) => {
+        if (open) close();
+        else { keyboardOpenRef.current = event.detail === 0; setDraft(value); setOpen(true); }
+      }}
     >
       <SlidersHorizontal size={16} aria-hidden="true" />
       <span className={styles.label}>Filters</span>
@@ -62,13 +65,20 @@ export function ExploreFilters({ value = DEFAULT_EXPLORE_FILTERS, onApply, disab
         <h2>Filters</h2>
         <button className={styles.close} type="button" aria-label="Close filters" onClick={() => close(true)}><X size={18} aria-hidden="true" /></button>
       </div>
-      <label className={styles.field}>
-        <span>Sort by</span>
-        <select ref={firstFieldRef} name="sort" value={draft.sort}
-          onChange={(event) => setDraft((current) => ({ ...current, sort: event.target.value as RobinhoodExploreFilters["sort"] }))}>
-          {LAUNCH_SORT_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
-        </select>
-      </label>
+      <fieldset className={styles.field}>
+        <legend>Age</legend>
+        <div className={styles.choices}>
+          <button type="button" aria-pressed={draft.sort === "oldest"} onClick={() => setDraft({ sort: "oldest" })}>Oldest</button>
+          <button type="button" aria-pressed={draft.sort === "newest"} onClick={() => setDraft({ sort: "newest" })}>Newest</button>
+        </div>
+      </fieldset>
+      <fieldset className={styles.field}>
+        <legend>Market cap</legend>
+        <div className={styles.choices}>
+          <button type="button" aria-pressed={draft.sort === "lowest"} onClick={() => setDraft({ sort: "lowest" })}>Lowest</button>
+          <button type="button" aria-pressed={draft.sort === "highest"} onClick={() => setDraft({ sort: "highest" })}>Highest</button>
+        </div>
+      </fieldset>
       <div className={styles.actions}>
         <button type="button" onClick={() => { onApply?.(DEFAULT_EXPLORE_FILTERS); close(true); }}>Reset</button>
         <button className={styles.apply} type="submit">Apply</button>

--- a/components/explore-index-reset-view.tsx
+++ b/components/explore-index-reset-view.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { ChevronDown, Search } from "lucide-react";
+import { Search } from "lucide-react";
 
 import { ExploreChainSelector } from "@/components/explore-chain-selector";
+import { ExploreFilters } from "@/components/explore-filters";
 import styles from "@/components/index-reset-view.module.css";
 
 export function ExploreIndexResetView({
@@ -34,22 +35,14 @@ export function ExploreIndexResetView({
               <input
                 id="explore-token-search"
                 type="search"
-                placeholder="Name, ticker or address"
+                placeholder="Name, symbol or address"
                 disabled
               />
             </div>
 
             <ExploreChainSelector />
 
-            <button
-              className={styles.disabledFilter}
-              type="button"
-              disabled
-              aria-label="Filters are unavailable while indexing is rebuilt"
-            >
-              <span>Filters</span>
-              <ChevronDown aria-hidden="true" size={15} />
-            </button>
+            <ExploreFilters disabled />
           </div>
         ) : null}
 

--- a/components/index-reset-view.module.css
+++ b/components/index-reset-view.module.css
@@ -42,10 +42,7 @@
   max-width: 100%;
 }
 
-.disabledSearch,
-.disabledFilter {
-  -webkit-backdrop-filter: blur(20px);
-  backdrop-filter: blur(20px);
+.disabledSearch {
   background: var(--webde-surface);
   border: 1px solid var(--webde-line);
   border-radius: var(--webde-radius-control);
@@ -57,11 +54,10 @@
   align-items: center;
   display: flex;
   flex: 0 1 448px;
-  gap: 9px;
+  gap: 8px;
   max-width: 448px;
   min-width: 0;
-  padding-inline: 15px;
-  width: min(46vw, 448px);
+  padding-inline: 16px 4px;
 }
 
 .disabledSearch input {
@@ -81,19 +77,7 @@
   opacity: 1;
 }
 
-.disabledFilter {
-  align-items: center;
-  display: inline-flex;
-  font: inherit;
-  font-size: 13px;
-  font-weight: 600;
-  gap: 8px;
-  justify-content: center;
-  padding-inline: 16px 14px;
-}
-
-.disabledSearch:has(input:disabled),
-.disabledFilter:disabled {
+.disabledSearch:has(input:disabled) {
   cursor: not-allowed;
   opacity: 0.58;
 }
@@ -223,7 +207,7 @@
 
   .toolbar {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 44px auto;
+    grid-template-columns: minmax(0, 1fr) 44px 44px;
   }
 
   .disabledSearch {
@@ -231,10 +215,8 @@
     width: 100%;
   }
 
-  .disabledFilter {
-    min-width: 44px;
-    padding-inline: 13px;
-  }
+  .disabledSearch { padding-inline-start: 12px; }
+  .disabledSearch input { font-size: 16px; }
 
   .resetState,
   .tokenResetState {
@@ -267,7 +249,6 @@
 
 @media (forced-colors: active) {
   .disabledSearch,
-  .disabledFilter,
   .resetState,
   .tokenResetState,
   .resetLabel {

--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -191,23 +191,30 @@ export function LaunchModelPicker({
       <header
         className={`launch-model-heading ${launchExperience.pickerHeading}`}
       >
-        <h1>Choose a chain</h1>
+        <h1 className="sr-only">Create</h1>
         <fieldset
           className={launchExperience.chainChoice}
           disabled={preparingModel !== null}
         >
           <legend className="sr-only">Launch chain</legend>
           {VIEW_CHAIN_OPTIONS.map((chain) => (
-            <label key={chain.id} className={launchExperience.chainOption}>
+            <label key={chain.id} className={launchExperience.chainOption} title={chain.label}>
               <input
                 className="sr-only"
                 type="radio"
                 name="launch-chain"
+                aria-label={chain.label}
                 value={chain.id}
                 checked={chainId === chain.id}
                 onChange={() => onChangeChain?.(chain.id)}
               />
-              {chain.label}
+              {chain.id === 1 ? (
+                <svg className={launchExperience.chainMark} viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false">
+                  <path d="M12 2 5.5 12.2 12 9.25l6.5 2.95L12 2Z" fill="currentColor" />
+                  <path d="m5.5 13.35 6.5 3.7 6.5-3.7L12 22 5.5 13.35Z" fill="currentColor" />
+                  <path d="m12 9.25-6.5 2.95L12 15.9l6.5-3.7L12 9.25Z" fill="currentColor" />
+                </svg>
+              ) : <span className={launchExperience.robinhoodMark} aria-hidden="true" />}
             </label>
           ))}
         </fieldset>
@@ -226,7 +233,7 @@ export function LaunchModelPicker({
             disabled={!classicV3LaunchAvailable || preparingModel !== null}
             aria-busy={preparingModel === "classic-v3"}
             aria-labelledby="launch-model-classic-title"
-            aria-describedby="launch-model-classic-description launch-model-classic-status"
+            aria-describedby={classicV3LaunchAvailable ? "launch-model-classic-description" : "launch-model-classic-description launch-model-classic-status"}
             onPointerEnter={
               classicV3LaunchAvailable ? preloadAvailableForm : undefined
             }
@@ -265,12 +272,12 @@ export function LaunchModelPicker({
                 className={`launch-model-card-heading ${launchExperience.modelHeading}`}
               >
                 <strong id="launch-model-classic-title">Classic</strong>
-                <small
+                {!classicV3LaunchAvailable ? <small
                   id="launch-model-classic-status"
-                  data-status={classicV3LaunchAvailable ? "ready" : "pending"}
+                  data-status="pending"
                 >
-                  {classicV3LaunchAvailable ? "Ethereum only" : "Unavailable"}
-                </small>
+                  Unavailable
+                </small> : null}
               </span>
               <span
                 className={`launch-model-description ${launchExperience.modelDescription}`}
@@ -300,7 +307,7 @@ export function LaunchModelPicker({
           data-launch-model-available="true"
           data-launch-model-entry="api-key-launch"
           data-launch-model-launchable="false"
-          href={`/developers/api-keys?start=custom&chainId=${chainId}`}
+          href="/developers/api-keys"
           aria-labelledby="launch-model-custom-title"
           aria-describedby="launch-model-custom-description"
         >

--- a/components/launch-entry.tsx
+++ b/components/launch-entry.tsx
@@ -6,9 +6,11 @@ import { useEffect, useState } from "react";
 import { ArrowRight } from "lucide-react";
 
 import launchExperience from "@/components/launch-experience.module.css";
+import { useViewChain, type ViewChainId } from "@/components/view-chain";
 import { isConfiguredClassicV3ReleaseReady } from "@/lib/classic-v3-release";
 import { resolveImplementedLaunchModel } from "@/lib/launch-model-gating";
 import type { LaunchModel } from "@/lib/launch";
+import { VIEW_CHAIN_OPTIONS } from "@/lib/view-chain";
 
 const launchEnvironment =
   process.env.NEXT_PUBLIC_PROGRAMMABLE_ONCHAIN_NETWORK === "rehearsal"
@@ -25,11 +27,25 @@ type LaunchBuilderComponent =
   (typeof import("@/components/launch-builder"))["LaunchBuilderForm"];
 type LaunchPickerChoice = LaunchModel;
 
-export function LaunchExperience() {
-  return <LaunchExperienceRuntime />;
+export function LaunchExperience({
+  initialViewChainId = 1,
+}: Readonly<{ initialViewChainId?: ViewChainId }>) {
+  const { hydrated, viewChainId, setViewChainId } = useViewChain();
+  return (
+    <LaunchExperienceRuntime
+      chainId={hydrated ? viewChainId : initialViewChainId}
+      onChangeChain={setViewChainId}
+    />
+  );
 }
 
-function LaunchExperienceRuntime() {
+function LaunchExperienceRuntime({
+  chainId,
+  onChangeChain,
+}: Readonly<{
+  chainId: ViewChainId;
+  onChangeChain: (chainId: ViewChainId) => void;
+}>) {
   const [selectedModel, setSelectedModel] = useState<LaunchPickerChoice | null>(null);
   const [loadedLaunchBuilder, setLoadedLaunchBuilder] =
     useState<LaunchBuilderComponent | null>(null);
@@ -37,12 +53,14 @@ function LaunchExperienceRuntime() {
   const [modelLoadError, setModelLoadError] = useState("");
 
   useEffect(() => {
+    if (chainId !== 1 || !classicV3LaunchAvailable) return;
     void loadLaunchForm().catch(() => undefined);
-  }, []);
+  }, [chainId]);
 
   async function chooseModel(candidate: LaunchPickerChoice) {
     const model = resolveImplementedLaunchModel(candidate);
     if (
+      chainId !== 1 ||
       !model ||
       model === "deep" ||
       model === "stock-paired" ||
@@ -71,9 +89,15 @@ function LaunchExperienceRuntime() {
     setSelectedModel(null);
   }
 
-  if (!selectedModel) {
+  if (!selectedModel || chainId !== 1) {
     return (
       <LaunchModelPicker
+        chainId={chainId}
+        onChangeChain={(nextChainId) => {
+          setSelectedModel(null);
+          setModelLoadError("");
+          onChangeChain(nextChainId);
+        }}
         modelLoadError={modelLoadError}
         onChoose={chooseModel}
         preparingModel={preparingModel}
@@ -94,16 +118,21 @@ function LaunchExperienceRuntime() {
 }
 
 export function LaunchModelPicker({
+  chainId = 1,
+  onChangeChain,
   modelLoadError = "",
   onChoose,
   preparingModel = null,
 }: {
+  chainId?: ViewChainId;
+  onChangeChain?: (chainId: ViewChainId) => void;
   modelLoadError?: string;
   onChoose: (model: LaunchPickerChoice) => void | Promise<void>;
   preparingModel?: LaunchModel | null;
 }) {
+  const isEthereum = chainId === 1;
   const preloadAvailableForm = () => {
-    void loadLaunchForm();
+    void loadLaunchForm().catch(() => undefined);
   };
 
   const customCardContent = (
@@ -137,14 +166,13 @@ export function LaunchModelPicker({
           className={`launch-model-card-heading ${launchExperience.modelHeading}`}
         >
           <strong id="launch-model-custom-title">Custom V4 Hook</strong>
-          <small data-status="pending">Preflight required</small>
         </span>
         <span
           className={`launch-model-description ${launchExperience.modelDescription}`}
           id="launch-model-custom-description"
         >
-          Upload an exact packed Custom launch, preflight it against Robinhood
-          Chain, then create the request. Your wallet reviews and signs later.
+          Build your own Uniswap v4 hook and submit it with an API key.
+          Your wallet reviews and signs the launch.
         </span>
         <span
           className={`launch-model-action ${launchExperience.modelAction}`}
@@ -163,85 +191,108 @@ export function LaunchModelPicker({
       <header
         className={`launch-model-heading ${launchExperience.pickerHeading}`}
       >
-        <h1>Choose a launch model</h1>
+        <h1>Choose a chain</h1>
+        <fieldset
+          className={launchExperience.chainChoice}
+          disabled={preparingModel !== null}
+        >
+          <legend className="sr-only">Launch chain</legend>
+          {VIEW_CHAIN_OPTIONS.map((chain) => (
+            <label key={chain.id} className={launchExperience.chainOption}>
+              <input
+                className="sr-only"
+                type="radio"
+                name="launch-chain"
+                value={chain.id}
+                checked={chainId === chain.id}
+                onChange={() => onChangeChain?.(chain.id)}
+              />
+              {chain.label}
+            </label>
+          ))}
+        </fieldset>
       </header>
 
-      <div className={`launch-model-grid ${launchExperience.modelGrid}`}>
-        <button
-          className={`launch-model-card ${launchExperience.modelCard} liquid-glass-surface`}
-          data-launch-model-option="classic"
-          data-launch-model-available={classicV3LaunchAvailable}
-          data-launch-model-launchable={classicV3LaunchAvailable}
-          type="button"
-          disabled={!classicV3LaunchAvailable || preparingModel !== null}
-          aria-busy={preparingModel === "classic-v3"}
-          aria-labelledby="launch-model-classic-title"
-          aria-describedby="launch-model-classic-description launch-model-classic-status"
-          onPointerEnter={
-            classicV3LaunchAvailable ? preloadAvailableForm : undefined
-          }
-          onPointerDown={
-            classicV3LaunchAvailable ? preloadAvailableForm : undefined
-          }
-          onFocus={classicV3LaunchAvailable ? preloadAvailableForm : undefined}
-          onClick={() => void onChoose("classic-v3")}
-        >
-          <span
-            className={`launch-model-art launch-model-art-classic ${launchExperience.modelArt} ${launchExperience.classicArt}`}
-            aria-hidden="true"
+      <div
+        className={`launch-model-grid ${launchExperience.modelGrid} ${isEthereum ? "" : launchExperience.singleModelGrid}`}
+      >
+        {isEthereum ? (
+          <button
+            className={`launch-model-card ${launchExperience.modelCard} liquid-glass-surface`}
+            data-launch-model-option="classic"
+            data-launch-model-available={classicV3LaunchAvailable}
+            data-launch-model-launchable={classicV3LaunchAvailable}
+            type="button"
+            disabled={!classicV3LaunchAvailable || preparingModel !== null}
+            aria-busy={preparingModel === "classic-v3"}
+            aria-labelledby="launch-model-classic-title"
+            aria-describedby="launch-model-classic-description launch-model-classic-status"
+            onPointerEnter={
+              classicV3LaunchAvailable ? preloadAvailableForm : undefined
+            }
+            onPointerDown={
+              classicV3LaunchAvailable ? preloadAvailableForm : undefined
+            }
+            onFocus={classicV3LaunchAvailable ? preloadAvailableForm : undefined}
+            onClick={() => void onChoose("classic-v3")}
           >
-            <Image
-              className={launchExperience.artImage}
-              src="/brand/atmosphere/programmable-floral-hooks-v1.avif"
-              alt=""
-              fill
-              sizes="(max-width: 760px) calc(100vw - 32px), (max-width: 1280px) calc((100vw - 96px) / 2), 560px"
-              priority
-            />
-            <Image
-              className={launchExperience.classicLogo}
-              src="/brand/loop/programmable-loop-mark-warm-ivory-v1-1536.png"
-              alt=""
-              width={1536}
-              height={1536}
-              sizes="128px"
-            />
-          </span>
+            <span
+              className={`launch-model-art launch-model-art-classic ${launchExperience.modelArt} ${launchExperience.classicArt}`}
+              aria-hidden="true"
+            >
+              <Image
+                className={launchExperience.artImage}
+                src="/brand/atmosphere/programmable-floral-hooks-v1.avif"
+                alt=""
+                fill
+                sizes="(max-width: 760px) calc(100vw - 32px), (max-width: 1280px) calc((100vw - 96px) / 2), 560px"
+                priority
+              />
+              <Image
+                className={launchExperience.classicLogo}
+                src="/brand/loop/programmable-loop-mark-warm-ivory-v1-1536.png"
+                alt=""
+                width={1536}
+                height={1536}
+                sizes="128px"
+              />
+            </span>
 
-          <span
-            className={`launch-model-card-body ${launchExperience.modelBody}`}
-          >
             <span
-              className={`launch-model-card-heading ${launchExperience.modelHeading}`}
+              className={`launch-model-card-body ${launchExperience.modelBody}`}
             >
-              <strong id="launch-model-classic-title">Classic</strong>
-              <small
-                id="launch-model-classic-status"
-                data-status={classicV3LaunchAvailable ? "ready" : "pending"}
-              >
-                {classicV3LaunchAvailable ? "Ethereum only" : "Unavailable"}
-              </small>
-            </span>
-            <span
-              className={`launch-model-description ${launchExperience.modelDescription}`}
-              id="launch-model-classic-description"
-            >
-              Create a fixed-supply token with permanently locked, one-sided
-              Uniswap v4 liquidity. Set buy and sell fees, reward recipients,
-              and the initial buy before you sign.
-            </span>
-            {classicV3LaunchAvailable ? (
               <span
-                className={`launch-model-action ${launchExperience.modelAction}`}
+                className={`launch-model-card-heading ${launchExperience.modelHeading}`}
               >
-                {preparingModel === "classic-v3"
-                  ? "Opening Classic"
-                  : "Create a Classic coin"}
-                <ArrowRight aria-hidden="true" size={16} />
+                <strong id="launch-model-classic-title">Classic</strong>
+                <small
+                  id="launch-model-classic-status"
+                  data-status={classicV3LaunchAvailable ? "ready" : "pending"}
+                >
+                  {classicV3LaunchAvailable ? "Ethereum only" : "Unavailable"}
+                </small>
               </span>
-            ) : null}
-          </span>
-        </button>
+              <span
+                className={`launch-model-description ${launchExperience.modelDescription}`}
+                id="launch-model-classic-description"
+              >
+                Create a fixed-supply token with permanently locked, one-sided
+                Uniswap v4 liquidity. Set buy and sell fees, reward recipients,
+                and the initial buy before you sign.
+              </span>
+              {classicV3LaunchAvailable ? (
+                <span
+                  className={`launch-model-action ${launchExperience.modelAction}`}
+                >
+                  {preparingModel === "classic-v3"
+                    ? "Opening Classic"
+                    : "Create a Classic coin"}
+                  <ArrowRight aria-hidden="true" size={16} />
+                </span>
+              ) : null}
+            </span>
+          </button>
+        ) : null}
 
         <Link
           className={`launch-model-card ${launchExperience.modelCard} liquid-glass-surface`}
@@ -249,7 +300,7 @@ export function LaunchModelPicker({
           data-launch-model-available="true"
           data-launch-model-entry="api-key-launch"
           data-launch-model-launchable="false"
-          href="/developers/api-keys?start=custom&chainId=4663"
+          href={`/developers/api-keys?start=custom&chainId=${chainId}`}
           aria-labelledby="launch-model-custom-title"
           aria-describedby="launch-model-custom-description"
         >

--- a/components/launch-experience.module.css
+++ b/components/launch-experience.module.css
@@ -2009,7 +2009,7 @@
   background: var(--webde-surface);
   display: inline-flex;
   gap: 4px;
-  margin: 24px 0 0;
+  margin: 0;
   max-width: 100%;
   min-inline-size: 0;
   padding: 4px;
@@ -2022,14 +2022,23 @@
   color: var(--webde-muted);
   cursor: pointer;
   display: flex;
-  flex: 1;
+  flex: none;
   font-size: 14px;
   font-weight: 550;
   justify-content: center;
   min-height: 44px;
-  min-width: 0;
-  padding-inline: 24px;
+  min-width: 44px;
+  padding: 0;
   position: relative;
+}
+
+.chainMark { display: block; height: 20px; width: 20px; }
+.robinhoodMark {
+  background: currentColor;
+  display: block;
+  height: 21px;
+  mask: url("/brand/networks/robinhood-feather-white.svg") center / contain no-repeat;
+  width: 16px;
 }
 
 .chainOption:has(input:checked) {
@@ -2039,8 +2048,14 @@
 }
 
 .chainOption:has(input:focus-visible) {
-  outline: 2px solid var(--focus);
+  outline: 2px solid var(--webde-muted);
   outline-offset: 2px;
+}
+
+@media (forced-colors: active) {
+  .chainOption:has(input:checked) { border-color: Highlight; }
+  .chainOption:has(input:focus-visible) { outline-color: Highlight; }
+  .robinhoodMark { background: CanvasText; forced-color-adjust: none; }
 }
 
 @media (hover: hover) and (pointer: fine) {

--- a/components/launch-experience.module.css
+++ b/components/launch-experience.module.css
@@ -1252,7 +1252,7 @@
 }
 
 .pickerHeading.pickerHeading h1 {
-  font-size: clamp(42px, 5.6vw, 72px);
+  font-size: clamp(36px, 4.6vw, 60px);
   font-weight: 540;
   letter-spacing: -0.035em;
   line-height: 1;
@@ -1262,7 +1262,7 @@
 }
 
 .modelGrid.modelGrid {
-  margin-top: 48px;
+  margin-top: 32px;
 }
 
 .modelLoadError {
@@ -1616,7 +1616,7 @@
 
 @media (max-width: 760px) {
   .pickerHeading.pickerHeading h1 {
-    font-size: clamp(42px, 12vw, 54px);
+    font-size: clamp(36px, 10vw, 48px);
     max-width: 11ch;
   }
 
@@ -1992,21 +1992,79 @@
 .pickerHeading {
   margin: 0;
   max-width: none;
-  text-align: left;
+  text-align: center;
 }
 
 .pickerHeading h1 {
-  font-size: clamp(58px, 6.5vw, 96px);
-  font-weight: 520;
-  letter-spacing: -0.062em;
-  line-height: 0.92;
+  font-size: clamp(36px, 4.6vw, 60px);
+  font-weight: 540;
+  letter-spacing: -0.035em;
+  line-height: 1;
   margin: 0;
+}
+
+.chainChoice {
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  background: var(--webde-surface);
+  display: inline-flex;
+  gap: 4px;
+  margin: 24px 0 0;
+  max-width: 100%;
+  min-inline-size: 0;
+  padding: 4px;
+}
+
+.chainOption {
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: calc(var(--webde-radius-control) - 4px);
+  color: var(--webde-muted);
+  cursor: pointer;
+  display: flex;
+  flex: 1;
+  font-size: 14px;
+  font-weight: 550;
+  justify-content: center;
+  min-height: 44px;
+  min-width: 0;
+  padding-inline: 24px;
+  position: relative;
+}
+
+.chainOption:has(input:checked) {
+  background: var(--webde-surface-raised);
+  border-color: var(--webde-line);
+  color: var(--webde-ink);
+}
+
+.chainOption:has(input:focus-visible) {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .chainOption:hover {
+    color: var(--webde-ink);
+  }
+}
+
+.chainChoice:disabled .chainOption {
+  cursor: default;
+  opacity: 0.6;
 }
 
 .modelGrid {
   gap: 16px;
-  margin-top: 58px;
+  margin-top: 32px;
   max-width: none;
+}
+
+.singleModelGrid {
+  grid-template-columns: minmax(0, 1fr);
+  margin-inline: auto;
+  max-width: 624px;
+  width: 100%;
 }
 
 .modelCard.modelCard {
@@ -2125,7 +2183,7 @@
   }
 
   .pickerHeading h1 {
-    font-size: clamp(44px, 13vw, 60px);
+    font-size: clamp(36px, 10vw, 48px);
     white-space: normal;
   }
 

--- a/components/profile-chain-selector.module.css
+++ b/components/profile-chain-selector.module.css
@@ -1,0 +1,38 @@
+.selector {
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: var(--webde-radius-control);
+  display: flex;
+  gap: 4px;
+  margin: 24px 0;
+  min-inline-size: 0;
+  padding: 4px;
+  width: fit-content;
+}
+
+.option {
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: var(--webde-radius-control);
+  color: var(--webde-muted);
+  cursor: pointer;
+  display: flex;
+  height: 44px;
+  justify-content: center;
+  position: relative;
+  width: 44px;
+}
+
+.option:has(input:checked) { background: var(--webde-surface-raised); border-color: var(--webde-line); color: var(--webde-ink); }
+.option:has(input:focus-visible) { outline: 2px solid var(--webde-muted); outline-offset: 2px; }
+.mark { height: 20px; width: 20px; }
+.robinhood { background: currentColor; height: 21px; mask: url("/brand/networks/robinhood-feather-white.svg") center / contain no-repeat; width: 16px; }
+
+@media (hover: hover) and (pointer: fine) {
+  .option:hover { color: var(--webde-ink); }
+}
+@media (forced-colors: active) {
+  .option:has(input:checked) { border-color: Highlight; }
+  .option:has(input:focus-visible) { outline-color: Highlight; }
+  .robinhood { background: CanvasText; forced-color-adjust: none; }
+}

--- a/components/profile-chain-selector.tsx
+++ b/components/profile-chain-selector.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useId } from "react";
+import { VIEW_CHAIN_OPTIONS, type ViewChainId } from "@/lib/view-chain";
+import styles from "./profile-chain-selector.module.css";
+
+export function ProfileChainSelector({ value, onChange }: {
+  value: ViewChainId;
+  onChange?: (chain: ViewChainId) => void;
+}) {
+  const name = useId();
+  return <fieldset className={styles.selector} disabled={!onChange}>
+    <legend className="sr-only">Profile chain</legend>
+    {VIEW_CHAIN_OPTIONS.map((chain) => <label key={chain.id} className={styles.option} title={chain.label}>
+      <input className="sr-only" type="radio" name={name} value={chain.id}
+        aria-label={chain.label} checked={value === chain.id}
+        onChange={() => onChange?.(chain.id)} />
+      {chain.id === 1 ? <svg className={styles.mark} viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false">
+        <path d="M12 2 5.5 12.2 12 9.25l6.5 2.95L12 2Z" fill="currentColor" />
+        <path d="m5.5 13.35 6.5 3.7 6.5-3.7L12 22 5.5 13.35Z" fill="currentColor" />
+        <path d="m12 9.25-6.5 2.95L12 15.9l6.5-3.7L12 9.25Z" fill="currentColor" />
+      </svg> : <span className={styles.robinhood} aria-hidden="true" />}
+    </label>)}
+  </fieldset>;
+}

--- a/components/profile-entry.tsx
+++ b/components/profile-entry.tsx
@@ -5,6 +5,8 @@ import Image from "next/image";
 import { useSearchParams } from "next/navigation";
 
 import { useWallet } from "@/components/wallet-provider";
+import { useViewChain, type ViewChainId } from "@/components/view-chain";
+import { ProfileChainSelector } from "@/components/profile-chain-selector";
 
 import styles from "./profile-entry.module.css";
 
@@ -42,10 +44,14 @@ function ProfileEntryFrame({
   loading,
   onConnect,
   onPrepareProfile,
+  viewChainId = 1,
+  onChangeChain,
 }: Readonly<{
   loading: boolean;
   onConnect?: () => void;
   onPrepareProfile?: () => void;
+  viewChainId?: ViewChainId;
+  onChangeChain?: (chain: ViewChainId) => void;
 }>) {
   const titleId = loading
     ? "profile-entry-loading-title"
@@ -72,6 +78,7 @@ function ProfileEntryFrame({
           priority
         />
         <h1 id={titleId}>Profile</h1>
+        {onChangeChain ? <ProfileChainSelector value={viewChainId} onChange={onChangeChain} /> : null}
         {loading ? (
           <>
             <span
@@ -113,6 +120,7 @@ export function ProfileEntryLoadingState() {
 export function ProfileEntry() {
   const searchParams = useSearchParams();
   const { connecting, openWallet, wallet } = useWallet();
+  const { viewChainId, setViewChainId } = useViewChain();
   const publicProfileRequested = profileEntryHasPublicAccount(
     searchParams?.getAll("account") ?? [],
   );
@@ -121,10 +129,10 @@ export function ProfileEntry() {
     account: wallet?.account,
     publicProfileRequested,
   })) {
-    return <ProfileView />;
+    return <ProfileView viewChainId={viewChainId} onChangeChain={setViewChainId} />;
   }
 
-  if (connecting) return <ProfileEntryLoadingState />;
+  if (connecting) return <ProfileEntryFrame loading viewChainId={viewChainId} onChangeChain={setViewChainId} />;
 
   function connectWallet() {
     preloadProfileView();
@@ -136,6 +144,8 @@ export function ProfileEntry() {
       loading={false}
       onConnect={connectWallet}
       onPrepareProfile={preloadProfileView}
+      viewChainId={viewChainId}
+      onChangeChain={setViewChainId}
     />
   );
 }

--- a/components/profile-experience.module.css
+++ b/components/profile-experience.module.css
@@ -2087,6 +2087,10 @@
   padding-top: 17px;
 }
 
+.hero.publicHero { align-items: center; min-height: 0; }
+.publicHero .avatar { margin: 0; }
+.publicHero .heroCopy { padding-top: 0; }
+
 .nameRow {
   gap: 14px;
 }

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -18,6 +18,9 @@ import {
 } from "react";
 
 import { useWallet } from "@/components/wallet-provider";
+import type { ViewChainId } from "@/lib/view-chain";
+import { ProfileChainSelector } from "@/components/profile-chain-selector";
+import { RobinhoodProfileLaunches } from "@/components/robinhood-profile-launches";
 import {
   ProfileProjects,
   ProfileProjectsLoadingState,
@@ -351,6 +354,8 @@ export function stockPairedCheckpointAfterReceipt(
 
 export type ProfileViewProps = {
   onchainData?: ProfileOnchainData;
+  viewChainId?: ViewChainId;
+  onChangeChain?: (chain: ViewChainId) => void;
 };
 
 type ProfileWorkspaceSourceStatus =
@@ -1396,7 +1401,8 @@ export function formatBannerPositionStatus(position: {
   )}, ${formatBannerPositionValue("vertical", position.y)}.`;
 }
 
-export function ProfileView({ onchainData }: ProfileViewProps = {}) {
+export function ProfileView({ onchainData, viewChainId = 1, onChangeChain }: ProfileViewProps = {}) {
+  const ethereumView = viewChainId === 1;
   const {
     wallet,
     openWallet,
@@ -1469,7 +1475,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     message: "",
   });
   const liveProfileRefresh = useLiveDataRefresh({
-    enabled: Boolean(account),
+    enabled: Boolean(account) && ethereumView,
     intervalMs: PROFILE_LIVE_REFRESH_INTERVAL_MS,
   });
   const [terminalErrorReadyKey, setTerminalErrorReadyKey] = useState("");
@@ -1628,6 +1634,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     };
   }, [abortTransactionPolls, account]);
 
+  // A view change must not interrupt receipt tracking for an already submitted transaction.
   useEffect(
     () => () => {
       abortTransactionPolls();
@@ -1663,7 +1670,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
 
   useEffect(() => {
     if (onchainData) return;
-    if (!account) return;
+    if (!account || !ethereumView) return;
 
     const controller = new AbortController();
     const confirmedTransactions = new Map(
@@ -1732,10 +1739,11 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     liveProfileRefresh,
     onchainData,
     profileRefresh,
+    ethereumView,
   ]);
 
   useEffect(() => {
-    if (!account || !classicV3ReleaseAvailable) return;
+    if (!account || !ethereumView || !classicV3ReleaseAvailable) return;
     const controller = new AbortController();
     let cancelled = false;
     const cachedProfile = readCachedClassicV3Profile(account);
@@ -1840,10 +1848,11 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     completeProfileRefreshSource,
     liveProfileRefresh,
     profileRefresh,
+    ethereumView,
   ]);
 
   useEffect(() => {
-    if (!account || !deepReleaseAvailable) return;
+    if (!account || !ethereumView || !deepReleaseAvailable) return;
     const controller = new AbortController();
     const confirmedTransactions = new Map(
       confirmedProfileTransactionsRef.current.deep,
@@ -1902,10 +1911,11 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     completeProfileRefreshSource,
     liveProfileRefresh,
     profileRefresh,
+    ethereumView,
   ]);
 
   useEffect(() => {
-    if (!account || !deepV3ReleaseAvailable) return;
+    if (!account || !ethereumView || !deepV3ReleaseAvailable) return;
     const controller = new AbortController();
     void fetchDeepV3CreatorProfile(account, controller.signal)
       .then((data) => {
@@ -1937,10 +1947,11 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     completeProfileRefreshSource,
     liveProfileRefresh,
     profileRefresh,
+    ethereumView,
   ]);
 
   useEffect(() => {
-    if (!account || !stockPairedReleaseAvailable) return;
+    if (!account || !ethereumView || !stockPairedReleaseAvailable) return;
     const controller = new AbortController();
     const confirmedTransactions = new Map(
       confirmedProfileTransactionsRef.current["stock-paired"],
@@ -2000,6 +2011,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     completeProfileRefreshSource,
     liveProfileRefresh,
     profileRefresh,
+    ethereumView,
   ]);
 
   function populateProfileDrafts(profile: typeof savedProfile) {
@@ -2398,7 +2410,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
   );
 
   useEffect(() => {
-    if (!account) return;
+    if (!account || !ethereumView) return;
     let pending: PendingProfileTransactionRecord[] = [];
     try {
       pending = readPendingProfileTransactions(window.localStorage, account);
@@ -2466,6 +2478,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
     account,
     liveProfileRefresh,
     profileRefresh,
+    ethereumView,
     settleSubmittedTransaction,
   ]);
 
@@ -3419,6 +3432,8 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
       <PublicCreatorProfile
         account={publicProfileAccount}
         onConnect={openWallet}
+        viewChainId={viewChainId}
+        onChangeChain={onChangeChain}
       />
     );
   }
@@ -3785,7 +3800,9 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
         </div>
       </section>
 
-      <ProfileProjects
+      <ProfileChainSelector value={viewChainId} onChange={onChangeChain} />
+
+      {ethereumView ? <><ProfileProjects
         key={account?.toLowerCase() ?? "disconnected"}
         classicRewards={
           scopedClassicV3Rewards.status === "ready"
@@ -3829,6 +3846,7 @@ export function ProfileView({ onchainData }: ProfileViewProps = {}) {
         refreshStatusMessage={profileRefreshStatusMessage}
         terminalErrorReady={terminalErrorReady}
       />
+      </> : <RobinhoodProfileLaunches key={account.toLowerCase()} account={account} />}
     </div>
   );
 }
@@ -4677,9 +4695,13 @@ export function ProfileRouterLaunches({
 function PublicCreatorProfile({
   account,
   onConnect,
+  viewChainId,
+  onChangeChain,
 }: {
   account: string;
   onConnect: () => void;
+  viewChainId: ViewChainId;
+  onChangeChain?: (chain: ViewChainId) => void;
 }) {
   const [refreshKey, setRefreshKey] = useState(0);
   const [data, setData] = useState<ProfileOnchainData>(() =>
@@ -4687,6 +4709,7 @@ function PublicCreatorProfile({
   );
 
   useEffect(() => {
+    if (viewChainId !== 1) return;
     const controller = new AbortController();
     queueMicrotask(() => {
       if (!controller.signal.aborted) setData(loadingProfileData(account));
@@ -4710,7 +4733,7 @@ function PublicCreatorProfile({
       },
     );
     return () => controller.abort();
-  }, [account, refreshKey]);
+  }, [account, refreshKey, viewChainId]);
 
   const entries = data.status === "ready"
     ? profileRouterLaunchEntries(
@@ -4743,7 +4766,8 @@ function PublicCreatorProfile({
         </div>
       </section>
 
-      {data.status === "loading" ? (
+      <ProfileChainSelector value={viewChainId} onChange={onChangeChain} />
+      {viewChainId === 4663 ? <RobinhoodProfileLaunches key={account.toLowerCase()} account={account} /> : data.status === "loading" ? (
         <section
           className={`${styles.launchesPanel} ${styles.publicProfileState}`}
           aria-busy="true"

--- a/components/profile-view.tsx
+++ b/components/profile-view.tsx
@@ -4743,7 +4743,7 @@ function PublicCreatorProfile({
 
   return (
     <div className={`${styles.page} page-width`}>
-      <section className={styles.hero} aria-labelledby="public-profile-title">
+      <section className={`${styles.hero} ${styles.publicHero}`} aria-labelledby="public-profile-title">
         <div className={styles.avatar} aria-hidden="true">
           <span>{account.slice(2, 4).toUpperCase()}</span>
         </div>

--- a/components/robinhood-coin-artwork.module.css
+++ b/components/robinhood-coin-artwork.module.css
@@ -12,12 +12,30 @@
   display: block;
   height: 100%;
   object-fit: cover;
+  opacity: 0;
+  transition: opacity 180ms ease-out;
   width: 100%;
 }
 
-.artwork span {
-  color: var(--webde-muted);
-  font-size: clamp(24px, 4vw, 48px);
-  font-weight: 500;
-  letter-spacing: -.04em;
+.artwork img.loaded {
+  opacity: 1;
+}
+
+.artwork[data-loading="true"]::after {
+  animation: pulse 1.6s ease-in-out infinite;
+  background: var(--webde-line);
+  content: "";
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: .25; }
+  50% { opacity: .65; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .artwork img { transition: none; }
+  .artwork[data-loading="true"]::after { animation: none; opacity: .4; }
 }

--- a/components/robinhood-coin-artwork.module.css
+++ b/components/robinhood-coin-artwork.module.css
@@ -1,0 +1,23 @@
+.artwork {
+  align-items: center;
+  aspect-ratio: 1;
+  background: var(--webde-surface-raised);
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+}
+
+.artwork img {
+  display: block;
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.artwork span {
+  color: var(--webde-muted);
+  font-size: clamp(24px, 4vw, 48px);
+  font-weight: 500;
+  letter-spacing: -.04em;
+}

--- a/components/robinhood-coin-artwork.tsx
+++ b/components/robinhood-coin-artwork.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+import { safePublicImageUrl } from "@/lib/safe-public-image-url";
+import { getTokenCardImageSource } from "@/lib/token-image";
+import styles from "./robinhood-coin-artwork.module.css";
+
+export function RobinhoodCoinArtwork({ imageUrl, name, symbol, className = "" }: {
+  imageUrl?: string | null;
+  name: string | null;
+  symbol: string | null;
+  className?: string;
+}) {
+  const [failedSource, setFailedSource] = useState<string | null>(null);
+  const safeSource = safePublicImageUrl(imageUrl);
+  const source = safeSource ? getTokenCardImageSource(safeSource) : null;
+  const initials = (symbol?.trim() || name?.trim() || "?").replace(/^\$/, "").slice(0, 3);
+  return <div className={`${styles.artwork} ${className}`} aria-hidden="true">
+    {source && source !== failedSource ? <Image
+      src={source} alt="" width={600} height={600} unoptimized
+      onError={() => setFailedSource(source)}
+    /> : <span>{initials}</span>}
+  </div>;
+}

--- a/components/robinhood-coin-artwork.tsx
+++ b/components/robinhood-coin-artwork.tsx
@@ -6,20 +6,30 @@ import { safePublicImageUrl } from "@/lib/safe-public-image-url";
 import { getTokenCardImageSource } from "@/lib/token-image";
 import styles from "./robinhood-coin-artwork.module.css";
 
-export function RobinhoodCoinArtwork({ imageUrl, name, symbol, className = "" }: {
+export function RobinhoodCoinArtwork({ imageUrl, loading = false, className = "" }: {
   imageUrl?: string | null;
-  name: string | null;
-  symbol: string | null;
+  loading?: boolean;
   className?: string;
 }) {
-  const [failedSource, setFailedSource] = useState<string | null>(null);
   const safeSource = safePublicImageUrl(imageUrl);
   const source = safeSource ? getTokenCardImageSource(safeSource) : null;
-  const initials = (symbol?.trim() || name?.trim() || "?").replace(/^\$/, "").slice(0, 3);
-  return <div className={`${styles.artwork} ${className}`} aria-hidden="true">
-    {source && source !== failedSource ? <Image
+  return <ArtworkImage key={source} source={source} loading={loading} className={className} />;
+}
+
+function ArtworkImage({ source, loading, className }: {
+  source: string | null;
+  loading: boolean;
+  className: string;
+}) {
+  const [status, setStatus] = useState<"loading" | "ready" | "failed">("loading");
+  const pending = source ? status === "loading" : loading;
+
+  return <div className={`${styles.artwork} ${className}`} data-loading={pending} aria-hidden="true">
+    {source && status !== "failed" ? <Image
       src={source} alt="" width={600} height={600} unoptimized
-      onError={() => setFailedSource(source)}
-    /> : <span>{initials}</span>}
+      className={status === "ready" ? styles.loaded : undefined}
+      onLoad={() => setStatus("ready")}
+      onError={() => setStatus("failed")}
+    /> : null}
   </div>;
 }

--- a/components/robinhood-launches-view.module.css
+++ b/components/robinhood-launches-view.module.css
@@ -39,7 +39,6 @@
 }
 
 .search,
-.refresh,
 .pagination button {
   background: var(--webde-surface);
   border: 1px solid var(--webde-line);
@@ -89,7 +88,6 @@
 }
 
 .clearSearch,
-.refresh,
 .pagination button {
   align-items: center;
   display: inline-flex;
@@ -110,7 +108,6 @@
   width: 44px;
 }
 
-.refresh,
 .pagination button {
   padding: 8px 16px;
 }
@@ -213,7 +210,6 @@
   text-align: center;
 }
 
-.refresh:disabled,
 .pagination button:disabled {
   cursor: default;
   opacity: 0.5;
@@ -221,13 +217,11 @@
 
 .row:active,
 .clearSearch:active,
-.refresh:active:not(:disabled),
 .pagination button:active:not(:disabled) {
   background: var(--webde-surface-raised);
 }
 
 .clearSearch:focus-visible,
-.refresh:focus-visible,
 .pagination button:focus-visible,
 .textButton:focus-visible,
 .row:focus-visible {
@@ -238,7 +232,6 @@
 @media (hover: hover) and (pointer: fine) {
   .row:hover,
   .clearSearch:hover,
-  .refresh:hover:not(:disabled),
   .pagination button:hover:not(:disabled) {
     background: var(--webde-surface-raised);
   }
@@ -271,14 +264,6 @@
     font-size: 16px;
   }
 
-  .refresh {
-    padding-inline: 0;
-  }
-
-  .refresh > span {
-    display: none;
-  }
-
   .list, .skeletonGrid { gap: 12px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .name { font-size: 16px; line-height: 24px; }
   .cardFooter { align-items: start; flex-direction: column; gap: 4px; margin-top: 12px; }
@@ -296,7 +281,6 @@
 
 @media (forced-colors: active) {
   .search,
-  .refresh,
   .list,
   .item,
   .empty,
@@ -307,7 +291,6 @@
   .row:focus-visible,
   .search:focus-within,
   .clearSearch:focus-visible,
-  .refresh:focus-visible,
   .pagination button:focus-visible,
   .textButton:focus-visible {
     outline-color: Highlight;

--- a/components/robinhood-launches-view.module.css
+++ b/components/robinhood-launches-view.module.css
@@ -25,8 +25,9 @@
 
 .body {
   margin-inline: auto;
-  max-width: 1040px;
+  max-width: 1184px;
   min-width: 0;
+  width: 100%;
 }
 
 .toolbar {
@@ -147,92 +148,45 @@
   min-height: 24px;
 }
 
-.list {
-  background: var(--webde-surface);
-  border: 1px solid var(--webde-line);
-  border-radius: var(--webde-radius-card);
+.list,
+.skeletonGrid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(208px, 1fr));
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.item + .item {
-  border-top: 1px solid var(--webde-line);
-}
-
-.item:first-child .row {
-  border-start-start-radius: var(--webde-radius-card);
-  border-start-end-radius: var(--webde-radius-card);
-}
-
-.item:last-child .row {
-  border-end-start-radius: var(--webde-radius-card);
-  border-end-end-radius: var(--webde-radius-card);
-}
+.item { min-width: 0; }
 
 .row {
-  align-items: center;
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: 16px;
   color: var(--webde-ink);
-  display: grid;
-  gap: 24px;
-  grid-template-columns: minmax(0, 1fr) auto 18px;
-  min-height: 104px;
-  padding: 24px;
-  text-decoration: none;
-}
-
-.identity {
-  min-width: 0;
-}
-
-.nameLine {
-  align-items: baseline;
   display: flex;
-  flex-wrap: wrap;
-  gap: 4px 12px;
-  line-height: 1.5;
+  flex-direction: column;
+  height: 100%;
+  padding: 8px;
+  text-decoration: none;
+  transition: background 160ms cubic-bezier(.2,.8,.2,1), border-color 160ms cubic-bezier(.2,.8,.2,1);
 }
 
-.nameLine strong {
-  font-size: 18px;
-  font-weight: 600;
-  overflow-wrap: anywhere;
-}
-
-.symbol,
-.classification,
-.launched,
-.address {
-  color: var(--webde-muted);
-  font-size: 14px;
-  line-height: 1.5;
-}
-
-.symbol {
-  overflow-wrap: anywhere;
-}
-
-.address {
-  display: block;
-  font-family: var(--font-plex-mono), monospace;
-  font-size: 12px;
-  margin-top: 4px;
-  overflow-wrap: anywhere;
-}
-
-.details {
-  display: grid;
-  gap: 4px;
-  text-align: end;
-}
-
-.classification {
-  color: var(--webde-ink);
-}
-
-.rowArrow {
-  color: var(--webde-muted);
-}
+.artwork { border-radius: 8px; width: 100%; }
+.identity { min-width: 0; padding: 12px 4px 0; }
+.name, .symbol { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.name { font-size: 18px; font-weight: 550; line-height: 28px; }
+.symbol { color: var(--webde-muted); font-size: 14px; line-height: 20px; }
+.cardFooter { align-items: flex-end; display: flex; gap: 8px; justify-content: space-between; margin-top: 16px; padding: 0 4px 8px; }
+.marketCap { display: grid; gap: 4px; min-width: 0; }
+.marketCap > span { color: var(--webde-muted); font-size: 12px; line-height: 16px; }
+.marketCap strong { font-size: 18px; font-weight: 500; font-variant-numeric: tabular-nums; line-height: 28px; }
+.launched { color: var(--webde-muted); flex-shrink: 0; font-size: 12px; line-height: 28px; }
+.skeletonCard { background: var(--webde-surface); border: 1px solid var(--webde-line); border-radius: 16px; padding: 8px 8px 24px; }
+.skeletonCard div { aspect-ratio: 1; background: var(--webde-surface-raised); border-radius: 8px; }
+.skeletonCard span { background: var(--webde-surface-raised); border-radius: 4px; display: block; height: 16px; margin: 16px 4px 0; width: 70%; }
+.skeletonCard span:last-child { margin-top: 8px; width: 40%; }
 
 .empty {
   border: 1px solid var(--webde-line);
@@ -351,31 +305,10 @@
     display: none;
   }
 
-  .row {
-    gap: 12px 16px;
-    grid-template-columns: minmax(0, 1fr) 18px;
-    padding: 24px 16px;
-  }
-
-  .details {
-    align-items: baseline;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px 12px;
-    grid-column: 1;
-    text-align: start;
-  }
-
-  .rowArrow {
-    grid-column: 2;
-    grid-row: 1 / 3;
-  }
-
-  .address {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+  .list, .skeletonGrid { gap: 12px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .name { font-size: 16px; line-height: 24px; }
+  .cardFooter { align-items: start; flex-direction: column; gap: 4px; margin-top: 12px; }
+  .launched { line-height: 20px; }
 
   .pagination {
     gap: 8px;
@@ -406,3 +339,5 @@
     outline-color: Highlight;
   }
 }
+
+@media (prefers-reduced-motion: reduce) { .row { transition: none; } }

--- a/components/robinhood-launches-view.module.css
+++ b/components/robinhood-launches-view.module.css
@@ -35,6 +35,7 @@
   display: flex;
   gap: 8px;
   justify-content: center;
+  margin-bottom: 32px;
 }
 
 .search,
@@ -114,38 +115,11 @@
   padding: 8px 16px;
 }
 
-.summary {
-  align-items: baseline;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 24px;
-  justify-content: space-between;
-  margin-top: 32px;
-}
-
-.summary p {
-  align-items: baseline;
-  display: flex;
-  gap: 12px;
-  margin: 0;
-}
-
-.summary strong {
-  font-size: 16px;
-  font-weight: 600;
-}
-
-.summary p > span,
-.updated,
 .status {
   color: var(--webde-muted);
   font-size: 14px;
   line-height: 1.5;
-}
-
-.status {
-  margin: 8px 0 16px;
-  min-height: 24px;
+  margin: 0 0 16px;
 }
 
 .list,

--- a/components/robinhood-launches-view.module.css
+++ b/components/robinhood-launches-view.module.css
@@ -119,8 +119,7 @@
   margin: 0 0 16px;
 }
 
-.list,
-.skeletonGrid {
+.list {
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(auto-fill, minmax(208px, 1fr));
@@ -146,6 +145,8 @@
 
 .artwork { border-radius: 8px; width: 100%; }
 .identity { min-width: 0; padding: 12px 4px 0; }
+.nameRow { align-items: center; display: flex; gap: 8px; min-width: 0; }
+.pin { color: var(--webde-muted); display: inline-flex; flex: none; }
 .name, .symbol { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .name { font-size: 18px; font-weight: 550; line-height: 28px; }
 .symbol { color: var(--webde-muted); font-size: 14px; line-height: 20px; }
@@ -154,10 +155,8 @@
 .marketCap > span { color: var(--webde-muted); font-size: 12px; line-height: 16px; }
 .marketCap strong { font-size: 18px; font-weight: 500; font-variant-numeric: tabular-nums; line-height: 28px; }
 .launched { color: var(--webde-muted); flex-shrink: 0; font-size: 12px; line-height: 28px; }
-.skeletonCard { background: var(--webde-surface); border: 1px solid var(--webde-line); border-radius: 16px; padding: 8px 8px 24px; }
-.skeletonCard div { aspect-ratio: 1; background: var(--webde-surface-raised); border-radius: 8px; }
-.skeletonCard span { background: var(--webde-surface-raised); border-radius: 4px; display: block; height: 16px; margin: 16px 4px 0; width: 70%; }
-.skeletonCard span:last-child { margin-top: 8px; width: 40%; }
+.loading { display: flex; justify-content: center; padding: 24px; }
+.loading span { background: var(--webde-surface-raised); border-radius: 4px; height: 8px; width: 120px; }
 
 .empty {
   border: 1px solid var(--webde-line);
@@ -264,7 +263,7 @@
     font-size: 16px;
   }
 
-  .list, .skeletonGrid { gap: 12px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .list { gap: 12px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .name { font-size: 16px; line-height: 24px; }
   .cardFooter { align-items: start; flex-direction: column; gap: 4px; margin-top: 12px; }
   .launched { line-height: 20px; }

--- a/components/robinhood-launches-view.tsx
+++ b/components/robinhood-launches-view.tsx
@@ -7,6 +7,9 @@ import { useEffect, useId, useRef, useState, type FormEvent } from "react";
 import { ExploreChainSelector } from "@/components/explore-chain-selector";
 import { ExploreIndexResetView } from "@/components/explore-index-reset-view";
 import { useViewChain } from "@/components/view-chain";
+import { RobinhoodCoinArtwork } from "@/components/robinhood-coin-artwork";
+import { useRobinhoodPresentation } from "@/components/use-robinhood-presentation";
+import { coinAge, coinDollars, coinTicker } from "@/lib/robinhood-presentation";
 import styles from "@/components/robinhood-launches-view.module.css";
 
 type Launch = {
@@ -92,10 +95,6 @@ function readResponse(value: unknown): LaunchResponse {
   return value as LaunchResponse;
 }
 
-function shortAddress(address: string) {
-  return `${address.slice(0, 8)}…${address.slice(-6)}`;
-}
-
 function launchTime(value: string | null) {
   return value ? DATE_FORMAT.format(new Date(value)) : "Time unavailable";
 }
@@ -131,6 +130,11 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
   const [snapshot, setSnapshot] = useState<Snapshot | null>(null);
   const [loading, setLoading] = useState(true);
   const [failed, setFailed] = useState(false);
+  const [now, setNow] = useState(Date.now);
+  const presentation = useRobinhoodPresentation(
+    new URLSearchParams({ page: String(request.page), q: request.q }).toString(), enabled, refresh,
+  );
+  const presentations = new Map(presentation.items.map((item) => [item.tokenAddress.toLowerCase(), item]));
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -173,6 +177,7 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
           return { request, data };
         });
         setFailed(false);
+        setNow(Date.now());
       } catch {
         if (!disposed && isVisible()) setFailed(true);
       } finally {
@@ -287,27 +292,34 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
 
         {hasRows ? (
           <ul className={styles.list} aria-label="Robinhood token launches" aria-busy={loading}>
-            {items.map((launch) => (
+            {items.map((launch) => {
+              const details = presentations.get(launch.tokenAddress.toLowerCase());
+              return (
               <li key={launch.launchId} className={styles.item}>
                 <Link className={styles.row} href={`/token/${launch.tokenAddress}?chain=4663`} prefetch={false}>
+                  <RobinhoodCoinArtwork
+                    imageUrl={details?.imageUrl} name={launch.name} symbol={launch.symbol}
+                    className={styles.artwork}
+                  />
                   <div className={styles.identity}>
-                    <div className={styles.nameLine}>
-                      <strong title={launch.name || launch.tokenAddress}>{launch.name?.trim() || shortAddress(launch.tokenAddress)}</strong>
-                      {launch.symbol?.trim() ? <span className={styles.symbol}>{launch.symbol}</span> : null}
+                    <strong className={styles.name} title={launch.name?.trim() || "Unnamed token"}>{launch.name?.trim() || "Unnamed token"}</strong>
+                    <span className={styles.symbol} title={launch.symbol || undefined}>{coinTicker(launch.symbol)}</span>
+                  </div>
+                  <div className={styles.cardFooter}>
+                    <div className={styles.marketCap}>
+                      <span>Market cap</span>
+                      <strong title={details?.market ? `DEX Screener · ${new Date(details.market.observedAt).toUTCString()}` : "Market data is not available yet"}>{coinDollars(details?.market?.marketCapUsd)}</strong>
                     </div>
-                    <span className={styles.address} title={launch.tokenAddress}>{launch.tokenAddress}</span>
+                    {launch.launchedAt ? <time className={styles.launched} dateTime={launch.launchedAt} title={`Launched ${new Date(launch.launchedAt).toUTCString()}`}>{coinAge(launch.launchedAt, now)}</time> : null}
                   </div>
-                  <div className={styles.details}>
-                    <span className={styles.classification}>Programmable Custom</span>
-                    <span className={styles.launched}>
-                      {launch.launchedAt ? <>Launched <time dateTime={launch.launchedAt} title={new Date(launch.launchedAt).toUTCString()}>{launchTime(launch.launchedAt)}</time></> : "Launch time unavailable"}
-                    </span>
-                  </div>
-                  <ChevronRight className={styles.rowArrow} aria-hidden="true" size={18} />
                 </Link>
               </li>
-            ))}
+            );})}
           </ul>
+        ) : loading ? (
+          <div className={styles.skeletonGrid} aria-label="Loading Robinhood launches" role="status">
+            {Array.from({ length: 5 }, (_, index) => <div className={styles.skeletonCard} aria-hidden="true" key={index}><div /><span /><span /></div>)}
+          </div>
         ) : (
           <div className={styles.empty} aria-busy={loading}>
             <StateHeading>{emptyTitle}</StateHeading>

--- a/components/robinhood-launches-view.tsx
+++ b/components/robinhood-launches-view.tsx
@@ -1,15 +1,18 @@
 "use client";
 
 import Link from "next/link";
-import { ChevronLeft, ChevronRight, RefreshCw, Search, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, Search, X } from "lucide-react";
 import { useEffect, useId, useRef, useState, type FormEvent } from "react";
 
 import { ExploreChainSelector } from "@/components/explore-chain-selector";
+import { ExploreFilters } from "@/components/explore-filters";
+import { AnimatedMarketCap } from "@/components/animated-market-cap";
 import { ExploreIndexResetView } from "@/components/explore-index-reset-view";
 import { useViewChain } from "@/components/view-chain";
 import { RobinhoodCoinArtwork } from "@/components/robinhood-coin-artwork";
 import { useRobinhoodPresentation } from "@/components/use-robinhood-presentation";
-import { coinAge, coinDollars, coinTicker } from "@/lib/robinhood-presentation";
+import { coinAge, coinTicker } from "@/lib/robinhood-presentation";
+import { activeExploreFilterCount, DEFAULT_EXPLORE_FILTERS, type RobinhoodExploreFilters } from "@/lib/robinhood-explore-filters";
 import styles from "@/components/robinhood-launches-view.module.css";
 
 type Launch = {
@@ -39,7 +42,7 @@ type LaunchResponse = {
   };
 };
 
-type Request = { page: number; q: string };
+type Request = { page: number; q: string } & RobinhoodExploreFilters;
 type Snapshot = { request: Request; data: LaunchResponse };
 
 const ADDRESS = /^0x[0-9a-f]{40}$/i;
@@ -115,21 +118,20 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
   const statusId = useId();
   const searchRef = useRef<HTMLInputElement>(null);
   const [search, setSearch] = useState("");
-  const [request, setRequest] = useState<Request>({ page: 1, q: "" });
-  const [refresh, setRefresh] = useState(0);
+  const [request, setRequest] = useState<Request>({ page: 1, q: "", ...DEFAULT_EXPLORE_FILTERS });
   const [snapshot, setSnapshot] = useState<Snapshot | null>(null);
   const [loading, setLoading] = useState(true);
   const [failed, setFailed] = useState(false);
   const [now, setNow] = useState(Date.now);
   const presentation = useRobinhoodPresentation(
-    new URLSearchParams({ page: String(request.page), q: request.q }).toString(), enabled, refresh,
+    new URLSearchParams({ page: String(request.page), q: request.q, age: request.age, sort: request.sort }).toString(), enabled,
   );
   const presentations = new Map(presentation.items.map((item) => [item.tokenAddress.toLowerCase(), item]));
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
       const q = search.trim();
-      setRequest((current) => current.q === q ? current : { page: 1, q });
+      setRequest((current) => current.q === q ? current : { ...current, page: 1, q });
     }, 300);
     return () => window.clearTimeout(timer);
   }, [search]);
@@ -149,7 +151,7 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
       setLoading(true);
 
       try {
-        const query = new URLSearchParams({ page: String(request.page), q: request.q });
+        const query = new URLSearchParams({ page: String(request.page), q: request.q, age: request.age, sort: request.sort });
         const response = await fetch(`/api/explore/robinhood?${query}`, {
           signal: activeController.signal,
           cache: "no-store",
@@ -159,7 +161,8 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
         const data = readResponse(await response.json());
         if (disposed || activeController.signal.aborted) return;
         setSnapshot((current) => {
-          const sameRequest = current?.request.page === request.page && current.request.q === request.q;
+          const sameRequest = current?.request.page === request.page && current.request.q === request.q
+            && current.request.age === request.age && current.request.sort === request.sort;
           if (sameRequest && current.data.items.length > 0
             && data.items.length === 0 && data.status !== "ready") {
             return { request, data: { ...current.data, status: data.status } };
@@ -169,20 +172,20 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
         setFailed(false);
         setNow(Date.now());
       } catch {
-        if (!disposed && isVisible()) setFailed(true);
+        if (!disposed && isVisible() && activeController.signal.reason !== "hidden") setFailed(true);
       } finally {
         window.clearTimeout(timeout);
         controller = null;
         if (!disposed) {
           setLoading(false);
-          if (isVisible()) refreshTimer = window.setTimeout(load, REFRESH_MS);
+          if (isVisible()) refreshTimer = window.setTimeout(load, activeController.signal.reason === "hidden" ? 0 : REFRESH_MS);
         }
       }
     }
 
     function visibilityChanged() {
       window.clearTimeout(refreshTimer);
-      if (!isVisible()) controller?.abort();
+      if (!isVisible()) controller?.abort("hidden");
       else void load();
     }
 
@@ -194,23 +197,29 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
       window.clearTimeout(refreshTimer);
       document.removeEventListener("visibilitychange", visibilityChanged);
     };
-  }, [enabled, refresh, request]);
+  }, [enabled, request]);
 
   function submitSearch(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    setRequest({ page: 1, q: search.trim() });
+    setRequest((current) => ({ ...current, page: 1, q: search.trim() }));
   }
 
   function clearSearch() {
     setSearch("");
-    setRequest({ page: 1, q: "" });
+    setRequest((current) => ({ ...current, page: 1, q: "" }));
     searchRef.current?.focus();
+  }
+
+  function applyFilters(filters: RobinhoodExploreFilters) {
+    setRequest((current) => current.age === filters.age && current.sort === filters.sort
+      ? current : { ...current, ...filters, page: 1 });
   }
 
   const data = snapshot?.data;
   const items = data?.items ?? [];
   const hasRows = items.length > 0;
-  const updatingSearch = search.trim() !== snapshot?.request.q;
+  const updatingSearch = search.trim() !== snapshot?.request.q || request.age !== snapshot?.request.age || request.sort !== snapshot?.request.sort;
+  const hasFilters = activeExploreFilterCount(snapshot?.request ?? request) > 0;
   const Heading = embedded ? "h2" : "h1";
   const StateHeading = embedded ? "h3" : "h2";
   const count = data?.page.totalItems ?? 0;
@@ -220,14 +229,14 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
       ? hasRows ? "Showing saved launches. Updates are temporarily unavailable." : "Launches are temporarily unavailable."
       : data?.status === "syncing"
         ? "New launches are being checked."
-        : updatingSearch ? "Loading launches…" : "";
+        : updatingSearch ? "Loading launches…" : presentation.delayed ? "Market data is temporarily delayed." : "";
   const emptyTitle = loading
     ? "Loading Robinhood launches"
     : failed || data?.status === "unavailable" || data?.status === "stale"
       ? "Launches are temporarily unavailable"
       : data?.status === "syncing"
         ? "Checking Robinhood launches"
-        : snapshot?.request.q ? "No matching launches" : "No finalized launches yet";
+        : snapshot?.request.q || hasFilters ? "No matching launches" : "No finalized launches yet";
 
   return (
     <div className={`${styles.page} explore-page page-width`}>
@@ -260,19 +269,10 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
             ) : null}
           </form>
           <ExploreChainSelector />
-          <button
-            className={styles.refresh}
-            type="button"
-            onClick={() => setRefresh((value) => value + 1)}
-            disabled={loading}
-            aria-label="Refresh Robinhood launches"
-          >
-            <RefreshCw aria-hidden="true" size={16} />
-            <span>Refresh</span>
-          </button>
+          <ExploreFilters value={request} onApply={applyFilters} />
         </div>
 
-        <p className={failed || data?.status === "stale" || data?.status === "unavailable" ? styles.status : "sr-only"} id={statusId} role="status">
+        <p className={failed || data?.status === "stale" || data?.status === "unavailable" || presentation.delayed ? styles.status : "sr-only"} id={statusId} role="status">
           {statusText || (data ? <span className="sr-only">{count} {count === 1 ? "launch found" : "launches found"}</span> : null)}
         </p>
 
@@ -292,9 +292,11 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
                     <span className={styles.symbol} title={launch.symbol || undefined}>{coinTicker(launch.symbol)}</span>
                   </div>
                   <div className={styles.cardFooter}>
-                    <div className={styles.marketCap}>
+                    <div className={styles.marketCap} title={details?.market ? `Observed ${new Date(details.market.observedAt).toUTCString()}` : "Market data is not available yet"}>
                       <span>Market cap</span>
-                      <strong title={details?.market ? `DEX Screener · ${new Date(details.market.observedAt).toUTCString()}` : "Market data is not available yet"}>{coinDollars(details?.market?.marketCapUsd)}</strong>
+                      {details?.market?.marketCapUsd != null && Number.isFinite(details.market.marketCapUsd) && details.market.marketCapUsd >= 0
+                        ? <AnimatedMarketCap metric={{ kind: "usd", value: details.market.marketCapUsd }} replayKey={`4663:${launch.tokenAddress.toLowerCase()}:${details.market.poolId.toLowerCase()}:market-cap`} />
+                        : <strong>—</strong>}
                     </div>
                     {launch.launchedAt ? <time className={styles.launched} dateTime={launch.launchedAt} title={`Launched ${new Date(launch.launchedAt).toUTCString()}`}>{coinAge(launch.launchedAt, now)}</time> : null}
                   </div>
@@ -309,8 +311,9 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
         ) : (
           <div className={styles.empty} aria-busy={loading}>
             <StateHeading>{emptyTitle}</StateHeading>
-            <p>{loading || data?.status === "syncing" ? "Verified launches will appear here." : failed || data?.status === "unavailable" || data?.status === "stale" ? "Try refreshing in a moment." : snapshot?.request.q ? "Try a token name, symbol or address." : "New Robinhood launches appear after verification."}</p>
+            <p>{loading || data?.status === "syncing" ? "Verified launches will appear here." : failed || data?.status === "unavailable" || data?.status === "stale" ? "Updates will resume automatically." : snapshot?.request.q || hasFilters ? "Try another search or change the filters." : "New Robinhood launches appear after verification."}</p>
             {!loading && snapshot?.request.q ? <button className={styles.textButton} type="button" onClick={clearSearch}>Clear search</button> : null}
+            {!loading && hasFilters ? <button className={styles.textButton} type="button" onClick={() => applyFilters(DEFAULT_EXPLORE_FILTERS)}>Clear filters</button> : null}
           </div>
         )}
 
@@ -319,13 +322,13 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
             <button
               type="button"
               disabled={loading || data.page.number <= 1 || updatingSearch}
-              onClick={() => setRequest({ page: data.page.number - 1, q: snapshot.request.q })}
+              onClick={() => setRequest({ ...snapshot.request, page: data.page.number - 1 })}
             ><ChevronLeft aria-hidden="true" size={16} /> Previous</button>
             <span>Page {data.page.number} of {data.page.totalPages}</span>
             <button
               type="button"
               disabled={loading || !data.page.hasMore || updatingSearch}
-              onClick={() => setRequest({ page: data.page.number + 1, q: snapshot.request.q })}
+              onClick={() => setRequest({ ...snapshot.request, page: data.page.number + 1 })}
             >Next <ChevronRight aria-hidden="true" size={16} /></button>
           </nav>
         ) : null}

--- a/components/robinhood-launches-view.tsx
+++ b/components/robinhood-launches-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { ChevronLeft, ChevronRight, Search, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, Pin, Search, X } from "lucide-react";
 import { useEffect, useId, useRef, useState, type FormEvent } from "react";
 
 import { ExploreChainSelector } from "@/components/explore-chain-selector";
@@ -10,9 +10,9 @@ import { AnimatedMarketCap } from "@/components/animated-market-cap";
 import { ExploreIndexResetView } from "@/components/explore-index-reset-view";
 import { useViewChain } from "@/components/view-chain";
 import { RobinhoodCoinArtwork } from "@/components/robinhood-coin-artwork";
-import { useRobinhoodPresentation } from "@/components/use-robinhood-presentation";
-import { coinAge, coinTicker } from "@/lib/robinhood-presentation";
+import { coinAge, coinTicker, mergeRobinhoodPresentations, type RobinhoodCoinPresentation } from "@/lib/robinhood-presentation";
 import { activeExploreFilterCount, DEFAULT_EXPLORE_FILTERS, type RobinhoodExploreFilters } from "@/lib/robinhood-explore-filters";
+import { isPinnedRobinhoodToken } from "@/lib/robinhood-explore-policy";
 import styles from "@/components/robinhood-launches-view.module.css";
 
 type Launch = {
@@ -33,6 +33,7 @@ type LaunchResponse = {
   status: "ready" | "syncing" | "stale" | "unavailable";
   updatedAt: string | null;
   items: Launch[];
+  presentations: RobinhoodCoinPresentation[];
   page: {
     number: number;
     size: number;
@@ -48,7 +49,21 @@ type Snapshot = { request: Request; data: LaunchResponse };
 const ADDRESS = /^0x[0-9a-f]{40}$/i;
 const HASH = /^0x[0-9a-f]{64}$/i;
 const REFRESH_MS = 30_000;
-const REQUEST_TIMEOUT_MS = 12_000;
+const REQUEST_TIMEOUT_MS = 15_000;
+
+// Public, browser-only navigation state. Nothing is written during server rendering.
+let rememberedSnapshot: { value: Snapshot; savedAt: number } | null = null;
+function readRememberedSnapshot() {
+  if (typeof window === "undefined" || !rememberedSnapshot || Date.now() - rememberedSnapshot.savedAt >= 300_000) return null;
+  const value = rememberedSnapshot.value;
+  return { ...value, data: { ...value.data,
+    presentations: mergeRobinhoodPresentations([], value.data.presentations).items,
+  } };
+}
+function rememberSnapshot(value: Snapshot) {
+  if (typeof window !== "undefined") rememberedSnapshot = { value, savedAt: Date.now() };
+  return value;
+}
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -79,7 +94,9 @@ function readResponse(value: unknown): LaunchResponse {
   if (!isObject(value) || value.chainId !== 4663
     || !["ready", "syncing", "stale", "unavailable"].includes(String(value.status))
     || !isDate(value.updatedAt) || !Array.isArray(value.items)
-    || value.items.length > 50 || !value.items.every(isLaunch) || !isObject(value.page)) {
+    || value.items.length > 50 || !value.items.every(isLaunch) || !isObject(value.page)
+    || !Array.isArray(value.presentations) || value.presentations.length > 50
+    || !value.presentations.every((item) => isObject(item) && typeof item.tokenAddress === "string" && ADDRESS.test(item.tokenAddress))) {
     throw new Error("Invalid launch response");
   }
   const page = value.page;
@@ -117,16 +134,14 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
   const searchId = useId();
   const statusId = useId();
   const searchRef = useRef<HTMLInputElement>(null);
-  const [search, setSearch] = useState("");
-  const [request, setRequest] = useState<Request>({ page: 1, q: "", ...DEFAULT_EXPLORE_FILTERS });
-  const [snapshot, setSnapshot] = useState<Snapshot | null>(null);
+  const [initial] = useState(readRememberedSnapshot);
+  const [search, setSearch] = useState(initial?.request.q ?? "");
+  const [request, setRequest] = useState<Request>(initial?.request ?? { page: 1, q: "", ...DEFAULT_EXPLORE_FILTERS });
+  const [snapshot, setSnapshot] = useState<Snapshot | null>(initial);
   const [loading, setLoading] = useState(true);
   const [failed, setFailed] = useState(false);
   const [now, setNow] = useState(Date.now);
-  const presentation = useRobinhoodPresentation(
-    new URLSearchParams({ page: String(request.page), q: request.q, age: request.age, sort: request.sort }).toString(), enabled,
-  );
-  const presentations = new Map(presentation.items.map((item) => [item.tokenAddress.toLowerCase(), item]));
+  const presentations = new Map((snapshot?.data.presentations ?? []).map((item) => [item.tokenAddress.toLowerCase(), item]));
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -151,7 +166,7 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
       setLoading(true);
 
       try {
-        const query = new URLSearchParams({ page: String(request.page), q: request.q, age: request.age, sort: request.sort });
+        const query = new URLSearchParams({ page: String(request.page), q: request.q, sort: request.sort });
         const response = await fetch(`/api/explore/robinhood?${query}`, {
           signal: activeController.signal,
           cache: "no-store",
@@ -162,17 +177,26 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
         if (disposed || activeController.signal.aborted) return;
         setSnapshot((current) => {
           const sameRequest = current?.request.page === request.page && current.request.q === request.q
-            && current.request.age === request.age && current.request.sort === request.sort;
+            && current.request.sort === request.sort;
           if (sameRequest && current.data.items.length > 0
             && data.items.length === 0 && data.status !== "ready") {
-            return { request, data: { ...current.data, status: data.status } };
+            return rememberSnapshot({ request, data: { ...current.data, status: data.status,
+              presentations: mergeRobinhoodPresentations(current.data.presentations, null).items,
+            } });
           }
-          return { request, data };
+          return rememberSnapshot({ request, data: { ...data,
+            presentations: mergeRobinhoodPresentations([], data.presentations).items,
+          } });
         });
         setFailed(false);
         setNow(Date.now());
       } catch {
-        if (!disposed && isVisible() && activeController.signal.reason !== "hidden") setFailed(true);
+        if (!disposed && isVisible() && activeController.signal.reason !== "hidden") {
+          setFailed(true);
+          setSnapshot((current) => current ? rememberSnapshot({ ...current, data: { ...current.data,
+            presentations: mergeRobinhoodPresentations(current.data.presentations, null).items,
+          } }) : null);
+        }
       } finally {
         window.clearTimeout(timeout);
         controller = null;
@@ -211,14 +235,14 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
   }
 
   function applyFilters(filters: RobinhoodExploreFilters) {
-    setRequest((current) => current.age === filters.age && current.sort === filters.sort
+    setRequest((current) => current.sort === filters.sort
       ? current : { ...current, ...filters, page: 1 });
   }
 
   const data = snapshot?.data;
   const items = data?.items ?? [];
   const hasRows = items.length > 0;
-  const updatingSearch = search.trim() !== snapshot?.request.q || request.age !== snapshot?.request.age || request.sort !== snapshot?.request.sort;
+  const updatingSearch = search.trim() !== snapshot?.request.q || request.sort !== snapshot?.request.sort;
   const hasFilters = activeExploreFilterCount(snapshot?.request ?? request) > 0;
   const Heading = embedded ? "h2" : "h1";
   const StateHeading = embedded ? "h3" : "h2";
@@ -229,7 +253,7 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
       ? hasRows ? "Showing saved launches. Updates are temporarily unavailable." : "Launches are temporarily unavailable."
       : data?.status === "syncing"
         ? "New launches are being checked."
-        : updatingSearch ? "Loading launches…" : presentation.delayed ? "Market data is temporarily delayed." : "";
+        : updatingSearch ? "Loading launches…" : "";
   const emptyTitle = loading
     ? "Loading Robinhood launches"
     : failed || data?.status === "unavailable" || data?.status === "stale"
@@ -272,8 +296,8 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
           <ExploreFilters value={request} onApply={applyFilters} />
         </div>
 
-        <p className={failed || data?.status === "stale" || data?.status === "unavailable" || presentation.delayed ? styles.status : "sr-only"} id={statusId} role="status">
-          {statusText || (data ? <span className="sr-only">{count} {count === 1 ? "launch found" : "launches found"}</span> : null)}
+        <p className="sr-only" id={statusId} role="status">
+          {statusText || (data ? `${count} ${count === 1 ? "token" : "tokens"} displayed` : null)}
         </p>
 
         {hasRows ? (
@@ -284,11 +308,14 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
               <li key={launch.launchId} className={styles.item}>
                 <Link className={styles.row} href={`/token/${launch.tokenAddress}?chain=4663`} prefetch={false}>
                   <RobinhoodCoinArtwork
-                    imageUrl={details?.imageUrl} loading={presentation.loading}
+                    imageUrl={details?.imageUrl} loading={loading && !details}
                     className={styles.artwork}
                   />
                   <div className={styles.identity}>
-                    <strong className={styles.name} title={launch.name?.trim() || "Unnamed token"}>{launch.name?.trim() || "Unnamed token"}</strong>
+                    <div className={styles.nameRow}>
+                      <strong className={styles.name} title={launch.name?.trim() || "Unnamed token"}>{launch.name?.trim() || "Unnamed token"}</strong>
+                      {isPinnedRobinhoodToken(launch.tokenAddress) ? <span className={styles.pin} title="Pinned"><Pin size={14} aria-hidden="true" /><span className="sr-only">Pinned</span></span> : null}
+                    </div>
                     <span className={styles.symbol} title={launch.symbol || undefined}>{coinTicker(launch.symbol)}</span>
                   </div>
                   <div className={styles.cardFooter}>
@@ -305,9 +332,7 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
             );})}
           </ul>
         ) : loading ? (
-          <div className={styles.skeletonGrid} aria-label="Loading Robinhood launches" role="status">
-            {Array.from({ length: 5 }, (_, index) => <div className={styles.skeletonCard} aria-hidden="true" key={index}><div /><span /><span /></div>)}
-          </div>
+          <div className={styles.loading} aria-label="Loading Robinhood launches" role="status"><span aria-hidden="true" /></div>
         ) : (
           <div className={styles.empty} aria-busy={loading}>
             <StateHeading>{emptyTitle}</StateHeading>

--- a/components/robinhood-launches-view.tsx
+++ b/components/robinhood-launches-view.tsx
@@ -46,12 +46,6 @@ const ADDRESS = /^0x[0-9a-f]{40}$/i;
 const HASH = /^0x[0-9a-f]{64}$/i;
 const REFRESH_MS = 30_000;
 const REQUEST_TIMEOUT_MS = 12_000;
-const DATE_FORMAT = new Intl.DateTimeFormat("en-GB", {
-  day: "numeric",
-  month: "short",
-  hour: "2-digit",
-  minute: "2-digit",
-});
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -93,10 +87,6 @@ function readResponse(value: unknown): LaunchResponse {
     throw new Error("Invalid launch pagination");
   }
   return value as LaunchResponse;
-}
-
-function launchTime(value: string | null) {
-  return value ? DATE_FORMAT.format(new Date(value)) : "Time unavailable";
 }
 
 export function RobinhoodLaunchesView({
@@ -282,11 +272,7 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
           </button>
         </div>
 
-        <div className={styles.summary}>
-          <p><strong>Robinhood</strong>{data && (data.status === "ready" || hasRows) ? <span>{count} {count === 1 ? "token" : "tokens"}</span> : null}</p>
-          {data?.updatedAt ? <span className={styles.updated}>Updated <time dateTime={data.updatedAt}>{launchTime(data.updatedAt)}</time></span> : null}
-        </div>
-        <p className={styles.status} id={statusId} role="status">
+        <p className={failed || data?.status === "stale" || data?.status === "unavailable" ? styles.status : "sr-only"} id={statusId} role="status">
           {statusText || (data ? <span className="sr-only">{count} {count === 1 ? "launch found" : "launches found"}</span> : null)}
         </p>
 

--- a/components/robinhood-launches-view.tsx
+++ b/components/robinhood-launches-view.tsx
@@ -284,7 +284,7 @@ function RobinhoodLaunchList({ embedded, enabled }: { embedded: boolean; enabled
               <li key={launch.launchId} className={styles.item}>
                 <Link className={styles.row} href={`/token/${launch.tokenAddress}?chain=4663`} prefetch={false}>
                   <RobinhoodCoinArtwork
-                    imageUrl={details?.imageUrl} name={launch.name} symbol={launch.symbol}
+                    imageUrl={details?.imageUrl} loading={presentation.loading}
                     className={styles.artwork}
                   />
                   <div className={styles.identity}>

--- a/components/robinhood-profile-launches.module.css
+++ b/components/robinhood-profile-launches.module.css
@@ -1,0 +1,25 @@
+.panel { border: 1px solid var(--webde-line); border-radius: var(--webde-radius-card); background: var(--webde-surface); margin-top: 20px; overflow: hidden; }
+.heading { padding: 20px 22px 12px; }
+.heading h2 { color: var(--webde-ink); font-size: 18px; font-weight: 550; margin: 0; }
+.list { list-style: none; margin: 0; padding: 0 12px 12px; }
+.row { align-items: center; border-radius: var(--webde-radius-control); display: flex; gap: 14px; min-height: 88px; padding: 12px 10px; }
+.artwork { border-radius: var(--webde-radius-control); flex: none; height: 56px; width: 56px; }
+.identity { display: grid; gap: 4px; min-width: 0; }
+.identity strong { color: var(--webde-ink); font-size: 16px; font-weight: 550; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.identity small, .metrics small, .metrics time { color: var(--webde-muted); font-size: 12px; }
+.metrics { display: grid; flex: none; gap: 3px; margin-left: auto; text-align: right; }
+.metrics strong { color: var(--webde-ink); font-size: 15px; font-variant-numeric: tabular-nums; }
+.empty { color: var(--webde-muted); padding: 8px 22px 24px; }
+.empty p { margin: 0 0 12px; }
+.empty a, .empty button, .pagination button { align-items: center; background: var(--webde-surface-raised); border: 1px solid var(--webde-line); border-radius: var(--webde-radius-control); color: var(--webde-ink); cursor: pointer; display: inline-flex; justify-content: center; min-height: 44px; padding: 10px 14px; }
+.pagination { align-items: center; display: flex; gap: 14px; justify-content: flex-end; padding: 0 22px 20px; }
+.pagination span { color: var(--webde-muted); font-size: 13px; font-variant-numeric: tabular-nums; }
+.pagination button:disabled { cursor: default; opacity: .4; }
+.row:focus-visible, .panel a:focus-visible, .panel button:focus-visible { outline: 2px solid var(--webde-muted); outline-offset: 2px; }
+.loading { padding: 16px 22px 24px; }
+.loading span { animation: pulse 1.5s ease-in-out infinite; background: var(--webde-surface-raised); border-radius: var(--webde-radius-control); display: block; height: 64px; }
+@keyframes pulse { 50% { opacity: .4; } }
+@media (hover: hover) and (pointer: fine) { .row:hover { background: var(--webde-surface-raised); } }
+@media (max-width: 480px) { .row { gap: 10px; } .identity strong { font-size: 14px; } .artwork { height: 44px; width: 44px; } .metrics strong { font-size: 13px; } }
+@media (prefers-reduced-motion: reduce) { .loading span { animation: none; } }
+@media (forced-colors: active) { .panel { border-color: CanvasText; } .row:focus-visible, .panel a:focus-visible, .panel button:focus-visible { outline-color: Highlight; } }

--- a/components/robinhood-profile-launches.tsx
+++ b/components/robinhood-profile-launches.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import Link from "next/link";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useEffect, useState } from "react";
+import { AnimatedMarketCap } from "@/components/animated-market-cap";
+import { RobinhoodCoinArtwork } from "@/components/robinhood-coin-artwork";
+import { useLiveDataRefresh } from "@/components/use-live-data-refresh";
+import { useRobinhoodPresentation } from "@/components/use-robinhood-presentation";
+import { readRobinhoodProfileResponse } from "@/lib/profile/robinhood-profile";
+import type { RobinhoodProfileLaunchList } from "@/lib/robinhood-launches";
+import { coinAge, coinTicker } from "@/lib/robinhood-presentation";
+import styles from "./robinhood-profile-launches.module.css";
+
+const snapshots = new Map<string, { data: RobinhoodProfileLaunchList; savedAt: number }>();
+const cacheKey = (account: string, page: number) => `4663:${account.toLowerCase()}:${page}`;
+function remembered(account: string) {
+  if (typeof window === "undefined") return null;
+  const saved = snapshots.get(cacheKey(account, 1));
+  return saved && Date.now() - saved.savedAt < 300_000 ? saved.data : null;
+}
+
+export function RobinhoodProfileLaunches({ account }: { account: string }) {
+  const [page, setPage] = useState(1);
+  const [data, setData] = useState(() => remembered(account));
+  const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+  const [retry, setRetry] = useState(0);
+  const [now, setNow] = useState(Date.now);
+  const refresh = useLiveDataRefresh({ intervalMs: 30_000 });
+  const scoped = data?.account === account.toLowerCase() ? data : null;
+  const items = scoped?.items ?? [];
+  const shownPage = scoped?.page.number ?? page;
+  const presentationQuery = new URLSearchParams({ account: account.toLowerCase(), page: String(shownPage) }).toString();
+  const presentation = useRobinhoodPresentation(presentationQuery, items.length > 0);
+  const details = new Map(presentation.items.map((item) => [item.tokenAddress.toLowerCase(), item]));
+
+  useEffect(() => {
+    let disposed = false;
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 10_000);
+    queueMicrotask(() => { if (!controller.signal.aborted) setLoading(true); });
+    const query = new URLSearchParams({ account: account.toLowerCase(), page: String(page) });
+    void fetch(`/api/profile/robinhood?${query}`, { signal: controller.signal, headers: { accept: "application/json" } })
+      .then(async (response) => {
+        if (!response.ok) throw new Error("Profile unavailable");
+        return readRobinhoodProfileResponse(await response.json(), account);
+      })
+      .then((next) => {
+        if (controller.signal.aborted) return;
+        if (next.status === "unavailable") throw new Error("Profile unavailable");
+        setData(next);
+        setFailed(false);
+        setNow(Date.now());
+        const key = cacheKey(account, next.page.number);
+        snapshots.delete(key);
+        snapshots.set(key, { data: next, savedAt: Date.now() });
+        while (snapshots.size > 8) snapshots.delete(snapshots.keys().next().value!);
+      })
+      .catch(() => { if (!disposed) setFailed(true); })
+      .finally(() => { window.clearTimeout(timeout); if (!disposed) setLoading(false); });
+    return () => { disposed = true; window.clearTimeout(timeout); controller.abort(); };
+  }, [account, page, refresh, retry]);
+
+  return <section className={styles.panel} aria-labelledby="robinhood-profile-launches-title">
+    <header className={styles.heading}>
+      <h2 id="robinhood-profile-launches-title">Launches</h2>
+      <span className="sr-only">Robinhood</span>
+    </header>
+    {items.length ? <ul className={styles.list} aria-busy={loading}>
+      {items.map((launch) => {
+        const detail = details.get(launch.tokenAddress.toLowerCase());
+        return <li key={launch.launchId}>
+          <Link className={styles.row} href={`/token/${launch.tokenAddress}?chain=4663`} prefetch={false}>
+            <RobinhoodCoinArtwork className={styles.artwork} imageUrl={detail?.imageUrl} loading={presentation.loading && !detail} />
+            <span className={styles.identity}><strong>{launch.name?.trim() || "Unnamed token"}</strong><small>{coinTicker(launch.symbol)}</small></span>
+            <span className={styles.metrics}>
+              {detail?.market?.marketCapUsd != null ? <><small>Market cap</small><AnimatedMarketCap metric={{ kind: "usd", value: detail.market.marketCapUsd }} replayKey={`profile:4663:${launch.tokenAddress.toLowerCase()}`} /></> : null}
+              {launch.launchedAt ? <time dateTime={launch.launchedAt}>{coinAge(launch.launchedAt, now)}</time> : null}
+            </span>
+          </Link>
+        </li>;
+      })}
+    </ul> : loading && !scoped ? <div className={styles.loading} role="status" aria-label="Loading launches"><span aria-hidden="true" /></div>
+      : failed || scoped?.status === "stale" ? <div className={styles.empty}><p>Couldn’t load launches.</p><button type="button" onClick={() => setRetry((value) => value + 1)}>Try again</button></div>
+      : <div className={styles.empty}><p>{scoped?.status === "syncing" ? "Checking launches…" : "No launches yet."}</p><Link href="/launch">Create a token</Link></div>}
+    {scoped && scoped.page.totalPages > 1 ? <nav className={styles.pagination} aria-label="Profile launch pages">
+      <button type="button" aria-label="Previous page" disabled={loading || shownPage <= 1} onClick={() => setPage(shownPage - 1)}><ChevronLeft size={18} aria-hidden="true" /></button>
+      <span>{shownPage} / {scoped.page.totalPages}</span>
+      <button type="button" aria-label="Next page" disabled={loading || !scoped.page.hasMore} onClick={() => setPage(shownPage + 1)}><ChevronRight size={18} aria-hidden="true" /></button>
+    </nav> : null}
+  </section>;
+}

--- a/components/robinhood-token-view.module.css
+++ b/components/robinhood-token-view.module.css
@@ -1,19 +1,83 @@
-.page { color: var(--webde-ink); min-height: calc(100svh - var(--header-height)); padding-block: 32px 80px; }
-.back { align-items: center; color: var(--webde-muted); display: inline-flex; font-size: 14px; min-height: 44px; text-decoration: none; }
-.content { margin: 44px auto 0; max-width: 800px; min-width: 0; }
-.network { color: var(--webde-muted); font-size: 14px; margin: 0 0 12px; }
-.content h1 { font-size: clamp(32px, 5vw, 52px); font-weight: 500; letter-spacing: -.035em; line-height: 1.1; margin: 0; overflow-wrap: anywhere; }
-.symbol { color: var(--webde-muted); font-size: 20px; margin: 10px 0 0; overflow-wrap: anywhere; }
-.stamp { border: 1px solid var(--webde-line); border-radius: var(--webde-radius-control); display: inline-block; font-size: 12px; margin: 24px 0 0; padding: 7px 10px; }
-.description, .notice, .note { color: var(--webde-muted); font-size: 15px; line-height: 1.6; max-width: 60ch; }
-.description { margin: 16px 0 28px; }
-.notice { margin: 0 0 24px; }
-.facts { margin: 0; }
-.facts > div { border-top: 1px solid var(--webde-line); display: grid; gap: 16px; grid-template-columns: 150px minmax(0, 1fr); padding-block: 18px; }
-.facts dt { color: var(--webde-muted); font-size: 13px; }
-.facts dd { font-family: var(--font-plex-mono), monospace; font-size: 12px; line-height: 1.65; margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.page { color: var(--webde-ink); min-height: calc(100svh - var(--header-height)); padding-block: 24px 80px; }
+.back { align-items: center; color: var(--webde-muted); display: inline-flex; font-size: 14px; gap: 8px; min-height: 44px; text-decoration: none; }
+.header { align-items: center; display: flex; gap: 24px; justify-content: space-between; margin-block: 24px 32px; }
+.identity { align-items: center; display: flex; gap: 16px; min-width: 0; }
+.avatar { border-radius: 16px; flex: none; width: 64px; }
+.identityText { min-width: 0; }
+.identityText h1 { font-size: 30px; font-weight: 550; letter-spacing: -.035em; line-height: 36px; margin: 0; overflow-wrap: anywhere; }
+.identityText p { color: var(--webde-muted); display: flex; flex-wrap: wrap; font-size: 14px; gap: 16px; line-height: 20px; margin: 8px 0 0; overflow-wrap: anywhere; }
+.headerActions { align-items: center; display: flex; flex-shrink: 0; gap: 8px; }
+.secondaryButton, .primaryButton { align-items: center; border: 1px solid var(--webde-line); border-radius: 8px; cursor: pointer; display: inline-flex; font: inherit; font-size: 14px; gap: 8px; justify-content: center; min-height: 44px; padding: 8px 12px; text-decoration: none; }
+.secondaryButton { background: var(--webde-surface); color: var(--webde-ink); }
+.layout { align-items: start; display: grid; gap: 24px; grid-template-columns: minmax(0, 1fr) 320px; }
+.market { background: var(--webde-surface); border: 1px solid var(--webde-line); border-radius: 16px; min-width: 0; overflow: hidden; padding: 24px; }
+.metrics { display: grid; gap: 16px; grid-template-columns: repeat(3, minmax(0, 1fr)); margin: 0; }
+.metrics dt, .label, .tradeFacts dt { color: var(--webde-muted); font-size: 12px; line-height: 16px; }
+.metrics dd { font-size: 18px; font-variant-numeric: tabular-nums; line-height: 28px; margin: 4px 0 0; }
+.priceHeading { align-items: end; display: flex; flex-wrap: wrap; gap: 16px; justify-content: space-between; padding-block: 32px 24px; }
+.price { font-size: 36px; font-variant-numeric: tabular-nums; font-weight: 500; letter-spacing: -.04em; line-height: 40px; margin: 4px 0 0; }
+.change { font-size: 14px; font-variant-numeric: tabular-nums; line-height: 20px; margin: 0 0 4px; }
+.change[data-direction="up"] { color: #9dddbe; }
+.change[data-direction="down"] { color: #f6a1ac; }
+.change span { color: var(--webde-muted); margin-left: 4px; }
+.chart { background: var(--webde-surface); border: 1px solid var(--webde-line); border-radius: 8px; height: 480px; overflow: hidden; position: relative; }
+.chart iframe { border: 0; height: 100%; position: relative; width: 100%; }
+.chartState { align-items: center; display: flex; flex-direction: column; height: 100%; justify-content: center; inset: 0; padding: 32px; position: absolute; text-align: center; }
+.chartState strong { font-size: 18px; font-weight: 500; line-height: 28px; }
+.chartState p { color: var(--webde-muted); font-size: 14px; line-height: 20px; margin: 8px 0 0; max-width: 32ch; text-wrap: pretty; }
+.chartFooter { align-items: center; color: var(--webde-muted); display: flex; flex-wrap: wrap; font-size: 12px; gap: 8px 16px; justify-content: space-between; line-height: 16px; margin-top: 12px; }
+.chartFooter a { align-items: center; color: inherit; display: inline-flex; gap: 8px; min-height: 24px; text-decoration: none; }
+.trade { background: var(--webde-surface); border: 1px solid var(--webde-line); border-radius: 16px; min-width: 0; padding: 24px; }
+.trade h2 { font-size: 20px; font-weight: 500; line-height: 28px; margin: 0 0 24px; }
+.tradeToken { align-items: center; display: flex; gap: 12px; }
+.tradeAvatar { border-radius: 8px; flex: none; width: 48px; }
+.tradeToken > div:last-child { min-width: 0; }
+.tradeToken strong, .tradeToken span { display: block; overflow-wrap: anywhere; }
+.tradeToken strong { font-size: 16px; font-weight: 500; line-height: 24px; }
+.tradeToken span { color: var(--webde-muted); font-size: 14px; line-height: 20px; margin-top: 4px; }
+.tradeDescription { color: var(--webde-muted); font-size: 14px; line-height: 20px; margin: 24px 0; text-wrap: pretty; }
+.primaryButton { background: var(--webde-ink); border-color: var(--webde-ink); color: var(--webde-canvas); font-weight: 550; width: 100%; }
+.tradeUnavailable { color: var(--webde-muted); font-size: 14px; line-height: 20px; margin: 0; }
+.tradeFacts { display: grid; gap: 12px; margin: 24px 0 0; }
+.tradeFacts > div { align-items: baseline; display: flex; gap: 12px; justify-content: space-between; }
+.tradeFacts dd { font-size: 12px; line-height: 16px; margin: 0; }
+.about { margin-top: 32px; max-width: 800px; }
+.about h2 { font-size: 18px; font-weight: 500; line-height: 28px; margin: 0; overflow-wrap: anywhere; }
+.about p { color: var(--webde-muted); font-size: 14px; line-height: 20px; margin: 8px 0 0; overflow-wrap: anywhere; text-wrap: pretty; white-space: pre-line; }
+.links { display: flex; flex-wrap: wrap; gap: 8px 24px; margin-top: 16px; }
+.links a, .empty a { align-items: center; color: var(--webde-ink); display: inline-flex; font-size: 14px; gap: 4px; min-height: 44px; text-decoration: none; }
+.provenance { border: 1px solid var(--webde-line); border-radius: 8px; margin-top: 32px; padding: 0 16px; }
+.provenance summary { align-items: center; cursor: pointer; font-size: 14px; min-height: 56px; padding-block: 16px; }
+.provenance summary span { color: var(--webde-muted); float: right; font-size: 12px; line-height: 20px; }
+.facts { margin: 0; padding-block: 8px 24px; }
+.facts > div { display: grid; gap: 16px; grid-template-columns: 160px minmax(0, 1fr); padding-block: 8px; }
+.facts dt { color: var(--webde-muted); font-size: 12px; line-height: 20px; }
+.facts dd { font-family: var(--font-plex-mono), monospace; font-size: 12px; line-height: 20px; margin: 0; min-width: 0; overflow-wrap: anywhere; }
 .facts a { color: inherit; text-decoration-color: var(--webde-line); text-underline-offset: 4px; }
-.back:focus-visible, .facts a:focus-visible { outline: 2px solid var(--webde-ink); outline-offset: 4px; }
-.note { border-top: 1px solid var(--webde-line); font-size: 13px; margin: 0; max-width: none; padding-top: 22px; }
-@media (hover: hover) { .back:hover, .facts a:hover { color: var(--webde-ink); text-decoration-color: currentColor; } }
-@media (max-width: 600px) { .content { margin-top: 30px; } .facts > div { gap: 8px; grid-template-columns: minmax(0, 1fr); } }
+.notice { color: var(--webde-muted); font-size: 14px; line-height: 20px; margin: 0 0 24px; }
+.empty { margin: 64px auto; max-width: 640px; }
+.empty h1 { font-size: 30px; font-weight: 500; line-height: 36px; }
+.empty p { color: var(--webde-muted); font-size: 16px; line-height: 24px; }
+.page :is(a, button, summary, iframe):focus-visible { outline: 2px solid var(--webde-ink); outline-offset: 4px; }
+@media (hover: hover) and (pointer: fine) { .back:hover, .links a:hover, .chartFooter a:hover { color: var(--webde-ink); text-decoration: underline; text-underline-offset: 4px; } .secondaryButton:hover { background: var(--webde-surface-raised); } .primaryButton:hover { background: #e7e7e5; } }
+.secondaryButton:active, .primaryButton:active { transform: translateY(1px); }
+@media (max-width: 1020px) { .layout { gap: 16px; grid-template-columns: minmax(0, 1fr) 280px; } .market, .trade { padding: 16px; } }
+@media (max-width: 800px) {
+  .page { padding-bottom: 48px; }
+  .header { align-items: flex-start; flex-direction: column; gap: 16px; margin-block: 16px 24px; }
+  .identityText h1 { font-size: 24px; line-height: 32px; }
+  .avatar { width: 48px; border-radius: 8px; }
+  .headerActions { flex-wrap: wrap; }
+  .layout { grid-template-columns: minmax(0, 1fr); }
+  .market { padding: 16px; }
+  .metrics { gap: 8px; }
+  .metrics dd { font-size: 16px; line-height: 24px; }
+  .priceHeading { padding-block: 24px 16px; }
+  .price { font-size: 30px; line-height: 36px; }
+  .chart { height: 400px; }
+  .trade { padding: 24px; }
+  .trade h2 { margin-bottom: 16px; }
+  .facts > div { gap: 4px; grid-template-columns: minmax(0, 1fr); }
+  .provenance summary span { display: none; }
+}
+@media (max-width: 360px) { .metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); row-gap: 16px; } .chart { height: 360px; } }

--- a/components/robinhood-token-view.module.css
+++ b/components/robinhood-token-view.module.css
@@ -108,6 +108,7 @@
   margin: 24px 0;
 }
 .metrics > div { min-width: 0; }
+.metrics dd strong { font: inherit; }
 .metrics dt { color: var(--webde-muted); font-size: 12px; line-height: 16px; }
 .metrics dd {
   font-size: 20px;

--- a/components/robinhood-token-view.module.css
+++ b/components/robinhood-token-view.module.css
@@ -1,83 +1,177 @@
-.page { color: var(--webde-ink); min-height: calc(100svh - var(--header-height)); padding-block: 24px 80px; }
-.back { align-items: center; color: var(--webde-muted); display: inline-flex; font-size: 14px; gap: 8px; min-height: 44px; text-decoration: none; }
-.header { align-items: center; display: flex; gap: 24px; justify-content: space-between; margin-block: 24px 32px; }
-.identity { align-items: center; display: flex; gap: 16px; min-width: 0; }
-.avatar { border-radius: 16px; flex: none; width: 64px; }
+.page {
+  color: var(--webde-ink);
+  min-height: calc(100svh - var(--header-height));
+  padding-block: 16px 48px;
+}
+
+.back {
+  align-items: center;
+  color: var(--webde-muted);
+  display: inline-flex;
+  font-size: 14px;
+  gap: 8px;
+  min-height: 44px;
+  text-decoration: none;
+}
+
+.market {
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: 16px;
+  margin-top: 16px;
+  min-width: 0;
+  padding: 24px;
+}
+
+.header {
+  align-items: flex-start;
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+}
+
+.identity {
+  align-items: flex-start;
+  display: flex;
+  gap: 16px;
+  min-width: 0;
+}
+
+.avatar { border-radius: 8px; flex: none; margin-top: 4px; width: 64px; }
 .identityText { min-width: 0; }
-.identityText h1 { font-size: 30px; font-weight: 550; letter-spacing: -.035em; line-height: 36px; margin: 0; overflow-wrap: anywhere; }
-.identityText p { color: var(--webde-muted); display: flex; flex-wrap: wrap; font-size: 14px; gap: 16px; line-height: 20px; margin: 8px 0 0; overflow-wrap: anywhere; }
-.headerActions { align-items: center; display: flex; flex-shrink: 0; gap: 8px; }
-.secondaryButton, .primaryButton { align-items: center; border: 1px solid var(--webde-line); border-radius: 8px; cursor: pointer; display: inline-flex; font: inherit; font-size: 14px; gap: 8px; justify-content: center; min-height: 44px; padding: 8px 12px; text-decoration: none; }
-.secondaryButton { background: var(--webde-surface); color: var(--webde-ink); }
-.layout { align-items: start; display: grid; gap: 24px; grid-template-columns: minmax(0, 1fr) 320px; }
-.market { background: var(--webde-surface); border: 1px solid var(--webde-line); border-radius: 16px; min-width: 0; overflow: hidden; padding: 24px; }
-.metrics { display: grid; gap: 16px; grid-template-columns: repeat(3, minmax(0, 1fr)); margin: 0; }
-.metrics dt, .label, .tradeFacts dt { color: var(--webde-muted); font-size: 12px; line-height: 16px; }
-.metrics dd { font-size: 18px; font-variant-numeric: tabular-nums; line-height: 28px; margin: 4px 0 0; }
-.priceHeading { align-items: end; display: flex; flex-wrap: wrap; gap: 16px; justify-content: space-between; padding-block: 32px 24px; }
-.price { font-size: 36px; font-variant-numeric: tabular-nums; font-weight: 500; letter-spacing: -.04em; line-height: 40px; margin: 4px 0 0; }
-.change { font-size: 14px; font-variant-numeric: tabular-nums; line-height: 20px; margin: 0 0 4px; }
+.nameRow { align-items: center; display: flex; flex-wrap: wrap; gap: 0 12px; }
+.nameRow h1 {
+  font-size: 30px;
+  font-weight: 550;
+  letter-spacing: -.035em;
+  line-height: 36px;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.subtitle {
+  color: var(--webde-muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 14px;
+  gap: 12px;
+  line-height: 20px;
+  margin: 4px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.bio {
+  color: var(--webde-muted);
+  font-size: 14px;
+  line-height: 20px;
+  margin: 8px 0 0;
+  max-width: 64ch;
+  overflow-wrap: anywhere;
+  text-wrap: pretty;
+  white-space: pre-line;
+}
+
+.socials { display: flex; flex-wrap: wrap; max-width: 100%; }
+.socials a {
+  align-items: center;
+  border-radius: 8px;
+  color: var(--webde-muted);
+  display: inline-flex;
+  height: 44px;
+  justify-content: center;
+  width: 44px;
+}
+.socials svg { height: 18px; width: 18px; }
+
+.headerActions { align-items: center; display: flex; flex-shrink: 0; flex-wrap: wrap; gap: 8px; }
+.secondaryButton {
+  align-items: center;
+  background: transparent;
+  border: 1px solid var(--webde-line);
+  border-radius: 8px;
+  color: var(--webde-ink);
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 14px;
+  gap: 8px;
+  justify-content: center;
+  min-height: 44px;
+  padding: 8px 12px;
+  text-decoration: none;
+}
+
+.metrics {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  margin: 24px 0;
+}
+.metrics > div { min-width: 0; }
+.metrics dt { color: var(--webde-muted); font-size: 12px; line-height: 16px; }
+.metrics dd {
+  font-size: 20px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  line-height: 28px;
+  margin: 4px 0 0;
+  overflow-wrap: anywhere;
+}
 .change[data-direction="up"] { color: #9dddbe; }
 .change[data-direction="down"] { color: #f6a1ac; }
-.change span { color: var(--webde-muted); margin-left: 4px; }
-.chart { background: var(--webde-surface); border: 1px solid var(--webde-line); border-radius: 8px; height: 480px; overflow: hidden; position: relative; }
+
+.chart {
+  background: var(--webde-surface);
+  border: 1px solid var(--webde-line);
+  border-radius: 8px;
+  height: 520px;
+  overflow: hidden;
+  position: relative;
+}
 .chart iframe { border: 0; height: 100%; position: relative; width: 100%; }
-.chartState { align-items: center; display: flex; flex-direction: column; height: 100%; justify-content: center; inset: 0; padding: 32px; position: absolute; text-align: center; }
+.chartState {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  inset: 0;
+  justify-content: center;
+  padding: 24px;
+  position: absolute;
+  text-align: center;
+}
 .chartState strong { font-size: 18px; font-weight: 500; line-height: 28px; }
 .chartState p { color: var(--webde-muted); font-size: 14px; line-height: 20px; margin: 8px 0 0; max-width: 32ch; text-wrap: pretty; }
-.chartFooter { align-items: center; color: var(--webde-muted); display: flex; flex-wrap: wrap; font-size: 12px; gap: 8px 16px; justify-content: space-between; line-height: 16px; margin-top: 12px; }
-.chartFooter a { align-items: center; color: inherit; display: inline-flex; gap: 8px; min-height: 24px; text-decoration: none; }
-.trade { background: var(--webde-surface); border: 1px solid var(--webde-line); border-radius: 16px; min-width: 0; padding: 24px; }
-.trade h2 { font-size: 20px; font-weight: 500; line-height: 28px; margin: 0 0 24px; }
-.tradeToken { align-items: center; display: flex; gap: 12px; }
-.tradeAvatar { border-radius: 8px; flex: none; width: 48px; }
-.tradeToken > div:last-child { min-width: 0; }
-.tradeToken strong, .tradeToken span { display: block; overflow-wrap: anywhere; }
-.tradeToken strong { font-size: 16px; font-weight: 500; line-height: 24px; }
-.tradeToken span { color: var(--webde-muted); font-size: 14px; line-height: 20px; margin-top: 4px; }
-.tradeDescription { color: var(--webde-muted); font-size: 14px; line-height: 20px; margin: 24px 0; text-wrap: pretty; }
-.primaryButton { background: var(--webde-ink); border-color: var(--webde-ink); color: var(--webde-canvas); font-weight: 550; width: 100%; }
-.tradeUnavailable { color: var(--webde-muted); font-size: 14px; line-height: 20px; margin: 0; }
-.tradeFacts { display: grid; gap: 12px; margin: 24px 0 0; }
-.tradeFacts > div { align-items: baseline; display: flex; gap: 12px; justify-content: space-between; }
-.tradeFacts dd { font-size: 12px; line-height: 16px; margin: 0; }
-.about { margin-top: 32px; max-width: 800px; }
-.about h2 { font-size: 18px; font-weight: 500; line-height: 28px; margin: 0; overflow-wrap: anywhere; }
-.about p { color: var(--webde-muted); font-size: 14px; line-height: 20px; margin: 8px 0 0; overflow-wrap: anywhere; text-wrap: pretty; white-space: pre-line; }
-.links { display: flex; flex-wrap: wrap; gap: 8px 24px; margin-top: 16px; }
-.links a, .empty a { align-items: center; color: var(--webde-ink); display: inline-flex; font-size: 14px; gap: 4px; min-height: 44px; text-decoration: none; }
-.provenance { border: 1px solid var(--webde-line); border-radius: 8px; margin-top: 32px; padding: 0 16px; }
-.provenance summary { align-items: center; cursor: pointer; font-size: 14px; min-height: 56px; padding-block: 16px; }
-.provenance summary span { color: var(--webde-muted); float: right; font-size: 12px; line-height: 20px; }
-.facts { margin: 0; padding-block: 8px 24px; }
-.facts > div { display: grid; gap: 16px; grid-template-columns: 160px minmax(0, 1fr); padding-block: 8px; }
-.facts dt { color: var(--webde-muted); font-size: 12px; line-height: 20px; }
-.facts dd { font-family: var(--font-plex-mono), monospace; font-size: 12px; line-height: 20px; margin: 0; min-width: 0; overflow-wrap: anywhere; }
-.facts a { color: inherit; text-decoration-color: var(--webde-line); text-underline-offset: 4px; }
-.notice { color: var(--webde-muted); font-size: 14px; line-height: 20px; margin: 0 0 24px; }
+.notice { color: var(--webde-muted); font-size: 14px; line-height: 20px; margin: 16px 0 0; }
+.notice a { color: var(--webde-ink); text-underline-offset: 4px; }
 .empty { margin: 64px auto; max-width: 640px; }
 .empty h1 { font-size: 30px; font-weight: 500; line-height: 36px; }
 .empty p { color: var(--webde-muted); font-size: 16px; line-height: 24px; }
-.page :is(a, button, summary, iframe):focus-visible { outline: 2px solid var(--webde-ink); outline-offset: 4px; }
-@media (hover: hover) and (pointer: fine) { .back:hover, .links a:hover, .chartFooter a:hover { color: var(--webde-ink); text-decoration: underline; text-underline-offset: 4px; } .secondaryButton:hover { background: var(--webde-surface-raised); } .primaryButton:hover { background: #e7e7e5; } }
-.secondaryButton:active, .primaryButton:active { transform: translateY(1px); }
-@media (max-width: 1020px) { .layout { gap: 16px; grid-template-columns: minmax(0, 1fr) 280px; } .market, .trade { padding: 16px; } }
-@media (max-width: 800px) {
-  .page { padding-bottom: 48px; }
-  .header { align-items: flex-start; flex-direction: column; gap: 16px; margin-block: 16px 24px; }
-  .identityText h1 { font-size: 24px; line-height: 32px; }
-  .avatar { width: 48px; border-radius: 8px; }
-  .headerActions { flex-wrap: wrap; }
-  .layout { grid-template-columns: minmax(0, 1fr); }
-  .market { padding: 16px; }
-  .metrics { gap: 8px; }
-  .metrics dd { font-size: 16px; line-height: 24px; }
-  .priceHeading { padding-block: 24px 16px; }
-  .price { font-size: 30px; line-height: 36px; }
-  .chart { height: 400px; }
-  .trade { padding: 24px; }
-  .trade h2 { margin-bottom: 16px; }
-  .facts > div { gap: 4px; grid-template-columns: minmax(0, 1fr); }
-  .provenance summary span { display: none; }
+.empty a { align-items: center; color: var(--webde-ink); display: inline-flex; font-size: 14px; gap: 4px; min-height: 44px; text-decoration: none; }
+.page :is(a, button, iframe):focus-visible { outline: 2px solid var(--webde-ink); outline-offset: 4px; }
+
+@media (hover: hover) and (pointer: fine) {
+  .back:hover { color: var(--webde-ink); text-decoration: underline; text-underline-offset: 4px; }
+  .secondaryButton:hover, .socials a:hover { background: var(--webde-surface-raised); color: var(--webde-ink); }
 }
-@media (max-width: 360px) { .metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); row-gap: 16px; } .chart { height: 360px; } }
+.secondaryButton:active, .socials a:active { transform: translateY(1px); }
+
+@media (max-width: 900px) {
+  .header { flex-wrap: wrap; gap: 16px; }
+}
+
+@media (max-width: 700px) {
+  .market { padding: 16px; }
+  .identity { gap: 12px; }
+  .avatar { width: 48px; }
+  .nameRow { gap: 0 8px; }
+  .nameRow h1 { font-size: 24px; line-height: 32px; }
+  .metrics { gap: 16px; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .metrics dd { font-size: 18px; line-height: 28px; }
+  .chart { height: 400px; }
+}
+
+@media (max-width: 360px) {
+  .metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .chart { height: 360px; }
+}

--- a/components/robinhood-token-view.tsx
+++ b/components/robinhood-token-view.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowLeft, Check, Copy, ExternalLink, ArrowUpRight } from "lucide-react";
+import { ArrowLeft, ArrowUpRight, BookOpen, Check, Copy, Globe, Link2, Send } from "lucide-react";
 import { useEffect, useState } from "react";
+import { DiscordBrandIcon, GitHubBrandIcon, XBrandIcon } from "@/components/brand-icons";
 import { RobinhoodCoinArtwork } from "@/components/robinhood-coin-artwork";
 import { useRobinhoodPresentation } from "@/components/use-robinhood-presentation";
 import type { RobinhoodLaunch } from "@/lib/robinhood-launches";
@@ -42,12 +43,21 @@ export function RobinhoodTokenView({ address, token, status }: {
     <div className={`${styles.page} page-width`}>
       <Link className={styles.back} href="/explore?chain=4663"><ArrowLeft aria-hidden="true" size={16} /> Explore</Link>
       {token ? <>
+        <section className={styles.market} aria-label={`${name} market`}>
         <header className={styles.header}>
           <div className={styles.identity}>
             <RobinhoodCoinArtwork className={styles.avatar} imageUrl={details?.imageUrl} name={token.name} symbol={token.symbol} />
             <div className={styles.identityText}>
-              <h1>{name}</h1>
-              <p><span>{coinTicker(token.symbol)}</span><span>Robinhood</span></p>
+              <div className={styles.nameRow}>
+                <h1>{name}</h1>
+                {details?.links.length ? <nav className={styles.socials} aria-label={`${name} links`}>
+                  {details.links.map((link) => <a key={`${link.label}:${link.url}`} href={link.url} target="_blank" rel="noreferrer" title={link.label} aria-label={`${link.label} (opens in a new tab)`}>
+                    <ProjectLinkIcon label={link.label} />
+                  </a>)}
+                </nav> : null}
+              </div>
+              <p className={styles.subtitle}><span>{coinTicker(token.symbol)}</span><span>Robinhood</span></p>
+              {details?.description ? <p className={styles.bio}>{details.description}</p> : null}
             </div>
           </div>
           <div className={styles.headerActions}>
@@ -58,61 +68,24 @@ export function RobinhoodTokenView({ address, token, status }: {
             <a className={styles.secondaryButton} href={`${EXPLORER}/token/${address}`} target="_blank" rel="noreferrer">Explorer <ArrowUpRight aria-hidden="true" size={16} /><span className="sr-only"> (opens in a new tab)</span></a>
           </div>
         </header>
-        <p className="sr-only" role="status">{copyState === "failed" ? "Could not copy. The full address is available in Launch details below." : copyState === "copied" ? "Token address copied" : ""}</p>
+        <p className="sr-only" role="status">{copyState === "copied" ? "Token address copied" : ""}</p>
+        {copyState === "failed" ? <p className={styles.notice} role="status">Could not copy. <a href={`${EXPLORER}/token/${address}`} target="_blank" rel="noreferrer">View the address on Explorer.</a></p> : null}
         {status === "stale" ? <p className={styles.notice} role="status">Showing saved launch details. Updates are temporarily unavailable.</p> : null}
 
-        <div className={styles.layout}>
-          <section className={styles.market} aria-label={`${name} market`}>
             <dl className={styles.metrics}>
+              <Metric label="Price" value={coinDollars(market?.priceUsd, true)} />
               <Metric label="Market cap" value={coinDollars(market?.marketCapUsd)} />
               <Metric label="Liquidity" value={coinDollars(market?.liquidityUsd)} />
               <Metric label="24h volume" value={coinDollars(market?.volume24hUsd)} />
+              <div>
+                <dt>24h change</dt>
+                <dd className={styles.change} data-direction={change != null && change < 0 ? "down" : change != null && change > 0 ? "up" : "flat"}>
+                  {change != null && Number.isFinite(change) ? `${change > 0 ? "+" : ""}${change.toFixed(2)}%` : "—"}
+                </dd>
+              </div>
             </dl>
-            <div className={styles.priceHeading}>
-              <div><span className={styles.label}>Price</span><p className={styles.price}>{coinDollars(market?.priceUsd, true)}</p></div>
-              {change != null && Number.isFinite(change) ? <p className={styles.change} data-direction={change < 0 ? "down" : change > 0 ? "up" : "flat"}>{change > 0 ? "+" : ""}{change.toFixed(2)}% <span>24h</span></p> : null}
-            </div>
             <RobinhoodChart poolId={token.poolId} name={name} available={Boolean(market)} loading={presentation.loading} />
-            <div className={styles.chartFooter}>
-              <span>{market ? <>DEX Screener · Updated <time dateTime={market.observedAt}>{new Date(market.observedAt).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" })}</time></> : "Market data appears when this pool is available."}</span>
-              {market ? <a href={market.sourceUrl} target="_blank" rel="noreferrer">Open chart <ExternalLink aria-hidden="true" size={12} /><span className="sr-only"> (opens in a new tab)</span></a> : null}
-            </div>
           </section>
-
-          <aside className={styles.trade} aria-labelledby="robinhood-trade-title">
-            <h2 id="robinhood-trade-title">Buy &amp; sell</h2>
-            <div className={styles.tradeToken}>
-              <RobinhoodCoinArtwork className={styles.tradeAvatar} imageUrl={details?.imageUrl} name={token.name} symbol={token.symbol} />
-              <div><strong>{name}</strong><span>{coinTicker(token.symbol)}</span></div>
-            </div>
-            <p className={styles.tradeDescription}>Trading on Programmable is not available for this token yet.</p>
-            {market ? <a className={styles.primaryButton} href={market.sourceUrl} target="_blank" rel="noreferrer">Open external market <ArrowUpRight aria-hidden="true" size={16} /><span className="sr-only"> (opens DEX Screener in a new tab)</span></a> : <p className={styles.tradeUnavailable}>{presentation.loading ? "Checking market availability…" : "No external market is available yet."}</p>}
-            <dl className={styles.tradeFacts}>
-              <Metric label="Network" value="Robinhood" />
-              <Metric label="Launched" value={token.launchedAt ? new Date(token.launchedAt).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric", timeZone: "UTC" }) : "—"} />
-            </dl>
-          </aside>
-        </div>
-
-        {details?.description || details?.links.length ? <section className={styles.about} aria-labelledby="robinhood-about-title">
-          <h2 id="robinhood-about-title">About {name}</h2>
-          {details.description ? <p>{details.description}</p> : null}
-          {details.links.length ? <div className={styles.links}>{details.links.map((link) => <a key={`${link.label}:${link.url}`} href={link.url} target="_blank" rel="noreferrer">{link.label}<ArrowUpRight aria-hidden="true" size={14} /><span className="sr-only"> (opens in a new tab)</span></a>)}</div> : null}
-        </section> : null}
-
-        <details className={styles.provenance}>
-          <summary>Launch details<span>Programmable stamp</span></summary>
-          <dl className={styles.facts}>
-            <Fact label="Token" value={token.tokenAddress} href={`${EXPLORER}/token/${token.tokenAddress}`} />
-            <Fact label="Hook" value={token.hookAddress} href={`${EXPLORER}/address/${token.hookAddress}`} />
-            <Fact label="Creator" value={token.creator} href={`${EXPLORER}/address/${token.creator}`} />
-            <Fact label="Launch transaction" value={token.transactionHash} href={`${EXPLORER}/tx/${token.transactionHash}`} />
-            <Fact label="Launch ID" value={token.launchId} />
-            <Fact label="Stamp hash" value={token.stampHash} />
-            <Fact label="Pool ID" value={token.poolId} />
-            {token.launchedAt ? <div><dt>Launched</dt><dd><time dateTime={token.launchedAt}>{new Date(token.launchedAt).toUTCString()}</time></dd></div> : null}
-          </dl>
-        </details>
       </> : <section className={styles.empty}>
         <h1>Token details</h1>
         <p>{status === "ready" ? "This token is not in the verified Robinhood launch index." : "Robinhood launch details are temporarily unavailable. Try again in a moment."}</p>
@@ -132,7 +105,7 @@ function RobinhoodChart({ poolId, name, available, loading }: { poolId: string; 
       <iframe
         key={poolId}
         title={`${name} price chart on DEX Screener`}
-        src={`https://dexscreener.com/robinhood/${poolId}?embed=1&loadChartSettings=0&trades=0&info=0&chartLeftToolbar=0&chartTheme=dark&theme=dark&chartStyle=2&chartType=usd&interval=15`}
+        src={`https://dexscreener.com/robinhood/${poolId}?embed=1&loadChartSettings=0&trades=0&info=0&chartLeftToolbar=0&chartTheme=dark&theme=dark&chartStyle=1&chartType=usd&interval=15`}
         onLoad={() => setLoadedPool(poolId)}
         referrerPolicy="no-referrer"
         sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
@@ -145,6 +118,12 @@ function Metric({ label, value }: { label: string; value: string }) {
   return <div><dt>{label}</dt><dd>{value}</dd></div>;
 }
 
-function Fact({ label, value, href }: { label: string; value: string; href?: string }) {
-  return <div><dt>{label}</dt><dd>{href ? <a href={href} target="_blank" rel="noreferrer">{value}<span className="sr-only"> (opens block explorer in a new tab)</span></a> : <span>{value}</span>}</dd></div>;
+function ProjectLinkIcon({ label }: { label: string }) {
+  if (label === "X") return <XBrandIcon />;
+  if (label === "Website") return <Globe aria-hidden="true" size={18} />;
+  if (label === "GitHub") return <GitHubBrandIcon />;
+  if (label === "Discord") return <DiscordBrandIcon />;
+  if (label === "Telegram") return <Send aria-hidden="true" size={18} />;
+  if (label === "Docs") return <BookOpen aria-hidden="true" size={18} />;
+  return <Link2 aria-hidden="true" size={18} />;
 }

--- a/components/robinhood-token-view.tsx
+++ b/components/robinhood-token-view.tsx
@@ -2,7 +2,8 @@
 
 import Link from "next/link";
 import { ArrowLeft, ArrowUpRight, BookOpen, Check, Copy, Globe, Link2, Send } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
+import { AnimatedMarketCap } from "@/components/animated-market-cap";
 import { DiscordBrandIcon, GitHubBrandIcon, XBrandIcon } from "@/components/brand-icons";
 import { RobinhoodCoinArtwork } from "@/components/robinhood-coin-artwork";
 import { useRobinhoodPresentation } from "@/components/use-robinhood-presentation";
@@ -71,10 +72,13 @@ export function RobinhoodTokenView({ address, token, status }: {
         <p className="sr-only" role="status">{copyState === "copied" ? "Token address copied" : ""}</p>
         {copyState === "failed" ? <p className={styles.notice} role="status">Could not copy. <a href={`${EXPLORER}/token/${address}`} target="_blank" rel="noreferrer">View the address on Explorer.</a></p> : null}
         {status === "stale" ? <p className={styles.notice} role="status">Showing saved launch details. Updates are temporarily unavailable.</p> : null}
+        {presentation.delayed && status !== "stale" ? <p className={styles.notice} role="status">Market data is temporarily delayed.</p> : null}
 
             <dl className={styles.metrics}>
               <Metric label="Price" value={coinDollars(market?.priceUsd, true)} />
-              <Metric label="Market cap" value={coinDollars(market?.marketCapUsd)} />
+              <Metric label="Market cap" value={market?.marketCapUsd != null && Number.isFinite(market.marketCapUsd) && market.marketCapUsd >= 0
+                ? <AnimatedMarketCap metric={{ kind: "usd", value: market.marketCapUsd }} replayKey={`4663:${address.toLowerCase()}:${market.poolId.toLowerCase()}:market-cap`} />
+                : "—"} />
               <Metric label="Liquidity" value={coinDollars(market?.liquidityUsd)} />
               <Metric label="24h volume" value={coinDollars(market?.volume24hUsd)} />
               <div>
@@ -114,7 +118,7 @@ function RobinhoodChart({ poolId, name, available, loading }: { poolId: string; 
   </div>;
 }
 
-function Metric({ label, value }: { label: string; value: string }) {
+function Metric({ label, value }: { label: string; value: ReactNode }) {
   return <div><dt>{label}</dt><dd>{value}</dd></div>;
 }
 

--- a/components/robinhood-token-view.tsx
+++ b/components/robinhood-token-view.tsx
@@ -1,5 +1,12 @@
+"use client";
+
 import Link from "next/link";
+import { ArrowLeft, Check, Copy, ExternalLink, ArrowUpRight } from "lucide-react";
+import { useEffect, useState } from "react";
+import { RobinhoodCoinArtwork } from "@/components/robinhood-coin-artwork";
+import { useRobinhoodPresentation } from "@/components/use-robinhood-presentation";
 import type { RobinhoodLaunch } from "@/lib/robinhood-launches";
+import { coinDollars, coinTicker } from "@/lib/robinhood-presentation";
 import styles from "./robinhood-token-view.module.css";
 
 const EXPLORER = "https://robinhoodchain.blockscout.com";
@@ -9,17 +16,92 @@ export function RobinhoodTokenView({ address, token, status }: {
   token: RobinhoodLaunch | null;
   status: "ready" | "syncing" | "stale" | "unavailable";
 }) {
+  const presentation = useRobinhoodPresentation(`token=${encodeURIComponent(address)}`, token !== null);
+  const details = presentation.items.find((item) => item.tokenAddress.toLowerCase() === address.toLowerCase());
+  const market = details?.market;
+  const name = token?.name?.trim() || "Unnamed token";
+  const change = market?.change24hPercent;
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: "instant" });
+  }, [address]);
+
+  useEffect(() => {
+    if (copyState === "idle") return;
+    const timer = setTimeout(() => setCopyState("idle"), 3_000);
+    return () => clearTimeout(timer);
+  }, [copyState]);
+
+  async function copyAddress() {
+    try { await navigator.clipboard.writeText(address); setCopyState("copied"); }
+    catch { setCopyState("failed"); }
+  }
+
   return (
     <div className={`${styles.page} page-width`}>
-      <Link className={styles.back} href="/explore?chain=4663">← Back to Explore</Link>
-      <section className={styles.content} aria-labelledby="robinhood-token-title">
-        <p className={styles.network}>Robinhood Chain</p>
-        <h1 id="robinhood-token-title">{token?.name || (token ? `${address.slice(0, 8)}…${address.slice(-6)}` : "Token details")}</h1>
-        {token?.symbol ? <p className={styles.symbol}>{token.symbol}</p> : null}
-        {token ? <>
-          <p className={styles.stamp}>Programmable Custom</p>
-          <p className={styles.description}>Launched through Programmable. The launch is recorded in the Programmable Stamp Router.</p>
-          {status === "stale" ? <p className={styles.notice} role="status">Showing saved launch details. Updates are temporarily unavailable.</p> : null}
+      <Link className={styles.back} href="/explore?chain=4663"><ArrowLeft aria-hidden="true" size={16} /> Explore</Link>
+      {token ? <>
+        <header className={styles.header}>
+          <div className={styles.identity}>
+            <RobinhoodCoinArtwork className={styles.avatar} imageUrl={details?.imageUrl} name={token.name} symbol={token.symbol} />
+            <div className={styles.identityText}>
+              <h1>{name}</h1>
+              <p><span>{coinTicker(token.symbol)}</span><span>Robinhood</span></p>
+            </div>
+          </div>
+          <div className={styles.headerActions}>
+            <button className={styles.secondaryButton} onClick={copyAddress} type="button" title={address}>
+              {copyState === "copied" ? <Check aria-hidden="true" size={16} /> : <Copy aria-hidden="true" size={16} />}
+              {copyState === "copied" ? "Copied" : "Copy address"}
+            </button>
+            <a className={styles.secondaryButton} href={`${EXPLORER}/token/${address}`} target="_blank" rel="noreferrer">Explorer <ArrowUpRight aria-hidden="true" size={16} /><span className="sr-only"> (opens in a new tab)</span></a>
+          </div>
+        </header>
+        <p className="sr-only" role="status">{copyState === "failed" ? "Could not copy. The full address is available in Launch details below." : copyState === "copied" ? "Token address copied" : ""}</p>
+        {status === "stale" ? <p className={styles.notice} role="status">Showing saved launch details. Updates are temporarily unavailable.</p> : null}
+
+        <div className={styles.layout}>
+          <section className={styles.market} aria-label={`${name} market`}>
+            <dl className={styles.metrics}>
+              <Metric label="Market cap" value={coinDollars(market?.marketCapUsd)} />
+              <Metric label="Liquidity" value={coinDollars(market?.liquidityUsd)} />
+              <Metric label="24h volume" value={coinDollars(market?.volume24hUsd)} />
+            </dl>
+            <div className={styles.priceHeading}>
+              <div><span className={styles.label}>Price</span><p className={styles.price}>{coinDollars(market?.priceUsd, true)}</p></div>
+              {change != null && Number.isFinite(change) ? <p className={styles.change} data-direction={change < 0 ? "down" : change > 0 ? "up" : "flat"}>{change > 0 ? "+" : ""}{change.toFixed(2)}% <span>24h</span></p> : null}
+            </div>
+            <RobinhoodChart poolId={token.poolId} name={name} available={Boolean(market)} loading={presentation.loading} />
+            <div className={styles.chartFooter}>
+              <span>{market ? <>DEX Screener · Updated <time dateTime={market.observedAt}>{new Date(market.observedAt).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" })}</time></> : "Market data appears when this pool is available."}</span>
+              {market ? <a href={market.sourceUrl} target="_blank" rel="noreferrer">Open chart <ExternalLink aria-hidden="true" size={12} /><span className="sr-only"> (opens in a new tab)</span></a> : null}
+            </div>
+          </section>
+
+          <aside className={styles.trade} aria-labelledby="robinhood-trade-title">
+            <h2 id="robinhood-trade-title">Buy &amp; sell</h2>
+            <div className={styles.tradeToken}>
+              <RobinhoodCoinArtwork className={styles.tradeAvatar} imageUrl={details?.imageUrl} name={token.name} symbol={token.symbol} />
+              <div><strong>{name}</strong><span>{coinTicker(token.symbol)}</span></div>
+            </div>
+            <p className={styles.tradeDescription}>Trading on Programmable is not available for this token yet.</p>
+            {market ? <a className={styles.primaryButton} href={market.sourceUrl} target="_blank" rel="noreferrer">Open external market <ArrowUpRight aria-hidden="true" size={16} /><span className="sr-only"> (opens DEX Screener in a new tab)</span></a> : <p className={styles.tradeUnavailable}>{presentation.loading ? "Checking market availability…" : "No external market is available yet."}</p>}
+            <dl className={styles.tradeFacts}>
+              <Metric label="Network" value="Robinhood" />
+              <Metric label="Launched" value={token.launchedAt ? new Date(token.launchedAt).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric", timeZone: "UTC" }) : "—"} />
+            </dl>
+          </aside>
+        </div>
+
+        {details?.description || details?.links.length ? <section className={styles.about} aria-labelledby="robinhood-about-title">
+          <h2 id="robinhood-about-title">About {name}</h2>
+          {details.description ? <p>{details.description}</p> : null}
+          {details.links.length ? <div className={styles.links}>{details.links.map((link) => <a key={`${link.label}:${link.url}`} href={link.url} target="_blank" rel="noreferrer">{link.label}<ArrowUpRight aria-hidden="true" size={14} /><span className="sr-only"> (opens in a new tab)</span></a>)}</div> : null}
+        </section> : null}
+
+        <details className={styles.provenance}>
+          <summary>Launch details<span>Programmable stamp</span></summary>
           <dl className={styles.facts}>
             <Fact label="Token" value={token.tokenAddress} href={`${EXPLORER}/token/${token.tokenAddress}`} />
             <Fact label="Hook" value={token.hookAddress} href={`${EXPLORER}/address/${token.hookAddress}`} />
@@ -30,14 +112,37 @@ export function RobinhoodTokenView({ address, token, status }: {
             <Fact label="Pool ID" value={token.poolId} />
             {token.launchedAt ? <div><dt>Launched</dt><dd><time dateTime={token.launchedAt}>{new Date(token.launchedAt).toUTCString()}</time></dd></div> : null}
           </dl>
-          <p className={styles.note}>The stamp identifies the launch origin. It is not a security audit of the token or hook.</p>
-        </> : <>
-          <p className={styles.description}>{status === "ready" ? "This token is not in the verified Robinhood launch index." : "Robinhood launch details are temporarily unavailable. Try again in a moment."}</p>
-          <dl className={styles.facts}><Fact label="Requested token" value={address} href={`${EXPLORER}/token/${address}`} /></dl>
-        </>}
-      </section>
+        </details>
+      </> : <section className={styles.empty}>
+        <h1>Token details</h1>
+        <p>{status === "ready" ? "This token is not in the verified Robinhood launch index." : "Robinhood launch details are temporarily unavailable. Try again in a moment."}</p>
+        <a href={`${EXPLORER}/token/${address}`} target="_blank" rel="noreferrer">View on explorer <ArrowUpRight aria-hidden="true" size={14} /></a>
+      </section>}
     </div>
   );
+}
+
+function RobinhoodChart({ poolId, name, available, loading }: { poolId: string; name: string; available: boolean; loading: boolean }) {
+  const [loadedPool, setLoadedPool] = useState<string | null>(null);
+  const safePool = /^0x[0-9a-f]{64}$/i.test(poolId);
+  const showChart = available && safePool;
+  return <div className={styles.chart}>
+    {showChart ? <>
+      {loadedPool !== poolId ? <div className={styles.chartState} role="status">Loading chart…</div> : null}
+      <iframe
+        key={poolId}
+        title={`${name} price chart on DEX Screener`}
+        src={`https://dexscreener.com/robinhood/${poolId}?embed=1&loadChartSettings=0&trades=0&info=0&chartLeftToolbar=0&chartTheme=dark&theme=dark&chartStyle=2&chartType=usd&interval=15`}
+        onLoad={() => setLoadedPool(poolId)}
+        referrerPolicy="no-referrer"
+        sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+      />
+    </> : <div className={styles.chartState} role="status"><strong>{loading ? "Loading market data…" : "No chart data yet"}</strong>{loading ? null : <p>The chart will appear when market data is available for this pool.</p>}</div>}
+  </div>;
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return <div><dt>{label}</dt><dd>{value}</dd></div>;
 }
 
 function Fact({ label, value, href }: { label: string; value: string; href?: string }) {

--- a/components/robinhood-token-view.tsx
+++ b/components/robinhood-token-view.tsx
@@ -71,8 +71,6 @@ export function RobinhoodTokenView({ address, token, status }: {
         </header>
         <p className="sr-only" role="status">{copyState === "copied" ? "Token address copied" : ""}</p>
         {copyState === "failed" ? <p className={styles.notice} role="status">Could not copy. <a href={`${EXPLORER}/token/${address}`} target="_blank" rel="noreferrer">View the address on Explorer.</a></p> : null}
-        {status === "stale" ? <p className={styles.notice} role="status">Showing saved launch details. Updates are temporarily unavailable.</p> : null}
-        {presentation.delayed && status !== "stale" ? <p className={styles.notice} role="status">Market data is temporarily delayed.</p> : null}
 
             <dl className={styles.metrics}>
               <Metric label="Price" value={coinDollars(market?.priceUsd, true)} />

--- a/components/robinhood-token-view.tsx
+++ b/components/robinhood-token-view.tsx
@@ -46,7 +46,7 @@ export function RobinhoodTokenView({ address, token, status }: {
         <section className={styles.market} aria-label={`${name} market`}>
         <header className={styles.header}>
           <div className={styles.identity}>
-            <RobinhoodCoinArtwork className={styles.avatar} imageUrl={details?.imageUrl} name={token.name} symbol={token.symbol} />
+            <RobinhoodCoinArtwork className={styles.avatar} imageUrl={details?.imageUrl} loading={presentation.loading} />
             <div className={styles.identityText}>
               <div className={styles.nameRow}>
                 <h1>{name}</h1>

--- a/components/robinhood-token-view.tsx
+++ b/components/robinhood-token-view.tsx
@@ -88,7 +88,7 @@ export function RobinhoodTokenView({ address, token, status }: {
                 </dd>
               </div>
             </dl>
-            <RobinhoodChart poolId={token.poolId} name={name} available={Boolean(market)} loading={presentation.loading} />
+            <RobinhoodChart poolId={token.poolId} name={name} />
           </section>
       </> : <section className={styles.empty}>
         <h1>Token details</h1>
@@ -99,12 +99,12 @@ export function RobinhoodTokenView({ address, token, status }: {
   );
 }
 
-function RobinhoodChart({ poolId, name, available, loading }: { poolId: string; name: string; available: boolean; loading: boolean }) {
+function RobinhoodChart({ poolId, name }: { poolId: string; name: string }) {
   const [loadedPool, setLoadedPool] = useState<string | null>(null);
   const safePool = /^0x[0-9a-f]{64}$/i.test(poolId);
-  const showChart = available && safePool;
+  // The embedded chart fetches its own data; metric refreshes must not remove it.
   return <div className={styles.chart}>
-    {showChart ? <>
+    {safePool ? <>
       {loadedPool !== poolId ? <div className={styles.chartState} role="status">Loading chart…</div> : null}
       <iframe
         key={poolId}
@@ -114,7 +114,7 @@ function RobinhoodChart({ poolId, name, available, loading }: { poolId: string; 
         referrerPolicy="no-referrer"
         sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
       />
-    </> : <div className={styles.chartState} role="status"><strong>{loading ? "Loading market data…" : "No chart data yet"}</strong>{loading ? null : <p>The chart will appear when market data is available for this pool.</p>}</div>}
+    </> : <div className={styles.chartState} role="status">Chart unavailable.</div>}
   </div>;
 }
 

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -116,9 +116,8 @@ export function SiteFooter() {
         <section className={styles.risk}>
           <h2 className={styles.label}>Risk notice</h2>
           <p>
-            Transactions may be irreversible. Tokens can be volatile, illiquid
-            or lose all value. Programmable does not provide financial advice or
-            guarantee a token&apos;s quality.
+            Transactions are irreversible. Tokens may lose all value or be
+            difficult to sell. No financial advice or guarantees.
           </p>
         </section>
       </div>

--- a/components/use-robinhood-presentation.ts
+++ b/components/use-robinhood-presentation.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { RobinhoodCoinPresentation } from "@/lib/robinhood-presentation";
+
+export function useRobinhoodPresentation(query: string, enabled = true, refresh = 0) {
+  const [state, setState] = useState<{
+    query: string; items: readonly RobinhoodCoinPresentation[]; loading: boolean;
+  }>({ query, items: [], loading: true });
+
+  useEffect(() => {
+    if (!enabled) return;
+    let disposed = false;
+    let controller: AbortController | null = null;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    async function load() {
+      if (disposed || controller || document.visibilityState === "hidden") return;
+      controller = new AbortController();
+      const active = controller;
+      const timeout = setTimeout(() => active.abort(), 10_000);
+      try {
+        const response = await fetch(`/api/explore/robinhood/presentation?${query}`, {
+          signal: active.signal, headers: { accept: "application/json" },
+        });
+        if (!response.ok) throw new Error("Presentation unavailable");
+        const body = await response.json();
+        if (!Array.isArray(body.items) || body.items.length > 50) throw new Error("Invalid presentation");
+        if (!disposed) setState({ query, items: body.items, loading: false });
+      } catch {
+        if (!disposed) setState((current) => ({
+          query, items: current.query === query ? current.items : [], loading: false,
+        }));
+      } finally {
+        clearTimeout(timeout);
+        controller = null;
+        if (!disposed) timer = setTimeout(load, 60_000);
+      }
+    }
+    function onVisibility() {
+      clearTimeout(timer);
+      if (document.visibilityState === "hidden") controller?.abort();
+      else void load();
+    }
+    void load();
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      disposed = true;
+      controller?.abort();
+      clearTimeout(timer);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [enabled, query, refresh]);
+
+  return state.query === query ? state : { query, items: [], loading: true };
+}

--- a/components/use-robinhood-presentation.ts
+++ b/components/use-robinhood-presentation.ts
@@ -1,20 +1,21 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { RobinhoodCoinPresentation } from "@/lib/robinhood-presentation";
+import { mergeRobinhoodPresentations, type RobinhoodCoinPresentation } from "@/lib/robinhood-presentation";
 
-export function useRobinhoodPresentation(query: string, enabled = true, refresh = 0) {
+export function useRobinhoodPresentation(query: string, enabled = true) {
   const [state, setState] = useState<{
-    query: string; items: readonly RobinhoodCoinPresentation[]; loading: boolean;
-  }>({ query, items: [], loading: true });
+    query: string; items: readonly RobinhoodCoinPresentation[]; loading: boolean; delayed: boolean;
+  }>({ query, items: [], loading: true, delayed: false });
 
   useEffect(() => {
     if (!enabled) return;
     let disposed = false;
     let controller: AbortController | null = null;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    const isVisible = () => document.visibilityState !== "hidden";
     async function load() {
-      if (disposed || controller || document.visibilityState === "hidden") return;
+      if (disposed || controller || !isVisible()) return;
       controller = new AbortController();
       const active = controller;
       const timeout = setTimeout(() => active.abort(), 10_000);
@@ -25,20 +26,22 @@ export function useRobinhoodPresentation(query: string, enabled = true, refresh 
         if (!response.ok) throw new Error("Presentation unavailable");
         const body = await response.json();
         if (!Array.isArray(body.items) || body.items.length > 50) throw new Error("Invalid presentation");
-        if (!disposed) setState({ query, items: body.items, loading: false });
-      } catch {
         if (!disposed) setState((current) => ({
-          query, items: current.query === query ? current.items : [], loading: false,
+          query, ...mergeRobinhoodPresentations(current.query === query ? current.items : [], body.items), loading: false,
+        }));
+      } catch {
+        if (!disposed && active.signal.reason !== "hidden") setState((current) => ({
+          query, ...mergeRobinhoodPresentations(current.query === query ? current.items : [], null), loading: false,
         }));
       } finally {
         clearTimeout(timeout);
         controller = null;
-        if (!disposed) timer = setTimeout(load, 60_000);
+        if (!disposed && isVisible()) timer = setTimeout(load, active.signal.reason === "hidden" ? 0 : 60_000);
       }
     }
     function onVisibility() {
       clearTimeout(timer);
-      if (document.visibilityState === "hidden") controller?.abort();
+      if (!isVisible()) controller?.abort("hidden");
       else void load();
     }
     void load();
@@ -49,7 +52,8 @@ export function useRobinhoodPresentation(query: string, enabled = true, refresh 
       clearTimeout(timer);
       document.removeEventListener("visibilitychange", onVisibility);
     };
-  }, [enabled, query, refresh]);
+  }, [enabled, query]);
 
-  return state.query === query ? state : { query, items: [], loading: true };
+  // The list keeps its previous rows until the next response; keep their matching artwork and values too.
+  return state.query === query ? state : { ...state, query, loading: true, delayed: false };
 }

--- a/components/view-chain-unavailable.tsx
+++ b/components/view-chain-unavailable.tsx
@@ -4,7 +4,7 @@ import styles from "@/components/view-chain-unavailable.module.css";
 import { useViewChain } from "@/components/view-chain";
 
 export function isRobinhoodUnavailableRoute(pathname: string): boolean {
-  return ["/profile", "/launch"].some(
+  return ["/profile"].some(
     (route) => pathname === route || pathname.startsWith(`${route}/`),
   );
 }

--- a/components/view-chain-unavailable.tsx
+++ b/components/view-chain-unavailable.tsx
@@ -4,7 +4,7 @@ import styles from "@/components/view-chain-unavailable.module.css";
 import { useViewChain } from "@/components/view-chain";
 
 export function isRobinhoodUnavailableRoute(pathname: string): boolean {
-  return ["/profile"].some(
+  return ([] as string[]).some(
     (route) => pathname === route || pathname.startsWith(`${route}/`),
   );
 }

--- a/lib/profile/robinhood-profile.ts
+++ b/lib/profile/robinhood-profile.ts
@@ -1,0 +1,33 @@
+import type { RobinhoodProfileLaunchList } from "@/lib/robinhood-launches";
+
+const ADDRESS = /^0x[\da-f]{40}$/i;
+const HASH = /^0x[\da-f]{64}$/i;
+const record = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+const text = (value: unknown) => value === null || (typeof value === "string" && value.length <= 128);
+
+export function readRobinhoodProfileResponse(value: unknown, account: string): RobinhoodProfileLaunchList {
+  if (!record(value) || value.chainId !== 4663 || !ADDRESS.test(account)
+    || value.account !== account.toLowerCase()
+    || !["ready", "syncing", "stale", "unavailable"].includes(String(value.status))
+    || !(value.updatedAt === null || (typeof value.updatedAt === "string" && Number.isFinite(Date.parse(value.updatedAt))))
+    || !Array.isArray(value.items) || value.items.length > 50 || !record(value.page)) {
+    throw new Error("Invalid Robinhood profile");
+  }
+  const tokens = new Set<string>();
+  for (const row of value.items) {
+    if (!record(row) || typeof row.creator !== "string" || row.creator.toLowerCase() !== account.toLowerCase()
+      || typeof row.tokenAddress !== "string" || !ADDRESS.test(row.tokenAddress)
+      || typeof row.launchId !== "string" || !HASH.test(row.launchId)
+      || !text(row.name) || !text(row.symbol)
+      || !(row.launchedAt === null || (typeof row.launchedAt === "string" && Number.isFinite(Date.parse(row.launchedAt))))
+      || tokens.has(row.tokenAddress.toLowerCase())) throw new Error("Invalid profile launch");
+    tokens.add(row.tokenAddress.toLowerCase());
+  }
+  const page = value.page;
+  if (!Number.isSafeInteger(page.number) || Number(page.number) < 1 || page.size !== 50
+    || !Number.isSafeInteger(page.totalItems) || Number(page.totalItems) < value.items.length
+    || !Number.isSafeInteger(page.totalPages) || Number(page.totalPages) < 0
+    || typeof page.hasMore !== "boolean") throw new Error("Invalid profile page");
+  return value as RobinhoodProfileLaunchList;
+}

--- a/lib/robinhood-explore-filters.ts
+++ b/lib/robinhood-explore-filters.ts
@@ -1,0 +1,34 @@
+export const LAUNCH_AGE_OPTIONS = [
+  { value: "any", label: "Any time" },
+  { value: "24h", label: "Last 24 hours" },
+  { value: "7d", label: "Last 7 days" },
+  { value: "30d", label: "Last 30 days" },
+] as const;
+
+export const LAUNCH_SORT_OPTIONS = [
+  { value: "newest", label: "Newest first" },
+  { value: "oldest", label: "Oldest first" },
+] as const;
+
+export type RobinhoodExploreFilters = {
+  age: typeof LAUNCH_AGE_OPTIONS[number]["value"];
+  sort: typeof LAUNCH_SORT_OPTIONS[number]["value"];
+};
+
+export const DEFAULT_EXPLORE_FILTERS: RobinhoodExploreFilters = { age: "any", sort: "newest" };
+
+export function activeExploreFilterCount(filters: RobinhoodExploreFilters) {
+  return Number(filters.age !== "any") + Number(filters.sort !== "newest");
+}
+
+export function parseRobinhoodExploreQuery(query: URLSearchParams) {
+  const page = query.get("page") ?? "1";
+  const q = query.get("q") ?? "";
+  const age = query.get("age") ?? "any";
+  const sort = query.get("sort") ?? "newest";
+  if ([...query.keys()].some((key) => !["page", "q", "age", "sort"].includes(key) || query.getAll(key).length !== 1)
+    || !/^[1-9]\d{0,5}$/.test(page) || q.length > 128
+    || !LAUNCH_AGE_OPTIONS.some((option) => option.value === age)
+    || !LAUNCH_SORT_OPTIONS.some((option) => option.value === sort)) return null;
+  return { page: Number(page), q, filters: { age, sort } as RobinhoodExploreFilters };
+}

--- a/lib/robinhood-explore-filters.ts
+++ b/lib/robinhood-explore-filters.ts
@@ -1,34 +1,26 @@
-export const LAUNCH_AGE_OPTIONS = [
-  { value: "any", label: "Any time" },
-  { value: "24h", label: "Last 24 hours" },
-  { value: "7d", label: "Last 7 days" },
-  { value: "30d", label: "Last 30 days" },
-] as const;
-
 export const LAUNCH_SORT_OPTIONS = [
-  { value: "newest", label: "Newest first" },
-  { value: "oldest", label: "Oldest first" },
+  { value: "highest", label: "Highest market cap" },
+  { value: "lowest", label: "Lowest market cap" },
+  { value: "newest", label: "Newest" },
+  { value: "oldest", label: "Oldest" },
 ] as const;
 
 export type RobinhoodExploreFilters = {
-  age: typeof LAUNCH_AGE_OPTIONS[number]["value"];
   sort: typeof LAUNCH_SORT_OPTIONS[number]["value"];
 };
 
-export const DEFAULT_EXPLORE_FILTERS: RobinhoodExploreFilters = { age: "any", sort: "newest" };
+export const DEFAULT_EXPLORE_FILTERS: RobinhoodExploreFilters = { sort: "highest" };
 
 export function activeExploreFilterCount(filters: RobinhoodExploreFilters) {
-  return Number(filters.age !== "any") + Number(filters.sort !== "newest");
+  return Number(filters.sort !== DEFAULT_EXPLORE_FILTERS.sort);
 }
 
 export function parseRobinhoodExploreQuery(query: URLSearchParams) {
   const page = query.get("page") ?? "1";
   const q = query.get("q") ?? "";
-  const age = query.get("age") ?? "any";
-  const sort = query.get("sort") ?? "newest";
-  if ([...query.keys()].some((key) => !["page", "q", "age", "sort"].includes(key) || query.getAll(key).length !== 1)
+  const sort = query.get("sort") ?? DEFAULT_EXPLORE_FILTERS.sort;
+  if ([...query.keys()].some((key) => !["page", "q", "sort"].includes(key) || query.getAll(key).length !== 1)
     || !/^[1-9]\d{0,5}$/.test(page) || q.length > 128
-    || !LAUNCH_AGE_OPTIONS.some((option) => option.value === age)
     || !LAUNCH_SORT_OPTIONS.some((option) => option.value === sort)) return null;
-  return { page: Number(page), q, filters: { age, sort } as RobinhoodExploreFilters };
+  return { page: Number(page), q, filters: { sort } as RobinhoodExploreFilters };
 }

--- a/lib/robinhood-explore-policy.ts
+++ b/lib/robinhood-explore-policy.ts
@@ -1,0 +1,14 @@
+// Website display policy only. Canonical launch records are never removed here.
+export const PINNED_ROBINHOOD_TOKEN = "0xc60ba256b44334a0cd2c7242e98b88f031abb006";
+
+const HIDDEN_ROBINHOOD_TOKENS = new Set([
+  "0x15fca474b23cafe775120b1fafbcff0e7a827af2", // Robinhood Clean Room
+]);
+
+export function isVisibleRobinhoodToken(address: string) {
+  return !HIDDEN_ROBINHOOD_TOKENS.has(address.toLowerCase());
+}
+
+export function isPinnedRobinhoodToken(address: string) {
+  return address.toLowerCase() === PINNED_ROBINHOOD_TOKEN;
+}

--- a/lib/robinhood-launches.ts
+++ b/lib/robinhood-launches.ts
@@ -30,3 +30,7 @@ export type RobinhoodLaunchList = Readonly<{
     hasMore: boolean;
   }>;
 }>;
+
+export type RobinhoodProfileLaunchList = RobinhoodLaunchList & Readonly<{
+  account: string;
+}>;

--- a/lib/robinhood-presentation.ts
+++ b/lib/robinhood-presentation.ts
@@ -17,6 +17,8 @@ export type RobinhoodCoinPresentation = Readonly<{
   market: RobinhoodCoinMarket | null;
 }>;
 
+export const ROBINHOOD_MARKET_MAX_AGE_MS = 180_000;
+
 export function mergeRobinhoodPresentations(
   previous: readonly RobinhoodCoinPresentation[],
   incoming: readonly RobinhoodCoinPresentation[] | null,
@@ -26,7 +28,7 @@ export function mergeRobinhoodPresentations(
   let delayed = incoming === null;
   function recent(market: RobinhoodCoinMarket | null | undefined) {
     const age = market ? now - Date.parse(market.observedAt) : NaN;
-    return age >= 0 && age <= 180_000 ? market : null;
+    return age >= 0 && age <= ROBINHOOD_MARKET_MAX_AGE_MS ? market : null;
   }
   const items = (incoming ?? previous.map((item) => ({ ...item, market: null }))).map((item) => {
     const previousMarket = saved.get(item.tokenAddress.toLowerCase());

--- a/lib/robinhood-presentation.ts
+++ b/lib/robinhood-presentation.ts
@@ -1,0 +1,45 @@
+export type RobinhoodCoinMarket = Readonly<{
+  poolId: string;
+  priceUsd: number | null;
+  marketCapUsd: number | null;
+  liquidityUsd: number | null;
+  volume24hUsd: number | null;
+  change24hPercent: number | null;
+  observedAt: string;
+  sourceUrl: string;
+}>;
+
+export type RobinhoodCoinPresentation = Readonly<{
+  tokenAddress: string;
+  imageUrl: string | null;
+  description: string | null;
+  links: readonly Readonly<{ label: string; url: string }>[];
+  market: RobinhoodCoinMarket | null;
+}>;
+
+const compactDollars = new Intl.NumberFormat("en-US", {
+  style: "currency", currency: "USD", notation: "compact", maximumFractionDigits: 2,
+});
+const priceDollars = new Intl.NumberFormat("en-US", {
+  style: "currency", currency: "USD", maximumSignificantDigits: 4,
+});
+
+export function coinDollars(value: number | null | undefined, price = false) {
+  if (value == null || !Number.isFinite(value) || value < 0) return "—";
+  return (price ? priceDollars : compactDollars).format(value);
+}
+
+export function coinAge(value: string | null, now: number) {
+  if (!value || !Number.isFinite(Date.parse(value))) return "Time unavailable";
+  const seconds = Math.max(0, Math.floor((now - Date.parse(value)) / 1_000));
+  if (seconds < 60) return "Just launched";
+  if (seconds < 3_600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3_600)}h ago`;
+  if (seconds < 2_592_000) return `${Math.floor(seconds / 86_400)}d ago`;
+  return new Intl.DateTimeFormat("en-GB", { day: "numeric", month: "short", year: "numeric", timeZone: "UTC" }).format(new Date(value));
+}
+
+export function coinTicker(value: string | null) {
+  const ticker = value?.trim();
+  return ticker ? ticker.startsWith("$") ? ticker : `$${ticker}` : "Ticker unavailable";
+}

--- a/lib/robinhood-presentation.ts
+++ b/lib/robinhood-presentation.ts
@@ -17,6 +17,31 @@ export type RobinhoodCoinPresentation = Readonly<{
   market: RobinhoodCoinMarket | null;
 }>;
 
+export function mergeRobinhoodPresentations(
+  previous: readonly RobinhoodCoinPresentation[],
+  incoming: readonly RobinhoodCoinPresentation[] | null,
+  now = Date.now(),
+) {
+  const saved = new Map(previous.map((item) => [item.tokenAddress.toLowerCase(), item.market]));
+  let delayed = incoming === null;
+  function recent(market: RobinhoodCoinMarket | null | undefined) {
+    const age = market ? now - Date.parse(market.observedAt) : NaN;
+    return age >= 0 && age <= 180_000 ? market : null;
+  }
+  const items = (incoming ?? previous.map((item) => ({ ...item, market: null }))).map((item) => {
+    const previousMarket = saved.get(item.tokenAddress.toLowerCase());
+    const samePool = !item.market || previousMarket?.poolId.toLowerCase() === item.market.poolId.toLowerCase();
+    const savedMarket = samePool ? recent(previousMarket) : null;
+    const nextMarket = recent(item.market);
+    // Keep a complete, recent observation; never give saved values a new timestamp.
+    const market = savedMarket && (!nextMarket || Date.parse(savedMarket.observedAt) > Date.parse(nextMarket.observedAt))
+      ? savedMarket : nextMarket ?? null;
+    if (market !== item.market || (previousMarket && !nextMarket)) delayed = true;
+    return market === item.market ? item : { ...item, market };
+  });
+  return { items, delayed };
+}
+
 const compactDollars = new Intl.NumberFormat("en-US", {
   style: "currency", currency: "USD", notation: "compact", maximumFractionDigits: 2,
 });

--- a/lib/server/robinhood-index/model.ts
+++ b/lib/server/robinhood-index/model.ts
@@ -1,5 +1,6 @@
 import type { RobinhoodLaunch, RobinhoodLaunchList } from "@/lib/robinhood-launches";
 import { DEFAULT_EXPLORE_FILTERS, type RobinhoodExploreFilters } from "@/lib/robinhood-explore-filters";
+import { isPinnedRobinhoodToken, isVisibleRobinhoodToken } from "@/lib/robinhood-explore-policy";
 
 export type Checkpoint = { number: string; hash: string };
 export type RobinhoodSnapshot = {
@@ -78,27 +79,39 @@ function asPending(value: unknown) {
   return value as { block: Checkpoint; items: RobinhoodLaunch[] };
 }
 
-export function launchList(snapshot: RobinhoodSnapshot | null, page = 1, query = "", now = Date.now(), filters: RobinhoodExploreFilters = DEFAULT_EXPLORE_FILTERS): RobinhoodLaunchList {
+export function launchList(snapshot: RobinhoodSnapshot | null, page = 1, query = "", now = Date.now(), filters: RobinhoodExploreFilters = DEFAULT_EXPLORE_FILTERS, marketCaps: ReadonlyMap<string, number> = new Map()): RobinhoodLaunchList {
   const q = query.trim().toLowerCase();
-  const ageMs = { any: null, "24h": 86_400_000, "7d": 604_800_000, "30d": 2_592_000_000 }[filters.age];
-  const items = (snapshot?.items ?? []).filter((row) => {
-    if (q && ![row.name, row.symbol, row.tokenAddress, row.hookAddress].some((value) => value?.toLowerCase().includes(q))) return false;
-    if (ageMs === null) return true;
-    const launched = row.launchedAt ? Date.parse(row.launchedAt) : NaN;
-    return launched >= now - ageMs && launched <= now;
-  }).toSorted((a, b) => {
+  const visible = (snapshot?.items ?? []).filter((row) => isVisibleRobinhoodToken(row.tokenAddress));
+  const pinned = visible.find((row) => isPinnedRobinhoodToken(row.tokenAddress));
+  const cap = (address: string) => {
+    const value = marketCaps.get(address.toLowerCase());
+    return value != null && Number.isFinite(value) && value >= 0 ? value : null;
+  };
+  const items = visible.filter((row) => row !== pinned && (!q
+    || [row.name, row.symbol, row.tokenAddress, row.hookAddress].some((value) => value?.toLowerCase().includes(q))))
+    .toSorted((a, b) => {
+    if (filters.sort === "highest" || filters.sort === "lowest") {
+      const aCap = cap(a.tokenAddress);
+      const bCap = cap(b.tokenAddress);
+      if (aCap === null && bCap !== null) return 1;
+      if (bCap === null && aCap !== null) return -1;
+      if (aCap !== null && bCap !== null && aCap !== bCap) return filters.sort === "highest" ? bCap - aCap : aCap - bCap;
+    }
     const newest = BigInt(a.blockNumber) === BigInt(b.blockNumber)
       ? b.logIndex - a.logIndex : BigInt(a.blockNumber) > BigInt(b.blockNumber) ? -1 : 1;
-    return filters.sort === "oldest" ? -newest : newest;
+    return (filters.sort === "oldest" ? -newest : newest) || a.tokenAddress.toLowerCase().localeCompare(b.tokenAddress.toLowerCase());
   });
-  const totalPages = Math.ceil(items.length / 50);
+  // Reserve the first slot for the verified main token on every page and sort.
+  const pageSize = pinned ? 49 : 50;
+  const totalItems = items.length + Number(Boolean(pinned));
+  const totalPages = Math.max(pinned ? 1 : 0, Math.ceil(items.length / pageSize));
   const number = Math.min(Math.max(1, page), Math.max(1, totalPages));
   const status = !snapshot ? "unavailable"
     : now - Date.parse(snapshot.updatedAt) > 300_000 ? "stale"
     : snapshot.pending || snapshot.cursor?.number !== snapshot.finalizedBlock ? "syncing" : "ready";
   return {
     chainId: 4663, status, updatedAt: snapshot?.updatedAt ?? null,
-    items: items.slice((number - 1) * 50, number * 50),
-    page: { number, size: 50, totalItems: items.length, totalPages, hasMore: number < totalPages },
+    items: [...(pinned ? [pinned] : []), ...items.slice((number - 1) * pageSize, number * pageSize)],
+    page: { number, size: 50, totalItems, totalPages, hasMore: number < totalPages },
   };
 }

--- a/lib/server/robinhood-index/model.ts
+++ b/lib/server/robinhood-index/model.ts
@@ -1,4 +1,4 @@
-import type { RobinhoodLaunch, RobinhoodLaunchList } from "@/lib/robinhood-launches";
+import type { RobinhoodLaunch, RobinhoodLaunchList, RobinhoodProfileLaunchList } from "@/lib/robinhood-launches";
 import { DEFAULT_EXPLORE_FILTERS, type RobinhoodExploreFilters } from "@/lib/robinhood-explore-filters";
 import { isPinnedRobinhoodToken, isVisibleRobinhoodToken } from "@/lib/robinhood-explore-policy";
 
@@ -113,5 +113,30 @@ export function launchList(snapshot: RobinhoodSnapshot | null, page = 1, query =
     chainId: 4663, status, updatedAt: snapshot?.updatedAt ?? null,
     items: [...(pinned ? [pinned] : []), ...items.slice((number - 1) * pageSize, number * pageSize)],
     page: { number, size: 50, totalItems, totalPages, hasMore: number < totalPages },
+  };
+}
+
+// A profile shows the recorded launch wallet's history. Explore's display policy
+// and market ranking do not change which canonical launches belong to that wallet.
+export function profileLaunchList(snapshot: RobinhoodSnapshot | null, account: string, page = 1, now = Date.now()): RobinhoodProfileLaunchList {
+  const normalizedAccount = account.toLowerCase();
+  if (!ADDRESS.test(normalizedAccount)) throw new Error("Invalid Robinhood profile account");
+  const items = (snapshot?.items ?? [])
+    .filter((row) => row.creator.toLowerCase() === normalizedAccount)
+    .toSorted((a, b) => {
+      const newest = BigInt(a.blockNumber) === BigInt(b.blockNumber)
+        ? b.logIndex - a.logIndex : BigInt(a.blockNumber) > BigInt(b.blockNumber) ? -1 : 1;
+      return newest || a.tokenAddress.toLowerCase().localeCompare(b.tokenAddress.toLowerCase());
+    });
+  const totalPages = Math.ceil(items.length / 50);
+  const requestedPage = Number.isSafeInteger(page) && page > 0 ? page : 1;
+  const number = Math.min(requestedPage, Math.max(1, totalPages));
+  const status = !snapshot ? "unavailable"
+    : now - Date.parse(snapshot.updatedAt) > 300_000 ? "stale"
+    : snapshot.pending || snapshot.cursor?.number !== snapshot.finalizedBlock ? "syncing" : "ready";
+  return {
+    chainId: 4663, account: normalizedAccount, status, updatedAt: snapshot?.updatedAt ?? null,
+    items: items.slice((number - 1) * 50, number * 50),
+    page: { number, size: 50, totalItems: items.length, totalPages, hasMore: number < totalPages },
   };
 }

--- a/lib/server/robinhood-index/model.ts
+++ b/lib/server/robinhood-index/model.ts
@@ -1,4 +1,5 @@
 import type { RobinhoodLaunch, RobinhoodLaunchList } from "@/lib/robinhood-launches";
+import { DEFAULT_EXPLORE_FILTERS, type RobinhoodExploreFilters } from "@/lib/robinhood-explore-filters";
 
 export type Checkpoint = { number: string; hash: string };
 export type RobinhoodSnapshot = {
@@ -77,12 +78,19 @@ function asPending(value: unknown) {
   return value as { block: Checkpoint; items: RobinhoodLaunch[] };
 }
 
-export function launchList(snapshot: RobinhoodSnapshot | null, page = 1, query = "", now = Date.now()): RobinhoodLaunchList {
+export function launchList(snapshot: RobinhoodSnapshot | null, page = 1, query = "", now = Date.now(), filters: RobinhoodExploreFilters = DEFAULT_EXPLORE_FILTERS): RobinhoodLaunchList {
   const q = query.trim().toLowerCase();
-  const items = (snapshot?.items ?? []).filter((row) => !q ||
-    [row.name, row.symbol, row.tokenAddress, row.hookAddress].some((value) => value?.toLowerCase().includes(q)))
-    .toSorted((a, b) => BigInt(a.blockNumber) === BigInt(b.blockNumber)
-      ? b.logIndex - a.logIndex : BigInt(a.blockNumber) > BigInt(b.blockNumber) ? -1 : 1);
+  const ageMs = { any: null, "24h": 86_400_000, "7d": 604_800_000, "30d": 2_592_000_000 }[filters.age];
+  const items = (snapshot?.items ?? []).filter((row) => {
+    if (q && ![row.name, row.symbol, row.tokenAddress, row.hookAddress].some((value) => value?.toLowerCase().includes(q))) return false;
+    if (ageMs === null) return true;
+    const launched = row.launchedAt ? Date.parse(row.launchedAt) : NaN;
+    return launched >= now - ageMs && launched <= now;
+  }).toSorted((a, b) => {
+    const newest = BigInt(a.blockNumber) === BigInt(b.blockNumber)
+      ? b.logIndex - a.logIndex : BigInt(a.blockNumber) > BigInt(b.blockNumber) ? -1 : 1;
+    return filters.sort === "oldest" ? -newest : newest;
+  });
   const totalPages = Math.ceil(items.length / 50);
   const number = Math.min(Math.max(1, page), Math.max(1, totalPages));
   const status = !snapshot ? "unavailable"

--- a/lib/server/robinhood-index/read.ts
+++ b/lib/server/robinhood-index/read.ts
@@ -1,6 +1,9 @@
 import "server-only";
 import { unstable_cache } from "next/cache";
 import { DEFAULT_EXPLORE_FILTERS, type RobinhoodExploreFilters } from "@/lib/robinhood-explore-filters";
+import { isVisibleRobinhoodToken } from "@/lib/robinhood-explore-policy";
+import { readRobinhoodMarkets, readRobinhoodPresentations } from "@/lib/server/robinhood-presentation";
+import type { RobinhoodCoinMarket, RobinhoodCoinPresentation } from "@/lib/robinhood-presentation";
 import { launchList } from "./model";
 import { indexStore } from "./store";
 
@@ -9,8 +12,15 @@ const readSnapshot = unstable_cache(async () => (await indexStore().read())?.sna
   ["robinhood-website-index-v1"], { revalidate: 15 });
 
 export async function readRobinhoodLaunches(page = 1, query = "", filters: RobinhoodExploreFilters = DEFAULT_EXPLORE_FILTERS) {
-  try { return launchList(await readSnapshot(), page, query, Date.now(), filters); }
-  catch { return launchList(null, page, query, Date.now(), filters); }
+  try {
+    const snapshot = await readSnapshot();
+    const visible = (snapshot?.items ?? []).filter((token) => isVisibleRobinhoodToken(token.tokenAddress));
+    const markets = await readRobinhoodMarkets(visible).catch(() => new Map<string, RobinhoodCoinMarket>());
+    const caps = new Map(Array.from(markets).flatMap(([address, market]) => market.marketCapUsd === null ? [] : [[address, market.marketCapUsd] as const]));
+    const list = launchList(snapshot, page, query, Date.now(), filters, caps);
+    // Ranking and card values use the same full-catalog market observation.
+    return { ...list, presentations: await readRobinhoodPresentations(list.items, markets) };
+  } catch { return { ...launchList(null, page, query, Date.now(), filters), presentations: [] as RobinhoodCoinPresentation[] }; }
 }
 
 export async function readRobinhoodToken(address: string) {

--- a/lib/server/robinhood-index/read.ts
+++ b/lib/server/robinhood-index/read.ts
@@ -4,7 +4,7 @@ import { DEFAULT_EXPLORE_FILTERS, type RobinhoodExploreFilters } from "@/lib/rob
 import { isVisibleRobinhoodToken } from "@/lib/robinhood-explore-policy";
 import { readRobinhoodMarkets, readRobinhoodPresentations } from "@/lib/server/robinhood-presentation";
 import type { RobinhoodCoinMarket, RobinhoodCoinPresentation } from "@/lib/robinhood-presentation";
-import { launchList } from "./model";
+import { launchList, profileLaunchList } from "./model";
 import { indexStore } from "./store";
 
 // A page reads the saved list only. Failures never fall through to an RPC.
@@ -32,4 +32,10 @@ export async function readRobinhoodToken(address: string) {
       token: snapshot?.items.find((row) => row.tokenAddress.toLowerCase() === address.toLowerCase()) ?? null,
     };
   } catch { return { status: "unavailable" as const, updatedAt: null, token: null }; }
+}
+
+export async function readRobinhoodProfileLaunches(account: string, page = 1) {
+  const unavailable = profileLaunchList(null, account, page);
+  try { return profileLaunchList(await readSnapshot(), unavailable.account, page); }
+  catch { return unavailable; }
 }

--- a/lib/server/robinhood-index/read.ts
+++ b/lib/server/robinhood-index/read.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { unstable_cache } from "next/cache";
+import { DEFAULT_EXPLORE_FILTERS, type RobinhoodExploreFilters } from "@/lib/robinhood-explore-filters";
 import { launchList } from "./model";
 import { indexStore } from "./store";
 
@@ -7,9 +8,9 @@ import { indexStore } from "./store";
 const readSnapshot = unstable_cache(async () => (await indexStore().read())?.snapshot ?? null,
   ["robinhood-website-index-v1"], { revalidate: 15 });
 
-export async function readRobinhoodLaunches(page = 1, query = "") {
-  try { return launchList(await readSnapshot(), page, query); }
-  catch { return launchList(null, page, query); }
+export async function readRobinhoodLaunches(page = 1, query = "", filters: RobinhoodExploreFilters = DEFAULT_EXPLORE_FILTERS) {
+  try { return launchList(await readSnapshot(), page, query, Date.now(), filters); }
+  catch { return launchList(null, page, query, Date.now(), filters); }
 }
 
 export async function readRobinhoodToken(address: string) {

--- a/lib/server/robinhood-presentation.ts
+++ b/lib/server/robinhood-presentation.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { unstable_cache } from "next/cache";
 import type { RobinhoodLaunch } from "@/lib/robinhood-launches";
-import type { RobinhoodCoinMarket, RobinhoodCoinPresentation } from "@/lib/robinhood-presentation";
+import { ROBINHOOD_MARKET_MAX_AGE_MS, type RobinhoodCoinMarket, type RobinhoodCoinPresentation } from "@/lib/robinhood-presentation";
 import { PROGRAMMABLE_MAIN_TOKEN_PRESENTATION } from "@/lib/programmable-main-token-presentation";
 import { safePublicImageUrl } from "@/lib/safe-public-image-url";
 // @ts-expect-error -- the canonical launch package is ESM JavaScript.
@@ -14,12 +14,14 @@ const MAIN_TOKEN = "0xc60ba256b44334a0cd2c7242e98b88f031abb006";
 const MAX_RESPONSE_BYTES = 2_000_000;
 const MAX_METADATA_PAGES = 8;
 const MAX_TOKENS = 50;
+const MAX_MARKET_TOKENS = 10_000;
 const ADDRESS = /^0x[\da-f]{40}$/i;
 const HASH = /^0x[\da-f]{64}$/i;
 
 type JsonObject = Record<string, unknown>;
 type Metadata = Pick<RobinhoodCoinPresentation, "imageUrl" | "description" | "links">;
 type MetadataBinding = Readonly<{ launch: JsonObject; metadata: Metadata }>;
+type MarketToken = Pick<RobinhoodLaunch, "tokenAddress" | "poolId">;
 const object = (value: unknown): value is JsonObject =>
   value !== null && typeof value === "object" && !Array.isArray(value);
 const same = (left: unknown, right: unknown) =>
@@ -184,28 +186,45 @@ function numeric(value: unknown, signed = false): number | null {
   return Number.isFinite(parsed) && (signed || parsed >= 0) ? parsed : null;
 }
 
-async function readMarkets(tokens: readonly RobinhoodLaunch[]): Promise<Map<string, RobinhoodCoinMarket>> {
+async function readMarkets(tokens: readonly MarketToken[]): Promise<Map<string, RobinhoodCoinMarket>> {
   const pools = [...new Set(tokens.map((token) => token.poolId.toLowerCase()))];
-  const signal = AbortSignal.timeout(4_000);
   const batches = Array.from({ length: Math.ceil(pools.length / 30) }, (_, index) => pools.slice(index * 30, (index + 1) * 30));
-  const results = await Promise.allSettled(batches.map(async (batch) => {
-    const payload = await readJson(`${DEX_PAIRS}${batch.join(",")}`, signal);
-    if (!object(payload) || !Array.isArray(payload.pairs) || payload.pairs.length > 100) {
-      if (object(payload) && payload.pairs === null) return [];
-      throw new Error("Invalid market response");
+  const pairs: { pair: unknown; observedAt: string }[] = [];
+  const overall = AbortSignal.timeout(6_000);
+  let nextBatch = 0;
+  let failed = false;
+  async function worker() {
+    while (nextBatch < batches.length && !overall.aborted) {
+      const batch = batches[nextBatch++];
+      try {
+        const payload = await readJson(`${DEX_PAIRS}${batch.join(",")}`,
+          AbortSignal.any([overall, AbortSignal.timeout(4_000)]));
+        if (!object(payload) || !(payload.pairs === null || Array.isArray(payload.pairs))
+          || (Array.isArray(payload.pairs) && payload.pairs.length > 100)) throw new Error("Invalid market response");
+        const observedAt = new Date().toISOString();
+        if (Array.isArray(payload.pairs)) pairs.push(...payload.pairs.map((pair) => ({ pair, observedAt })));
+      } catch { failed = true; }
     }
-    return payload.pairs;
-  }));
-  const pairs = results.flatMap((result) => result.status === "fulfilled" ? result.value : []);
+  }
+  await Promise.all(Array.from({ length: Math.min(4, batches.length) }, worker));
+  // Reject an incomplete refresh so the cache retains the last complete observation.
+  // The reader still expires it after three minutes; token membership is independent.
+  if (failed || nextBatch < batches.length) throw new Error("Market observation unavailable");
+  const byIdentity = new Map<string, { pair: JsonObject; observedAt: string } | null>();
+  for (const { pair, observedAt } of pairs) {
+    if (!object(pair) || pair.chainId !== "robinhood" || pair.dexId !== "uniswap"
+      || !Array.isArray(pair.labels) || !pair.labels.includes("v4")
+      || typeof pair.pairAddress !== "string" || !HASH.test(pair.pairAddress)
+      || !object(pair.baseToken) || typeof pair.baseToken.address !== "string" || !ADDRESS.test(pair.baseToken.address)) continue;
+    const key = `${pair.baseToken.address.toLowerCase()}:${pair.pairAddress.toLowerCase()}`;
+    // Ambiguous duplicates never become a price for a verified launch.
+    byIdentity.set(key, byIdentity.has(key) ? null : { pair, observedAt });
+  }
   const markets = new Map<string, RobinhoodCoinMarket>();
-  const observedAt = new Date().toISOString();
   for (const token of tokens) {
-    const matches = pairs.filter((pair) => object(pair) && pair.chainId === "robinhood"
-      && pair.dexId === "uniswap" && Array.isArray(pair.labels) && pair.labels.includes("v4")
-      && same(pair.pairAddress, token.poolId) && object(pair.baseToken)
-      && same(pair.baseToken.address, token.tokenAddress));
-    if (matches.length !== 1) continue;
-    const pair = matches[0] as JsonObject;
+    const match = byIdentity.get(`${token.tokenAddress.toLowerCase()}:${token.poolId.toLowerCase()}`);
+    if (!match) continue;
+    const { pair, observedAt } = match;
     markets.set(token.tokenAddress.toLowerCase(), {
       poolId: token.poolId,
       priceUsd: numeric(pair.priceUsd),
@@ -220,8 +239,37 @@ async function readMarkets(tokens: readonly RobinhoodLaunch[]): Promise<Map<stri
   return markets;
 }
 
-const cachedPresentations = unstable_cache(async (tokens: readonly RobinhoodLaunch[]) => {
-  const [metadata, markets] = await Promise.allSettled([readMetadata(tokens), readMarkets(tokens)]);
+const cachedMetadata = unstable_cache(async (tokens: readonly RobinhoodLaunch[]) =>
+  Array.from(await readMetadata(tokens)), ["robinhood-coin-metadata-v2"], { revalidate: 60 });
+
+// A shared full-catalog observation makes sorting independent of the current page.
+const cachedMarkets = unstable_cache(async (tokens: readonly MarketToken[]) =>
+  Array.from(await readMarkets(tokens)), ["robinhood-coin-markets-v2"], { revalidate: 60 });
+
+export async function readRobinhoodMarkets(tokens: readonly MarketToken[]): Promise<Map<string, RobinhoodCoinMarket>> {
+  if (tokens.length === 0) return new Map();
+  if (tokens.length > MAX_MARKET_TOKENS || tokens.some((token) => !ADDRESS.test(token.tokenAddress) || !HASH.test(token.poolId))) {
+    throw new Error("Invalid market request");
+  }
+  const identities = tokens.map((token) => ({ tokenAddress: token.tokenAddress.toLowerCase(), poolId: token.poolId.toLowerCase() }))
+    .toSorted((a, b) => a.tokenAddress.localeCompare(b.tokenAddress));
+  const entries = await cachedMarkets(identities);
+  const now = Date.now();
+  return new Map(entries.filter(([, market]) => {
+    const age = now - Date.parse(market.observedAt);
+    return age >= 0 && age <= ROBINHOOD_MARKET_MAX_AGE_MS;
+  }));
+}
+
+export async function readRobinhoodPresentations(tokens: readonly RobinhoodLaunch[], knownMarkets?: ReadonlyMap<string, RobinhoodCoinMarket>): Promise<RobinhoodCoinPresentation[]> {
+  if (tokens.length === 0) return [];
+  if (tokens.length > MAX_TOKENS || tokens.some((token) => !ADDRESS.test(token.tokenAddress) || !HASH.test(token.poolId))) {
+    throw new Error("Invalid presentation request");
+  }
+  const [metadata, markets] = await Promise.allSettled([
+    cachedMetadata(tokens.toSorted((a, b) => a.tokenAddress.toLowerCase().localeCompare(b.tokenAddress.toLowerCase()))).then((entries) => new Map(entries)),
+    knownMarkets ? Promise.resolve(knownMarkets) : readRobinhoodMarkets(tokens),
+  ]);
   return tokens.map((token): RobinhoodCoinPresentation => {
     const key = token.tokenAddress.toLowerCase();
     const presentation = metadata.status === "fulfilled" ? metadata.value.get(key) : undefined;
@@ -233,12 +281,4 @@ const cachedPresentations = unstable_cache(async (tokens: readonly RobinhoodLaun
       market: markets.status === "fulfilled" ? markets.value.get(key) ?? null : null,
     };
   });
-}, ["robinhood-coin-presentation-v1"], { revalidate: 60 });
-
-export async function readRobinhoodPresentations(tokens: readonly RobinhoodLaunch[]): Promise<RobinhoodCoinPresentation[]> {
-  if (tokens.length === 0) return [];
-  if (tokens.length > MAX_TOKENS || tokens.some((token) => !ADDRESS.test(token.tokenAddress) || !HASH.test(token.poolId))) {
-    throw new Error("Invalid presentation request");
-  }
-  return cachedPresentations(tokens);
 }

--- a/lib/server/robinhood-presentation.ts
+++ b/lib/server/robinhood-presentation.ts
@@ -1,0 +1,244 @@
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+import type { RobinhoodLaunch } from "@/lib/robinhood-launches";
+import type { RobinhoodCoinMarket, RobinhoodCoinPresentation } from "@/lib/robinhood-presentation";
+import { PROGRAMMABLE_MAIN_TOKEN_PRESENTATION } from "@/lib/programmable-main-token-presentation";
+import { safePublicImageUrl } from "@/lib/safe-public-image-url";
+// @ts-expect-error -- the canonical launch package is ESM JavaScript.
+import { hashProjectMetadata, validateProjectMetadata } from "@/packages/launch/src/project-metadata.mjs";
+
+const FINALIZED_FEED = "https://api.programmable.market/v4/chains/4663/finalized-custom-launches";
+const DEX_PAIRS = "https://api.dexscreener.com/latest/dex/pairs/robinhood/";
+const MAIN_TOKEN = "0xc60ba256b44334a0cd2c7242e98b88f031abb006";
+const MAX_RESPONSE_BYTES = 2_000_000;
+const MAX_METADATA_PAGES = 8;
+const MAX_TOKENS = 50;
+const ADDRESS = /^0x[\da-f]{40}$/i;
+const HASH = /^0x[\da-f]{64}$/i;
+
+type JsonObject = Record<string, unknown>;
+type Metadata = Pick<RobinhoodCoinPresentation, "imageUrl" | "description" | "links">;
+type MetadataBinding = Readonly<{ launch: JsonObject; metadata: Metadata }>;
+const object = (value: unknown): value is JsonObject =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+const same = (left: unknown, right: unknown) =>
+  typeof left === "string" && typeof right === "string" && left.toLowerCase() === right.toLowerCase();
+const count = (value: unknown): value is number =>
+  typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+
+async function readJson(url: string, signal: AbortSignal): Promise<unknown> {
+  const response = await fetch(url, {
+    signal, redirect: "error", cache: "no-store", headers: { accept: "application/json" },
+  });
+  if (!response.ok || response.redirected
+    || response.headers.get("content-type")?.split(";", 1)[0]?.trim() !== "application/json"
+    || Number(response.headers.get("content-length")) > MAX_RESPONSE_BYTES
+    || !response.body) throw new Error("Presentation source unavailable");
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > MAX_RESPONSE_BYTES) throw new Error("Presentation response too large");
+      chunks.push(value);
+    }
+    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } finally {
+    await reader.cancel().catch(() => undefined);
+    reader.releaseLock();
+  }
+}
+
+function httpsUrl(value: unknown): string | null {
+  if (typeof value !== "string" || value.length > 2_048) return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && !url.username && !url.password ? url.href : null;
+  } catch { return null; }
+}
+
+function projectImageUrl(value: string): string | null {
+  // These are the same public gateways used by the existing finalized feed reader.
+  // The canonical metadata validator has already checked the CID or transaction ID.
+  const url = new URL(value);
+  if (url.protocol === "ipfs:") return `https://ipfs.io/ipfs/${url.hostname}`;
+  if (url.protocol === "ar:") return `https://arweave.net/${url.hostname}`;
+  return safePublicImageUrl(value) ?? null;
+}
+
+function parseMetadata(launch: unknown): MetadataBinding | null {
+  if (!object(launch) || launch.schemaVersion !== "programmable.finalized-custom-launch-metadata.v4"
+    || launch.apiVersion !== "v4" || launch.chainId !== "4663" || launch.caip2 !== "eip155:4663"
+    || launch.platformId !== "programmable" || launch.category !== "custom"
+    || launch.chainDeploymentId !== "robinhood-mainnet-custom-launch-v1"
+    || !object(launch.onchain) || !object(launch.commitments)
+    || !object(launch.sourceVerification) || launch.sourceVerification.status !== "exact_match"
+    || !Array.isArray(launch.sourceVerification.components)
+    || launch.sourceVerification.components.length === 0
+    || !launch.sourceVerification.components.every((component) => object(component) && component.status === "exact_match")) return null;
+  const onchain = launch.onchain;
+  if (onchain.schemaVersion !== "programmable.custom-launch-onchain-evidence.v3"
+    || onchain.chainId !== "4663" || onchain.caip2 !== "eip155:4663"
+    || onchain.terminal !== true || onchain.checkpointType !== "ethereum_finalized"
+    || !object(onchain.commitments) || !object(onchain.l2Inclusion)
+    || !same(onchain.commitments.metadata, launch.commitments.metadata)) return null;
+  try {
+    const metadata = validateProjectMetadata(launch.projectMetadata, { requireComplete: true });
+    if (hashProjectMetadata(metadata, { requireComplete: true }) !== launch.commitments.metadata) return null;
+    const presentation = metadata.presentation as {
+      description: string; image: { uri: string }; links: { kind: string; uri: string }[];
+    };
+    const labels: Record<string, string> = {
+      website: "Website", x: "X", telegram: "Telegram", discord: "Discord",
+      github: "GitHub", documentation: "Docs",
+    };
+    return { launch, metadata: {
+      imageUrl: projectImageUrl(presentation.image.uri),
+      description: presentation.description || null,
+      links: presentation.links.flatMap(({ kind, uri }) => {
+        const url = httpsUrl(uri);
+        return url ? [{ label: labels[kind] ?? "Project link", url }] : [];
+      }),
+    } };
+  } catch { return null; }
+}
+
+function metadataMatches(binding: MetadataBinding, token: RobinhoodLaunch): boolean {
+  const launch = binding.launch;
+  const onchain = launch.onchain as JsonObject;
+  const l2 = onchain.l2Inclusion as JsonObject;
+  const source = launch.sourceVerification as JsonObject;
+  const metadata = launch.projectMetadata as JsonObject;
+  const declaredToken = metadata.token as JsonObject;
+  const components = source.components as JsonObject[];
+  return same(onchain.router, token.routerAddress) && same(onchain.routerLaunchId, token.launchId)
+    && same(onchain.transactionHash, token.transactionHash) && same(l2.transactionHash, token.transactionHash)
+    && l2.chainId === "4663" && l2.caip2 === "eip155:4663" && l2.receiptStatus === "success"
+    && l2.blockNumber === token.blockNumber && same(l2.blockHash, token.blockHash)
+    && l2.launchEventLogIndex === token.logIndex
+    && (token.name === null || declaredToken.name === token.name)
+    && (token.symbol === null || declaredToken.symbol === token.symbol)
+    && components.some((component) => same(component.address, token.tokenAddress))
+    && components.some((component) => same(component.address, token.hookAddress));
+}
+
+async function readMetadata(tokens: readonly RobinhoodLaunch[]): Promise<Map<string, Metadata>> {
+  const result = new Map<string, Metadata>();
+  const seenLaunches = new Set<string>();
+  const seenCursors = new Set<string>();
+  const signal = AbortSignal.timeout(6_000);
+  let cursor: string | null = null;
+  let datasetCount: number | null = null;
+  // This is optional artwork lookup, never launch discovery. An unmatched older
+  // launch keeps its card when the bounded lookup or either provider fails.
+  for (let page = 0; page < MAX_METADATA_PAGES; page++) {
+    const url = new URL(FINALIZED_FEED);
+    url.searchParams.set("limit", "25");
+    if (cursor !== null) url.searchParams.set("cursor", cursor);
+    const value = await readJson(url.href, signal);
+    if (!object(value) || value.schemaVersion !== "programmable.custom-launch-list.v4"
+      || value.apiVersion !== "v4" || value.chainId !== "4663" || value.caip2 !== "eip155:4663"
+      || !object(value.quality) || value.quality.status !== "ready"
+      || !count(value.quality.publishedRowCount) || !count(value.quality.sourceRowCount)
+      || value.quality.publishedRowCount !== value.quality.sourceRowCount
+      || value.quality.quarantinedRowCount !== 0
+      || !Array.isArray(value.launches) || value.launches.length > 25
+      || value.launches.length > value.quality.publishedRowCount
+      || typeof value.generatedAt !== "string" || !Number.isFinite(Date.parse(value.generatedAt))
+      || Date.now() - Date.parse(value.generatedAt) > 300_000
+      || Date.parse(value.generatedAt) - Date.now() > 60_000
+      || !(value.nextCursor === null || (typeof value.nextCursor === "string"
+        && value.nextCursor.length > 0 && value.nextCursor.length <= 2_048))) {
+      throw new Error("Invalid finalized metadata feed");
+    }
+    if (datasetCount !== null && datasetCount !== value.quality.publishedRowCount) {
+      throw new Error("Finalized metadata changed during pagination");
+    }
+    datasetCount = value.quality.publishedRowCount;
+    for (const item of value.launches) {
+      const binding = parseMetadata(item);
+      if (!binding) continue;
+      const onchain = binding.launch.onchain as JsonObject;
+      const key = `${String(onchain.router).toLowerCase()}:${String(onchain.routerLaunchId).toLowerCase()}`;
+      if (seenLaunches.has(key)) throw new Error("Duplicate finalized metadata");
+      seenLaunches.add(key);
+      const token = tokens.find((candidate) => metadataMatches(binding, candidate));
+      if (token) result.set(token.tokenAddress.toLowerCase(), binding.metadata);
+    }
+    if (value.nextCursor === null || result.size === tokens.length) return result;
+    cursor = value.nextCursor as string;
+    if (seenCursors.has(cursor) || value.launches.length === 0) throw new Error("Invalid finalized metadata cursor");
+    seenCursors.add(cursor);
+  }
+  return result;
+}
+
+function numeric(value: unknown, signed = false): number | null {
+  if (typeof value !== "number" && typeof value !== "string") return null;
+  if (typeof value === "string" && !/^-?\d+(?:\.\d+)?(?:e[+-]?\d+)?$/i.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && (signed || parsed >= 0) ? parsed : null;
+}
+
+async function readMarkets(tokens: readonly RobinhoodLaunch[]): Promise<Map<string, RobinhoodCoinMarket>> {
+  const pools = [...new Set(tokens.map((token) => token.poolId.toLowerCase()))];
+  const signal = AbortSignal.timeout(4_000);
+  const batches = Array.from({ length: Math.ceil(pools.length / 30) }, (_, index) => pools.slice(index * 30, (index + 1) * 30));
+  const results = await Promise.allSettled(batches.map(async (batch) => {
+    const payload = await readJson(`${DEX_PAIRS}${batch.join(",")}`, signal);
+    if (!object(payload) || !Array.isArray(payload.pairs) || payload.pairs.length > 100) {
+      if (object(payload) && payload.pairs === null) return [];
+      throw new Error("Invalid market response");
+    }
+    return payload.pairs;
+  }));
+  const pairs = results.flatMap((result) => result.status === "fulfilled" ? result.value : []);
+  const markets = new Map<string, RobinhoodCoinMarket>();
+  const observedAt = new Date().toISOString();
+  for (const token of tokens) {
+    const matches = pairs.filter((pair) => object(pair) && pair.chainId === "robinhood"
+      && pair.dexId === "uniswap" && Array.isArray(pair.labels) && pair.labels.includes("v4")
+      && same(pair.pairAddress, token.poolId) && object(pair.baseToken)
+      && same(pair.baseToken.address, token.tokenAddress));
+    if (matches.length !== 1) continue;
+    const pair = matches[0] as JsonObject;
+    markets.set(token.tokenAddress.toLowerCase(), {
+      poolId: token.poolId,
+      priceUsd: numeric(pair.priceUsd),
+      marketCapUsd: numeric(pair.marketCap),
+      liquidityUsd: object(pair.liquidity) ? numeric(pair.liquidity.usd) : null,
+      volume24hUsd: object(pair.volume) ? numeric(pair.volume.h24) : null,
+      change24hPercent: object(pair.priceChange) ? numeric(pair.priceChange.h24, true) : null,
+      observedAt,
+      sourceUrl: `https://dexscreener.com/robinhood/${token.poolId.toLowerCase()}`,
+    });
+  }
+  return markets;
+}
+
+const cachedPresentations = unstable_cache(async (tokens: readonly RobinhoodLaunch[]) => {
+  const [metadata, markets] = await Promise.allSettled([readMetadata(tokens), readMarkets(tokens)]);
+  return tokens.map((token): RobinhoodCoinPresentation => {
+    const key = token.tokenAddress.toLowerCase();
+    const presentation = metadata.status === "fulfilled" ? metadata.value.get(key) : undefined;
+    return {
+      tokenAddress: token.tokenAddress,
+      imageUrl: presentation?.imageUrl ?? (key === MAIN_TOKEN ? PROGRAMMABLE_MAIN_TOKEN_PRESENTATION.imageUrl : null),
+      description: presentation?.description ?? null,
+      links: presentation?.links ?? [],
+      market: markets.status === "fulfilled" ? markets.value.get(key) ?? null : null,
+    };
+  });
+}, ["robinhood-coin-presentation-v1"], { revalidate: 60 });
+
+export async function readRobinhoodPresentations(tokens: readonly RobinhoodLaunch[]): Promise<RobinhoodCoinPresentation[]> {
+  if (tokens.length === 0) return [];
+  if (tokens.length > MAX_TOKENS || tokens.some((token) => !ADDRESS.test(token.tokenAddress) || !HASH.test(token.poolId))) {
+    throw new Error("Invalid presentation request");
+  }
+  return cachedPresentations(tokens);
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -30,6 +30,7 @@ export function createContentSecurityPolicy(isDevelopment: boolean) {
     ].filter(Boolean).join(" "),
     [
       "frame-src 'self'",
+      "https://dexscreener.com",
       "https://auth.privy.io",
       "https://*.privy.io",
       "https://verify.walletconnect.com",

--- a/tests/developer-api-keys-ui.test.ts
+++ b/tests/developer-api-keys-ui.test.ts
@@ -287,8 +287,9 @@ describe("developer API key interface", () => {
     expect(apiKeysSource).toContain('aria-pressed={activeSection === "history"}');
     expect(apiKeysSource).toContain('activeSection === "keys" ?');
     expect(apiKeysSource).not.toContain("Before anything reaches your wallet");
-    expect(apiKeysSource).toContain('href="/profile"');
-    expect(apiKeysSource).toContain("Back to profile");
+    expect(apiKeysSource).toContain('href="/launch"');
+    expect(apiKeysSource).toContain("<span>Back</span>");
+    expect(apiKeysSource).not.toContain("Back to profile");
     expect(apiKeysSource).toContain("const API_KEY_PAGE_SIZE = 3");
     expect(apiKeysSource).toContain("visibleApiKeys.map");
     expect(apiKeysSource).toContain('aria-label="API key pages"');

--- a/tests/developer-robinhood-launch.test.tsx
+++ b/tests/developer-robinhood-launch.test.tsx
@@ -252,9 +252,9 @@ describe("Robinhood Custom launch website flow", () => {
     expect(html).not.toContain("fee-policy-pending");
   });
 
-  it("routes the Custom card into the chain-bound launch section", () => {
+  it("shares key management while retaining explicit Robinhood launch deep links", () => {
     expect(launchEntrySource).toContain(
-      'href={`/developers/api-keys?start=custom&chainId=${chainId}`}',
+      'href="/developers/api-keys"',
     );
     expect(launchEntrySource).toContain('data-launch-model-launchable="false"');
     expect(launchEntrySource).not.toContain("Live API");

--- a/tests/developer-robinhood-launch.test.tsx
+++ b/tests/developer-robinhood-launch.test.tsx
@@ -254,11 +254,9 @@ describe("Robinhood Custom launch website flow", () => {
 
   it("routes the Custom card into the chain-bound launch section", () => {
     expect(launchEntrySource).toContain(
-      'href="/developers/api-keys?start=custom&chainId=4663"',
+      'href={`/developers/api-keys?start=custom&chainId=${chainId}`}',
     );
-    expect(launchEntrySource).toContain(
-      'data-status="pending">Preflight required</small>',
-    );
+    expect(launchEntrySource).toContain('data-launch-model-launchable="false"');
     expect(launchEntrySource).not.toContain("Live API");
     expect(apiKeysSource).toContain(
       'url.searchParams.get("start") === "custom"',

--- a/tests/explore-ui-contract.test.ts
+++ b/tests/explore-ui-contract.test.ts
@@ -30,7 +30,7 @@ describe("Explore UI contract", () => {
       resetView.indexOf("className={styles.disabledSearch}"),
     );
     expect(resetView.indexOf("<ExploreChainSelector />")).toBeLessThan(
-      resetView.indexOf("className={styles.disabledFilter}"),
+      resetView.indexOf("<ExploreFilters disabled />"),
     );
     expect(resetView).toContain("disabled");
     expect(resetView).toContain("Launch indexing is being rebuilt");

--- a/tests/launch-model-gating.test.ts
+++ b/tests/launch-model-gating.test.ts
@@ -169,7 +169,7 @@ describe("unreleased launch model gating", () => {
     ).toEqual([-1, -1, 0, -1, -1, -1]);
   });
 
-  it("routes Custom to the held release boundary instead of the legacy runtime", () => {
+  it("offers Classic and Custom on Ethereum without bypassing launch authority", () => {
     const html = renderToStaticMarkup(
       createElement(LaunchModelPicker, {
         onChoose: () => undefined,
@@ -177,7 +177,9 @@ describe("unreleased launch model gating", () => {
     );
 
     expect(html.match(/data-launch-model-option=/g)).toHaveLength(2);
-    expect(html).toContain("<h1>Choose a launch model</h1>");
+    expect(html).toContain("<h1>Choose a chain</h1>");
+    expect(html).toContain('<legend class="sr-only">Launch chain</legend>');
+    expect(html).toMatch(/name="launch-chain"[^>]*checked=""[^>]*value="1"/);
     expect(html).not.toContain('data-launch-model-option="prediction"');
     expect(html).toContain('data-launch-model-option="classic"');
     const classicCard = html.match(
@@ -200,7 +202,7 @@ describe("unreleased launch model gating", () => {
     expect(customCard).toContain('data-launch-model-entry="api-key-launch"');
     expect(customCard).toContain('data-launch-model-launchable="false"');
     expect(customCard).toContain(
-      'href="/developers/api-keys?start=custom&amp;chainId=4663"',
+      'href="/developers/api-keys?start=custom&amp;chainId=1"',
     );
     expect(customCard).not.toContain("disabled");
     expect(html).toContain(
@@ -208,10 +210,7 @@ describe("unreleased launch model gating", () => {
     );
     expect(html).toContain("Create a Classic coin");
     expect(html).toContain(
-      'data-status="pending">Preflight required</small>',
-    );
-    expect(html).toContain(
-      "Upload an exact packed Custom launch, preflight it against Robinhood Chain, then create the request. Your wallet reviews and signs later.",
+      "Build your own Uniswap v4 hook and submit it with an API key. Your wallet reviews and signs the launch.",
     );
     expect(html).toContain("Open Custom V4 Hook");
     expect(html).not.toContain("approved GitHub revision");
@@ -235,22 +234,23 @@ describe("unreleased launch model gating", () => {
     expect(html).not.toContain("Liquidity Growth");
   });
 
-  it("keeps the Robinhood Custom entry independent of the legacy gate", () => {
+  it("offers only Custom on Robinhood and opens the chain-bound launch section", () => {
     const html = renderToStaticMarkup(
       createElement(LaunchModelPicker, {
+        chainId: 4663,
         onChoose: () => undefined,
       }),
     );
-    expect(html.match(/data-launch-model-option=/g)).toHaveLength(2);
+    expect(html.match(/data-launch-model-option=/g)).toHaveLength(1);
+    expect(html).not.toContain('data-launch-model-option="classic"');
+    expect(html).toMatch(/name="launch-chain"[^>]*checked=""[^>]*value="4663"/);
     expect(html).not.toContain('data-launch-model-option="prediction"');
     expect(html).toContain('data-launch-model-option="custom"');
     expect(html).toContain('id="launch-model-custom-title"');
     expect(html).toContain('data-launch-model-available="true"');
     expect(html).toContain('data-launch-model-entry="api-key-launch"');
     expect(html).toContain('data-launch-model-launchable="false"');
-    expect(html).toContain(
-      'data-status="pending">Preflight required</small>',
-    );
+    expect(html).not.toContain("Preflight required");
     expect(html).toContain(
       'href="/developers/api-keys?start=custom&amp;chainId=4663"',
     );

--- a/tests/launch-model-gating.test.ts
+++ b/tests/launch-model-gating.test.ts
@@ -177,8 +177,11 @@ describe("unreleased launch model gating", () => {
     );
 
     expect(html.match(/data-launch-model-option=/g)).toHaveLength(2);
-    expect(html).toContain("<h1>Choose a chain</h1>");
+    expect(html).toContain('<h1 class="sr-only">Create</h1>');
     expect(html).toContain('<legend class="sr-only">Launch chain</legend>');
+    expect(html).toContain('aria-label="Ethereum"');
+    expect(html).toContain('aria-label="Robinhood"');
+    expect(html).not.toContain("Choose a chain");
     expect(html).toMatch(/name="launch-chain"[^>]*checked=""[^>]*value="1"/);
     expect(html).not.toContain('data-launch-model-option="prediction"');
     expect(html).toContain('data-launch-model-option="classic"');
@@ -189,10 +192,10 @@ describe("unreleased launch model gating", () => {
     expect(html).toContain(
       'id="launch-model-classic-title">Classic</strong>',
     );
-    expect(html).toContain('data-status="ready">Ethereum only</small>');
-    expect(html).toContain('id="launch-model-classic-status"');
+    expect(html).not.toContain("Ethereum only");
+    expect(html).not.toContain('id="launch-model-classic-status"');
     expect(html).toContain(
-      'aria-describedby="launch-model-classic-description launch-model-classic-status"',
+      'aria-describedby="launch-model-classic-description"',
     );
     expect(html).toContain('data-launch-model-option="custom"');
     const customCard = html.match(
@@ -202,7 +205,7 @@ describe("unreleased launch model gating", () => {
     expect(customCard).toContain('data-launch-model-entry="api-key-launch"');
     expect(customCard).toContain('data-launch-model-launchable="false"');
     expect(customCard).toContain(
-      'href="/developers/api-keys?start=custom&amp;chainId=1"',
+      'href="/developers/api-keys"',
     );
     expect(customCard).not.toContain("disabled");
     expect(html).toContain(
@@ -234,7 +237,7 @@ describe("unreleased launch model gating", () => {
     expect(html).not.toContain("Liquidity Growth");
   });
 
-  it("offers only Custom on Robinhood and opens the chain-bound launch section", () => {
+  it("offers only Custom on Robinhood and opens the shared API-key page", () => {
     const html = renderToStaticMarkup(
       createElement(LaunchModelPicker, {
         chainId: 4663,
@@ -252,7 +255,7 @@ describe("unreleased launch model gating", () => {
     expect(html).toContain('data-launch-model-launchable="false"');
     expect(html).not.toContain("Preflight required");
     expect(html).toContain(
-      'href="/developers/api-keys?start=custom&amp;chainId=4663"',
+      'href="/developers/api-keys"',
     );
     expect(html).toContain("Open Custom V4 Hook");
     expect(html).not.toContain("approved GitHub revision");

--- a/tests/launch-model-motion.test.ts
+++ b/tests/launch-model-motion.test.ts
@@ -66,13 +66,13 @@ describe("launch model artwork", () => {
     expect(source).toContain('data-launch-model-available="true"');
     expect(source).toContain('data-launch-model-entry="api-key-launch"');
     expect(source).toContain(
-      'href="/developers/api-keys?start=custom&chainId=4663"',
+      'href={`/developers/api-keys?start=custom&chainId=${chainId}`}',
     );
     expect(source).not.toContain('onChoose("custom")');
     expect(source).not.toContain("customLaunchPublicEnabled");
     expect(source).not.toContain("custom-launch-experience");
     expect(source).not.toContain("custom-launch-local-preview");
-    expect(route).toContain("return <LaunchExperience />;");
+    expect(route).toContain("return <LaunchExperience initialViewChainId={initialViewChainId} />;");
     expect(route).not.toContain("isCustomLaunchPublicEnabled");
     expect(route).not.toContain("configuredLaunchPermitSignersV2");
     for (const marker of removedPartnerMarkers) {

--- a/tests/launch-model-motion.test.ts
+++ b/tests/launch-model-motion.test.ts
@@ -54,7 +54,7 @@ describe("launch model artwork", () => {
       'aria-labelledby="launch-model-classic-title"',
     );
     expect(source).toContain(
-      'aria-describedby="launch-model-classic-description launch-model-classic-status"',
+      'aria-describedby={classicV3LaunchAvailable ? "launch-model-classic-description" : "launch-model-classic-description launch-model-classic-status"}',
     );
     expect(source).toContain(
       'aria-labelledby="launch-model-custom-title"',
@@ -66,7 +66,7 @@ describe("launch model artwork", () => {
     expect(source).toContain('data-launch-model-available="true"');
     expect(source).toContain('data-launch-model-entry="api-key-launch"');
     expect(source).toContain(
-      'href={`/developers/api-keys?start=custom&chainId=${chainId}`}',
+      'href="/developers/api-keys"',
     );
     expect(source).not.toContain('onChoose("custom")');
     expect(source).not.toContain("customLaunchPublicEnabled");

--- a/tests/prediction-market-v2-local-preview.test.tsx
+++ b/tests/prediction-market-v2-local-preview.test.tsx
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import { LaunchExperience } from "../components/launch-entry";
+import { ViewChainProvider } from "../components/view-chain";
 import {
   PredictionMarketV2LocalPreview,
   createPredictionV2LocalPreviewDiscovery,
@@ -31,7 +32,9 @@ function preview(
 describe("Prediction V2 development-only local preview", () => {
   it("keeps the internal fixture out of the public launch runtime", () => {
     expect(process.env.NODE_ENV).not.toBe("development");
-    const html = renderToStaticMarkup(<LaunchExperience />);
+    const html = renderToStaticMarkup(
+      <ViewChainProvider><LaunchExperience /></ViewChainProvider>,
+    );
 
     expect(html).not.toContain('data-launch-model-option="prediction"');
     expect(html).not.toContain("programmable-prediction-v2-local-preview-v1");

--- a/tests/profile-entry.test.ts
+++ b/tests/profile-entry.test.ts
@@ -63,7 +63,7 @@ describe("profile entry", () => {
       /from\s+["']@\/components\/profile-view["']/u,
     );
     expect(profileEntrySource).toMatch(
-      /if \(shouldLoadProfileEntryView\([\s\S]*?return <ProfileView \/>;/u,
+      /if \(shouldLoadProfileEntryView\([\s\S]*?return <ProfileView viewChainId=\{viewChainId\} onChangeChain=\{setViewChainId\} \/>;/u,
     );
     expect(profileEntrySource).toContain(
       "loadProfileView().catch(() => undefined)",

--- a/tests/profile-robinhood-ui.test.tsx
+++ b/tests/profile-robinhood-ui.test.tsx
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ProfileChainSelector } from "@/components/profile-chain-selector";
+import { readRobinhoodProfileResponse } from "@/lib/profile/robinhood-profile";
+
+const mocks = vi.hoisted(() => ({ profile: vi.fn(), presentation: vi.fn() }));
+vi.mock("@/lib/server/robinhood-index/read", () => ({ readRobinhoodProfileLaunches: mocks.profile }));
+vi.mock("@/lib/server/robinhood-presentation", () => ({ readRobinhoodPresentations: mocks.presentation }));
+import { GET } from "@/app/api/explore/robinhood/presentation/route";
+
+const account = `0x${"a".repeat(40)}`;
+const other = `0x${"b".repeat(40)}`;
+const row = { launchId: `0x${"1".repeat(64)}`, tokenAddress: `0x${"c".repeat(40)}`, creator: account, name: "Example", symbol: "EX", launchedAt: "2026-09-05T00:00:00.000Z" };
+const response = () => ({ chainId: 4663, account, status: "ready", updatedAt: row.launchedAt, items: [row], page: { number: 1, size: 50, totalItems: 1, totalPages: 1, hasMore: false } });
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("Robinhood profile account and chain boundaries", () => {
+  it("accepts launches only for the requested account and chain", () => {
+    expect(readRobinhoodProfileResponse(response(), account).items).toHaveLength(1);
+    expect(() => readRobinhoodProfileResponse(response(), other)).toThrow();
+    expect(() => readRobinhoodProfileResponse({ ...response(), chainId: 1 }, account)).toThrow();
+    expect(() => readRobinhoodProfileResponse({ ...response(), items: [{ ...row, creator: other }] }, account)).toThrow();
+    expect(() => readRobinhoodProfileResponse({ ...response(), items: [row, row] }, account)).toThrow();
+  });
+
+  it.each([1, 4663] as const)("keeps both chain controls accessible with %s selected", (value) => {
+    const html = renderToStaticMarkup(<ProfileChainSelector value={value} onChange={() => {}} />);
+    expect(html).toContain("Profile chain");
+    expect(html).toContain('aria-label="Ethereum"');
+    expect(html).toContain('aria-label="Robinhood"');
+    expect(html.match(/checked=""/g)).toHaveLength(1);
+    expect(html).toContain(`checked="" value="${value}"`);
+  });
+
+  it("enriches only the creator-scoped page in one batch", async () => {
+    mocks.profile.mockResolvedValue(response());
+    mocks.presentation.mockResolvedValue([{ tokenAddress: row.tokenAddress }]);
+    const result = await GET(new Request(`https://website.invalid/api/explore/robinhood/presentation?account=${account}&page=2`));
+    expect(result.status).toBe(200);
+    expect(mocks.profile).toHaveBeenCalledWith(account, 2);
+    expect(mocks.presentation).toHaveBeenCalledExactlyOnceWith([row]);
+    expect(await result.json()).toEqual({ items: [{ tokenAddress: row.tokenAddress }] });
+  });
+
+  it.each([`account=${account}&account=${other}`, `account=${account}&token=${row.tokenAddress}`, `account=${account}&q=V4`, `account=${account}&page=0`, "account=invalid"])("rejects an ambiguous presentation request: %s", async (query) => {
+    expect((await GET(new Request(`https://website.invalid/api/explore/robinhood/presentation?${query}`))).status).toBe(400);
+    expect(mocks.profile).not.toHaveBeenCalled();
+    expect(mocks.presentation).not.toHaveBeenCalled();
+  });
+});

--- a/tests/robinhood-explore-read.test.ts
+++ b/tests/robinhood-explore-read.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RobinhoodLaunch } from "@/lib/robinhood-launches";
+import type { RobinhoodCoinMarket } from "@/lib/robinhood-presentation";
+import type { RobinhoodSnapshot } from "@/lib/server/robinhood-index/model";
+
+const mocks = vi.hoisted(() => ({ read: vi.fn(), markets: vi.fn(), presentations: vi.fn() }));
+vi.mock("server-only", () => ({}));
+vi.mock("next/cache", () => ({ unstable_cache: (callback: unknown) => callback }));
+vi.mock("@/lib/server/robinhood-index/store", () => ({ indexStore: () => ({ read: mocks.read }) }));
+vi.mock("@/lib/server/robinhood-presentation", () => ({ readRobinhoodMarkets: mocks.markets, readRobinhoodPresentations: mocks.presentations }));
+import { readRobinhoodLaunches } from "@/lib/server/robinhood-index/read";
+
+const hex = (value: number, length: number) => `0x${value.toString(16).padStart(length, "0")}`;
+function token(id: number): RobinhoodLaunch {
+  return { routerAddress: hex(1, 40), launchId: hex(id, 64), tokenAddress: hex(id, 40), hookAddress: hex(id + 100, 40),
+    creator: hex(2, 40), poolManager: hex(3, 40), poolId: hex(id + 200, 64), stampHash: hex(id + 300, 64),
+    transactionHash: hex(id + 400, 64), blockNumber: String(id), blockHash: hex(id + 500, 64), logIndex: 1,
+    launchedAt: null, name: `Token ${id}`, symbol: `T${id}`, decimals: 18 };
+}
+function saved(items: RobinhoodLaunch[]): RobinhoodSnapshot {
+  return { version: 1, chainId: 4663, routerAddress: hex(1, 40), binding: hex(1, 64), startBlock: "1",
+    cursor: { number: "100", hash: hex(100, 64) }, checkpoints: [], finalizedBlock: "100", updatedAt: new Date().toISOString(), items };
+}
+function market(row: RobinhoodLaunch, value: number): RobinhoodCoinMarket {
+  return { poolId: row.poolId, priceUsd: null, marketCapUsd: value, liquidityUsd: null, volume24hUsd: null,
+    change24hPercent: null, observedAt: new Date().toISOString(), sourceUrl: "https://dexscreener.com/" };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.presentations.mockImplementation(async (rows: RobinhoodLaunch[], markets: Map<string, RobinhoodCoinMarket>) =>
+    rows.map((row) => ({ tokenAddress: row.tokenAddress, imageUrl: null, description: null, links: [], market: markets.get(row.tokenAddress) ?? null })));
+});
+
+describe("Robinhood Explore read model", () => {
+  it("ranks the full visible catalog and presents only the selected page using the same prices", async () => {
+    const rows = Array.from({ length: 60 }, (_, index) => token(index + 1));
+    const hidden = { ...token(61), tokenAddress: "0x15fca474b23cafe775120b1fafbcff0e7a827af2" };
+    const observations = new Map(rows.map((row, index) => [row.tokenAddress, market(row, 60 - index)]));
+    mocks.read.mockResolvedValue({ snapshot: saved([...rows, hidden]) });
+    mocks.markets.mockResolvedValue(observations);
+    const result = await readRobinhoodLaunches(2);
+    expect(mocks.markets).toHaveBeenCalledWith(rows);
+    expect(result.items).toEqual(rows.slice(50));
+    expect(mocks.presentations).toHaveBeenCalledWith(rows.slice(50), observations);
+    expect(result.presentations[0].market).toBe(observations.get(rows[50].tokenAddress));
+    expect(result.page.totalItems).toBe(60);
+  });
+
+  it("keeps verified launches when the market provider is unavailable", async () => {
+    const rows = [token(1), token(2)];
+    mocks.read.mockResolvedValue({ snapshot: saved(rows) });
+    mocks.markets.mockRejectedValue(new Error("provider unavailable"));
+    const result = await readRobinhoodLaunches();
+    expect(result.status).toBe("ready");
+    expect(result.items).toEqual(rows.toReversed());
+    expect(result.presentations.map((item) => item.market)).toEqual([null, null]);
+  });
+});

--- a/tests/robinhood-presentation-refresh.test.ts
+++ b/tests/robinhood-presentation-refresh.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { mergeRobinhoodPresentations, type RobinhoodCoinPresentation } from "@/lib/robinhood-presentation";
+
+const now = Date.parse("2026-09-05T12:00:00Z");
+const saved: RobinhoodCoinPresentation = {
+  tokenAddress: `0x${"ab".repeat(20)}`, imageUrl: null, description: null, links: [],
+  market: {
+    poolId: `0x${"1".repeat(64)}`, marketCapUsd: 3_270_000, priceUsd: .00327,
+    liquidityUsd: 200_000, volume24hUsd: 50_000, change24hPercent: 2,
+    observedAt: new Date(now - 60_000).toISOString(), sourceUrl: "https://dexscreener.com/robinhood/example",
+  },
+};
+
+describe("Robinhood market refresh", () => {
+  it("keeps the entire recent observation when optional market data is unavailable", () => {
+    const result = mergeRobinhoodPresentations([saved], [{ ...saved, market: null }], now);
+    expect(result.items[0].market).toBe(saved.market);
+    expect(result.delayed).toBe(true);
+    expect(result.items[0].market?.observedAt).toBe(saved.market?.observedAt);
+  });
+
+  it("expires saved values after three minutes, including failed requests", () => {
+    for (const incoming of [null, [{ ...saved, market: null }]]) {
+      expect(mergeRobinhoodPresentations([saved], incoming, now + 120_000).items[0].market).toBe(saved.market);
+      const result = mergeRobinhoodPresentations([saved], incoming, now + 120_001);
+      expect(result.items[0].market).toBeNull();
+      expect(result.delayed).toBe(true);
+    }
+  });
+
+  it("accepts new values and zero without combining fields from different observations", () => {
+    const next = { ...saved, market: { ...saved.market!, marketCapUsd: 0, liquidityUsd: null, observedAt: new Date(now).toISOString() } };
+    const result = mergeRobinhoodPresentations([saved], [next], now);
+    expect(result.items[0].market).toBe(next.market);
+    expect(result.items[0].market?.liquidityUsd).toBeNull();
+    expect(result.delayed).toBe(false);
+  });
+
+  it("does not roll back to an older response or animate a fabricated zero", () => {
+    const old = { ...saved, market: { ...saved.market!, marketCapUsd: 3_000_000, observedAt: new Date(now - 90_000).toISOString() } };
+    expect(mergeRobinhoodPresentations([saved], [old], now).items[0].market).toBe(saved.market);
+    expect(mergeRobinhoodPresentations([], [{ ...saved, market: null }], now).items[0].market).toBeNull();
+  });
+
+  it("keeps successful list membership and does not transfer another token's values", () => {
+    expect(mergeRobinhoodPresentations([saved], [], now).items).toEqual([]);
+    const other = { ...saved, tokenAddress: `0x${"cd".repeat(20)}`, market: null };
+    expect(mergeRobinhoodPresentations([saved], [other], now).items).toEqual([other]);
+    const same = { ...saved, tokenAddress: saved.tokenAddress.toUpperCase(), market: null };
+    expect(mergeRobinhoodPresentations([saved], [same], now).items[0].market).toBe(saved.market);
+  });
+
+  it("clears expired observations instead of falling back to an even older response", () => {
+    const expired = { ...saved, market: { ...saved.market!, observedAt: new Date(now - 181_000).toISOString() } };
+    const older = { ...expired, market: { ...expired.market, observedAt: new Date(now - 200_000).toISOString() } };
+    for (const incoming of [expired, older]) {
+      const result = mergeRobinhoodPresentations([expired], [incoming], now);
+      expect(result.items[0].market).toBeNull();
+      expect(result.delayed).toBe(true);
+    }
+  });
+
+  it.each(["invalid", new Date(now + 1).toISOString()])("rejects an invalid or future observation %s", (observedAt) => {
+    const incoming = { ...saved, market: { ...saved.market!, observedAt } };
+    expect(mergeRobinhoodPresentations([], [incoming], now).items[0].market).toBeNull();
+    expect(mergeRobinhoodPresentations([saved], [incoming], now).items[0].market).toBe(saved.market);
+  });
+
+  it("does not substitute a previous pool's market for a new pool", () => {
+    const otherPool = { ...saved, market: { ...saved.market!, poolId: `0x${"2".repeat(64)}`, observedAt: new Date(now - 90_000).toISOString() } };
+    expect(mergeRobinhoodPresentations([saved], [otherPool], now).items[0].market).toBe(otherPool.market);
+    const expired = { ...otherPool, market: { ...otherPool.market, observedAt: new Date(now - 200_000).toISOString() } };
+    expect(mergeRobinhoodPresentations([saved], [expired], now).items[0].market).toBeNull();
+  });
+});

--- a/tests/robinhood-presentation.test.ts
+++ b/tests/robinhood-presentation.test.ts
@@ -206,6 +206,7 @@ describe("Robinhood presentation HTTP boundary", () => {
   const endpoint = "https://website.invalid/api/explore/robinhood/presentation";
   it.each([
     "chain=1", "page=0", "page=1000000", "page=1&page=2", "q=a&q=b", `q=${"x".repeat(129)}`,
+    "age=invalid", "sort=market-cap", "age=7d&age=30d", `token=${TOKEN.tokenAddress}&age=7d`,
     "token=bad", `token=${TOKEN.tokenAddress}&page=1`, `token=${TOKEN.tokenAddress}&token=${TOKEN.tokenAddress}`,
   ])("rejects invalid query %s before storage or providers", async (query) => {
     const fetcher = sourceFetch();
@@ -230,9 +231,16 @@ describe("Robinhood presentation HTTP boundary", () => {
     vi.stubGlobal("fetch", sourceFetch());
     storage.list.mockResolvedValue({ items: [TOKEN] });
     const response = await GET(new Request(`${endpoint}?page=2&q=RHV4`));
-    expect(storage.list).toHaveBeenCalledWith(2, "RHV4");
+    expect(storage.list).toHaveBeenCalledWith(2, "RHV4", { age: "any", sort: "newest" });
     expect(storage.token).not.toHaveBeenCalled();
     expect(response.headers.get("cache-control")).toContain("s-maxage=60");
     expect((await response.json()).items[0].tokenAddress).toBe(TOKEN.tokenAddress);
+  });
+  it("enriches the same filtered page as the launch list", async () => {
+    vi.stubGlobal("fetch", sourceFetch());
+    storage.list.mockResolvedValue({ items: [TOKEN] });
+    const response = await GET(new Request(`${endpoint}?page=2&q=RHV4&age=30d&sort=oldest`));
+    expect(response.status).toBe(200);
+    expect(storage.list).toHaveBeenCalledWith(2, "RHV4", { age: "30d", sort: "oldest" });
   });
 });

--- a/tests/robinhood-presentation.test.ts
+++ b/tests/robinhood-presentation.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RobinhoodLaunch } from "@/lib/robinhood-launches";
+
+const storage = vi.hoisted(() => ({ list: vi.fn(), token: vi.fn() }));
+vi.mock("server-only", () => ({}));
+vi.mock("next/cache", () => ({ unstable_cache: (callback: unknown) => callback }));
+vi.mock("@/lib/server/robinhood-index/read", () => ({
+  readRobinhoodLaunches: storage.list,
+  readRobinhoodToken: storage.token,
+}));
+
+import { readRobinhoodPresentations } from "@/lib/server/robinhood-presentation";
+import { GET } from "@/app/api/explore/robinhood/presentation/route";
+// @ts-expect-error -- package fixtures are intentionally JavaScript.
+import { validV4ProjectMetadata } from "../packages/launch/test/fixtures/v4.mjs";
+// @ts-expect-error -- canonical metadata hashing is intentionally JavaScript.
+import { hashProjectMetadata } from "../packages/launch/src/project-metadata.mjs";
+
+const hash = (digit: string) => `0x${digit.repeat(64)}`;
+const address = (digit: string) => `0x${digit.repeat(40)}`;
+const TOKEN: RobinhoodLaunch = {
+  routerAddress: address("1"), launchId: hash("1"), tokenAddress: address("2"),
+  hookAddress: address("3"), creator: address("4"), poolManager: address("5"),
+  poolId: hash("2"), stampHash: hash("3"), transactionHash: hash("4"),
+  blockNumber: "50000", blockHash: hash("5"), logIndex: 7,
+  launchedAt: "2026-09-04T12:00:00.000Z", name: "Robinhood V4 Test", symbol: "RHV4", decimals: 18,
+};
+
+function finalizedLaunch() {
+  const projectMetadata = validV4ProjectMetadata();
+  const commitment = hashProjectMetadata(projectMetadata, { requireComplete: true });
+  return {
+    schemaVersion: "programmable.finalized-custom-launch-metadata.v4", apiVersion: "v4",
+    chainId: "4663", caip2: "eip155:4663", platformId: "programmable", category: "custom",
+    chainDeploymentId: "robinhood-mainnet-custom-launch-v1",
+    projectMetadata, commitments: { metadata: commitment },
+    onchain: {
+      schemaVersion: "programmable.custom-launch-onchain-evidence.v3", chainId: "4663", caip2: "eip155:4663",
+      terminal: true, checkpointType: "ethereum_finalized", router: TOKEN.routerAddress,
+      routerLaunchId: TOKEN.launchId, transactionHash: TOKEN.transactionHash, commitments: { metadata: commitment },
+      l2Inclusion: {
+        chainId: "4663", caip2: "eip155:4663", receiptStatus: "success",
+        transactionHash: TOKEN.transactionHash, blockNumber: TOKEN.blockNumber,
+        blockHash: TOKEN.blockHash, launchEventLogIndex: TOKEN.logIndex,
+      },
+    },
+    sourceVerification: { status: "exact_match", components: [
+      { address: TOKEN.tokenAddress, status: "exact_match" },
+      { address: TOKEN.hookAddress, status: "exact_match" },
+    ] },
+  };
+}
+
+function feed(launches = [finalizedLaunch()]) {
+  return {
+    schemaVersion: "programmable.custom-launch-list.v4", apiVersion: "v4", chainId: "4663", caip2: "eip155:4663",
+    generatedAt: new Date().toISOString(), quality: {
+      status: "ready", sourceRowCount: launches.length, publishedRowCount: launches.length, quarantinedRowCount: 0,
+    }, launches, nextCursor: null as string | null,
+  };
+}
+
+function pair() {
+  return {
+    chainId: "robinhood", dexId: "uniswap", labels: ["v4"], pairAddress: TOKEN.poolId,
+    baseToken: { address: TOKEN.tokenAddress }, priceUsd: "0.003", marketCap: 3_000_000,
+    fdv: 8_000_000, liquidity: { usd: 250_000 }, volume: { h24: 0 }, priceChange: { h24: -2.5 },
+    url: "https://wrong-provider-url.example/",
+  };
+}
+
+function sourceFetch(metadata: unknown = feed(), market: unknown = { pairs: [pair()] }) {
+  return vi.fn(async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.startsWith("https://api.programmable.market/v4/chains/4663/finalized-custom-launches")) {
+      if (metadata instanceof Error) throw metadata;
+      return metadata instanceof Response ? metadata : Response.json(metadata);
+    }
+    if (url.startsWith("https://api.dexscreener.com/latest/dex/pairs/robinhood/")) {
+      if (market instanceof Error) throw market;
+      return market instanceof Response ? market : Response.json(market);
+    }
+    throw new Error("Unexpected source request");
+  });
+}
+
+beforeEach(() => { vi.clearAllMocks(); });
+afterEach(() => { vi.unstubAllGlobals(); });
+
+describe("Robinhood optional coin presentation", () => {
+  it("joins the committed artwork to the saved launch and keeps exact-pool MC separate from FDV", async () => {
+    const fetcher = sourceFetch();
+    vi.stubGlobal("fetch", fetcher);
+    const [value] = await readRobinhoodPresentations([TOKEN]);
+    expect(value).toMatchObject({ tokenAddress: TOKEN.tokenAddress, imageUrl: "https://example.com/token.png",
+      links: [{ label: "Website", url: "https://example.com/" }, { label: "X", url: "https://x.com/programmable" }],
+      market: { poolId: TOKEN.poolId, priceUsd: 0.003, marketCapUsd: 3_000_000, liquidityUsd: 250_000,
+        volume24hUsd: 0, change24hPercent: -2.5, sourceUrl: `https://dexscreener.com/robinhood/${TOKEN.poolId}` },
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher.mock.calls.map(([url]) => String(url))).toEqual(expect.arrayContaining([
+      `https://api.dexscreener.com/latest/dex/pairs/robinhood/${TOKEN.poolId}`,
+      "https://api.programmable.market/v4/chains/4663/finalized-custom-launches?limit=25",
+    ]));
+  });
+
+  it.each([
+    ["chain", (value: ReturnType<typeof finalizedLaunch>) => { value.chainId = "1"; }],
+    ["router", (value: ReturnType<typeof finalizedLaunch>) => { value.onchain.router = address("9"); }],
+    ["launch", (value: ReturnType<typeof finalizedLaunch>) => { value.onchain.routerLaunchId = hash("9"); }],
+    ["receipt", (value: ReturnType<typeof finalizedLaunch>) => { value.onchain.l2Inclusion.transactionHash = hash("9"); }],
+    ["block", (value: ReturnType<typeof finalizedLaunch>) => { value.onchain.l2Inclusion.blockHash = hash("9"); }],
+    ["log", (value: ReturnType<typeof finalizedLaunch>) => { value.onchain.l2Inclusion.launchEventLogIndex++; }],
+    ["token", (value: ReturnType<typeof finalizedLaunch>) => { value.sourceVerification.components[0].address = address("9"); }],
+    ["hook", (value: ReturnType<typeof finalizedLaunch>) => { value.sourceVerification.components[1].address = address("9"); }],
+    ["metadata hash", (value: ReturnType<typeof finalizedLaunch>) => { value.projectMetadata.presentation.description = "Changed after commitment"; }],
+    ["finality", (value: ReturnType<typeof finalizedLaunch>) => { value.onchain.terminal = false; }],
+  ])("does not attach metadata with a different %s, but keeps the coin and market", async (_, mutate) => {
+    const launch = finalizedLaunch();
+    mutate(launch);
+    vi.stubGlobal("fetch", sourceFetch(feed([launch])));
+    const [value] = await readRobinhoodPresentations([TOKEN]);
+    expect(value.tokenAddress).toBe(TOKEN.tokenAddress);
+    expect(value.imageUrl).toBeNull();
+    expect(value.description).toBeNull();
+    expect(value.market?.marketCapUsd).toBe(3_000_000);
+  });
+
+  it.each([
+    ["chain", { chainId: "ethereum" }], ["pool", { pairAddress: hash("9") }],
+    ["token", { baseToken: { address: address("9") } }], ["DEX", { dexId: "other" }],
+    ["generation", { labels: ["v3"] }],
+  ])("rejects a market for another %s without removing the verified artwork", async (_, change) => {
+    vi.stubGlobal("fetch", sourceFetch(feed(), { pairs: [{ ...pair(), ...change }] }));
+    const [value] = await readRobinhoodPresentations([TOKEN]);
+    expect(value.market).toBeNull();
+    expect(value.imageUrl).toBe("https://example.com/token.png");
+  });
+
+  it("leaves missing market cap empty instead of relabelling FDV", async () => {
+    const market: Record<string, unknown> = pair();
+    delete market.marketCap;
+    vi.stubGlobal("fetch", sourceFetch(feed(), { pairs: [market] }));
+    expect((await readRobinhoodPresentations([TOKEN]))[0].market).toMatchObject({ marketCapUsd: null, priceUsd: 0.003 });
+  });
+
+  it("resolves committed IPFS artwork through the established public gateway", async () => {
+    const launch = finalizedLaunch();
+    const cid = "QmYwAPJzv5CZsnAzt8auVZRnGi1Wm4eQNf6gMss5QZb7S6";
+    launch.projectMetadata.presentation.image.uri = `ipfs://${cid}`;
+    const commitment = hashProjectMetadata(launch.projectMetadata, { requireComplete: true });
+    launch.commitments.metadata = commitment;
+    launch.onchain.commitments.metadata = commitment;
+    vi.stubGlobal("fetch", sourceFetch(feed([launch])));
+    expect((await readRobinhoodPresentations([TOKEN]))[0].imageUrl).toBe(`https://ipfs.io/ipfs/${cid}`);
+  });
+
+  it("rejects ambiguous duplicate pool matches", async () => {
+    vi.stubGlobal("fetch", sourceFetch(feed(), { pairs: [pair(), pair()] }));
+    expect((await readRobinhoodPresentations([TOKEN]))[0].market).toBeNull();
+  });
+
+  it("keeps successful artwork when the market provider fails", async () => {
+    vi.stubGlobal("fetch", sourceFetch(feed(), new Error("offline")));
+    const [value] = await readRobinhoodPresentations([TOKEN]);
+    expect(value.market).toBeNull();
+    expect(value.imageUrl).toBe("https://example.com/token.png");
+  });
+
+  it("keeps successful market data when the metadata provider fails", async () => {
+    vi.stubGlobal("fetch", sourceFetch(new Error("offline")));
+    const [value] = await readRobinhoodPresentations([TOKEN]);
+    expect(value.imageUrl).toBeNull();
+    expect(value.market?.marketCapUsd).toBe(3_000_000);
+  });
+
+  it("uses only the known main-token artwork when both providers are unavailable", async () => {
+    vi.stubGlobal("fetch", sourceFetch(new Error("offline"), new Error("offline")));
+    const main = { ...TOKEN, tokenAddress: "0xC60bA256B44334A0Cd2C7242E98B88f031abB006" };
+    const values = await readRobinhoodPresentations([main, TOKEN]);
+    expect(values[0].imageUrl).toBe("/brand/projects/programmable-main-token-v1.webp");
+    expect(values[1].imageUrl).toBeNull();
+    expect(values).toHaveLength(2);
+  });
+
+  it("rejects stale metadata and oversized responses without affecting token identity", async () => {
+    const stale = feed();
+    stale.generatedAt = "2020-01-01T00:00:00.000Z";
+    const oversized = new Response("{}", { headers: { "content-type": "application/json", "content-length": "2000001" } });
+    vi.stubGlobal("fetch", sourceFetch(stale, oversized));
+    expect(await readRobinhoodPresentations([TOKEN])).toEqual([
+      { tokenAddress: TOKEN.tokenAddress, imageUrl: null, description: null, links: [], market: null },
+    ]);
+  });
+
+  it("does not send provider requests for no tokens or an excessive batch", async () => {
+    const fetcher = sourceFetch();
+    vi.stubGlobal("fetch", fetcher);
+    expect(await readRobinhoodPresentations([])).toEqual([]);
+    await expect(readRobinhoodPresentations(Array(51).fill(TOKEN))).rejects.toThrow("Invalid presentation request");
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});
+
+describe("Robinhood presentation HTTP boundary", () => {
+  const endpoint = "https://website.invalid/api/explore/robinhood/presentation";
+  it.each([
+    "chain=1", "page=0", "page=1000000", "page=1&page=2", "q=a&q=b", `q=${"x".repeat(129)}`,
+    "token=bad", `token=${TOKEN.tokenAddress}&page=1`, `token=${TOKEN.tokenAddress}&token=${TOKEN.tokenAddress}`,
+  ])("rejects invalid query %s before storage or providers", async (query) => {
+    const fetcher = sourceFetch();
+    vi.stubGlobal("fetch", fetcher);
+    expect((await GET(new Request(`${endpoint}?${query}`))).status).toBe(400);
+    expect(storage.list).not.toHaveBeenCalled();
+    expect(storage.token).not.toHaveBeenCalled();
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("does not look up unverified token addresses at a provider", async () => {
+    const fetcher = sourceFetch();
+    vi.stubGlobal("fetch", fetcher);
+    storage.token.mockResolvedValue({ token: null, status: "ready" });
+    const response = await GET(new Request(`${endpoint}?token=${TOKEN.tokenAddress}`));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ items: [] });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("resolves a bounded search from the saved list before enriching", async () => {
+    vi.stubGlobal("fetch", sourceFetch());
+    storage.list.mockResolvedValue({ items: [TOKEN] });
+    const response = await GET(new Request(`${endpoint}?page=2&q=RHV4`));
+    expect(storage.list).toHaveBeenCalledWith(2, "RHV4");
+    expect(storage.token).not.toHaveBeenCalled();
+    expect(response.headers.get("cache-control")).toContain("s-maxage=60");
+    expect((await response.json()).items[0].tokenAddress).toBe(TOKEN.tokenAddress);
+  });
+});

--- a/tests/robinhood-presentation.test.ts
+++ b/tests/robinhood-presentation.test.ts
@@ -9,7 +9,7 @@ vi.mock("@/lib/server/robinhood-index/read", () => ({
   readRobinhoodToken: storage.token,
 }));
 
-import { readRobinhoodPresentations } from "@/lib/server/robinhood-presentation";
+import { readRobinhoodMarkets, readRobinhoodPresentations } from "@/lib/server/robinhood-presentation";
 import { GET } from "@/app/api/explore/robinhood/presentation/route";
 // @ts-expect-error -- package fixtures are intentionally JavaScript.
 import { validV4ProjectMetadata } from "../packages/launch/test/fixtures/v4.mjs";
@@ -202,6 +202,58 @@ describe("Robinhood optional coin presentation", () => {
   });
 });
 
+describe("Robinhood catalog market observations", () => {
+  it.each([new Error("offline"), { invalid: true }])("rejects failed refreshes so they cannot replace a cached observation", async (failure) => {
+    vi.stubGlobal("fetch", sourceFetch(feed(), failure));
+    await expect(readRobinhoodMarkets([TOKEN])).rejects.toThrow("Market observation unavailable");
+  });
+
+  it("accepts a successful response with no indexed pair as unknown market data", async () => {
+    vi.stubGlobal("fetch", sourceFetch(feed(), { pairs: null }));
+    expect(await readRobinhoodMarkets([TOKEN])).toEqual(new Map());
+  });
+
+  it("batches the full catalog beyond the visible page with bounded concurrency and exact pool joins", async () => {
+    const tokens = Array.from({ length: 151 }, (_, index) => ({ ...TOKEN,
+      tokenAddress: `0x${(index + 1).toString(16).padStart(40, "0")}`,
+      poolId: `0x${(index + 1).toString(16).padStart(64, "0")}`,
+    }));
+    let active = 0;
+    let peak = 0;
+    const sizes: number[] = [];
+    const fetcher = vi.fn(async (input: string) => {
+      active++;
+      peak = Math.max(peak, active);
+      const pools = input.split("/").at(-1)!.split(",");
+      sizes.push(pools.length);
+      await Promise.resolve();
+      active--;
+      return Response.json({ pairs: pools.map((pool) => {
+        const token = tokens.find((row) => row.poolId === pool)!;
+        return { ...pair(), pairAddress: pool, baseToken: { address: token.tokenAddress } };
+      }) });
+    });
+    vi.stubGlobal("fetch", fetcher);
+    const result = await readRobinhoodMarkets(tokens.toReversed());
+    expect(result.size).toBe(151);
+    expect(fetcher).toHaveBeenCalledTimes(6);
+    expect(Math.max(...sizes)).toBe(30);
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(result.get(tokens[150].tokenAddress)?.poolId).toBe(tokens[150].poolId);
+  });
+
+  it("uses the supplied catalog observation for card values without fetching prices again", async () => {
+    const fetcher = sourceFetch();
+    vi.stubGlobal("fetch", fetcher);
+    const market = { poolId: TOKEN.poolId, priceUsd: 2, marketCapUsd: 42, liquidityUsd: null,
+      volume24hUsd: null, change24hPercent: null, observedAt: new Date().toISOString(), sourceUrl: "https://dexscreener.com/" };
+    const result = await readRobinhoodPresentations([TOKEN], new Map([[TOKEN.tokenAddress, market]]));
+    expect(result[0].market).toBe(market);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(String(fetcher.mock.calls[0][0])).toContain("finalized-custom-launches");
+  });
+});
+
 describe("Robinhood presentation HTTP boundary", () => {
   const endpoint = "https://website.invalid/api/explore/robinhood/presentation";
   it.each([
@@ -227,20 +279,21 @@ describe("Robinhood presentation HTTP boundary", () => {
     expect(fetcher).not.toHaveBeenCalled();
   });
 
-  it("resolves a bounded search from the saved list before enriching", async () => {
+  it("reuses the selected page presentation without a second provider observation", async () => {
     vi.stubGlobal("fetch", sourceFetch());
-    storage.list.mockResolvedValue({ items: [TOKEN] });
+    storage.list.mockResolvedValue({ items: [TOKEN], presentations: [{ tokenAddress: TOKEN.tokenAddress, market: null }] });
     const response = await GET(new Request(`${endpoint}?page=2&q=RHV4`));
-    expect(storage.list).toHaveBeenCalledWith(2, "RHV4", { age: "any", sort: "newest" });
+    expect(storage.list).toHaveBeenCalledWith(2, "RHV4", { sort: "highest" });
     expect(storage.token).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
     expect(response.headers.get("cache-control")).toContain("s-maxage=60");
     expect((await response.json()).items[0].tokenAddress).toBe(TOKEN.tokenAddress);
   });
   it("enriches the same filtered page as the launch list", async () => {
     vi.stubGlobal("fetch", sourceFetch());
-    storage.list.mockResolvedValue({ items: [TOKEN] });
-    const response = await GET(new Request(`${endpoint}?page=2&q=RHV4&age=30d&sort=oldest`));
+    storage.list.mockResolvedValue({ items: [TOKEN], presentations: [{ tokenAddress: TOKEN.tokenAddress, market: null }] });
+    const response = await GET(new Request(`${endpoint}?page=2&q=RHV4&sort=lowest`));
     expect(response.status).toBe(200);
-    expect(storage.list).toHaveBeenCalledWith(2, "RHV4", { age: "30d", sort: "oldest" });
+    expect(storage.list).toHaveBeenCalledWith(2, "RHV4", { sort: "lowest" });
   });
 });

--- a/tests/robinhood-profile.test.ts
+++ b/tests/robinhood-profile.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getAddress } from "viem";
+
+const boundary = vi.hoisted(() => ({
+  store: vi.fn(), read: vi.fn(), write: vi.fn(), markets: vi.fn(), presentations: vi.fn(),
+}));
+vi.mock("server-only", () => ({}));
+vi.mock("next/cache", () => ({ unstable_cache: (callback: unknown) => callback }));
+vi.mock("@/lib/server/robinhood-index/store", () => ({ indexStore: boundary.store }));
+vi.mock("@/lib/server/robinhood-presentation", () => ({
+  readRobinhoodMarkets: boundary.markets,
+  readRobinhoodPresentations: boundary.presentations,
+}));
+
+import { GET } from "@/app/api/profile/robinhood/route";
+import type { RobinhoodLaunch } from "@/lib/robinhood-launches";
+import { profileLaunchList, type RobinhoodSnapshot } from "@/lib/server/robinhood-index/model";
+import { readRobinhoodProfileLaunches } from "@/lib/server/robinhood-index/read";
+
+const NOW = Date.parse("2026-09-05T12:00:00.000Z");
+const OWNER = "0xa123456789012345678901234567890123456789";
+const OTHER = "0xb123456789012345678901234567890123456789";
+const MAIN_TOKEN = "0xc60ba256b44334a0cd2c7242e98b88f031abb006";
+const CLEAN_ROOM = "0x15fca474b23cafe775120b1fafbcff0e7a827af2";
+const address = (value: number) => `0x${value.toString(16).padStart(40, "0")}`;
+const hash = (value: number) => `0x${value.toString(16).padStart(64, "0")}`;
+
+function launch(id: number, overrides: Partial<RobinhoodLaunch> = {}): RobinhoodLaunch {
+  return {
+    routerAddress: address(1), launchId: hash(id), tokenAddress: address(1_000 + id),
+    hookAddress: address(2_000 + id), creator: OWNER, poolManager: address(3),
+    poolId: hash(3_000 + id), stampHash: hash(4_000 + id), transactionHash: hash(5_000 + id),
+    blockNumber: String(100 + id), blockHash: hash(6_000 + id), logIndex: id,
+    launchedAt: new Date(NOW - 60_000).toISOString(), name: `Token ${id}`, symbol: `T${id}`,
+    decimals: 18, ...overrides,
+  };
+}
+
+function snapshot(items: RobinhoodLaunch[] = [], overrides: Partial<RobinhoodSnapshot> = {}): RobinhoodSnapshot {
+  return {
+    version: 1, chainId: 4663, routerAddress: address(1), binding: hash(1), startBlock: "100",
+    cursor: { number: "999", hash: hash(999) }, checkpoints: [], finalizedBlock: "999",
+    updatedAt: new Date(NOW).toISOString(), items, ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.spyOn(Date, "now").mockReturnValue(NOW);
+  boundary.store.mockReturnValue({ read: boundary.read, write: boundary.write });
+  boundary.read.mockResolvedValue(null);
+  vi.stubGlobal("fetch", vi.fn(() => Promise.reject(new Error("Unexpected provider request"))));
+});
+
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+describe("Robinhood creator launch history", () => {
+  it("matches only the exact canonical launch wallet, case-insensitively", () => {
+    const owned = launch(1, { creator: getAddress(OWNER) });
+    const unrelated = launch(2, { creator: OTHER, name: OWNER, symbol: OWNER, hookAddress: OWNER });
+    const main = launch(3, { creator: OTHER, tokenAddress: MAIN_TOKEN });
+    const result = profileLaunchList(snapshot([unrelated, main, owned]), getAddress(OWNER));
+    expect(result).toMatchObject({ chainId: 4663, account: OWNER, status: "ready", items: [owned] });
+    expect(result.page.totalItems).toBe(1);
+  });
+
+  it("preserves hidden creator history and does not pin the main token in a profile", () => {
+    const main = launch(1, { tokenAddress: MAIN_TOKEN });
+    const cleanRoom = launch(2, { tokenAddress: CLEAN_ROOM, name: null, symbol: null });
+    const recent = launch(3);
+    const saved = snapshot([main, cleanRoom, recent]);
+    expect(profileLaunchList(saved, OWNER).items).toEqual([recent, cleanRoom, main]);
+    expect(saved.items).toEqual([main, cleanRoom, recent]);
+    expect(profileLaunchList(saved, OTHER).items).toEqual([]);
+  });
+
+  it("filters the full catalog before 50-row pagination", () => {
+    const owned = Array.from({ length: 55 }, (_, index) => launch(index + 1));
+    const others = Array.from({ length: 80 }, (_, index) => launch(index + 100, { creator: OTHER }));
+    const saved = snapshot([...owned, ...others]);
+    const first = profileLaunchList(saved, OWNER);
+    const second = profileLaunchList(saved, OWNER, 2);
+    expect(first.page).toEqual({ number: 1, size: 50, totalItems: 55, totalPages: 2, hasMore: true });
+    expect(second.page).toEqual({ number: 2, size: 50, totalItems: 55, totalPages: 2, hasMore: false });
+    expect(first.items).toEqual(owned.slice(5).toReversed());
+    expect(second.items).toEqual(owned.slice(0, 5).toReversed());
+    expect(new Set([...first.items, ...second.items].map((row) => row.launchId)).size).toBe(55);
+    expect(profileLaunchList(saved, OWNER, 999_999)).toEqual(second);
+  });
+
+  it("orders by exact block and log position with a deterministic address tie-break", () => {
+    const earlier = launch(1, { blockNumber: "9007199254740992", logIndex: 99 });
+    const firstLog = launch(2, { blockNumber: "9007199254740993", logIndex: 1 });
+    const sameLogB = launch(4, { blockNumber: "9007199254740993", logIndex: 2 });
+    const sameLogA = launch(3, { blockNumber: "9007199254740993", logIndex: 2 });
+    expect(profileLaunchList(snapshot([earlier, sameLogB, firstLog, sameLogA]), OWNER).items)
+      .toEqual([sameLogA, sameLogB, firstLog, earlier]);
+  });
+
+  it("distinguishes an empty ready profile from an unavailable index", () => {
+    const ready = profileLaunchList(snapshot([launch(1, { creator: OTHER })]), OWNER, 9);
+    expect(ready).toMatchObject({ status: "ready", items: [], updatedAt: new Date(NOW).toISOString() });
+    expect(ready.page).toEqual({ number: 1, size: 50, totalItems: 0, totalPages: 0, hasMore: false });
+    expect(profileLaunchList(null, OWNER)).toMatchObject({
+      chainId: 4663, account: OWNER, status: "unavailable", updatedAt: null, items: [],
+    });
+  });
+
+  it("retains owner rows when stale or syncing and excludes pending verification", () => {
+    const owned = launch(1);
+    const pending = launch(2);
+    expect(profileLaunchList(snapshot([owned], {
+      updatedAt: new Date(NOW - 300_001).toISOString(),
+    }), OWNER)).toMatchObject({ status: "stale", items: [owned] });
+    expect(profileLaunchList(snapshot([owned], { finalizedBlock: "1000" }), OWNER))
+      .toMatchObject({ status: "syncing", items: [owned] });
+    expect(profileLaunchList(snapshot([owned], {
+      pending: { block: { number: pending.blockNumber, hash: pending.blockHash }, items: [pending] },
+    }), OWNER)).toMatchObject({ status: "syncing", items: [owned] });
+  });
+
+  it.each([0, -1, 1.5, NaN, Infinity, Number.MAX_SAFE_INTEGER + 1])("normalizes invalid internal page %s to page one", (page) => {
+    expect(profileLaunchList(snapshot([launch(1)]), OWNER, page).page.number).toBe(1);
+  });
+
+  it.each(["", "0x123", `${OWNER}0`, ` ${OWNER}`, "not-an-address"])("rejects invalid internal account %s", (account) => {
+    expect(() => profileLaunchList(null, account)).toThrow("Invalid Robinhood profile account");
+  });
+});
+
+describe("Robinhood profile snapshot reader", () => {
+  it("reads the saved snapshot without querying market providers or writing storage", async () => {
+    const owned = launch(1);
+    boundary.read.mockResolvedValue({ snapshot: snapshot([owned, launch(2, { creator: OTHER })]), etag: "saved" });
+    expect(await readRobinhoodProfileLaunches(getAddress(OWNER))).toMatchObject({
+      account: OWNER, chainId: 4663, status: "ready", items: [owned],
+    });
+    expect(boundary.read).toHaveBeenCalledOnce();
+    expect(boundary.markets).not.toHaveBeenCalled();
+    expect(boundary.presentations).not.toHaveBeenCalled();
+    expect(boundary.write).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns an account-scoped unavailable result without exposing storage errors", async () => {
+    boundary.read.mockRejectedValue(new Error("private provider credentials"));
+    const result = await readRobinhoodProfileLaunches(getAddress(OWNER), 8);
+    expect(result).toMatchObject({ account: OWNER, status: "unavailable", updatedAt: null, items: [] });
+    expect(result.page.number).toBe(1);
+    expect(JSON.stringify(result)).not.toContain("private");
+    expect(boundary.markets).not.toHaveBeenCalled();
+    expect(boundary.write).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid account before storage access", async () => {
+    await expect(readRobinhoodProfileLaunches("invalid")).rejects.toThrow("Invalid Robinhood profile account");
+    expect(boundary.store).not.toHaveBeenCalled();
+  });
+});
+
+describe("Robinhood public profile HTTP boundary", () => {
+  const request = (query: string) => new Request(`https://website.invalid/api/profile/robinhood?${query}`);
+
+  it("serves a normalized public wallet profile without an auth credential", async () => {
+    const owned = launch(1);
+    boundary.read.mockResolvedValue({ snapshot: snapshot([owned]), etag: "saved" });
+    const response = await GET(request(`account=${getAddress(OWNER)}`));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ chainId: 4663, account: OWNER, status: "ready", items: [owned] });
+    expect(response.headers.get("cache-control")).toBe("public, max-age=0, s-maxage=15, stale-while-revalidate=30");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(boundary.write).not.toHaveBeenCalled();
+  });
+
+  it("serves the requested creator page with no cross-account rows", async () => {
+    const owned = Array.from({ length: 51 }, (_, index) => launch(index + 1));
+    boundary.read.mockResolvedValue({ snapshot: snapshot([...owned, launch(90, { creator: OTHER })]), etag: "saved" });
+    const response = await GET(request(`account=${OWNER}&page=2`));
+    expect(await response.json()).toMatchObject({
+      items: [owned[0]], page: { number: 2, totalItems: 51, totalPages: 2, hasMore: false },
+    });
+  });
+
+  it.each([
+    "", "page=1", "account=", "account=invalid", "account=0x123", `account=%20${OWNER}`,
+    `account=${OWNER}&account=${OWNER}`, `account=${OWNER}&page=1&page=2`,
+    `account=${OWNER}&chainId=1`, `account=${OWNER}&chainId=4663`, `account=${OWNER}&sort=newest`,
+    `account=${OWNER}&page=`, `account=${OWNER}&page=0`, `account=${OWNER}&page=-1`,
+    `account=${OWNER}&page=1.5`, `account=${OWNER}&page=01`, `account=${OWNER}&page=1000000`,
+  ])("rejects invalid query %s before any index read", async (query) => {
+    const response = await GET(request(query));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "invalid_query" });
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(boundary.store).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not accept write methods", async () => {
+    const response = await GET(new Request(`https://website.invalid/api/profile/robinhood?account=${OWNER}`, {
+      method: "POST", body: "{}",
+    }));
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("GET");
+    expect(boundary.store).not.toHaveBeenCalled();
+  });
+
+  it("returns the unavailable contract when the saved index is missing", async () => {
+    const response = await GET(request(`account=${OWNER}`));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ account: OWNER, chainId: 4663, status: "unavailable", items: [] });
+  });
+});

--- a/tests/robinhood-website-index.test.ts
+++ b/tests/robinhood-website-index.test.ts
@@ -646,6 +646,18 @@ describe("Robinhood website launch list", () => {
     expect(saved.items).toEqual([...rows, pinned, hidden]);
   });
 
+  it.each(["highest", "lowest", "newest", "oldest"] as const)("applies %s to V4 search matches while keeping the main token pinned", (sort) => {
+    const pinned = launch(70, 170, { symbol: "V4", tokenAddress: "0xC60bA256B44334A0Cd2C7242E98B88f031abB006" });
+    const matches = Array.from({ length: 20 }, (_, index) => launch(index + 1, 100 + index, { symbol: "V4" }));
+    const unrelated = launch(71, 171, { name: "Another token", symbol: "OTHER" });
+    const caps = new Map(matches.map((row, index) => [row.tokenAddress, 20 - index]));
+    caps.set(unrelated.tokenAddress, 1_000_000);
+    const ordered = sort === "highest" || sort === "oldest" ? matches : matches.toReversed();
+    const result = launchList(snapshot([...matches, unrelated, pinned]), 1, " v4 ", NOW, { sort }, caps);
+    expect(result.items).toEqual([pinned, ...ordered]);
+    expect(result.page.totalItems).toBe(21);
+  });
+
   it("hides only the exact Clean Room address without removing canonical records or inventing a pinned token", () => {
     const hidden = launch(1, 100, { tokenAddress: "0x15fca474b23cafe775120b1fafbcff0e7a827af2" });
     const other = launch(2, 101, { name: "Robinhood Clean Room", symbol: "RHCR" });

--- a/tests/robinhood-website-index.test.ts
+++ b/tests/robinhood-website-index.test.ts
@@ -610,6 +610,35 @@ describe("Robinhood website launch list", () => {
     }));
 
     expect(launchList(saved, 1, "", NOW).items).toEqual([rows[1], rows[2], rows[0]]);
+    expect(launchList(saved, 1, "", NOW, { age: "any", sort: "oldest" }).items).toEqual([rows[0], rows[2], rows[1]]);
+  });
+
+  it("filters the entire catalog before paging oldest-first and combines age with search", () => {
+    const rows = Array.from({ length: 60 }, (_, index) => launch(index + 1, 100 + index, {
+      launchedAt: new Date(NOW - (index < 5 ? 2 * 86_400_000 : (60 - index) * 60_000)).toISOString(),
+    }));
+    const saved = snapshot(rows);
+    const filters = { age: "24h", sort: "oldest" } as const;
+    const first = launchList(saved, 1, "", NOW, filters);
+    const second = launchList(saved, 2, "", NOW, filters);
+    expect(first.items).toEqual(rows.slice(5, 55));
+    expect(first.page).toMatchObject({ totalItems: 55, totalPages: 2, hasMore: true });
+    expect(second.items).toEqual(rows.slice(55));
+    expect(launchList(saved, 99, "", NOW, filters)).toEqual(second);
+    expect(launchList(saved, 1, rows[59].tokenAddress, NOW, filters).items).toEqual([rows[59]]);
+    expect(launchList(saved, 1, rows[0].tokenAddress, NOW, filters).items).toEqual([]);
+    expect(saved.items).toEqual(rows);
+  });
+
+  it.each([ ["24h", 86_400_000], ["7d", 604_800_000], ["30d", 2_592_000_000] ] as const)("respects the %s boundary and excludes unknown or future launch times", (age, ageMs) => {
+    const rows = [
+      launch(1, 100, { launchedAt: new Date(NOW - ageMs).toISOString() }),
+      launch(2, 101, { launchedAt: new Date(NOW - ageMs - 1).toISOString() }),
+      launch(3, 102, { launchedAt: null }),
+      launch(4, 103, { launchedAt: new Date(NOW + 1).toISOString() }),
+    ];
+    expect(launchList(snapshot(rows), 1, "", NOW, { age, sort: "newest" }).items).toEqual([rows[0]]);
+    expect(launchList(snapshot(rows), 1, "", NOW).page.totalItems).toBe(4);
   });
 
   it("distinguishes unavailable, syncing, ready and stale while retaining indexed rows", () => {

--- a/tests/robinhood-website-index.test.ts
+++ b/tests/robinhood-website-index.test.ts
@@ -610,35 +610,56 @@ describe("Robinhood website launch list", () => {
     }));
 
     expect(launchList(saved, 1, "", NOW).items).toEqual([rows[1], rows[2], rows[0]]);
-    expect(launchList(saved, 1, "", NOW, { age: "any", sort: "oldest" }).items).toEqual([rows[0], rows[2], rows[1]]);
+    expect(launchList(saved, 1, "", NOW, { sort: "oldest" }).items).toEqual([rows[0], rows[2], rows[1]]);
   });
 
-  it("filters the entire catalog before paging oldest-first and combines age with search", () => {
-    const rows = Array.from({ length: 60 }, (_, index) => launch(index + 1, 100 + index, {
-      launchedAt: new Date(NOW - (index < 5 ? 2 * 86_400_000 : (60 - index) * 60_000)).toISOString(),
-    }));
+  it.each(["highest", "lowest"] as const)("sorts the entire catalog by %s market cap before pagination", (sort) => {
+    const rows = Array.from({ length: 60 }, (_, index) => launch(index + 1, 100 + index));
     const saved = snapshot(rows);
-    const filters = { age: "24h", sort: "oldest" } as const;
-    const first = launchList(saved, 1, "", NOW, filters);
-    const second = launchList(saved, 2, "", NOW, filters);
-    expect(first.items).toEqual(rows.slice(5, 55));
-    expect(first.page).toMatchObject({ totalItems: 55, totalPages: 2, hasMore: true });
-    expect(second.items).toEqual(rows.slice(55));
-    expect(launchList(saved, 99, "", NOW, filters)).toEqual(second);
-    expect(launchList(saved, 1, rows[59].tokenAddress, NOW, filters).items).toEqual([rows[59]]);
-    expect(launchList(saved, 1, rows[0].tokenAddress, NOW, filters).items).toEqual([]);
+    const caps = new Map(rows.map((row, index) => [row.tokenAddress, (60 - index) * 100]));
+    const ordered = sort === "highest" ? rows : rows.toReversed();
+    const first = launchList(saved, 1, "", NOW, { sort }, caps);
+    const second = launchList(saved, 2, "", NOW, { sort }, caps);
+    expect(first.items).toEqual(ordered.slice(0, 50));
+    expect(first.page).toMatchObject({ totalItems: 60, totalPages: 2, hasMore: true });
+    expect(second.items).toEqual(ordered.slice(50));
+    expect(launchList(saved, 99, "", NOW, { sort }, caps)).toEqual(second);
+    expect(launchList(saved, 1, rows[59].tokenAddress, NOW, { sort }, caps).items).toEqual([rows[59]]);
     expect(saved.items).toEqual(rows);
   });
 
-  it.each([ ["24h", 86_400_000], ["7d", 604_800_000], ["30d", 2_592_000_000] ] as const)("respects the %s boundary and excludes unknown or future launch times", (age, ageMs) => {
-    const rows = [
-      launch(1, 100, { launchedAt: new Date(NOW - ageMs).toISOString() }),
-      launch(2, 101, { launchedAt: new Date(NOW - ageMs - 1).toISOString() }),
-      launch(3, 102, { launchedAt: null }),
-      launch(4, 103, { launchedAt: new Date(NOW + 1).toISOString() }),
-    ];
-    expect(launchList(snapshot(rows), 1, "", NOW, { age, sort: "newest" }).items).toEqual([rows[0]]);
-    expect(launchList(snapshot(rows), 1, "", NOW).page.totalItems).toBe(4);
+  it.each(["highest", "lowest", "newest", "oldest"] as const)("keeps the verified Programmable token first for %s, every page and search", (sort) => {
+    const pinned = launch(70, 170, { tokenAddress: "0xC60bA256B44334A0Cd2C7242E98B88f031abB006" });
+    const hidden = launch(71, 171, { tokenAddress: "0x15FCA474B23CAFE775120B1FAfbCFF0E7a827af2" });
+    const rows = Array.from({ length: 55 }, (_, index) => launch(index + 1, 100 + index));
+    const saved = snapshot([...rows, pinned, hidden]);
+    const caps = new Map([...rows, pinned, hidden].map((row, index) => [row.tokenAddress.toLowerCase(), index]));
+    const ascending = sort === "lowest" || sort === "oldest";
+    const ordered = ascending ? rows : rows.toReversed();
+    const first = launchList(saved, 1, "", NOW, { sort }, caps);
+    const second = launchList(saved, 2, "", NOW, { sort }, caps);
+    expect(first.items).toEqual([pinned, ...ordered.slice(0, 49)]);
+    expect(second.items).toEqual([pinned, ...ordered.slice(49)]);
+    expect(first.page).toMatchObject({ totalItems: 56, totalPages: 2 });
+    expect(launchList(saved, 1, rows[3].tokenAddress, NOW, { sort }, caps).items).toEqual([pinned, rows[3]]);
+    expect(launchList(saved, 1, hidden.tokenAddress, NOW, { sort }, caps).items).toEqual([pinned]);
+    expect(saved.items).toEqual([...rows, pinned, hidden]);
+  });
+
+  it("hides only the exact Clean Room address without removing canonical records or inventing a pinned token", () => {
+    const hidden = launch(1, 100, { tokenAddress: "0x15fca474b23cafe775120b1fafbcff0e7a827af2" });
+    const other = launch(2, 101, { name: "Robinhood Clean Room", symbol: "RHCR" });
+    const saved = snapshot([hidden, other]);
+    expect(launchList(saved, 1, "", NOW).items).toEqual([other]);
+    expect(saved.items).toHaveLength(2);
+  });
+
+  it.each(["highest", "lowest"] as const)("keeps unknown caps last for %s, preserves zero and breaks ties by launch order", (sort) => {
+    const rows = Array.from({ length: 6 }, (_, index) => launch(index + 1, 100 + index));
+    const caps = new Map([[rows[0].tokenAddress, 0], [rows[1].tokenAddress, 5], [rows[2].tokenAddress, 5],
+      [rows[3].tokenAddress, -1], [rows[4].tokenAddress, NaN]]);
+    const known = sort === "highest" ? [rows[2], rows[1], rows[0]] : [rows[0], rows[2], rows[1]];
+    expect(launchList(snapshot(rows), 1, "", NOW, { sort }, caps).items).toEqual([...known, rows[5], rows[4], rows[3]]);
   });
 
   it("distinguishes unavailable, syncing, ready and stale while retaining indexed rows", () => {

--- a/tests/robinhood-website-routes.test.ts
+++ b/tests/robinhood-website-routes.test.ts
@@ -11,7 +11,7 @@ import { GET as update } from "@/app/api/ops/robinhood-index/route";
 beforeEach(() => { vi.clearAllMocks(); vi.stubEnv("CRON_SECRET", "a".repeat(48)); });
 
 describe("Robinhood website HTTP boundaries", () => {
-  it.each(["chainId=1", "page=0", "page=1&page=2", "q=a&q=b", `q=${"x".repeat(129)}`, "age=0", "age=7d&age=30d", "sort=market-cap", "sort=oldest&sort=newest"])("rejects invalid public query %s without reading storage", async (query) => {
+  it.each(["chainId=1", "page=0", "page=1&page=2", "q=a&q=b", `q=${"x".repeat(129)}`, "age=0", "age=any", "age=7d&age=30d", "sort=market-cap", "sort=oldest&sort=newest"])("rejects invalid public query %s without reading storage", async (query) => {
     expect((await list(new Request(`https://website.invalid/api/explore/robinhood?${query}`))).status).toBe(400);
     expect(mocks.read).not.toHaveBeenCalled();
     expect(mocks.source).not.toHaveBeenCalled();
@@ -20,13 +20,13 @@ describe("Robinhood website HTTP boundaries", () => {
     mocks.read.mockResolvedValue({ chainId: 4663, status: "ready", items: [] });
     const response = await list(new Request("https://website.invalid/api/explore/robinhood?page=2&q=V4"));
     expect(response.status).toBe(200);
-    expect(mocks.read).toHaveBeenCalledWith(2, "V4", { age: "any", sort: "newest" });
+    expect(mocks.read).toHaveBeenCalledWith(2, "V4", { sort: "highest" });
     expect(mocks.source).not.toHaveBeenCalled();
   });
-  it("passes age and order to the complete saved list", async () => {
+  it.each(["highest", "lowest", "newest", "oldest"])("passes %s order to the complete saved list", async (sort) => {
     mocks.read.mockResolvedValue({ chainId: 4663, status: "ready", items: [] });
-    expect((await list(new Request("https://website.invalid/api/explore/robinhood?page=2&q=V4&age=7d&sort=oldest"))).status).toBe(200);
-    expect(mocks.read).toHaveBeenCalledWith(2, "V4", { age: "7d", sort: "oldest" });
+    expect((await list(new Request(`https://website.invalid/api/explore/robinhood?page=2&q=V4&sort=${sort}`))).status).toBe(200);
+    expect(mocks.read).toHaveBeenCalledWith(2, "V4", { sort });
     expect(mocks.source).not.toHaveBeenCalled();
   });
   it.each([undefined, "Bearer wrong", `Bearer ${"b".repeat(48)}`])("does not start background work with invalid authorization", async (authorization) => {

--- a/tests/robinhood-website-routes.test.ts
+++ b/tests/robinhood-website-routes.test.ts
@@ -11,7 +11,7 @@ import { GET as update } from "@/app/api/ops/robinhood-index/route";
 beforeEach(() => { vi.clearAllMocks(); vi.stubEnv("CRON_SECRET", "a".repeat(48)); });
 
 describe("Robinhood website HTTP boundaries", () => {
-  it.each(["chainId=1", "page=0", "page=1&page=2", "q=a&q=b", `q=${"x".repeat(129)}`])("rejects invalid public query %s without reading storage", async (query) => {
+  it.each(["chainId=1", "page=0", "page=1&page=2", "q=a&q=b", `q=${"x".repeat(129)}`, "age=0", "age=7d&age=30d", "sort=market-cap", "sort=oldest&sort=newest"])("rejects invalid public query %s without reading storage", async (query) => {
     expect((await list(new Request(`https://website.invalid/api/explore/robinhood?${query}`))).status).toBe(400);
     expect(mocks.read).not.toHaveBeenCalled();
     expect(mocks.source).not.toHaveBeenCalled();
@@ -20,7 +20,13 @@ describe("Robinhood website HTTP boundaries", () => {
     mocks.read.mockResolvedValue({ chainId: 4663, status: "ready", items: [] });
     const response = await list(new Request("https://website.invalid/api/explore/robinhood?page=2&q=V4"));
     expect(response.status).toBe(200);
-    expect(mocks.read).toHaveBeenCalledWith(2, "V4");
+    expect(mocks.read).toHaveBeenCalledWith(2, "V4", { age: "any", sort: "newest" });
+    expect(mocks.source).not.toHaveBeenCalled();
+  });
+  it("passes age and order to the complete saved list", async () => {
+    mocks.read.mockResolvedValue({ chainId: 4663, status: "ready", items: [] });
+    expect((await list(new Request("https://website.invalid/api/explore/robinhood?page=2&q=V4&age=7d&sort=oldest"))).status).toBe(200);
+    expect(mocks.read).toHaveBeenCalledWith(2, "V4", { age: "7d", sort: "oldest" });
     expect(mocks.source).not.toHaveBeenCalled();
   });
   it.each([undefined, "Bearer wrong", `Bearer ${"b".repeat(48)}`])("does not start background work with invalid authorization", async (authorization) => {

--- a/tests/security-headers-error-boundaries.test.ts
+++ b/tests/security-headers-error-boundaries.test.ts
@@ -81,6 +81,14 @@ describe("website security headers", () => {
     expect(createContentSecurityPolicy(false)).not.toContain("'unsafe-eval'");
     expect(createContentSecurityPolicy(true)).toContain("'unsafe-eval'");
   });
+
+  it("limits the market embed to its exact frame host without adding script access", () => {
+    const policy = createContentSecurityPolicy(false).split("; ");
+    const frame = policy.find((directive) => directive.startsWith("frame-src "));
+    expect(frame).toContain("https://dexscreener.com");
+    expect(frame).not.toContain("https://*.dexscreener.com");
+    expect(policy.find((directive) => directive.startsWith("script-src "))).not.toContain("dexscreener");
+  });
 });
 
 describe("application error boundaries", () => {

--- a/tests/stock-paired-public-activation.test.ts
+++ b/tests/stock-paired-public-activation.test.ts
@@ -37,9 +37,9 @@ function publicPreflightRequest() {
 
 describe("Stock-Paired launch closure", () => {
   it("removes Stock-Paired from the public launch picker", async () => {
-    const html = renderToStaticMarkup(createElement(ViewChainProvider, {
-      children: await LaunchPage(),
-    }));
+    const html = renderToStaticMarkup(
+      createElement(ViewChainProvider, null, await LaunchPage()),
+    );
 
     expect(html).toContain('data-launch-model-option="classic"');
     expect(html).not.toContain('data-launch-model-option="stock-paired"');

--- a/tests/stock-paired-public-activation.test.ts
+++ b/tests/stock-paired-public-activation.test.ts
@@ -4,8 +4,12 @@ import { NextRequest } from "next/server";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ get: () => undefined }),
+}));
 
 import LaunchPage from "../app/launch/page";
+import { ViewChainProvider } from "../components/view-chain";
 import { POST } from "../app/api/launch/preflight/route";
 import { createStockPairedDraft } from "../lib/launch";
 import { STOCK_PAIRED_ETH_QUOTE_ASSETS } from "../lib/stock-paired";
@@ -32,8 +36,10 @@ function publicPreflightRequest() {
 }
 
 describe("Stock-Paired launch closure", () => {
-  it("removes Stock-Paired from the public launch picker", () => {
-    const html = renderToStaticMarkup(createElement(LaunchPage));
+  it("removes Stock-Paired from the public launch picker", async () => {
+    const html = renderToStaticMarkup(createElement(ViewChainProvider, {
+      children: await LaunchPage(),
+    }));
 
     expect(html).toContain('data-launch-model-option="classic"');
     expect(html).not.toContain('data-launch-model-option="stock-paired"');

--- a/tests/view-chain-scope-gate.test.ts
+++ b/tests/view-chain-scope-gate.test.ts
@@ -9,8 +9,9 @@ const read = (path: string) => readFileSync(join(root, path), "utf8");
 
 describe("Robinhood view-chain scope gate", () => {
   it("gates only Ethereum-bound product data routes", () => {
-    expect(isRobinhoodUnavailableRoute("/profile")).toBe(true);
-    expect(isRobinhoodUnavailableRoute("/profile/settings")).toBe(true);
+    expect(isRobinhoodUnavailableRoute("/profile")).toBe(false);
+    expect(isRobinhoodUnavailableRoute("/profile/settings")).toBe(false);
+    expect(read("app/profile/layout.tsx")).not.toContain("ResolvedViewChainLayout");
     expect(isRobinhoodUnavailableRoute("/launch")).toBe(false);
     expect(isRobinhoodUnavailableRoute("/launch/history")).toBe(false);
     expect(isRobinhoodUnavailableRoute("/token/0x1234")).toBe(false);

--- a/tests/view-chain-scope-gate.test.ts
+++ b/tests/view-chain-scope-gate.test.ts
@@ -11,8 +11,8 @@ describe("Robinhood view-chain scope gate", () => {
   it("gates only Ethereum-bound product data routes", () => {
     expect(isRobinhoodUnavailableRoute("/profile")).toBe(true);
     expect(isRobinhoodUnavailableRoute("/profile/settings")).toBe(true);
-    expect(isRobinhoodUnavailableRoute("/launch")).toBe(true);
-    expect(isRobinhoodUnavailableRoute("/launch/history")).toBe(true);
+    expect(isRobinhoodUnavailableRoute("/launch")).toBe(false);
+    expect(isRobinhoodUnavailableRoute("/launch/history")).toBe(false);
     expect(isRobinhoodUnavailableRoute("/token/0x1234")).toBe(false);
 
     expect(isRobinhoodUnavailableRoute("/explore")).toBe(false);

--- a/tests/view-chain.test.ts
+++ b/tests/view-chain.test.ts
@@ -118,12 +118,11 @@ describe("view chain", () => {
     expect(routeBoundary).toContain("initialViewChainId === null");
     expect(routeBoundary).toContain("<ViewChainPending />");
     expect(routeBoundary).toContain("resolvedViewChainId === 4663");
-    for (const routeLayout of [
-      "app/profile/layout.tsx",
-      "app/launch/layout.tsx",
-    ]) {
-      expect(read(routeLayout)).toContain("ResolvedViewChainLayout as default");
-    }
+    expect(read("app/profile/layout.tsx"))
+      .toContain("ResolvedViewChainLayout as default");
+    expect(existsSync("app/launch/layout.tsx")).toBe(false);
+    expect(read("app/launch/page.tsx"))
+      .toContain("requestCookies.get(VIEW_CHAIN_COOKIE_NAME)?.value");
     expect(existsSync("app/token/layout.tsx")).toBe(false);
   });
 

--- a/tests/view-chain.test.ts
+++ b/tests/view-chain.test.ts
@@ -119,7 +119,7 @@ describe("view chain", () => {
     expect(routeBoundary).toContain("<ViewChainPending />");
     expect(routeBoundary).toContain("resolvedViewChainId === 4663");
     expect(read("app/profile/layout.tsx"))
-      .toContain("ResolvedViewChainLayout as default");
+      .not.toContain("ResolvedViewChainLayout");
     expect(existsSync("app/launch/layout.tsx")).toBe(false);
     expect(read("app/launch/page.tsx"))
       .toContain("requestCookies.get(VIEW_CHAIN_COOKIE_NAME)?.value");


### PR DESCRIPTION
Robinhood launches now appear as coin cards with stable artwork loading, searchable sorting, and a compact token detail view. Profile sign-in and identity are shared across Ethereum and Robinhood; the selected chain changes the profile data shown.

- Read Robinhood creator launches from the existing verified stamp snapshot, scoped by launch wallet before pagination. Market enrichment runs separately from the profile list. Ethereum reward and claim flows retain their existing chain bindings.
- Default Explore to highest market cap, keep the canonical Programmable token pinned, apply four ordering buttons to search results, and refresh without clearing existing cards. Hide the Clean Room token from the public overview while preserving its canonical history and detail page.
- Use standard chart candles, compact metrics and socials, artwork skeletons, and no inactive trade panel or redundant launch details.
- Present Ethereum Classic/Custom and Robinhood Custom in Create through chain logo controls. Both Custom entries open the shared API-key manager, with Back returning to Create. Simplify the footer risk copy.

Validation: 261 targeted profile, chain, index, presentation and client tests passed; earlier Explore/Create/API navigation suites passed; focused ESLint and production-mode build passed. Desktop (1440 px) and mobile (390 px) screenshots, keyboard chain switching, creator isolation, and the token-to-candlestick-chart path passed browser acceptance. Public profile spacing was corrected after the visual review. Browser warnings were confined to the installed wallet extension; no application errors were observed in the Robinhood flows. Local preview does not include production wallet credentials, so no authenticated signing or reward transaction was performed. The complete PR Verify run 33960337819 passed, including Interface, Custom V2, Contracts, Database, credential scanning, the indexer and the aggregate. TypeScript and 49 targeted integration tests also passed after incorporating the latest production wallet fix. Exact production staging and promotion checks follow the merge.

No contracts, wallet authorization, API-key scopes, external launch authority or production environment settings are changed. Existing submitted transactions keep receipt tracking across a view change.
