### PR TITLE
Restore Module option checks and scoped production proofs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -798,7 +798,18 @@ jobs:
 
   production-proof:
     name: Bind production Verify proof
+    # Scoped workers may be skipped transitively; attest only after every
+    # protected aggregate has explicitly succeeded in this same run.
     if: >-
+      always() && !cancelled() &&
+      needs.scope.result == 'success' &&
+      needs.secret-scan.result == 'success' &&
+      needs.indexer.result == 'success' &&
+      needs.database-pglite.result == 'success' &&
+      needs.interface.result == 'success' &&
+      needs.contracts.result == 'success' &&
+      needs.custom-v2.result == 'success' &&
+      needs.aggregate.result == 'success' &&
       github.ref == 'refs/heads/production' &&
       (github.event_name == 'push' ||
       (github.event_name == 'workflow_dispatch' &&
@@ -811,6 +822,7 @@ jobs:
       - interface
       - contracts
       - custom-v2
+      - aggregate
     permissions:
       contents: read
       id-token: write

--- a/components/module-mode-builder.module.css
+++ b/components/module-mode-builder.module.css
@@ -129,7 +129,7 @@
 .recordField { min-width: 0; }
 .recordField > .field { margin-bottom: 0; }
 .optionalToggle { align-items: center !important; color: #eee; cursor: pointer; display: inline-flex; font-size: 14px; gap: 12px; min-height: 44px; }
-.optionalToggle > input { accent-color: #e2eadc; flex: 0 0 20px; height: 20px; min-height: 20px; padding: 0; width: 20px; }
+.optionalToggle > input { accent-color: #e2eadc; appearance: auto; cursor: pointer; flex: 0 0 20px; height: 20px; min-height: 20px; padding: 0; width: 20px; }
 .optionalToggle small { color: var(--mm-muted); font-size: 12px; margin-left: 8px; }
 .collection { border: 1px solid #484848; border-radius: 8px; display: grid; gap: 12px; margin: 0; min-width: 0; padding: 16px; }
 .collection > legend { color: #eee; font-size: 14px; padding-inline: 4px; }

--- a/scripts/ci/verify-interface-workflow.test.mjs
+++ b/scripts/ci/verify-interface-workflow.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import test from "node:test";
+import { runInNewContext } from "node:vm";
 import yaml from "js-yaml";
 
 const workflow = yaml.load(readFileSync(
@@ -194,6 +195,61 @@ test("the stable Interface result remains an always-run dependency of release pr
   "${{ needs.scope.outputs.interface == 'true' && needs.interface.result || 'skipped' }}");
   assert.equal(step(jobs.aggregate, "Require every protected verification lane to complete")
     .env.INTERFACE_RESULT, "${{ needs.interface.result }}");
+});
+
+test("production proof survives scoped worker skips only after every protected aggregate succeeds", () => {
+  const proof = jobs["production-proof"];
+  const required = ["scope", "secret-scan", "indexer", "database-pglite",
+    "interface", "contracts", "custom-v2", "aggregate"];
+  const upstream = new Set();
+  function collect(id) {
+    for (const dependency of [jobs[id].needs ?? []].flat()) {
+      if (upstream.has(dependency)) continue;
+      upstream.add(dependency);
+      collect(dependency);
+    }
+  }
+  collect("production-proof");
+  const results = Object.fromEntries([...upstream].map((id) => [id, "success"]));
+  // Reproduce the Custom V2-only run: both protected aggregates pass while
+  // all seven Interface/Contracts workers are intentionally untouched.
+  const workers = [...jobs.interface.needs, ...jobs.contracts.needs]
+    .filter((id) => id !== "scope");
+  assert.equal(workers.length, 7);
+  for (const id of workers) results[id] = "skipped";
+
+  const condition = proof.if.replaceAll(
+    /needs\.([a-z0-9-]+)\.result/gu, 'needs["$1"].result',
+  );
+  // Actions adds implicit success() when the condition has no status function.
+  const expression = /\b(?:always|cancelled|failure|success)\s*\(/u.test(condition)
+    ? condition : `success() && (${condition})`;
+  function shouldRun({ overrides = {}, cancelled = false,
+    ref = "refs/heads/production", event = "workflow_dispatch",
+    mode = "custom-v2-release" } = {}) {
+    const observed = { ...results, ...overrides };
+    return runInNewContext(expression, {
+      always: () => true,
+      cancelled: () => cancelled,
+      success: () => [...upstream].every((id) => observed[id] === "success"),
+      github: { ref, event_name: event },
+      inputs: { verification_mode: mode },
+      needs: Object.fromEntries(required.map((id) => [id, { result: observed[id] }])),
+    }, { timeout: 100 });
+  }
+  assert.equal(shouldRun(), true);
+  assert.deepEqual(proof.needs, required);
+  assert.equal(shouldRun({ event: "push", mode: "change" }), true);
+  assert.equal(shouldRun({ cancelled: true }), false);
+  assert.equal(shouldRun({ ref: "refs/heads/main" }), false);
+  assert.equal(shouldRun({ event: "pull_request" }), false);
+  assert.equal(shouldRun({ mode: "change" }), false);
+  for (const id of required) {
+    for (const result of ["failure", "cancelled", "skipped", "queued", "unknown", "", undefined]) {
+      assert.equal(shouldRun({ overrides: { [id]: result } }), false,
+        `${id}=${result} must not produce an attested proof`);
+    }
+  }
 });
 
 function aggregateResult(overrides = {}) {


### PR DESCRIPTION
Scoped Verify runs could finish successfully while skipping the production proof because optional worker jobs were skipped transitively. Evaluate the proof job explicitly after all protected results and the existing aggregate succeed, while refusing failed, cancelled or missing results.

Also restore the native checked appearance and pointer cursor for Module Mode options. The global input reset previously hid the checkmark, making an enabled module setting look unchecked.

Validation: 46 focused workflow/proof tests, including a regression that fails on the previous scheduling condition; actionlint, ESLint and diff checks. The checkbox was verified in the rendered builder on desktop and at 390px, including Space-key toggling, visible checked state and no mobile horizontal overflow. The production proof must still be observed on the final hosted release run.
