### PR TITLE
Fix public Custom Launch guide routing

### DIFF
--- a/app/developer-reference/custom-launch/page.tsx
+++ b/app/developer-reference/custom-launch/page.tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  metadata,
+} from "@/app/docs/developers/custom-launch/page";

--- a/app/docs/developers/custom-launch/page.tsx
+++ b/app/docs/developers/custom-launch/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
   title: "Custom Launch API · Programmable",
   description:
     "Package, submit and track live Ethereum V3 launches, and use verified Robinhood Chain V4 release discovery.",
-  alternates: { canonical: "/docs/developers/custom-launch" },
+  alternates: { canonical: "/developer-reference/custom-launch" },
 };
 
 const customLaunchSections = [

--- a/lib/agent-connection.ts
+++ b/lib/agent-connection.ts
@@ -26,7 +26,7 @@ export const PROGRAMMABLE_AGENT_ENTRY = Object.freeze({
   workflows: {
     customLaunch: {
       scopes: ["custom-launch:create", "custom-launch:read"],
-      guide: "https://programmable.market/docs/developers/custom-launch",
+      guide: "https://programmable.market/developer-reference/custom-launch",
       ethereum: { chainId: 1, capabilities: "https://api.programmable.market/v3/capabilities", openApi: "https://programmable.market/openapi/custom-launch-v3.json" },
       robinhood: { chainId: 4663, capabilities: "https://api.programmable.market/v4/chains/4663/capabilities", readiness: "https://api.programmable.market/v4/chains/4663/readiness", openApi: "https://programmable.market/openapi/custom-launch-v4.json" },
     },

--- a/tests/custom-launch-docs.test.ts
+++ b/tests/custom-launch-docs.test.ts
@@ -31,7 +31,7 @@ describe("Custom Launch API documentation", () => {
       "[Custom Launch API](developers/custom-launch.md)",
     );
     expect(websiteGuide).toContain(
-      'alternates: { canonical: "/docs/developers/custom-launch" }',
+      'alternates: { canonical: "/developer-reference/custom-launch" }',
     );
     expect(websiteGuide).toContain(
       'currentPath="/docs/developers/custom-launch"',

--- a/tests/developer-docs-experience.test.ts
+++ b/tests/developer-docs-experience.test.ts
@@ -52,7 +52,7 @@ describe("Developer documentation experience", () => {
       [
         customLaunchPage,
         "/docs/developers/custom-launch",
-        'alternates: { canonical: "/docs/developers/custom-launch" }',
+        'alternates: { canonical: "/developer-reference/custom-launch" }',
       ],
       [
         verifyPage,

--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,11 @@
   ],
   "redirects": [
     {
+      "source": "/docs/developers/custom-launch",
+      "destination": "/developer-reference/custom-launch",
+      "permanent": false
+    },
+    {
       "source": "/docs/developers/module-mode",
       "destination": "/developer-reference/module-mode",
       "permanent": false


### PR DESCRIPTION
The public Custom Launch guide URL still resolves to an outdated hosted GitBook page, so readers miss the current MultiRole instructions. Serve the existing product guide at `/developer-reference/custom-launch`, redirect the previous URL there, and point agent discovery and canonical metadata to the working route. This uses the same routing pattern already used for Module Mode and reuses the existing guide without duplicating its content.

Validation: all 47 tests across the four affected documentation and agent discovery suites pass; scoped ESLint and `git diff --check` pass. The two existing canonical URL expectations now match the new public route. Production rendering and deployment verification follow the normal release workflow.
