### PR TITLE
Bind the deployed Module Mode host for private review

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -10,6 +10,14 @@ paths = ['''^config/module-mode/robinhood\.preview\.json$''']
 regexes = ['''^\s*"tokenCreationCodeHash": "0x445809d9f7a34e959de4a96dec1e1beddfb265755bf28c57c42744adea1128ef",\s*$''']
 
 [[allowlists]]
+description = "Module Mode provenance regression repeats the verified public bytecode commitment"
+targetRules = ["generic-api-key"]
+condition = "AND"
+regexTarget = "line"
+paths = ['''^tests/module-mode-provenance\.test\.ts$''']
+regexes = ['''^\s*tokenCreationCodeHash: "0x445809d9f7a34e959de4a96dec1e1beddfb265755bf28c57c42744adea1128ef",\s*$''']
+
+[[allowlists]]
 description = "Module launchers assign a public numeric liquidity amount, not a credential"
 targetRules = ["generic-api-key"]
 condition = "AND"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,6 +2,14 @@
 useDefault = true
 
 [[allowlists]]
+description = "Module Mode pins the verified public token creation-bytecode commitment"
+targetRules = ["generic-api-key"]
+condition = "AND"
+regexTarget = "line"
+paths = ['''^config/module-mode/robinhood\.preview\.json$''']
+regexes = ['''^\s*"tokenCreationCodeHash": "0x445809d9f7a34e959de4a96dec1e1beddfb265755bf28c57c42744adea1128ef",\s*$''']
+
+[[allowlists]]
 description = "Module launchers assign a public numeric liquidity amount, not a credential"
 targetRules = ["generic-api-key"]
 condition = "AND"

--- a/config/module-mode/robinhood.preview.json
+++ b/config/module-mode/robinhood.preview.json
@@ -4,75 +4,75 @@
   "chainId": 4663,
   "enabled": false,
   "status": "preview",
-  "releaseDigest": null,
-  "sourceCommit": null,
-  "deploymentEvidenceDigest": null,
-  "sourceVerificationDigest": null,
+  "releaseDigest": "0x546172aa670b543c19f00a707a0e9328acfd770f3040fbdd03a8bc709f786dee",
+  "sourceCommit": "9a2a1257a1b97dc0658157247890105a26e824ec",
+  "deploymentEvidenceDigest": "0xc75f4baa2142d61e4f007bf969d9a52638ab2ffa80af333f8612144ba07ba705",
+  "sourceVerificationDigest": "0x429c32b033bee913c85424c27d1bd1f34e1a5f9af82ce5b0d89ee3b9da51e7b1",
   "lifecycleEvidenceDigest": null,
-  "startBlock": null,
-  "minimumInitialBuyNative": null,
-  "tokenCreationCodeHash": null,
+  "startBlock": "56160214",
+  "minimumInitialBuyNative": "400000000000000",
+  "tokenCreationCodeHash": "0x445809d9f7a34e959de4a96dec1e1beddfb265755bf28c57c42744adea1128ef",
   "finalityPolicy": "robinhood-ethereum-finalized-v1",
   "contracts": {
     "launcher": {
-      "address": null,
-      "runtimeCodeHash": null
+      "address": "0x351cb006f7aaf61374be4be4de8572d62d89fd83",
+      "runtimeCodeHash": "0x57b48bb97d67f6153b4d836464df131c6407442a4b4fb81b42012d67a41e46b3"
     },
     "hook": {
-      "address": null,
-      "runtimeCodeHash": null
+      "address": "0x72b206dbff61ed0f4c1a75205fddc9e9d0a720cc",
+      "runtimeCodeHash": "0x4cff2e59596cbfbf509960cd3be5a7b62216268a4007192690adfeca8346ae26"
     },
     "runtime": {
-      "address": null,
-      "runtimeCodeHash": null
+      "address": "0x6d5d86557c1d1e0e40bcada22f9d71842c83a318",
+      "runtimeCodeHash": "0x5d2985eb6af4c932ced8734409c32c3369a393cd50a79fd415c014488ed19547"
     },
     "registry": {
-      "address": null,
-      "runtimeCodeHash": null
+      "address": "0x0082094ebeb3817cd78b2bc3725ca23b5720d884",
+      "runtimeCodeHash": "0x364028382d38d4d1d4994ad305e0538f72ef2f2360a0f671ae82912c44374fdd"
     },
     "poolManager": {
-      "address": null,
-      "runtimeCodeHash": null
+      "address": "0x8366a39cc670b4001a1121b8f6a443a643e40951",
+      "runtimeCodeHash": "0xbd3881180b547f5fe817545743cfb4343e96b1bc6640dcd70c106b0066e95626"
     },
     "tokenFactory": {
-      "address": null,
-      "runtimeCodeHash": null
+      "address": "0x754e8c1ade3c6c4c863590a91f2ed020baf8e779",
+      "runtimeCodeHash": "0x9354ef051bafa1edccb95c91d999e31025c012ee8d93392a78a51d83594845f2"
     },
     "swapRouter": {
-      "address": null,
-      "runtimeCodeHash": null
+      "address": "0x1d79039c339dcef234809be2259f1e767f6f4db9",
+      "runtimeCodeHash": "0xa0797bb55cbe8ccfa8ed7a934dd18ffaf130e72449676762efae395f743020fb"
     },
     "positionManager": {
-      "address": null,
-      "runtimeCodeHash": null
+      "address": "0x58daec3116aae6d93017baaea7749052e8a04fa7",
+      "runtimeCodeHash": "0xc873e135dc9aaec88489cfbad146b4cb49d6a32e0d80326377784b7ba17670b2"
     },
     "positionPlanner": {
-      "address": null,
-      "runtimeCodeHash": null
+      "address": "0x79a6281fc6910600b0aa73c0439266a6e9399de2",
+      "runtimeCodeHash": "0x1c2e74e2161589f3650fe2955e86da8890178a49b86ab7b742c6eeb80c9a2ae9"
     },
     "launchPolicy": {
-      "address": null,
-      "runtimeCodeHash": null
+      "address": "0xf3ff250759a66edc7893bba9d34daf4ba4ae4caa",
+      "runtimeCodeHash": "0x1c485a64c77174e0b2a78adf2527128792180def26cbab2ca00fcfa74b73ba91"
     },
     "positionForwarderFactory": {
-      "address": null,
-      "runtimeCodeHash": null
+      "address": "0xc9ec66eca31b8bee9479025eb5467bb2926d5e8d",
+      "runtimeCodeHash": "0xbe86703ef1ab24716bddcb5be981d224d891fe1336c68d4daf587cbc105b16d4"
     },
     "rewardLedger": {
-      "address": null,
-      "runtimeCodeHash": null
+      "address": "0x8e40080836af89952071d241684c7a848a485ac4",
+      "runtimeCodeHash": "0x8298013645213dc3c4c9981c303a48820cb87d4d4c334fd547983e1f9f28eee7"
     },
     "runtimeFactory": {
-      "address": null,
-      "runtimeCodeHash": null
+      "address": "0xee5d8f7a17dd14ce86a5b8d745add285f88f9bb4",
+      "runtimeCodeHash": "0xf924c7114ee699300e86975829e109a69fdc3d3df2f3b8893cb83a4c4a7cceae"
     },
     "budgetVault": {
-      "address": null,
-      "runtimeCodeHash": null
+      "address": "0x29a25543a2ac83009c729134d725c6c3e6d8596e",
+      "runtimeCodeHash": "0x8d7fad0b30313ba2fd117e8f94cd975e038c6650c04309fcbec736f9e9625371"
     },
     "swapRouterFactory": {
-      "address": null,
-      "runtimeCodeHash": null
+      "address": "0xf49ccf40f88c7d38fb464c753edd0c16796e0e42",
+      "runtimeCodeHash": "0xca407350e0aa188e97aec7c7e09bde210e193634e6b0f9f5bdc3c5a678e97cf8"
     }
   }
 }

--- a/tests/module-mode-provenance.test.ts
+++ b/tests/module-mode-provenance.test.ts
@@ -25,11 +25,28 @@ describe("Module Mode native source provenance",()=>{
     expect(rows).toHaveLength(2); expect(rows[0].selections).toEqual([]); expect(rows[0].revisions).toEqual([]);
     expect(rows[0].tokenRuntimeCodeHash).not.toBe(rows[1].tokenRuntimeCodeHash);
   });
-  it("keeps the checked-in profile disabled and unbound",()=>{
-    expect(preview.enabled).toBe(false); expect(preview.status).toBe("preview");
-    expect(Object.values(preview.contracts).every(pin=>pin.address===null&&pin.runtimeCodeHash===null)).toBe(true);
-    expect(()=>bindActiveModuleModeRelease(preview)).toThrow(ModuleModeProvenanceError);
-    expect(()=>normalizeModuleModeLaunches([],preview)).toThrow(ModuleModeProvenanceError);
+  it("pins the deployed source identity while keeping public provenance disabled",()=>{
+    expect(preview).toMatchObject({
+      schemaVersion: "programmable.module-mode-source.v1", sourceVersion: "module-native-v1", chainId: 4663,
+      enabled: false, status: "preview",
+      releaseDigest: "0x546172aa670b543c19f00a707a0e9328acfd770f3040fbdd03a8bc709f786dee",
+      sourceCommit: "9a2a1257a1b97dc0658157247890105a26e824ec",
+      deploymentEvidenceDigest: "0xc75f4baa2142d61e4f007bf969d9a52638ab2ffa80af333f8612144ba07ba705",
+      sourceVerificationDigest: "0x429c32b033bee913c85424c27d1bd1f34e1a5f9af82ce5b0d89ee3b9da51e7b1",
+      lifecycleEvidenceDigest: null,
+      startBlock: "56160214", minimumInitialBuyNative: "400000000000000",
+      tokenCreationCodeHash: "0x445809d9f7a34e959de4a96dec1e1beddfb265755bf28c57c42744adea1128ef",
+      finalityPolicy: "robinhood-ethereum-finalized-v1",
+    });
+    // The fixed identity commits every deployed address and runtime hash, without authorizing activation.
+    expect(computeModuleModeReleaseDigest(preview)).toBe(preview.releaseDigest);
+    expect(()=>bindActiveModuleModeRelease(preview)).toThrow("release.enabled");
+    const {evidence}=moduleEvidenceFixture();
+    expect(()=>normalizeModuleModeLaunch(evidence,preview)).toThrow("release.enabled");
+    expect(()=>normalizeModuleModeLaunches([evidence],preview)).toThrow("release.enabled");
+    expect(()=>normalizeModuleModeLaunches([],preview)).toThrow("release.enabled");
+    expect(()=>bindActiveModuleModeRelease({...preview,enabled:true,status:"active"}))
+      .toThrow("release.lifecycleEvidenceDigest");
   });
   it.each([
     ["header.chainId",1], ["receipt.status","reverted"], ["event.removed",true], ["event.address",a(999)],

--- a/tests/module-review-admin-bff.test.ts
+++ b/tests/module-review-admin-bff.test.ts
@@ -7,7 +7,10 @@ import { computeModuleReviewDecisionDigestV1, type ModuleReviewDecisionCommandV1
 import type { WalletPrincipalAuthenticatorV1 } from "../lib/server/creator-article/wallet-principal.server";
 import { moduleReviewAdminFixture } from "./fixtures/module-review-admin";
 import { reviewDigest } from "../lib/module-mode/review-contract";
-import { computeModuleModeHostManifestHash } from "../lib/server/module-mode/catalog";
+import { computeModuleModeHostManifestHash, createModuleModeAvailabilityReader, createModuleModeHostManifest, type ModuleModeHostReleaseIdentity } from "../lib/server/module-mode/catalog";
+import { bindActiveModuleModeRelease, computeModuleModeReleaseDigest } from "../lib/module-mode/release";
+import configuredRelease from "../config/module-mode/robinhood.preview.json";
+import configuredCatalog from "../config/module-mode/catalog.json";
 
 vi.mock("server-only", () => ({}));
 
@@ -15,7 +18,7 @@ const WEBSITE_TOKEN = "service_" + "a".repeat(48);
 const ASSERTION_KEY = "assert_" + "b".repeat(48);
 const TIME = "2026-09-06T02:00:00.000Z";
 const NONCE = "abcdefghijklmnopqrstuv";
-function setup(options: { wallet?: string; release?: boolean } = {}) {
+function setup(options: { wallet?: string; release?: boolean | "configured" } = {}) {
   const f = moduleReviewAdminFixture(); const wallet = options.wallet ?? f.reviewer;
   const authenticate = vi.fn(async () => ({ privyUserId: "did:privy:test-reviewer", privySessionId: "session-review", wallets: [wallet] }));
   const queue = { schemaVersion: "programmable.modules.review-queue.v1", jobs: [{ ...f.job, plan: null, artifact: null }], nextCursor: null };
@@ -32,7 +35,8 @@ function setup(options: { wallet?: string; release?: boolean } = {}) {
     }
     return Response.json(path.endsWith(f.subject.submissionId) ? detail : queue);
   });
-  const client = createModuleReviewClient({ authenticator: { authenticate } as WalletPrincipalAuthenticatorV1, backendBaseUrl: "https://review.example.invalid", websiteToken: WEBSITE_TOKEN, bffAssertionKeyV2: ASSERTION_KEY, fetchBackend, now: () => new Date(TIME), nonce: () => NONCE, ...(options.release === false ? {} : { releaseIdentity: f.release }) });
+  const client = createModuleReviewClient({ authenticator: { authenticate } as WalletPrincipalAuthenticatorV1, backendBaseUrl: "https://review.example.invalid", websiteToken: WEBSITE_TOKEN, bffAssertionKeyV2: ASSERTION_KEY, fetchBackend, now: () => new Date(TIME), nonce: () => NONCE,
+    ...(options.release === "configured" ? {} : { releaseIdentity: options.release === false ? { enabled: false, status: "preview", releaseDigest: null } : f.release }) });
   const read = (suffix = "") => new Request(`https://programmable.example/api/admin/modules${suffix}?walletAddress=${wallet}`, { headers: { Authorization: "Bearer browser-private-token", "X-Programmable-Bff-Assertion-Signature": "forged-browser-value" } });
   const post = (suffix: string, body: object) => new Request(`https://programmable.example/api/admin/modules/${f.subject.submissionId}/${suffix}`, { method: "POST", headers: { "Content-Type": "application/json", Authorization: "Bearer browser-private-token" }, body: JSON.stringify({ walletAddress: wallet, ...body }) });
   const command = (outcome: ModuleReviewDecisionCommandV1["outcome"] = "accept"): ModuleReviewDecisionCommandV1 => ({ schemaVersion: "programmable.modules.review-command.v1", submissionId: f.subject.submissionId, requestDigest: f.subject.requestDigest, expectedReviewRevision: 2, outcome, reason: "Synthetic review test only. Do not publish this fixture.", artifactDigest: outcome === "accept" ? f.artifact.artifactDigest : null, hostManifestHash: outcome === "accept" ? f.manifestHash : null, acknowledgedReviewAreas: outcome === "accept" ? f.artifact.reviewRequired : [] });
@@ -112,6 +116,31 @@ describe("Module review admin BFF", () => {
     const f = setup(); const result = await f.client.handle(f.post("manifest", { expectedReviewRevision: 2, hostManifestJson: JSON.stringify(f.manifest) }), "manifest", f.subject.submissionId);
     expect(result.status).toBe(200); expect(await result.json()).toMatchObject({ hostManifestHash: f.manifestHash, artifactDigest: f.artifact.artifactDigest, reviewRevision: 2 });
     expect(f.fetchBackend.mock.calls.every(([, init]) => init?.method === "GET")).toBe(true);
+  });
+  it("checks a private manifest against the real pending host identity without an active release", async () => {
+    const f = setup({ release: "configured" });
+    expect(configuredRelease.releaseDigest).toBe(computeModuleModeReleaseDigest(configuredRelease));
+    expect(configuredRelease.lifecycleEvidenceDigest).toBeNull();
+    expect(() => bindActiveModuleModeRelease(configuredRelease)).toThrow("release.enabled");
+    // Only the host identity is real here; the source/build fixture remains synthetic and unapproved.
+    const manifest = createModuleModeHostManifest({ release: configuredRelease as ModuleModeHostReleaseIdentity,
+      definition: f.definition, nativeBinding: f.binding, descriptor: f.source.descriptor });
+    const result = await f.client.handle(f.post("manifest", { expectedReviewRevision: 2, hostManifestJson: JSON.stringify(manifest) }), "manifest", f.subject.submissionId);
+    expect(result.status).toBe(200);
+    expect(await result.json()).toMatchObject({ hostManifestHash: computeModuleModeHostManifestHash(manifest), artifactDigest: f.artifact.artifactDigest });
+    expect(f.fetchBackend.mock.calls.every(([, init]) => init?.method === "GET")).toBe(true);
+  });
+  it("keeps public launches disabled while the pending host identity permits private review", async () => {
+    const authenticateRelease = vi.fn(async () => { throw new Error("A disabled preview must not authenticate as active"); });
+    const fetchPublic = vi.fn<typeof fetch>(async () => { throw new Error("A disabled preview must not fetch publications"); });
+    const read = createModuleModeAvailabilityReader({ releaseProfile: configuredRelease, catalogFile: configuredCatalog,
+      collector: () => ({ authenticateRelease }), fetchPublic });
+    const result = await read();
+    expect(result.release).toBeNull();
+    expect(result.catalog.length).toBeGreaterThan(0);
+    expect(result.catalog.every(entry => entry.status === "preview" && !("nativeBinding" in entry))).toBe(true);
+    expect(authenticateRelease).not.toHaveBeenCalled();
+    expect(fetchPublic).not.toHaveBeenCalled();
   });
   it.each(["type", "order"] as const)("rejects an internally canonical host manifest whose ABI %s differs from the built plan", async kind => {
     const f = setup(); const manifest = structuredClone(f.manifest);


### PR DESCRIPTION
The private module review cannot validate a host manifest while the configured host identity is empty. Bind the actual Robinhood deployment identity, all contract runtime hashes, and the completed deployment/source evidence so reviewers can validate the two submitted starter modules against the deployed engine.

Public launches remain disabled: `enabled` is false, status is `preview`, and lifecycle evidence is still absent. This change does not publish a module, record an approval, or admit a factory onchain. The original contract source remains `9a2a1257a1b97dc0658157247890105a26e824ec`.

Validation: 66 focused BFF/catalogue tests pass; regression coverage proves that private manifest checks use the real pending identity while public availability returns preview entries without invoking activation or publication readers. Targeted ESLint and `git diff --check` pass. The evidence binds nine successful deployment transactions and complete source/runtime readbacks for all 13 core contracts; finality and lifecycle remain separate release steps.

The credential scanner classified the public `tokenCreationCodeHash` as a generic API key. Its exception is limited to the exact verified hash, exact JSON field/line, exact profile path and that single scanner rule. The complete commit range scans clean; a different high-entropy value in the same field still triggers detection.
