### PR TITLE
Restrict Admin Dashboard to the owner wallet

### DIFF
--- a/app/admin/modules/page.tsx
+++ b/app/admin/modules/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { ModuleReviewAdminConsole } from "@/components/module-review-admin-console";
 
 export const metadata: Metadata = {
-  title: "Module review · Programmable",
+  title: "Admin Dashboard · Programmable",
   description: "Review module submissions and build evidence.",
   robots: { index: false, follow: false },
 };

--- a/components/admin-dashboard-link.tsx
+++ b/components/admin-dashboard-link.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+import { isWebsiteAdminWallet } from "@/lib/admin-access";
+
+export function AdminDashboardLink({ account, authenticated, menuOpen, onNavigate }: {
+  account: string | null;
+  authenticated: boolean;
+  menuOpen: boolean;
+  onNavigate: () => void;
+}) {
+  if (!authenticated || !isWebsiteAdminWallet(account)) return null;
+  return <Link href="/admin/modules" prefetch={false}
+    tabIndex={menuOpen ? undefined : -1} onClick={onNavigate}>
+    Admin Dashboard
+  </Link>;
+}

--- a/components/module-review-admin-console.tsx
+++ b/components/module-review-admin-console.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type FormEvent } from "react";
 import { ArrowDownToLine, ArrowLeft, ArrowRight, Check, RefreshCw } from "lucide-react";
 import { useWallet } from "@/components/wallet-provider";
+import { isWebsiteAdminWallet } from "@/lib/admin-access";
 import { isReviewDigest, parseReviewPlan, reviewStateLabel, type ModuleReviewDecisionCommandV1, type ModuleReviewDecisionRecordV1, type ReviewDetail, type ReviewManifestCheck, type ReviewQueue } from "@/lib/module-mode/review-contract";
 import styles from "./module-review-admin-console.module.css";
 
@@ -44,7 +45,8 @@ const AREA_LABELS: Record<string, string> = {
 
 export function ModuleReviewAdminConsole() {
   const { authenticated, connecting, wallet, getAccessToken, getIdentityToken, openWallet } = useWallet();
-  const account = authenticated ? wallet?.account.toLowerCase() ?? null : null;
+  const account = authenticated && isWebsiteAdminWallet(wallet?.account)
+    ? wallet?.account.toLowerCase() ?? null : null;
   const session = useRef(account);
   useLayoutEffect(() => { session.current = account; }, [account]);
   const request = useCallback<RequestReview>(async (path, body, signal, asText) => {
@@ -68,12 +70,12 @@ export function ModuleReviewAdminConsole() {
   }, [account, getAccessToken, getIdentityToken]);
   return <div className={`${styles.page} page-width`}>
     <header className={styles.header}>
-      <div><p className={styles.eyebrow}>Admin / Module Mode</p><h1>Module review</h1><p>Review the source, check the build, and decide what comes next.</p></div>
+      <div><p className={styles.eyebrow}>Modules</p><h1>Admin Dashboard</h1></div>
       <Link className={styles.textLink} href="/admin/partners">Partner access <ArrowRight size={15} aria-hidden="true" /></Link>
     </header>
     {account ? <ModuleReviewWorkspace key={account} account={account} request={request} /> : <section className={styles.gate}>
-      <div className={styles.gateMark} aria-hidden="true">M</div><h2>Connect your admin wallet</h2>
-      <p>Module submissions are private. The review service checks your wallet’s permission after you connect.</p>
+      <div className={styles.gateMark} aria-hidden="true">M</div><h2>Admin wallet required</h2>
+      <p>Connect the admin wallet to review submissions.</p>
       <button className={styles.primary} type="button" disabled={connecting} onClick={openWallet}>{connecting ? "Connecting…" : "Connect wallet"}</button>
     </section>}
   </div>;

--- a/components/partner-admin-console.tsx
+++ b/components/partner-admin-console.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 
 import { useWallet } from "@/components/wallet-provider";
+import { isWebsiteAdminWallet } from "@/lib/admin-access";
 import {
   PARTNER_ADMIN_LIST_LIMITS_V1,
   PARTNER_ADMIN_SCHEMA_V1,
@@ -166,7 +167,8 @@ export function PartnerAdminConsole() {
     openWallet,
     wallet,
   } = useWallet();
-  const account = wallet?.account ?? null;
+  const account = authenticated && isWebsiteAdminWallet(wallet?.account)
+    ? wallet?.account ?? null : null;
   const [partners, setPartners] = useState<PartnerSummaryV1[]>([]);
   const [partnerPagination, setPartnerPagination] =
     useState<PartnerListPaginationV1>(EMPTY_PARTNER_PAGINATION);
@@ -678,7 +680,7 @@ export function PartnerAdminConsole() {
       </p>
       <header className={styles.hero}>
         <div>
-          <p className={styles.kicker}>Admin · <Link href="/admin/modules">Module review</Link></p>
+          <p className={styles.kicker}><Link href="/admin/modules">Admin Dashboard</Link> · Partners</p>
           <h1>Partner access</h1>
           <p>
             Give a partner its own launch infrastructure without sharing a
@@ -702,12 +704,8 @@ export function PartnerAdminConsole() {
         </section>
       ) : !account ? (
         <section className={styles.statePanel}>
-          <h2>{authenticated ? "Link an admin wallet" : "Connect the admin wallet"}</h2>
-          <p>
-            {authenticated
-              ? "Link or select an Ethereum wallet before checking partner access."
-              : "The backend verifies admin access after the wallet session is connected."}
-          </p>
+          <h2>Admin wallet required</h2>
+          <p>Connect the admin wallet to manage partner access.</p>
           <button type="button" disabled={connecting} onClick={openWallet}>
             {connecting
               ? "Connecting wallet"

--- a/components/site-navigation.tsx
+++ b/components/site-navigation.tsx
@@ -23,6 +23,7 @@ import {
   NavigationMenuIcon,
 } from "@/components/navigation-icons";
 import { useWallet } from "@/components/wallet-provider";
+import { AdminDashboardLink } from "@/components/admin-dashboard-link";
 import styles from "@/components/site-navigation.module.css";
 
 const desktopNavItems = [
@@ -130,6 +131,7 @@ function HeaderWalletButton({
 }>) {
   const {
     wallet,
+    authenticated,
     hasSession,
     connecting,
     openingWallet,
@@ -208,6 +210,8 @@ function HeaderWalletButton({
             onPointerEnter={() => warmNavigationRoute(router, "/profile")}
             onPointerDown={() => warmNavigationRoute(router, "/profile")}
             onClick={onClose}>Profile</Link>
+          <AdminDashboardLink account={wallet.account} authenticated={authenticated}
+            menuOpen={menuOpen} onNavigate={onClose} />
           <button type="button" onClick={async () => {
             try {
               await navigator.clipboard.writeText(wallet.account);

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { AdminDashboardLink } from "@/components/admin-dashboard-link";
 import { usePathname } from "next/navigation";
 import type { PrivyClientConfig } from "@privy-io/react-auth";
 import {
@@ -3448,8 +3449,6 @@ export function WalletButton({ compact = false }: { compact?: boolean }) {
     disconnect,
     openWallet,
     preloadWallet,
-    getAccessToken,
-    getIdentityToken,
   } = useWallet();
   const menuRef = useRef<HTMLDivElement>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
@@ -3457,10 +3456,6 @@ export function WalletButton({ compact = false }: { compact?: boolean }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuCopied, setMenuCopied] = useState(false);
   const [menuError, setMenuError] = useState("");
-  const [partnerAdminAccount, setPartnerAdminAccount] =
-    useState<string | null>(null);
-  const [moduleReviewerAccount, setModuleReviewerAccount] =
-    useState<string | null>(null);
   const hydrationPending = connecting && !openingWallet;
 
   useEffect(() => {
@@ -3489,51 +3484,6 @@ export function WalletButton({ compact = false }: { compact?: boolean }) {
       window.removeEventListener("keydown", closeOnEscape);
     };
   }, [menuOpen]);
-
-  useEffect(() => {
-    const account = wallet?.account ?? null;
-    if (!menuOpen || !account) return;
-    const controller = new AbortController();
-    void (async () => {
-      try {
-        const [accessToken, identityToken] = await Promise.all([
-          getAccessToken(),
-          getIdentityToken().catch(() => null),
-        ]);
-        if (!accessToken || controller.signal.aborted) return;
-        const headers = new Headers({
-          Accept: "application/json",
-          Authorization: `Bearer ${accessToken}`,
-        });
-        if (identityToken) {
-          headers.set("X-Privy-Identity-Token", identityToken);
-        }
-        const query = new URLSearchParams({
-          walletAddress: account,
-          page: "1",
-          pageSize: "1",
-        });
-        const moduleQuery = new URLSearchParams({ walletAddress: account });
-        const [partner, modules] = await Promise.allSettled([
-          fetch(`/api/admin/partners?${query}`, {
-            cache: "no-store", headers, signal: controller.signal, redirect: "error",
-          }),
-          fetch(`/api/admin/modules?${moduleQuery}`, {
-            cache: "no-store", headers, signal: controller.signal, redirect: "error",
-          }),
-        ]);
-        if (controller.signal.aborted) return;
-        setPartnerAdminAccount(partner.status === "fulfilled" && partner.value.ok ? account : null);
-        setModuleReviewerAccount(modules.status === "fulfilled" && modules.value.ok ? account : null);
-      } catch (error) {
-        if (!(error instanceof DOMException && error.name === "AbortError")) {
-          setPartnerAdminAccount(null);
-          setModuleReviewerAccount(null);
-        }
-      }
-    })();
-    return () => controller.abort();
-  }, [getAccessToken, getIdentityToken, menuOpen, wallet?.account]);
 
   const label = disconnecting
     ? "Disconnecting"
@@ -3578,8 +3528,6 @@ export function WalletButton({ compact = false }: { compact?: boolean }) {
       onClick={() => {
         if (wallet) {
           setMenuError("");
-          setPartnerAdminAccount(null);
-          setModuleReviewerAccount(null);
           setMenuOpen((current) => !current);
         } else {
           openWallet();
@@ -3661,27 +3609,8 @@ export function WalletButton({ compact = false }: { compact?: boolean }) {
         >
           API keys
         </Link>
-        {partnerAdminAccount?.toLowerCase()
-            === wallet.account.toLowerCase() ? (
-          <Link
-            href="/admin/partners"
-            prefetch={false}
-            tabIndex={menuOpen ? undefined : -1}
-            onClick={() => setMenuOpen(false)}
-          >
-            Partner admin
-          </Link>
-        ) : null}
-        {moduleReviewerAccount?.toLowerCase() === wallet.account.toLowerCase() ? (
-          <Link
-            href="/admin/modules"
-            prefetch={false}
-            tabIndex={menuOpen ? undefined : -1}
-            onClick={() => setMenuOpen(false)}
-          >
-            Module reviews
-          </Link>
-        ) : null}
+        <AdminDashboardLink account={wallet.account} authenticated={authenticated}
+          menuOpen={menuOpen} onNavigate={() => setMenuOpen(false)} />
         <button
           type="button"
           tabIndex={menuOpen ? undefined : -1}

--- a/lib/admin-access.ts
+++ b/lib/admin-access.ts
@@ -1,0 +1,7 @@
+/** Website administration. Authentication and backend permissions remain required. */
+export const WEBSITE_ADMIN_WALLET = "0x79879fe6f00c0986Ca521eA6F5b276b5E28b1b9C" as const;
+
+export function isWebsiteAdminWallet(wallet: string | null | undefined): boolean {
+  return typeof wallet === "string"
+    && wallet.toLowerCase() === WEBSITE_ADMIN_WALLET.toLowerCase();
+}

--- a/lib/server/custom-launch/partner-admin-bridge-v1.ts
+++ b/lib/server/custom-launch/partner-admin-bridge-v1.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { randomBytes, randomUUID } from "node:crypto";
 
 import { getAddress, isAddress } from "viem";
+import { isWebsiteAdminWallet } from "@/lib/admin-access";
 
 import {
   PARTNER_ADMIN_LIST_LIMITS_V1,
@@ -808,6 +809,9 @@ function requireLinkedWallet(principal: AuthenticatedWalletPrincipalV1, value: s
   if (!principal.wallets.some((wallet) =>
     wallet.toLowerCase() === walletAddress.toLowerCase())) {
     throw new BrowserRequestErrorV1(403, "wallet_not_linked");
+  }
+  if (!isWebsiteAdminWallet(walletAddress)) {
+    throw new BrowserRequestErrorV1(403, "admin_wallet_required");
   }
   return walletAddress;
 }

--- a/lib/server/module-mode/review-client.ts
+++ b/lib/server/module-mode/review-client.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { randomBytes } from "node:crypto";
 import { getAddress, isAddress } from "viem";
+import { isWebsiteAdminWallet } from "@/lib/admin-access";
 import configuredRelease from "@/config/module-mode/robinhood.preview.json";
 import { isReviewId, parseReviewAttempt, parseReviewJob, parseReviewPlan, reviewDigest, reviewRecord, parseReviewQueueItem, type ReviewDetail } from "@/lib/module-mode/review-contract";
 import { nativeCanonicalJson } from "@/lib/module-mode/native-catalog";
@@ -63,6 +64,7 @@ export function createModuleReviewClient(input: {
       if (typeof rawWallet !== "string" || !isAddress(rawWallet) || BigInt(rawWallet) === 0n) fail(400, "wallet_address_invalid");
       const wallet = getAddress(rawWallet).toLowerCase() as `0x${string}`;
       if (!principal.wallets.some((linked) => linked.toLowerCase() === wallet)) fail(403, "wallet_not_linked");
+      if (!isWebsiteAdminWallet(wallet)) fail(403, "admin_wallet_required");
       const signal = AbortSignal.any([request.signal, AbortSignal.timeout(20_000)]);
       const call = async (path: string, method: "GET" | "POST" = "GET", payload?: unknown, maximum = 4 * 1024 * 1024) => {
         const target = new URL(path, base);

--- a/tests/admin-dashboard-access.test.tsx
+++ b/tests/admin-dashboard-access.test.tsx
@@ -1,0 +1,36 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { AdminDashboardLink } from "../components/admin-dashboard-link";
+import { WEBSITE_ADMIN_WALLET } from "../lib/admin-access";
+
+function menu(account: string | null, authenticated = true, menuOpen = true) {
+  return renderToStaticMarkup(<AdminDashboardLink account={account}
+    authenticated={authenticated} menuOpen={menuOpen} onNavigate={() => {}} />);
+}
+
+describe("admin dashboard wallet boundary", () => {
+  it.each([WEBSITE_ADMIN_WALLET, WEBSITE_ADMIN_WALLET.toLowerCase()])(
+    "shows one dashboard entry for the authenticated admin %s", account => {
+      const html = menu(account);
+      expect(html).toContain('href="/admin/modules"');
+      expect(html.match(/Admin Dashboard/g)).toHaveLength(1);
+      expect(html).not.toContain('tabindex="-1"');
+    },
+  );
+  it.each([null, "", "0x2222222222222222222222222222222222222222",
+    `${WEBSITE_ADMIN_WALLET} `, WEBSITE_ADMIN_WALLET.slice(0, -1)])(
+    "does not expose the entry for another or invalid wallet %s", account => {
+      expect(menu(account)).toBe("");
+    },
+  );
+  it("removes the entry when authentication is lost", () => {
+    expect(menu(WEBSITE_ADMIN_WALLET, false)).toBe("");
+  });
+  it("does not keep the admin entry after switching to another account", () => {
+    expect(menu(WEBSITE_ADMIN_WALLET)).toContain("Admin Dashboard");
+    expect(menu("0x2222222222222222222222222222222222222222")).toBe("");
+  });
+  it("keeps a closed menu out of keyboard tab order", () => {
+    expect(menu(WEBSITE_ADMIN_WALLET, true, false)).toContain('tabindex="-1"');
+  });
+});

--- a/tests/browser/fixtures/wallet-session-runtime.tsx
+++ b/tests/browser/fixtures/wallet-session-runtime.tsx
@@ -1,4 +1,5 @@
 import { useSyncExternalStore, type ReactNode } from "react";
+import { WEBSITE_ADMIN_WALLET } from "../../../lib/admin-access";
 
 // Only the SDK boundary is substituted. Wallet ownership, selection, login
 // gating and the application dialog remain in the production WalletProvider.
@@ -203,6 +204,8 @@ function chooseScenario(scenario: string) {
     providerAccountOverride: null, providerChainOverride: null,
   };
   switch (scenario) {
+    case "website-admin":
+      update({ ...base, user: user("fixture-website-admin", WEBSITE_ADMIN_WALLET, [WEBSITE_ADMIN_WALLET]), wallets: [wallet(WEBSITE_ADMIN_WALLET)] }); break;
     case "both-owned":
       update({ ...base, user: alphaBoth, wallets: [wallet(accountB, true, 900), wallet(accountA)] }); break;
     case "foreign-linked":
@@ -236,6 +239,7 @@ export function FixtureControls() {
   return <section aria-label="SDK fixture controls">
     <label>SDK scenario <select aria-label="SDK scenario" onChange={(event) => chooseScenario(event.target.value)} defaultValue="primary">
       <option value="primary">Primary wallet with unlinked recent wallet</option>
+      <option value="website-admin">Website admin wallet</option>
       <option value="both-owned">Two linked owned wallets</option>
       <option value="foreign-linked">Foreign linked recent wallet</option>
       <option value="owned-with-foreign">Two owned wallets and one foreign wallet</option>

--- a/tests/browser/wallet-session.spec.ts
+++ b/tests/browser/wallet-session.spec.ts
@@ -65,6 +65,33 @@ async function expectMethods(page: Page, methods: string[]) {
   await expect.poll(async () => (await calls(page)).map((call) => call.method)).toEqual(methods);
 }
 
+test("only the admin wallet gets one dashboard entry, including keyboard and account changes", async ({ page }) => {
+  await open(page);
+  const header = page.getByRole("banner");
+  await header.getByRole("button", { name: "Wallet 0xaaaa…aaaa", exact: true }).click();
+  await expect(header.getByRole("link", { name: "Admin Dashboard", exact: true })).toHaveCount(0);
+  await page.keyboard.press("Escape");
+  await scenario(page, "website-admin");
+  const button = header.getByRole("button", { name: /^Wallet 0x7987…1b9c$/i });
+  await button.focus();
+  await page.keyboard.press("Enter");
+  const link = header.getByRole("link", { name: "Admin Dashboard", exact: true });
+  await expect(link).toHaveCount(1);
+  await expect(link).toHaveAttribute("href", "/admin/modules");
+  await page.keyboard.press("Tab");
+  await page.keyboard.press("Tab");
+  await expect(link).toBeFocused();
+  await page.keyboard.press("Escape");
+  await expect(button).toBeFocused();
+  await expect(link).toBeHidden();
+  await button.click();
+  await scenario(page, "primary");
+  await expect(header.getByRole("link", { name: "Admin Dashboard", exact: true })).toHaveCount(0);
+  await scenario(page, "website-admin");
+  await scenario(page, "anonymous");
+  await expect(header.getByRole("link", { name: "Admin Dashboard", exact: true })).toHaveCount(0);
+});
+
 for (const path of ["/profile", "/developers/api-keys"]) {
   test(`${path}: primary account wins over a newer unlinked or foreign wallet`, async ({ page }) => {
     await open(page, path);

--- a/tests/fixtures/module-review-admin.ts
+++ b/tests/fixtures/module-review-admin.ts
@@ -7,9 +7,10 @@ import { reviewDigest, type ReviewBuildArtifact, type ReviewDetail, type ReviewJ
 import { createModuleModeHostManifest, computeModuleModeHostManifestHash, type ModuleModeCatalogDefinition } from "../../lib/server/module-mode/catalog";
 import { validateModuleSubmissionRequest, type ModuleSubmissionRequest } from "../../packages/classic-modules/src/open-transport.mjs";
 import { a, h, moduleEvidenceFixture } from "./module-mode-evidence";
+import { WEBSITE_ADMIN_WALLET } from "../../lib/admin-access";
 
 // Synthetic parser and UI fixtures. Never deployment, worker, reviewer, or publication evidence.
-export function moduleReviewAdminFixture() {
+export function moduleReviewAdminFixture(author = a(900)) {
   const release = bindActiveModuleModeRelease(moduleEvidenceFixture().release);
   const files = [{ path: "README.md", text: "Synthetic module review fixture. Never publish or admit." },
     { path: "src/Program.sol", text: "// Synthetic parser fixture, not a deployable module.\ncontract Program {}\ncontract Factory {}\n" }].map(file => ({
@@ -17,7 +18,7 @@ export function moduleReviewAdminFixture() {
   }));
   const schema = { type: "record" as const, fields: { capNative: { type: "uint" as const, bits: 128, min: "1", label: "Maximum buys" }, duration: { type: "uint" as const, bits: 64, min: "1", label: "Duration" } }, required: ["capNative", "duration"] };
   const source: ModuleSubmissionRequest = { format: "programmable.modules.submission.v0.1", files, descriptor: {
-    format: "programmable.classic.source-package.v0.1", name: "Synthetic opening cap", version: "1.0.0", author: a(900), rewardWallet: a(901), familySalt: h(902),
+    format: "programmable.classic.source-package.v0.1", name: "Synthetic opening cap", version: "1.0.0", author, rewardWallet: a(901), familySalt: h(902),
     source: { files: files.map(({ path, sha256 }) => ({ path, sha256 })) }, configuration: schema,
     components: [
       { id: "program", runtime: "programmable.module-native-runtime@1", sourcePath: "src/Program.sol", entrypoint: "Program" },
@@ -27,7 +28,7 @@ export function moduleReviewAdminFixture() {
   } };
   const checked = validateModuleSubmissionRequest(source);
   if (!checked.ok) throw new Error(JSON.stringify(checked.errors));
-  const subject: ReviewSubject = { submissionId: "00000000-0000-4000-8000-000000000001", principalId: "00000000-0000-4000-8000-000000000002", author: a(900), requestDigest: checked.requestDigest };
+  const subject: ReviewSubject = { submissionId: "00000000-0000-4000-8000-000000000001", principalId: "00000000-0000-4000-8000-000000000002", author, requestDigest: checked.requestDigest };
   const plan: ReviewPlan = { schemaVersion: "programmable.modules.native-build-plan.v1", submissionId: subject.submissionId, requestDigest: subject.requestDigest,
     programComponentId: "program", factoryComponentId: "factory", configurationCodec: "programmable.native-abi@1", programAbi: [{ path: ["capNative"], type: "uint128" }, { path: ["duration"], type: "uint64" }], callbackGas: 75000,
     cases: [{ id: "basic", parameters: { capNative: "1", duration: "60" }, budgetWei: "0", expectedDeployment: "success" }] };
@@ -55,5 +56,5 @@ export function moduleReviewAdminFixture() {
   const binding = { familyId: checked.familyId, packageId: checked.packageId, factory: a(800), factoryCodeHash: artifact.factory.runtimeCodeHash, moduleCodeHash: artifact.program.runtimeCodeHash, callbackGas: 75000 };
   const manifest = createModuleModeHostManifest({ release, definition, nativeBinding: binding, descriptor: source.descriptor });
   const detail: ReviewDetail = { schemaVersion: "programmable.modules.website-review-detail.v1", job, decisions: [], attempts: [{ attempt: 1, event: "completed", requestDigest: subject.requestDigest, planDigest, workerIdentity: { sourceCommit: "a".repeat(40), runId: "12345", runAttempt: "1", workflowRef: "synthetic/fixture/.github/workflows/review.yml@refs/heads/test", identityDigest: h(11) }, artifactDigest: artifact.artifactDigest, errorCode: null, createdAt: job.updatedAt }], source: { descriptor: source.descriptor, packageId: checked.packageId, familyId: checked.familyId, files: files.map(file => ({ path: file.path, sha256: file.sha256, bytes: Buffer.from(file.bytes, "base64").byteLength })) } };
-  return { release, source, subject, plan, artifact, job, definition, binding, manifest, manifestHash: computeModuleModeHostManifestHash(manifest), detail, reviewer: a(903), policyDigest: h(904) };
+  return { release, source, subject, plan, artifact, job, definition, binding, manifest, manifestHash: computeModuleModeHostManifestHash(manifest), detail, reviewer: WEBSITE_ADMIN_WALLET.toLowerCase() as `0x${string}`, policyDigest: h(904) };
 }

--- a/tests/module-review-admin-bff.test.ts
+++ b/tests/module-review-admin-bff.test.ts
@@ -20,8 +20,8 @@ const TIME = "2026-09-06T02:00:00.000Z";
 const NONCE = "abcdefghijklmnopqrstuv";
 // Real immutable host pins with an explicit pending lifecycle, independent of production activation.
 const pendingRelease = { ...configuredRelease, enabled: false, status: "preview", lifecycleEvidenceDigest: null };
-function setup(options: { wallet?: string; release?: boolean | "pending" } = {}) {
-  const f = moduleReviewAdminFixture(); const wallet = options.wallet ?? f.reviewer;
+function setup(options: { wallet?: string; author?: `0x${string}`; release?: boolean | "pending" } = {}) {
+  const f = moduleReviewAdminFixture(options.author); const wallet = options.wallet ?? f.reviewer;
   const authenticate = vi.fn(async () => ({ privyUserId: "did:privy:test-reviewer", privySessionId: "session-review", wallets: [wallet] }));
   const queue = { schemaVersion: "programmable.modules.review-queue.v1", jobs: [{ ...f.job, plan: null, artifact: null }], nextCursor: null };
   const detail = { schemaVersion: "programmable.modules.review-detail.v1", job: f.job, decisions: [] as ModuleReviewDecisionRecordV1[], attempts: f.detail.attempts };
@@ -97,6 +97,15 @@ describe("Module review admin BFF", () => {
   });
   it("rejects an unlinked wallet before any backend read", async () => {
     const f = setup(); const result = await f.client.handle(new Request(f.read().url.replace(f.wallet, f.subject.author)), "list"); expect(result.status).toBe(403); expect(f.fetchBackend).not.toHaveBeenCalled();
+  });
+  it.each(["list", "decision"] as const)("rejects another linked wallet for %s without forwarding credentials", async operation => {
+    const f = setup({ wallet: "0x2222222222222222222222222222222222222222" });
+    const request = operation === "list" ? f.read()
+      : f.post("decisions", { command: f.command("reject"), hostManifestJson: null });
+    const result = await f.client.handle(request, operation, operation === "list" ? undefined : f.subject.submissionId);
+    expect(result.status).toBe(403);
+    expect((await result.json()).error.code).toBe("admin_wallet_required");
+    expect(f.fetchBackend).not.toHaveBeenCalled();
   });
   it("binds detail to the verified source and preserves original download bytes", async () => {
     const f = setup(); const result = await f.client.handle(f.read(`/${f.subject.submissionId}`), "detail", f.subject.submissionId);
@@ -193,9 +202,12 @@ describe("Module review admin BFF", () => {
     expect([400, 409]).toContain(result.status); expect(f.fetchBackend.mock.calls.every(([, init]) => init?.method === "GET")).toBe(true);
   });
   it("forbids author self-review even when the backend authenticated reads succeed", async () => {
-    const base = moduleReviewAdminFixture(); const f = setup({ wallet: base.subject.author });
+    const base = moduleReviewAdminFixture(); const f = setup({ author: base.reviewer });
     const result = await f.client.handle(f.post("decisions", { command: f.command("reject"), hostManifestJson: null }), "decision", f.subject.submissionId);
-    expect(result.status).toBe(403); expect(f.fetchBackend.mock.calls.every(([, init]) => init?.method === "GET")).toBe(true);
+    expect(result.status).toBe(403);
+    expect((await result.json()).error.code).toBe("MODULE_REVIEW_SELF_DECISION_FORBIDDEN");
+    expect(f.fetchBackend).toHaveBeenCalled();
+    expect(f.fetchBackend.mock.calls.every(([, init]) => init?.method === "GET")).toBe(true);
   });
   it("requires no host pins for a request-changes decision", async () => {
     const f = setup({ release: false }); const result = await f.client.handle(f.post("decisions", { command: f.command("request_changes"), hostManifestJson: null }), "decision", f.subject.submissionId);

--- a/tests/partner-admin-bridge-v1.test.ts
+++ b/tests/partner-admin-bridge-v1.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 import { PARTNER_ADMIN_SCHEMA_V1 } from "../lib/partner-admin-contract";
+import { WEBSITE_ADMIN_WALLET } from "../lib/admin-access";
 import {
   createPartnerAdminBridgeV1,
 } from "../lib/server/custom-launch/partner-admin-bridge-v1";
@@ -13,7 +14,7 @@ import {
   WalletPrincipalAuthenticationErrorV1,
 } from "../lib/server/creator-article/wallet-principal.server";
 
-const WALLET = "0x1111111111111111111111111111111111111111" as const;
+const WALLET = WEBSITE_ADMIN_WALLET;
 const OTHER_WALLET = "0x2222222222222222222222222222222222222222" as const;
 const PARTNER_ID = "018f3e2a-7b4c-7d5e-8f90-123456789abc";
 const OTHER_PARTNER_ID = "038f3e2a-7b4c-7d5e-8f90-123456789abc";
@@ -169,7 +170,7 @@ function expectedAssertion(
     method,
     requestTarget,
     "did:privy:test-user",
-    WALLET,
+    WALLET.toLowerCase(),
     ASSERTION_ISSUED_AT,
     ASSERTION_NONCE,
     bodySha256,
@@ -304,6 +305,27 @@ describe("partner admin same-origin bridge", () => {
     ));
     expect(unlinkedMutation.status).toBe(403);
     expect((await unlinkedMutation.json()).error.code).toBe("wallet_not_linked");
+    expect(fetchBackend).not.toHaveBeenCalled();
+  });
+
+  it.each(["read", "write"])("rejects another linked wallet on admin %s before any backend access", async operation => {
+    authenticate.mockResolvedValueOnce({
+      privyUserId: "did:privy:test-user",
+      privySessionId: "session-1",
+      wallets: [WALLET, OTHER_WALLET],
+    });
+    const result = operation === "read"
+      ? await bridge().list(new Request(
+        `https://programmable.market/api/admin/partners?walletAddress=${OTHER_WALLET}`,
+        { headers: browserHeaders() },
+      ))
+      : await bridge().create(new Request("https://programmable.market/api/admin/partners", {
+        method: "POST",
+        headers: { ...browserHeaders(true), "idempotency-key": IDEMPOTENCY_VALUE },
+        body: JSON.stringify({ ...createBrowserBody(), walletAddress: OTHER_WALLET }),
+      }));
+    expect(result.status).toBe(403);
+    expect((await result.json()).error.code).toBe("admin_wallet_required");
     expect(fetchBackend).not.toHaveBeenCalled();
   });
 

--- a/tests/partner-attribution-ui.test.tsx
+++ b/tests/partner-attribution-ui.test.tsx
@@ -221,21 +221,6 @@ describe("partner attribution UI", () => {
     );
   });
 
-  it("discovers partner administration only after the server allows the wallet", () => {
-    const wallet = readFileSync(
-      new URL("../components/wallet-provider.tsx", import.meta.url),
-      "utf8",
-    );
-    expect(wallet).toContain("fetch(`/api/admin/partners?${query}`");
-    expect(wallet).toMatch(
-      /if \(controller\.signal\.aborted\) return;\s+setPartnerAdminAccount\(partner\.status === "fulfilled" && partner\.value\.ok \? account : null\)/,
-    );
-    expect(wallet).toMatch(
-      /partnerAdminAccount\?\.toLowerCase\(\)\s+=== wallet\.account\.toLowerCase\(\) \? \(/,
-    );
-    expect(wallet).toContain('href="/admin/partners"');
-  });
-
   it("keeps permanent partner revocation and bounded pages explicit", () => {
     const source = readFileSync(
       new URL("../components/partner-admin-console.tsx", import.meta.url),


### PR DESCRIPTION
The upper-right wallet menu now shows one **Admin Dashboard** link for the authenticated wallet `0x79879fe6f00c0986Ca521eA6F5b276b5E28b1b9C`. It opens the module submission queue, with partner access available from that dashboard. Other wallets see neither the entry nor private console content, including after an account or authentication change.

The website's module-review and partner-admin bridges enforce the same wallet restriction after authenticating the session and checking wallet ownership. Existing backend permissions, signed assertions and the prohibition on author self-review remain required. Opening a wallet menu no longer fetches private review or partner queues to discover its navigation links.

Validation: 105 focused access, BFF, review and partner tests passed; TypeScript and affected-file lint passed. The browser regression covers the real header and wallet provider, owner/non-owner menu visibility, keyboard navigation, Escape focus restoration and account/session changes. Contract authorities and backend allowlists are unchanged.
