### PR TITLE
Link Robinhood 4.1 discovery to its existing launch guide

### DIFF
--- a/lib/custom-launch/v4-public-contract-discovery.ts
+++ b/lib/custom-launch/v4-public-contract-discovery.ts
@@ -18,7 +18,7 @@ export function robinhoodV4PublicContractDiscovery(profileVersion: string) {
     packConfigSchemaUrl: `${SITE_ORIGIN}/schemas/custom-launch/v4.1/pack-config.json`,
     sourceVerificationSchemaUrl: `${SITE_ORIGIN}/schemas/custom-launch/v4.1/source-verification-status.json`,
     createRequestSchemaUrl: `${SITE_ORIGIN}/schemas/custom-launch/v4.1/create-request.json`,
-    guideUrl: `${SITE_ORIGIN}/docs/developers.md`,
+    guideUrl: `${SITE_ORIGIN}/developers/custom-launch-api-v1.md`,
     admissionDescriptorUrl: "https://github.com/programmablehq/Launch-Policy/blob/main/policy/custom-launch-admission-v4.1.json",
     advertisedFundingModes: ["wallet-transaction-value"],
     initialBuyQuotePath: INITIAL_BUY_QUOTE_PATH,

--- a/tests/public-robinhood-v41-agent-docs.test.ts
+++ b/tests/public-robinhood-v41-agent-docs.test.ts
@@ -36,7 +36,7 @@ describe("active Robinhood agent setup and generated documentation", () => {
     expect(programmableAgentSetupLinksV1("4.1.0")).toMatchObject({
       robinhoodOpenApi: "https://programmable.market/openapi/custom-launch-v4.1.json",
       robinhoodPackConfigSchema: "https://programmable.market/schemas/custom-launch/v4.1/pack-config.json",
-      robinhoodGuide: "https://programmable.market/docs/developers.md",
+      robinhoodGuide: "https://programmable.market/developers/custom-launch-api-v1.md",
     });
     for (const text of ["CLI for profile 4.1.0", "required fundingPlan", "wallet-transaction-value",
       "initial buy of at least USD 1", "positive minimum token output", "gas is additional",


### PR DESCRIPTION
Point Robinhood 4.1 discovery and its generated agent setup link to the existing public Custom Launch raw guide. The previously advertised `/docs/developers.md` URL currently serves the general Ethereum/V3.3 overview without Robinhood 4.1 instructions; `/developers/custom-launch-api-v1.md` already contains the exact 4.1 CLI, funding plan, atomic initial buy and native 20 bps guidance.

Only the 4.1 guide URL and its existing test expectation change. Activation evidence, immutable CLI, backend, historical 4.0 behavior and the merged website UX from #697 are preserved.

Validation: both public guide URLs were read directly after promotion; the target returned HTTP 200 with the existing 4.1 funding/initial-buy/fee instructions. All 9 existing focused agent-documentation and well-known discovery tests passed, including historical and Ethereum preservation; `git diff --check` passed.
