### PR TITLE
Keep restricted API keys visible and show their saved permissions

### DIFF
--- a/components/developer-api-keys.module.css
+++ b/components/developer-api-keys.module.css
@@ -442,6 +442,7 @@
 .scopeLedger ul {
   display: grid;
   gap: 8px;
+  padding-top: 8px;
   padding-bottom: 12px;
 }
 

--- a/components/developer-api-keys.tsx
+++ b/components/developer-api-keys.tsx
@@ -163,7 +163,9 @@ export function apiKeyPurposeLabel(scopes: unknown): string {
   const purpose = apiKeyPurpose(scopes);
   if (purpose === "custom-launches") return "Custom launches";
   if (purpose === "module-contributions") return "Module contributions";
-  return "Unrecognized purpose";
+  if (Array.isArray(scopes) && scopes.length === 1
+    && fixedScopes.includes(scopes[0])) return "Custom launches";
+  return "Other permissions";
 }
 
 export function moduleContributionKeysAvailable(value: unknown): boolean {
@@ -172,6 +174,13 @@ export function moduleContributionKeysAvailable(value: unknown): boolean {
   return isRecord(capability)
     && capability.apiKeyIssuance === true
     && capability.submissions === true;
+}
+
+function validMetadataScopes(value: unknown): value is string[] {
+  return Array.isArray(value) && value.length > 0 && value.length <= 16
+    && new Set(value).size === value.length
+    && value.every((scope) => typeof scope === "string"
+      && /^[a-z][a-z0-9-]{1,63}:[a-z][a-z0-9-]{1,63}$/u.test(scope));
 }
 
 function parseApiKeySummary(value: unknown): ApiKeySummary | null {
@@ -184,8 +193,7 @@ function parseApiKeySummary(value: unknown): ApiKeySummary | null {
     typeof value.id !== "string" ||
     typeof value.label !== "string" ||
     typeof value.keyPrefix !== "string" ||
-    !Array.isArray(value.scopes) ||
-    apiKeyPurpose(value.scopes) === null ||
+    !validMetadataScopes(value.scopes) ||
     typeof value.createdAt !== "string" ||
     expiresAt === undefined ||
     lastUsedAt === undefined ||
@@ -206,18 +214,18 @@ function parseApiKeySummary(value: unknown): ApiKeySummary | null {
   };
 }
 
-function parseApiKeyList(value: unknown): ApiKeySummary[] | null {
+export function parseApiKeyList(value: unknown): ApiKeySummary[] | null {
   if (
     !isRecord(value) ||
     value.schemaVersion !== schemaVersion ||
-    !Array.isArray(value.apiKeys)
+    !Array.isArray(value.apiKeys) || value.apiKeys.length > 100
   ) {
     return null;
   }
   const apiKeys: ApiKeySummary[] = [];
   for (const candidate of value.apiKeys) {
     const parsed = parseApiKeySummary(candidate);
-    if (!parsed) return null;
+    if (!parsed || apiKeys.some((key) => key.id === parsed.id)) return null;
     apiKeys.push(parsed);
   }
   return apiKeys;
@@ -244,6 +252,7 @@ export function parseApiKeyMutationResult(
   );
   if (
     !apiKey
+    || apiKeyPurpose(apiKey.scopes) === null
     || (expectedPurpose !== undefined && apiKeyPurpose(apiKey.scopes) !== expectedPurpose)
     || (secretState !== "delivered-once" && secretState !== "already-delivered")
     || (secretState === "delivered-once" && status !== 201)
@@ -271,6 +280,32 @@ export function parseApiKeyMutationResult(
     apiKeySecret: value.apiKeySecret,
     ...rotation,
   };
+}
+
+export function ApiKeyPermissions({ scopes }: Readonly<{ scopes: readonly string[] }>) {
+  const purpose = apiKeyPurpose(scopes);
+  const summary = purpose === "custom-launches" ? "Launch + read"
+    : purpose === "module-contributions" ? "Submit + read"
+      : scopes.length === 1 && scopes[0] === "custom-launch:read" ? "Read only"
+        : scopes.length === 1 && scopes[0] === "custom-launch:create" ? "Launch only"
+          : `${scopes.length} ${scopes.length === 1 ? "scope" : "scopes"}`;
+  const descriptions: Readonly<Record<string, string>> = {
+    "custom-launch:create": "Prepare launch requests. Your controller wallet must sign each transaction.",
+    "custom-launch:read": "Read launch history across API keys and linked wallets in your account.",
+    "modules:submit": "Submit module source packages for review. This does not approve or deploy a module.",
+    "modules:read": "Read module submission status.",
+  };
+  return (
+    <details className={styles.scopeLedger}>
+      <summary><span>Permissions</span><strong>{summary}</strong></summary>
+      <ul>{scopes.map((scope) => (
+        <li key={scope}>
+          <code>{scope}</code>
+          <p>{descriptions[scope] ?? "Not recognized by this manager."}</p>
+        </li>
+      ))}</ul>
+    </details>
+  );
 }
 
 export function ApiKeyPurposeChoice({
@@ -1593,19 +1628,7 @@ export function DeveloperApiKeysView({
                     </button>
                   </div>
 
-                  <details className={styles.scopeLedger}>
-                    <summary>
-                      <span>Permissions</span>
-                      <strong>{purpose === "module-contributions" ? "2 module scopes" : "2 launch scopes"}</strong>
-                    </summary>
-                    <ul>
-                      {(purpose === "module-contributions" ? moduleScopes : fixedScopes).map((scope) => (
-                        <li key={scope}>
-                          <code>{scope}</code>
-                        </li>
-                      ))}
-                    </ul>
-                  </details>
+                  <ApiKeyPermissions scopes={purpose === "module-contributions" ? moduleScopes : fixedScopes} />
 
                   <p className={styles.securityNote}>
                     API keys cannot sign or broadcast wallet transactions.
@@ -1767,6 +1790,10 @@ export function DeveloperApiKeysView({
                               </span>
                             </div>
                             <code>{displayPrefix(apiKey.keyPrefix)}</code>
+                            <ApiKeyPermissions scopes={apiKey.scopes} />
+                            {status === "Active" && !apiKeyPurpose(apiKey.scopes) ? (
+                              <p className={styles.securityNote}>Rotation is unavailable for this key&apos;s permissions.</p>
+                            ) : null}
                           </div>
 
                           <dl className={styles.keyMetadata}>
@@ -1884,7 +1911,7 @@ export function DeveloperApiKeysView({
                             <div className={styles.keyActions}>
                               <button
                                 className={styles.secondaryButton}
-                                disabled={mutationBusy}
+                                disabled={mutationBusy || apiKeyPurpose(apiKey.scopes) === null}
                                 type="button"
                                 onClick={(event) =>
                                   beginRotate(apiKey.id, event.currentTarget)

--- a/lib/server/custom-launch/api-key-bridge-v1.ts
+++ b/lib/server/custom-launch/api-key-bridge-v1.ts
@@ -41,9 +41,7 @@ const MODULE_SCOPES = Object.freeze([
   "modules:submit",
   "modules:read",
 ] as const);
-type DeveloperApiKeyScopeV1 =
-  | (typeof CURRENT_SCOPES)[number]
-  | (typeof MODULE_SCOPES)[number];
+const METADATA_SCOPE_PATTERN = /^[a-z][a-z0-9-]{1,63}:[a-z][a-z0-9-]{1,63}$/u;
 type DeveloperApiKeyPurposeV1 = "custom-launches" | "module-contributions";
 
 const RESPONSE_HEADERS = Object.freeze({
@@ -57,7 +55,7 @@ export type DeveloperApiKeySummaryV1 = Readonly<{
   id: string;
   label: string;
   keyPrefix: string;
-  scopes: readonly DeveloperApiKeyScopeV1[];
+  scopes: readonly string[];
   createdAt: string;
   expiresAt: string | null;
   lastUsedAt: string | null;
@@ -493,7 +491,9 @@ function parseApiKeyList(value: JsonValue | undefined) {
   if (!Array.isArray(value) || value.length > 100) {
     throw new BackendContractErrorV1();
   }
-  return Object.freeze(value.map(parseApiKeySummary));
+  const keys = value.map(parseApiKeySummary);
+  if (new Set(keys.map((key) => key.id)).size !== keys.length) throw new BackendContractErrorV1();
+  return Object.freeze(keys);
 }
 
 function parseApiKeySummary(value: JsonValue | undefined): DeveloperApiKeySummaryV1 {
@@ -517,15 +517,15 @@ function parseApiKeySummary(value: JsonValue | undefined): DeveloperApiKeySummar
   });
 }
 
-function parseScopes(value: JsonValue | undefined): readonly DeveloperApiKeyScopeV1[] {
-  if (!Array.isArray(value) || value.length !== 2 || new Set(value).size !== 2) {
+function parseScopes(value: JsonValue | undefined): readonly string[] {
+  // Persisted metadata can outlive this reader. Unknown names are displayed,
+  // never interpreted as selectable issuance permissions.
+  if (!Array.isArray(value) || value.length < 1 || value.length > 16
+    || new Set(value).size !== value.length
+    || value.some((scope) => typeof scope !== "string" || !METADATA_SCOPE_PATTERN.test(scope))) {
     throw new BackendContractErrorV1();
   }
-  const pair = [CURRENT_SCOPES, MODULE_SCOPES].find((candidate) =>
-    candidate.every((scope) => value.includes(scope)),
-  );
-  if (!pair) throw new BackendContractErrorV1();
-  return Object.freeze(value as DeveloperApiKeyScopeV1[]);
+  return Object.freeze(value as string[]);
 }
 
 function parseApiKeyMutationResult(
@@ -537,6 +537,9 @@ function parseApiKeyMutationResult(
   const record = jsonRecord(value);
   requireBackendSchema(record);
   const apiKey = parseApiKeySummary(record.apiKey);
+  const supportedPair = [CURRENT_SCOPES, MODULE_SCOPES].some((pair) =>
+    apiKey.scopes.length === pair.length && pair.every((scope) => apiKey.scopes.includes(scope)));
+  if (!supportedPair) throw new BackendContractErrorV1();
   if (expectedPurpose !== undefined) {
     const expectedScopes = expectedPurpose === "module-contributions"
       ? MODULE_SCOPES

--- a/tests/custom-launch-api-key-bridge-v1.test.ts
+++ b/tests/custom-launch-api-key-bridge-v1.test.ts
@@ -298,20 +298,12 @@ describe("developer API key same-origin bridge", () => {
     });
   });
 
-  it.each([
-    [],
-    ["modules:submit"],
-    ["modules:submit", "modules:submit"],
-    ["modules:submit", "custom-launch:read"],
-    ["modules:submit", "modules:read", "custom-launch:create"],
-    ["modules:submit", "modules:approve"],
-  ].map((scopes) => ({ scopes })))("rejects malformed, mixed or broader scope sets ($scopes)", async ({ scopes }) => {
-    fetchBackend.mockResolvedValueOnce(backendJson({ apiKeys: [summary({ scopes })] }));
+  it("rejects duplicate credential IDs in metadata", async () => {
+    fetchBackend.mockResolvedValueOnce(backendJson({ apiKeys: [summary(), summary({ scopes: ["custom-launch:read"] })] }));
     const response = await bridge().list(new Request(
       `https://programmable.market/api/developer/api-keys?walletAddress=${WALLET}`,
     ));
     expect(response.status).toBe(503);
-    expect((await response.json()).error.code).toBe("api_key_service_unavailable");
   });
 
   it.each(["custom-launches", "module-contributions"])(
@@ -374,6 +366,127 @@ describe("developer API key same-origin bridge", () => {
     const [, init] = fetchBackend.mock.calls[0] as [URL, RequestInit];
     expect(JSON.parse(String(init.body))).not.toHaveProperty("scopes");
     expect(JSON.parse(String(init.body))).not.toHaveProperty("purpose");
+  });
+
+  it.each([
+    ["read-only", ["custom-launch:read"]],
+    ["create-only", ["custom-launch:create"]],
+    ["additive future", ["custom-launch:create", "custom-launch:read", "fees:read"]],
+    ["future-only", ["future-namespace:future-operation"]],
+    ["maximum bounded", Array.from({ length: 16 }, (_, index) => `future:scope-${index}`)],
+    ["maximum scope length", [`${"a".repeat(64)}:${"b".repeat(64)}`]],
+  ])("preserves %s metadata without breaking other keys in the list", async (_, scopes) => {
+    const restricted = summary({
+      id: "028f3e2a-7b4c-7d5e-8f90-123456789abc",
+      scopes,
+    });
+    fetchBackend.mockResolvedValueOnce(backendJson({
+      apiKeys: [summary(), { ...restricted, apiKeySecret: "must-not-cross-the-bff" }],
+    }));
+
+    const response = await bridge().list(new Request(
+      `https://programmable.market/api/developer/api-keys?walletAddress=${WALLET}`,
+    ));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      schemaVersion: CUSTOM_LAUNCH_API_SCHEMA_V1,
+      apiKeys: [summary(), restricted],
+    });
+    const [, init] = fetchBackend.mock.calls[0] as [URL, RequestInit];
+    expect(init.method).toBe("GET");
+    expect(init.body).toBeUndefined();
+  });
+
+  it.each([
+    { scopes: null },
+    { scopes: [] },
+    { scopes: ["custom-launch:read", "custom-launch:read"] },
+    { scopes: ["custom-launch:*"] },
+    { scopes: ["custom-launch:Read"] },
+    { scopes: ["custom-launch:read "] },
+    { scopes: ["custom-launch"] },
+    { scopes: ["x:read"] },
+    { scopes: [17] },
+    { scopes: [`${"a".repeat(65)}:read`] },
+    { scopes: [`future:${"b".repeat(65)}`] },
+    { scopes: Array.from({ length: 17 }, (_, index) => `future:scope-${index}`) },
+    { id: "invalid-credential-id" },
+    { keyPrefix: `pm_live_${"*".repeat(22)}` },
+    { createdAt: "not-a-timestamp" },
+    { expiresAt: "not-a-timestamp" },
+    { lastUsedAt: "not-a-timestamp" },
+    { revokedAt: "not-a-timestamp" },
+  ])("retains validation of restricted metadata: %j", async (invalid) => {
+    fetchBackend.mockResolvedValueOnce(backendJson({
+      apiKeys: [summary({ scopes: ["custom-launch:read"], ...invalid })],
+    }));
+
+    const response = await bridge().list(new Request(
+      `https://programmable.market/api/developer/api-keys?walletAddress=${WALLET}`,
+    ));
+
+    expect(response.status).toBe(503);
+    expect((await correlatedError(response)).body.error.code).toBe(
+      "api_key_service_unavailable",
+    );
+  });
+
+  it.each(["create", "rotate"] as const)(
+    "does not accept scope selection in the existing %s contract",
+    async (operation) => {
+      const request = new Request("https://programmable.market/api/developer/api-keys", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "idempotency-key": IDEMPOTENCY_ID,
+        },
+        body: JSON.stringify({
+          schemaVersion: CUSTOM_LAUNCH_API_SCHEMA_V1,
+          walletAddress: WALLET,
+          label: "Restricted key",
+          scopes: ["custom-launch:read"],
+        }),
+      });
+      const response = operation === "create"
+        ? await bridge().create(request)
+        : await bridge().rotate(request, CREDENTIAL_ID);
+
+      expect(response.status).toBe(400);
+      expect(authenticate).not.toHaveBeenCalled();
+      expect(fetchBackend).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ["custom-launch:read"],
+    ["custom-launch:create", "custom-launch:read", "fees:read"],
+  ])("does not reinterpret a V1 mutation response as new issuance permissions: %j", async (...scopes) => {
+    fetchBackend.mockResolvedValueOnce(backendJson({
+      apiKey: summary({ scopes }),
+      secretState: "delivered-once",
+      apiKeySecret: API_KEY_SECRET,
+    }, 201));
+    const response = await bridge().create(new Request(
+      "https://programmable.market/api/developer/api-keys",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "idempotency-key": IDEMPOTENCY_ID,
+        },
+        body: JSON.stringify({
+          schemaVersion: CUSTOM_LAUNCH_API_SCHEMA_V1,
+          walletAddress: WALLET,
+          label: "Launch agent",
+        }),
+      },
+    ));
+
+    expect(response.status).toBe(503);
+    expect((await correlatedError(response)).body.error.code).toBe(
+      "api_key_service_unavailable",
+    );
   });
 
   it("accepts an idempotent issue replay without inventing or leaking a secret", async () => {

--- a/tests/developer-api-keys-ui.test.ts
+++ b/tests/developer-api-keys-ui.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   DeveloperApiKeysView,
+  ApiKeyPermissions,
+  parseApiKeyList,
   ApiKeyPurposeChoice,
   PROGRAMMABLE_MODULE_AGENT_SETUP_TEXT_V1,
   applyApiKeyMutationResult,
@@ -205,6 +207,43 @@ function v3Launch(
 }
 
 describe("developer API key interface", () => {
+  it("describes read-only permissions as account-wide history without claiming create access", () => {
+    const html = renderToStaticMarkup(createElement(ApiKeyPermissions, {
+      scopes: ["custom-launch:read"],
+    }));
+
+    expect(html).toContain("Read only");
+    expect(html).toContain("custom-launch:read");
+    expect(html).toContain("Read launch history across API keys and linked wallets in your account.");
+    expect(html).not.toContain("custom-launch:create");
+    expect(html).not.toContain("Prepare launch requests");
+  });
+
+  it("describes current preparation permissions without claiming wallet authority", () => {
+    const html = renderToStaticMarkup(createElement(ApiKeyPermissions, {
+      scopes: ["custom-launch:read", "custom-launch:create"],
+    }));
+
+    expect(html).toContain("Launch + read");
+    expect(html).toContain("custom-launch:create");
+    expect(html).toContain("Your controller wallet must sign each transaction.");
+    expect(html).toContain("Read launch history across API keys and linked wallets in your account.");
+  });
+
+  it("keeps future scope metadata visible without inventing its permissions", () => {
+    const html = renderToStaticMarkup(createElement(ApiKeyPermissions, {
+      scopes: ["custom-launch:read", "fees:read"],
+    }));
+
+    expect(html).toContain("2 scopes");
+    expect(html).toContain("fees:read");
+    expect(html).toContain("Not recognized by this manager.");
+    expect(html).not.toContain("Read only");
+    expect(html).not.toContain("custom-launch:create");
+    expect(html).not.toContain("claim");
+  });
+
+
   it("models one-time and replayed mutations without leaking a replay secret", () => {
     const oldCredentialId = "018f3e2a-7b4c-7d5e-8f90-123456789abc";
     const replacement = apiKey("028f3e2a-7b4c-7d5e-8f90-123456789abc", {
@@ -409,6 +448,22 @@ describe("developer API key interface", () => {
     expect(copySetup).not.toContain("apiKeySecret");
   });
 
+  it("reads narrowed and future metadata alongside historical launch and module keys", () => {
+    const keys = [
+      apiKey("launch"),
+      apiKey("reader", { scopes: ["custom-launch:read"] }),
+      apiKey("module", { scopes: ["modules:submit", "modules:read"] }),
+      apiKey("future", { scopes: ["custom-launch:read", "fees:read"] }),
+    ];
+    const response = { schemaVersion: "programmable.custom-launch-api.v1", apiKeys: keys };
+    expect(parseApiKeyList(response)).toEqual(keys);
+    for (const scopes of [[], ["custom-launch:read", "custom-launch:read"], ["bad"], ["custom-launch:*"]]) {
+      expect(parseApiKeyList({ ...response, apiKeys: [apiKey("invalid", { scopes })] })).toBeNull();
+    }
+    expect(parseApiKeyList({ ...response, apiKeys: [keys[0], keys[0]] })).toBeNull();
+    expect(apiKeyPurposeLabel(["custom-launch:read"])).toBe("Custom launches");
+  });
+
   it("recognizes only the two complete purpose pairs", () => {
     expect(apiKeyPurpose(["custom-launch:create", "custom-launch:read"]))
       .toBe("custom-launches");
@@ -422,7 +477,7 @@ describe("developer API key interface", () => {
       ["modules:submit", "modules:read", "modules:approve"],
     ]) {
       expect(apiKeyPurpose(scopes)).toBeNull();
-      expect(apiKeyPurposeLabel(scopes)).toBe("Unrecognized purpose");
+      expect(apiKeyPurposeLabel(scopes)).toBe("Other permissions");
       expect(parseApiKeyMutationResult({
         schemaVersion: "programmable.custom-launch-api.v1",
         apiKey: apiKey("invalid", { scopes }),


### PR DESCRIPTION
Existing API-key metadata can contain read-only permissions or additional bounded scopes. The manager previously required one of two complete permission pairs, so a valid restricted key could make the entire list fail to load.

Read and display the actual saved scopes, while retaining the existing closed validation for V1 create/rotate responses. Restricted and unknown permission sets remain visible and revocable; the compatibility stage does not offer V1 rotation for them. The existing Module availability wrapper is preserved. Permission details explain that read access spans the account's linked wallets. Add spacing so expanded scope text clears the keyboard focus outline.

Validation: 99 focused bridge/UI tests passed on the integration source; the implementation's complete targeted suite, ESLint and typecheck passed. Independent source review found no issues. Root browser acceptance used the actual component with synthetic local API data at 1440px, 390px and 320px: permission disclosure by keyboard, no horizontal overflow, key creation and one-time-secret dismissal worked, and browser warning/error logs were empty. The focus-spacing correction was rendered and rechecked. No real keys or wallet actions were used.

This is the compatibility stage preceding restricted V2 issuance. Required production CI and normal deployment remain separate release gates.
