### PR TITLE
Authorize updated MultiRole Router CI candidate

### DIFF
--- a/.github/workflows/verify-hook-builder.yml
+++ b/.github/workflows/verify-hook-builder.yml
@@ -114,8 +114,8 @@ jobs:
           EXPECTED_BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
           EXPECTED_CANDIDATE_COMMIT: ${{ github.event.pull_request.head.sha }}
           EXPECTED_MERGE_COMMIT: ${{ steps.candidate_fetch.outputs.merge_commit }}
-          APPROVED_MAIN_CI_CONTROL_COMMIT: 346c72c8b2328382e993c704278b02c4d10a1707
-          APPROVED_MAIN_CI_CONTROL_TREE: c2e41b19abac40f7849cf343b68ee3f783b53bdd
+          APPROVED_MAIN_CI_CONTROL_COMMIT: 7466a691e5cc3190d6fa24bc9b428ad90548fab3
+          APPROVED_MAIN_CI_CONTROL_TREE: dfa11713925e3463d702e477f5921a073354ce40
         run: |
           set -euo pipefail
 

--- a/.github/workflows/verify-hook-builder.yml
+++ b/.github/workflows/verify-hook-builder.yml
@@ -114,8 +114,8 @@ jobs:
           EXPECTED_BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
           EXPECTED_CANDIDATE_COMMIT: ${{ github.event.pull_request.head.sha }}
           EXPECTED_MERGE_COMMIT: ${{ steps.candidate_fetch.outputs.merge_commit }}
-          APPROVED_MAIN_CI_CONTROL_COMMIT: e15bb397604a19d6622af5a5ee9622a8edac9d18
-          APPROVED_MAIN_CI_CONTROL_TREE: 92eecc16da2c59b87295fcb4012e57fe4f1feae7
+          APPROVED_MAIN_CI_CONTROL_COMMIT: 346c72c8b2328382e993c704278b02c4d10a1707
+          APPROVED_MAIN_CI_CONTROL_TREE: c2e41b19abac40f7849cf343b68ee3f783b53bdd
         run: |
           set -euo pipefail
 

--- a/scripts/test/verify-main-ci-control-workflow.test.mjs
+++ b/scripts/test/verify-main-ci-control-workflow.test.mjs
@@ -39,8 +39,8 @@ test("CI control guard executes only exact default-branch code over inert candid
 });
 
 test("trusted guard is bound to the exact audited main candidate commit and tree", () => {
-  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_COMMIT: 346c72c8b2328382e993c704278b02c4d10a1707/u);
-  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_TREE: c2e41b19abac40f7849cf343b68ee3f783b53bdd/u);
+  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_COMMIT: 7466a691e5cc3190d6fa24bc9b428ad90548fab3/u);
+  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_TREE: dfa11713925e3463d702e477f5921a073354ce40/u);
   assert.match(workflow, /--approved-commit "\$APPROVED_MAIN_CI_CONTROL_COMMIT"/u);
   assert.match(workflow, /--approved-tree "\$APPROVED_MAIN_CI_CONTROL_TREE"/u);
 });

--- a/scripts/test/verify-main-ci-control-workflow.test.mjs
+++ b/scripts/test/verify-main-ci-control-workflow.test.mjs
@@ -39,8 +39,8 @@ test("CI control guard executes only exact default-branch code over inert candid
 });
 
 test("trusted guard is bound to the exact audited main candidate commit and tree", () => {
-  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_COMMIT: e15bb397604a19d6622af5a5ee9622a8edac9d18/u);
-  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_TREE: 92eecc16da2c59b87295fcb4012e57fe4f1feae7/u);
+  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_COMMIT: 346c72c8b2328382e993c704278b02c4d10a1707/u);
+  assert.match(workflow, /APPROVED_MAIN_CI_CONTROL_TREE: c2e41b19abac40f7849cf343b68ee3f783b53bdd/u);
   assert.match(workflow, /--approved-commit "\$APPROVED_MAIN_CI_CONTROL_COMMIT"/u);
   assert.match(workflow, /--approved-tree "\$APPROVED_MAIN_CI_CONTROL_TREE"/u);
 });


### PR DESCRIPTION
PR #702 now has candidate commit `7466a691e5cc3190d6fa24bc9b428ad90548fab3` and tree `dfa11713925e3463d702e477f5921a073354ce40`, including the completed canonical and mirrored verifier diagnostic fixes. Its existing CI workflow change causes the trusted public-intake guard to reject this updated candidate while the production authorization still names `e15bb397604a19d6622af5a5ee9622a8edac9d18` and its previous tree.

Update only the two candidate-authorization literals in the trusted workflow and their two matching test assertions. The guard logic, permissions, exact Git identity checks, and ordinary candidate validation remain unchanged. This authorizes only the stated candidate to enter ordinary PR CI; independent Router review and the normal merge and deployment gates remain separate.

Validation:

- Both focused CI control test files: 10 tests passed.
- `actionlint` 1.7.12: passed for the changed workflow.
- `git diff --check`: passed.
- Gitleaks 8.30.1 with the existing repository configuration: no leaks in the exact two-commit PR range through `566c6ee7fa162edf20cb1368f3b93666a6be58cc`.
