### PR TITLE
Automate bounded contract maintenance with source-bound release evidence

### DIFF
--- a/.github/workflows/platform-maintenance-post-merge.yml
+++ b/.github/workflows/platform-maintenance-post-merge.yml
@@ -1,0 +1,264 @@
+name: Verify protected platform maintenance merge
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: Original first-party main pull request
+        type: string
+        required: true
+      merge_sha:
+        description: Exact returned squash commit; must remain protected main tip
+        type: string
+        required: true
+      producer_run:
+        description: Original independently authenticated evidence producer
+        type: string
+        required: true
+      controller_sha:
+        description: Exact protected policy and workflow source
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: platform-maintenance-post-merge-${{ inputs.merge_sha }}
+  cancel-in-progress: false
+
+jobs:
+  select:
+    name: Authenticate protected main merge
+    if: >-
+      github.repository_id == 1314365508 &&
+      github.ref == 'refs/heads/production' &&
+      github.ref_protected == true
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read
+      attestations: read
+      pull-requests: read
+    outputs:
+      merge_sha: ${{ steps.select.outputs.merge_sha }}
+      subject_artifact: ${{ steps.upload.outputs.artifact-id }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: trusted
+          persist-credentials: false
+          lfs: false
+          submodules: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.14.0
+      - id: producer
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAINTENANCE_PRODUCER_RUN: ${{ inputs.producer_run }}
+          MAINTENANCE_OUTPUT: ${{ runner.temp }}/maintenance-post-select
+        run: node trusted/scripts/ci/platform-maintenance-runner.mjs post-resolve
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ steps.producer.outputs.artifact_id }}
+          run-id: ${{ steps.producer.outputs.run_id }}
+          github-token: ${{ github.token }}
+          repository: programmablehq/PROGRAMMABLE
+          path: ${{ runner.temp }}/maintenance-original-evidence
+          digest-mismatch: error
+      - id: select
+        name: Bind actual merged PR, parent, tree and current protected refs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAINTENANCE_PRODUCER: ${{ runner.temp }}/maintenance-post-select/producer.json
+          MAINTENANCE_EVIDENCE: ${{ runner.temp }}/maintenance-original-evidence/evidence.json
+          MAINTENANCE_MERGED_SHA: ${{ inputs.merge_sha }}
+          MAINTENANCE_CONTROLLER_SHA: ${{ inputs.controller_sha }}
+          MAINTENANCE_PR: ${{ inputs.pull_request }}
+          MAINTENANCE_OUTPUT: ${{ runner.temp }}/maintenance-subject
+        run: node trusted/scripts/ci/platform-maintenance-runner.mjs post-select
+      - id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: platform-maintenance-post-merge-subject-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/maintenance-subject/subject.json
+          if-no-files-found: error
+          retention-days: 2
+          overwrite: false
+
+  foundry:
+    name: Exact head foundry
+    needs: select
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: trusted
+          persist-credentials: false
+          lfs: false
+          submodules: false
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.select.outputs.merge_sha }}
+          path: candidate
+          fetch-depth: 0
+          persist-credentials: false
+          lfs: false
+          submodules: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.select.outputs.subject_artifact }}
+          path: ${{ runner.temp }}/maintenance-subject
+          digest-mismatch: error
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.14.0
+      - uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1
+        with:
+          version: v1.7.1
+      - name: Execute exact head with no signing, write or deployment credentials
+        env:
+          MAINTENANCE_SUBJECT: ${{ runner.temp }}/maintenance-subject/subject.json
+          MAINTENANCE_CANDIDATE: ${{ github.workspace }}/candidate
+          MAINTENANCE_LANE: foundry
+          MAINTENANCE_OUTPUT: ${{ runner.temp }}/maintenance-foundry
+        run: node trusted/scripts/ci/platform-maintenance-runner.mjs post-worker
+      - id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: platform-maintenance-foundry-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/maintenance-foundry/foundry.json
+          if-no-files-found: error
+          retention-days: 2
+          overwrite: false
+    outputs:
+      artifact: ${{ steps.upload.outputs.artifact-id }}
+
+  slither:
+    name: Exact head slither
+    needs: select
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: trusted
+          persist-credentials: false
+          lfs: false
+          submodules: false
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.select.outputs.merge_sha }}
+          path: candidate
+          fetch-depth: 0
+          persist-credentials: false
+          lfs: false
+          submodules: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.select.outputs.subject_artifact }}
+          path: ${{ runner.temp }}/maintenance-subject
+          digest-mismatch: error
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.14.0
+      - uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1
+        with:
+          version: v1.7.1
+      - name: Install exact Slither
+        run: pipx install slither-analyzer==0.11.5
+      - name: Execute exact head scan and fail on every unbound finding
+        env:
+          MAINTENANCE_SUBJECT: ${{ runner.temp }}/maintenance-subject/subject.json
+          MAINTENANCE_CANDIDATE: ${{ github.workspace }}/candidate
+          MAINTENANCE_LANE: slither
+          MAINTENANCE_OUTPUT: ${{ runner.temp }}/maintenance-slither
+        run: node trusted/scripts/ci/platform-maintenance-runner.mjs post-worker
+      - name: Retain scan diagnostics without granting approval
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: platform-maintenance-slither-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/maintenance-slither/slither.raw.json
+          if-no-files-found: warn
+          retention-days: 7
+          overwrite: false
+      - id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: platform-maintenance-slither-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/maintenance-slither/slither.json
+          if-no-files-found: error
+          retention-days: 2
+          overwrite: false
+    outputs:
+      artifact: ${{ steps.upload.outputs.artifact-id }}
+
+  attest:
+    name: Attest maintenance evidence
+    needs: [select, foundry, slither]
+    if: >-
+      always() && needs.select.result == 'success' &&
+      needs.foundry.result == 'success' && needs.slither.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: trusted
+          persist-credentials: false
+          lfs: false
+          submodules: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.14.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.select.outputs.subject_artifact }}
+          path: ${{ runner.temp }}/maintenance-subject
+          digest-mismatch: error
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.foundry.outputs.artifact }}
+          path: ${{ runner.temp }}/maintenance-foundry
+          digest-mismatch: error
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.slither.outputs.artifact }}
+          path: ${{ runner.temp }}/maintenance-slither
+          digest-mismatch: error
+      - name: Revalidate and assemble inert technical evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAINTENANCE_SUBJECT: ${{ runner.temp }}/maintenance-subject/subject.json
+          MAINTENANCE_FOUNDRY: ${{ runner.temp }}/maintenance-foundry/foundry.json
+          MAINTENANCE_SLITHER: ${{ runner.temp }}/maintenance-slither/slither.json
+          MAINTENANCE_OUTPUT: ${{ runner.temp }}/maintenance-evidence
+        run: node trusted/scripts/ci/platform-maintenance-runner.mjs post-attest
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: ${{ runner.temp }}/maintenance-evidence/post-merge-evidence.json
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: platform-maintenance-post-merge-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/maintenance-evidence/post-merge-evidence.json
+          if-no-files-found: error
+          retention-days: 2
+          overwrite: false

--- a/.github/workflows/platform-maintenance-release.yml
+++ b/.github/workflows/platform-maintenance-release.yml
@@ -21,6 +21,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    environment: platform-maintenance-policy
     outputs:
       producer_run: ${{ steps.consume.outputs.producer_run }}
       merge_sha: ${{ steps.consume.outputs.merge_sha }}
@@ -57,10 +58,30 @@ jobs:
           repository: programmablehq/PROGRAMMABLE
           path: ${{ runner.temp }}/maintenance-evidence
           digest-mismatch: error
+      - name: Resolve independently reviewed policy-reader source pins
+        id: policy
+        env:
+          MAINTENANCE_OUTPUT: ${{ runner.temp }}/maintenance-consumer
+        run: node trusted/scripts/ci/platform-maintenance-runner.mjs policy-config
+      - name: Create repository-scoped read-only policy token
+        id: policy_token
+        if: steps.policy.outputs.configured == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ steps.policy.outputs.app_id }}
+          private-key: ${{ secrets.PLATFORM_MAINTENANCE_POLICY_APP_PRIVATE_KEY }}
+          owner: programmablehq
+          repositories: PROGRAMMABLE
+          permission-administration: read
+          permission-metadata: read
+          skip-token-revoke: false
       - name: Verify provenance, all live bindings and protected merge policy
         id: consume
         env:
           GH_TOKEN: ${{ github.token }}
+          MAINTENANCE_POLICY_APP_ID: ${{ steps.policy.outputs.app_id }}
+          MAINTENANCE_POLICY_INSTALLATION_ID: ${{ steps.policy_token.outputs.installation-id }}
+          MAINTENANCE_POLICY_READ_TOKEN: ${{ steps.policy_token.outputs.token }}
           MAINTENANCE_PRODUCER: ${{ runner.temp }}/maintenance-consumer/producer.json
           MAINTENANCE_EVIDENCE: ${{ runner.temp }}/maintenance-evidence/evidence.json
           MAINTENANCE_OUTPUT: ${{ runner.temp }}/maintenance-consumer

--- a/.github/workflows/platform-maintenance-release.yml
+++ b/.github/workflows/platform-maintenance-release.yml
@@ -1,0 +1,131 @@
+name: Consume platform maintenance evidence
+
+on:
+  workflow_run:
+    workflows: [Verify platform maintenance]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: protected-platform-maintenance-main
+  cancel-in-progress: false
+
+jobs:
+  consume:
+    name: Verify immutable evidence and request ordinary protected merge
+    if: >-
+      github.repository_id == 1314365508 &&
+      github.ref == 'refs/heads/production' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    outputs:
+      producer_run: ${{ steps.consume.outputs.producer_run }}
+      merge_sha: ${{ steps.consume.outputs.merge_sha }}
+      merge_artifact: ${{ steps.upload.outputs.artifact-id }}
+    permissions:
+      actions: read
+      attestations: read
+      checks: write
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: trusted
+          persist-credentials: false
+          lfs: false
+          submodules: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.14.0
+      - name: Resolve exact successful producer, attempt and immutable artifact
+        id: producer
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAINTENANCE_PRODUCER_RUN: ${{ github.event.workflow_run.id }}
+          MAINTENANCE_OUTPUT: ${{ runner.temp }}/maintenance-consumer
+        run: node trusted/scripts/ci/platform-maintenance-runner.mjs resolve
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ steps.producer.outputs.artifact_id }}
+          run-id: ${{ steps.producer.outputs.run_id }}
+          github-token: ${{ github.token }}
+          repository: programmablehq/PROGRAMMABLE
+          path: ${{ runner.temp }}/maintenance-evidence
+          digest-mismatch: error
+      - name: Verify provenance, all live bindings and protected merge policy
+        id: consume
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAINTENANCE_PRODUCER: ${{ runner.temp }}/maintenance-consumer/producer.json
+          MAINTENANCE_EVIDENCE: ${{ runner.temp }}/maintenance-evidence/evidence.json
+          MAINTENANCE_OUTPUT: ${{ runner.temp }}/maintenance-consumer
+        run: node trusted/scripts/ci/platform-maintenance-runner.mjs consume
+      - id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: platform-maintenance-merge-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/maintenance-consumer/merge-observation.json
+          if-no-files-found: error
+          retention-days: 30
+          overwrite: false
+
+  dispatch:
+    name: Dispatch exact protected post-merge verification
+    needs: consume
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: read
+      attestations: read
+      actions: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: trusted
+          persist-credentials: false
+          lfs: false
+          submodules: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.14.0
+      - id: producer
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAINTENANCE_PRODUCER_RUN: ${{ needs.consume.outputs.producer_run }}
+          MAINTENANCE_OUTPUT: ${{ runner.temp }}/maintenance-dispatch
+        run: node trusted/scripts/ci/platform-maintenance-runner.mjs resolve
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ steps.producer.outputs.artifact_id }}
+          run-id: ${{ steps.producer.outputs.run_id }}
+          github-token: ${{ github.token }}
+          repository: programmablehq/PROGRAMMABLE
+          path: ${{ runner.temp }}/maintenance-evidence
+          digest-mismatch: error
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.consume.outputs.merge_artifact }}
+          path: ${{ runner.temp }}/maintenance-merge
+          digest-mismatch: error
+      - name: Revalidate actual merge and dispatch with separate Actions authority
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAINTENANCE_PRODUCER: ${{ runner.temp }}/maintenance-dispatch/producer.json
+          MAINTENANCE_EVIDENCE: ${{ runner.temp }}/maintenance-evidence/evidence.json
+          MAINTENANCE_MERGE_OBSERVATION: ${{ runner.temp }}/maintenance-merge/merge-observation.json
+          MAINTENANCE_OUTPUT: ${{ runner.temp }}/maintenance-dispatch
+        run: node trusted/scripts/ci/platform-maintenance-runner.mjs dispatch
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: platform-maintenance-dispatch-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/maintenance-dispatch/post-merge-dispatch.json
+          if-no-files-found: error
+          retention-days: 30
+          overwrite: false

--- a/.github/workflows/platform-maintenance-verify.yml
+++ b/.github/workflows/platform-maintenance-verify.yml
@@ -1,0 +1,243 @@
+name: Verify platform maintenance
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_run:
+    workflows: [Verify, Security, Verify hook builder intake feedback]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: Existing first-party main PR to revalidate against live GitHub state
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: platform-maintenance-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || inputs.pull_request }}
+  cancel-in-progress: true
+
+jobs:
+  select:
+    name: Select maintenance subject
+    if: >-
+      github.repository_id == 1314365508 &&
+      github.ref == 'refs/heads/production' &&
+      (github.event_name != 'workflow_run' ||
+       (github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.pull_requests[0].base.ref == 'main'))
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
+    outputs:
+      head_sha: ${{ steps.select.outputs.head_sha }}
+      subject_artifact: ${{ steps.upload.outputs.artifact-id }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: trusted
+          persist-credentials: false
+          lfs: false
+          submodules: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.14.0
+      - name: Verify the trusted policy and execution contracts
+        run: node --test trusted/scripts/test/platform-maintenance-release.test.mjs trusted/scripts/test/platform-maintenance-workflow.test.mjs
+      - id: select
+        name: Resolve current PR, exact trees and existing authoritative checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAINTENANCE_PR: ${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || inputs.pull_request }}
+          MAINTENANCE_OUTPUT: ${{ runner.temp }}/maintenance-subject
+        run: node trusted/scripts/ci/platform-maintenance-runner.mjs select
+      - id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: platform-maintenance-subject-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/maintenance-subject/subject.json
+          if-no-files-found: error
+          retention-days: 2
+          overwrite: false
+
+  foundry:
+    name: Exact head foundry
+    needs: select
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: trusted
+          persist-credentials: false
+          lfs: false
+          submodules: false
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.select.outputs.head_sha }}
+          path: candidate
+          fetch-depth: 0
+          persist-credentials: false
+          lfs: false
+          submodules: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.select.outputs.subject_artifact }}
+          path: ${{ runner.temp }}/maintenance-subject
+          digest-mismatch: error
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.14.0
+      - uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1
+        with:
+          version: v1.7.1
+      - name: Execute exact head with no signing, write or deployment credentials
+        env:
+          MAINTENANCE_SUBJECT: ${{ runner.temp }}/maintenance-subject/subject.json
+          MAINTENANCE_CANDIDATE: ${{ github.workspace }}/candidate
+          MAINTENANCE_LANE: foundry
+          MAINTENANCE_OUTPUT: ${{ runner.temp }}/maintenance-foundry
+        run: node trusted/scripts/ci/platform-maintenance-runner.mjs worker
+      - id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: platform-maintenance-foundry-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/maintenance-foundry/foundry.json
+          if-no-files-found: error
+          retention-days: 2
+          overwrite: false
+    outputs:
+      artifact: ${{ steps.upload.outputs.artifact-id }}
+
+  slither:
+    name: Exact head slither
+    needs: select
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: trusted
+          persist-credentials: false
+          lfs: false
+          submodules: false
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.select.outputs.head_sha }}
+          path: candidate
+          fetch-depth: 0
+          persist-credentials: false
+          lfs: false
+          submodules: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.select.outputs.subject_artifact }}
+          path: ${{ runner.temp }}/maintenance-subject
+          digest-mismatch: error
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.14.0
+      - uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1
+        with:
+          version: v1.7.1
+      - name: Install exact Slither
+        run: pipx install slither-analyzer==0.11.5
+      - name: Execute exact head scan and fail on every unbound finding
+        env:
+          MAINTENANCE_SUBJECT: ${{ runner.temp }}/maintenance-subject/subject.json
+          MAINTENANCE_CANDIDATE: ${{ github.workspace }}/candidate
+          MAINTENANCE_LANE: slither
+          MAINTENANCE_OUTPUT: ${{ runner.temp }}/maintenance-slither
+        run: node trusted/scripts/ci/platform-maintenance-runner.mjs worker
+      - name: Retain scan diagnostics without granting approval
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: platform-maintenance-slither-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/maintenance-slither/slither.raw.json
+          if-no-files-found: warn
+          retention-days: 7
+          overwrite: false
+      - id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: platform-maintenance-slither-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/maintenance-slither/slither.json
+          if-no-files-found: error
+          retention-days: 2
+          overwrite: false
+    outputs:
+      artifact: ${{ steps.upload.outputs.artifact-id }}
+
+  attest:
+    name: Attest maintenance evidence
+    needs: [select, foundry, slither]
+    if: >-
+      always() && needs.select.result == 'success' &&
+      needs.foundry.result == 'success' && needs.slither.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: trusted
+          persist-credentials: false
+          lfs: false
+          submodules: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.14.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.select.outputs.subject_artifact }}
+          path: ${{ runner.temp }}/maintenance-subject
+          digest-mismatch: error
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.foundry.outputs.artifact }}
+          path: ${{ runner.temp }}/maintenance-foundry
+          digest-mismatch: error
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.slither.outputs.artifact }}
+          path: ${{ runner.temp }}/maintenance-slither
+          digest-mismatch: error
+      - name: Revalidate and assemble inert technical evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAINTENANCE_SUBJECT: ${{ runner.temp }}/maintenance-subject/subject.json
+          MAINTENANCE_FOUNDRY: ${{ runner.temp }}/maintenance-foundry/foundry.json
+          MAINTENANCE_SLITHER: ${{ runner.temp }}/maintenance-slither/slither.json
+          MAINTENANCE_OUTPUT: ${{ runner.temp }}/maintenance-evidence
+        run: node trusted/scripts/ci/platform-maintenance-runner.mjs attest
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: ${{ runner.temp }}/maintenance-evidence/evidence.json
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: platform-maintenance-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/maintenance-evidence/evidence.json
+          if-no-files-found: error
+          retention-days: 2
+          overwrite: false

--- a/scripts/ci/platform-maintenance-README.md
+++ b/scripts/ci/platform-maintenance-README.md
@@ -35,6 +35,10 @@ The producer first checks the existing successful `foundry`,
 their actual GitHub Actions app, run, workflow path, PR/base/head identity, job
 and current run attempt. A name-only status, skipped job, old attempt, wrong
 workflow or another repository does not satisfy the policy.
+Job identity is resolved through its actual URL and `check_run_url`, with the
+check suite bound independently to the workflow run. For `pull_request_target`,
+the REST run/job/check head is the PR subject; it does not identify the separate
+trusted default-branch workflow source.
 
 Two fresh runners then independently execute the exact candidate head:
 
@@ -60,8 +64,9 @@ attempt, immutable artifact ID/digest and repository metadata.
 The consumer checks the exact signer workflow, source ref, source SHA, signer
 SHA and hosted-runner provenance with `gh attestation verify`. It then checks
 the live PR, current protected refs, source tree and all technical observations
-again. It can publish a real technical `platform-maintenance-release` success
-before protection migration; that publication alone never requests a merge.
+again. It publishes real technical `platform-maintenance-evidence` separately
+from the required `platform-maintenance-release` context. A technical success
+before protection migration never satisfies the required release context.
 
 The merge operation separately requires the complete target branch protection.
 It uses the ordinary GitHub squash-merge endpoint with the exact head `sha`.
@@ -70,6 +75,115 @@ head/base/check drift withdraws the consumer's success context. The returned
 squash commit is read back and must have the selected base as its sole parent
 and the selected canonical merge tree. An ambiguous API result is a failure,
 not a claim that a merge did or did not occur.
+
+There is one publication-and-consumption entry. It first replaces any old
+release context with `in_progress`, then publishes technical evidence. All
+later operations, including early revalidation and post-merge readback, are
+inside its withdrawal scope. An intentionally unmet protection rule or a
+missing policy reader may preserve only technical success, after another fresh
+subject, technical-run and expiry verification; the release context fails.
+Only after a successful separate policy read and complete protection check can
+the release context succeed. Policy, subject and technical state are read again
+before the conditional merge. If withdrawal cannot be confirmed, the controller
+reports uncertain state and requires reconciliation.
+
+## Policy-read authority is an activation blocker
+
+The complete classic branch-protection read requires repository
+`Administration:read`, which is not an available `GITHUB_TOKEN` workflow
+permission. The ordinary GitHub client explicitly refuses protection reads.
+The consumer uses a separate App token and closed policy-reader transport for
+that purpose. Its source pins are initially `policyReadAuthority: null`, so
+automatic merging remains unconfigured. Missing configuration has the specific
+failure `MAINTENANCE_POLICY_READ_AUTHORITY_UNCONFIGURED`; an authenticated but
+forbidden protection read has `MAINTENANCE_PROTECTION_READ_AUTHORITY_REQUIRED`.
+No fallback accepts a missing policy, manually supplied JSON or a named status.
+See GitHub's [branch-protection API permissions](https://docs.github.com/en/rest/branches/branch-protection#get-branch-protection)
+and [workflow token permissions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions).
+
+The inspected private admission App implementation allows `checks:write` and
+`contents/metadata/pull_requests:read`. The separate release-read App
+implementation binds exact `actions/attestations/contents/metadata/pull_requests`
+read scopes and rejects additional permissions. Neither existing source path
+proves the necessary administration authority, and neither is silently reused
+or broadened by this candidate. No installation token or credential was read
+or issued during implementation.
+
+The one-time setup is concrete:
+
+1. Establish a dedicated private App named **Programmable Maintenance Policy
+   Reader**, owned by **programmablehq**, with the configuration below. This is
+   the proposed registration name, not a claim an App already exists. Limit its
+   installation to Public repository
+   `programmablehq/PROGRAMMABLE`, numeric ID `1314365508`, with only
+   `Administration:read` and mandatory `Metadata:read`. Do not extend the
+   existing admission or release-reader App scope contracts. Do not add this
+   App to any bypass list or grant it check, content, merge or settings writes.
+2. Configure environment `platform-maintenance-policy` to allow only protected
+   `production`. Store the App private key there under
+   `PLATFORM_MAINTENANCE_POLICY_APP_PRIVATE_KEY`, not as a broadly available
+   repository secret. This environment needs no recurring manual-review gate.
+3. Independently review the observed numeric App and installation IDs, then
+   replace the null `policyReadAuthority` in protected controller source with
+   the exact `appId` and `installationId`. No PR, artifact, workflow input or
+   mutable repository variable can provide these expected pins. This changes
+   the policy hash and requires new source-bound producer evidence.
+4. Verify one real read of the complete current `main` protection with this
+   configured workflow before migrating the branch rule. A successful local
+   fixture or an owner token read does not prove the installed App's authority.
+
+Minimal inert manifest candidate; this document does not submit it:
+
+```json
+{
+  "name": "Programmable Maintenance Policy Reader",
+  "url": "https://programmable.family",
+  "public": false,
+  "hook_attributes": {
+    "url": "https://programmable.family/.well-known/disabled-github-app-webhook",
+    "active": false
+  },
+  "request_oauth_on_install": false,
+  "setup_on_update": false,
+  "default_permissions": {
+    "administration": "read",
+    "metadata": "read"
+  },
+  "default_events": []
+}
+```
+
+Choose the organization owner `programmablehq` when registering. Select only
+`PROGRAMMABLE` when installing; neither owner selection nor repository selection
+is inferred from the manifest. Leave webhook delivery, OAuth user authorization,
+callbacks and event subscriptions disabled. No repository or organization
+variable is required. The sole credential name is the environment secret
+`PLATFORM_MAINTENANCE_POLICY_APP_PRIVATE_KEY`; the only source-pin fields are
+numeric `policyReadAuthority.appId` and `policyReadAuthority.installationId`.
+Repository ID, repository name and target branch remain fixed in source policy.
+
+The protected workflow automatically creates a fresh installation token using
+the SHA-pinned `actions/create-github-app-token` action, explicit repository
+selection and explicit read-only permissions. It checks the returned
+installation ID against source policy. The key is passed only to that pinned
+action; the token is passed only to the closed policy reader and revoked at
+job completion. The reader checks `/installation/repositories` is exactly the
+selected numeric repository, then performs only the exact `main` protection
+GET. It checks the response URL is the selected branch, and repeats scope and
+policy reads before merge. Credentials never enter artifacts or error text.
+See the [official App-token action](https://github.com/actions/create-github-app-token/tree/bcd2ba49218906704ab6c1aa796996da409d3eb1)
+and [installation repository-scope API](https://docs.github.com/en/rest/apps/installations#list-repositories-accessible-to-the-app-installation).
+
+This integration is implemented but its App, environment, key and source pins
+are not provisioned by the candidate. After the one-time setup, policy reads
+are automatic for every merge; no manual policy JSON is part of the run path.
+Candidate workers, the evidence issuer and the post-merge dispatcher never
+receive this credential.
+
+Public ruleset metadata is not substituted for this read: it does not represent
+the existing classic protection, and a ruleset response can omit bypass actors.
+A policy observation for `main` never authorizes a `production` PR or website
+promotion. Production is only this lane's trusted controller source.
 
 ## Slither baseline
 
@@ -128,15 +242,17 @@ deployment/phase controllers retain their separate authority and evidence.
    an already-open PR, dispatch `Verify platform maintenance` on production
    with only its PR number. GitHub refetch, not that selector, chooses the
    authorized source. New ordinary PRs trigger automatically.
-4. Obtain a real successful producer and authenticated technical check at the
+4. Obtain a real successful producer and authenticated technical
+   `platform-maintenance-evidence` check at the
    current exact head. If Slither finds anything, review its actual diagnostics
    and land any justified exact-source disposition through a new protected
    production policy revision, then regenerate the evidence. Do not replace
    the empty baseline with a blanket allowlist. The consumer still refuses
    merge while the old protection rule is active.
-5. Read back the new successful check and its authentic GitHub Actions app
+5. Read back the new successful technical check and its authentic GitHub Actions app
    (`15368`), source/CI/Sigstore evidence and live PR/base/head. Only after that
-   evidence and the source policy have been reviewed, migrate `main` to the
+   evidence and the source policy have been reviewed, and the separately bound
+   policy-read authority above is installed and tested, configure `main` with the
    following **persistent replacement**, preserving any stronger unrelated
    rules: strict required checks `foundry`, `security`,
    `hook-builder-maintenance`, `public-intake`, `platform-maintenance-release`,
@@ -144,6 +260,10 @@ deployment/phase controllers retain their separate authority and evidence.
    pushes and deletion off. The machine rule replaces the internal maintenance
    requirement for one human review, CODEOWNER review and last-push approval.
    Do not remove a required technical check or temporarily bypass protection.
+   Add the required `platform-maintenance-release` context before retiring the
+   human-only rule: its pending/failure/missing state keeps the branch closed.
+   The successful bootstrap evidence has a different name and cannot satisfy
+   it. This avoids both a circular trigger bootstrap and an unprotected window.
 6. Regenerate the producer at the unchanged current subject, or let the next
    authentic technical-completion event do so. The consumer revalidates the
    rule and all evidence, requests the conditional protected merge, reads back
@@ -161,9 +281,10 @@ receipts to avoid that integration requirement.
 
 The existing admission App candidate has `checks:write` and only
 `pull_requests:read`; its approved-review orchestrator consumes an existing
-authenticated review and does not author `APPROVE` reviews. No new App, key,
-credential, bot self-review or administrative bypass is required by this
-maintenance gate. Initial developer branch publication uses the existing
+authenticated review and does not author `APPROVE` reviews. This candidate
+creates no App, key, credential, bot self-review or administrative bypass.
+Automatic merging still requires the separately reviewed one-time policy-reader
+setup described above. Initial developer branch publication uses the existing
 authorized developer/agent path; this workflow does not autonomously create
 arbitrary candidate branches or pull requests.
 

--- a/scripts/ci/platform-maintenance-README.md
+++ b/scripts/ci/platform-maintenance-README.md
@@ -1,0 +1,181 @@
+# Internal platform maintenance publication
+
+This is a source candidate for a bounded Public `main` maintenance gate. It
+does not change GitHub settings, produce a GitHub review, deploy the website,
+or confer application, wallet, provider, financial or onchain authority.
+
+The inspected public repository is `programmablehq/PROGRAMMABLE`, repository
+ID `1314365508`. Its default branch and website branch are **production**.
+`main` is the contracts and release-evidence branch. The controller workflows
+live on protected `production`; candidate execution uses a separately checked
+out exact `main` PR head. No new workflow needs to be installed on `main` to be
+discovered by the default-branch triggers.
+
+## Source and execution boundaries
+
+`platform-maintenance-policy.mjs` is the closed policy. It accepts only an open,
+non-draft, mergeable, first-party `main` PR whose author currently has repository
+write authority. Source, test and documentation additions/modifications have a
+bounded path and file-mode policy. Submissions, renames, removals, symlinks,
+unknown paths and analyzer-suppression changes do not receive this authority.
+
+The policy preserves the existing exceptional CI-control subject:
+
+- Commit `e15bb397604a19d6622af5a5ee9622a8edac9d18`.
+- Tree `92eecc16da2c59b87295fcb4012e57fe4f1feae7`.
+- Only its listed CI/configuration/generated-validator paths are exceptions.
+
+That pin already exists in the protected `verify-hook-builder.yml` control
+guard. This candidate does not change it. A different control-plane change,
+including a change to this gate or its baseline, needs a separately reviewed
+protected-source policy revision. A PR cannot supply its own new pin.
+
+The producer first checks the existing successful `foundry`,
+`hook-builder-maintenance`, `security` and `public-intake` checks. It refetches
+their actual GitHub Actions app, run, workflow path, PR/base/head identity, job
+and current run attempt. A name-only status, skipped job, old attempt, wrong
+workflow or another repository does not satisfy the policy.
+
+Two fresh runners then independently execute the exact candidate head:
+
+- Foundry 1.7.1 with the existing CI fuzz/invariant profile and Solidity 0.8.26;
+  formatting, build and actual nonempty successful test results are required.
+- Slither 0.11.5 with complete JSON output and no unclassified diagnostics;
+  every reported detector, including informational results, must be accounted
+  for by the trusted disposition policy.
+
+Both execution jobs have only a read token, no token in the tool environment,
+no OIDC grant, no application secrets and no deployment credentials. The only
+bootstrap script they execute must be unchanged from the trusted PR base.
+Foundry FFI is disabled and filesystem permissions must be read-only. Artifact
+or candidate bytes are never executed in the issuer, consumer or dispatch job.
+
+The isolated issuer reparses both worker records, revalidates the live subject
+and existing checks, and uses the existing GitHub OIDC/Sigstore attestation
+mechanism. The resulting `programmable.platform-maintenance-evidence.v1` is
+distinct from production Verify, application-admission and launch receipts.
+The evidence lifetime is one hour. Artifacts are selected by exact run,
+attempt, immutable artifact ID/digest and repository metadata.
+
+The consumer checks the exact signer workflow, source ref, source SHA, signer
+SHA and hosted-runner provenance with `gh attestation verify`. It then checks
+the live PR, current protected refs, source tree and all technical observations
+again. It can publish a real technical `platform-maintenance-release` success
+before protection migration; that publication alone never requests a merge.
+
+The merge operation separately requires the complete target branch protection.
+It uses the ordinary GitHub squash-merge endpoint with the exact head `sha`.
+Strict/up-to-date required checks remain GitHub's base-race protection. A later
+head/base/check drift withdraws the consumer's success context. The returned
+squash commit is read back and must have the selected base as its sole parent
+and the selected canonical merge tree. An ambiguous API result is a failure,
+not a claim that a merge did or did not occur.
+
+## Slither baseline
+
+The initial baseline is deliberately empty. The existing main security job's
+`--fail-none` is reporting behavior, not a finding disposition. Existing
+`production/contracts/security/` reports for other source graphs are not
+imported or relabeled.
+
+If a scan reports findings, it fails and retains the raw scan as a diagnostic
+artifact. No maintenance-approval artifact is issued. To authorize a known
+finding, an independently reviewed policy revision must contain its complete
+finding hash, full analysis source-tree/toolchain hash, explicit disposition,
+substantive rationale, reviewed source commit and protected evidence path/blob.
+The controller verifies that the referenced evidence blob actually exists at
+its own immutable source revision. A changed analysis source or finding does
+not inherit an old disposition. This conservative policy can therefore require
+new triage when an existing disposition's source closure changes.
+
+## Automatic post-merge verification
+
+A `GITHUB_TOKEN` merge does not trigger a new `push` workflow. This controller
+does not rely on that event. After a successful merge, a separate job with
+`actions:write` and only `contents:read` authenticates the original evidence and
+actual merged PR/commit again, then explicitly dispatches
+`platform-maintenance-post-merge.yml` on the exact protected controller source.
+
+The dispatch contains the actual returned merge SHA, original PR, original
+evidence producer and controller SHA. The receiving workflow requires that SHA
+to remain the protected `main` tip, with the exact parent/tree and original PR
+head. It reruns both unprivileged workers and separately attests
+`programmable.platform-maintenance-post-merge-evidence.v1`. A dispatch receipt
+states only that dispatch was accepted; the post-merge verification run must
+actually succeed before reporting publication as remotely verified.
+
+This completes the bounded Public contracts-source publication/verification
+chain. It does not promote a Vercel candidate or deploy contracts. The existing
+website production Verify/staging/promotion controllers and private backend
+deployment/phase controllers retain their separate authority and evidence.
+
+## Integration-owner bootstrap sequence
+
+1. Review the exact additive source commit and independent local checks. This
+   worktree started at protected production
+   `53e0b1b338a17ac451072ec18c58cbc34129ce39`; revalidate current production
+   before integration. The current GitHub billing lock is an external hold:
+   do not retry CI or change account/payment settings through this workflow.
+2. Once hosted CI can run again, open/verify the additive candidate against
+   `production` and complete the existing protected production checks. Merge
+   through ordinary protection. Production currently needs no human PR review;
+   this step does not require changing `main`'s review rule, CODEOWNERS or any
+   required status. It is the one-time source-policy bootstrap, not a recurring
+   fabricated reviewer action.
+3. Confirm all three workflow files and helper files exist at the exact
+   protected default-branch SHA. The producer's `pull_request_target` and
+   technical-completion `workflow_run` triggers now discover this source. For
+   an already-open PR, dispatch `Verify platform maintenance` on production
+   with only its PR number. GitHub refetch, not that selector, chooses the
+   authorized source. New ordinary PRs trigger automatically.
+4. Obtain a real successful producer and authenticated technical check at the
+   current exact head. If Slither finds anything, review its actual diagnostics
+   and land any justified exact-source disposition through a new protected
+   production policy revision, then regenerate the evidence. Do not replace
+   the empty baseline with a blanket allowlist. The consumer still refuses
+   merge while the old protection rule is active.
+5. Read back the new successful check and its authentic GitHub Actions app
+   (`15368`), source/CI/Sigstore evidence and live PR/base/head. Only after that
+   evidence and the source policy have been reviewed, migrate `main` to the
+   following **persistent replacement**, preserving any stronger unrelated
+   rules: strict required checks `foundry`, `security`,
+   `hook-builder-maintenance`, `public-intake`, `platform-maintenance-release`,
+   each pinned to app `15368`; admin enforcement on; linear history on; force
+   pushes and deletion off. The machine rule replaces the internal maintenance
+   requirement for one human review, CODEOWNER review and last-push approval.
+   Do not remove a required technical check or temporarily bypass protection.
+6. Regenerate the producer at the unchanged current subject, or let the next
+   authentic technical-completion event do so. The consumer revalidates the
+   rule and all evidence, requests the conditional protected merge, reads back
+   the actual commit and automatically dispatches post-merge verification.
+   Confirm that separate run and its attested result, not merely dispatch
+   acceptance or an earlier green job.
+
+The new branch-required context is deliberately a closed **internal** lane.
+Application submissions cannot pass it. Before using a global branch rule for
+both lanes, preserve an independently authenticated application-admission
+route, or explicitly leave application merges held. Do not make an unknown,
+external, skipped or application classification a successful maintenance no-op.
+This candidate does not install an application reviewer or alter application
+receipts to avoid that integration requirement.
+
+The existing admission App candidate has `checks:write` and only
+`pull_requests:read`; its approved-review orchestrator consumes an existing
+authenticated review and does not author `APPROVE` reviews. No new App, key,
+credential, bot self-review or administrative bypass is required by this
+maintenance gate. Initial developer branch publication uses the existing
+authorized developer/agent path; this workflow does not autonomously create
+arbitrary candidate branches or pull requests.
+
+## Local checks
+
+```sh
+node --test scripts/test/platform-maintenance-release.test.mjs scripts/test/platform-maintenance-workflow.test.mjs
+actionlint .github/workflows/platform-maintenance-verify.yml .github/workflows/platform-maintenance-release.yml .github/workflows/platform-maintenance-post-merge.yml
+```
+
+The tests use inert fixtures and mocked GitHub transport. They do not sign,
+broadcast, dispatch, change repository protection, call a live RPC, access
+production secrets or claim successful hosted workflow execution. Hosted
+execution, real Slither dispositions, protection migration and post-merge
+evidence remain independent activation evidence.

--- a/scripts/ci/platform-maintenance-evidence.mjs
+++ b/scripts/ci/platform-maintenance-evidence.mjs
@@ -1,0 +1,183 @@
+import {
+  MAINTENANCE_POLICY, REQUIRED_LEGACY_CHECKS, canonical, digest, exactKeys, executionBinding, hash,
+  oid, requireValue, safePath, snapshotJson, validateSubject,
+} from "./platform-maintenance-policy.mjs";
+
+export const EVIDENCE_SCHEMA = "programmable.platform-maintenance-evidence.v1";
+export const WORKER_SCHEMA = "programmable.platform-maintenance-worker.v1";
+
+export function slitherAnalysisHash(subject, policy = MAINTENANCE_POLICY) {
+  const execution = executionBinding(subject, policy);
+  return digest({ domain: "programmable.platform-maintenance-slither-input.v1",
+    sourceTree: execution.sourceTree, slither: policy.slitherVersion, solc: policy.solcVersion,
+    foundry: policy.foundryVersion });
+}
+
+export function evaluateSlither(raw, subjectValue, policy = MAINTENANCE_POLICY) {
+  const { subject } = executionBinding(subjectValue, policy);
+  const report = snapshotJson(raw);
+  requireValue(report.success === true && (report.error === null || report.error === "")
+    && report.results && Array.isArray(report.results.detectors), "MAINTENANCE_SLITHER_INCOMPLETE");
+  requireValue(report.results.detectors.length <= 10000, "MAINTENANCE_SLITHER_TOO_LARGE");
+  const findings = report.results.detectors.map((finding) => {
+    requireValue(typeof finding.check === "string" && /^[a-z0-9-]{1,128}$/.test(finding.check)
+      && ["High", "Medium", "Low", "Informational", "Optimization"].includes(finding.impact)
+      && ["High", "Medium", "Low"].includes(finding.confidence)
+      && typeof finding.description === "string" && finding.description.length > 0
+      && /^[0-9a-f]{64}$/.test(finding.id)
+      && Array.isArray(finding.elements) && finding.elements.length > 0,
+    "MAINTENANCE_SLITHER_FINDING_INVALID");
+    const locations = finding.elements.map((element) => {
+      const source = element.source_mapping;
+      requireValue(source && safePath(source.filename_relative)
+        && Number.isSafeInteger(source.start) && source.start >= 0
+        && Number.isSafeInteger(source.length) && source.length > 0
+        && Array.isArray(source.lines) && source.lines.length > 0
+        && source.lines.every((line) => Number.isSafeInteger(line) && line > 0),
+      "MAINTENANCE_SLITHER_LOCATION_INVALID");
+      return { path: source.filename_relative, start: source.start, length: source.length, lines: source.lines };
+    });
+    return { id: finding.id, check: finding.check, impact: finding.impact, confidence: finding.confidence,
+      description: finding.description, locations };
+  });
+  const findingHashes = findings.map((finding) => digest({
+    domain: "programmable.platform-maintenance-slither-finding.v1", finding,
+  }));
+  requireValue(new Set(findingHashes).size === findings.length
+    && new Set(findings.map((finding) => finding.id)).size === findings.length,
+  "MAINTENANCE_SLITHER_DUPLICATE_FINDING");
+  const analysisHash = slitherAnalysisHash(subject, policy);
+  const dispositions = snapshotJson(policy.slitherDispositions);
+  const accepted = new Set();
+  for (const disposition of dispositions) {
+    exactKeys(disposition, ["findingHash", "analysisHash", "disposition", "rationale",
+      "reviewedSourceCommit", "evidencePath", "evidenceBlob"]);
+    requireValue(hash(disposition.findingHash) && hash(disposition.analysisHash)
+      && ["false-positive", "accepted-risk"].includes(disposition.disposition)
+      && typeof disposition.rationale === "string" && disposition.rationale.trim().length >= 40
+      && oid(disposition.reviewedSourceCommit) && safePath(disposition.evidencePath)
+      && oid(disposition.evidenceBlob), "MAINTENANCE_SLITHER_DISPOSITION_INVALID");
+    // Dispositions for a different analysis source are not reusable exceptions.
+    if (disposition.analysisHash !== analysisHash) continue;
+    requireValue(!accepted.has(disposition.findingHash), "MAINTENANCE_SLITHER_DUPLICATE_DISPOSITION");
+    accepted.add(disposition.findingHash);
+  }
+  const unresolved = findingHashes.filter((findingHash) => !accepted.has(findingHash));
+  requireValue(unresolved.length === 0, "MAINTENANCE_SLITHER_UNRESOLVED_FINDING");
+  requireValue([...accepted].every((findingHash) => findingHashes.includes(findingHash)),
+    "MAINTENANCE_SLITHER_STALE_DISPOSITION");
+  return snapshotJson({ analysisHash, findingHashes: [...findingHashes].sort(),
+    dispositionHash: digest(dispositions), rawReportHash: digest(report) });
+}
+
+export function validateWorker(value, subjectValue, lane, policy = MAINTENANCE_POLICY) {
+  const { subject, sourceCommit, sourceTree } = executionBinding(subjectValue, policy);
+  const worker = snapshotJson(value);
+  exactKeys(worker, ["schema", "lane", "subjectHash", "sourceCommit", "sourceTree", "foundryVersion",
+    "solcVersion", "slitherVersion", "testCount", "testReportHash", "slitherReport"]);
+  requireValue(worker.schema === WORKER_SCHEMA && worker.lane === lane
+    && worker.subjectHash === digest(subject) && worker.sourceCommit === sourceCommit
+    && worker.sourceTree === sourceTree && worker.foundryVersion === policy.foundryVersion
+    && worker.solcVersion === policy.solcVersion, "MAINTENANCE_WORKER_BINDING_INVALID");
+  if (lane === "foundry") {
+    requireValue(Number.isSafeInteger(worker.testCount) && worker.testCount > 0 && hash(worker.testReportHash)
+      && worker.slitherVersion === null && worker.slitherReport === null, "MAINTENANCE_TEST_EVIDENCE_INVALID");
+  } else {
+    requireValue(lane === "slither" && worker.slitherVersion === policy.slitherVersion
+      && worker.testCount === null && worker.testReportHash === null, "MAINTENANCE_SCAN_EVIDENCE_INVALID");
+    evaluateSlither(worker.slitherReport, subject, policy);
+  }
+  return worker;
+}
+
+export function createPostMergeEvidence({ subject: input, foundry, slither, runId, runAttempt, issuedAt },
+  policy = MAINTENANCE_POLICY) {
+  const { subject } = executionBinding(input, policy);
+  requireValue(subject.schema === "programmable.platform-maintenance-post-merge-subject.v1"
+    && Number.isSafeInteger(runId) && runId > 0 && Number.isSafeInteger(runAttempt) && runAttempt > 0
+    && Number.isSafeInteger(issuedAt) && issuedAt > 0, "MAINTENANCE_POST_MERGE_PRODUCER_INVALID");
+  return snapshotJson({ schema: "programmable.platform-maintenance-post-merge-evidence.v1", subject,
+    producer: { workflow: policy.postMergeWorkflow, sourceCommit: subject.original.controllerSha, runId, runAttempt },
+    issuedAt, authority: "protected-main-post-merge-local-verification-only",
+    foundry: validateWorker(foundry, subject, "foundry", policy),
+    slither: validateWorker(slither, subject, "slither", policy),
+    websiteDeployment: false, applicationAuthority: false, onchainAuthority: false });
+}
+
+export function validateLegacyChecks(observationValue, subjectValue, policy = MAINTENANCE_POLICY) {
+  const subject = validateSubject(subjectValue, policy);
+  const observation = snapshotJson(observationValue);
+  exactKeys(observation, ["checks", "runs", "jobs"]);
+  requireValue([observation.checks, observation.runs, observation.jobs].every(Array.isArray),
+    "MAINTENANCE_CHECK_OBSERVATION_INVALID");
+  return REQUIRED_LEGACY_CHECKS.map((required) => {
+    const checks = observation.checks.filter((check) => check.name === required.name)
+      .sort((left, right) => right.id - left.id);
+    const check = checks[0];
+    requireValue(check && check.status === "completed" && check.conclusion === "success"
+      && check.head_sha === subject.headSha && check.app?.id === policy.githubActionsAppId
+      && check.app.slug === "github-actions" && check.app.owner?.login === "github",
+    "MAINTENANCE_REQUIRED_CHECK_NOT_AUTHENTICATED");
+    const details = new RegExp(`^https://github\\.com/${policy.repository}/actions/runs/([1-9][0-9]*)/job/([1-9][0-9]*)$`)
+      .exec(check.details_url);
+    requireValue(details && Number(details[2]) === check.id, "MAINTENANCE_CHECK_RUN_IDENTITY_INVALID");
+    const runId = Number(details[1]);
+    const run = observation.runs.find((item) => item.id === runId);
+    const job = observation.jobs.find((item) => item.id === check.id);
+    requireValue(run && job && run.path === required.path
+      && run.repository?.id === policy.repositoryId && run.head_repository?.id === policy.repositoryId
+      && run.head_sha === subject.headSha && run.status === "completed" && run.conclusion === "success"
+      && run.event === (required.name === "public-intake" ? "pull_request_target" : "pull_request")
+      && run.pull_requests?.some((pr) => pr.number === subject.pullRequest && pr.base?.sha === subject.baseSha
+        && pr.head?.sha === subject.headSha && pr.head.repo?.id === policy.repositoryId
+        && pr.base.repo?.id === policy.repositoryId)
+      && Number.isSafeInteger(run.run_attempt) && run.run_attempt > 0
+      && job.run_id === runId && job.run_attempt === run.run_attempt && job.head_sha === subject.headSha
+      && job.status === "completed" && job.conclusion === "success" && job.name === required.name,
+    "MAINTENANCE_CHECK_WORKFLOW_MISMATCH");
+    return { name: required.name, workflow: required.path, appId: check.app.id,
+      checkId: check.id, runId, runAttempt: run.run_attempt };
+  });
+}
+
+export function createEvidence({ subject: inputSubject, foundry, slither, legacyObservation,
+  runId, runAttempt, issuedAt }, policy = MAINTENANCE_POLICY) {
+  const subject = validateSubject(inputSubject, policy);
+  requireValue(Number.isSafeInteger(runId) && runId > 0 && Number.isSafeInteger(runAttempt)
+    && runAttempt > 0 && Number.isSafeInteger(issuedAt) && issuedAt > 0, "MAINTENANCE_PRODUCER_INVALID");
+  const foundryWorker = validateWorker(foundry, subject, "foundry", policy);
+  const slitherWorker = validateWorker(slither, subject, "slither", policy);
+  const checks = validateLegacyChecks(legacyObservation, subject, policy);
+  return snapshotJson({ schema: EVIDENCE_SCHEMA, subject,
+    producer: { workflow: policy.producerWorkflow, sourceCommit: subject.controllerSha, runId, runAttempt },
+    issuedAt, expiresAt: issuedAt + policy.maxAgeMs,
+    authority: "internal-platform-source-consistency-only", foundry: foundryWorker, slither: slitherWorker,
+    checks, decision: "eligible-for-protected-maintenance-merge" });
+}
+
+// A valid JSON object is not a signature. The production consumer first
+// authenticates the exact immutable artifact with GitHub/Sigstore, then calls
+// this verifier with independently resolved run, checkout and current PR data.
+export function verifyEvidence(value, expected, policy = MAINTENANCE_POLICY) {
+  const evidence = snapshotJson(value);
+  const bound = snapshotJson(expected);
+  exactKeys(evidence, ["schema", "subject", "producer", "issuedAt", "expiresAt", "authority",
+    "foundry", "slither", "checks", "decision"]);
+  exactKeys(evidence.producer, ["workflow", "sourceCommit", "runId", "runAttempt"]);
+  requireValue(evidence.schema === EVIDENCE_SCHEMA && evidence.authority === "internal-platform-source-consistency-only"
+    && evidence.decision === "eligible-for-protected-maintenance-merge", "MAINTENANCE_EVIDENCE_SCHEMA_INVALID");
+  const subject = validateSubject(evidence.subject, policy);
+  requireValue(canonical(subject) === canonical(validateSubject(bound.subject, policy))
+    && evidence.producer.workflow === policy.producerWorkflow
+    && evidence.producer.sourceCommit === subject.controllerSha
+    && evidence.producer.runId === bound.runId && evidence.producer.runAttempt === bound.runAttempt,
+  "MAINTENANCE_EVIDENCE_SUBJECT_DRIFT");
+  requireValue(Number.isSafeInteger(bound.now) && Number.isSafeInteger(evidence.issuedAt)
+    && evidence.issuedAt <= bound.now && evidence.expiresAt === evidence.issuedAt + policy.maxAgeMs
+    && evidence.expiresAt > bound.now, "MAINTENANCE_EVIDENCE_EXPIRED");
+  validateWorker(evidence.foundry, subject, "foundry", policy);
+  validateWorker(evidence.slither, subject, "slither", policy);
+  requireValue(canonical(evidence.checks) === canonical(validateLegacyChecks(bound.legacyObservation, subject, policy)),
+    "MAINTENANCE_TECHNICAL_EVIDENCE_DRIFT");
+  return snapshotJson({ subject, evidenceHash: digest(evidence), expiresAt: evidence.expiresAt });
+}

--- a/scripts/ci/platform-maintenance-evidence.mjs
+++ b/scripts/ci/platform-maintenance-evidence.mjs
@@ -120,10 +120,11 @@ export function validateLegacyChecks(observationValue, subjectValue, policy = MA
     "MAINTENANCE_REQUIRED_CHECK_NOT_AUTHENTICATED");
     const details = new RegExp(`^https://github\\.com/${policy.repository}/actions/runs/([1-9][0-9]*)/job/([1-9][0-9]*)$`)
       .exec(check.details_url);
-    requireValue(details && Number(details[2]) === check.id, "MAINTENANCE_CHECK_RUN_IDENTITY_INVALID");
-    const runId = Number(details[1]);
+    requireValue(details && Number.isSafeInteger(check.id) && check.id > 0,
+      "MAINTENANCE_CHECK_RUN_IDENTITY_INVALID");
+    const runId = Number(details[1]); const jobId = Number(details[2]);
     const run = observation.runs.find((item) => item.id === runId);
-    const job = observation.jobs.find((item) => item.id === check.id);
+    const job = observation.jobs.find((item) => item.id === jobId);
     requireValue(run && job && run.path === required.path
       && run.repository?.id === policy.repositoryId && run.head_repository?.id === policy.repositoryId
       && run.head_sha === subject.headSha && run.status === "completed" && run.conclusion === "success"
@@ -132,11 +133,15 @@ export function validateLegacyChecks(observationValue, subjectValue, policy = MA
         && pr.head?.sha === subject.headSha && pr.head.repo?.id === policy.repositoryId
         && pr.base.repo?.id === policy.repositoryId)
       && Number.isSafeInteger(run.run_attempt) && run.run_attempt > 0
+      && Number.isSafeInteger(run.check_suite_id) && run.check_suite_id > 0
+      && check.check_suite?.id === run.check_suite_id
       && job.run_id === runId && job.run_attempt === run.run_attempt && job.head_sha === subject.headSha
+      && job.check_run_url === `https://api.github.com/repos/${policy.repository}/check-runs/${check.id}`
+      && job.html_url === check.details_url
       && job.status === "completed" && job.conclusion === "success" && job.name === required.name,
     "MAINTENANCE_CHECK_WORKFLOW_MISMATCH");
     return { name: required.name, workflow: required.path, appId: check.app.id,
-      checkId: check.id, runId, runAttempt: run.run_attempt };
+      checkId: check.id, checkSuiteId: run.check_suite_id, jobId, runId, runAttempt: run.run_attempt };
   });
 }
 

--- a/scripts/ci/platform-maintenance-github.mjs
+++ b/scripts/ci/platform-maintenance-github.mjs
@@ -1,45 +1,115 @@
 import { createHash } from "node:crypto";
 import {
   MAINTENANCE_POLICY, REQUIRED_LEGACY_CHECKS, assertLivePullRequest, assertMergeProtection,
-  canonical, digest, executionBinding, oid, requireValue, snapshotJson, validateSubject,
+  canonical, digest, exactKeys, executionBinding, oid, requireValue, snapshotJson, validateSubject,
 } from "./platform-maintenance-policy.mjs";
 import { verifyEvidence } from "./platform-maintenance-evidence.mjs";
 
 const API_ROOT = "https://api.github.com";
 const ROOT = `/repos/${MAINTENANCE_POLICY.repository}`;
 
+async function requestGitHubJson(token, transport, method, route, body) {
+  let response;
+  try {
+    response = await transport(`${API_ROOT}${route}`, {
+      method, redirect: "error", signal: AbortSignal.timeout(30000),
+      headers: { authorization: `Bearer ${token}`, accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2026-03-10", ...(body === undefined ? {} : { "content-type": "application/json" }) },
+      ...(body === undefined ? {} : { body: canonical(body) }),
+    });
+  } catch { throw new Error("MAINTENANCE_GITHUB_TRANSPORT_FAILED"); }
+  if (!response.ok && response.status === 403
+    && route === `${ROOT}/branches/${MAINTENANCE_POLICY.baseRef}/protection`) {
+    throw new Error("MAINTENANCE_PROTECTION_READ_AUTHORITY_REQUIRED");
+  }
+  requireValue(response.ok, "MAINTENANCE_GITHUB_REQUEST_FAILED");
+  if (response.status === 204 && method === "POST"
+    && route === `${ROOT}/actions/workflows/platform-maintenance-post-merge.yml/dispatches`) return null;
+  requireValue(response.body, "MAINTENANCE_GITHUB_REQUEST_FAILED");
+  const chunks = []; let size = 0;
+  for await (const chunk of response.body) {
+    size += chunk.length;
+    requireValue(size <= MAINTENANCE_POLICY.maxEvidenceBytes, "MAINTENANCE_GITHUB_RESPONSE_TOO_LARGE");
+    chunks.push(chunk);
+  }
+  try { return snapshotJson(JSON.parse(Buffer.concat(chunks).toString("utf8"))); }
+  catch { throw new Error("MAINTENANCE_GITHUB_RESPONSE_INVALID"); }
+}
+
 export function createGitHubClient(token, transport = fetch) {
   requireValue(typeof token === "string" && token.length > 0, "MAINTENANCE_GITHUB_AUTH_REQUIRED");
   async function request(method, route, body) {
     requireValue(["GET", "POST", "PUT"].includes(method) && route.startsWith(`${ROOT}/`)
       && !route.includes("..") && !/[\\\r\n#]/.test(route), "MAINTENANCE_GITHUB_ROUTE_INVALID");
-    let response;
-    try {
-      response = await transport(`${API_ROOT}${route}`, {
-        method, redirect: "error", signal: AbortSignal.timeout(30000),
-        headers: { authorization: `Bearer ${token}`, accept: "application/vnd.github+json",
-          "X-GitHub-Api-Version": "2026-03-10", ...(body === undefined ? {} : { "content-type": "application/json" }) },
-        ...(body === undefined ? {} : { body: canonical(body) }),
-      });
-    } catch { throw new Error("MAINTENANCE_GITHUB_TRANSPORT_FAILED"); }
-    requireValue(response.ok, "MAINTENANCE_GITHUB_REQUEST_FAILED");
-    if (response.status === 204 && method === "POST"
-      && route === `${ROOT}/actions/workflows/platform-maintenance-post-merge.yml/dispatches`) return null;
-    requireValue(response.body, "MAINTENANCE_GITHUB_REQUEST_FAILED");
-    const chunks = []; let size = 0;
-    for await (const chunk of response.body) {
-      size += chunk.length;
-      requireValue(size <= MAINTENANCE_POLICY.maxEvidenceBytes, "MAINTENANCE_GITHUB_RESPONSE_TOO_LARGE");
-      chunks.push(chunk);
-    }
-    try { return snapshotJson(JSON.parse(Buffer.concat(chunks).toString("utf8"))); }
-    catch { throw new Error("MAINTENANCE_GITHUB_RESPONSE_INVALID"); }
+    requireValue(!route.includes("/protection"), "MAINTENANCE_SEPARATE_POLICY_READER_REQUIRED");
+    return requestGitHubJson(token, transport, method, route, body);
   }
   return Object.freeze({
     get: (route) => request("GET", route),
     post: (route, body) => request("POST", route, body),
     put: (route, body) => request("PUT", route, body),
   });
+}
+
+export function policyReadConfiguration(policy = MAINTENANCE_POLICY) {
+  if (policy.policyReadAuthority === null) return null;
+  const pins = snapshotJson(policy.policyReadAuthority);
+  exactKeys(pins, ["appId", "installationId"], "MAINTENANCE_POLICY_READER_CONFIGURATION_INVALID");
+  requireValue(Number.isSafeInteger(pins.appId) && pins.appId > 0
+    && Number.isSafeInteger(pins.installationId) && pins.installationId > 0,
+  "MAINTENANCE_POLICY_READER_CONFIGURATION_INVALID");
+  return snapshotJson({ ...pins, repository: policy.repository, repositoryId: policy.repositoryId,
+    baseRef: policy.baseRef });
+}
+
+const policyReaders = new WeakSet();
+
+// Configuration is trusted constructor policy, never PR or artifact input.
+// The protected workflow supplies credentials exclusively from the pinned App
+// token action. This reader cannot send writes or use the ordinary merge token.
+export function createPolicyReadAuthority(configurationValue, credentialValue, transport = fetch) {
+  requireValue(configurationValue !== null, "MAINTENANCE_POLICY_READ_AUTHORITY_UNCONFIGURED");
+  const configuration = snapshotJson(configurationValue);
+  const credential = snapshotJson(credentialValue);
+  exactKeys(configuration, ["appId", "installationId", "repository", "repositoryId", "baseRef"]);
+  exactKeys(credential, ["appId", "installationId", "token"]);
+  requireValue(configuration.repository === MAINTENANCE_POLICY.repository
+    && configuration.repositoryId === MAINTENANCE_POLICY.repositoryId
+    && configuration.baseRef === MAINTENANCE_POLICY.baseRef
+    && Number.isSafeInteger(configuration.appId) && configuration.appId > 0
+    && Number.isSafeInteger(configuration.installationId) && configuration.installationId > 0,
+  "MAINTENANCE_POLICY_READER_CONFIGURATION_INVALID");
+  requireValue(credential.appId === configuration.appId
+    && credential.installationId === configuration.installationId
+    && typeof credential.token === "string" && credential.token.length > 0,
+  "MAINTENANCE_POLICY_READER_CREDENTIAL_BINDING_INVALID");
+  const reader = Object.freeze({
+    async readProtection(subjectValue) {
+      const selected = snapshotJson(subjectValue);
+      exactKeys(selected, ["repository", "repositoryId", "baseRef"]);
+      requireValue(selected.repository === configuration.repository
+        && selected.repositoryId === configuration.repositoryId && selected.baseRef === configuration.baseRef,
+      "MAINTENANCE_POLICY_READER_SUBJECT_MISMATCH");
+      const scope = await requestGitHubJson(credential.token, transport, "GET",
+        "/installation/repositories?per_page=100&page=1");
+      requireValue(scope.total_count === 1 && Array.isArray(scope.repositories) && scope.repositories.length === 1
+        && scope.repositories[0].id === configuration.repositoryId
+        && scope.repositories[0].full_name === configuration.repository,
+      "MAINTENANCE_POLICY_READER_REPOSITORY_SCOPE_MISMATCH");
+      const route = `${ROOT}/branches/${configuration.baseRef}/protection`;
+      const protection = await requestGitHubJson(credential.token, transport, "GET", route);
+      requireValue(protection.url === `${API_ROOT}${route}`, "MAINTENANCE_POLICY_READER_RESPONSE_SUBJECT_MISMATCH");
+      return protection;
+    },
+  });
+  policyReaders.add(reader);
+  return reader;
+}
+
+async function readMergeProtection(reader, subject, policy) {
+  requireValue(reader !== null, "MAINTENANCE_POLICY_READ_AUTHORITY_UNCONFIGURED");
+  requireValue(policyReaders.has(reader), "MAINTENANCE_POLICY_READER_UNAUTHENTICATED");
+  return reader.readProtection({ repository: subject.repository, repositoryId: subject.repositoryId, baseRef: policy.baseRef });
 }
 
 async function paginate(client, route, field, limit) {
@@ -152,10 +222,10 @@ export async function observeLegacyChecks(client, subject) {
     const check = checks.filter((item) => item.name === required.name).sort((a, b) => b.id - a.id)[0];
     const match = new RegExp(`^https://github\\.com/${MAINTENANCE_POLICY.repository}/actions/runs/([1-9][0-9]*)/job/([1-9][0-9]*)$`)
       .exec(check?.details_url ?? "");
-    requireValue(match && Number(match[2]) === check.id, "MAINTENANCE_CHECK_RUN_MISSING");
+    requireValue(match && Number.isSafeInteger(check.id) && check.id > 0, "MAINTENANCE_CHECK_RUN_MISSING");
     const runId = Number(match[1]);
     if (!runs.has(runId)) runs.set(runId, await client.get(`${ROOT}/actions/runs/${runId}`));
-    jobs.push(await client.get(`${ROOT}/actions/jobs/${check.id}`));
+    jobs.push(await client.get(`${ROOT}/actions/jobs/${Number(match[2])}`));
   }
   return snapshotJson({ checks, runs: [...runs.values()], jobs });
 }
@@ -191,30 +261,34 @@ export async function resolveProducer(client, runId, policy = MAINTENANCE_POLICY
   return snapshotJson({ run, artifact: matches[0] });
 }
 
-async function publishTechnicalCheck(client, subject, verified, policy) {
+async function publishMaintenanceCheck(client, subject, verified, policy, name, conclusion) {
+  const technical = name === policy.evidenceCheckName;
+  const status = conclusion === null ? "in_progress" : "completed";
   const check = await client.post(`${ROOT}/check-runs`, {
-    name: policy.checkName, head_sha: subject.headSha, status: "completed", conclusion: "success",
+    name, head_sha: subject.headSha, status, ...(conclusion === null ? {} : { conclusion }),
     external_id: verified.evidenceHash,
-    output: { title: "Exact platform maintenance evidence verified",
-      summary: `Source ${subject.headSha}; policy ${subject.policyHash}; evidence ${verified.evidenceHash}. Technical evidence only; protected merge authorization is checked separately. No application, deployment or onchain authority.` },
+    output: conclusion === null ? { title: "Current maintenance release policy is being verified",
+      summary: "No release authorization has been established for this verification attempt." }
+      : conclusion === "success" ? { title: technical ? "Exact platform maintenance evidence verified"
+        : "Current protected maintenance release verified",
+      summary: `Source ${subject.headSha}; policy ${subject.policyHash}; evidence ${verified.evidenceHash}. ${technical
+        ? "Technical evidence only; this context never grants merge permission."
+        : "Current authenticated protection and technical evidence verified for the conditional merge."} No application, deployment or onchain authority.` }
+      : { title: "Maintenance release state changed or could not be confirmed",
+        summary: "A subsequent subject, technical-evidence or conditional-merge check failed. Fresh evidence and state reconciliation are required." },
   });
-  requireValue(check.name === policy.checkName && check.head_sha === subject.headSha
+  requireValue(check.name === name && check.head_sha === subject.headSha
     && check.app?.id === policy.githubActionsAppId && check.external_id === verified.evidenceHash
-    && check.status === "completed" && check.conclusion === "success", "MAINTENANCE_CHECK_PUBLICATION_INVALID");
+    && check.status === status && (conclusion === null ? check.conclusion == null : check.conclusion === conclusion),
+  "MAINTENANCE_CHECK_PUBLICATION_INVALID");
 }
 
-// Bootstrap publication is real verified technical evidence, never a PR review
-// or a merge request. Keeping it separate lets the new required context exist
-// before an integration owner changes any branch-protection rule.
-export async function publishAuthenticatedEvidenceCheck(client, evidenceValue, producerValue,
-  now = Date.now, policy = MAINTENANCE_POLICY) {
-  const evidence = snapshotJson(evidenceValue); const producer = snapshotJson(producerValue);
-  const subject = validateSubject(evidence.subject, policy);
-  await revalidateSubject(client, subject, policy);
+async function currentEvidence(client, evidence, producer, now, policy) {
+  const subject = evidence.subject;
+  const pr = await revalidateSubject(client, subject, policy);
   const verified = verifyEvidence(evidence, { subject, runId: producer.run.id, runAttempt: producer.run.run_attempt,
     legacyObservation: await observeLegacyChecks(client, subject), now: now() }, policy);
-  await publishTechnicalCheck(client, subject, verified, policy);
-  return verified;
+  return { pr, verified };
 }
 
 // Only the trusted CLI calls this after gh attestation verify has succeeded.
@@ -222,49 +296,63 @@ export async function publishAuthenticatedEvidenceCheck(client, evidenceValue, p
 // substitute for that provenance step. The SHA condition is sent to GitHub's
 // ordinary merge endpoint; protected strict status checks remain authoritative.
 export async function consumeAuthenticatedEvidence(client, evidenceValue, producerValue,
-  now = Date.now, policy = MAINTENANCE_POLICY) {
+  now = Date.now, policy = MAINTENANCE_POLICY, policyReader = null) {
   const evidence = snapshotJson(evidenceValue);
   const producer = snapshotJson(producerValue);
   const subject = validateSubject(evidence.subject, policy);
-  await revalidateSubject(client, subject, policy);
-  const legacyObservation = await observeLegacyChecks(client, subject);
-  const verified = verifyEvidence(evidence, { subject, runId: producer.run.id,
-    runAttempt: producer.run.run_attempt, legacyObservation, now: now() }, policy);
-  const protection = await client.get(`${ROOT}/branches/${policy.baseRef}/protection`);
-  assertMergeProtection(protection, policy);
-  await publishTechnicalCheck(client, subject, verified, policy);
-  let result;
+  const { verified } = await currentEvidence(client, evidence, producer, now, policy);
+  let bootstrapProtectionHold = false;
   try {
-    // Re-observe every technical run after publishing the gate, then refetch
-    // the PR and protected refs immediately before the conditional merge.
-    verifyEvidence(evidence, { subject, runId: producer.run.id, runAttempt: producer.run.run_attempt,
-      legacyObservation: await observeLegacyChecks(client, subject), now: now() }, policy);
-    const finalPr = await revalidateSubject(client, subject, policy);
-    requireValue(finalPr.mergeable_state === "clean", "MAINTENANCE_MERGE_NOT_READY");
+    // Reset any prior release context. Genuine technical bootstrap evidence
+    // uses a different name and cannot later become a required merge success.
+    // Every operation after this pending publication is in the failure scope.
+    await publishMaintenanceCheck(client, subject, verified, policy, policy.checkName, null);
+    await publishMaintenanceCheck(client, subject, verified, policy, policy.evidenceCheckName, "success");
+    await currentEvidence(client, evidence, producer, now, policy);
+    try {
+      const protection = await readMergeProtection(policyReader, subject, policy);
+      assertMergeProtection(protection, policy);
+    } catch (error) {
+      const protectionHold = ["MAINTENANCE_BRANCH_PROTECTION_INCOMPLETE",
+        "MAINTENANCE_HUMAN_RULE_STILL_ACTIVE", "MAINTENANCE_REQUIRED_CHECK_MISSING",
+        "MAINTENANCE_PROTECTION_READ_AUTHORITY_REQUIRED",
+        "MAINTENANCE_POLICY_READ_AUTHORITY_UNCONFIGURED"].includes(error?.message);
+      if (!protectionHold) throw error;
+      // Retain real bootstrap evidence only after another fresh subject,
+      // technical-run and expiry check. A policy-read limitation never merges.
+      await currentEvidence(client, evidence, producer, now, policy);
+      bootstrapProtectionHold = true;
+      throw error;
+    }
+    await currentEvidence(client, evidence, producer, now, policy);
+    await publishMaintenanceCheck(client, subject, verified, policy, policy.checkName, "success");
+    // Re-observe after the release context, including fresh policy authority,
+    // before GitHub enforces its ordinary conditional protected merge.
+    assertMergeProtection(await readMergeProtection(policyReader, subject, policy), policy);
+    const { pr } = await currentEvidence(client, evidence, producer, now, policy);
+    requireValue(pr.mergeable_state === "clean", "MAINTENANCE_MERGE_NOT_READY");
     requireValue(now() < verified.expiresAt, "MAINTENANCE_EVIDENCE_EXPIRED");
-    result = await client.put(`${ROOT}/pulls/${subject.pullRequest}/merge`, {
+    const result = await client.put(`${ROOT}/pulls/${subject.pullRequest}/merge`, {
       sha: subject.headSha, merge_method: "squash",
     });
     requireValue(result.merged === true && oid(result.sha), "MAINTENANCE_MERGE_FAILED");
+    const postSubject = { schema: "programmable.platform-maintenance-post-merge-subject.v1", original: subject,
+      originalEvidenceHash: verified.evidenceHash, mergeCommit: result.sha,
+      mergeTree: subject.mergeTree, parentCommit: subject.baseSha };
+    await revalidateMergedSubject(client, postSubject, policy);
+    return snapshotJson({ schema: "programmable.platform-maintenance-merge-observation.v1",
+      subjectHash: digest(subject), evidenceHash: verified.evidenceHash, mergeCommit: result.sha,
+      mergeTree: subject.mergeTree, parentCommit: subject.baseSha, producerRunId: producer.run.id,
+      websiteDeployment: false, applicationAuthority: false });
   } catch (error) {
-    // Supersede our own green context when a later currentness gate fails.
-    // Do not leave a reusable success after head/base/technical evidence drift.
     try {
-      await client.post(`${ROOT}/check-runs`, { name: policy.checkName, head_sha: subject.headSha,
-        status: "completed", conclusion: "failure", external_id: verified.evidenceHash,
-        output: { title: "Maintenance merge did not complete",
-          summary: "The final protected-state or conditional-merge check failed. Fresh evidence is required." } });
+      await publishMaintenanceCheck(client, subject, verified, policy, policy.checkName, "failure");
+      if (!bootstrapProtectionHold) {
+        await publishMaintenanceCheck(client, subject, verified, policy, policy.evidenceCheckName, "failure");
+      }
     } catch { throw new Error("MAINTENANCE_MERGE_STATE_UNCERTAIN"); }
     throw error;
   }
-  const postSubject = { schema: "programmable.platform-maintenance-post-merge-subject.v1", original: subject,
-    originalEvidenceHash: verified.evidenceHash, mergeCommit: result.sha,
-    mergeTree: subject.mergeTree, parentCommit: subject.baseSha };
-  await revalidateMergedSubject(client, postSubject, policy);
-  return snapshotJson({ schema: "programmable.platform-maintenance-merge-observation.v1",
-    subjectHash: digest(subject), evidenceHash: verified.evidenceHash, mergeCommit: result.sha,
-    mergeTree: subject.mergeTree, parentCommit: subject.baseSha, producerRunId: producer.run.id,
-    websiteDeployment: false, applicationAuthority: false });
 }
 
 export async function revalidateMergedSubject(client, value, policy = MAINTENANCE_POLICY) {

--- a/scripts/ci/platform-maintenance-github.mjs
+++ b/scripts/ci/platform-maintenance-github.mjs
@@ -1,0 +1,304 @@
+import { createHash } from "node:crypto";
+import {
+  MAINTENANCE_POLICY, REQUIRED_LEGACY_CHECKS, assertLivePullRequest, assertMergeProtection,
+  canonical, digest, executionBinding, oid, requireValue, snapshotJson, validateSubject,
+} from "./platform-maintenance-policy.mjs";
+import { verifyEvidence } from "./platform-maintenance-evidence.mjs";
+
+const API_ROOT = "https://api.github.com";
+const ROOT = `/repos/${MAINTENANCE_POLICY.repository}`;
+
+export function createGitHubClient(token, transport = fetch) {
+  requireValue(typeof token === "string" && token.length > 0, "MAINTENANCE_GITHUB_AUTH_REQUIRED");
+  async function request(method, route, body) {
+    requireValue(["GET", "POST", "PUT"].includes(method) && route.startsWith(`${ROOT}/`)
+      && !route.includes("..") && !/[\\\r\n#]/.test(route), "MAINTENANCE_GITHUB_ROUTE_INVALID");
+    let response;
+    try {
+      response = await transport(`${API_ROOT}${route}`, {
+        method, redirect: "error", signal: AbortSignal.timeout(30000),
+        headers: { authorization: `Bearer ${token}`, accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2026-03-10", ...(body === undefined ? {} : { "content-type": "application/json" }) },
+        ...(body === undefined ? {} : { body: canonical(body) }),
+      });
+    } catch { throw new Error("MAINTENANCE_GITHUB_TRANSPORT_FAILED"); }
+    requireValue(response.ok, "MAINTENANCE_GITHUB_REQUEST_FAILED");
+    if (response.status === 204 && method === "POST"
+      && route === `${ROOT}/actions/workflows/platform-maintenance-post-merge.yml/dispatches`) return null;
+    requireValue(response.body, "MAINTENANCE_GITHUB_REQUEST_FAILED");
+    const chunks = []; let size = 0;
+    for await (const chunk of response.body) {
+      size += chunk.length;
+      requireValue(size <= MAINTENANCE_POLICY.maxEvidenceBytes, "MAINTENANCE_GITHUB_RESPONSE_TOO_LARGE");
+      chunks.push(chunk);
+    }
+    try { return snapshotJson(JSON.parse(Buffer.concat(chunks).toString("utf8"))); }
+    catch { throw new Error("MAINTENANCE_GITHUB_RESPONSE_INVALID"); }
+  }
+  return Object.freeze({
+    get: (route) => request("GET", route),
+    post: (route, body) => request("POST", route, body),
+    put: (route, body) => request("PUT", route, body),
+  });
+}
+
+async function paginate(client, route, field, limit) {
+  const values = [];
+  for (let page = 1; page <= Math.ceil(limit / 100) + 1; page++) {
+    const response = await client.get(`${route}${route.includes("?") ? "&" : "?"}per_page=100&page=${page}`);
+    const items = field === null ? response : response[field];
+    requireValue(Array.isArray(items) && items.length <= 100, "MAINTENANCE_GITHUB_PAGE_INVALID");
+    values.push(...items);
+    requireValue(values.length <= limit, "MAINTENANCE_GITHUB_PAGINATION_LIMIT");
+    if (items.length < 100) return values;
+  }
+  throw new Error("MAINTENANCE_GITHUB_PAGINATION_INCOMPLETE");
+}
+
+function treeEntries(value, expected) {
+  requireValue(value.sha === expected && value.truncated === false && Array.isArray(value.tree)
+    && value.tree.length <= 50000, "MAINTENANCE_GIT_TREE_INCOMPLETE");
+  const entries = new Map();
+  for (const entry of value.tree) {
+    requireValue(!entries.has(entry.path), "MAINTENANCE_GIT_TREE_DUPLICATE");
+    entries.set(entry.path, entry);
+  }
+  return entries;
+}
+
+async function assertNoSuppressionChange(client, file) {
+  if (!file.path.endsWith(".sol") || file.headBlob === file.baseBlob) return;
+  for (const objectId of [file.baseBlob, file.headBlob].filter(Boolean)) {
+    const blob = await client.get(`${ROOT}/git/blobs/${objectId}`);
+    requireValue(blob.sha === objectId && blob.encoding === "base64" && typeof blob.content === "string"
+      && Number.isSafeInteger(blob.size) && blob.size >= 0 && blob.size <= 2 * 1024 * 1024,
+    "MAINTENANCE_SOURCE_BLOB_INVALID");
+    const bytes = Buffer.from(blob.content, "base64");
+    const computed = createHash("sha1").update(`blob ${bytes.length}\0`).update(bytes).digest("hex");
+    requireValue(bytes.length === blob.size && computed === objectId, "MAINTENANCE_SOURCE_BLOB_MISMATCH");
+    // Changing a file containing analyzer suppression requires a separately
+    // reviewed policy path. A source comment cannot silently weaken the scan.
+    requireValue(!/slither\s*[-_]\s*(disable|enable)/i.test(bytes.toString("utf8")),
+      "MAINTENANCE_SUPPRESSION_REVIEW_REQUIRED");
+  }
+}
+
+export async function selectSubject(client, pullRequest, controllerSha, policy = MAINTENANCE_POLICY) {
+  requireValue(Number.isSafeInteger(pullRequest) && pullRequest > 0 && oid(controllerSha),
+    "MAINTENANCE_SELECTION_INVALID");
+  const pr = snapshotJson(await client.get(`${ROOT}/pulls/${pullRequest}`));
+  requireValue(pr.number === pullRequest && oid(pr.head?.sha) && oid(pr.base?.sha)
+    && oid(pr.merge_commit_sha) && /^[A-Za-z0-9-]{1,39}$/.test(pr.user?.login ?? "")
+    && pr.base.repo?.id === policy.repositoryId && pr.head.repo?.id === policy.repositoryId,
+  "MAINTENANCE_FIRST_PARTY_REQUIRED");
+  const [baseRef, controllerRef, base, head, merge, permission, files] = await Promise.all([
+    client.get(`${ROOT}/git/ref/heads/${policy.baseRef}`),
+    client.get(`${ROOT}/git/ref/heads/${policy.controllerRef}`),
+    client.get(`${ROOT}/git/commits/${pr.base.sha}`),
+    client.get(`${ROOT}/git/commits/${pr.head.sha}`),
+    client.get(`${ROOT}/git/commits/${pr.merge_commit_sha}`),
+    client.get(`${ROOT}/collaborators/${pr.user.login}/permission`),
+    paginate(client, `${ROOT}/pulls/${pullRequest}/files`, null, policy.maxChangedFiles),
+  ]);
+  requireValue(baseRef.object?.sha === pr.base.sha && controllerRef.object?.sha === controllerSha,
+    "MAINTENANCE_TRUSTED_REF_DRIFT");
+  requireValue(base.sha === pr.base.sha && head.sha === pr.head.sha && merge.sha === pr.merge_commit_sha
+    && [base.tree?.sha, head.tree?.sha, merge.tree?.sha].every(oid)
+    && merge.parents?.length === 2 && merge.parents[0].sha === base.sha && merge.parents[1].sha === head.sha,
+  "MAINTENANCE_GIT_MERGE_MISMATCH");
+  const [baseTree, headTree] = await Promise.all([
+    client.get(`${ROOT}/git/trees/${base.tree.sha}?recursive=1`),
+    client.get(`${ROOT}/git/trees/${head.tree.sha}?recursive=1`),
+  ]);
+  const oldEntries = treeEntries(baseTree, base.tree.sha);
+  const newEntries = treeEntries(headTree, head.tree.sha);
+  const subject = validateSubject({ schema: "programmable.platform-maintenance-subject.v1",
+    repository: policy.repository, repositoryId: policy.repositoryId, pullRequest, authorId: pr.user.id,
+    baseSha: base.sha, baseTree: base.tree.sha, headSha: head.sha, headTree: head.tree.sha,
+    mergeSha: merge.sha, mergeTree: merge.tree.sha, controllerSha, policyHash: digest(policy),
+    files: files.map((file) => ({ path: file.filename, status: file.status,
+      baseBlob: oldEntries.get(file.filename)?.sha ?? null, baseMode: oldEntries.get(file.filename)?.mode ?? null,
+      headBlob: newEntries.get(file.filename)?.sha ?? null, headMode: newEntries.get(file.filename)?.mode ?? null,
+    })).sort((left, right) => left.path.localeCompare(right.path, "en")),
+  }, policy);
+  assertLivePullRequest(pr, subject, permission, policy);
+  for (const file of subject.files) await assertNoSuppressionChange(client, file);
+  await revalidateSubject(client, subject, policy);
+  return subject;
+}
+
+export async function revalidateSubject(client, value, policy = MAINTENANCE_POLICY) {
+  const subject = validateSubject(value, policy);
+  const [pr, baseRef, controllerRef, head, merge] = await Promise.all([
+    client.get(`${ROOT}/pulls/${subject.pullRequest}`), client.get(`${ROOT}/git/ref/heads/${policy.baseRef}`),
+    client.get(`${ROOT}/git/ref/heads/${policy.controllerRef}`), client.get(`${ROOT}/git/commits/${subject.headSha}`),
+    client.get(`${ROOT}/git/commits/${subject.mergeSha}`),
+  ]);
+  requireValue(/^[A-Za-z0-9-]{1,39}$/.test(pr.user?.login ?? ""), "MAINTENANCE_AUTHOR_INVALID");
+  const permission = await client.get(`${ROOT}/collaborators/${pr.user.login}/permission`);
+  assertLivePullRequest(pr, subject, permission, policy);
+  requireValue(baseRef.object?.sha === subject.baseSha && controllerRef.object?.sha === subject.controllerSha
+    && head.sha === subject.headSha && head.tree?.sha === subject.headTree
+    && merge.sha === subject.mergeSha && merge.tree?.sha === subject.mergeTree
+    && merge.parents?.length === 2 && merge.parents[0].sha === subject.baseSha
+    && merge.parents[1].sha === subject.headSha, "MAINTENANCE_LIVE_REF_DRIFT");
+  return pr;
+}
+
+export async function observeLegacyChecks(client, subject) {
+  const checks = await paginate(client, `${ROOT}/commits/${subject.headSha}/check-runs`, "check_runs", 1000);
+  const runs = new Map(); const jobs = [];
+  for (const required of REQUIRED_LEGACY_CHECKS) {
+    const check = checks.filter((item) => item.name === required.name).sort((a, b) => b.id - a.id)[0];
+    const match = new RegExp(`^https://github\\.com/${MAINTENANCE_POLICY.repository}/actions/runs/([1-9][0-9]*)/job/([1-9][0-9]*)$`)
+      .exec(check?.details_url ?? "");
+    requireValue(match && Number(match[2]) === check.id, "MAINTENANCE_CHECK_RUN_MISSING");
+    const runId = Number(match[1]);
+    if (!runs.has(runId)) runs.set(runId, await client.get(`${ROOT}/actions/runs/${runId}`));
+    jobs.push(await client.get(`${ROOT}/actions/jobs/${check.id}`));
+  }
+  return snapshotJson({ checks, runs: [...runs.values()], jobs });
+}
+
+export async function resolveProducer(client, runId, policy = MAINTENANCE_POLICY) {
+  requireValue(Number.isSafeInteger(runId) && runId > 0, "MAINTENANCE_PRODUCER_ID_INVALID");
+  const run = await client.get(`${ROOT}/actions/runs/${runId}`);
+  requireValue(run.id === runId && run.repository?.id === policy.repositoryId
+    && run.head_repository?.id === policy.repositoryId && run.path === policy.producerWorkflow
+    && run.name === policy.producerName && ["pull_request_target", "workflow_dispatch", "workflow_run"].includes(run.event)
+    && run.status === "completed" && run.conclusion === "success"
+    && Number.isSafeInteger(run.run_attempt) && run.run_attempt > 0, "MAINTENANCE_PRODUCER_NOT_AUTHENTICATED");
+  const jobs = await paginate(client, `${ROOT}/actions/runs/${runId}/attempts/${run.run_attempt}/jobs`, "jobs", 100);
+  const names = ["Select maintenance subject", "Exact head foundry", "Exact head slither", "Attest maintenance evidence"];
+  requireValue(jobs.length === names.length && names.every((name) => {
+    const matches = jobs.filter((job) => job.name === name);
+    return matches.length === 1 && matches[0].conclusion === "success" && matches[0].status === "completed"
+      && matches[0].run_attempt === run.run_attempt && matches[0].run_id === runId
+      && Number.isSafeInteger(matches[0].id) && matches[0].id > 0;
+  }), "MAINTENANCE_PRODUCER_JOBS_INVALID");
+  const artifacts = await paginate(client, `${ROOT}/actions/runs/${runId}/artifacts`, "artifacts", 100);
+  const matches = artifacts.filter((artifact) => artifact.name === `platform-maintenance-evidence-${runId}-${run.run_attempt}`);
+  requireValue(matches.length === 1 && matches[0].expired === false
+    && Number.isSafeInteger(matches[0].id) && matches[0].id > 0
+    && /^sha256:[a-f0-9]{64}$/.test(matches[0].digest) && matches[0].workflow_run?.id === runId
+    && matches[0].workflow_run.repository_id === policy.repositoryId
+    && matches[0].workflow_run.head_repository_id === policy.repositoryId
+    && matches[0].workflow_run.head_sha === run.head_sha
+    && matches[0].workflow_run.head_branch === run.head_branch
+    && Number.isSafeInteger(matches[0].size_in_bytes) && matches[0].size_in_bytes > 0
+    && matches[0].size_in_bytes <= policy.maxEvidenceBytes,
+  "MAINTENANCE_ARTIFACT_INVALID");
+  return snapshotJson({ run, artifact: matches[0] });
+}
+
+async function publishTechnicalCheck(client, subject, verified, policy) {
+  const check = await client.post(`${ROOT}/check-runs`, {
+    name: policy.checkName, head_sha: subject.headSha, status: "completed", conclusion: "success",
+    external_id: verified.evidenceHash,
+    output: { title: "Exact platform maintenance evidence verified",
+      summary: `Source ${subject.headSha}; policy ${subject.policyHash}; evidence ${verified.evidenceHash}. Technical evidence only; protected merge authorization is checked separately. No application, deployment or onchain authority.` },
+  });
+  requireValue(check.name === policy.checkName && check.head_sha === subject.headSha
+    && check.app?.id === policy.githubActionsAppId && check.external_id === verified.evidenceHash
+    && check.status === "completed" && check.conclusion === "success", "MAINTENANCE_CHECK_PUBLICATION_INVALID");
+}
+
+// Bootstrap publication is real verified technical evidence, never a PR review
+// or a merge request. Keeping it separate lets the new required context exist
+// before an integration owner changes any branch-protection rule.
+export async function publishAuthenticatedEvidenceCheck(client, evidenceValue, producerValue,
+  now = Date.now, policy = MAINTENANCE_POLICY) {
+  const evidence = snapshotJson(evidenceValue); const producer = snapshotJson(producerValue);
+  const subject = validateSubject(evidence.subject, policy);
+  await revalidateSubject(client, subject, policy);
+  const verified = verifyEvidence(evidence, { subject, runId: producer.run.id, runAttempt: producer.run.run_attempt,
+    legacyObservation: await observeLegacyChecks(client, subject), now: now() }, policy);
+  await publishTechnicalCheck(client, subject, verified, policy);
+  return verified;
+}
+
+// Only the trusted CLI calls this after gh attestation verify has succeeded.
+// No input JSON, PR label, check name or caller-supplied 'approved' flag can
+// substitute for that provenance step. The SHA condition is sent to GitHub's
+// ordinary merge endpoint; protected strict status checks remain authoritative.
+export async function consumeAuthenticatedEvidence(client, evidenceValue, producerValue,
+  now = Date.now, policy = MAINTENANCE_POLICY) {
+  const evidence = snapshotJson(evidenceValue);
+  const producer = snapshotJson(producerValue);
+  const subject = validateSubject(evidence.subject, policy);
+  await revalidateSubject(client, subject, policy);
+  const legacyObservation = await observeLegacyChecks(client, subject);
+  const verified = verifyEvidence(evidence, { subject, runId: producer.run.id,
+    runAttempt: producer.run.run_attempt, legacyObservation, now: now() }, policy);
+  const protection = await client.get(`${ROOT}/branches/${policy.baseRef}/protection`);
+  assertMergeProtection(protection, policy);
+  await publishTechnicalCheck(client, subject, verified, policy);
+  let result;
+  try {
+    // Re-observe every technical run after publishing the gate, then refetch
+    // the PR and protected refs immediately before the conditional merge.
+    verifyEvidence(evidence, { subject, runId: producer.run.id, runAttempt: producer.run.run_attempt,
+      legacyObservation: await observeLegacyChecks(client, subject), now: now() }, policy);
+    const finalPr = await revalidateSubject(client, subject, policy);
+    requireValue(finalPr.mergeable_state === "clean", "MAINTENANCE_MERGE_NOT_READY");
+    requireValue(now() < verified.expiresAt, "MAINTENANCE_EVIDENCE_EXPIRED");
+    result = await client.put(`${ROOT}/pulls/${subject.pullRequest}/merge`, {
+      sha: subject.headSha, merge_method: "squash",
+    });
+    requireValue(result.merged === true && oid(result.sha), "MAINTENANCE_MERGE_FAILED");
+  } catch (error) {
+    // Supersede our own green context when a later currentness gate fails.
+    // Do not leave a reusable success after head/base/technical evidence drift.
+    try {
+      await client.post(`${ROOT}/check-runs`, { name: policy.checkName, head_sha: subject.headSha,
+        status: "completed", conclusion: "failure", external_id: verified.evidenceHash,
+        output: { title: "Maintenance merge did not complete",
+          summary: "The final protected-state or conditional-merge check failed. Fresh evidence is required." } });
+    } catch { throw new Error("MAINTENANCE_MERGE_STATE_UNCERTAIN"); }
+    throw error;
+  }
+  const postSubject = { schema: "programmable.platform-maintenance-post-merge-subject.v1", original: subject,
+    originalEvidenceHash: verified.evidenceHash, mergeCommit: result.sha,
+    mergeTree: subject.mergeTree, parentCommit: subject.baseSha };
+  await revalidateMergedSubject(client, postSubject, policy);
+  return snapshotJson({ schema: "programmable.platform-maintenance-merge-observation.v1",
+    subjectHash: digest(subject), evidenceHash: verified.evidenceHash, mergeCommit: result.sha,
+    mergeTree: subject.mergeTree, parentCommit: subject.baseSha, producerRunId: producer.run.id,
+    websiteDeployment: false, applicationAuthority: false });
+}
+
+export async function revalidateMergedSubject(client, value, policy = MAINTENANCE_POLICY) {
+  const binding = executionBinding(value, policy);
+  const subject = binding.subject; const original = binding.original;
+  requireValue(subject.schema === "programmable.platform-maintenance-post-merge-subject.v1",
+    "MAINTENANCE_POST_MERGE_SUBJECT_REQUIRED");
+  const [pr, commit, baseRef, controllerRef] = await Promise.all([
+    client.get(`${ROOT}/pulls/${original.pullRequest}`), client.get(`${ROOT}/git/commits/${subject.mergeCommit}`),
+    client.get(`${ROOT}/git/ref/heads/${policy.baseRef}`), client.get(`${ROOT}/git/ref/heads/${policy.controllerRef}`),
+  ]);
+  requireValue(pr.number === original.pullRequest && pr.state === "closed" && pr.merged === true
+    && pr.merge_commit_sha === subject.mergeCommit && pr.head?.sha === original.headSha
+    && pr.head.repo?.id === policy.repositoryId && pr.base?.repo?.id === policy.repositoryId
+    && pr.base.ref === policy.baseRef && pr.user?.id === original.authorId,
+  "MAINTENANCE_MERGED_PR_MISMATCH");
+  requireValue(baseRef.object?.sha === subject.mergeCommit && controllerRef.object?.sha === original.controllerSha
+    && commit.sha === subject.mergeCommit && commit.tree?.sha === subject.mergeTree
+    && commit.parents?.length === 1 && commit.parents[0].sha === subject.parentCommit,
+  "MAINTENANCE_POST_MERGE_REF_DRIFT");
+  return subject;
+}
+
+export async function dispatchPostMergeVerification(client, postSubject, producerRunId, policy = MAINTENANCE_POLICY) {
+  const subject = executionBinding(postSubject, policy).subject;
+  requireValue(Number.isSafeInteger(producerRunId) && producerRunId > 0, "MAINTENANCE_PRODUCER_ID_INVALID");
+  await revalidateMergedSubject(client, subject, policy);
+  await client.post(`${ROOT}/actions/workflows/platform-maintenance-post-merge.yml/dispatches`, {
+    ref: policy.controllerRef,
+    inputs: { pull_request: String(subject.original.pullRequest), merge_sha: subject.mergeCommit,
+      producer_run: String(producerRunId), controller_sha: subject.original.controllerSha },
+  });
+  await revalidateMergedSubject(client, subject, policy);
+  return snapshotJson({ schema: "programmable.platform-maintenance-post-merge-dispatch.v1",
+    subjectHash: digest(subject), mergeCommit: subject.mergeCommit, dispatchAccepted: true,
+    verificationCompleted: false, deploymentCompleted: false });
+}

--- a/scripts/ci/platform-maintenance-policy.mjs
+++ b/scripts/ci/platform-maintenance-policy.mjs
@@ -1,0 +1,183 @@
+import { createHash } from "node:crypto";
+
+export const MAINTENANCE_POLICY = Object.freeze({
+  schema: "programmable.platform-maintenance-policy.v1",
+  repository: "programmablehq/PROGRAMMABLE",
+  repositoryId: 1314365508,
+  baseRef: "main",
+  controllerRef: "production",
+  producerWorkflow: ".github/workflows/platform-maintenance-verify.yml",
+  producerName: "Verify platform maintenance",
+  consumerWorkflow: ".github/workflows/platform-maintenance-release.yml",
+  postMergeWorkflow: ".github/workflows/platform-maintenance-post-merge.yml",
+  checkName: "platform-maintenance-release",
+  githubActionsAppId: 15368,
+  maxChangedFiles: 256,
+  maxEvidenceBytes: 16 * 1024 * 1024,
+  maxAgeMs: 60 * 60 * 1000,
+  foundryVersion: "1.7.1",
+  slitherVersion: "0.11.5",
+  solcVersion: "0.8.26",
+  // This is the existing production CI-control authorization, not permission
+  // to alter this policy or to manufacture an application-admission receipt.
+  controlAuthorization: Object.freeze({
+    commit: "e15bb397604a19d6622af5a5ee9622a8edac9d18",
+    tree: "92eecc16da2c59b87295fcb4012e57fe4f1feae7",
+    controlPaths: Object.freeze([
+      ".github/workflows/verify.yml",
+      "config/multi-role-router-v2/foundry.toml",
+      "plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/test/verify-skill-static.test.mjs",
+      "plugins/marketplace/plugins/programmable/skills/programmable-v4-hook-builder/scripts/verify-skill.mjs",
+      "plugins/marketplace/test/plugin-packaging.test.mjs",
+      "skills/programmable-v4-hook-builder/scripts/test/verify-skill-static.test.mjs",
+      "skills/programmable-v4-hook-builder/scripts/verify-skill.mjs",
+    ]),
+  }),
+  // No commit-bound main-branch dispositions were found. Existing reporting-
+  // only Slither success must never silently become an accepted baseline.
+  slitherDispositions: Object.freeze([]),
+});
+
+export const REQUIRED_LEGACY_CHECKS = Object.freeze([
+  Object.freeze({ name: "foundry", path: ".github/workflows/verify.yml" }),
+  Object.freeze({ name: "hook-builder-maintenance", path: ".github/workflows/verify.yml" }),
+  Object.freeze({ name: "security", path: ".github/workflows/security.yml" }),
+  Object.freeze({ name: "public-intake", path: ".github/workflows/verify-hook-builder.yml" }),
+]);
+
+export function requireValue(condition, code) {
+  if (!condition) throw new Error(code);
+}
+
+// Helpers accept inert JSON only. Never read accessors while producing an
+// authorization snapshot that will survive asynchronous GitHub operations.
+export function snapshotJson(value, budget = { nodes: 200000 }, seen = new Set()) {
+  requireValue(--budget.nodes >= 0, "MAINTENANCE_INPUT_TOO_LARGE");
+  if (value === null || typeof value === "boolean" || typeof value === "string") return value;
+  if (typeof value === "number") {
+    requireValue(Number.isSafeInteger(value), "MAINTENANCE_NUMBER_INVALID");
+    return value;
+  }
+  requireValue(typeof value === "object" && !seen.has(value), "MAINTENANCE_INPUT_NOT_INERT");
+  requireValue(Object.getPrototypeOf(value) === Object.prototype
+    || Object.getPrototypeOf(value) === null || Array.isArray(value), "MAINTENANCE_INPUT_NOT_INERT");
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  requireValue(Reflect.ownKeys(value).every((key) => typeof key === "string"), "MAINTENANCE_INPUT_NOT_INERT");
+  seen.add(value);
+  let result;
+  if (Array.isArray(value)) {
+    requireValue(Object.getPrototypeOf(value) === Array.prototype, "MAINTENANCE_INPUT_NOT_INERT");
+    requireValue(Object.keys(descriptors).length === value.length + 1, "MAINTENANCE_ARRAY_INVALID");
+    result = Array.from({ length: value.length }, (_, index) => {
+      const property = descriptors[String(index)];
+      requireValue(property && "value" in property, "MAINTENANCE_INPUT_NOT_INERT");
+      return snapshotJson(property.value, budget, seen);
+    });
+  } else {
+    result = Object.create(null);
+    for (const key of Object.keys(descriptors).sort()) {
+      const property = descriptors[key];
+      requireValue("value" in property && property.enumerable, "MAINTENANCE_INPUT_NOT_INERT");
+      result[key] = snapshotJson(property.value, budget, seen);
+    }
+  }
+  seen.delete(value);
+  return Object.freeze(result);
+}
+
+export function canonical(value) { return JSON.stringify(snapshotJson(value)); }
+export function digest(value) {
+  return `sha256:${createHash("sha256").update(canonical(value)).digest("hex")}`;
+}
+export function byteDigest(bytes) {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+export const oid = (value) => typeof value === "string" && /^[0-9a-f]{40}$/.test(value);
+export const hash = (value) => typeof value === "string" && /^sha256:[0-9a-f]{64}$/.test(value);
+export function exactKeys(value, keys, code = "MAINTENANCE_SCHEMA_INVALID") {
+  requireValue(value !== null && typeof value === "object" && !Array.isArray(value)
+    && Object.keys(value).sort().join("\0") === [...keys].sort().join("\0"), code);
+}
+export function safePath(value) {
+  return typeof value === "string" && value.length > 0 && Buffer.byteLength(value) <= 4096
+    && !/[\\\u0000-\u001f\u007f-\u009f\u200e\u200f\u202a-\u202e\u2066-\u2069]/u.test(value)
+    && value.split("/").every((part) => part && part !== "." && part !== ".." && part !== ".git");
+}
+
+export function validateSubject(value, policy = MAINTENANCE_POLICY) {
+  const subject = snapshotJson(value);
+  exactKeys(subject, ["schema", "repository", "repositoryId", "pullRequest", "authorId", "baseSha", "baseTree",
+    "headSha", "headTree", "mergeSha", "mergeTree", "controllerSha", "policyHash", "files"]);
+  requireValue(subject.schema === "programmable.platform-maintenance-subject.v1"
+    && subject.repository === policy.repository && subject.repositoryId === policy.repositoryId
+    && Number.isSafeInteger(subject.pullRequest) && subject.pullRequest > 0
+    && Number.isSafeInteger(subject.authorId) && subject.authorId > 0, "MAINTENANCE_SUBJECT_INVALID");
+  requireValue(["baseSha", "baseTree", "headSha", "headTree", "mergeSha", "mergeTree", "controllerSha"]
+    .every((key) => oid(subject[key])) && subject.baseSha !== subject.headSha, "MAINTENANCE_REVISION_INVALID");
+  requireValue(subject.policyHash === digest(policy), "MAINTENANCE_POLICY_DRIFT");
+  requireValue(Array.isArray(subject.files) && subject.files.length > 0
+    && subject.files.length <= policy.maxChangedFiles, "MAINTENANCE_FILES_INVALID");
+  const paths = new Set();
+  const ownerPinned = subject.headSha === policy.controlAuthorization.commit
+    && subject.headTree === policy.controlAuthorization.tree;
+  for (const file of subject.files) {
+    exactKeys(file, ["path", "status", "baseBlob", "headBlob", "baseMode", "headMode"]);
+    requireValue(safePath(file.path) && !paths.has(file.path), "MAINTENANCE_PATH_INVALID");
+    paths.add(file.path);
+    requireValue(!file.path.startsWith("submissions/"), "MAINTENANCE_APPLICATION_NOT_AUTHORIZED");
+    requireValue(["added", "modified"].includes(file.status), "MAINTENANCE_CHANGE_UNSUPPORTED");
+    requireValue(oid(file.headBlob) && file.headMode === "100644"
+      && (file.status === "added" ? file.baseBlob === null && file.baseMode === null
+        : oid(file.baseBlob) && file.baseMode === "100644"), "MAINTENANCE_BLOB_INVALID");
+    const sourcePath = /^(src|test)\/[A-Za-z0-9_./-]+\.sol$/.test(file.path)
+      || /^docs\/[A-Za-z0-9_./-]+\.md$/.test(file.path)
+      || file.path === ".gas-snapshot";
+    requireValue(sourcePath || ownerPinned && policy.controlAuthorization.controlPaths.includes(file.path),
+      "MAINTENANCE_CONTROL_AUTHORIZATION_REQUIRED");
+  }
+  return subject;
+}
+
+export function assertLivePullRequest(value, subject, permission, policy = MAINTENANCE_POLICY) {
+  const pr = snapshotJson(value);
+  requireValue(pr.number === subject.pullRequest && pr.state === "open" && pr.draft === false
+    && pr.merged === false && pr.mergeable === true, "MAINTENANCE_PR_NOT_CURRENT");
+  requireValue(pr.base?.repo?.id === policy.repositoryId && pr.head?.repo?.id === policy.repositoryId
+    && pr.base.repo.full_name === policy.repository && pr.head.repo.full_name === policy.repository
+    && pr.base.ref === policy.baseRef && pr.base.sha === subject.baseSha
+    && pr.head.sha === subject.headSha && pr.merge_commit_sha === subject.mergeSha
+    && pr.user?.id === subject.authorId, "MAINTENANCE_PR_BINDING_DRIFT");
+  requireValue(pr.changed_files === subject.files.length, "MAINTENANCE_FILE_LIST_INCOMPLETE");
+  requireValue(permission.user?.id === subject.authorId
+    && ["admin", "write", "maintain"].includes(permission.permission), "MAINTENANCE_FIRST_PARTY_REQUIRED");
+}
+
+export function executionBinding(value, policy = MAINTENANCE_POLICY) {
+  const input = snapshotJson(value);
+  if (input.schema === "programmable.platform-maintenance-post-merge-subject.v1") {
+    exactKeys(input, ["schema", "original", "originalEvidenceHash", "mergeCommit", "mergeTree", "parentCommit"]);
+    const original = validateSubject(input.original, policy);
+    requireValue(hash(input.originalEvidenceHash) && oid(input.mergeCommit)
+      && input.mergeCommit !== original.headSha && input.mergeTree === original.mergeTree
+      && input.parentCommit === original.baseSha, "MAINTENANCE_POST_MERGE_SUBJECT_INVALID");
+    return Object.freeze({ subject: input, original, sourceCommit: input.mergeCommit, sourceTree: input.mergeTree });
+  }
+  const subject = validateSubject(input, policy);
+  return Object.freeze({ subject, original: subject, sourceCommit: subject.headSha, sourceTree: subject.headTree });
+}
+
+export function assertMergeProtection(value, policy = MAINTENANCE_POLICY) {
+  const protection = snapshotJson(value);
+  const required = protection.required_status_checks;
+  requireValue(required?.strict === true && protection.enforce_admins?.enabled === true
+    && protection.required_linear_history?.enabled === true
+    && protection.allow_force_pushes?.enabled === false && protection.allow_deletions?.enabled === false,
+  "MAINTENANCE_BRANCH_PROTECTION_INCOMPLETE");
+  const review = protection.required_pull_request_reviews;
+  requireValue(review?.required_approving_review_count === 0 && review.require_code_owner_reviews === false
+    && review.require_last_push_approval === false, "MAINTENANCE_HUMAN_RULE_STILL_ACTIVE");
+  for (const name of [...REQUIRED_LEGACY_CHECKS.map((check) => check.name), policy.checkName]) {
+    requireValue(required.checks?.some((check) => check.context === name
+      && check.app_id === policy.githubActionsAppId), "MAINTENANCE_REQUIRED_CHECK_MISSING");
+  }
+}

--- a/scripts/ci/platform-maintenance-policy.mjs
+++ b/scripts/ci/platform-maintenance-policy.mjs
@@ -11,6 +11,7 @@ export const MAINTENANCE_POLICY = Object.freeze({
   consumerWorkflow: ".github/workflows/platform-maintenance-release.yml",
   postMergeWorkflow: ".github/workflows/platform-maintenance-post-merge.yml",
   checkName: "platform-maintenance-release",
+  evidenceCheckName: "platform-maintenance-evidence",
   githubActionsAppId: 15368,
   maxChangedFiles: 256,
   maxEvidenceBytes: 16 * 1024 * 1024,
@@ -18,6 +19,9 @@ export const MAINTENANCE_POLICY = Object.freeze({
   foundryVersion: "1.7.1",
   slitherVersion: "0.11.5",
   solcVersion: "0.8.26",
+  // One-time owner-reviewed App/installation pins. Null is deliberately not
+  // an installed policy reader and cannot authorize automatic merging.
+  policyReadAuthority: null,
   // This is the existing production CI-control authorization, not permission
   // to alter this policy or to manufacture an application-admission receipt.
   controlAuthorization: Object.freeze({

--- a/scripts/ci/platform-maintenance-runner.mjs
+++ b/scripts/ci/platform-maintenance-runner.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+import { execFileSync, spawnSync } from "node:child_process";
+import { appendFileSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  MAINTENANCE_POLICY as policy, canonical, digest, executionBinding, oid, requireValue, safePath, validateSubject,
+} from "./platform-maintenance-policy.mjs";
+import { WORKER_SCHEMA, createEvidence, createPostMergeEvidence, evaluateSlither,
+  validateLegacyChecks, verifyEvidence } from "./platform-maintenance-evidence.mjs";
+import { consumeAuthenticatedEvidence, createGitHubClient, dispatchPostMergeVerification,
+  observeLegacyChecks, publishAuthenticatedEvidenceCheck, revalidateMergedSubject, revalidateSubject,
+  resolveProducer, selectSubject } from "./platform-maintenance-github.mjs";
+
+const controllerRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const MAX_TOOL_BYTES = 64 * 1024 * 1024;
+function run(command, arguments_, cwd = controllerRoot, env = process.env) {
+  try {
+    return execFileSync(command, arguments_, { cwd, env, encoding: "utf8", maxBuffer: MAX_TOOL_BYTES,
+      timeout: 40 * 60 * 1000, stdio: ["ignore", "pipe", "pipe"] });
+  } catch { throw new Error("MAINTENANCE_TOOL_EXECUTION_FAILED"); }
+}
+function git(arguments_, cwd = controllerRoot) {
+  return run("git", ["--no-pager", "--no-replace-objects", ...arguments_], cwd).trim();
+}
+function readJson(file, canonicalRequired = true) {
+  const stat = lstatSync(file);
+  requireValue(stat.isFile() && !stat.isSymbolicLink() && stat.size > 0
+    && stat.size <= policy.maxEvidenceBytes, "MAINTENANCE_FILE_INVALID");
+  const bytes = readFileSync(file);
+  const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  const value = JSON.parse(text);
+  requireValue(!canonicalRequired || `${canonical(value)}\n` === text, "MAINTENANCE_ARTIFACT_NOT_CANONICAL");
+  return value;
+}
+function writeJson(file, value) {
+  const bytes = `${canonical(value)}\n`;
+  requireValue(Buffer.byteLength(bytes) <= policy.maxEvidenceBytes, "MAINTENANCE_ARTIFACT_TOO_LARGE");
+  writeFileSync(file, bytes, { flag: "wx", mode: 0o600 });
+}
+function output(values) {
+  requireValue(typeof process.env.GITHUB_OUTPUT === "string", "MAINTENANCE_OUTPUT_UNAVAILABLE");
+  for (const [key, value] of Object.entries(values)) {
+    requireValue(/^[a-z_]+$/.test(key) && /^[A-Za-z0-9:_./-]+$/.test(String(value)), "MAINTENANCE_OUTPUT_INVALID");
+    appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+  }
+}
+function assertController(workflow) {
+  const sha = process.env.GITHUB_WORKFLOW_SHA;
+  requireValue(oid(sha) && process.env.GITHUB_SHA === sha
+    && process.env.GITHUB_REPOSITORY === policy.repository
+    && process.env.GITHUB_REPOSITORY_ID === String(policy.repositoryId)
+    && process.env.GITHUB_REF === `refs/heads/${policy.controllerRef}`
+    && process.env.GITHUB_REF_PROTECTED === "true"
+    && process.env.GITHUB_WORKFLOW_REF === `${policy.repository}/${workflow}@refs/heads/${policy.controllerRef}`,
+  "MAINTENANCE_CONTROLLER_NOT_PROTECTED_SOURCE");
+  requireValue(git(["rev-parse", "HEAD"]) === sha && git(["status", "--porcelain"]) === ""
+    && git(["remote", "get-url", "origin"]) === `https://github.com/${policy.repository}`,
+  "MAINTENANCE_CONTROLLER_CHECKOUT_INVALID");
+  for (const disposition of policy.slitherDispositions) {
+    requireValue(safePath(disposition.evidencePath)
+      && git(["rev-parse", `${sha}:${disposition.evidencePath}`]) === disposition.evidenceBlob,
+    "MAINTENANCE_DISPOSITION_SOURCE_MISSING");
+  }
+  return sha;
+}
+
+export function assertWorkerEnvironment(env) {
+  requireValue(!env.GH_TOKEN && !env.GITHUB_TOKEN && !env.ACTIONS_ID_TOKEN_REQUEST_TOKEN
+    && !env.ACTIONS_ID_TOKEN_REQUEST_URL, "MAINTENANCE_WORKER_CREDENTIAL_PRESENT");
+}
+export function summarizeFoundryReport(report) {
+  requireValue(report && typeof report === "object" && !Array.isArray(report), "MAINTENANCE_FORGE_REPORT_INVALID");
+  let testCount = 0;
+  for (const suite of Object.values(report)) {
+    requireValue(suite && suite.test_results && typeof suite.test_results === "object"
+      && !Array.isArray(suite.test_results), "MAINTENANCE_FORGE_SUITE_INVALID");
+    for (const test of Object.values(suite.test_results)) {
+      requireValue(test.status === "Success", "MAINTENANCE_FORGE_TEST_NOT_SUCCESSFUL");
+      testCount++;
+    }
+  }
+  requireValue(testCount > 0, "MAINTENANCE_FORGE_TESTS_MISSING");
+  return { testCount, testReportHash: digest(report) };
+}
+export function attestationArguments(file, sourceCommit) {
+  requireValue(oid(sourceCommit), "MAINTENANCE_ATTESTATION_SOURCE_INVALID");
+  return ["attestation", "verify", file, "--repo", policy.repository,
+    "--signer-workflow", `${policy.repository}/${policy.producerWorkflow}`,
+    "--source-ref", `refs/heads/${policy.controllerRef}`, "--source-digest", sourceCommit,
+    "--signer-digest", sourceCommit, "--deny-self-hosted-runners", "--format", "json"];
+}
+
+function worker(subjectPath, candidateRoot, lane, destination) {
+  assertWorkerEnvironment(process.env);
+  requireValue(["foundry", "slither"].includes(lane), "MAINTENANCE_WORKER_LANE_INVALID");
+  const { subject, original, sourceCommit, sourceTree } = executionBinding(readJson(subjectPath));
+  requireValue(git(["rev-parse", "HEAD"], candidateRoot) === sourceCommit
+    && git(["rev-parse", "HEAD^{tree}"], candidateRoot) === sourceTree
+    && git(["status", "--porcelain"], candidateRoot) === "", "MAINTENANCE_CANDIDATE_CHECKOUT_INVALID");
+  // Only the unchanged base bootstrap may execute on this unprivileged runner.
+  const bootstrap = "scripts/bootstrap-deps.sh";
+  requireValue(git(["rev-parse", `${original.baseSha}:${bootstrap}`], candidateRoot)
+    === git(["rev-parse", `${sourceCommit}:${bootstrap}`], candidateRoot),
+  "MAINTENANCE_BOOTSTRAP_CHANGED");
+  const env = { ...process.env, FOUNDRY_FFI: "false", FOUNDRY_PROFILE: "ci" };
+  run("bash", [bootstrap], candidateRoot, env);
+  const forgeVersion = run("forge", ["--version"], candidateRoot, env);
+  requireValue(/\b1\.7\.1(?:[-+\s]|$)/.test(forgeVersion), "MAINTENANCE_FOUNDRY_VERSION_INVALID");
+  const config = JSON.parse(run("forge", ["config", "--json"], candidateRoot, env));
+  requireValue(config.ffi === false && config.solc === policy.solcVersion
+    && config.evm_version === "cancun" && Array.isArray(config.fs_permissions)
+    && config.fs_permissions.every((permission) => permission.access === "read"
+      && safePath(permission.path.replace(/^\.\//, ""))), "MAINTENANCE_FOUNDRY_CONFIG_INVALID");
+  const report = { schema: WORKER_SCHEMA, lane, subjectHash: digest(subject), sourceCommit,
+    sourceTree, foundryVersion: policy.foundryVersion, solcVersion: policy.solcVersion,
+    slitherVersion: null, testCount: null, testReportHash: null, slitherReport: null };
+  if (lane === "foundry") {
+    run("forge", ["fmt", "--check"], candidateRoot, env);
+    run("forge", ["build", "--sizes"], candidateRoot, env);
+    Object.assign(report, summarizeFoundryReport(JSON.parse(run("forge", ["test", "--json",
+      "--no-match-contract", "ClassicV3MainnetForkTest"], candidateRoot, env))));
+  } else {
+    requireValue(run("slither", ["--version"], candidateRoot, env).trim() === policy.slitherVersion,
+      "MAINTENANCE_SLITHER_VERSION_INVALID");
+    const rawPath = path.join(destination, "slither.raw.json");
+    const configPath = path.join(destination, "slither.config.json");
+    writeJson(configPath, { filter_paths: "(^|/)(lib|test)/" });
+    // Slither's finding exit code is reporting data, never merge approval.
+    // The trusted evaluator below and the separate issuer both parse every
+    // detector and require an explicit, exact-source disposition.
+    const scan = spawnSync("slither", [".", "--config-file", configPath, "--json", rawPath], {
+      cwd: candidateRoot, env, encoding: "utf8", timeout: 40 * 60 * 1000, maxBuffer: MAX_TOOL_BYTES,
+    });
+    requireValue(!scan.error && scan.signal === null && [0, 255].includes(scan.status)
+      && !/ERROR:|Error in|Unable to|failed to|not supported|WARNING:/i.test(`${scan.stdout}\n${scan.stderr}`),
+    "MAINTENANCE_SLITHER_EXECUTION_INCOMPLETE");
+    report.slitherVersion = policy.slitherVersion;
+    report.slitherReport = readJson(rawPath, false);
+    evaluateSlither(report.slitherReport, subject);
+  }
+  requireValue(git(["rev-parse", "HEAD"], candidateRoot) === sourceCommit
+    && git(["diff", "--name-only", "HEAD", "--"], candidateRoot) === "",
+  "MAINTENANCE_SOURCE_CHANGED_DURING_EXECUTION");
+  writeJson(path.join(destination, `${lane}.json`), report);
+}
+
+async function authenticatedInput(client, sha) {
+  const producer = readJson(process.env.MAINTENANCE_PRODUCER);
+  const fresh = await resolveProducer(client, producer.run.id);
+  requireValue(canonical(fresh) === canonical(producer), "MAINTENANCE_PRODUCER_ARTIFACT_DRIFT");
+  const file = process.env.MAINTENANCE_EVIDENCE;
+  const evidence = readJson(file);
+  requireValue(evidence.subject?.controllerSha === sha, "MAINTENANCE_CONTROLLER_DRIFT");
+  const attestation = JSON.parse(run("gh", attestationArguments(file, sha)));
+  requireValue(Array.isArray(attestation) && attestation.length > 0, "MAINTENANCE_ATTESTATION_MISSING");
+  verifyEvidence(evidence, { subject: evidence.subject, runId: fresh.run.id, runAttempt: fresh.run.run_attempt,
+    legacyObservation: await observeLegacyChecks(client, evidence.subject), now: Date.now() });
+  return { evidence, producer: fresh };
+}
+
+async function main() {
+  const operation = process.argv[2];
+  requireValue(process.argv.length === 3, "MAINTENANCE_ARGUMENTS_INVALID");
+  const sha = assertController(operation?.startsWith("post-") ? policy.postMergeWorkflow
+    : ["resolve", "consume", "dispatch"].includes(operation) ? policy.consumerWorkflow : policy.producerWorkflow);
+  const destination = path.resolve(process.env.MAINTENANCE_OUTPUT ?? "");
+  requireValue(destination.startsWith(`${process.env.RUNNER_TEMP}/`), "MAINTENANCE_OUTPUT_PATH_INVALID");
+  mkdirSync(destination, { recursive: true, mode: 0o700 });
+  if (operation === "worker" || operation === "post-worker") {
+    worker(process.env.MAINTENANCE_SUBJECT, process.env.MAINTENANCE_CANDIDATE,
+      process.env.MAINTENANCE_LANE, destination);
+    return;
+  }
+  const client = createGitHubClient(process.env.GH_TOKEN);
+  if (operation === "select") {
+    const subject = await selectSubject(client, Number(process.env.MAINTENANCE_PR), sha);
+    validateLegacyChecks(await observeLegacyChecks(client, subject), subject);
+    writeJson(path.join(destination, "subject.json"), subject);
+    output({ head_sha: subject.headSha, subject_hash: digest(subject), pull_request: subject.pullRequest });
+  } else if (operation === "attest") {
+    const subject = validateSubject(readJson(process.env.MAINTENANCE_SUBJECT));
+    requireValue(subject.controllerSha === sha, "MAINTENANCE_CONTROLLER_DRIFT");
+    await revalidateSubject(client, subject);
+    const evidence = createEvidence({ subject, foundry: readJson(process.env.MAINTENANCE_FOUNDRY),
+      slither: readJson(process.env.MAINTENANCE_SLITHER), legacyObservation: await observeLegacyChecks(client, subject),
+      runId: Number(process.env.GITHUB_RUN_ID), runAttempt: Number(process.env.GITHUB_RUN_ATTEMPT), issuedAt: Date.now() });
+    writeJson(path.join(destination, "evidence.json"), evidence);
+  } else if (operation === "resolve" || operation === "post-resolve") {
+    const producer = await resolveProducer(client, Number(process.env.MAINTENANCE_PRODUCER_RUN));
+    writeJson(path.join(destination, "producer.json"), producer);
+    output({ artifact_id: producer.artifact.id, run_id: producer.run.id, run_attempt: producer.run.run_attempt });
+  } else if (operation === "consume") {
+    const { evidence, producer } = await authenticatedInput(client, sha);
+    await publishAuthenticatedEvidenceCheck(client, evidence, producer);
+    const result = await consumeAuthenticatedEvidence(client, evidence, producer);
+    writeJson(path.join(destination, "merge-observation.json"), result);
+    output({ merge_sha: result.mergeCommit, producer_run: producer.run.id });
+  } else if (operation === "dispatch" || operation === "post-select") {
+    const { evidence, producer } = await authenticatedInput(client, sha);
+    const merge = operation === "dispatch" ? readJson(process.env.MAINTENANCE_MERGE_OBSERVATION) : null;
+    if (merge !== null) requireValue(merge.schema === "programmable.platform-maintenance-merge-observation.v1"
+      && merge.subjectHash === digest(evidence.subject) && merge.evidenceHash === digest(evidence)
+      && merge.producerRunId === producer.run.id, "MAINTENANCE_MERGE_OBSERVATION_INVALID");
+    else requireValue(Number(process.env.MAINTENANCE_PR) === evidence.subject.pullRequest
+      && process.env.MAINTENANCE_CONTROLLER_SHA === sha, "MAINTENANCE_POST_MERGE_SELECTOR_INVALID");
+    const subject = { schema: "programmable.platform-maintenance-post-merge-subject.v1",
+      original: evidence.subject, originalEvidenceHash: digest(evidence),
+      mergeCommit: merge?.mergeCommit ?? process.env.MAINTENANCE_MERGED_SHA,
+      mergeTree: evidence.subject.mergeTree, parentCommit: evidence.subject.baseSha };
+    await revalidateMergedSubject(client, subject);
+    if (operation === "dispatch") {
+      const result = await dispatchPostMergeVerification(client, subject, producer.run.id);
+      writeJson(path.join(destination, "post-merge-dispatch.json"), result);
+    } else {
+      writeJson(path.join(destination, "subject.json"), subject);
+      output({ merge_sha: subject.mergeCommit });
+    }
+  } else if (operation === "post-attest") {
+    const subject = executionBinding(readJson(process.env.MAINTENANCE_SUBJECT)).subject;
+    requireValue(subject.original?.controllerSha === sha, "MAINTENANCE_CONTROLLER_DRIFT");
+    await revalidateMergedSubject(client, subject);
+    const evidence = createPostMergeEvidence({ subject, foundry: readJson(process.env.MAINTENANCE_FOUNDRY),
+      slither: readJson(process.env.MAINTENANCE_SLITHER), runId: Number(process.env.GITHUB_RUN_ID),
+      runAttempt: Number(process.env.GITHUB_RUN_ATTEMPT), issuedAt: Date.now() });
+    writeJson(path.join(destination, "post-merge-evidence.json"), evidence);
+  } else throw new Error("MAINTENANCE_OPERATION_INVALID");
+}
+
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    // Deliberately omit provider response bodies, credentials and argv.
+    process.stderr.write(`${/^MAINTENANCE_[A-Z_]+$/.test(error?.message ?? "")
+      ? error.message : "MAINTENANCE_EXECUTION_FAILED"}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ci/platform-maintenance-runner.mjs
+++ b/scripts/ci/platform-maintenance-runner.mjs
@@ -8,8 +8,8 @@ import {
 } from "./platform-maintenance-policy.mjs";
 import { WORKER_SCHEMA, createEvidence, createPostMergeEvidence, evaluateSlither,
   validateLegacyChecks, verifyEvidence } from "./platform-maintenance-evidence.mjs";
-import { consumeAuthenticatedEvidence, createGitHubClient, dispatchPostMergeVerification,
-  observeLegacyChecks, publishAuthenticatedEvidenceCheck, revalidateMergedSubject, revalidateSubject,
+import { consumeAuthenticatedEvidence, createGitHubClient, createPolicyReadAuthority, dispatchPostMergeVerification,
+  observeLegacyChecks, policyReadConfiguration, revalidateMergedSubject, revalidateSubject,
   resolveProducer, selectSubject } from "./platform-maintenance-github.mjs";
 
 const controllerRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
@@ -67,7 +67,8 @@ function assertController(workflow) {
 
 export function assertWorkerEnvironment(env) {
   requireValue(!env.GH_TOKEN && !env.GITHUB_TOKEN && !env.ACTIONS_ID_TOKEN_REQUEST_TOKEN
-    && !env.ACTIONS_ID_TOKEN_REQUEST_URL, "MAINTENANCE_WORKER_CREDENTIAL_PRESENT");
+    && !env.ACTIONS_ID_TOKEN_REQUEST_URL && !env.MAINTENANCE_POLICY_READ_TOKEN,
+  "MAINTENANCE_WORKER_CREDENTIAL_PRESENT");
 }
 export function summarizeFoundryReport(report) {
   requireValue(report && typeof report === "object" && !Array.isArray(report), "MAINTENANCE_FORGE_REPORT_INVALID");
@@ -163,13 +164,20 @@ async function main() {
   const operation = process.argv[2];
   requireValue(process.argv.length === 3, "MAINTENANCE_ARGUMENTS_INVALID");
   const sha = assertController(operation?.startsWith("post-") ? policy.postMergeWorkflow
-    : ["resolve", "consume", "dispatch"].includes(operation) ? policy.consumerWorkflow : policy.producerWorkflow);
+    : ["resolve", "consume", "dispatch", "policy-config"].includes(operation) ? policy.consumerWorkflow : policy.producerWorkflow);
   const destination = path.resolve(process.env.MAINTENANCE_OUTPUT ?? "");
   requireValue(destination.startsWith(`${process.env.RUNNER_TEMP}/`), "MAINTENANCE_OUTPUT_PATH_INVALID");
   mkdirSync(destination, { recursive: true, mode: 0o700 });
   if (operation === "worker" || operation === "post-worker") {
     worker(process.env.MAINTENANCE_SUBJECT, process.env.MAINTENANCE_CANDIDATE,
       process.env.MAINTENANCE_LANE, destination);
+    return;
+  }
+  if (operation === "policy-config") {
+    const configuration = policyReadConfiguration();
+    output(configuration === null ? { configured: "false" } : {
+      configured: "true", app_id: configuration.appId, installation_id: configuration.installationId,
+    });
     return;
   }
   const client = createGitHubClient(process.env.GH_TOKEN);
@@ -192,8 +200,13 @@ async function main() {
     output({ artifact_id: producer.artifact.id, run_id: producer.run.id, run_attempt: producer.run.run_attempt });
   } else if (operation === "consume") {
     const { evidence, producer } = await authenticatedInput(client, sha);
-    await publishAuthenticatedEvidenceCheck(client, evidence, producer);
-    const result = await consumeAuthenticatedEvidence(client, evidence, producer);
+    const configuration = policyReadConfiguration();
+    const reader = configuration === null ? null : createPolicyReadAuthority(configuration, {
+      appId: Number(process.env.MAINTENANCE_POLICY_APP_ID),
+      installationId: Number(process.env.MAINTENANCE_POLICY_INSTALLATION_ID),
+      token: process.env.MAINTENANCE_POLICY_READ_TOKEN ?? "",
+    });
+    const result = await consumeAuthenticatedEvidence(client, evidence, producer, Date.now, policy, reader);
     writeJson(path.join(destination, "merge-observation.json"), result);
     output({ merge_sha: result.mergeCommit, producer_run: producer.run.id });
   } else if (operation === "dispatch" || operation === "post-select") {

--- a/scripts/test/platform-maintenance-release.test.mjs
+++ b/scripts/test/platform-maintenance-release.test.mjs
@@ -1,0 +1,405 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import { MAINTENANCE_POLICY as policy, REQUIRED_LEGACY_CHECKS, assertLivePullRequest,
+  assertMergeProtection, canonical, digest, executionBinding, snapshotJson, validateSubject,
+} from "../ci/platform-maintenance-policy.mjs";
+import { WORKER_SCHEMA, createEvidence, createPostMergeEvidence, evaluateSlither, slitherAnalysisHash,
+  validateLegacyChecks, verifyEvidence } from "../ci/platform-maintenance-evidence.mjs";
+import { consumeAuthenticatedEvidence, createGitHubClient, dispatchPostMergeVerification,
+  publishAuthenticatedEvidenceCheck, revalidateMergedSubject, resolveProducer, selectSubject } from "../ci/platform-maintenance-github.mjs";
+import { assertWorkerEnvironment, attestationArguments, summarizeFoundryReport } from "../ci/platform-maintenance-runner.mjs";
+
+const sha = (character) => character.repeat(40);
+const ROOT = `/repos/${policy.repository}`;
+const NOW = 1788650000000;
+const MERGED = sha("8");
+const clone = (value) => JSON.parse(JSON.stringify(value));
+const blob = (text) => {
+  const bytes = Buffer.from(text);
+  return { sha: createHash("sha1").update(`blob ${bytes.length}\0`).update(bytes).digest("hex"),
+    size: bytes.length, encoding: "base64", content: bytes.toString("base64") };
+};
+const BASE_BLOB = blob("pragma solidity ^0.8.26; contract Example {}\n");
+const HEAD_BLOB = blob("pragma solidity ^0.8.26; contract Example { uint256 public n; }\n");
+function subject(customPolicy = policy) {
+  return { schema: "programmable.platform-maintenance-subject.v1", repository: policy.repository,
+    repositoryId: policy.repositoryId, pullRequest: 702, authorId: 7, baseSha: sha("1"), baseTree: sha("2"),
+    headSha: sha("3"), headTree: sha("4"), mergeSha: sha("5"), mergeTree: sha("4"), controllerSha: sha("6"),
+    policyHash: digest(customPolicy), files: [{ path: "src/Example.sol", status: "modified",
+      baseBlob: BASE_BLOB.sha, headBlob: HEAD_BLOB.sha, baseMode: "100644", headMode: "100644" }] };
+}
+function pr(s = subject()) {
+  const repo = { id: policy.repositoryId, full_name: policy.repository };
+  return { number: s.pullRequest, state: "open", merged: false, draft: false, mergeable: true,
+    mergeable_state: "clean", merge_commit_sha: s.mergeSha, changed_files: s.files.length,
+    head: { sha: s.headSha, repo }, base: { sha: s.baseSha, ref: "main", repo }, user: { id: s.authorId, login: "maintainer" } };
+}
+const permission = { permission: "write", user: { id: 7 } };
+function protection() {
+  return { enforce_admins: { enabled: true }, required_linear_history: { enabled: true },
+    allow_force_pushes: { enabled: false }, allow_deletions: { enabled: false },
+    required_pull_request_reviews: { required_approving_review_count: 0, require_code_owner_reviews: false,
+      require_last_push_approval: false },
+    required_status_checks: { strict: true, checks: [...REQUIRED_LEGACY_CHECKS.map((check) => check.name), policy.checkName]
+      .map((context) => ({ context, app_id: policy.githubActionsAppId })) } };
+}
+function observation(s = subject()) {
+  const result = { checks: [], runs: [], jobs: [] };
+  for (const [index, required] of REQUIRED_LEGACY_CHECKS.entries()) {
+    const id = 100 + index, runId = 200 + index;
+    result.checks.push({ id, name: required.name, status: "completed", conclusion: "success", head_sha: s.headSha,
+      app: { id: policy.githubActionsAppId, slug: "github-actions", owner: { login: "github" } },
+      details_url: `https://github.com/${policy.repository}/actions/runs/${runId}/job/${id}` });
+    result.runs.push({ id: runId, path: required.path, repository: { id: policy.repositoryId },
+      head_repository: { id: policy.repositoryId }, head_sha: s.headSha, status: "completed", conclusion: "success",
+      event: required.name === "public-intake" ? "pull_request_target" : "pull_request", run_attempt: 1,
+      pull_requests: [{ number: s.pullRequest, base: { sha: s.baseSha, repo: { id: policy.repositoryId } },
+        head: { sha: s.headSha, repo: { id: policy.repositoryId } } }] });
+    result.jobs.push({ id, run_id: runId, run_attempt: 1, head_sha: s.headSha,
+      name: required.name, status: "completed", conclusion: "success" });
+  }
+  return result;
+}
+function workers(input = subject()) {
+  const binding = executionBinding(input);
+  const common = { schema: WORKER_SCHEMA, subjectHash: digest(binding.subject), sourceCommit: binding.sourceCommit,
+    sourceTree: binding.sourceTree, foundryVersion: policy.foundryVersion, solcVersion: policy.solcVersion };
+  return { foundry: { ...common, lane: "foundry", slitherVersion: null, testCount: 41,
+    testReportHash: `sha256:${"a".repeat(64)}`, slitherReport: null },
+  slither: { ...common, lane: "slither", slitherVersion: policy.slitherVersion, testCount: null,
+    testReportHash: null, slitherReport: { success: true, error: null, results: { detectors: [] } } } };
+}
+function evidence(s = subject()) {
+  return createEvidence({ subject: s, ...workers(s), legacyObservation: observation(s), runId: 901, runAttempt: 1, issuedAt: NOW });
+}
+function expected(s = subject()) {
+  return { subject: s, runId: 901, runAttempt: 1, legacyObservation: observation(s), now: NOW + 1 };
+}
+function postSubject(s = subject()) {
+  return { schema: "programmable.platform-maintenance-post-merge-subject.v1", original: s,
+    originalEvidenceHash: digest(evidence(s)), mergeCommit: MERGED, mergeTree: s.mergeTree, parentCommit: s.baseSha };
+}
+function fixtureClient(s = subject(), alter = () => {}) {
+  const seen = []; let merged = false;
+  const observed = observation(s);
+  return { seen, setMerged: () => { merged = true; },
+    async get(route) {
+      seen.push({ method: "GET", route });
+      let value;
+      if (route === `${ROOT}/pulls/${s.pullRequest}`) {
+        value = pr(s);
+        if (merged) Object.assign(value, { state: "closed", merged: true, merge_commit_sha: MERGED });
+      } else if (route === `${ROOT}/git/ref/heads/main`) value = { object: { sha: merged ? MERGED : s.baseSha } };
+      else if (route === `${ROOT}/git/ref/heads/production`) value = { object: { sha: s.controllerSha } };
+      else if (route === `${ROOT}/git/commits/${s.baseSha}`) value = { sha: s.baseSha, tree: { sha: s.baseTree } };
+      else if (route === `${ROOT}/git/commits/${s.headSha}`) value = { sha: s.headSha, tree: { sha: s.headTree } };
+      else if (route === `${ROOT}/git/commits/${s.mergeSha}`) value = { sha: s.mergeSha, tree: { sha: s.mergeTree },
+        parents: [{ sha: s.baseSha }, { sha: s.headSha }] };
+      else if (route === `${ROOT}/git/commits/${MERGED}`) value = { sha: MERGED, tree: { sha: s.mergeTree }, parents: [{ sha: s.baseSha }] };
+      else if (route.includes("/git/trees/")) {
+        const base = route.includes(s.baseTree);
+        value = { sha: base ? s.baseTree : s.headTree, truncated: false,
+          tree: [{ path: "src/Example.sol", sha: base ? BASE_BLOB.sha : HEAD_BLOB.sha, mode: "100644", type: "blob" }] };
+      } else if (route === `${ROOT}/git/blobs/${BASE_BLOB.sha}`) value = BASE_BLOB;
+      else if (route === `${ROOT}/git/blobs/${HEAD_BLOB.sha}`) value = HEAD_BLOB;
+      else if (route.endsWith("/collaborators/maintainer/permission")) value = permission;
+      else if (route.includes(`/pulls/${s.pullRequest}/files?`)) value = [{ filename: "src/Example.sol", status: "modified" }];
+      else if (route.includes("/check-runs?")) value = { check_runs: observed.checks };
+      else if (route.includes("/actions/runs/")) value = observed.runs.find((run) => route.endsWith(`/${run.id}`));
+      else if (route.includes("/actions/jobs/")) value = observed.jobs.find((job) => route.endsWith(`/${job.id}`));
+      else if (route.endsWith("/branches/main/protection")) value = protection();
+      assert.notEqual(value, undefined, `Unexpected GET ${route}`);
+      value = clone(value); await alter(route, value, seen); return value;
+    },
+    async post(route, body) {
+      seen.push({ method: "POST", route, body: clone(body) });
+      if (route.endsWith("/dispatches")) return null;
+      assert.equal(route, `${ROOT}/check-runs`);
+      return { ...clone(body), app: { id: policy.githubActionsAppId } };
+    },
+    async put(route, body) {
+      seen.push({ method: "PUT", route, body: clone(body) });
+      assert.equal(route, `${ROOT}/pulls/${s.pullRequest}/merge`);
+      assert.deepEqual(body, { sha: s.headSha, merge_method: "squash" });
+      merged = true; return { merged: true, sha: MERGED };
+    } };
+}
+
+test("inert policy snapshots reject getters, cycles, sparse arrays and shared memory without invoking getters", () => {
+  let calls = 0;
+  const getter = { get headSha() { calls++; return sha("1"); } };
+  const cycle = {}; cycle.self = cycle;
+  for (const value of [getter, cycle, new Array(1), new SharedArrayBuffer(8), new Uint8Array(8)]) {
+    assert.throws(() => snapshotJson(value));
+  }
+  assert.equal(calls, 0);
+  const s = subject(); const frozen = validateSubject(s); s.files[0].path = "submissions/a/application.json";
+  assert.equal(frozen.files[0].path, "src/Example.sol"); assert.ok(Object.isFrozen(frozen.files[0]));
+});
+
+test("ordinary source maintenance and the existing exact 702 CI pin are separate closed cases", () => {
+  assert.equal(validateSubject(subject()).headSha, sha("3"));
+  const pinned = subject(); pinned.headSha = policy.controlAuthorization.commit;
+  pinned.headTree = policy.controlAuthorization.tree; pinned.files[0].path = ".github/workflows/verify.yml";
+  assert.doesNotThrow(() => validateSubject(pinned));
+  pinned.headTree = sha("7"); assert.throws(() => validateSubject(pinned), /CONTROL_AUTHORIZATION_REQUIRED/);
+});
+
+for (const [name, change] of [
+  ["application", (s) => { s.files[0].path = "submissions/a/application.json"; }],
+  ["self-changing policy", (s) => { s.files[0].path = "scripts/ci/platform-maintenance-policy.mjs"; }],
+  ["symlink", (s) => { s.files[0].headMode = "120000"; }],
+  ["renamed file", (s) => { s.files[0].status = "renamed"; }],
+  ["deleted file", (s) => { s.files[0].status = "removed"; }],
+  ["path traversal", (s) => { s.files[0].path = "src/../Example.sol"; }],
+  ["policy substitution", (s) => { s.policyHash = `sha256:${"f".repeat(64)}`; }],
+]) test(`policy rejects ${name}`, () => { const s = subject(); change(s); assert.throws(() => validateSubject(s)); });
+
+for (const [name, change] of [
+  ["fork", (p) => { p.head.repo = { id: 999, full_name: "attacker/repo" }; }],
+  ["different head", (p) => { p.head.sha = sha("9"); }],
+  ["different base", (p) => { p.base.sha = sha("9"); }],
+  ["draft", (p) => { p.draft = true; }],
+  ["closed", (p) => { p.state = "closed"; }],
+  ["incomplete file pagination", (p) => { p.changed_files = 2; }],
+]) test(`live binding rejects ${name}`, () => {
+  const p = pr(); change(p); assert.throws(() => assertLivePullRequest(p, subject(), permission));
+});
+
+const finding = { id: "d".repeat(64), check: "reentrancy-eth", impact: "High", confidence: "Medium",
+  description: "Synthetic fixture finding, not a production disposition.", elements: [{
+    source_mapping: { filename_relative: "src/Example.sol", start: 10, length: 20, lines: [2, 3] } }] };
+const scan = (findings = []) => ({ success: true, error: null, results: { detectors: findings } });
+test("Slither command success is insufficient: every undispositioned impact fails closed", () => {
+  assert.equal(evaluateSlither(scan(), subject()).findingHashes.length, 0);
+  for (const impact of ["High", "Medium", "Low", "Informational", "Optimization"]) {
+    assert.throws(() => evaluateSlither(scan([{ ...finding, impact }]), subject()), /UNRESOLVED_FINDING/);
+  }
+  for (const report of [{ success: true, results: {} }, { success: false, error: "compile error", results: { detectors: [] } },
+    { success: true, error: "partial analysis", results: { detectors: [] } }]) {
+    assert.throws(() => evaluateSlither(report, subject()), /SLITHER_INCOMPLETE/);
+  }
+});
+
+test("explicit synthetic disposition binds the complete finding, tool/source closure and review evidence", () => {
+  const normalized = { id: finding.id, check: finding.check, impact: finding.impact, confidence: finding.confidence,
+    description: finding.description, locations: [{ path: "src/Example.sol", start: 10, length: 20, lines: [2, 3] }] };
+  const customPolicy = { ...policy, slitherDispositions: [{
+    findingHash: digest({ domain: "programmable.platform-maintenance-slither-finding.v1", finding: normalized }),
+    analysisHash: slitherAnalysisHash(subject()), disposition: "false-positive",
+    rationale: "Synthetic test authority explicitly reviews this exact fixture only.",
+    reviewedSourceCommit: sha("3"), evidencePath: "security/fixture-review.json", evidenceBlob: sha("b"),
+  }] };
+  assert.equal(evaluateSlither(scan([finding]), subject(customPolicy), customPolicy).findingHashes.length, 1);
+  const changed = subject(customPolicy); changed.headTree = sha("f");
+  assert.throws(() => evaluateSlither(scan([finding]), changed, customPolicy), /UNRESOLVED_FINDING/);
+  assert.throws(() => evaluateSlither(scan([{ ...finding, description: "Substituted finding" }]), subject(customPolicy), customPolicy), /UNRESOLVED_FINDING/);
+  assert.throws(() => evaluateSlither(scan(), subject(customPolicy), customPolicy), /STALE_DISPOSITION/);
+  assert.throws(() => evaluateSlither(scan([finding, finding]), subject(customPolicy), customPolicy), /DUPLICATE_FINDING/);
+  assert.deepEqual(policy.slitherDispositions, []);
+});
+
+test("complete exact-head evidence round-trips under its separate schema", () => {
+  const proof = evidence(); assert.equal(verifyEvidence(proof, expected()).evidenceHash, digest(proof));
+  for (const schema of ["programmable.autonomous-admission-decision.v1", "programmable.production-verify-proof.v1"]) {
+    assert.throws(() => verifyEvidence({ ...proof, schema }, expected()), /SCHEMA_INVALID/);
+  }
+  assert.throws(() => verifyEvidence(proof, { ...expected(), now: NOW + policy.maxAgeMs }), /EXPIRED/);
+  assert.throws(() => verifyEvidence(proof, { ...expected(), now: NOW - 1 }), /EXPIRED/);
+  assert.throws(() => verifyEvidence(proof, { ...expected(), runAttempt: 2 }), /SUBJECT_DRIFT/);
+});
+
+for (const [name, change] of [
+  ["spoofed app", (o) => { o.checks[0].app.id = 9; }],
+  ["unrelated workflow", (o) => { o.runs[0].path = ".github/workflows/spoof.yml"; }],
+  ["another head", (o) => { o.runs[0].head_sha = sha("7"); }],
+  ["fork run", (o) => { o.runs[0].head_repository.id = 9; }],
+  ["stale base", (o) => { o.runs[0].pull_requests[0].base.sha = sha("7"); }],
+  ["stale attempt", (o) => { o.runs[0].run_attempt = 2; }],
+  ["skipped gate", (o) => { o.checks[0].conclusion = "skipped"; }],
+  ["newer failure", (o) => { o.checks.push({ ...o.checks[0], id: 999, conclusion: "failure" }); }],
+  ["missing gate", (o) => { o.checks.pop(); }],
+]) test(`check authentication rejects ${name}`, () => {
+  const observed = observation(); change(observed); assert.throws(() => validateLegacyChecks(observed, subject()));
+});
+
+test("subject selection binds full GitHub identity, paginated files, canonical merge parents and inert blobs", async () => {
+  const client = fixtureClient(); assert.equal(canonical(await selectSubject(client, 702, sha("6"))), canonical(subject()));
+  assert.equal(client.seen.filter((call) => call.method !== "GET").length, 0);
+  for (const change of [
+    (route, value) => { if (route.includes("/git/trees/")) value.truncated = true; },
+    (route, value) => { if (route.endsWith(`/git/commits/${sha("5")}`)) value.parents.reverse(); },
+    (route, value) => { if (route.endsWith("/permission")) value.permission = "read"; },
+  ]) await assert.rejects(selectSubject(fixtureClient(subject(), change), 702, sha("6")));
+});
+
+test("consumer uses standard head-conditioned merge and verifies actual protected squash parent/tree", async () => {
+  const client = fixtureClient(); const proof = evidence();
+  const result = await consumeAuthenticatedEvidence(client, proof, { run: { id: 901, run_attempt: 1 } }, () => NOW + 1);
+  assert.equal(result.mergeCommit, MERGED); assert.equal(result.websiteDeployment, false);
+  assert.equal(client.seen.filter((call) => call.method === "PUT").length, 1);
+  assert.ok(client.seen.findIndex((call) => call.route.endsWith("/protection"))
+    < client.seen.findIndex((call) => call.method === "POST"));
+  assert.ok(client.seen.some((call) => call.route.endsWith(`/git/commits/${MERGED}`)));
+});
+
+test("current human rules or absent authenticated machine context block before any write", async () => {
+  for (const change of [
+    (p) => { p.required_pull_request_reviews.required_approving_review_count = 1; },
+    (p) => { p.required_pull_request_reviews.require_code_owner_reviews = true; },
+    (p) => { p.required_status_checks.checks.pop(); },
+    (p) => { p.required_status_checks.checks[0].app_id = null; },
+    (p) => { p.required_status_checks.strict = false; },
+    (p) => { p.enforce_admins.enabled = false; },
+  ]) {
+    const p = protection(); change(p); assert.throws(() => assertMergeProtection(p));
+    const client = fixtureClient(subject(), (route, value) => { if (route.endsWith("/protection")) change(value); });
+    await assert.rejects(consumeAuthenticatedEvidence(client, evidence(), { run: { id: 901, run_attempt: 1 } }, () => NOW + 1));
+    assert.equal(client.seen.some((call) => call.method !== "GET"), false);
+  }
+});
+
+test("bootstrap can publish genuine authenticated technical evidence without invoking merge or changing protection", async () => {
+  const client = fixtureClient(subject(), (route, value) => {
+    if (route.endsWith("/protection")) value.required_pull_request_reviews.required_approving_review_count = 1;
+  });
+  const result = await publishAuthenticatedEvidenceCheck(client, evidence(), { run: { id: 901, run_attempt: 1 } }, () => NOW + 1);
+  assert.equal(result.evidenceHash, digest(evidence()));
+  const writes = client.seen.filter((call) => call.method !== "GET");
+  assert.equal(writes.length, 1); assert.equal(writes[0].route, `${ROOT}/check-runs`);
+  assert.equal(writes[0].body.conclusion, "success");
+  assert.doesNotMatch(writes[0].route, /\/merge|\/reviews|\/protection/);
+  const invalid = clone(evidence()); invalid.slither.sourceCommit = sha("9");
+  const untouched = fixtureClient();
+  await assert.rejects(publishAuthenticatedEvidenceCheck(untouched, invalid, { run: { id: 901, run_attempt: 1 } }, () => NOW + 1));
+  assert.equal(untouched.seen.some((call) => call.method !== "GET"), false);
+});
+
+test("head change after check publication is revalidated before the merge endpoint", async () => {
+  const client = fixtureClient(subject(), (route, value, seen) => {
+    if (route.endsWith("/pulls/702") && seen.some((call) => call.method === "POST")) value.head.sha = sha("9");
+  });
+  await assert.rejects(consumeAuthenticatedEvidence(client, evidence(), { run: { id: 901, run_attempt: 1 } }, () => NOW + 1), /BINDING_DRIFT/);
+  assert.equal(client.seen.some((call) => call.method === "PUT"), false);
+  assert.equal(client.seen.filter((call) => call.method === "POST").at(-1).body.conclusion, "failure");
+});
+
+test("caller mutation after await cannot substitute nested merge subject or evidence", async () => {
+  const mutable = clone(evidence()); const producer = { run: { id: 901, run_attempt: 1 } };
+  const client = fixtureClient();
+  const promise = consumeAuthenticatedEvidence(client, mutable, producer, () => NOW + 1);
+  mutable.subject.headSha = sha("9"); mutable.checks[0].workflow = ".github/workflows/spoof.yml";
+  producer.run.id = 999;
+  const result = await promise; assert.equal(result.evidenceHash, digest(evidence()));
+  assert.equal(client.seen.find((call) => call.method === "PUT").body.sha, subject().headSha);
+});
+
+test("post-merge dispatch is independently bound and remains distinct from completion evidence", async () => {
+  const client = fixtureClient(); client.setMerged(); const post = postSubject();
+  const receipt = await dispatchPostMergeVerification(client, post, 901);
+  assert.equal(receipt.dispatchAccepted, true); assert.equal(receipt.verificationCompleted, false);
+  const dispatched = client.seen.find((call) => call.method === "POST");
+  assert.equal(dispatched.route, `${ROOT}/actions/workflows/platform-maintenance-post-merge.yml/dispatches`);
+  assert.deepEqual(dispatched.body, { ref: "production", inputs: { pull_request: "702", merge_sha: MERGED,
+    producer_run: "901", controller_sha: subject().controllerSha } });
+  const proof = createPostMergeEvidence({ subject: post, ...workers(post), runId: 902, runAttempt: 1, issuedAt: NOW });
+  assert.equal(proof.schema, "programmable.platform-maintenance-post-merge-evidence.v1");
+  assert.throws(() => verifyEvidence(proof, expected()));
+  assert.throws(() => createPostMergeEvidence({ subject: post, ...workers(), runId: 902, runAttempt: 1, issuedAt: NOW }), /WORKER_BINDING_INVALID/);
+});
+
+test("post-merge base, tree, controller and current main drift cannot dispatch", async () => {
+  for (const change of [
+    (route, value) => { if (route.endsWith("/heads/main")) value.object.sha = sha("a"); },
+    (route, value) => { if (route.endsWith("/heads/production")) value.object.sha = sha("a"); },
+    (route, value) => { if (route.endsWith(`/git/commits/${MERGED}`)) value.tree.sha = sha("a"); },
+    (route, value) => { if (route.endsWith(`/git/commits/${MERGED}`)) value.parents[0].sha = sha("a"); },
+  ]) {
+    const client = fixtureClient(subject(), change); client.setMerged();
+    await assert.rejects(dispatchPostMergeVerification(client, postSubject(), 901), /POST_MERGE_REF_DRIFT/);
+    assert.equal(client.seen.some((call) => call.method !== "GET"), false);
+  }
+});
+
+test("worker guards require zero privileged credential exposure and actual successful tests", () => {
+  assert.doesNotThrow(() => assertWorkerEnvironment({}));
+  for (const key of ["GH_TOKEN", "GITHUB_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_URL"]) {
+    assert.throws(() => assertWorkerEnvironment({ [key]: "fixture-only" }), /CREDENTIAL_PRESENT/);
+  }
+  assert.equal(summarizeFoundryReport({ Example: { test_results: { example: { status: "Success" } } } }).testCount, 1);
+  for (const report of [{}, { Example: { test_results: {} } }, { Example: { test_results: { example: { status: "Skipped" } } } }]) {
+    assert.throws(() => summarizeFoundryReport(report));
+  }
+  const args = attestationArguments("/tmp/evidence.json", sha("6"));
+  assert.ok(args.includes("--deny-self-hosted-runners"));
+  assert.equal(args[args.indexOf("--source-digest") + 1], sha("6"));
+  assert.equal(args[args.indexOf("--signer-digest") + 1], sha("6"));
+});
+
+test("bounded GitHub transport stays on the fixed repository and does not expose server error text", async () => {
+  const seen = [];
+  const client = createGitHubClient("synthetic-unit-token", async (url, init) => {
+    seen.push({ url, init }); return new Response(JSON.stringify({ answer: 1 }));
+  });
+  assert.equal((await client.get(`${ROOT}/pulls/702`)).answer, 1);
+  assert.equal(seen[0].init.redirect, "error");
+  await assert.rejects(client.get("/repos/attacker/other/pulls/702"), /ROUTE_INVALID/);
+  assert.equal(seen.length, 1);
+  const failing = createGitHubClient("synthetic-unit-token", async () => new Response("secret-like-fixture", { status: 403 }));
+  await assert.rejects(failing.get(`${ROOT}/pulls/702`), /^Error: MAINTENANCE_GITHUB_REQUEST_FAILED$/);
+  const dispatch = createGitHubClient("synthetic-unit-token", async () => new Response(null, { status: 204 }));
+  assert.equal(await dispatch.post(`${ROOT}/actions/workflows/platform-maintenance-post-merge.yml/dispatches`, {}), null);
+});
+
+function producerFixture(alter = () => {}) {
+  const run = { id: 901, repository: { id: policy.repositoryId }, head_repository: { id: policy.repositoryId },
+    path: policy.producerWorkflow, name: policy.producerName, event: "pull_request_target",
+    status: "completed", conclusion: "success", run_attempt: 1, head_sha: sha("3"), head_branch: "codex/fixture" };
+  const jobs = ["Select maintenance subject", "Exact head foundry", "Exact head slither", "Attest maintenance evidence"]
+    .map((name, index) => ({ name, id: 9000 + index, run_id: 901, run_attempt: 1, status: "completed", conclusion: "success" }));
+  const artifact = { id: 1000, name: "platform-maintenance-evidence-901-1", expired: false,
+    digest: `sha256:${"a".repeat(64)}`, size_in_bytes: 5000,
+    workflow_run: { id: 901, repository_id: policy.repositoryId, head_repository_id: policy.repositoryId,
+      head_sha: run.head_sha, head_branch: run.head_branch } };
+  const state = { run, jobs, artifacts: [artifact] }; alter(state);
+  return { async get(route) {
+    if (route === `${ROOT}/actions/runs/901`) return clone(state.run);
+    if (route.includes("/jobs?")) return { jobs: clone(state.jobs) };
+    if (route.includes("/artifacts?")) return { artifacts: clone(state.artifacts) };
+    assert.fail(`Unexpected producer route ${route}`);
+  } };
+}
+
+test("producer resolution requires one complete independent job set and one exact immutable artifact", async () => {
+  const selected = await resolveProducer(producerFixture(), 901);
+  assert.equal(selected.artifact.id, 1000); assert.equal(selected.run.run_attempt, 1);
+  for (const change of [
+    (state) => { state.run.path = ".github/workflows/spoof.yml"; },
+    (state) => { state.run.repository.id = 42; },
+    (state) => { state.jobs[1].conclusion = "skipped"; },
+    (state) => { state.jobs[2].run_id = 42; },
+    (state) => { state.jobs[3].run_attempt = 2; },
+    (state) => { state.jobs.pop(); },
+    (state) => { state.artifacts[0].id = 0; },
+    (state) => { state.artifacts[0].expired = true; },
+    (state) => { state.artifacts[0].digest = "unbound"; },
+    (state) => { state.artifacts[0].workflow_run.head_repository_id = 42; },
+    (state) => { state.artifacts[0].workflow_run.head_sha = sha("f"); },
+    (state) => { state.artifacts[0].name = "platform-maintenance-evidence-901-2"; },
+    (state) => { state.artifacts.push(clone(state.artifacts[0])); },
+  ]) await assert.rejects(resolveProducer(producerFixture(change), 901));
+});
+
+test("malformed worker bindings and scan locations cannot enter a signed evidence subject", () => {
+  const original = { subject: subject(), ...workers(), legacyObservation: observation(), runId: 901, runAttempt: 1, issuedAt: NOW };
+  for (const change of [
+    (input) => { input.foundry.sourceCommit = sha("9"); },
+    (input) => { input.slither.sourceTree = sha("9"); },
+    (input) => { input.foundry.solcVersion = "0.8.25"; },
+    (input) => { input.foundry.testCount = 0; },
+    (input) => { input.slither.slitherReport.success = false; },
+  ]) { const input = clone(original); change(input); assert.throws(() => createEvidence(input)); }
+  const invalid = clone(finding); invalid.elements[0].source_mapping.filename_relative = "../private/file.sol";
+  assert.throws(() => evaluateSlither(scan([invalid]), subject()), /LOCATION_INVALID/);
+});

--- a/scripts/test/platform-maintenance-release.test.mjs
+++ b/scripts/test/platform-maintenance-release.test.mjs
@@ -6,14 +6,30 @@ import { MAINTENANCE_POLICY as policy, REQUIRED_LEGACY_CHECKS, assertLivePullReq
 } from "../ci/platform-maintenance-policy.mjs";
 import { WORKER_SCHEMA, createEvidence, createPostMergeEvidence, evaluateSlither, slitherAnalysisHash,
   validateLegacyChecks, verifyEvidence } from "../ci/platform-maintenance-evidence.mjs";
-import { consumeAuthenticatedEvidence, createGitHubClient, dispatchPostMergeVerification,
-  publishAuthenticatedEvidenceCheck, revalidateMergedSubject, resolveProducer, selectSubject } from "../ci/platform-maintenance-github.mjs";
+import { consumeAuthenticatedEvidence as consumeWithReader, createGitHubClient, createPolicyReadAuthority,
+  dispatchPostMergeVerification, policyReadConfiguration,
+  revalidateMergedSubject, resolveProducer, selectSubject } from "../ci/platform-maintenance-github.mjs";
 import { assertWorkerEnvironment, attestationArguments, summarizeFoundryReport } from "../ci/platform-maintenance-runner.mjs";
 
 const sha = (character) => character.repeat(40);
 const ROOT = `/repos/${policy.repository}`;
 const NOW = 1788650000000;
 const MERGED = sha("8");
+const READER_CONFIGURATION = { appId: 41, installationId: 42, repository: policy.repository,
+  repositoryId: policy.repositoryId, baseRef: policy.baseRef };
+const READER_CREDENTIAL = { appId: 41, installationId: 42, token: "synthetic-policy-reader-token" };
+const READER_SUBJECT = { repository: policy.repository, repositoryId: policy.repositoryId, baseRef: policy.baseRef };
+function consumeAuthenticatedEvidence(client, proof, producer, now) {
+  return consumeWithReader(client, proof, producer, now, policy, client.policyReader ?? null);
+}
+function checkTransitions(client, name) {
+  return client.seen.filter((call) => call.method === "POST" && call.body.name === name)
+    .map((call) => call.body.status === "in_progress" ? "in_progress" : call.body.conclusion);
+}
+function assertWithdrawn(client) {
+  assert.equal(checkTransitions(client, policy.checkName).at(-1), "failure");
+  assert.deepEqual(checkTransitions(client, policy.evidenceCheckName), ["success", "failure"]);
+}
 const clone = (value) => JSON.parse(JSON.stringify(value));
 const blob = (text) => {
   const bytes = Buffer.from(text);
@@ -37,7 +53,8 @@ function pr(s = subject()) {
 }
 const permission = { permission: "write", user: { id: 7 } };
 function protection() {
-  return { enforce_admins: { enabled: true }, required_linear_history: { enabled: true },
+  return { url: `https://api.github.com${ROOT}/branches/main/protection`,
+    enforce_admins: { enabled: true }, required_linear_history: { enabled: true },
     allow_force_pushes: { enabled: false }, allow_deletions: { enabled: false },
     required_pull_request_reviews: { required_approving_review_count: 0, require_code_owner_reviews: false,
       require_last_push_approval: false },
@@ -47,16 +64,19 @@ function protection() {
 function observation(s = subject()) {
   const result = { checks: [], runs: [], jobs: [] };
   for (const [index, required] of REQUIRED_LEGACY_CHECKS.entries()) {
-    const id = 100 + index, runId = 200 + index;
+    const id = 100 + index, runId = 200 + index, jobId = 300 + index, suiteId = 400 + index;
+    const details = `https://github.com/${policy.repository}/actions/runs/${runId}/job/${jobId}`;
     result.checks.push({ id, name: required.name, status: "completed", conclusion: "success", head_sha: s.headSha,
       app: { id: policy.githubActionsAppId, slug: "github-actions", owner: { login: "github" } },
-      details_url: `https://github.com/${policy.repository}/actions/runs/${runId}/job/${id}` });
+      check_suite: { id: suiteId }, details_url: details });
     result.runs.push({ id: runId, path: required.path, repository: { id: policy.repositoryId },
       head_repository: { id: policy.repositoryId }, head_sha: s.headSha, status: "completed", conclusion: "success",
       event: required.name === "public-intake" ? "pull_request_target" : "pull_request", run_attempt: 1,
+      check_suite_id: suiteId,
       pull_requests: [{ number: s.pullRequest, base: { sha: s.baseSha, repo: { id: policy.repositoryId } },
         head: { sha: s.headSha, repo: { id: policy.repositoryId } } }] });
-    result.jobs.push({ id, run_id: runId, run_attempt: 1, head_sha: s.headSha,
+    result.jobs.push({ id: jobId, run_id: runId, run_attempt: 1, head_sha: s.headSha,
+      check_run_url: `https://api.github.com/repos/${policy.repository}/check-runs/${id}`, html_url: details,
       name: required.name, status: "completed", conclusion: "success" });
   }
   return result;
@@ -83,7 +103,7 @@ function postSubject(s = subject()) {
 function fixtureClient(s = subject(), alter = () => {}) {
   const seen = []; let merged = false;
   const observed = observation(s);
-  return { seen, setMerged: () => { merged = true; },
+  const client = { seen, setMerged: () => { merged = true; },
     async get(route) {
       seen.push({ method: "GET", route });
       let value;
@@ -108,7 +128,6 @@ function fixtureClient(s = subject(), alter = () => {}) {
       else if (route.includes("/check-runs?")) value = { check_runs: observed.checks };
       else if (route.includes("/actions/runs/")) value = observed.runs.find((run) => route.endsWith(`/${run.id}`));
       else if (route.includes("/actions/jobs/")) value = observed.jobs.find((job) => route.endsWith(`/${job.id}`));
-      else if (route.endsWith("/branches/main/protection")) value = protection();
       assert.notEqual(value, undefined, `Unexpected GET ${route}`);
       value = clone(value); await alter(route, value, seen); return value;
     },
@@ -124,6 +143,17 @@ function fixtureClient(s = subject(), alter = () => {}) {
       assert.deepEqual(body, { sha: s.headSha, merge_method: "squash" });
       merged = true; return { merged: true, sha: MERGED };
     } };
+  client.policyReader = createPolicyReadAuthority(READER_CONFIGURATION, READER_CREDENTIAL, async (url, init) => {
+    assert.equal(init.method, "GET");
+    assert.equal(init.headers.authorization, `Bearer ${READER_CREDENTIAL.token}`);
+    const route = url.replace("https://api.github.com", "");
+    seen.push({ method: "GET", route, authority: "policy-reader" });
+    if (route === "/installation/repositories?per_page=100&page=1") return Response.json({ total_count: 1,
+      repositories: [{ id: policy.repositoryId, full_name: policy.repository }] });
+    assert.equal(route, `${ROOT}/branches/main/protection`);
+    const value = protection(); await alter(route, value, seen); return Response.json(value);
+  });
+  return client;
 }
 
 test("inert policy snapshots reject getters, cycles, sparse arrays and shared memory without invoking getters", () => {
@@ -160,6 +190,7 @@ for (const [name, change] of [
   ["fork", (p) => { p.head.repo = { id: 999, full_name: "attacker/repo" }; }],
   ["different head", (p) => { p.head.sha = sha("9"); }],
   ["different base", (p) => { p.base.sha = sha("9"); }],
+  ["production target", (p) => { p.base.ref = "production"; }],
   ["draft", (p) => { p.draft = true; }],
   ["closed", (p) => { p.state = "closed"; }],
   ["incomplete file pagination", (p) => { p.changed_files = 2; }],
@@ -217,6 +248,9 @@ for (const [name, change] of [
   ["fork run", (o) => { o.runs[0].head_repository.id = 9; }],
   ["stale base", (o) => { o.runs[0].pull_requests[0].base.sha = sha("7"); }],
   ["stale attempt", (o) => { o.runs[0].run_attempt = 2; }],
+  ["another check suite", (o) => { o.runs[0].check_suite_id = 999; }],
+  ["job linked to another check", (o) => { o.jobs[0].check_run_url = `https://api.github.com/repos/${policy.repository}/check-runs/999`; }],
+  ["job linked to another run URL", (o) => { o.jobs[0].html_url = `https://github.com/${policy.repository}/actions/runs/999/job/300`; }],
   ["skipped gate", (o) => { o.checks[0].conclusion = "skipped"; }],
   ["newer failure", (o) => { o.checks.push({ ...o.checks[0], id: 999, conclusion: "failure" }); }],
   ["missing gate", (o) => { o.checks.pop(); }],
@@ -239,12 +273,17 @@ test("consumer uses standard head-conditioned merge and verifies actual protecte
   const result = await consumeAuthenticatedEvidence(client, proof, { run: { id: 901, run_attempt: 1 } }, () => NOW + 1);
   assert.equal(result.mergeCommit, MERGED); assert.equal(result.websiteDeployment, false);
   assert.equal(client.seen.filter((call) => call.method === "PUT").length, 1);
+  assert.deepEqual(checkTransitions(client, policy.checkName), ["in_progress", "success"]);
+  assert.deepEqual(checkTransitions(client, policy.evidenceCheckName), ["success"]);
   assert.ok(client.seen.findIndex((call) => call.route.endsWith("/protection"))
-    < client.seen.findIndex((call) => call.method === "POST"));
+    < client.seen.findIndex((call) => call.method === "POST" && call.body.name === policy.checkName
+      && call.body.conclusion === "success"));
   assert.ok(client.seen.some((call) => call.route.endsWith(`/git/commits/${MERGED}`)));
+  assert.equal(client.seen.filter((call) => call.route.endsWith("/branches/main/protection")
+    && call.authority === "policy-reader").length, 2);
 });
 
-test("current human rules or absent authenticated machine context block before any write", async () => {
+test("bootstrap protection holds preserve genuine technical evidence but never request merge", async () => {
   for (const change of [
     (p) => { p.required_pull_request_reviews.required_approving_review_count = 1; },
     (p) => { p.required_pull_request_reviews.require_code_owner_reviews = true; },
@@ -256,7 +295,10 @@ test("current human rules or absent authenticated machine context block before a
     const p = protection(); change(p); assert.throws(() => assertMergeProtection(p));
     const client = fixtureClient(subject(), (route, value) => { if (route.endsWith("/protection")) change(value); });
     await assert.rejects(consumeAuthenticatedEvidence(client, evidence(), { run: { id: 901, run_attempt: 1 } }, () => NOW + 1));
-    assert.equal(client.seen.some((call) => call.method !== "GET"), false);
+    const writes = client.seen.filter((call) => call.method !== "GET");
+    assert.equal(writes.length, 3); assert.equal(writes.every((call) => call.route === `${ROOT}/check-runs`), true);
+    assert.deepEqual(checkTransitions(client, policy.checkName), ["in_progress", "failure"]);
+    assert.deepEqual(checkTransitions(client, policy.evidenceCheckName), ["success"]);
   }
 });
 
@@ -264,15 +306,15 @@ test("bootstrap can publish genuine authenticated technical evidence without inv
   const client = fixtureClient(subject(), (route, value) => {
     if (route.endsWith("/protection")) value.required_pull_request_reviews.required_approving_review_count = 1;
   });
-  const result = await publishAuthenticatedEvidenceCheck(client, evidence(), { run: { id: 901, run_attempt: 1 } }, () => NOW + 1);
-  assert.equal(result.evidenceHash, digest(evidence()));
+  await assert.rejects(consumeAuthenticatedEvidence(client, evidence(), { run: { id: 901, run_attempt: 1 } },
+    () => NOW + 1), /HUMAN_RULE_STILL_ACTIVE/);
   const writes = client.seen.filter((call) => call.method !== "GET");
-  assert.equal(writes.length, 1); assert.equal(writes[0].route, `${ROOT}/check-runs`);
-  assert.equal(writes[0].body.conclusion, "success");
-  assert.doesNotMatch(writes[0].route, /\/merge|\/reviews|\/protection/);
+  assert.equal(writes.length, 3); assert.equal(writes.every((call) => call.route === `${ROOT}/check-runs`), true);
+  assert.deepEqual(checkTransitions(client, policy.evidenceCheckName), ["success"]);
+  assert.deepEqual(checkTransitions(client, policy.checkName), ["in_progress", "failure"]);
   const invalid = clone(evidence()); invalid.slither.sourceCommit = sha("9");
   const untouched = fixtureClient();
-  await assert.rejects(publishAuthenticatedEvidenceCheck(untouched, invalid, { run: { id: 901, run_attempt: 1 } }, () => NOW + 1));
+  await assert.rejects(consumeAuthenticatedEvidence(untouched, invalid, { run: { id: 901, run_attempt: 1 } }, () => NOW + 1));
   assert.equal(untouched.seen.some((call) => call.method !== "GET"), false);
 });
 
@@ -283,6 +325,105 @@ test("head change after check publication is revalidated before the merge endpoi
   await assert.rejects(consumeAuthenticatedEvidence(client, evidence(), { run: { id: 901, run_attempt: 1 } }, () => NOW + 1), /BINDING_DRIFT/);
   assert.equal(client.seen.some((call) => call.method === "PUT"), false);
   assert.equal(client.seen.filter((call) => call.method === "POST").at(-1).body.conclusion, "failure");
+});
+
+test("the CLI consumer entry withdraws early base and technical drifts after bootstrap publication", async () => {
+  for (const change of [
+    (route, value) => { if (route.endsWith("/heads/main")) value.object.sha = sha("9"); },
+    (route, value) => { if (route.endsWith("/heads/production")) value.object.sha = sha("9"); },
+    (route, value) => { if (route.includes("/check-runs?")) value.check_runs[0].conclusion = "failure"; },
+  ]) {
+    const client = fixtureClient(subject(), (route, value, seen) => {
+      if (seen.some((call) => call.method === "POST")) change(route, value);
+    });
+    await assert.rejects(consumeAuthenticatedEvidence(client, evidence(), { run: { id: 901, run_attempt: 1 } }, () => NOW + 1));
+    const writes = client.seen.filter((call) => call.method !== "GET");
+    assertWithdrawn(client);
+    assert.deepEqual(checkTransitions(client, policy.checkName), ["in_progress", "failure"]);
+    assert.equal(writes.every((call) => call.route === `${ROOT}/check-runs`), true);
+    assert.equal(client.seen.some((call) => call.route.endsWith("/protection")), false);
+  }
+});
+
+test("evidence expiring immediately after publication is withdrawn before protection inspection", async () => {
+  let reads = 0; const client = fixtureClient();
+  await assert.rejects(consumeAuthenticatedEvidence(client, evidence(), { run: { id: 901, run_attempt: 1 } },
+    () => ++reads === 1 ? NOW + 1 : NOW + policy.maxAgeMs), /EVIDENCE_EXPIRED/);
+  assertWithdrawn(client);
+  assert.equal(client.seen.some((call) => call.method === "PUT" || call.route.endsWith("/protection")), false);
+});
+
+test("a bootstrap hold cannot preserve success when the subject drifts during protection inspection", async () => {
+  const client = fixtureClient(subject(), (route, value, seen) => {
+    if (route.endsWith("/protection")) value.required_pull_request_reviews.required_approving_review_count = 1;
+    if (route.endsWith("/pulls/702") && seen.some((call) => call.route.endsWith("/protection"))) value.head.sha = sha("9");
+  });
+  await assert.rejects(consumeAuthenticatedEvidence(client, evidence(), { run: { id: 901, run_attempt: 1 } },
+    () => NOW + 1), /BINDING_DRIFT/);
+  assertWithdrawn(client);
+  assert.equal(client.seen.some((call) => call.method === "PUT"), false);
+});
+
+test("missing policy-read authority preserves only refreshed technical evidence and keeps merging closed", async () => {
+  const client = fixtureClient(); client.policyReader = null;
+  await assert.rejects(consumeAuthenticatedEvidence(client, evidence(), { run: { id: 901, run_attempt: 1 } },
+    () => NOW + 1), /POLICY_READ_AUTHORITY_UNCONFIGURED/);
+  const writes = client.seen.filter((call) => call.method !== "GET");
+  assert.equal(writes.length, 3);
+  assert.deepEqual(checkTransitions(client, policy.checkName), ["in_progress", "failure"]);
+  assert.deepEqual(checkTransitions(client, policy.evidenceCheckName), ["success"]);
+});
+
+test("an old release success is replaced before a new bootstrap-only attempt can return", async () => {
+  const client = fixtureClient(subject(), (route, value) => {
+    if (route.includes("/check-runs?")) value.check_runs.push({ name: policy.checkName,
+      id: 9999, head_sha: subject().headSha, status: "completed", conclusion: "success" });
+  });
+  client.policyReader = null;
+  await assert.rejects(consumeAuthenticatedEvidence(client, evidence(), { run: { id: 901, run_attempt: 1 } },
+    () => NOW + 1), /AUTHORITY_UNCONFIGURED/);
+  const writes = client.seen.filter((call) => call.method === "POST");
+  assert.equal(writes[0].body.name, policy.checkName); assert.equal(writes[0].body.status, "in_progress");
+  assert.deepEqual(checkTransitions(client, policy.checkName), ["in_progress", "failure"]);
+  assert.deepEqual(checkTransitions(client, policy.evidenceCheckName), ["success"]);
+});
+
+test("protection drift after release success is withdrawn before the merge endpoint", async () => {
+  const client = fixtureClient(subject(), (route, value, seen) => {
+    if (route.endsWith("/protection") && seen.some((call) => call.method === "POST"
+      && call.body.name === policy.checkName && call.body.conclusion === "success")) {
+      value.required_pull_request_reviews.require_last_push_approval = true;
+    }
+  });
+  await assert.rejects(consumeAuthenticatedEvidence(client, evidence(), { run: { id: 901, run_attempt: 1 } },
+    () => NOW + 1), /HUMAN_RULE_STILL_ACTIVE/);
+  assertWithdrawn(client);
+  assert.deepEqual(checkTransitions(client, policy.checkName), ["in_progress", "success", "failure"]);
+  assert.equal(client.seen.some((call) => call.method === "PUT"), false);
+});
+
+test("post-merge tree mismatch withdraws success and emits no merged-state receipt", async () => {
+  const client = fixtureClient(subject(), (route, value) => {
+    if (route.endsWith(`/git/commits/${MERGED}`)) value.tree.sha = sha("9");
+  });
+  await assert.rejects(consumeAuthenticatedEvidence(client, evidence(), { run: { id: 901, run_attempt: 1 } },
+    () => NOW + 1), /POST_MERGE_REF_DRIFT/);
+  assert.equal(client.seen.filter((call) => call.method === "PUT").length, 1);
+  assertWithdrawn(client);
+  assert.deepEqual(checkTransitions(client, policy.checkName), ["in_progress", "success", "failure"]);
+});
+
+test("an unsuccessful withdrawal reports uncertain merge state without exposing transport details", async () => {
+  const client = fixtureClient(subject(), (route, value, seen) => {
+    if (route.endsWith("/pulls/702") && seen.some((call) => call.method === "POST")) value.head.sha = sha("9");
+  });
+  const post = client.post;
+  client.post = async (route, body) => {
+    if (body.conclusion === "failure") throw new Error("synthetic transport detail");
+    return post(route, body);
+  };
+  await assert.rejects(consumeAuthenticatedEvidence(client, evidence(), { run: { id: 901, run_attempt: 1 } },
+    () => NOW + 1), /^Error: MAINTENANCE_MERGE_STATE_UNCERTAIN$/);
 });
 
 test("caller mutation after await cannot substitute nested merge subject or evidence", async () => {
@@ -324,7 +465,7 @@ test("post-merge base, tree, controller and current main drift cannot dispatch",
 
 test("worker guards require zero privileged credential exposure and actual successful tests", () => {
   assert.doesNotThrow(() => assertWorkerEnvironment({}));
-  for (const key of ["GH_TOKEN", "GITHUB_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_URL"]) {
+  for (const key of ["GH_TOKEN", "GITHUB_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_URL", "MAINTENANCE_POLICY_READ_TOKEN"]) {
     assert.throws(() => assertWorkerEnvironment({ [key]: "fixture-only" }), /CREDENTIAL_PRESENT/);
   }
   assert.equal(summarizeFoundryReport({ Example: { test_results: { example: { status: "Success" } } } }).testCount, 1);
@@ -348,8 +489,90 @@ test("bounded GitHub transport stays on the fixed repository and does not expose
   assert.equal(seen.length, 1);
   const failing = createGitHubClient("synthetic-unit-token", async () => new Response("secret-like-fixture", { status: 403 }));
   await assert.rejects(failing.get(`${ROOT}/pulls/702`), /^Error: MAINTENANCE_GITHUB_REQUEST_FAILED$/);
+  await assert.rejects(failing.get(`${ROOT}/branches/main/protection`), /^Error: MAINTENANCE_SEPARATE_POLICY_READER_REQUIRED$/);
   const dispatch = createGitHubClient("synthetic-unit-token", async () => new Response(null, { status: 204 }));
   assert.equal(await dispatch.post(`${ROOT}/actions/workflows/platform-maintenance-post-merge.yml/dispatches`, {}), null);
+});
+
+test("policy-reader installation pins require a separate reviewed configuration", () => {
+  assert.equal(policyReadConfiguration({ ...policy, policyReadAuthority: null }), null);
+  assert.throws(() => createPolicyReadAuthority(null, READER_CREDENTIAL), /AUTHORITY_UNCONFIGURED/);
+  for (const pins of [{ appId: 41 }, { appId: 0, installationId: 42 },
+    { appId: 41, installationId: 42, repository: "attacker/other" }]) {
+    assert.throws(() => policyReadConfiguration({ ...policy, policyReadAuthority: pins }));
+  }
+  assert.equal(canonical(policyReadConfiguration({ ...policy, policyReadAuthority: { appId: 41, installationId: 42 } })),
+    canonical(READER_CONFIGURATION));
+});
+
+test("policy reader binds App installation and immutable subject before the first request", async () => {
+  let calls = 0;
+  const transport = async () => { calls++; return Response.json({}); };
+  for (const credential of [{ ...READER_CREDENTIAL, appId: 99 }, { ...READER_CREDENTIAL, installationId: 99 },
+    { ...READER_CREDENTIAL, token: "" }]) {
+    assert.throws(() => createPolicyReadAuthority(READER_CONFIGURATION, credential, transport), /CREDENTIAL_BINDING_INVALID/);
+  }
+  for (const configuration of [{ ...READER_CONFIGURATION, repositoryId: 99 },
+    { ...READER_CONFIGURATION, baseRef: "production" }]) {
+    assert.throws(() => createPolicyReadAuthority(configuration, READER_CREDENTIAL, transport), /CONFIGURATION_INVALID/);
+  }
+  const reader = createPolicyReadAuthority(READER_CONFIGURATION, READER_CREDENTIAL, transport);
+  assert.deepEqual(Object.keys(reader), ["readProtection"]);
+  await assert.rejects(reader.readProtection({ ...READER_SUBJECT, baseRef: "production" }), /SUBJECT_MISMATCH/);
+  assert.equal(calls, 0);
+});
+
+test("policy reader uses only its separate token and refetches exact repository scope for every read", async () => {
+  const seen = []; const mutableConfig = clone(READER_CONFIGURATION); const mutableCredential = clone(READER_CREDENTIAL);
+  const reader = createPolicyReadAuthority(mutableConfig, mutableCredential, async (url, init) => {
+    seen.push(url); assert.equal(init.method, "GET"); assert.equal(init.redirect, "error");
+    assert.equal(init.headers.authorization, `Bearer ${READER_CREDENTIAL.token}`);
+    if (url.includes("/installation/repositories?")) return Response.json({ total_count: 1,
+      repositories: [{ id: policy.repositoryId, full_name: policy.repository }] });
+    assert.equal(url, `https://api.github.com${ROOT}/branches/main/protection`);
+    return Response.json(protection());
+  });
+  const mutableSubject = clone(READER_SUBJECT); const pending = reader.readProtection(mutableSubject);
+  mutableConfig.baseRef = "production"; mutableCredential.token = "unrelated-token"; mutableSubject.baseRef = "production";
+  assert.equal((await pending).url, protection().url);
+  await reader.readProtection(READER_SUBJECT);
+  assert.equal(seen.length, 4); assert.equal(seen.filter((url) => url.includes("/installation/repositories?")).length, 2);
+});
+
+test("wrong or broad policy-token scope and wrong-branch policy responses fail closed", async () => {
+  for (const scope of [{ total_count: 2, repositories: [{ id: policy.repositoryId, full_name: policy.repository }] },
+    { total_count: 1, repositories: [{ id: 99, full_name: policy.repository }] },
+    { total_count: 1, repositories: [{ id: policy.repositoryId, full_name: "attacker/other" }] }]) {
+    let calls = 0;
+    const reader = createPolicyReadAuthority(READER_CONFIGURATION, READER_CREDENTIAL, async () => {
+      calls++; return Response.json(scope);
+    });
+    await assert.rejects(reader.readProtection(READER_SUBJECT), /REPOSITORY_SCOPE_MISMATCH/);
+    assert.equal(calls, 1);
+  }
+  const reader = createPolicyReadAuthority(READER_CONFIGURATION, READER_CREDENTIAL, async (url) =>
+    url.includes("/installation/repositories?") ? Response.json({ total_count: 1,
+      repositories: [{ id: policy.repositoryId, full_name: policy.repository }] })
+      : Response.json({ ...protection(), url: `https://api.github.com${ROOT}/branches/production/protection` }));
+  await assert.rejects(reader.readProtection(READER_SUBJECT), /RESPONSE_SUBJECT_MISMATCH/);
+});
+
+test("unavailable policy administration permission is explicit and is never borrowed from GITHUB_TOKEN", async () => {
+  const reader = createPolicyReadAuthority(READER_CONFIGURATION, READER_CREDENTIAL, async (url) =>
+    url.includes("/installation/repositories?") ? Response.json({ total_count: 1,
+      repositories: [{ id: policy.repositoryId, full_name: policy.repository }] })
+      : new Response("sensitive provider detail", { status: 403 }));
+  await assert.rejects(reader.readProtection(READER_SUBJECT), /^Error: MAINTENANCE_PROTECTION_READ_AUTHORITY_REQUIRED$/);
+  let calls = 0;
+  const client = createGitHubClient("synthetic-workflow-token", async () => { calls++; return Response.json(protection()); });
+  await assert.rejects(client.get(`${ROOT}/branches/main/protection`), /SEPARATE_POLICY_READER_REQUIRED/);
+  assert.equal(calls, 0);
+  const consumer = fixtureClient(); let invoked = false;
+  consumer.policyReader = { readProtection() { invoked = true; return protection(); } };
+  await assert.rejects(consumeAuthenticatedEvidence(consumer, evidence(), { run: { id: 901, run_attempt: 1 } },
+    () => NOW + 1), /POLICY_READER_UNAUTHENTICATED/);
+  assert.equal(invoked, false);
+  assert.equal(consumer.seen.filter((call) => call.method === "POST").at(-1).body.conclusion, "failure");
 });
 
 function producerFixture(alter = () => {}) {

--- a/scripts/test/platform-maintenance-workflow.test.mjs
+++ b/scripts/test/platform-maintenance-workflow.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (name) => readFileSync(new URL(`../../.github/workflows/${name}.yml`, import.meta.url), "utf8");
+const producer = read("platform-maintenance-verify");
+const consumer = read("platform-maintenance-release");
+const postMerge = read("platform-maintenance-post-merge");
+function job(source, id) {
+  const expression = new RegExp(`^  ${id}:\\n([\\s\\S]*?)(?=^  [a-z][a-z-]*:\\n|$(?![\\s\\S]))`, "m");
+  const match = expression.exec(source);
+  assert.ok(match, `missing job ${id}`);
+  return match[1];
+}
+
+test("both independent execution lanes use exact source checkouts and no privileged credentials", () => {
+  for (const workflow of [producer, postMerge]) {
+    for (const lane of ["foundry", "slither"]) {
+      const worker = job(workflow, lane);
+      assert.match(worker, /permissions:\n      contents: read\n/);
+      assert.doesNotMatch(worker, /(?:id-token|attestations|checks|actions|pull-requests): write|GH_TOKEN:|GITHUB_TOKEN:|secrets\./);
+      assert.match(worker, /ref: \$\{\{ github\.workflow_sha \}\}/);
+      assert.match(worker, /ref: \$\{\{ needs\.select\.outputs\.(head_sha|merge_sha) \}\}/);
+      assert.match(worker, /run: node trusted\/scripts\/ci\/platform-maintenance-runner\.mjs (post-)?worker/);
+      assert.equal((worker.match(/uses: actions\/checkout@/g) ?? []).length, 2);
+      assert.equal((worker.match(/persist-credentials: false/g) ?? []).length, 2);
+      assert.doesNotMatch(worker, /continue-on-error|\|\| true|--fail-none/);
+    }
+  }
+});
+
+test("attestation is a separate trusted job requiring both successful lanes and immutable artifacts", () => {
+  for (const workflow of [producer, postMerge]) {
+    const issuer = job(workflow, "attest");
+    assert.match(issuer, /needs: \[select, foundry, slither\]/);
+    assert.match(issuer, /needs\.select\.result == 'success'/);
+    assert.match(issuer, /needs\.foundry\.result == 'success'/);
+    assert.match(issuer, /needs\.slither\.result == 'success'/);
+    assert.match(issuer, /id-token: write/);
+    assert.match(issuer, /attestations: write/);
+    assert.doesNotMatch(issuer, /path: candidate|contents: write|checks: write|secrets\./);
+    assert.equal((issuer.match(/uses: actions\/download-artifact@/g) ?? []).length, 3);
+    assert.equal((issuer.match(/digest-mismatch: error/g) ?? []).length, 3);
+    assert.equal((issuer.match(/artifact-ids:/g) ?? []).length, 3);
+    assert.match(issuer, /uses: actions\/attest@[a-f0-9]{40}/);
+  }
+});
+
+test("privileged consumer never checks out or executes candidate code and cannot submit a review", () => {
+  const merge = job(consumer, "consume");
+  assert.match(merge, /checks: write/);
+  assert.match(merge, /contents: write/);
+  assert.match(merge, /pull-requests: read/);
+  assert.doesNotMatch(merge, /path: candidate|needs\.select\.outputs|id-token: write|secrets\./);
+  assert.match(merge, /artifact-ids: \$\{\{ steps\.producer\.outputs\.artifact_id \}\}/);
+  assert.match(merge, /run-id: \$\{\{ steps\.producer\.outputs\.run_id \}\}/);
+  assert.match(merge, /digest-mismatch: error/);
+  const source = readFileSync(new URL("../ci/platform-maintenance-github.mjs", import.meta.url), "utf8");
+  assert.doesNotMatch(source, /\/reviews|merge_action|admin_bypass|gh pr merge/);
+});
+
+test("post-merge dispatch has its own Actions-only write authority and exact returned merge input", () => {
+  const dispatch = job(consumer, "dispatch");
+  assert.match(dispatch, /needs: consume/);
+  assert.match(dispatch, /actions: write/);
+  assert.match(dispatch, /contents: read/);
+  assert.doesNotMatch(dispatch, /contents: write|checks: write|pull-requests: write|id-token: write|secrets\./);
+  assert.match(dispatch, /artifact-ids: \$\{\{ needs\.consume\.outputs\.merge_artifact \}\}/);
+  assert.match(dispatch, /runner\.mjs dispatch/);
+  assert.match(postMerge, /workflow_dispatch:/);
+  assert.match(postMerge, /merge_sha:/);
+  assert.match(postMerge, /controller_sha:/);
+  assert.match(postMerge, /runner\.mjs post-select/);
+  assert.match(postMerge, /post-merge-evidence\.json/);
+  assert.doesNotMatch(postMerge, /contents: write|checks: write|vercel|flyctl|broadcast|secrets\./);
+});
+
+test("existing technical-completion events retry selection automatically without executing candidate workflow code", () => {
+  assert.match(producer, /workflow_run:\n    workflows: \[Verify, Security, Verify hook builder intake feedback\]/);
+  assert.match(producer, /github\.event\.workflow_run\.conclusion == 'success'/);
+  assert.match(producer, /github\.event\.workflow_run\.pull_requests\[0\]\.base\.ref == 'main'/);
+  assert.match(consumer, /workflows: \[Verify platform maintenance\]/);
+  for (const workflow of [producer, consumer, postMerge]) {
+    for (const line of workflow.split("\n").filter((line) => line.includes("uses:"))) {
+      assert.match(line, /@[0-9a-f]{40}(?:\s|$)/);
+    }
+    for (const line of workflow.split("\n").filter((line) => /^\s+(?:-\s+)?run:/.test(line))) {
+      assert.doesNotMatch(line, /\$\{\{/);
+    }
+  }
+});
+
+test("the current source-bound 702 control authorization stays unchanged", () => {
+  const intake = read("verify-hook-builder");
+  assert.match(intake, /APPROVED_MAIN_CI_CONTROL_COMMIT: e15bb397604a19d6622af5a5ee9622a8edac9d18/);
+  assert.match(intake, /APPROVED_MAIN_CI_CONTROL_TREE: 92eecc16da2c59b87295fcb4012e57fe4f1feae7/);
+  assert.match(intake, /feedback-only/);
+});

--- a/scripts/test/platform-maintenance-workflow.test.mjs
+++ b/scripts/test/platform-maintenance-workflow.test.mjs
@@ -51,12 +51,33 @@ test("privileged consumer never checks out or executes candidate code and cannot
   assert.match(merge, /checks: write/);
   assert.match(merge, /contents: write/);
   assert.match(merge, /pull-requests: read/);
-  assert.doesNotMatch(merge, /path: candidate|needs\.select\.outputs|id-token: write|secrets\./);
+  assert.doesNotMatch(merge, /path: candidate|needs\.select\.outputs|id-token: write/);
   assert.match(merge, /artifact-ids: \$\{\{ steps\.producer\.outputs\.artifact_id \}\}/);
   assert.match(merge, /run-id: \$\{\{ steps\.producer\.outputs\.run_id \}\}/);
   assert.match(merge, /digest-mismatch: error/);
   const source = readFileSync(new URL("../ci/platform-maintenance-github.mjs", import.meta.url), "utf8");
   assert.doesNotMatch(source, /\/reviews|merge_action|admin_bypass|gh pr merge/);
+  const runner = readFileSync(new URL("../ci/platform-maintenance-runner.mjs", import.meta.url), "utf8");
+  assert.equal((runner.match(/await consumeAuthenticatedEvidence\(/g) ?? []).length, 1);
+  assert.doesNotMatch(runner, /publishAuthenticatedEvidenceCheck/);
+});
+
+test("only the trusted consumer mints a separately scoped policy-read token from source-pinned App identity", () => {
+  const merge = job(consumer, "consume");
+  assert.match(merge, /environment: platform-maintenance-policy/);
+  assert.match(merge, /runner\.mjs policy-config/);
+  assert.match(merge, /if: steps\.policy\.outputs\.configured == 'true'/);
+  assert.match(merge, /uses: actions\/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1/);
+  assert.match(merge, /app-id: \$\{\{ steps\.policy\.outputs\.app_id \}\}/);
+  assert.match(merge, /owner: programmablehq\n          repositories: PROGRAMMABLE/);
+  assert.match(merge, /permission-administration: read\n          permission-metadata: read/);
+  assert.match(merge, /skip-token-revoke: false/);
+  assert.match(merge, /MAINTENANCE_POLICY_INSTALLATION_ID: \$\{\{ steps\.policy_token\.outputs\.installation-id \}\}/);
+  assert.match(merge, /MAINTENANCE_POLICY_READ_TOKEN: \$\{\{ steps\.policy_token\.outputs\.token \}\}/);
+  assert.deepEqual(merge.match(/secrets\.[A-Z_]+/g), ["secrets.PLATFORM_MAINTENANCE_POLICY_APP_PRIVATE_KEY"]);
+  for (const source of [producer, postMerge, job(consumer, "dispatch")]) {
+    assert.doesNotMatch(source, /POLICY_READ_TOKEN|POLICY_APP_PRIVATE_KEY|create-github-app-token/);
+  }
 });
 
 test("post-merge dispatch has its own Actions-only write authority and exact returned merge input", () => {


### PR DESCRIPTION
Internal contract maintenance currently depends on a manual review decision even after its technical checks finish. This adds a bounded controller for eligible first-party `main` changes: independent candidate verification produces source-bound evidence, a separate consumer verifies the live branch rules, and an ordinary SHA-bound merge triggers explicit post-merge verification.

The controller runs from protected `production`. It keeps application admission and production website releases under their existing controls. Candidate jobs receive no App credentials, deployment credentials, or signing authority. The required release check fails on stale evidence, changed source or policy, incomplete checks, or an unconfigured policy reader.

Validation: 68 focused tests, syntax checks for four modules, actionlint on all three workflows, independent review of head `487675fa1a6a31a9b2c540c3eab8a6ceacda3229`, and Gitleaks over the complete candidate range passed locally. Hosted execution is still blocked by the account billing lock.

This remains a draft until the dedicated read-only policy App is configured and pinned, hosted verification succeeds, any Slither findings receive explicit reviewed dispositions, and the branch-rule transition is verified. The included README specifies the single-repository App and environment setup. No GitHub protection, App permission, or existing release authority is changed by this PR.
