### PR TITLE
Verify Module Mode source against real provider readbacks

### DIFF
--- a/contracts/scripts/module-mode/build.mjs
+++ b/contracts/scripts/module-mode/build.mjs
@@ -55,10 +55,14 @@ export async function sealBuild({ root = REPOSITORY_ROOT, output = path.join(roo
       } });
     }
   }
-  const artifacts = {}, sourceHashes = new Map(), standardInputs = {};
+  const artifacts = {}, sourceHashes = new Map(), standardInputs = {}, compilerMetadata = {};
   for (const [role, relative] of Object.entries(ARTIFACTS)) {
     const artifact = JSON.parse(await readFile(path.join(output, relative), 'utf8'));
     const metadata = typeof artifact.metadata === 'string' ? JSON.parse(artifact.metadata) : artifact.metadata;
+    // Foundry's typed metadata drops some NatSpec fields and normalizes remappings.
+    // Keep the compiler's complete JSON separately: existing plan/build commitments remain unchanged.
+    need(typeof artifact.rawMetadata === 'string', `${role}: complete compiler metadata missing`);
+    compilerMetadata[role] = JSON.parse(artifact.rawMetadata);
     need(metadata?.compiler?.version === '0.8.26+commit.8a97fa7a' && metadata.settings.optimizer.enabled === true
       && metadata.settings.optimizer.runs === 1000 && metadata.settings.evmVersion === 'cancun'
       && metadata.settings.metadata.bytecodeHash === 'none' && metadata.settings.metadata.appendCBOR === false
@@ -99,5 +103,5 @@ export async function sealBuild({ root = REPOSITORY_ROOT, output = path.join(roo
   const commitments = { sourceCommit: before.sourceCommit, sourceTree: before.sourceTree, compiler: '0.8.26+commit.8a97fa7a', forge: '1.7.1+4072e48705af9d93e3c0f6e29e93b5e9a40caed8',
     sourcePinsDigest: sha256(sourcePinsText), sources: Object.fromEntries([...sourceHashes].sort()), dependencies: dependencyStates,
     artifacts: Object.fromEntries(Object.entries(artifacts).map(([role, a]) => [role, digest('programmable.module-mode-build-artifact.v1', a)])) };
-  return { ...before, sourceClean: before.sourceClean && !candidate, buildDigest: digest('programmable.module-mode-build.v1', commitments), commitments, artifacts, standardInputs };
+  return { ...before, sourceClean: before.sourceClean && !candidate, buildDigest: digest('programmable.module-mode-build.v1', commitments), commitments, artifacts, standardInputs, compilerMetadata };
 }

--- a/contracts/scripts/module-mode/collect.mjs
+++ b/contracts/scripts/module-mode/collect.mjs
@@ -12,9 +12,13 @@ import { exactJson } from './source-readback.mjs';
 
 async function main(argv) {
   const command = argv.shift(); const options = {};
-  for (let i = 0; i < argv.length; i += 2) { need(['--plan', '--journal', '--output', '--identity', '--step', '--transaction-hash', '--deployment', '--provider'].includes(argv[i]) && argv[i + 1], 'Unsupported or incomplete collection argument'); options[argv[i].slice(2)] = argv[i + 1]; }
+  for (let i = 0; i < argv.length; i += 2) { need(['--plan', '--journal', '--output', '--identity', '--step', '--transaction-hash', '--deployment', '--provider', '--source-root'].includes(argv[i]) && argv[i + 1], 'Unsupported or incomplete collection argument'); options[argv[i].slice(2)] = argv[i + 1]; }
   need(['observe', 'record', 'deployment', 'source', 'source-requests'].includes(command) && options.plan, 'Use observe, record, deployment, source or source-requests with --plan');
-  const plan = exactJson(await readFile(options.plan), 'Deployment plan'); const build = await sealBuild(); assertPlan(plan, build);
+  need(!options['source-root'] || ['source', 'source-requests'].includes(command), '--source-root is only for read-only source collection');
+  const plan = exactJson(await readFile(options.plan), 'Deployment plan');
+  // A newer collector may read the original clean deployment checkout. Its exact source/build digest still
+  // has to match the old immutable plan; this option grants no wallet or deployment authority.
+  const build = await sealBuild(options['source-root'] ? { root: path.resolve(options['source-root']) } : {}); assertPlan(plan, build);
   if (command === 'observe') {
     const index = Number(options.step); need(options.step !== undefined && Number.isSafeInteger(index), '--step required');
     const observation = await observeStage(plan, index, await reviewedProviders());

--- a/contracts/scripts/module-mode/evidence.mjs
+++ b/contracts/scripts/module-mode/evidence.mjs
@@ -1,11 +1,12 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { encodeAbiParameters, keccak256, parseAbiParameters } from 'viem';
-import { bytes, canonicalJson, hash, need } from './core.mjs';
+import { address, bytes, canonicalJson, hash, need } from './core.mjs';
 import { sharedValidators } from './shared.mjs';
 import { journalEntry } from './journal.mjs';
 import { observeReceipt } from './rpc.mjs';
-import { SOURCIFY_BASE, SOURCIFY_COMPILER, boundedPublicJson, exactJson, sourcifyPreflight, validateSourcifySource } from './source-readback.mjs';
+import { SOURCIFY_BASE, SOURCIFY_COMPILER, boundedPublicJson, exactJson, sourcifyNeedsRecompilation, sourcifyPreflight, validateSourcifySource } from './source-readback.mjs';
+import { recompileSourcifyInput } from './source-recompile.mjs';
 
 export const EVIDENCE_FILENAMES = Object.freeze({ deployment: 'deployment.json', sourceVerification: 'source-verification.json', lifecycle: 'lifecycle.json' });
 export function evidenceBytes(value) { return Buffer.from(`${JSON.stringify(value, null, 2)}\n`, 'utf8'); }
@@ -58,8 +59,10 @@ export function sourceCreation(plan, role, deploymentEvidence) {
     && record.transaction.hash === record.receipt.transactionHash, `${role}: deployment code/receipt differs`);
   const deployer = { rewardLedger: plan.contracts.hook.address, runtime: plan.contracts.runtimeFactory.address,
     budgetVault: plan.contracts.runtime.address, swapRouter: plan.contracts.swapRouterFactory.address }[role] ?? plan.official.deterministicDeployer.address;
+  const step = plan.steps.find(step => step.role === parentRole);
+  need(address(record.transaction.from) === address(step.sender), `${role}: creation transaction sender differs`);
   return { transactionHash: hash(record.receipt.transactionHash), blockNumber: record.receipt.blockNumber,
-    transactionIndex: record.receipt.transactionIndex, deployer };
+    transactionIndex: record.receipt.transactionIndex, deployer, transactionSender: address(record.transaction.from) };
 }
 export function sourcifyVerificationRequests(plan, build, deploymentEvidence = null) {
   return Object.fromEntries(Object.entries(plan.contracts).map(([role, pin]) => {
@@ -118,7 +121,9 @@ export async function collectSourceVerificationEvidence(plan, build, deploymentE
     const url = provider === 'sourcify-v2' ? `${SOURCIFY_BASE}/v2/contract/4663/${pin.address}?fields=all`
       : `https://robinhoodchain.blockscout.com/api/v2/smart-contracts/${pin.address}`;
     const { raw, value } = await boundedPublicJson(url, fetchImpl);
-    const verified = provider === 'sourcify-v2' ? validateSourcifySource({ plan, build, role, constructorArguments: constructorArguments(plan, role), creation }, value)
+    const recompilation = provider === 'sourcify-v2' && sourcifyNeedsRecompilation(build.standardInputs[role], value)
+      ? await recompileSourcifyInput(value, build.standardInputs[role]) : undefined;
+    const verified = provider === 'sourcify-v2' ? validateSourcifySource({ plan, build, role, constructorArguments: constructorArguments(plan, role), creation, recompilation }, value)
       : { ...validatePublishedSource(plan, build, role, value), creationTransactionHash: creation.transactionHash };
     records.push({ ...verified, url, responseBytesDigest: evidenceDigest(raw) });
   }

--- a/contracts/scripts/module-mode/source-readback.mjs
+++ b/contracts/scripts/module-mode/source-readback.mjs
@@ -31,10 +31,44 @@ export async function sourcifyPreflight(fetchImpl = fetch) {
 }
 function equal(actual, expected, label) { need(canonicalJson(actual) === canonicalJson(expected), label); }
 function empty(value, label) { need(value && typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length === 0, label); }
-function settings(value) { return Object.fromEntries(Object.entries(value ?? {}).filter(([key]) => key !== 'outputSelection')); }
+function settings(value) {
+  const result = Object.fromEntries(Object.entries(value ?? {}).filter(([key]) => key !== 'outputSelection'));
+  // Explicit false and omitted are the same two documented solc defaults. No other settings are discarded.
+  if (result.viaIR === false) delete result.viaIR;
+  if (result.metadata?.useLiteralContent === false) {
+    result.metadata = { ...result.metadata }; delete result.metadata.useLiteralContent;
+  }
+  return result;
+}
+function abiEntries(value) {
+  need(Array.isArray(value), 'ABI array required');
+  const entries = value.map(canonicalJson).sort();
+  need(new Set(entries).size === entries.length, 'Duplicate ABI entry');
+  return entries;
+}
+export function sourcifyNeedsRecompilation(input, value) {
+  return canonicalJson(settings(value.compilation?.compilerSettings)) !== canonicalJson(settings(input.settings));
+}
+function publicationSettings(input, value, artifact, recompilation, role) {
+  const expected = settings(input.settings), actual = settings(value.compilation?.compilerSettings);
+  equal(settings(value.stdJsonInput?.settings), actual, `${role}: Sourcify input/settings disagree`);
+  if (canonicalJson(actual) !== canonicalJson(expected)) {
+    // Sourcify deduplicates compilations by compiler/version and both bytecode hashes. This can retain
+    // an older list of unused import remappings. Accept it only after an actual local recompilation.
+    const withoutRemappings = settings => Object.fromEntries(Object.entries(settings).filter(([key]) => key !== 'remappings'));
+    equal(withoutRemappings(actual), withoutRemappings(expected), `${role}: Sourcify compiler settings differ`);
+    need(Array.isArray(actual.remappings) && actual.remappings.every(value => typeof value === 'string'), `${role}: invalid remappings`);
+    need(recompilation?.compilerVersion === SOURCIFY_COMPILER
+      && recompilation.inputDigest === keccak256(new TextEncoder().encode(canonicalJson(value.stdJsonInput)))
+      && bytes(recompilation.creationBytecode) === bytes(artifact.bytecode.object)
+      && bytes(recompilation.runtimeBytecode) === bytes(artifact.deployedBytecode.object), `${role}: pinned source recompilation required`);
+    equal(abiEntries(recompilation.abi), abiEntries(artifact.abi), `${role}: recompiled ABI differs`);
+  }
+  equal({ ...value.stdJsonInput, settings: expected }, { ...input, settings: expected }, `${role}: Sourcify standard input differs`);
+}
 
 /** Independent complete-byte comparison. Provider `match` is preserved as such, never relabelled `exact_match`. */
-export function validateSourcifySource({ plan, build, role, constructorArguments, creation }, value) {
+export function validateSourcifySource({ plan, build, role, constructorArguments, creation, recompilation }, value) {
   const artifact = build.artifacts[role], pin = plan.contracts[role], input = build.standardInputs[role];
   need(artifact && pin && input, 'Unknown Sourcify target');
   const [file, name] = Object.entries(artifact.compilationTarget)[0];
@@ -45,16 +79,15 @@ export function validateSourcifySource({ plan, build, role, constructorArguments
   const compilation = value.compilation;
   need(compilation?.language === 'Solidity' && compilation.compiler === 'solc' && compilation.compilerVersion === SOURCIFY_COMPILER
     && compilation.name === name && compilation.fullyQualifiedName === `${file}:${name}`, `${role}: Sourcify compiler/target differs`);
-  // Sourcify documents outputSelection replacement. It selects returned artifacts, not compilation semantics.
-  equal(settings(compilation.compilerSettings), settings(input.settings), `${role}: Sourcify compiler settings differ`);
-  equal({ ...value.stdJsonInput, settings: settings(value.stdJsonInput?.settings) }, { ...input, settings: settings(input.settings) }, `${role}: Sourcify standard input differs`);
+  publicationSettings(input, value, artifact, recompilation, role);
   equal(value.sources, input.sources, `${role}: Sourcify source closure differs`);
-  equal(value.metadata, artifact.metadata, `${role}: Sourcify full compiler metadata differs`);
-  equal(value.abi, artifact.abi, `${role}: Sourcify ABI differs`);
+  equal(value.metadata, build.compilerMetadata?.[role] ?? artifact.metadata, `${role}: Sourcify full compiler metadata differs`);
+  // ABI item order has no semantic meaning; argument, tuple and output order remain exact.
+  equal(abiEntries(value.abi), abiEntries(artifact.abi), `${role}: Sourcify ABI differs`);
   need(value.deployment?.transactionHash === hash(creation.transactionHash)
     && BigInt(value.deployment.blockNumber) === BigInt(creation.blockNumber)
     && BigInt(value.deployment.transactionIndex) === BigInt(creation.transactionIndex)
-    && address(value.deployment.deployer) === address(creation.deployer), `${role}: Sourcify actual creation transaction differs`);
+    && address(value.deployment.deployer) === address(creation.transactionSender), `${role}: Sourcify actual creation transaction differs`);
   const c = value.creationBytecode, r = value.runtimeBytecode;
   need(c && r, `${role}: Sourcify creation/runtime bytes unavailable`);
   const compiledCreation = bytes(artifact.bytecode.object), compiledRuntime = bytes(artifact.deployedBytecode.object);

--- a/contracts/scripts/module-mode/source-readback.test.mjs
+++ b/contracts/scripts/module-mode/source-readback.test.mjs
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict';
 import { keccak256, toHex } from 'viem';
 import { build, plan, addr } from './test-fixtures.mjs';
 import { constructorArguments, sourceCreation, sourcifyVerificationRequests, validatePublishedSource } from './evidence.mjs';
-import { exactJson, boundedPublicJson, sourcifyPreflight, validateSourcifySource } from './source-readback.mjs';
+import { exactJson, boundedPublicJson, sourcifyNeedsRecompilation, sourcifyPreflight, validateSourcifySource } from './source-readback.mjs';
+import { canonicalJson } from './core.mjs';
 
 const txHash = keccak256(toHex('test-only-never-live-transaction'));
 function context(role = 'positionForwarderFactory') {
@@ -12,13 +13,13 @@ function context(role = 'positionForwarderFactory') {
   const sources = { [`src/${role}.sol`]: { content: '// synthetic unit fixture, not deployed\n' } };
   const settings = { optimizer: { enabled: true, runs: 1000 }, evmVersion: 'cancun', metadata: { appendCBOR: false, bytecodeHash: 'none' }, libraries: {}, remappings: [] };
   sourceBuild.standardInputs = { [role]: { language: 'Solidity', sources, settings: { ...settings, outputSelection: { '*': { '*': ['abi'] } } } } };
-  const creation = { transactionHash: txHash, blockNumber: '123', transactionIndex: '2', deployer: plan.official.deterministicDeployer.address };
+  const creation = { transactionHash: txHash, blockNumber: '123', transactionIndex: '2', deployer: plan.official.deterministicDeployer.address, transactionSender: plan.parameters.owner };
   const refs = artifact.deployedBytecode.immutableReferences;
   const transforms = Object.entries(refs).flatMap(([id, list]) => list.map(ref => ({ id, type: 'replace', offset: ref.start, reason: 'immutable' })));
   const immutables = Object.fromEntries(Object.entries(refs).map(([id, [ref]]) => [id, `0x${plan.contracts[role].runtime.slice(2 + ref.start * 2, 2 + (ref.start + ref.length) * 2)}`]));
   const value = { chainId: '4663', address: plan.contracts[role].address, match: 'match', creationMatch: 'match', runtimeMatch: 'match', matchId: '12', verifiedAt: '2026-09-06T12:00:00Z',
     compilation: { language: 'Solidity', compiler: 'solc', compilerVersion: '0.8.26+commit.8a97fa7a', compilerSettings: settings, name: role, fullyQualifiedName: `src/${role}.sol:${role}` },
-    stdJsonInput: { language: 'Solidity', sources, settings }, sources, metadata: artifact.metadata, abi: artifact.abi, deployment: creation,
+    stdJsonInput: { language: 'Solidity', sources, settings }, sources, metadata: artifact.metadata, abi: artifact.abi, deployment: { ...creation, deployer: creation.transactionSender },
     creationBytecode: { recompiledBytecode: artifact.bytecode.object, onchainBytecode: `${artifact.bytecode.object}${args.slice(2)}`, cborAuxdata: {}, linkReferences: {},
       transformations: args === '0x' ? [] : [{ type: 'insert', offset: (artifact.bytecode.object.length - 2) / 2, reason: 'constructorArguments' }], transformationValues: args === '0x' ? {} : { constructorArguments: args } },
     runtimeBytecode: { recompiledBytecode: artifact.deployedBytecode.object, onchainBytecode: plan.contracts[role].runtime, cborAuxdata: {}, linkReferences: {}, immutableReferences: refs,
@@ -75,15 +76,74 @@ test('source requests require actual parent transaction evidence, including chil
   assert.equal(Object.hasOwn(before.runtime.body, 'creationTransactionHash'), false);
   const evidence = { schemaVersion: 'programmable.module-mode-deployment-evidence.v1', chainId: 4663, sourceCommit: plan.sourceCommit, planDigest: plan.planDigest,
     buildDigest: plan.buildDigest, status: 'included-code-verified', records: plan.steps.map(step => ({ role: step.role, status: 'included-code-verified-unfinalized',
-      transaction: { hash: txHash }, receipt: { status: '0x1', transactionHash: txHash, blockNumber: '0x7b', transactionIndex: '0x2' },
+      transaction: { hash: txHash, from: step.sender }, receipt: { status: '0x1', transactionHash: txHash, blockNumber: '0x7b', transactionIndex: '0x2' },
       contracts: Object.fromEntries(step.expectedRoles.map(role => [role, structuredClone(plan.contracts[role])])) })) };
   const requests = sourcifyVerificationRequests(plan, sourceBuild, evidence);
   assert.equal(requests.runtime.body.creationTransactionHash, txHash);
   assert.equal(sourceCreation(plan, 'runtime', evidence).deployer, plan.contracts.runtimeFactory.address);
   assert.equal(sourceCreation(plan, 'budgetVault', evidence).deployer, plan.contracts.runtime.address);
   assert.equal(sourceCreation(plan, 'rewardLedger', evidence).deployer, plan.contracts.hook.address);
+  assert.equal(sourceCreation(plan, 'rewardLedger', evidence).transactionSender, plan.parameters.owner);
   evidence.records[8].contracts.runtime.runtimeCodeHash = keccak256(toHex('wrong'));
   assert.throws(() => sourceCreation(plan, 'runtime', evidence), /code\/receipt/);
+});
+test('complete raw compiler metadata and ABI entries survive Foundry presentation differences', () => {
+  const { expected, value } = context();
+  expected.build.compilerMetadata = { [expected.role]: { ...value.metadata, output: { devdoc: { title: 'Real NatSpec' } } } };
+  value.metadata = structuredClone(expected.build.compilerMetadata[expected.role]);
+  value.abi = [...value.abi].reverse();
+  assert.equal(validateSourcifySource(expected, value).providerMatch, 'match');
+  value.metadata.output.devdoc.title = 'Altered';
+  assert.throws(() => validateSourcifySource(expected, value), /metadata differs/);
+});
+test('only explicit false compiler defaults are normalized', () => {
+  const { expected, value } = context();
+  value.compilation.compilerSettings = structuredClone(value.compilation.compilerSettings);
+  value.compilation.compilerSettings.viaIR = false;
+  value.compilation.compilerSettings.metadata.useLiteralContent = false;
+  value.stdJsonInput.settings = structuredClone(value.compilation.compilerSettings);
+  assert.equal(sourcifyNeedsRecompilation(expected.build.standardInputs[expected.role], value), false);
+  assert.equal(validateSourcifySource(expected, value).providerMatch, 'match');
+  value.compilation.compilerSettings.viaIR = true;
+  value.stdJsonInput.settings.viaIR = true;
+  assert.throws(() => validateSourcifySource(expected, value), /compiler settings differ/);
+});
+test('deduplicated remappings require an exact input-bound pinned recompilation', () => {
+  const { expected, value } = context();
+  value.compilation.compilerSettings = structuredClone(value.compilation.compilerSettings);
+  value.compilation.compilerSettings.remappings = ['unused/=lib/unused/'];
+  value.stdJsonInput.settings = structuredClone(value.compilation.compilerSettings);
+  assert.equal(sourcifyNeedsRecompilation(expected.build.standardInputs[expected.role], value), true);
+  assert.throws(() => validateSourcifySource(expected, value), /recompilation required/);
+  const a = expected.build.artifacts[expected.role];
+  expected.recompilation = { compilerVersion: '0.8.26+commit.8a97fa7a', inputDigest: keccak256(toHex(canonicalJson(value.stdJsonInput))),
+    creationBytecode: a.bytecode.object, runtimeBytecode: a.deployedBytecode.object, abi: a.abi };
+  assert.equal(validateSourcifySource(expected, value).providerMatch, 'match');
+  for (const change of [r => { r.inputDigest = txHash; }, r => { r.runtimeBytecode += '00'; }, r => { r.creationBytecode += '00'; }, r => { r.compilerVersion = '0.8.27'; }, r => { r.abi = []; }]) {
+    const changed = structuredClone(expected); change(changed.recompilation); assert.throws(() => validateSourcifySource(changed, value));
+  }
+});
+test('ABI comparison ignores item order only and Sourcify deployer means transaction sender', () => {
+  const { expected, value } = context();
+  value.abi = [...value.abi].reverse();
+  assert.equal(validateSourcifySource(expected, value).providerMatch, 'match');
+  value.deployment.deployer = expected.creation.deployer;
+  assert.throws(() => validateSourcifySource(expected, value), /creation transaction differs/);
+  value.deployment.deployer = expected.creation.transactionSender;
+  value.abi.push(value.abi[0]);
+  assert.throws(() => validateSourcifySource(expected, value), /Duplicate ABI/);
+});
+test('ABI argument order and published input/source identity remain exact', () => {
+  const { expected, value } = context();
+  const item = { type: 'function', name: 'synthetic', stateMutability: 'view',
+    inputs: [{ name: 'recipient', type: 'address' }, { name: 'amount', type: 'uint256' }], outputs: [] };
+  expected.build.artifacts[expected.role].abi = [item]; value.abi = structuredClone([item]);
+  assert.equal(validateSourcifySource(expected, value).providerMatch, 'match');
+  value.abi[0].inputs.reverse();
+  assert.throws(() => validateSourcifySource(expected, value), /ABI differs/);
+  value.abi = structuredClone([item]); value.stdJsonInput = structuredClone(value.stdJsonInput);
+  value.stdJsonInput.sources['src/positionForwarderFactory.sol'].content += ' ';
+  assert.throws(() => validateSourcifySource(expected, value), /standard input differs/);
 });
 test('Blockscout full flag alone never accepts absent creation bytes or incomplete source', () => {
   const { expected } = context();

--- a/contracts/scripts/module-mode/source-recompile.mjs
+++ b/contracts/scripts/module-mode/source-recompile.mjs
@@ -1,0 +1,33 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { keccak256, toHex } from 'viem';
+import { canonicalJson, need } from './core.mjs';
+import { exactJson, SOURCIFY_COMPILER } from './source-readback.mjs';
+
+const exec = promisify(execFile);
+
+/** Reproduce the provider's complete source/settings with the pinned compiler and no filesystem imports. */
+export async function recompileSourcifyInput(value, expectedInput, environment = process.env) {
+  need(value.compilation?.compilerVersion === SOURCIFY_COMPILER && value.stdJsonInput?.language === 'Solidity', 'Pinned Solidity compiler required');
+  need(canonicalJson(value.sources) === canonicalJson(expectedInput.sources)
+    && canonicalJson(value.stdJsonInput.sources) === canonicalJson(expectedInput.sources), 'Recompilation source closure differs');
+  const binary = environment.MODULE_MODE_SOLC ?? 'solc';
+  const { stdout: version } = await exec(binary, ['--version'], { timeout: 10000, maxBuffer: 4096 });
+  need(version.includes(`Version: ${SOURCIFY_COMPILER}`), 'Pinned solc 0.8.26 required; set MODULE_MODE_SOLC');
+  const input = { ...value.stdJsonInput, settings: { ...value.stdJsonInput.settings,
+    outputSelection: { '*': { '*': ['abi', 'evm.bytecode', 'evm.deployedBytecode'] } } } };
+  const encoded = JSON.stringify(input); need(Buffer.byteLength(encoded) <= 16 * 1024 * 1024, 'Recompilation input too large');
+  const output = await new Promise((resolve, reject) => {
+    const child = execFile(binary, ['--standard-json', '--no-import-callback'],
+      { timeout: 45000, maxBuffer: 32 * 1024 * 1024, encoding: 'utf8', env: { PATH: environment.PATH ?? '' } },
+      (error, stdout) => error ? reject(new Error('Pinned source recompilation failed')) : resolve(stdout));
+    child.stdin.on('error', () => {}); child.stdin.end(encoded);
+  });
+  const result = exactJson(Buffer.from(output), 'Local compiler output');
+  need(!(result.errors ?? []).some(error => error.severity === 'error'), 'Published compiler input does not compile');
+  const separator = value.compilation.fullyQualifiedName.lastIndexOf(':');
+  const file = value.compilation.fullyQualifiedName.slice(0, separator), name = value.compilation.fullyQualifiedName.slice(separator + 1);
+  const artifact = result.contracts?.[file]?.[name]; need(artifact?.evm?.bytecode && artifact?.evm?.deployedBytecode, 'Recompiled target missing');
+  return { compilerVersion: SOURCIFY_COMPILER, inputDigest: keccak256(toHex(canonicalJson(value.stdJsonInput))),
+    creationBytecode: `0x${artifact.evm.bytecode.object}`, runtimeBytecode: `0x${artifact.evm.deployedBytecode.object}`, abi: artifact.abi };
+}

--- a/docs/operations/module-mode-deployment.md
+++ b/docs/operations/module-mode-deployment.md
@@ -289,6 +289,31 @@ compiler settings, ABI, metadata and actual creation transaction. Only construct
 arguments and compiled immutables may explain byte transformations. Partial source
 flags or metadata-ignore transforms cannot substitute for this comparison.
 
+Provider readback uses the compiler's complete `rawMetadata`, because Foundry's
+typed metadata representation omits some NatSpec fields and normalizes import
+remappings. The build commitment remains unchanged. ABI entries may be reordered;
+each complete entry and the order of its arguments/tuple members stay exact.
+
+Sourcify's `deployment.deployer` is the creation transaction's `from` address,
+including factory-created children. The source collector binds that field to the
+actual recorded sender and retains the internal factory/deployer separately.
+This follows [the provider implementation](https://github.com/argotorg/sourcify/blob/9b4877ebfe483de4774c16c1ea55791546021029/packages/lib-sourcify/src/Verification/Verification.ts#L255-L265).
+
+Sourcify [deduplicates compilation records by compiler/version and bytecode](https://github.com/argotorg/sourcify/blob/9b4877ebfe483de4774c16c1ea55791546021029/services/server/src/server/services/utils/Database.ts#L675-L691).
+An older record can retain different unused remappings. Only explicit `viaIR:false`
+and `metadata.useLiteralContent:false` defaults are normalized. Other semantic
+settings must match. A remapping difference additionally requires an actual local
+recompilation of the exact published sources/settings using solc
+`0.8.26+commit.8a97fa7a`, with filesystem imports disabled, and a complete match of
+creation bytecode, runtime bytecode and ABI. Set `MODULE_MODE_SOLC` to that compiler's
+executable. The source closure and full original raw metadata must still match;
+there is no generic "ignore compiler settings" option.
+
+After a collector-only correction, `source` and `source-requests` may use
+`--source-root /absolute/path/to/original-clean-checkout`. The collector rebuilds
+that source and asserts its exact original plan/build digest. It does not change
+the immutable contract identity or confer wallet/deployment authority.
+
 An explicit `--provider blockscout` path is also available. It requires full
 verification, complete creation/runtime bytes and source closure from that API;
 an HTTP success or `is_verified` flag alone is insufficient.


### PR DESCRIPTION
Actual chain-4663 source verification was rejected because Sourcify reports the transaction sender as deployer, deduplicates compiler records, and returns the full compiler metadata while Foundry presents a reduced form. Bind the actual sender, compare complete raw metadata and unordered ABI entries, and require pinned local recompilation when only import remappings differ. All complete bytecode, source, constructor and immutable checks remain enforced.

The read-only collector can rebuild the original clean deployment checkout without changing its immutable plan or build digest. No Solidity, deployment payload, fee or activation change.

Validation: 33 focused operator/source tests; targeted ESLint and diff checks; all 13 actual Sourcify readbacks reproduced locally, including both changed remapping inputs, with the original deployment build digest unchanged. Source matching is separate from lifecycle/finality and public activation.
