### PR TITLE
Fix Robinhood network switching in Module Mode

### DIFF
--- a/components/module-coin-console.tsx
+++ b/components/module-coin-console.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useId, useRef, useState, type FormEvent } from 
 import { ArrowLeft, ArrowUpRight, RefreshCw } from "lucide-react";
 import { formatUnits, isAddress, type Address, type Hex } from "viem";
 import { useWallet } from "@/components/wallet-provider";
+import { switchModuleModeNetwork } from "@/components/module-mode-wallet-state";
 import { ModuleSchemaField } from "@/components/module-mode-fields";
 import { ROBINHOOD_BLOCK_EXPLORER_URL } from "@/lib/chains";
 import { configurationFromForm, defaultSchemaValue, parseExactUnits, type FormValue } from "@/lib/module-mode/builder";
@@ -144,7 +145,7 @@ export function ModuleCoinConsole({ token }: { token: Address }) {
     onPrepareTrade={intent => { void prepareTrade(intent); }}
     onCheckReceipt={transactionHash => { void checkReceipt(transactionHash); }}
     onCancel={() => { if (phase === "review") { setPrepared(null); setPhase("idle"); } }} onRefresh={() => { setLoading(true); void refresh(); }}
-    onWallet={wallet.openWallet} onSwitch={() => { void wallet.switchNetwork("0x1237").catch(caught => setError(errorMessage(caught))); }} />;
+    onWallet={wallet.openWallet} onSwitch={() => { setError(""); void switchModuleModeNetwork(wallet.switchNetwork).catch(caught => setError(errorMessage(caught))); }} />;
 }
 
 export interface ModuleCoinConsoleViewProps {

--- a/components/module-mode-launch-host.tsx
+++ b/components/module-mode-launch-host.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import { formatUnits, toHex, type Address, type Hex } from "viem";
 
 import { ModuleModeBuilder, type ModuleModeLaunchAction } from "@/components/module-mode-builder";
-import { assertModuleModeWalletUnchanged, isModuleModeWalletRejection, moduleModeSubmissionIsUncertain, moduleModeWalletStep, uploadModuleModeImage, type ModuleModeWalletSnapshot } from "@/components/module-mode-wallet-state";
+import { assertModuleModeWalletUnchanged, isModuleModeWalletRejection, moduleModeSubmissionIsUncertain, moduleModeWalletStep, switchModuleModeNetwork, uploadModuleModeImage, type ModuleModeWalletSnapshot } from "@/components/module-mode-wallet-state";
 import { useWallet } from "@/components/wallet-provider";
 import styles from "@/components/module-mode-builder.module.css";
 import { ROBINHOOD_BLOCK_EXPLORER_URL } from "@/lib/chains";
@@ -100,7 +100,7 @@ export function ModuleModeLaunchHost() {
     if (flow.phase === "reverted") submitted.current = null;
     if (!release) throw new Error("Wallet launching is not available. You can keep or export this draft.");
     if (walletStep === "connect") { openWallet(); return; }
-    if (walletStep === "switch") { await switchNetwork("0x1237"); return; }
+    if (walletStep === "switch") { await switchModuleModeNetwork(switchNetwork); return; }
     if (!wallet) return;
     const account = wallet.account as Address;
     const requestId = ++operation.current;

--- a/components/module-mode-wallet-state.tsx
+++ b/components/module-mode-wallet-state.tsx
@@ -1,5 +1,6 @@
 import { sha256, type Hex } from "viem";
 
+import { ROBINHOOD_CHAIN_ID } from "@/lib/chains";
 import type { ModuleModeDraft } from "@/lib/module-mode/builder";
 import { isProgrammableTokenImageUrl, readTokenImageUploadResponse } from "@/lib/token-image";
 
@@ -17,6 +18,13 @@ export function isModuleModeChain(chainId: string | undefined) {
 export function moduleModeWalletStep(wallet: ModuleModeWalletSnapshot): "connect" | "switch" | "prepare" {
   if (!wallet.authenticated || !wallet.sessionReady || !wallet.account) return "connect";
   return isModuleModeChain(wallet.chainId) ? "prepare" : "switch";
+}
+
+/** The wallet context accepts decimal network IDs; its EIP-1193 state uses hex. */
+export async function switchModuleModeNetwork(switchNetwork: (chainId: string) => Promise<boolean>): Promise<void> {
+  if (!await switchNetwork(String(ROBINHOOD_CHAIN_ID))) {
+    throw new Error("The network change was not completed. Switch your wallet to Robinhood Chain and try again.");
+  }
 }
 
 export function assertModuleModeWalletUnchanged(current: ModuleModeWalletSnapshot, expectedAccount: string) {

--- a/tests/module-mode-wallet-state.test.ts
+++ b/tests/module-mode-wallet-state.test.ts
@@ -1,13 +1,34 @@
 import { describe, expect, it, vi } from "vitest";
 import { sha256 } from "viem";
 
-import { assertModuleModeWalletUnchanged, isModuleModeChain, isModuleModeWalletRejection, moduleModeSubmissionIsUncertain, moduleModeWalletStep, uploadModuleModeImage } from "@/components/module-mode-wallet-state";
+import { assertModuleModeWalletUnchanged, isModuleModeChain, isModuleModeWalletRejection, moduleModeSubmissionIsUncertain, moduleModeWalletStep, switchModuleModeNetwork, uploadModuleModeImage } from "@/components/module-mode-wallet-state";
 import { PROGRAMMABLE_TOKEN_IMAGE_HOST } from "@/lib/token-image";
 
 const account = `0x${"12".repeat(20)}`;
 const connected = { account, chainId: "0x1237", authenticated: true, sessionReady: true };
 
 describe("Module Mode wallet boundary", () => {
+  it("switches through the wallet context's decimal network contract before allowing preparation", async () => {
+    const state = { ...connected, chainId: "0x1" };
+    const switchNetwork = vi.fn(async (chainId: string) => {
+      // Match the public wallet context: RPC hex IDs are not accepted as network requests.
+      if (chainId !== "4663") return false;
+      state.chainId = "0x1237";
+      return true;
+    });
+    expect(moduleModeWalletStep(state)).toBe("switch");
+    await switchModuleModeNetwork(switchNetwork);
+    expect(switchNetwork).toHaveBeenCalledOnce();
+    expect(moduleModeWalletStep(state)).toBe("prepare");
+  });
+
+  it("reports a refused network change and preserves thrown wallet errors", async () => {
+    await expect(switchModuleModeNetwork(async () => false)).rejects.toThrow("network change was not completed");
+    const rejected = new Error("Network change cancelled.");
+    await expect(switchModuleModeNetwork(async () => { throw rejected; })).rejects.toBe(rejected);
+    expect(moduleModeWalletStep({ ...connected, chainId: "0x1" })).toBe("switch");
+  });
+
   it("requires explicit connection and the actual Robinhood wallet chain before preparation", () => {
     expect(moduleModeWalletStep({ ...connected, authenticated: false })).toBe("connect");
     expect(moduleModeWalletStep({ ...connected, sessionReady: false })).toBe("connect");


### PR DESCRIPTION
Module Mode users connected to Ethereum could not switch to Robinhood from either the launch review or coin controls: both sent the RPC hex chain ID to a wallet context that accepts decimal network IDs. Both now use the shared Robinhood switch helper, and a refused change produces a visible retry message. Existing session and transaction validation stays in place.

Validation: 34 targeted wallet, builder and management tests passed, including successful switching and refused/rejected changes; TypeScript and targeted ESLint passed. The original failure was reproduced on the production wallet UI. The corrected deployed wallet interaction will be checked after the protected release gate.
