### PR TITLE
Add graph V2 representation for combined token and hook contracts

### DIFF
--- a/packages/launch/src/graph-v2.mjs
+++ b/packages/launch/src/graph-v2.mjs
@@ -1,0 +1,246 @@
+import { keccak256 } from "viem";
+
+import { canonicalIdentifier } from "./build.mjs";
+import { canonicalizeJson } from "./canonical-json.mjs";
+import { HOOK_PERMISSIONS, MAX_GRAPH_TARGETS } from "./constants.mjs";
+import { assertExactKeys, compareUtf8, sha256Digest } from "./io.mjs";
+
+export const CUSTOM_GRAPH_BUNDLE_SCHEMA_V2 = "programmable.custom-graph-bundle.v2";
+export const PROJECT_METADATA_GRAPH_HASH_DOMAIN_V2 = "programmable.custom-graph-project-metadata.v2";
+export const GRAPH_TOPOLOGY_HASH_DOMAIN_V2 = "programmable.create2-graph-topology.v2";
+
+/**
+ * Structural foundation only. This does not select a deployment root, predict an
+ * address, authorize a profile, prove fee behavior, or construct a wallet request.
+ * V1/V4.1 packing and transport continue to use their frozen graph contracts.
+ */
+export function parseCustomGraphBundleV2(value) {
+  assertExactKeys(value, ["schemaVersion", "sourceBundleSha256", "targets", "pool"], "graph V2");
+  if (value.schemaVersion !== CUSTOM_GRAPH_BUNDLE_SCHEMA_V2) {
+    throw new TypeError("graph V2 schemaVersion is unsupported");
+  }
+  if (!Array.isArray(value.targets) || value.targets.length < 1 || value.targets.length > MAX_GRAPH_TARGETS) {
+    throw new TypeError("graph V2 requires between 1 and 16 targets");
+  }
+  const parsed = value.targets.map(parseTarget);
+  const byId = new Map();
+  for (const target of parsed) {
+    if (byId.has(target.targetId)) throw new TypeError(`duplicate graph target ${target.targetId}`);
+    byId.set(target.targetId, target);
+  }
+  const targets = topologicalTargetOrder(byId);
+  for (const target of targets) {
+    for (const locator of [...target.constructorAddressLocators, ...target.initializerAddressLocators]) {
+      if (!byId.has(locator.targetId)) {
+        throw new TypeError(`target ${target.targetId} references unknown target ${locator.targetId}`);
+      }
+    }
+  }
+  const tokenTargets = targets.filter((target) => target.componentRoles.includes("token"));
+  const hookTargets = targets.filter((target) => target.componentRoles.includes("hook"));
+  if (tokenTargets.length !== 1 || hookTargets.length !== 1) {
+    throw new TypeError("graph V2 requires exactly one token role and one hook role");
+  }
+  assertExactKeys(value.pool, ["tokenTargetId", "hookTargetId", "fee", "tickSpacing"], "graph V2 pool");
+  const tokenTargetId = canonicalIdentifier(value.pool.tokenTargetId, "pool.tokenTargetId");
+  const hookTargetId = canonicalIdentifier(value.pool.hookTargetId, "pool.hookTargetId");
+  if (tokenTargetId !== tokenTargets[0].targetId || hookTargetId !== hookTargets[0].targetId) {
+    throw new TypeError("graph V2 pool IDs do not match the declared token and hook roles");
+  }
+  if (!Number.isSafeInteger(value.pool.fee) || value.pool.fee < 0
+    || (value.pool.fee > 1_000_000 && value.pool.fee !== 0x800000)) {
+    throw new TypeError("graph V2 pool fee is outside Uniswap v4 bounds");
+  }
+  if (!Number.isSafeInteger(value.pool.tickSpacing)
+    || value.pool.tickSpacing < 1 || value.pool.tickSpacing > 32_767) {
+    throw new TypeError("graph V2 pool tickSpacing is outside Uniswap v4 bounds");
+  }
+  return deepFreeze({
+    schemaVersion: CUSTOM_GRAPH_BUNDLE_SCHEMA_V2,
+    sourceBundleSha256: canonicalSha256(value.sourceBundleSha256, "sourceBundleSha256"),
+    targets,
+    pool: { tokenTargetId, hookTargetId, fee: value.pool.fee, tickSpacing: value.pool.tickSpacing },
+  });
+}
+
+/** Only the four canonical role arrays are accepted; unknown rights are never inferred. */
+export function componentRoleMaskV2(roles) {
+  if (!Array.isArray(roles) || roles.length > 2
+    || (roles.length === 1 && roles[0] !== "token" && roles[0] !== "hook")
+    || (roles.length === 2 && (roles[0] !== "token" || roles[1] !== "hook"))) {
+    throw new TypeError("componentRoles must be [], [token], [hook], or [token, hook] in that order");
+  }
+  return (roles.includes("token") ? 1 : 0) | (roles.includes("hook") ? 2 : 0);
+}
+
+export function hashGraphBundleV2(value, projectMetadataHash) {
+  const bundle = parseCustomGraphBundleV2(value);
+  const unboundGraphBundleHash = sha256Digest(Buffer.from(canonicalizeJson(bundle), "utf8"));
+  if (projectMetadataHash === undefined) {
+    return { graphBundleHash: unboundGraphBundleHash, unboundGraphBundleHash };
+  }
+  const metadata = canonicalSha256(projectMetadataHash, "projectMetadataHash");
+  return {
+    graphBundleHash: sha256Digest(Buffer.concat([
+      Buffer.from(PROJECT_METADATA_GRAPH_HASH_DOMAIN_V2, "utf8"), Buffer.from([0]),
+      Buffer.from(canonicalizeJson({ graphBundleHash: unboundGraphBundleHash, projectMetadataHash: metadata }), "utf8"),
+    ])),
+    unboundGraphBundleHash,
+  };
+}
+
+/**
+ * V1 target-ID and locator frames retain their exact meaning. V2 topology adds
+ * a 32-byte unsigned role mask to each target frame and versions both topology
+ * domains. Fields are framed as uint32 big-endian byte length followed by bytes.
+ */
+export function topologyHashV2(value) {
+  const bundle = parseCustomGraphBundleV2(value);
+  return framedKeccak(GRAPH_TOPOLOGY_HASH_DOMAIN_V2, bundle.targets.map((target) =>
+    hexBytes(framedKeccak("programmable.create2-graph-topology-target.v2", [
+      hexBytes(targetIdHashV1(target.targetId)),
+      uint256Bytes(componentRoleMaskV2(target.componentRoles)),
+      ...target.constructorAddressLocators.map((locator) => locatorFrameV1("constructor", locator)),
+      ...target.initializerAddressLocators.map((locator) => locatorFrameV1("initializer", locator)),
+    ]))));
+}
+
+function parseTarget(value, index) {
+  const label = `graph V2 target ${index}`;
+  assertExactKeys(value, [
+    "targetId", "applicantSalt", "creationBytecode", "constructorArguments", "initializerCalldata",
+    "constructorAddressLocators", "initializerAddressLocators", "deploymentValueWei", "initializerValueWei",
+    "expectedRuntimeCodeHash", "componentRoles", "declaredHookPermissions",
+  ], label);
+  const roleMask = componentRoleMaskV2(value.componentRoles);
+  if (!(roleMask & 2) && value.declaredHookPermissions !== null) {
+    throw new TypeError(`${label}.declaredHookPermissions must be null without the hook role`);
+  }
+  return {
+    targetId: canonicalIdentifier(value.targetId, `${label}.targetId`),
+    applicantSalt: canonicalHex32(value.applicantSalt, `${label}.applicantSalt`, true),
+    creationBytecode: canonicalHex(value.creationBytecode, `${label}.creationBytecode`, false),
+    constructorArguments: canonicalHex(value.constructorArguments, `${label}.constructorArguments`),
+    initializerCalldata: canonicalHex(value.initializerCalldata, `${label}.initializerCalldata`),
+    constructorAddressLocators: normalizeLocators(value.constructorAddressLocators, `${label}.constructorAddressLocators`),
+    initializerAddressLocators: normalizeLocators(value.initializerAddressLocators, `${label}.initializerAddressLocators`),
+    deploymentValueWei: canonicalUint256(value.deploymentValueWei, `${label}.deploymentValueWei`),
+    initializerValueWei: canonicalUint256(value.initializerValueWei, `${label}.initializerValueWei`),
+    expectedRuntimeCodeHash: canonicalHex32(value.expectedRuntimeCodeHash, `${label}.expectedRuntimeCodeHash`),
+    componentRoles: [...value.componentRoles],
+    declaredHookPermissions: roleMask & 2 ? normalizeHookPermissions(value.declaredHookPermissions) : null,
+  };
+}
+
+function normalizeHookPermissions(value) {
+  if (!Array.isArray(value) || value.length > HOOK_PERMISSIONS.length
+    || value.some((permission) => !HOOK_PERMISSIONS.includes(permission))
+    || new Set(value).size !== value.length) {
+    throw new TypeError("declaredHookPermissions contains an unknown or duplicate permission");
+  }
+  return HOOK_PERMISSIONS.filter((permission) => value.includes(permission));
+}
+
+function normalizeLocators(value, label) {
+  if (!Array.isArray(value) || value.length > 256) throw new TypeError(`${label} must be a bounded locator array`);
+  const locators = value.map((locator, index) => {
+    assertExactKeys(locator, ["targetId", "byteOffset", "encoding"], `${label}[${index}]`);
+    if (!Number.isSafeInteger(locator.byteOffset) || locator.byteOffset < 0
+      || !["abi-address-word", "packed-address-20"].includes(locator.encoding)) {
+      throw new TypeError(`${label}[${index}] is invalid`);
+    }
+    return { targetId: canonicalIdentifier(locator.targetId, `${label}[${index}].targetId`),
+      byteOffset: locator.byteOffset, encoding: locator.encoding };
+  }).sort((a, b) => a.byteOffset - b.byteOffset
+    || compareUtf8(a.targetId, b.targetId) || compareUtf8(a.encoding, b.encoding));
+  let occupiedUntil = 0;
+  for (const locator of locators) {
+    if (locator.byteOffset < occupiedUntil) throw new TypeError(`${label} locators overlap`);
+    occupiedUntil = locator.byteOffset + (locator.encoding === "abi-address-word" ? 32 : 20);
+  }
+  return locators;
+}
+
+function topologicalTargetOrder(byId) {
+  const indegree = new Map([...byId.keys()].map((id) => [id, 0]));
+  const dependents = new Map([...byId.keys()].map((id) => [id, new Set()]));
+  for (const target of byId.values()) {
+    const dependencies = new Set(target.constructorAddressLocators.map((locator) => locator.targetId));
+    for (const id of dependencies) {
+      if (id === target.targetId) throw new TypeError(`constructor for ${id} cannot reference itself`);
+      if (!byId.has(id)) throw new TypeError(`constructor for ${target.targetId} references unknown target ${id}`);
+      dependents.get(id).add(target.targetId);
+    }
+    indegree.set(target.targetId, dependencies.size);
+  }
+  const ready = [...indegree.keys()].filter((id) => indegree.get(id) === 0).sort(compareUtf8);
+  const result = [];
+  while (ready.length) {
+    const id = ready.shift();
+    result.push(byId.get(id));
+    for (const dependent of dependents.get(id)) {
+      const remaining = indegree.get(dependent) - 1;
+      indegree.set(dependent, remaining);
+      if (remaining === 0) { ready.push(dependent); ready.sort(compareUtf8); }
+    }
+  }
+  if (result.length !== byId.size) throw new TypeError("graph constructor dependencies contain a cycle");
+  return result;
+}
+
+function targetIdHashV1(id) {
+  return framedKeccak("programmable.create2-graph-target-id.v1", [Buffer.from(id, "utf8")]);
+}
+
+function locatorFrameV1(phase, locator) {
+  return hexBytes(framedKeccak("programmable.create2-graph-address-locator.v1", [
+    Buffer.from(phase, "utf8"), hexBytes(targetIdHashV1(locator.targetId)),
+    uint256Bytes(locator.byteOffset), Buffer.from(locator.encoding, "utf8"),
+  ]));
+}
+
+function framedKeccak(domain, fields) {
+  const frames = [Buffer.from(domain, "utf8"), Buffer.from([0])];
+  for (const field of fields) {
+    const length = Buffer.alloc(4);
+    length.writeUInt32BE(field.byteLength, 0);
+    frames.push(length, field);
+  }
+  return keccak256(`0x${Buffer.concat(frames).toString("hex")}`);
+}
+
+function hexBytes(value) { return Buffer.from(value.slice(2), "hex"); }
+function uint256Bytes(value) { return Buffer.from(BigInt(value).toString(16).padStart(64, "0"), "hex"); }
+
+function canonicalHex(value, label, allowEmpty = true) {
+  if (typeof value !== "string" || !/^0x(?:[0-9a-fA-F]{2})*$/u.test(value)
+    || (!allowEmpty && value === "0x")) throw new TypeError(`${label} must be even-length hex`);
+  return value.toLowerCase();
+}
+
+function canonicalHex32(value, label, allowZero = false) {
+  if (typeof value !== "string" || !/^0x[0-9a-fA-F]{64}$/u.test(value)
+    || (!allowZero && BigInt(value) === 0n)) throw new TypeError(`${label} must be ${allowZero ? "" : "nonzero "}bytes32`);
+  return value.toLowerCase();
+}
+
+function canonicalSha256(value, label) {
+  if (typeof value !== "string" || !/^sha256:[0-9a-fA-F]{64}$/u.test(value)) {
+    throw new TypeError(`${label} must be a sha256 digest`);
+  }
+  return value.toLowerCase();
+}
+
+function canonicalUint256(value, label) {
+  if (typeof value !== "string" || !/^(?:0|[1-9][0-9]*)$/u.test(value)
+    || BigInt(value) >= 1n << 256n) throw new TypeError(`${label} must be a canonical uint256 decimal string`);
+  return value;
+}
+
+function deepFreeze(value) {
+  if (value !== null && typeof value === "object") {
+    Object.values(value).forEach(deepFreeze);
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/packages/launch/test/fixtures/custom-graph-v2-parity.json
+++ b/packages/launch/test/fixtures/custom-graph-v2-parity.json
@@ -1,0 +1,355 @@
+[
+  {
+    "name": "combined-self-initializer",
+    "input": {
+      "schemaVersion": "programmable.custom-graph-bundle.v2",
+      "sourceBundleSha256": "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "targets": [
+        {
+          "targetId": "combined",
+          "applicantSalt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "creationBytecode": "0x60AA",
+          "constructorArguments": "0x",
+          "initializerCalldata": "0x123456780000000000000000000000000000000000000000000000000000000000000000",
+          "constructorAddressLocators": [],
+          "initializerAddressLocators": [
+            {
+              "targetId": "combined",
+              "byteOffset": 4,
+              "encoding": "abi-address-word"
+            }
+          ],
+          "deploymentValueWei": "0",
+          "initializerValueWei": "0",
+          "expectedRuntimeCodeHash": "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          "componentRoles": [
+            "token",
+            "hook"
+          ],
+          "declaredHookPermissions": [
+            "afterSwap",
+            "beforeInitialize",
+            "beforeSwap"
+          ]
+        }
+      ],
+      "pool": {
+        "tokenTargetId": "combined",
+        "hookTargetId": "combined",
+        "fee": 3000,
+        "tickSpacing": 60
+      }
+    },
+    "projectMetadataHash": "sha256:CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+    "normalized": {
+      "schemaVersion": "programmable.custom-graph-bundle.v2",
+      "sourceBundleSha256": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "targets": [
+        {
+          "targetId": "combined",
+          "applicantSalt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "creationBytecode": "0x60aa",
+          "constructorArguments": "0x",
+          "initializerCalldata": "0x123456780000000000000000000000000000000000000000000000000000000000000000",
+          "constructorAddressLocators": [],
+          "initializerAddressLocators": [
+            {
+              "targetId": "combined",
+              "byteOffset": 4,
+              "encoding": "abi-address-word"
+            }
+          ],
+          "deploymentValueWei": "0",
+          "initializerValueWei": "0",
+          "expectedRuntimeCodeHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "componentRoles": [
+            "token",
+            "hook"
+          ],
+          "declaredHookPermissions": [
+            "beforeInitialize",
+            "beforeSwap",
+            "afterSwap"
+          ]
+        }
+      ],
+      "pool": {
+        "tokenTargetId": "combined",
+        "hookTargetId": "combined",
+        "fee": 3000,
+        "tickSpacing": 60
+      }
+    },
+    "expected": {
+      "graphBundleHash": "sha256:c71c7e2c8251df986e35b4c4d3c3734fae798ae342f262aa06700550c15aed66",
+      "unboundGraphBundleHash": "sha256:8209b1196f0a2c5655241a70914f9d7602fddabd76a628bd1df057eb032f9184",
+      "topologyHash": "0x5cd9e45002838d03caf8d809b41dccd80d60ebf3408a3bf8666af640fc3ee63c"
+    }
+  },
+  {
+    "name": "combined-and-auxiliary",
+    "input": {
+      "schemaVersion": "programmable.custom-graph-bundle.v2",
+      "sourceBundleSha256": "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "targets": [
+        {
+          "targetId": "combined",
+          "applicantSalt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "creationBytecode": "0x60AA",
+          "constructorArguments": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "initializerCalldata": "0x123456780000000000000000000000000000000000000000000000000000000000000000",
+          "constructorAddressLocators": [
+            {
+              "targetId": "vault",
+              "byteOffset": 0,
+              "encoding": "abi-address-word"
+            }
+          ],
+          "initializerAddressLocators": [
+            {
+              "targetId": "combined",
+              "byteOffset": 4,
+              "encoding": "abi-address-word"
+            }
+          ],
+          "deploymentValueWei": "0",
+          "initializerValueWei": "0",
+          "expectedRuntimeCodeHash": "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          "componentRoles": [
+            "token",
+            "hook"
+          ],
+          "declaredHookPermissions": [
+            "afterSwap",
+            "beforeInitialize",
+            "beforeSwap"
+          ]
+        },
+        {
+          "targetId": "vault",
+          "applicantSalt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "creationBytecode": "0x60AA",
+          "constructorArguments": "0x",
+          "initializerCalldata": "0xabcdef1200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "constructorAddressLocators": [],
+          "initializerAddressLocators": [
+            {
+              "targetId": "combined",
+              "byteOffset": 36,
+              "encoding": "packed-address-20"
+            },
+            {
+              "targetId": "vault",
+              "byteOffset": 4,
+              "encoding": "abi-address-word"
+            }
+          ],
+          "deploymentValueWei": "0",
+          "initializerValueWei": "0",
+          "expectedRuntimeCodeHash": "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          "componentRoles": [],
+          "declaredHookPermissions": null
+        }
+      ],
+      "pool": {
+        "tokenTargetId": "combined",
+        "hookTargetId": "combined",
+        "fee": 3000,
+        "tickSpacing": 60
+      }
+    },
+    "projectMetadataHash": "sha256:CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+    "normalized": {
+      "schemaVersion": "programmable.custom-graph-bundle.v2",
+      "sourceBundleSha256": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "targets": [
+        {
+          "targetId": "vault",
+          "applicantSalt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "creationBytecode": "0x60aa",
+          "constructorArguments": "0x",
+          "initializerCalldata": "0xabcdef1200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "constructorAddressLocators": [],
+          "initializerAddressLocators": [
+            {
+              "targetId": "vault",
+              "byteOffset": 4,
+              "encoding": "abi-address-word"
+            },
+            {
+              "targetId": "combined",
+              "byteOffset": 36,
+              "encoding": "packed-address-20"
+            }
+          ],
+          "deploymentValueWei": "0",
+          "initializerValueWei": "0",
+          "expectedRuntimeCodeHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "componentRoles": [],
+          "declaredHookPermissions": null
+        },
+        {
+          "targetId": "combined",
+          "applicantSalt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "creationBytecode": "0x60aa",
+          "constructorArguments": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "initializerCalldata": "0x123456780000000000000000000000000000000000000000000000000000000000000000",
+          "constructorAddressLocators": [
+            {
+              "targetId": "vault",
+              "byteOffset": 0,
+              "encoding": "abi-address-word"
+            }
+          ],
+          "initializerAddressLocators": [
+            {
+              "targetId": "combined",
+              "byteOffset": 4,
+              "encoding": "abi-address-word"
+            }
+          ],
+          "deploymentValueWei": "0",
+          "initializerValueWei": "0",
+          "expectedRuntimeCodeHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "componentRoles": [
+            "token",
+            "hook"
+          ],
+          "declaredHookPermissions": [
+            "beforeInitialize",
+            "beforeSwap",
+            "afterSwap"
+          ]
+        }
+      ],
+      "pool": {
+        "tokenTargetId": "combined",
+        "hookTargetId": "combined",
+        "fee": 3000,
+        "tickSpacing": 60
+      }
+    },
+    "expected": {
+      "graphBundleHash": "sha256:541b7ee3443441cfcd1bae3d24142e6497dee51ae692b2424b666ddbbb3fe959",
+      "unboundGraphBundleHash": "sha256:1d0b30b78661f49812e674f6e15595e4b9f98ddcc02d21b31b0835255846d790",
+      "topologyHash": "0x3a79639be282a00d23a86f524645969970a7542d574fc3cc07a31b6b79d0ef65"
+    }
+  },
+  {
+    "name": "distinct-token-hook",
+    "input": {
+      "schemaVersion": "programmable.custom-graph-bundle.v2",
+      "sourceBundleSha256": "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "targets": [
+        {
+          "targetId": "hook",
+          "applicantSalt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "creationBytecode": "0x60AA",
+          "constructorArguments": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "initializerCalldata": "0x",
+          "constructorAddressLocators": [
+            {
+              "targetId": "token",
+              "byteOffset": 0,
+              "encoding": "abi-address-word"
+            }
+          ],
+          "initializerAddressLocators": [],
+          "deploymentValueWei": "0",
+          "initializerValueWei": "0",
+          "expectedRuntimeCodeHash": "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          "componentRoles": [
+            "hook"
+          ],
+          "declaredHookPermissions": [
+            "afterSwap",
+            "beforeInitialize",
+            "beforeSwap"
+          ]
+        },
+        {
+          "targetId": "token",
+          "applicantSalt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "creationBytecode": "0x60AA",
+          "constructorArguments": "0x",
+          "initializerCalldata": "0x",
+          "constructorAddressLocators": [],
+          "initializerAddressLocators": [],
+          "deploymentValueWei": "0",
+          "initializerValueWei": "0",
+          "expectedRuntimeCodeHash": "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          "componentRoles": [
+            "token"
+          ],
+          "declaredHookPermissions": null
+        }
+      ],
+      "pool": {
+        "tokenTargetId": "token",
+        "hookTargetId": "hook",
+        "fee": 3000,
+        "tickSpacing": 60
+      }
+    },
+    "projectMetadataHash": "sha256:CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+    "normalized": {
+      "schemaVersion": "programmable.custom-graph-bundle.v2",
+      "sourceBundleSha256": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "targets": [
+        {
+          "targetId": "token",
+          "applicantSalt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "creationBytecode": "0x60aa",
+          "constructorArguments": "0x",
+          "initializerCalldata": "0x",
+          "constructorAddressLocators": [],
+          "initializerAddressLocators": [],
+          "deploymentValueWei": "0",
+          "initializerValueWei": "0",
+          "expectedRuntimeCodeHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "componentRoles": [
+            "token"
+          ],
+          "declaredHookPermissions": null
+        },
+        {
+          "targetId": "hook",
+          "applicantSalt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "creationBytecode": "0x60aa",
+          "constructorArguments": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "initializerCalldata": "0x",
+          "constructorAddressLocators": [
+            {
+              "targetId": "token",
+              "byteOffset": 0,
+              "encoding": "abi-address-word"
+            }
+          ],
+          "initializerAddressLocators": [],
+          "deploymentValueWei": "0",
+          "initializerValueWei": "0",
+          "expectedRuntimeCodeHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "componentRoles": [
+            "hook"
+          ],
+          "declaredHookPermissions": [
+            "beforeInitialize",
+            "beforeSwap",
+            "afterSwap"
+          ]
+        }
+      ],
+      "pool": {
+        "tokenTargetId": "token",
+        "hookTargetId": "hook",
+        "fee": 3000,
+        "tickSpacing": 60
+      }
+    },
+    "expected": {
+      "graphBundleHash": "sha256:5fb8b83ae43ce1a6e03077c0b2a595380f4a124a6ac6eceae083d51de162f5db",
+      "unboundGraphBundleHash": "sha256:919fbd1fd267c267724c392fd2f6d9f2b96f97c49fcea7c8c60b0fce5dd6c344",
+      "topologyHash": "0x220a51ae2c2c6e2ccf1c82f66fc73f4c49e1cbcaa9645c1dbca5a13d986ad82d"
+    }
+  }
+]

--- a/packages/launch/test/graph-v2.test.mjs
+++ b/packages/launch/test/graph-v2.test.mjs
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import Ajv2020 from "ajv/dist/2020.js";
+
+import { canonicalizeJson } from "../src/canonical-json.mjs";
+import { hashGraphBundle, normalizeAndPredictSubmittedGraph } from "../src/graph.mjs";
+import {
+  CUSTOM_GRAPH_BUNDLE_SCHEMA_V2,
+  componentRoleMaskV2,
+  hashGraphBundleV2,
+  parseCustomGraphBundleV2,
+  topologyHashV2,
+} from "../src/graph-v2.mjs";
+import { sha256Digest } from "../src/io.mjs";
+
+const fixtures = JSON.parse(readFileSync(new URL("./fixtures/custom-graph-v2-parity.json", import.meta.url)));
+const schema = JSON.parse(readFileSync(new URL("../../../public/schemas/custom-launch/graph/v2/bundle.json", import.meta.url)));
+const ajv = new Ajv2020({ strict: true, allErrors: true });
+ajv.addKeyword({ keyword: "x-programmable-contract", schemaType: "object" });
+const validateSchema = ajv.compile(schema);
+const example = () => structuredClone(fixtures[0].input);
+
+for (const fixture of fixtures) {
+  test(`V2 client/backend golden: ${fixture.name}`, () => {
+    assert.deepEqual(parseCustomGraphBundleV2(fixture.input), fixture.normalized);
+    assert.deepEqual(hashGraphBundleV2(fixture.input, fixture.projectMetadataHash), {
+      graphBundleHash: fixture.expected.graphBundleHash,
+      unboundGraphBundleHash: fixture.expected.unboundGraphBundleHash,
+    });
+    assert.equal(topologyHashV2(fixture.input), fixture.expected.topologyHash);
+    assert.equal(validateSchema(fixture.input), true, JSON.stringify(validateSchema.errors));
+    assert.equal(validateSchema(fixture.normalized), true, JSON.stringify(validateSchema.errors));
+  });
+}
+
+test("combined roles occupy one target and allow a self initializer", () => {
+  const graph = parseCustomGraphBundleV2(example());
+  assert.equal(graph.targets.length, 1);
+  assert.equal(graph.pool.tokenTargetId, graph.pool.hookTargetId);
+  assert.equal(componentRoleMaskV2(graph.targets[0].componentRoles), 3);
+  assert.equal(graph.targets[0].initializerAddressLocators[0].targetId, graph.targets[0].targetId);
+  assert.equal(Object.hasOwn(graph.targets[0], "componentKind"), false);
+});
+
+test("normalization is deterministic, immutable, and does not change the caller's input", () => {
+  const graph = structuredClone(fixtures[1].input);
+  const original = structuredClone(graph);
+  const normalized = parseCustomGraphBundleV2(graph);
+  assert.deepEqual(graph, original);
+  assert.deepEqual(normalized.targets.map(({ targetId }) => targetId), ["vault", "combined"]);
+  assert.equal(normalized.sourceBundleSha256, graph.sourceBundleSha256.toLowerCase());
+  assert.deepEqual(normalized.targets[1].declaredHookPermissions, ["beforeInitialize", "beforeSwap", "afterSwap"]);
+  assert.throws(() => normalized.targets[0].componentRoles.push("token"), TypeError);
+  assert.throws(() => { normalized.targets[0].initializerAddressLocators[0].byteOffset = 8; }, TypeError);
+  graph.targets.reverse();
+  graph.targets[0].initializerAddressLocators.reverse();
+  assert.deepEqual(parseCustomGraphBundleV2(graph), normalized);
+  assert.deepEqual(hashGraphBundleV2(graph), hashGraphBundleV2(normalized));
+});
+
+test("V2 hashes bind normalized graph and metadata with the exact versioned wrapper", () => {
+  const graph = parseCustomGraphBundleV2(example());
+  const metadata = fixtures[0].projectMetadataHash.toLowerCase();
+  const unbound = sha256Digest(Buffer.from(canonicalizeJson(graph), "utf8"));
+  assert.deepEqual(hashGraphBundleV2(graph), { graphBundleHash: unbound, unboundGraphBundleHash: unbound });
+  const framed = Buffer.concat([
+    Buffer.from("programmable.custom-graph-project-metadata.v2"), Buffer.from([0]),
+    Buffer.from(canonicalizeJson({ graphBundleHash: unbound, projectMetadataHash: metadata })),
+  ]);
+  assert.equal(hashGraphBundleV2(graph, metadata).graphBundleHash, sha256Digest(framed));
+  assert.notEqual(hashGraphBundleV2(graph, metadata).graphBundleHash, hashGraphBundle(graph, metadata).graphBundleHash);
+  assert.notEqual(hashGraphBundleV2(graph, `sha256:${"dd".repeat(32)}`).graphBundleHash,
+    hashGraphBundleV2(graph, metadata).graphBundleHash);
+  assert.throws(() => hashGraphBundleV2(graph, "sha256:invalid"));
+});
+
+test("role assignment and locator phase are bound into V2 topology", () => {
+  const graph = structuredClone(fixtures[2].input);
+  const before = topologyHashV2(graph);
+  graph.targets[0].componentRoles = [];
+  graph.targets[0].declaredHookPermissions = null;
+  graph.targets[1].componentRoles = ["token", "hook"];
+  graph.targets[1].declaredHookPermissions = ["beforeSwap"];
+  graph.pool.hookTargetId = "token";
+  assert.notEqual(topologyHashV2(graph), before);
+  const dependency = structuredClone(fixtures[1].input);
+  const locator = dependency.targets[0].constructorAddressLocators.pop();
+  dependency.targets[0].initializerAddressLocators = [locator];
+  assert.notEqual(topologyHashV2(dependency), fixtures[1].expected.topologyHash);
+  const changedBytes = example();
+  changedBytes.targets[0].creationBytecode = "0x60ff";
+  assert.notEqual(hashGraphBundleV2(changedBytes).graphBundleHash, hashGraphBundleV2(example()).graphBundleHash);
+  assert.equal(topologyHashV2(changedBytes), topologyHashV2(example()));
+});
+
+for (const [roles, mask] of [[[], 0], [["token"], 1], [["hook"], 2], [["token", "hook"], 3]]) {
+  test(`role mask accepts only the canonical meaning ${JSON.stringify(roles)}`, () => {
+    assert.equal(componentRoleMaskV2(roles), mask);
+  });
+}
+
+for (const roles of [null, {}, "token", ["other"], ["hook", "token"], ["token", "token"],
+  ["hook", "hook"], ["token", "hook", "admin"], ["admin"], [1], ["Token"]]) {
+  test(`rejects unsupported role representation ${JSON.stringify(roles)}`, () => {
+    assert.throws(() => componentRoleMaskV2(roles), /componentRoles/);
+    const graph = example();
+    graph.targets[0].componentRoles = roles;
+    assert.throws(() => parseCustomGraphBundleV2(graph));
+    assert.equal(validateSchema(graph), false);
+  });
+}
+
+for (const permissions of [null, ["unknown"], ["constructor"], ["beforeSwap", "beforeSwap"], {}, "beforeSwap"]) {
+  test(`hook role rejects malformed permissions ${JSON.stringify(permissions)}`, () => {
+    const graph = example();
+    graph.targets[0].declaredHookPermissions = permissions;
+    assert.throws(() => parseCustomGraphBundleV2(graph), /declaredHookPermissions/);
+    assert.equal(validateSchema(graph), false);
+  });
+}
+
+test("token and auxiliary roles require null permissions; empty hook flags stay structural", () => {
+  const graph = structuredClone(fixtures[2].input);
+  graph.targets[1].declaredHookPermissions = [];
+  assert.throws(() => parseCustomGraphBundleV2(graph), /must be null/);
+  assert.equal(validateSchema(graph), false);
+  const combined = example();
+  combined.targets[0].declaredHookPermissions = [];
+  assert.deepEqual(parseCustomGraphBundleV2(combined).targets[0].declaredHookPermissions, []);
+});
+
+test("global roles and pool IDs resolve independently and exactly once", () => {
+  for (const roles of [[], ["token"], ["hook"]]) {
+    const graph = example();
+    graph.targets[0].componentRoles = roles;
+    if (!roles.includes("hook")) graph.targets[0].declaredHookPermissions = null;
+    assert.throws(() => parseCustomGraphBundleV2(graph), /exactly one token role/);
+    assert.equal(validateSchema(graph), false);
+  }
+  const graph = example();
+  const second = structuredClone(graph.targets[0]); second.targetId = "second";
+  graph.targets.push(second);
+  assert.throws(() => parseCustomGraphBundleV2(graph), /exactly one token role/);
+  assert.equal(validateSchema(graph), false);
+  for (const key of ["tokenTargetId", "hookTargetId"]) {
+    const invalid = example(); invalid.pool[key] = "missing";
+    assert.throws(() => parseCustomGraphBundleV2(invalid), /pool IDs/);
+  }
+});
+
+test("constructor DAG rejects duplicate IDs, self dependencies, cycles and unknown references", () => {
+  const duplicate = example(); duplicate.targets.push(structuredClone(duplicate.targets[0]));
+  assert.throws(() => parseCustomGraphBundleV2(duplicate), /duplicate graph target/);
+  const self = example(); self.targets[0].constructorAddressLocators = [
+    { targetId: "combined", byteOffset: 0, encoding: "abi-address-word" },
+  ];
+  assert.throws(() => parseCustomGraphBundleV2(self), /cannot reference itself/);
+  const cycle = structuredClone(fixtures[1].input);
+  cycle.targets[1].constructorAddressLocators = [{ targetId: "combined", byteOffset: 0, encoding: "abi-address-word" }];
+  assert.throws(() => parseCustomGraphBundleV2(cycle), /contain a cycle/);
+  for (const phase of ["constructorAddressLocators", "initializerAddressLocators"]) {
+    const unknown = example(); unknown.targets[0][phase] = [
+      { targetId: "missing", byteOffset: 0, encoding: "abi-address-word" },
+    ];
+    assert.throws(() => parseCustomGraphBundleV2(unknown), /unknown target/);
+  }
+});
+
+test("retains locator overlap, shape, numeric and cardinality bounds", () => {
+  for (const locators of [
+    [{ targetId: "combined", byteOffset: -1, encoding: "abi-address-word" }],
+    [{ targetId: "combined", byteOffset: 0.5, encoding: "abi-address-word" }],
+    [{ targetId: "combined", byteOffset: Number.MAX_SAFE_INTEGER + 1, encoding: "abi-address-word" }],
+    [{ targetId: "combined", byteOffset: 0, encoding: "unknown" }],
+    [{ targetId: "combined", byteOffset: 0, encoding: "abi-address-word", extra: true }],
+    [{ targetId: "combined", byteOffset: 4, encoding: "abi-address-word" },
+      { targetId: "combined", byteOffset: 20, encoding: "packed-address-20" }],
+    Array.from({ length: 257 }, (_, i) => ({ targetId: "combined", byteOffset: i * 32, encoding: "abi-address-word" })),
+  ]) {
+    const graph = example(); graph.targets[0].initializerAddressLocators = locators;
+    assert.throws(() => parseCustomGraphBundleV2(graph));
+  }
+});
+
+test("retains physical target, uint256, byte syntax, hash, identifier and pool bounds", () => {
+  const empty = example(); empty.targets = [];
+  assert.throws(() => parseCustomGraphBundleV2(empty), /between 1 and 16/);
+  const graph = example();
+  for (let i = 1; i < 16; i++) {
+    graph.targets.push({ ...structuredClone(graph.targets[0]), targetId: `aux-${i}`,
+      componentRoles: [], declaredHookPermissions: null });
+  }
+  assert.equal(parseCustomGraphBundleV2(graph).targets.length, 16);
+  graph.targets.push({ ...graph.targets[15], targetId: "aux-16" });
+  assert.throws(() => parseCustomGraphBundleV2(graph), /between 1 and 16/);
+  for (const [field, value] of [
+    ["deploymentValueWei", "01"], ["initializerValueWei", (1n << 256n).toString()],
+    ["creationBytecode", "0x"], ["constructorArguments", "0x1"], ["initializerCalldata", "nothex"],
+    ["applicantSalt", "0x1"], ["expectedRuntimeCodeHash", `0x${"00".repeat(32)}`],
+    ["targetId", "x".repeat(257)],
+  ]) {
+    const invalid = example(); invalid.targets[0][field] = value;
+    assert.throws(() => parseCustomGraphBundleV2(invalid));
+  }
+  for (const [field, value] of [["fee", -1], ["fee", 1_000_001], ["fee", 0.5], ["tickSpacing", 0], ["tickSpacing", 32_768]]) {
+    const invalid = example(); invalid.pool[field] = value;
+    assert.throws(() => parseCustomGraphBundleV2(invalid));
+  }
+  const dynamic = example(); dynamic.pool.fee = 0x800000;
+  assert.equal(parseCustomGraphBundleV2(dynamic).pool.fee, 0x800000);
+});
+
+test("version discrimination stays closed and V1 never accepts a V2 graph", () => {
+  const graph = example();
+  assert.throws(() => normalizeAndPredictSubmittedGraph(graph), /schemaVersion/);
+  const old = example(); old.schemaVersion = "programmable.custom-graph-bundle.v1";
+  assert.throws(() => parseCustomGraphBundleV2(old), /schemaVersion/);
+  const mixed = example(); mixed.targets[0].componentKind = "hook";
+  assert.throws(() => parseCustomGraphBundleV2(mixed), /must contain exactly/);
+  assert.equal(validateSchema(mixed), false);
+  const extra = example(); extra.profile = "bypass";
+  assert.throws(() => hashGraphBundleV2(extra), /must contain exactly/);
+  assert.equal(validateSchema(extra), false);
+  assert.equal(schema.properties.schemaVersion.const, CUSTOM_GRAPH_BUNDLE_SCHEMA_V2);
+  assert.equal(schema["x-programmable-contract"].status, "standalone-foundation-not-activated");
+});

--- a/public/schemas/custom-launch/graph/v2/bundle.json
+++ b/public/schemas/custom-launch/graph/v2/bundle.json
@@ -1,0 +1,337 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://programmable.market/schemas/custom-launch/graph/v2/bundle.json",
+  "title": "Programmable multi-role custom graph bundle V2",
+  "description": "Standalone structural foundation for a future explicitly bound launch profile and Router. Existing V1 graphs and V4.1 routes do not accept this schema. This schema does not prove runtime, callback, fee, funding, source, deployment or admission safety. A future preparation step must retain init code (49152 bytes), initializer (131072 bytes), aggregate graph (524288 bytes), address locator placeholder, hook address-bit and unique deployment checks.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "sourceBundleSha256",
+    "targets",
+    "pool"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "programmable.custom-graph-bundle.v2"
+    },
+    "sourceBundleSha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-fA-F]{64}$"
+    },
+    "targets": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 16,
+      "items": {
+        "$ref": "#/$defs/target"
+      },
+      "allOf": [
+        {
+          "contains": {
+            "type": "object",
+            "required": [
+              "componentRoles"
+            ],
+            "properties": {
+              "componentRoles": {
+                "enum": [
+                  [
+                    "token"
+                  ],
+                  [
+                    "token",
+                    "hook"
+                  ]
+                ]
+              }
+            }
+          },
+          "minContains": 1,
+          "maxContains": 1
+        },
+        {
+          "contains": {
+            "type": "object",
+            "required": [
+              "componentRoles"
+            ],
+            "properties": {
+              "componentRoles": {
+                "enum": [
+                  [
+                    "hook"
+                  ],
+                  [
+                    "token",
+                    "hook"
+                  ]
+                ]
+              }
+            }
+          },
+          "minContains": 1,
+          "maxContains": 1
+        }
+      ],
+      "description": "Unique target IDs, constructor dependency topological order with UTF-8 tie-break, exactly one token role and one hook role; both may resolve to the same target. Initializer references do not introduce constructor dependencies."
+    },
+    "pool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tokenTargetId",
+        "hookTargetId",
+        "fee",
+        "tickSpacing"
+      ],
+      "properties": {
+        "tokenTargetId": {
+          "$ref": "#/$defs/identifier",
+          "description": "Must identify the unique target containing the token role."
+        },
+        "hookTargetId": {
+          "$ref": "#/$defs/identifier",
+          "description": "Must identify the unique target containing the hook role; it may equal tokenTargetId."
+        },
+        "fee": {
+          "anyOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1000000
+            },
+            {
+              "const": 8388608
+            }
+          ]
+        },
+        "tickSpacing": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 32767
+        }
+      }
+    }
+  },
+  "x-programmable-contract": {
+    "status": "standalone-foundation-not-activated",
+    "unboundHash": "sha256(JCS(normalized graph))",
+    "metadataHashDomain": "programmable.custom-graph-project-metadata.v2",
+    "metadataHashFields": [
+      "graphBundleHash",
+      "projectMetadataHash"
+    ],
+    "topologyHashDomain": "programmable.create2-graph-topology.v2",
+    "targetTopologyHashDomain": "programmable.create2-graph-topology-target.v2",
+    "componentRoleMask": {
+      "token": 1,
+      "hook": 2,
+      "auxiliary": 0
+    },
+    "initializerPlacement": "each target owns initializerCalldata; no separate initializer target required"
+  },
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@/+\\-]{0,255}$"
+    },
+    "uint256": {
+      "type": "string",
+      "pattern": "^(?:0|[1-9][0-9]*)$",
+      "maxLength": 78,
+      "description": "Canonical uint256 decimal string; the semantic parser rejects values above 2^256 - 1."
+    },
+    "locator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "targetId",
+        "byteOffset",
+        "encoding"
+      ],
+      "properties": {
+        "targetId": {
+          "$ref": "#/$defs/identifier"
+        },
+        "byteOffset": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "encoding": {
+          "enum": [
+            "abi-address-word",
+            "packed-address-20"
+          ]
+        }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "targetId",
+        "applicantSalt",
+        "creationBytecode",
+        "constructorArguments",
+        "initializerCalldata",
+        "constructorAddressLocators",
+        "initializerAddressLocators",
+        "deploymentValueWei",
+        "initializerValueWei",
+        "expectedRuntimeCodeHash",
+        "componentRoles",
+        "declaredHookPermissions"
+      ],
+      "properties": {
+        "targetId": {
+          "$ref": "#/$defs/identifier"
+        },
+        "applicantSalt": {
+          "type": "string",
+          "pattern": "^0x[0-9a-fA-F]{64}$"
+        },
+        "creationBytecode": {
+          "type": "string",
+          "pattern": "^0x(?:[0-9a-fA-F]{2})+$"
+        },
+        "constructorArguments": {
+          "type": "string",
+          "pattern": "^0x(?:[0-9a-fA-F]{2})*$"
+        },
+        "initializerCalldata": {
+          "type": "string",
+          "pattern": "^0x(?:[0-9a-fA-F]{2})*$"
+        },
+        "constructorAddressLocators": {
+          "type": "array",
+          "maxItems": 256,
+          "items": {
+            "$ref": "#/$defs/locator"
+          }
+        },
+        "initializerAddressLocators": {
+          "type": "array",
+          "maxItems": 256,
+          "items": {
+            "$ref": "#/$defs/locator"
+          }
+        },
+        "deploymentValueWei": {
+          "$ref": "#/$defs/uint256"
+        },
+        "initializerValueWei": {
+          "$ref": "#/$defs/uint256"
+        },
+        "expectedRuntimeCodeHash": {
+          "type": "string",
+          "pattern": "^0x(?!0{64}$)[0-9a-fA-F]{64}$"
+        },
+        "componentRoles": {
+          "enum": [
+            [],
+            [
+              "token"
+            ],
+            [
+              "hook"
+            ],
+            [
+              "token",
+              "hook"
+            ]
+          ],
+          "description": "Canonical role order is token then hook. An empty array is an auxiliary target. A target with both roles is deployed exactly once.",
+          "type": "array"
+        },
+        "declaredHookPermissions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "maxItems": 14,
+              "uniqueItems": true,
+              "items": {
+                "enum": [
+                  "beforeInitialize",
+                  "afterInitialize",
+                  "beforeAddLiquidity",
+                  "afterAddLiquidity",
+                  "beforeRemoveLiquidity",
+                  "afterRemoveLiquidity",
+                  "beforeSwap",
+                  "afterSwap",
+                  "beforeDonate",
+                  "afterDonate",
+                  "beforeSwapReturnDelta",
+                  "afterSwapReturnDelta",
+                  "afterAddLiquidityReturnDelta",
+                  "afterRemoveLiquidityReturnDelta"
+                ]
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "componentRoles": {
+                "enum": [
+                  [
+                    "hook"
+                  ],
+                  [
+                    "token",
+                    "hook"
+                  ]
+                ]
+              }
+            },
+            "required": [
+              "componentRoles"
+            ]
+          },
+          "then": {
+            "properties": {
+              "declaredHookPermissions": {
+                "type": "array",
+                "maxItems": 14,
+                "uniqueItems": true,
+                "items": {
+                  "enum": [
+                    "beforeInitialize",
+                    "afterInitialize",
+                    "beforeAddLiquidity",
+                    "afterAddLiquidity",
+                    "beforeRemoveLiquidity",
+                    "afterRemoveLiquidity",
+                    "beforeSwap",
+                    "afterSwap",
+                    "beforeDonate",
+                    "afterDonate",
+                    "beforeSwapReturnDelta",
+                    "afterSwapReturnDelta",
+                    "afterAddLiquidityReturnDelta",
+                    "afterRemoveLiquidityReturnDelta"
+                  ]
+                }
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "declaredHookPermissions": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Projects whose token contract also implements their Uniswap v4 hook cannot represent that physical deployment in graph V1. Add an isolated graph V2 parser and public JSON schema with explicit token/hook role arrays, including both roles on one target. Keep one deployment per target, unique IDs, acyclic constructor dependencies, and independent token/hook bindings.

This publishes the versioned representation and shared commitment vectors. It does not change the active 4.1 CLI, profile, preparation route, or deployment roots; activation requires the corresponding backend, multi-role router, execution evidence, and release bindings.

Validation: 179/179 launch package tests, strict JSON Schema 2020 validation, scoped ESLint, machine-contract verification, and the 4.1 synchronization check pass. Three vectors match the backend byte-for-byte and cover a combined target, an auxiliary target, and split token/hook targets.
