### PR TITLE
Clarify launch verification sources and preserve GitBook links

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -3,3 +3,8 @@ root: ./docs/public/
 structure:
   readme: README.md
   summary: SUMMARY.md
+
+redirects:
+  launch-stamps: launch-stamps.md
+  trust: trust.md
+  status: status.md

--- a/docs/public/developers/indexing.md
+++ b/docs/public/developers/indexing.md
@@ -12,7 +12,7 @@ Identify a coin by its chain and token contract address. Select a verifier by it
 | --- | --- |
 | Module Mode on Robinhood | [Native launcher guide](module-mode-indexing.md) and [indexer contract](https://programmable.market/api/module-mode/indexer/v1) |
 | Custom V4 on Robinhood | [Router V1 guide](robinhood-terminal-indexer.md) and [finalized feed](https://api.programmable.market/v4/chains/4663/finalized-custom-launches) |
-| MultiRole Custom on Robinhood | [Router V2 guide](robinhood-terminal-indexer.md#multi-role-v2) and [MultiRole finalized feed](https://api.programmable.market/v4/chains/4663/multi-role-custom-launches/finalized) |
+| MultiRole Custom on Robinhood | [Router V2 guide](robinhood-terminal-indexer.md#multirole-v2) and [MultiRole finalized feed](https://api.programmable.market/v4/chains/4663/multi-role-custom-launches/finalized) |
 | Ethereum Classic and Custom | [Developer manifest](https://developers.programmable.family/api/v2/manifest), [launch feed](https://developers.programmable.family/api/v2/launches) and [Router verification](verify.md) |
 
 Robinhood Chain is `eip155:4663`; Ethereum Mainnet is `eip155:1`. Never merge contracts with the same address on different chains. API request UUIDs and Router launch IDs are different identifiers and should be stored separately.

--- a/docs/public/developers/robinhood-terminal-indexer.md
+++ b/docs/public/developers/robinhood-terminal-indexer.md
@@ -11,7 +11,7 @@ Robinhood Custom Launches have two provenance interfaces. Separate token and hoo
 | Layout | Integration |
 | --- | --- |
 | Separate token and hook contracts | [V4 Router V1](#start-with-the-live-authorities) |
-| Shared token/hook or other supported combined roles | [MultiRole V2](#multi-role-v2) |
+| Shared token/hook or other supported combined roles | [MultiRole V2](#multirole-v2) |
 
 The V1 addresses, events, schema and exact-source rules below apply to the V4 source. MultiRole uses the separate section at the end of this guide. Launch availability is read from each source's capabilities; historical finalized records retain their own bindings.
 

--- a/docs/public/developers/verify.md
+++ b/docs/public/developers/verify.md
@@ -1,25 +1,40 @@
 ---
-description: Reproduce Programmable launch provenance from the public manifest and Ethereum
+description: Verify Module Mode and Custom Launch records using the correct chain and source
 ---
 
 # Verify a launch
 
-Router verification begins with the live manifest and ends with direct reads at one canonical block. The hosted launch feed is useful for discovery but is not the trust root.
+Start with the chain and the launch source. A token address alone does not identify its network or prove that it was launched through Programmable. Use the published deployment and source contract to select the event decoder, record format and finality rules.
 
-## Resolve the deployment
+## Choose the source
 
-Fetch `https://developers.programmable.family/api/v2/manifest`, require Ethereum chain id `1`, and require the `launchStampRouter` entry to be live. Verify the Router runtime hash and ABI SHA 256 before using the published event descriptors or getter selectors.
+| Launch | Verification reference |
+| --- | --- |
+| Module Mode on Robinhood Chain | [Native Module Mode source](module-mode-indexing.md) |
+| Robinhood Custom with separate token and hook contracts | [V4 with Router V1](robinhood-terminal-indexer.md#bind-the-exact-identity) |
+| Robinhood Custom with a shared token and hook contract | [MultiRole V2 with Router V2](robinhood-terminal-indexer.md#multirole-v2) |
+| Classic and Custom on Ethereum | The Ethereum manifest procedure below |
 
-## Read the launch identity
+The [indexing guide](indexing.md) explains how these sources share a coin identity while keeping their provenance records separate. Use `(chain, token address)` for the coin and retain each source's own launch identifier.
 
-Backfill Router events from the manifest start block and follow new blocks with the published finality policy. Extract the launch id, token, hook, PoolManager and pool id, then cross check the appropriate point lookup and read `launchStamp` and `stampProof` at the same canonical block.
+## Verify Robinhood launches
 
-The token lookup is the primary interoperable path for a token page. Pool identity is the stronger route for trading integrations. Component lookup can confirm an exclusive component but should not be used to identify one launch when the component is shared infrastructure.
+Module Mode uses its native launch contract, launch record, program and deployment bindings. It does not require a Custom Launch stamp. Select the release and verifier from the module indexer contract and validate the canonical receipt and record before publishing a coin.
 
-## Preserve the boundary
+Separate-contract Custom Launches use V4 and Router V1. Shared-role launches use MultiRole V2 and Router V2. Read the corresponding finalized feed, preserve its complete source and finality evidence, and reproduce the required Router lookups and receipt checks. A shared token and hook address is valid when the V2 component's role mask binds both roles; applying V1's distinct-role rule to that record is incorrect.
 
-Only assign a Programmable Classic or Programmable Custom label when the Router identity, runtime, record and proof agree. Unknown, zero or inconsistent values should remain unlabelled rather than being forced into a familiar category.
+Keep Robinhood L2 inclusion, Ethereum posting and Ethereum finality separate. Their coordinates and response fields differ between source versions. Follow the selected reference instead of copying a block number or event decoder from another profile. A project's API resource ID and its onchain launch ID are also distinct identifiers.
 
-A valid result proves canonical Router provenance. It does not prove present liquidity, audit status, sellability, quoting support or price quality.
+## Verify Ethereum launches
 
-The complete implementation reference and conformance fixtures live in the [Programmable Developers repository](https://github.com/programmablehq/Developers).
+Fetch the [Developer manifest](https://developers.programmable.family/api/v2/manifest), select Ethereum chain ID `1`, and require the `launchStampRouter` entry to be live. Verify the Router runtime hash and ABI SHA-256 before using its published events or getter selectors.
+
+Backfill Router events from the manifest start block and follow its finality policy. Extract the launch ID, token, hook, PoolManager and pool ID. Cross-check the appropriate point lookup, `launchStamp` and `stampProof` at the same canonical block. The hosted launch feed is a discovery aid; it does not replace these onchain checks.
+
+The token lookup identifies a token's launch record, while the pool lookup binds the market used by a trading integration. A component lookup must not identify one launch when that component is shared infrastructure. The [Developers repository](https://github.com/programmablehq/Developers) contains the complete Ethereum verifier and conformance fixtures.
+
+## Interpret the result
+
+Assign a Programmable label only when the selected source's identity, runtime, record and proof agree. Preserve missing evidence and conflicting evidence as explicit outcomes. Do not turn an unavailable provider response into a finding that a coin was not launched through Programmable.
+
+Provenance, source verification and finality are separate results. A valid launch record does not establish present liquidity, sellability, trading support, an external audit or future price. Verify those properties independently when an integration needs them.


### PR DESCRIPTION
The generic verification page previously instructed every reader to select Ethereum chain ID 1. Add a source selector for native Module Mode, separate-contract Robinhood V4, shared-role MultiRole V2 and Ethereum, then describe their distinct verification requirements. Link to the full existing source references using verified published anchors.

Preserve older /docs/launch-stamps, /docs/trust and /docs/status links with GitBook space redirects to their existing pages under How it works. These three old URLs returned 404 during the public documentation review. Correct the two MultiRole section links to match GitBook's published multirole-v2 anchor.

Validation: 26 focused documentation tests passed; changed Markdown and redirect targets reviewed. This change contains GitBook content and configuration only; it does not change the website application, API, fee contracts or deployment configuration. Public GitBook verification follows the merge.
