### PR TITLE
Remove homepage explanations and update Dune links

### DIFF
--- a/app/analytics/route.ts
+++ b/app/analytics/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 
 const DUNE_ANALYTICS_URL =
-  "https://dune.com/0xprogrammable6098/programmable-analytics";
+  "https://dune.com/programmablehq/analytics";
 
 export function GET() {
   return NextResponse.redirect(DUNE_ANALYTICS_URL);

--- a/components/landing-page.module.css
+++ b/components/landing-page.module.css
@@ -120,8 +120,7 @@
   width: 64px;
 }
 
-.hero h1,
-.definition h2 {
+.hero h1 {
   color: #fff;
   font-weight: 560;
   letter-spacing: -0.04em;
@@ -167,103 +166,6 @@
 .scrollCue span:last-child {
   animation: cue-pulse 2.8s var(--webde-ease) infinite;
   font-size: 20px;
-}
-
-.definition {
-  padding: clamp(88px, 9vh, 112px)
-    max(clamp(24px, 4vw, 40px), calc((100% - 1280px) / 2))
-    clamp(88px, 9vh, 112px);
-  scroll-margin-top: 0;
-}
-
-.definitionHeader {
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  text-align: center;
-}
-
-.definition h2 {
-  align-items: baseline;
-  display: flex;
-  font-size: clamp(64px, 7vw, 96px);
-  gap: 0.28em;
-  justify-content: center;
-  line-height: 1;
-  white-space: nowrap;
-}
-
-.definitionLogoFrame {
-  align-items: flex-end;
-  align-self: baseline;
-  display: inline-flex;
-  height: 0.9em;
-  justify-content: center;
-  transform: translateY(0.065em);
-  width: 0.69em;
-}
-
-.definitionLogo {
-  filter: grayscale(1) brightness(0) invert(1);
-  height: 100%;
-  object-fit: contain;
-  width: 100%;
-}
-
-.definitionQuestion {
-  display: inline-block;
-}
-
-.docsLink {
-  color: var(--webde-muted);
-  font-size: 18px;
-  line-height: 1.55;
-  margin-top: 24px;
-  text-decoration: underline;
-  text-decoration-color: var(--webde-dim);
-  text-decoration-thickness: 1px;
-  text-underline-offset: 6px;
-  transition:
-    color 180ms var(--webde-ease),
-    text-decoration-color 180ms var(--webde-ease);
-}
-
-.definitionColumns {
-  align-items: start;
-  display: grid;
-  gap: clamp(64px, 9vw, 128px);
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  margin: clamp(72px, 12vh, 116px) auto 0;
-  max-width: 1280px;
-}
-
-.definitionColumns p {
-  color: var(--webde-muted);
-  font-size: clamp(20px, 1.7vw, 24px);
-  line-height: 1.55;
-  margin: 0;
-  max-width: 36rem;
-  text-wrap: pretty;
-}
-
-.definitionColumns .definitionLead {
-  color: var(--webde-ink);
-  font-size: clamp(24px, 2.15vw, 30px);
-  font-weight: 500;
-  letter-spacing: -0.012em;
-  line-height: 1.45;
-}
-
-.definitionDetail p + p {
-  margin-top: 40px;
-}
-
-.inlineLink {
-  color: inherit;
-  text-decoration: underline;
-  text-decoration-color: var(--webde-dim);
-  text-decoration-thickness: 1px;
-  text-underline-offset: 5px;
 }
 
 .exploreChapter {
@@ -404,9 +306,7 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .scrollCue:hover,
-  .docsLink:hover,
-  .inlineLink:hover {
+  .scrollCue:hover {
     color: #fff;
     text-decoration-color: #fff;
   }
@@ -463,22 +363,6 @@
   .heroContent {
     padding-inline: clamp(20px, 4vw, 40px);
   }
-
-  .definition {
-    min-height: 100svh;
-    padding-block: 88px 104px;
-    scroll-margin-top: 0;
-  }
-
-  .definitionColumns {
-    gap: 44px;
-    grid-template-columns: 1fr;
-    margin-top: 64px;
-  }
-
-  .definitionColumns p {
-    max-width: 42rem;
-  }
 }
 
 @media (max-width: 42.5rem) {
@@ -493,8 +377,7 @@
     width: 52px;
   }
 
-  .hero h1,
-  .definition h2 {
+  .hero h1 {
     font-size: clamp(40px, 12.8vw, 64px);
   }
 
@@ -506,18 +389,6 @@
     bottom: 14px;
     font-size: 14px;
     max-width: calc(100% - 32px);
-  }
-
-  .definition h2 {
-    gap: 10px;
-  }
-
-  .definitionColumns p {
-    font-size: 18px;
-  }
-
-  .definitionColumns .definitionLead {
-    font-size: 24px;
   }
 
   .exploreChapter {
@@ -537,16 +408,6 @@
 
   .exploreFallbackHeading h2 {
     font-size: clamp(38px, 11vw, 48px);
-  }
-}
-
-@media (max-width: 23rem) {
-  .definition {
-    padding-inline: 16px;
-  }
-
-  .definition h2 {
-    font-size: 36px;
   }
 }
 

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useLayoutEffect, useRef, type CSSProperties } from "react";
 import Image from "next/image";
-import Link from "next/link";
 
 import { LandingExploreGate } from "@/components/landing-explore-gate";
 import styles from "@/components/landing-page.module.css";
@@ -156,93 +155,10 @@ export function LandingPage() {
           <p>Build and launch custom Uniswap v4 hooks</p>
         </div>
 
-        <a className={styles.scrollCue} href="#what-is-programmable">
+        <a className={styles.scrollCue} href="#explore">
           <span>Discover Programmable</span>
           <span aria-hidden="true">↓</span>
         </a>
-      </section>
-
-      <section
-        className={`${styles.definition} ${styles.revealSection}`}
-        id="what-is-programmable"
-        aria-labelledby="programmable-definition-title"
-        data-reveal-section
-      >
-        <header className={styles.definitionHeader}>
-          <h2
-            id="programmable-definition-title"
-            aria-label="What is Programmable?"
-          >
-            <span>What is</span>
-            <span className={styles.definitionLogoFrame} aria-hidden="true">
-              <Image
-                className={styles.definitionLogo}
-                src={loopMark}
-                alt=""
-                width={1168}
-                height={1536}
-                sizes="96px"
-              />
-            </span>
-            <span className={styles.definitionQuestion} aria-hidden="true">
-              ?
-            </span>
-          </h2>
-          <Link className={styles.docsLink} href="/docs">
-            Read the Programmable overview
-          </Link>
-        </header>
-
-        <div className={styles.definitionColumns}>
-          <p className={styles.definitionLead}>
-            Programmable brings products built with Uniswap v4 hooks into one
-            place, together with tools to create your own.
-          </p>
-          <p>
-            Explore what each project does, how its hook changes the way its
-            pool works, and the public information behind it. Our goal is
-            simple: make it easier to turn a hook idea into a launchable
-            project.
-          </p>
-        </div>
-      </section>
-
-      <section
-        className={`${styles.definition} ${styles.revealSection}`}
-        id="what-is-a-hook"
-        aria-labelledby="hook-definition-title"
-        data-reveal-section
-      >
-        <header className={styles.definitionHeader}>
-          <h2 id="hook-definition-title">What is a hook?</h2>
-        </header>
-
-        <div className={styles.definitionColumns}>
-          <p className={styles.definitionLead}>
-            A{" "}
-            <a
-              className={styles.inlineLink}
-              href="https://docs.uniswap.org/contracts/v4/overview"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Uniswap v4
-            </a>{" "}
-            pool is a market where two assets can be traded. A hook is a smart
-            contract connected to that pool. It adds rules for how that market
-            works.
-          </p>
-          <div className={styles.definitionDetail}>
-            <p>
-              Those rules can run at specific moments, such as before or after a
-              trade or when liquidity changes.
-            </p>
-            <p>
-              They can adjust a fee, reward an action, or shape what happens
-              when people use the pool.
-            </p>
-          </div>
-        </div>
       </section>
 
       <div

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -27,7 +27,7 @@ const resourceLinks = [
     external: true,
   },
   {
-    href: "https://dune.com/0xprogrammable6098/programmable-analytics",
+    href: "https://dune.com/programmablehq/analytics",
     label: "Dune analytics",
     external: true,
   },

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -91,7 +91,7 @@ function HeaderSocialLinks({ mobile = false }: { mobile?: boolean }) {
       </a>
       <a
         className="header-social-link"
-        href="https://dune.com/0xprogrammable6098/programmable-analytics"
+        href="https://dune.com/programmablehq/analytics"
         target="_blank"
         rel="noreferrer"
         aria-label="Programmable analytics on Dune"

--- a/tests/analytics-redirect.test.ts
+++ b/tests/analytics-redirect.test.ts
@@ -8,7 +8,7 @@ describe("analytics short link", () => {
 
     expect(response.status).toBe(307);
     expect(response.headers.get("location")).toBe(
-      "https://dune.com/0xprogrammable6098/programmable-analytics",
+      "https://dune.com/programmablehq/analytics",
     );
   });
 });

--- a/tests/interaction-accessibility.test.ts
+++ b/tests/interaction-accessibility.test.ts
@@ -231,8 +231,7 @@ describe("interaction accessibility", () => {
     expect(source).toContain('aria-label="Programmable on GitHub"');
     expect(source).toContain('aria-label="Programmable on Discord"');
     expect(source).toContain('aria-label="Programmable on DEX Screener"');
-    expect(landing).toContain('href="#what-is-programmable"');
-    expect(landing).toContain('href="/docs"');
+    expect(landing).toContain('href="#explore"');
     expect(css).toMatch(/\.scrollCue\s*\{[^}]*min-height:\s*52px;/s);
   });
 

--- a/tests/landing-page-contract.test.ts
+++ b/tests/landing-page-contract.test.ts
@@ -60,15 +60,9 @@ describe("landing page contract", () => {
     expect(landing).toContain('<h1 id="landing-title">Programmable</h1>');
     expect(landing).toContain("Build and launch custom Uniswap v4 hooks");
     expect(landing).toContain('id="intro"');
-    expect(landing).toContain('href="#what-is-programmable"');
-    expect(landing).toContain('id="what-is-programmable"');
-    expect(landing).toContain('id="what-is-a-hook"');
+    expect(landing).toContain('href="#explore"');
     expect(landing).toContain('id="explore"');
     expect(landing).toContain("<LandingExploreGate />");
-    expect(landing).toContain('href="/docs"');
-    expect(landing).toContain(
-      'href="https://docs.uniswap.org/contracts/v4/overview"',
-    );
     expect(landing).not.toContain("liquid-glass-distortion");
 
     for (const asset of [
@@ -120,18 +114,14 @@ describe("landing page contract", () => {
       /\.hero\s*\{[^}]*min-height:\s*calc\(100svh - 88px\);/s,
     );
     expect(styles).toMatch(/\.hero\s*\{[^}]*z-index:\s*1;/s);
-    expect(styles).toMatch(/\.definition\s*\{[^}]*min-height:\s*100svh;/s);
     expect(styles).toMatch(/\.scrollCue\s*\{[^}]*min-height:\s*52px;/s);
     expect(styles).toMatch(
       /\.hero h1\s*\{[^}]*font-size:\s*clamp\(64px, 7\.2vw, 104px\);/s,
     );
-    expect(styles).toContain("scroll-margin-top: 0;");
     expect(styles).toContain("object-position: center bottom;");
     expect(styles).not.toContain("mask-image:");
     expect(styles).not.toContain("translateY(27vh)");
     expect(styles).not.toContain("translateY(31vh)");
-    expect(styles).toContain("align-items: baseline;");
-    expect(styles).toContain(".definitionLogoFrame");
     expect(landing).toContain("new IntersectionObserver(");
     expect(landing).toContain('rootMargin: "0px 0px 48% 0px"');
     expect(landing).toContain("useLayoutEffect(() =>");
@@ -231,11 +221,7 @@ describe("landing page contract", () => {
 
   it("uses fluid shared gutters instead of a desktop to mobile width jump", () => {
     const finalStyles = read("app/webde-final-ui.css");
-    const landingStyles = read("components/landing-page.module.css");
 
     expect(finalStyles).toContain("calc(100% - clamp(2rem, 5vw, 5rem))");
-    expect(landingStyles).toContain(
-      "max(clamp(24px, 4vw, 40px), calc((100% - 1280px) / 2))",
-    );
   });
 });

--- a/tests/site-footer.test.ts
+++ b/tests/site-footer.test.ts
@@ -49,7 +49,7 @@ describe("Site footer", () => {
   it("places Dune analytics between DEX Screener and Discord", () => {
     const dexscreener = footerSource.indexOf("https://dexscreener.com/");
     const dune = footerSource.indexOf(
-      "https://dune.com/0xprogrammable6098/programmable-analytics",
+      "https://dune.com/programmablehq/analytics",
     );
     const discord = footerSource.indexOf(
       "https://discord.com/invite/programmable",

--- a/tests/topbar-hero-polish.test.ts
+++ b/tests/topbar-hero-polish.test.ts
@@ -44,8 +44,6 @@ describe("topbar and Explore hero polish", () => {
 
   it("keeps one ordered navigation with social links and wallet access on every route", () => {
     const navigation = read("components/site-navigation.tsx");
-    const landing = read("components/landing-page.tsx");
-    const landingCss = read("components/landing-page.module.css");
     const navigationCss = read("components/site-navigation.module.css");
 
     expect(navigation).toContain(
@@ -61,7 +59,7 @@ describe("topbar and Explore hero polish", () => {
     expect(navigation).toContain('aria-label="Programmable on DEX Screener"');
     expect(navigation).toContain('aria-label="Programmable analytics on Dune"');
     expect(navigation).toContain(
-      "https://dune.com/0xprogrammable6098/programmable-analytics",
+      "https://dune.com/programmablehq/analytics",
     );
     expect(
       navigation.indexOf('aria-label="Programmable on DEX Screener"'),
@@ -71,8 +69,6 @@ describe("topbar and Explore hero polish", () => {
     expect(
       navigation.indexOf('aria-label="Programmable analytics on Dune"'),
     ).toBeLessThan(navigation.indexOf('aria-label="Programmable on Discord"'));
-    expect(landing).toContain('href="/docs"');
-    expect(landing).toContain("Read the Programmable overview");
     expect(navigation).not.toContain("ThemeToggle");
     expect(navigation).not.toContain('if (pathname === "/") return null;');
     expect(navigation).toContain("<HeaderWalletButton");
@@ -119,7 +115,6 @@ describe("topbar and Explore hero polish", () => {
     expect(navigationCss).toMatch(
       /@media \(max-width: 26rem\)[\s\S]*?\.mobileSheet\s*\{[^}]*width:\s*calc\(100vw - 24px\);/s,
     );
-    expect(landingCss).toMatch(/\.docsLink\s*\{[^}]*font-size:\s*18px;/s);
   });
 
   it("keeps the wallet menu mounted for a smooth accessible exit", () => {


### PR DESCRIPTION
Remove the homepage’s “What is Programmable?” and “What is a hook?” sections, including their unused styles. The existing discovery arrow now leads directly to Explore.

Point the navigation, footer, and `/analytics` redirect to https://dune.com/programmablehq/analytics.

Validation: 39 tests across the five affected test files passed, targeted ESLint and `git diff --check` passed. Rendered desktop and mobile checks verified the hero-to-Explore transition, menu operation, both Dune links, absence of the removed sections, and no horizontal overflow or browser console errors. `/analytics` returns a 307 redirect to the new dashboard. The local Explore feed uses its existing unavailable state without production credentials.
