### PR TITLE
Fix migration wallet network recovery and actionable errors

### DIFF
--- a/components/late-migration-claim.tsx
+++ b/components/late-migration-claim.tsx
@@ -7,6 +7,7 @@ import { formatUnits, getAddress, type Address } from "viem";
 
 import styles from "@/components/late-migration-claim.module.css";
 import { useWallet } from "@/components/wallet-provider";
+import { MigrationPermitWalletError } from "@/lib/main-token-migration-wallet-error";
 import {
   LATE_MIGRATION_UNTRACKED_DEPOSIT_MESSAGE,
   lateMigrationIntakeFailureMessageV1,
@@ -330,6 +331,7 @@ export function lateMigrationIntakeUiErrorMessage(
   if (context === "status_unknown") {
     return "Deposit status is temporarily unavailable. A saved deposit may already be processing.";
   }
+  if (error instanceof MigrationPermitWalletError) return error.message;
   if (!(error instanceof Error)) {
     return "Deposits are temporarily unavailable. Nothing was moved.";
   }

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -59,11 +59,10 @@ import { parseLocalProfile } from "@/lib/profile/local-profile";
 import { robinhoodChain } from "@/lib/chains";
 import {
   assertMainTokenMigrationTransaction,
-  buildMainTokenMigrationPermitTypedData,
-  parseMainTokenMigrationPermitSignature,
-  serializeMainTokenMigrationPermitTypedData,
   type MainTokenMigrationPermitSignature,
 } from "@/lib/main-token-migration";
+import { signMainTokenMigrationPermitWithWallet } from "@/lib/main-token-migration-wallet";
+import { MigrationPermitWalletError } from "@/lib/main-token-migration-wallet-error";
 import {
   buildPredictionPermitTypedData,
   buildUsdgPermitTypedData,
@@ -2207,66 +2206,27 @@ function PrivyWalletBridge({
     value: bigint;
   }>) => {
     if (!connectedWallet || !wallet) {
-      throw new Error("Connect an Ethereum wallet before continuing");
+      throw new MigrationPermitWalletError("connection", "session");
     }
     const sessionSubject = user?.id ?? null;
     if (sessionSubject === null) {
-      throw new Error("Your wallet session expired. Reconnect and try again");
+      throw new MigrationPermitWalletError("session_changed", "session");
     }
     const expectedAccount = wallet.account.toLowerCase();
     const assertCurrentSession = () => {
       const current = walletRequestSessionRef.current;
       if (!current.authenticated || current.privyUserId !== sessionSubject ||
         current.account?.toLowerCase() !== expectedAccount) {
-        throw new Error("The wallet session changed. Reconnect and try again");
+        throw new MigrationPermitWalletError("session_changed", "session");
       }
     };
-    const typedData = buildMainTokenMigrationPermitTypedData({
-      ...input,
-      owner: wallet.account,
+    return signMainTokenMigrationPermitWithWallet({
+      account: wallet.account,
+      sessionSubject,
+      wallet: connectedWallet,
+      assertCurrentSession,
+      permit: input,
     });
-    const mainnetChainHex = `0x${mainnet.id.toString(16)}`;
-
-    try {
-      if (normalizeChainId(wallet.chainId) !== mainnetChainHex) {
-        await connectedWallet.switchChain(mainnet.id);
-        assertCurrentSession();
-      }
-      const provider = await connectedWallet.getEthereumProvider();
-      await assertExternalWalletAuthorityCurrent({
-        expectedAccount: wallet.account,
-        expectedChainId: mainnetChainHex,
-        networkName: mainnet.name,
-        request: (method) => provider.request({ method }),
-      });
-      const signature = await runWithBrowserWalletRequestLock({
-        sessionSubject,
-        account: wallet.account,
-        chainId: String(mainnet.id),
-        requestSubject: JSON.stringify([
-          "main-token-migration-permit-v1",
-          input.spender.toLowerCase(),
-          input.value.toString(),
-          input.nonce.toString(),
-          input.deadline.toString(),
-        ]),
-        assertCurrentSession,
-        execute: () => provider.request({
-          method: "eth_signTypedData_v4",
-          params: [
-            wallet.account,
-            serializeMainTokenMigrationPermitTypedData(typedData),
-          ],
-        }),
-      });
-      assertCurrentSession();
-      if (typeof signature !== "string") {
-        throw new Error("The wallet returned an invalid migration permit signature");
-      }
-      return parseMainTokenMigrationPermitSignature(signature as Hex);
-    } catch (caught) {
-      throw new Error(getWalletTransactionErrorMessage(caught));
-    }
   }, [connectedWallet, user?.id, wallet]);
 
   const signLaunchMessage = useCallback(async (

--- a/lib/main-token-migration-wallet-error.ts
+++ b/lib/main-token-migration-wallet-error.ts
@@ -1,0 +1,121 @@
+export type MigrationPermitWalletFailure =
+  | "cancelled"
+  | "connection"
+  | "network"
+  | "account_changed"
+  | "session_changed"
+  | "request_pending"
+  | "browser_unavailable"
+  | "signing_unsupported"
+  | "invalid_signature"
+  | "unknown";
+
+export type MigrationPermitWalletStage =
+  | "session"
+  | "network"
+  | "authority"
+  | "locking"
+  | "signature";
+
+const messages: Record<MigrationPermitWalletFailure, string> = {
+  cancelled: "Signature cancelled. Nothing was moved.",
+  connection: "Reconnect this wallet, then try again. Nothing was moved.",
+  network: "Switch your wallet to Ethereum, then try again. Nothing was moved.",
+  account_changed: "Select the same wallet you connected on this page, then try again. Nothing was moved.",
+  session_changed: "Your wallet session changed. Reconnect this wallet, then try again. Nothing was moved.",
+  request_pending: "A wallet request is already open. Check your wallet and other Programmable tabs. If you closed it, wait five minutes before trying again.",
+  browser_unavailable: "This browser cannot safely open the wallet request. Update your wallet app or open this page in an up to date browser and reconnect. Nothing was moved.",
+  signing_unsupported: "This wallet connection cannot sign the Ethereum permit. Update your wallet app, then reconnect and try again. Nothing was moved.",
+  invalid_signature: "The wallet returned a signature this deposit cannot use. Update your wallet app and reconnect. If it happens again, contact support. Nothing was moved.",
+  unknown: "Your wallet could not finish signing. Reconnect and try again. If it happens again, contact support. Nothing was moved.",
+};
+
+export class MigrationPermitWalletError extends Error {
+  readonly kind: MigrationPermitWalletFailure;
+  readonly stage: MigrationPermitWalletStage;
+  readonly code?: number;
+
+  constructor(
+    kind: MigrationPermitWalletFailure,
+    stage: MigrationPermitWalletStage,
+    code?: number,
+  ) {
+    super(messages[kind]);
+    this.name = "MigrationPermitWalletError";
+    this.kind = kind;
+    this.stage = stage;
+    this.code = code;
+  }
+}
+
+// Wallet adapters may wrap the original RPC error. Inspect only a bounded set
+// of standard fields; never forward provider messages, payloads or URLs to UI.
+function errorFacts(error: unknown) {
+  const pending: unknown[] = [error];
+  const visited = new Set<object>();
+  const codes: number[] = [];
+  const texts: string[] = [];
+  for (let index = 0; index < pending.length && index < 8; index++) {
+    const value = pending[index];
+    if (value === null || typeof value !== "object" || visited.has(value)) continue;
+    visited.add(value);
+    const record = value as Record<string, unknown>;
+    if (typeof record.code === "number" && Number.isSafeInteger(record.code)) {
+      codes.push(record.code);
+    } else if (typeof record.code === "string" && /^-?[0-9]{1,6}$/u.test(record.code)) {
+      codes.push(Number(record.code));
+    }
+    if (typeof record.message === "string") texts.push(record.message.slice(0, 1_024));
+    if (typeof record.name === "string") texts.push(record.name.slice(0, 80));
+    const data = record.data !== null && typeof record.data === "object"
+      ? record.data as Record<string, unknown> : null;
+    for (const nested of [record.cause, record.error, record.originalError, data?.originalError]) {
+      if (nested !== null && typeof nested === "object") pending.push(nested);
+    }
+  }
+  return { codes, text: texts.join(" ") };
+}
+
+export function classifyMigrationPermitWalletError(
+  error: unknown,
+  stage: MigrationPermitWalletStage,
+): MigrationPermitWalletError {
+  if (error instanceof MigrationPermitWalletError) return error;
+  const { codes, text } = errorFacts(error);
+  if (codes.includes(4001) || /user rejected|user denied|transaction cancelled in wallet/iu.test(text)) {
+    // Preserve explicit rejection for the existing request lock's lease cleanup.
+    return new MigrationPermitWalletError("cancelled", stage, 4001);
+  }
+  if (codes.includes(-32002) || /wallet request is already pending/iu.test(text)) {
+    return new MigrationPermitWalletError("request_pending", stage, -32002);
+  }
+  if (codes.includes(4900) || codes.includes(4901) ||
+    /disconnected|lost connection|connection was interrupted|background|postmessage failed/iu.test(text)) {
+    return new MigrationPermitWalletError("connection", stage);
+  }
+  if (codes.includes(4100)) return new MigrationPermitWalletError("connection", stage, 4100);
+  if (codes.includes(4200) || codes.includes(-32601) ||
+    /unsupported|not supported|method not found|sign typed|signing method/iu.test(text)) {
+    return new MigrationPermitWalletError(
+      stage === "signature" ? "signing_unsupported" : "network", stage,
+      codes.find((code) => code === 4200 || code === -32601),
+    );
+  }
+  if (/wallet session (?:changed|expired)/iu.test(text)) {
+    return new MigrationPermitWalletError("session_changed", stage);
+  }
+  if (/active wallet account changed/iu.test(text)) {
+    return new MigrationPermitWalletError("account_changed", stage);
+  }
+  if (/not connected to Ethereum/iu.test(text) || codes.includes(4902)) {
+    return new MigrationPermitWalletError("network", stage);
+  }
+  if (/invalid migration permit signature/iu.test(text)) {
+    return new MigrationPermitWalletError("invalid_signature", stage);
+  }
+  if (stage === "locking" &&
+    /wallet request (?:locking|lock|tab identity)|storage|SecurityError|NotAllowedError/iu.test(text)) {
+    return new MigrationPermitWalletError("browser_unavailable", stage);
+  }
+  return new MigrationPermitWalletError("unknown", stage);
+}

--- a/lib/main-token-migration-wallet.ts
+++ b/lib/main-token-migration-wallet.ts
@@ -1,0 +1,119 @@
+import type { Address, Hex } from "viem";
+import {
+  buildMainTokenMigrationPermitTypedData,
+  MAIN_TOKEN_MIGRATION_CHAIN_ID,
+  parseMainTokenMigrationPermitSignature,
+  serializeMainTokenMigrationPermitTypedData,
+} from "./main-token-migration";
+import {
+  classifyMigrationPermitWalletError,
+  MigrationPermitWalletError,
+  type MigrationPermitWalletStage,
+} from "./main-token-migration-wallet-error";
+import { runWithBrowserWalletRequestLock } from "./wallet-request-lock";
+
+type PermitProvider = Readonly<{
+  request: (input: {
+    method: "eth_chainId" | "eth_accounts" | "eth_signTypedData_v4";
+    params?: string[];
+  }) => Promise<unknown>;
+}>;
+
+type PermitWallet = Readonly<{
+  getEthereumProvider: () => Promise<PermitProvider>;
+  switchChain: (chainId: number) => Promise<void>;
+}>;
+
+function parseProviderChain(value: unknown): bigint {
+  if (typeof value !== "string" ||
+    !/^(?:0x[0-9a-f]{1,64}|eip155:[0-9]{1,78})$/iu.test(value)) {
+    throw new MigrationPermitWalletError("network", "network");
+  }
+  return BigInt(value.replace(/^eip155:/iu, ""));
+}
+
+async function assertProviderAuthority(
+  provider: PermitProvider,
+  account: Address,
+  assertCurrentSession: () => void,
+) {
+  const chainId = parseProviderChain(await provider.request({ method: "eth_chainId" }));
+  assertCurrentSession();
+  if (chainId !== BigInt(MAIN_TOKEN_MIGRATION_CHAIN_ID)) {
+    throw new MigrationPermitWalletError("network", "authority");
+  }
+  const accounts = await provider.request({ method: "eth_accounts" });
+  assertCurrentSession();
+  const selected = Array.isArray(accounts) ? accounts[0] : undefined;
+  if (typeof selected !== "string" || selected.toLowerCase() !== account.toLowerCase()) {
+    throw new MigrationPermitWalletError("account_changed", "authority");
+  }
+}
+
+export async function signMainTokenMigrationPermitWithWallet(input: Readonly<{
+  account: Address;
+  sessionSubject: string;
+  wallet: PermitWallet;
+  assertCurrentSession: () => void;
+  permit: Readonly<{ deadline: bigint; nonce: bigint; spender: Address; value: bigint }>;
+}>) {
+  let stage: MigrationPermitWalletStage = "session";
+  try {
+    input.assertCurrentSession();
+    const typedData = buildMainTokenMigrationPermitTypedData({
+      ...input.permit, owner: input.account,
+    });
+    stage = "network";
+    let provider = await input.wallet.getEthereumProvider();
+    input.assertCurrentSession();
+    const chainId = parseProviderChain(await provider.request({ method: "eth_chainId" }));
+    input.assertCurrentSession();
+    // The provider is authoritative. Cached wallet metadata can lag behind a
+    // network change in mobile wallet browsers and WalletConnect sessions.
+    if (chainId !== BigInt(MAIN_TOKEN_MIGRATION_CHAIN_ID)) {
+      await input.wallet.switchChain(MAIN_TOKEN_MIGRATION_CHAIN_ID);
+      input.assertCurrentSession();
+      provider = await input.wallet.getEthereumProvider();
+      input.assertCurrentSession();
+    }
+    stage = "authority";
+    await assertProviderAuthority(provider, input.account, input.assertCurrentSession);
+    stage = "locking";
+    const signature = await runWithBrowserWalletRequestLock({
+      sessionSubject: input.sessionSubject,
+      account: input.account,
+      chainId: String(MAIN_TOKEN_MIGRATION_CHAIN_ID),
+      requestSubject: JSON.stringify([
+        "main-token-migration-permit-v1", input.permit.spender.toLowerCase(),
+        input.permit.value.toString(), input.permit.nonce.toString(), input.permit.deadline.toString(),
+      ]),
+      assertCurrentSession: async () => {
+        input.assertCurrentSession();
+        stage = "authority";
+        await assertProviderAuthority(provider, input.account, input.assertCurrentSession);
+      },
+      execute: async () => {
+        stage = "signature";
+        try {
+          return await provider.request({
+            method: "eth_signTypedData_v4",
+            params: [input.account, serializeMainTokenMigrationPermitTypedData(typedData)],
+          });
+        } catch (error) {
+          throw classifyMigrationPermitWalletError(error, stage);
+        }
+      },
+    });
+    input.assertCurrentSession();
+    if (typeof signature !== "string") {
+      throw new MigrationPermitWalletError("invalid_signature", "signature");
+    }
+    try {
+      return parseMainTokenMigrationPermitSignature(signature as Hex);
+    } catch {
+      throw new MigrationPermitWalletError("invalid_signature", "signature");
+    }
+  } catch (error) {
+    throw classifyMigrationPermitWalletError(error, stage);
+  }
+}

--- a/tests/browser/fixtures/late-migration-wallet.tsx
+++ b/tests/browser/fixtures/late-migration-wallet.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
 import type { Address } from "viem";
+import { signMainTokenMigrationPermitWithWallet } from "../../../lib/main-token-migration-wallet";
 
 // This module is only substituted by late-migration-server.mjs. No product route
 // or production import enables fixtures, fake eligibility or fake signatures.
@@ -17,11 +18,13 @@ export type FixtureOptions = {
   holdPrepare: boolean; holdSignature: boolean; holdAccessToken: boolean;
   untrackedDeposit: boolean; submitFailure: boolean; submitStatus: DepositStatus; tamperSpender: boolean;
   currentBalanceRaw: string;
+  providerChainId: string; permitErrorCode: number | null;
 };
 export type FixtureSnapshot = {
   connects: number; signatures: Array<Record<string, string>>;
   requests: Array<{ method: string; path: string; headers: Record<string, string>; body: Record<string, unknown> | null }>;
   currentBalanceRaw: string;
+  walletMethods: string[]; networkSwitches: number[];
 };
 export type FixtureControl = {
   configure: (options: Partial<FixtureOptions>) => void;
@@ -36,8 +39,10 @@ const options: FixtureOptions = {
   statusFailures: query.get("statusFailure") === "true" ? 1 : 0, rejectSignature: false,
   holdPrepare: false, holdSignature: false, holdAccessToken: false, submitFailure: false,
   untrackedDeposit: false, submitStatus: "deposit_submitted", tamperSpender: false, currentBalanceRaw: "99999999999999999999999999",
+  providerChainId: query.get("providerChainId") || "0x1",
+  permitErrorCode: query.has("permitErrorCode") ? Number(query.get("permitErrorCode")) : null,
 };
-const observations: FixtureSnapshot = { connects: 0, signatures: [], requests: [], currentBalanceRaw: options.currentBalanceRaw };
+const observations: FixtureSnapshot = { connects: 0, signatures: [], requests: [], currentBalanceRaw: options.currentBalanceRaw, walletMethods: [], networkSwitches: [] };
 let releasePrepare: (() => void) | undefined;
 let releaseSignature: (() => void) | undefined;
 let releaseAccessToken: (() => void) | undefined;
@@ -89,9 +94,26 @@ const getIdentityToken = async () => "fixture-identity-token";
 const preloadWallet = () => {};
 const signMainTokenMigrationPermit = async (input: PermitInput) => {
   observations.signatures.push(Object.fromEntries(Object.entries(input).map(([key, value]) => [key, String(value)])));
-  if (options.holdSignature) await new Promise<void>(resolve => { releaseSignature = resolve; });
-  if (options.rejectSignature) throw new Error("User rejected the request");
-  return { signature: `0x${"ab".repeat(64)}1b` as const, r: `0x${"ab".repeat(32)}` as const, s: `0x${"ab".repeat(32)}` as const, v: 27 };
+  // Exercise the production signing helper and browser Web Locks. Only the
+  // wallet RPC transport is controlled here; it cannot contact a real wallet.
+  return signMainTokenMigrationPermitWithWallet({
+    account: FIXTURE_WALLET,
+    sessionSubject: "fixture-session",
+    assertCurrentSession: () => undefined,
+    permit: input,
+    wallet: {
+      switchChain: async (chainId) => { observations.networkSwitches.push(chainId); options.providerChainId = `0x${chainId.toString(16)}`; },
+      getEthereumProvider: async () => ({ request: async ({ method }) => {
+        observations.walletMethods.push(method);
+        if (method === "eth_chainId") return options.providerChainId;
+        if (method === "eth_accounts") return [FIXTURE_WALLET];
+        if (options.holdSignature) await new Promise<void>(resolve => { releaseSignature = resolve; });
+        if (options.rejectSignature) throw { code: 4001, message: "Fixture wallet rejection" };
+        if (options.permitErrorCode !== null) throw { code: options.permitErrorCode, message: "Fixture wallet error" };
+        return `0x${"ab".repeat(64)}1b`;
+      } }),
+    },
+  });
 };
 const Context = createContext<{
   wallet: { account: Address; chainId: string } | null; connecting: boolean;

--- a/tests/browser/late-migration.spec.ts
+++ b/tests/browser/late-migration.spec.ts
@@ -142,6 +142,45 @@ test("one explicit click signs exact permit once and submits authenticated bound
   expect(submitted.headers["idempotency-key"]).toMatch(/^late-migration-intake-/u);
 });
 
+test("a stale cached chain switches the actual provider to Ethereum before signing", async ({ page }) => {
+  await ready(page); await selectMax(page);
+  await configure(page, { providerChainId: "0x1237" });
+  await page.getByRole("button", { name: "Sign and send", exact: true }).click();
+  await expect(page.getByText("Deposit submitted. Waiting for confirmation.", { exact: true })).toBeVisible();
+  const data = await snapshot(page);
+  expect(data.networkSwitches).toEqual([1]);
+  expect(data.walletMethods.filter(method => method === "eth_signTypedData_v4")).toHaveLength(1);
+  expect(submits(data)).toHaveLength(1);
+});
+
+test("numeric unsupported signing errors show actionable recovery without submitting", async ({ page }) => {
+  await ready(page); await selectMax(page); await configure(page, { permitErrorCode: 4200 });
+  await page.getByRole("button", { name: "Sign and send", exact: true }).click();
+  await expect(page.getByRole("alert")).toHaveText("This wallet connection cannot sign the Ethereum permit. Update your wallet app, then reconnect and try again. Nothing was moved.");
+  expect(submits(await snapshot(page))).toHaveLength(0);
+});
+
+test("missing browser Web Locks explains compatibility and never opens a signature", async ({ page }) => {
+  await page.addInitScript(() => Object.defineProperty(navigator, "locks", { configurable: true, value: undefined }));
+  await ready(page); await selectMax(page);
+  await page.getByRole("button", { name: "Sign and send", exact: true }).click();
+  await expect(page.getByRole("alert")).toContainText("This browser cannot safely open the wallet request.");
+  const data = await snapshot(page);
+  expect(data.walletMethods).not.toContain("eth_signTypedData_v4");
+  expect(submits(data)).toHaveLength(0);
+});
+
+test("an interrupted wallet request remains locked and a second click explains the pending request", async ({ page }) => {
+  await ready(page); await selectMax(page); await configure(page, { permitErrorCode: 4900 });
+  await page.getByRole("button", { name: "Sign and send", exact: true }).click();
+  await expect(page.getByRole("alert")).toHaveText("Reconnect this wallet, then try again. Nothing was moved.");
+  await page.getByRole("button", { name: "Sign and send", exact: true }).click();
+  await expect(page.getByRole("alert")).toContainText("A wallet request is already open.");
+  const data = await snapshot(page);
+  expect(data.walletMethods.filter(method => method === "eth_signTypedData_v4")).toHaveLength(1);
+  expect(submits(data)).toHaveLength(0);
+});
+
 test("signature rejection never submits and permits a new explicit attempt", async ({ page }) => {
   await ready(page); await selectMax(page); await configure(page, { rejectSignature: true });
   await page.getByRole("button", { name: "Sign and send", exact: true }).click();

--- a/tests/late-migration-claim-ui.test.ts
+++ b/tests/late-migration-claim-ui.test.ts
@@ -8,6 +8,7 @@ import {
   lateMigrationIntakeFailureMessageV1, lateMigrationIntakeProgressCopyV1,
   parseLateMigrationIntakeResponseV1, type LateMigrationIntakeExpectationV1,
 } from "../lib/late-migration-intake-client-v1";
+import { MigrationPermitWalletError } from "../lib/main-token-migration-wallet-error";
 
 const walletAddress = "0x228Be90653fDDAa408fB6cf9ca0AEC311dbE9A0D";
 const otherWallet = "0x1111111111111111111111111111111111111111";
@@ -99,6 +100,15 @@ describe("intake response and permit binding", () => {
 });
 
 describe("intake error context", () => {
+  it.each(["network", "connection", "request_pending", "browser_unavailable", "signing_unsupported", "account_changed", "session_changed", "invalid_signature"] as const)("shows actionable %s errors only before a returned signature", (kind) => {
+    const error = new MigrationPermitWalletError(kind, "signature");
+    expect(lateMigrationIntakeUiErrorMessage(error)).toBe(error.message);
+    expect(lateMigrationIntakeUiErrorMessage(error)).not.toBe("The wallet could not complete this deposit. Nothing was moved.");
+    for (const context of ["after_signature", "status_unknown"] as const) {
+      expect(lateMigrationIntakeUiErrorMessage(error, context)).toContain("may already be processing");
+      expect(lateMigrationIntakeUiErrorMessage(error, context)).not.toContain("Nothing was moved");
+    }
+  });
   it("preserves recovery instructions for an existing onchain deposit", () => {
     const message = lateMigrationIntakeFailureMessageV1(409, { error: { code: "deposit_already_recorded" } });
     expect(message).toBe("An Ethereum deposit already exists for this wallet. Do not sign again. Contact support.");

--- a/tests/main-token-migration-wallet.test.ts
+++ b/tests/main-token-migration-wallet.test.ts
@@ -1,0 +1,212 @@
+import { webcrypto } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MAIN_TOKEN_ADDRESS } from "../lib/main-token-migration";
+import { signMainTokenMigrationPermitWithWallet } from "../lib/main-token-migration-wallet";
+import { classifyMigrationPermitWalletError, MigrationPermitWalletError } from "../lib/main-token-migration-wallet-error";
+
+const account = "0x2222222222222222222222222222222222222222";
+const other = "0x3333333333333333333333333333333333333333";
+const permit = { deadline: 1_788_500_000n, nonce: 7n, spender: other, value: 12_345_000_000_000_000_000_001n } as const;
+const signature = `0x${"ab".repeat(64)}1b`;
+
+class StorageFixture {
+  values = new Map<string, string>();
+  getItem(key: string) { return this.values.get(key) ?? null; }
+  setItem(key: string, value: string) { this.values.set(key, value); }
+  removeItem(key: string) { this.values.delete(key); }
+}
+let localStorage: StorageFixture;
+let sessionStorage: StorageFixture;
+let beforeLock: () => void;
+
+beforeEach(() => {
+  localStorage = new StorageFixture();
+  sessionStorage = new StorageFixture();
+  beforeLock = () => undefined;
+  vi.stubGlobal("window", { localStorage, sessionStorage, dispatchEvent: vi.fn() });
+  vi.stubGlobal("crypto", webcrypto);
+  const active = new Set<string>();
+  vi.stubGlobal("navigator", { locks: { request: async (
+    name: string,
+    _options: unknown,
+    callback: (lock: { name: string } | null) => Promise<unknown>,
+  ) => {
+    if (active.has(name)) return callback(null);
+    active.add(name);
+    try { beforeLock(); return await callback({ name }); }
+    finally { active.delete(name); }
+  } } });
+});
+afterEach(() => vi.unstubAllGlobals());
+
+function fixture() {
+  const state = {
+    chain: "0x1", accounts: [account] as string[], authenticated: true,
+    signatureResult: signature as unknown, signatureError: undefined as unknown,
+  };
+  const request = vi.fn(async (input: { method: string; params?: string[] }) => {
+    if (input.method === "eth_chainId") return state.chain;
+    if (input.method === "eth_accounts") return state.accounts;
+    if (input.method === "eth_signTypedData_v4") {
+      if (state.signatureError !== undefined) throw state.signatureError;
+      return state.signatureResult;
+    }
+    throw new Error("Unexpected wallet method");
+  });
+  const wallet = {
+    // Deliberately stale metadata: the signing helper must read the provider.
+    chainId: "eip155:1",
+    getEthereumProvider: vi.fn(async () => ({ request })),
+    switchChain: vi.fn(async (chainId: number) => { state.chain = `0x${chainId.toString(16)}`; }),
+  };
+  const assertCurrentSession = () => {
+    if (!state.authenticated) throw new MigrationPermitWalletError("session_changed", "session");
+  };
+  const sign = () => signMainTokenMigrationPermitWithWallet({ account, sessionSubject: "fixture-session", wallet, assertCurrentSession, permit });
+  const signatureCalls = () => request.mock.calls.filter(([input]) => input.method === "eth_signTypedData_v4");
+  return { state, request, wallet, sign, signatureCalls };
+}
+
+describe("migration permit provider execution", () => {
+  it("production provider delegates to the tested helper without flattening its errors", () => {
+    const source = readFileSync(join(process.cwd(), "components/wallet-provider.tsx"), "utf8");
+    const method = source.slice(source.indexOf("const signMainTokenMigrationPermit = useCallback"), source.indexOf("const signLaunchMessage = useCallback"));
+    expect(method).toContain("return signMainTokenMigrationPermitWithWallet({");
+    expect(method).toContain("assertCurrentSession,");
+    expect(method).not.toContain("getWalletTransactionErrorMessage");
+    expect(method).not.toContain("wallet.chainId");
+  });
+
+  it("switches a stale cached Ethereum wallet using the actual provider and reacquires it", async () => {
+    const f = fixture(); f.state.chain = "0x1237";
+    await expect(f.sign()).resolves.toMatchObject({ signature, v: 27 });
+    expect(f.wallet.switchChain).toHaveBeenCalledExactlyOnceWith(1);
+    expect(f.wallet.getEthereumProvider).toHaveBeenCalledTimes(2);
+    expect(f.signatureCalls()).toHaveLength(1);
+    expect(localStorage.values.size).toBe(0);
+  });
+
+  it("does not switch an Ethereum provider because cached metadata names a different chain", async () => {
+    const f = fixture(); f.wallet.chainId = "eip155:4663";
+    await f.sign(); expect(f.wallet.switchChain).not.toHaveBeenCalled();
+    const [owner, serialized] = f.signatureCalls()[0][0].params!;
+    expect(owner).toBe(account);
+    expect(JSON.parse(serialized)).toMatchObject({
+      domain: { chainId: 1, name: "Programmable", version: "1", verifyingContract: MAIN_TOKEN_ADDRESS.toLowerCase() },
+      primaryType: "Permit", types: { EIP712Domain: expect.any(Array), Permit: expect.any(Array) },
+      message: { owner: account, spender: other, value: permit.value.toString(), nonce: "7", deadline: permit.deadline.toString() },
+    });
+  });
+
+  it("uses the new provider returned after a network switch", async () => {
+    const f = fixture(); f.state.chain = "0x1237";
+    const stale = vi.fn(async () => "0x1237");
+    f.wallet.getEthereumProvider.mockResolvedValueOnce({ request: stale });
+    await f.sign(); expect(stale).toHaveBeenCalledExactlyOnceWith({ method: "eth_chainId" });
+    expect(f.signatureCalls()).toHaveLength(1);
+  });
+
+  it("never signs if switching reports success but the provider remains on another chain", async () => {
+    const f = fixture(); f.state.chain = "0x1237";
+    f.wallet.switchChain.mockImplementationOnce(async () => undefined);
+    await expect(f.sign()).rejects.toMatchObject({ kind: "network" });
+    expect(f.signatureCalls()).toHaveLength(0);
+  });
+
+  it.each(["1", "unavailable", "0x", "eip155:abc"])("rejects malformed provider chain %s before switching or signing", async (chain) => {
+    const f = fixture(); f.state.chain = chain;
+    await expect(f.sign()).rejects.toMatchObject({ kind: "network" });
+    expect(f.wallet.switchChain).not.toHaveBeenCalled(); expect(f.signatureCalls()).toHaveLength(0);
+  });
+
+  it("never signs for a different active account", async () => {
+    const f = fixture(); f.state.accounts = [other];
+    await expect(f.sign()).rejects.toMatchObject({ kind: "account_changed" });
+    expect(f.signatureCalls()).toHaveLength(0);
+  });
+
+  it("rechecks the authenticated session after a network switch", async () => {
+    const f = fixture(); f.state.chain = "0x1237";
+    f.wallet.switchChain.mockImplementationOnce(async () => { f.state.chain = "0x1"; f.state.authenticated = false; });
+    await expect(f.sign()).rejects.toMatchObject({ kind: "session_changed" });
+    expect(f.signatureCalls()).toHaveLength(0);
+  });
+
+  it.each(["account", "chain", "session"])("rechecks %s inside the Web Lock and releases when no signature request started", async (changed) => {
+    const f = fixture();
+    beforeLock = () => {
+      if (changed === "account") f.state.accounts = [other];
+      if (changed === "chain") f.state.chain = "0x1237";
+      if (changed === "session") f.state.authenticated = false;
+    };
+    await expect(f.sign()).rejects.toBeInstanceOf(MigrationPermitWalletError);
+    expect(f.signatureCalls()).toHaveLength(0); expect(localStorage.values.size).toBe(0);
+  });
+
+  it.each([
+    { code: 4001, message: "Request failed" },
+    { code: -32603, message: "Internal error", data: { originalError: { code: 4001 } } },
+  ])("preserves explicit cancellation and releases the request lease: %j", async (error) => {
+    const f = fixture(); f.state.signatureError = error;
+    await expect(f.sign()).rejects.toMatchObject({ kind: "cancelled", code: 4001 });
+    expect(localStorage.values.size).toBe(0);
+    f.state.signatureError = undefined;
+    await expect(f.sign()).resolves.toMatchObject({ signature });
+    expect(f.signatureCalls()).toHaveLength(2);
+  });
+
+  it.each([4200, -32601])("recognizes unsupported signature RPC code %s without relying on message text", async (code) => {
+    const f = fixture(); f.state.signatureError = { code, message: "RPC provider https://private.example/token=secret failed" };
+    await expect(f.sign()).rejects.toMatchObject({ kind: "signing_unsupported", code });
+    expect(localStorage.values.size).toBe(1);
+  });
+
+  it("gives manual Ethereum switch instructions when switching itself is unsupported", async () => {
+    const f = fixture(); f.state.chain = "0x1237";
+    f.wallet.switchChain.mockRejectedValueOnce({ code: 4200 });
+    await expect(f.sign()).rejects.toMatchObject({ kind: "network", stage: "network" });
+    expect(f.signatureCalls()).toHaveLength(0);
+  });
+
+  it("keeps an ambiguous signature request locked and blocks a second wallet request", async () => {
+    const f = fixture(); f.state.signatureError = { code: 4900 };
+    await expect(f.sign()).rejects.toMatchObject({ kind: "connection" });
+    expect(localStorage.values.size).toBe(1);
+    await expect(f.sign()).rejects.toMatchObject({ kind: "request_pending" });
+    expect(f.signatureCalls()).toHaveLength(1);
+  });
+
+  it.each([null, "0xab", `0x${"ab".repeat(64)}ff`, `0x${"ab".repeat(64)}`])("still rejects invalid or compact signatures: %s", async (value) => {
+    const f = fixture(); f.state.signatureResult = value;
+    await expect(f.sign()).rejects.toMatchObject({ kind: "invalid_signature" });
+  });
+
+  it.each(["locks", "crypto", "storage"])("fails before signing when browser %s capability is unavailable", async (capability) => {
+    const f = fixture();
+    if (capability === "locks") vi.stubGlobal("navigator", {});
+    if (capability === "crypto") vi.stubGlobal("crypto", {});
+    if (capability === "storage") vi.spyOn(sessionStorage, "setItem").mockImplementation(() => { throw new DOMException("Storage access blocked", "SecurityError"); });
+    await expect(f.sign()).rejects.toMatchObject({ kind: "browser_unavailable" });
+    expect(f.signatureCalls()).toHaveLength(0);
+  });
+
+  it("does not return a signed permit after the session changes while the wallet is open", async () => {
+    const f = fixture();
+    f.request.mockImplementation(async ({ method }) => {
+      if (method === "eth_chainId") return "0x1";
+      if (method === "eth_accounts") return [account];
+      f.state.authenticated = false; return signature;
+    });
+    await expect(f.sign()).rejects.toMatchObject({ kind: "session_changed" });
+  });
+
+  it("sanitizes wrapped, circular and unknown errors without exposing provider details", () => {
+    const error: { message: string; cause?: unknown } = { message: "private endpoint and signature bytes" };
+    error.cause = error;
+    expect(classifyMigrationPermitWalletError(error, "signature")).toMatchObject({ kind: "unknown" });
+    expect(classifyMigrationPermitWalletError(error, "signature").message).not.toContain("private endpoint");
+    expect(classifyMigrationPermitWalletError({ cause: { cause: { code: "4200" } } }, "signature")).toMatchObject({ kind: "signing_unsupported", code: 4200 });
+  });
+});


### PR DESCRIPTION
Wallet metadata can still name Ethereum after the connected provider has changed networks. Migration permits now read the provider chain, request the Ethereum switch when needed, reacquire the provider, and recheck the active account, network, and authenticated session inside the existing browser request lock before signing.

Wallet failures retain their bounded RPC error category and show a specific recovery action for unsupported signing, disconnected sessions, pending requests, browser capabilities, and invalid signatures. Permit validation, gas sponsorship, frozen allocations, and ambiguous post-submit recovery remain intact.

Validation: 143 focused tests passed; 28 browser tests passed using the actual signing helper with a controlled wallet provider, including stale network recovery and request locking. Focused ESLint and TypeScript checks passed. Desktop (1440px) and mobile (390px) screenshots were reviewed, exact amounts and recovery messages fit, and the browser console had no errors. The production release gates are in progress. The original reporter's wallet app has not been identified, so a successful retry on that device is still separate evidence.
