### PR TITLE
Make the module developer guide publicly reachable

### DIFF
--- a/app/developer-reference/module-mode/page.tsx
+++ b/app/developer-reference/module-mode/page.tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  metadata,
+} from "@/app/docs/developers/module-mode/page";

--- a/app/docs/developers/module-mode/page.tsx
+++ b/app/docs/developers/module-mode/page.tsx
@@ -6,7 +6,7 @@ import styles from "@/components/developer-docs.module.css";
 export const metadata: Metadata = {
   title: "Build a module · Programmable",
   description: "Create, submit and track a Module Mode source package with your EVM wallet and an API key.",
-  alternates: { canonical: "/docs/developers/module-mode" },
+  alternates: { canonical: "/developer-reference/module-mode" },
 };
 const sections = [
   { id: "start", label: "Get started" },
@@ -29,9 +29,10 @@ export default function ModuleModeDeveloperPage() {
     <section id="start">
       <h2>Get started</h2>
       <ol className={styles.steps}>
-        <li>Connect your EVM wallet on <Link href="/developers/api-keys">API keys</Link> and choose
-          <strong> Module contributions</strong>. The option becomes available when the API accepts submissions.</li>
-        <li>Give your agent the <a href="/developers/module-mode-api-v1.md">API guide</a> and the
+        <li>Connect your EVM wallet on <Link href="/developers/api-keys">API keys</Link> and create a key with
+          <strong> Launches + modules</strong> access.</li>
+        <li>Choose <strong>Copy connection</strong> and give it to your agent. It includes the key and
+          instructions for finding the <a href="/developers/module-mode-api-v1.md">API guide</a> and
           <a href={`${cliDirectory}/manifest.json`}> pinned CLI manifest</a>. Verify the file hash from
           that manifest before running the standalone CLI with Node.js 24.14 or later in the Node 24 line.</li>
         <li>Provide your idea, author wallet and reward wallet. Keep the API key in the agent&apos;s

--- a/components/module-contribution-entry.tsx
+++ b/components/module-contribution-entry.tsx
@@ -18,6 +18,6 @@ export function ModuleContributionEntry() {
       <li><span>3</span><div><h2>Submit for review</h2><p>Include your EVM author and reward wallets. After approval and publication, others can add your module and you share in its fees.</p></div></li>
     </ol>
     {error ? <p role="alert">{error}</p> : null}
-    <nav className={styles.resources} aria-label="Module developer resources"><Link href="/docs/developers/module-mode">Developer docs<ArrowRight size={16} /></Link><a href="/agents.md">Agent guide<ArrowRight size={16} /></a></nav>
+    <nav className={styles.resources} aria-label="Module developer resources"><Link href="/developer-reference/module-mode">Developer docs<ArrowRight size={16} /></Link><a href="/agents.md">Agent guide<ArrowRight size={16} /></a></nav>
   </div>;
 }

--- a/lib/agent-connection.ts
+++ b/lib/agent-connection.ts
@@ -39,7 +39,7 @@ export const PROGRAMMABLE_AGENT_ENTRY = Object.freeze({
     moduleContribution: {
       scopes: ["modules:submit", "modules:read"],
       guide: "https://programmable.market/developers/module-mode-api-v1.md",
-      developerGuide: "https://programmable.market/docs/developers/module-mode",
+      developerGuide: "https://programmable.market/developer-reference/module-mode",
       capabilities: "https://api.programmable.market/v1/modules/capabilities",
       reviewCapabilities: "https://api.programmable.market/v1/modules/review-capabilities",
       submissions: "https://api.programmable.market/v1/modules/submissions",

--- a/tests/module-mode-guide-routing.test.ts
+++ b/tests/module-mode-guide-routing.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { expect, it } from "vitest";
+import { PROGRAMMABLE_AGENT_ENTRY } from "../lib/agent-connection";
+
+it("keeps the module host guide outside the externally managed docs namespace", () => {
+  const path = new URL(PROGRAMMABLE_AGENT_ENTRY.workflows.moduleContribution.developerGuide).pathname;
+  expect(path).not.toMatch(/^\/docs(?:\/|$)/);
+  const alias = readFileSync(`app${path}/page.tsx`, "utf8");
+  expect(alias).toContain('from "@/app/docs/developers/module-mode/page"');
+  const page = readFileSync("app/docs/developers/module-mode/page.tsx", "utf8");
+  expect(page).toContain(`canonical: "${path}"`);
+  expect(page).toContain("Copy connection");
+  expect(page).toContain("Launches + modules");
+  expect(readFileSync("components/module-contribution-entry.tsx", "utf8")).toContain(`href="${path}"`);
+  const config = JSON.parse(readFileSync("vercel.json", "utf8"));
+  expect(config.redirects).toContainEqual({ source: "/docs/developers/module-mode", destination: path, permanent: false });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,11 @@
   ],
   "redirects": [
     {
+      "source": "/docs/developers/module-mode",
+      "destination": "/developer-reference/module-mode",
+      "permanent": false
+    },
+    {
       "source": "/docs/developers/robinhood-terminal-indexer",
       "destination": "/developer-reference/robinhood-terminal-indexer",
       "permanent": false


### PR DESCRIPTION
The public `/docs/developers/module-mode` URL returns 404, so the new agent connection and contribution entry lead builders to a missing host guide. Serve the existing guide at `/developer-reference/module-mode`, using the same standalone route pattern as the Robinhood integration guide, and redirect the old URL there. Both new entry points link directly to the canonical guide.

The guide now uses the released “Launches + modules” and “Copy connection” labels. General GitBook routing remains unchanged.

Validation: nine targeted routing, discovery and existing Robinhood documentation tests passed; TypeScript passed. The old public URL was verified as HTTP 404 before the change. Final candidate and production HTTP readbacks are required before promotion.
