### PR TITLE
Authorize the reviewed MultiRole Router CI candidate

### DIFF
--- a/.github/workflows/verify-hook-builder.yml
+++ b/.github/workflows/verify-hook-builder.yml
@@ -114,8 +114,8 @@ jobs:
           EXPECTED_BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
           EXPECTED_CANDIDATE_COMMIT: ${{ github.event.pull_request.head.sha }}
           EXPECTED_MERGE_COMMIT: ${{ steps.candidate_fetch.outputs.merge_commit }}
-          APPROVED_MAIN_CI_CONTROL_COMMIT: 140771f8fc2b3a30cc021f6352ccd830850e68e6
-          APPROVED_MAIN_CI_CONTROL_TREE: a5f359e200ab42917e6c2055e1d5a9685e33c137
+          APPROVED_MAIN_CI_CONTROL_COMMIT: e15bb397604a19d6622af5a5ee9622a8edac9d18
+          APPROVED_MAIN_CI_CONTROL_TREE: 92eecc16da2c59b87295fcb4012e57fe4f1feae7
         run: |
           set -euo pipefail
 

--- a/scripts/test/verify-main-ci-control-workflow.test.mjs
+++ b/scripts/test/verify-main-ci-control-workflow.test.mjs
@@ -39,8 +39,8 @@ test("CI control guard executes only exact default-branch code over inert candid
 });
 
 test("trusted guard is bound to the exact audited main candidate commit and tree", () => {
-  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_COMMIT: 140771f8fc2b3a30cc021f6352ccd830850e68e6/u);
-  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_TREE: a5f359e200ab42917e6c2055e1d5a9685e33c137/u);
+  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_COMMIT: e15bb397604a19d6622af5a5ee9622a8edac9d18/u);
+  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_TREE: 92eecc16da2c59b87295fcb4012e57fe4f1feae7/u);
   assert.match(workflow, /--approved-commit "\$APPROVED_MAIN_CI_CONTROL_COMMIT"/u);
   assert.match(workflow, /--approved-tree "\$APPROVED_MAIN_CI_CONTROL_TREE"/u);
 });


### PR DESCRIPTION
The MultiRole Router candidate in #702 pins Foundry to 1.7.1 so its canonical build and gas checks use the same tested compiler toolchain as the portable tests. The trusted main CI-control guard currently rejects that workflow change because it still names an earlier candidate.

Authorize only commit `e15bb397604a19d6622af5a5ee9622a8edac9d18` and tree `92eecc16da2c59b87295fcb4012e57fe4f1feae7`, and update the matching exact workflow assertion. The guard, permissions, candidate-as-inert-data handling and all other classifications remain unchanged. Main's separate contract CI and approving-review requirement still apply; this grants no deployment, signing or launch authority.

The candidate also contains the reviewed diagnostic flush correction and its generated copies, with an independently recomputed packaging golden. Both canonical verifier modes passed in the preceding remote run; its packaging mismatch is reproduced and resolved by the exact golden update. The original transient deterministic-shard failure did not recur and has no speculative test relaxation.

Validation: trusted CI-control change and workflow tests, plus the source-bound candidate review described in #702. Production CI must pass before merging this authorization.
