### PR TITLE
Require initial-buy quote in Robinhood 4.1 promotion evidence

### DIFF
--- a/contracts/scripts/robinhood-backend-promotion-v1.mjs
+++ b/contracts/scripts/robinhood-backend-promotion-v1.mjs
@@ -123,6 +123,7 @@ const COMPOSITION_KEYS = Object.freeze([
   "sourceVerificationWorkerConfigured",
   "sourceVerificationWorkerStarted",
   "sourceVerificationWorkerLifecycle",
+  ...(release?.profile?.profileVersion === "4.1.0" ? ["nativeInitialBuyQuote"] : []),
 ]);
 
 function failFlyV1TokenWire() {

--- a/contracts/scripts/test/robinhood-custom-launch-v41-promotion.test.mjs
+++ b/contracts/scripts/test/robinhood-custom-launch-v41-promotion.test.mjs
@@ -129,6 +129,59 @@ test("exact successor backend identity accepts its own pins and rejects predeces
   assert.deepEqual(bytes(stage), originalBytes);
 });
 
+test("successor requires the initial-buy quote in raw and public readiness while predecessor stays closed", (t) => {
+  const { root, stage } = fixture(t);
+  const context = robinhoodV41BackendStageContext({ repositoryRoot: root, stageBundle: stage });
+  const successor = backend.buildRobinhoodBackendPromotionPublicFixture(context);
+  const predecessor = previousBackend.buildRobinhoodBackendPromotionPublicFixture(stage);
+  const oldComposition = predecessor.publicInput.runtimeReadiness.releaseIdentity.composition;
+  assert.equal(Object.keys(oldComposition).length, 17);
+  assert.equal(Object.hasOwn(oldComposition, "nativeInitialBuyQuote"), false);
+  assert.deepEqual(successor.publicInput.runtimeReadiness.releaseIdentity.composition, {
+    ...oldComposition, nativeInitialBuyQuote: true,
+  });
+
+  for (const [tools, stageBundle, sample] of [
+    [backend, context, successor],
+    [previousBackend, stage, predecessor],
+  ]) {
+    const now = () => new Date(sample.publicInput.observedAt);
+    assert.doesNotThrow(() => tools.validateRobinhoodBackendPromotionInput({
+      input: sample.privateInput, stageBundle, now,
+    }));
+    assert.doesNotThrow(() => tools.validateRobinhoodBackendPromotionPublicInput({
+      input: sample.publicInput, stageBundle, now,
+    }));
+    const mutations = tools === backend ? [
+      [(value) => { delete value.nativeInitialBuyQuote; }, /backend readiness composition/u],
+      [(value) => { value.nativeInitialBuyQuote = false; }, /production composition is incomplete/u],
+      [(value) => { value.unreviewedCapability = true; }, /backend readiness composition/u],
+    ] : [
+      [(value) => { value.nativeInitialBuyQuote = true; }, /backend readiness composition/u],
+    ];
+    for (const [mutate, expected] of mutations) {
+      const raw = structuredClone(sample.privateInput);
+      const response = raw.readinessReadback.response;
+      const readiness = JSON.parse(Buffer.from(response.bodyBytesBase64, "base64").toString("utf8"));
+      mutate(readiness.composition);
+      const bodyBytes = bytes(readiness);
+      response.bodyBytesBase64 = bodyBytes.toString("base64");
+      response.bodyByteLength = String(bodyBytes.byteLength);
+      response.bodySha256 = sha256Digest(bodyBytes);
+      assert.throws(() => tools.validateRobinhoodBackendPromotionInput({
+        input: tools.buildRobinhoodBackendPromotionInput(raw), stageBundle, now,
+      }), expected);
+
+      const safe = structuredClone(sample.publicInput);
+      mutate(safe.runtimeReadiness.releaseIdentity.composition);
+      // Refresh the outer digest so the exact composition guard is reached first.
+      assert.throws(() => tools.validateRobinhoodBackendPromotionPublicInput({
+        input: tools.buildRobinhoodBackendPromotionPublicInput(safe), stageBundle, now,
+      }), expected);
+    }
+  }
+});
+
 test("successor authorization cannot borrow a redigested predecessor workflow or path", (t) => {
   const { root, stage } = fixture(t);
   const context = robinhoodV41BackendStageContext({ repositoryRoot: root, stageBundle: stage });


### PR DESCRIPTION
The Robinhood 4.1 backend now requires its server-owned initial-buy USD quote reader in the readiness contract. The public promotion verifier still expected the historical 17-component contract, so it would reject the real 4.1 readiness response.

Require `nativeInitialBuyQuote: true` only for the exact 4.1 successor profile. Preserve the historical 4.0 key set and strict rejection of missing, false, and additional components. No OpenAPI, schema, deployment, or activation artifacts change.

Validation: six successor validator tests and one historical regression pass, covering both raw and public envelopes after recomputing their hashes. Independent source review accepted the exact commit. This source fix does not claim production capture or activation.
