### PR TITLE
Route legacy Custom Launch guides before GitBook

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -98,6 +98,16 @@ const nextConfig: NextConfig = {
   async redirects() {
     return [
       {
+        source: "/docs/developers/custom-launch.md",
+        destination: "/developers/custom-launch-api-v1.md",
+        permanent: false,
+      },
+      {
+        source: "/docs/developers/custom-launch",
+        destination: "/developer-reference/custom-launch",
+        permanent: false,
+      },
+      {
         source: "/:path*",
         has: [{ type: "host", value: "www.programmable.market" }],
         destination: "https://programmable.market/:path*",

--- a/tests/programmable-market-domain.test.ts
+++ b/tests/programmable-market-domain.test.ts
@@ -32,8 +32,11 @@ describe("programmable.market website origin", () => {
 
   it("redirects only the new www host to the apex", async () => {
     const redirects = await nextConfig.redirects?.();
+    const hostRedirects = redirects?.filter(({ has }) =>
+      has?.some(({ type }) => type === "host"),
+    );
 
-    expect(redirects).toEqual([
+    expect(hostRedirects).toEqual([
       {
         source: "/:path*",
         has: [{ type: "host", value: "www.programmable.market" }],

--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,11 @@
   ],
   "redirects": [
     {
+      "source": "/docs/developers/custom-launch.md",
+      "destination": "/developers/custom-launch-api-v1.md",
+      "permanent": false
+    },
+    {
       "source": "/docs/developers/custom-launch",
       "destination": "/developer-reference/custom-launch",
       "permanent": false

--- a/vercel.json
+++ b/vercel.json
@@ -15,16 +15,6 @@
   ],
   "redirects": [
     {
-      "source": "/docs/developers/custom-launch.md",
-      "destination": "/developers/custom-launch-api-v1.md",
-      "permanent": false
-    },
-    {
-      "source": "/docs/developers/custom-launch",
-      "destination": "/developer-reference/custom-launch",
-      "permanent": false
-    },
-    {
       "source": "/docs/developers/module-mode",
       "destination": "/developer-reference/module-mode",
       "permanent": false


### PR DESCRIPTION
The legacy HTML and Markdown Custom Launch guide URLs can still resolve to outdated GitBook content. Handle both exact addresses in Next.js redirects, before the GitBook fallback, so the HTML route reaches the current product guide and the Markdown route reaches the maintained raw agent guide. Remove the redundant Custom Launch redirect from the separate Vercel configuration.

Keep the existing canonical-domain regression scoped to host redirects so route-specific documentation redirects can coexist with the unchanged www-to-apex rule.

Validation: the installed Next.js configuration checker returns the intended HTTP 307 destinations for both URLs and preserves the Markdown query string; all four canonical-domain tests, scoped ESLint and `git diff --check` pass. The redirect destinations and their current MultiRole content already exist. The actual staged browser routing will be checked before promotion.
