### PR TITLE
Explain fees and token burns in plain language

### DIFF
--- a/docs/PUBLIC-DOCS-STYLE.md
+++ b/docs/PUBLIC-DOCS-STYLE.md
@@ -1,6 +1,8 @@
 # Public documentation
 
-Write for a developer who needs to complete a task. Begin with the purpose, required inputs and next action. Use short paragraphs, explicit units, concrete field names and descriptive links.
+Write product pages for someone learning how Programmable works. Explain what they pay, what they receive and what happens next in everyday language. Use connected paragraphs, clear percentages and a simple worked example when it helps. Keep contract internals, event names and accounting terminology in the technical references unless a reader needs them to make a decision.
+
+Write API and integration references for a developer who needs to complete a task. Begin with the purpose, required inputs and next action. Keep exact units, field names, contract versions and verification rules where they are needed to build an integration. Use descriptive links between the product explanation and the technical details.
 
 Use factual language. Avoid marketing, em dashes, filler, rhetorical questions and phrases such as "not just", "seamless" or "game-changing". Keep product terminology consistent across GitBook, GitHub, the website and agent instructions.
 

--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -24,7 +24,7 @@ Open [Create](https://programmable.market/launch) to start a launch, or [Explore
 
 Coin creators choose the settings and creator fees supported by their launch path. Module authors publish reusable behavior that other creators can select and earn rewards when their eligible modules are used. Custom developers control their project's code within the selected API's contract and evidence requirements.
 
-Programmable receives the platform share of trading fees. Its revenue policy allocates half of net protocol revenue to V4 buybacks and burns. [Fees and revenue](economics.md) explains each fee model and the distinction between protocol revenue, creator rewards and module author rewards. The [V4 token page](v4-token.md) covers the main token, its liquidity fees and burn accounting.
+Programmable earns a share of trading fees. We use half of our platform fee revenue to buy and burn V4 each day, and keep the other half in the treasury. [Fees and revenue](economics.md) shows what each launch model charges and who receives it. The [V4 token page](v4-token.md) explains the main token and its burns.
 
 ## Build and integrate
 

--- a/docs/public/creators/earnings.md
+++ b/docs/public/creators/earnings.md
@@ -1,29 +1,31 @@
 ---
-description: How creator fees accrue, how they differ from platform fees, and where to read earnings
+description: How coin creators earn trading fees and receive their rewards
 ---
 
 # Creator earnings
 
-Creator earnings come from the fee configuration and activity of a deployed project. Choose the creator recipient and buy and sell rates before launching.
+Creators earn fees when people buy or sell their coin. Before launching, choose your buy and sell fees and the wallet that will receive your earnings.
 
 ## Robinhood Custom Launches
 
-Native20 charges **20 bps (0.20%)** of gross native ETH per successful buy or sell for Programmable. The full 20 bps belongs to the platform. A project's creator fees are additional and accrue separately to its configured recipient. The Uniswap pool fee is also separate.
+Your creator fee belongs to you. Programmable's **0.20% (20 bps)** fee and the pool's trading fee are added separately.
 
-If the creator buy and sell rates are both 0%, the creator receives no fee from those trades, while Programmable still receives its 20 bps. This is why a Custom Creator Rewards counter can be zero alongside positive Custom Protocol Revenue.
+If you set your buy and sell fees to **0%**, you earn no creator fees from those trades. Programmable still receives its platform fee. That is why Dune can show **Custom Creator Rewards of 0** while Custom Protocol Revenue is above zero.
 
-Fees count as earned when the contract credits them. Claiming transfers an accrued balance to its configured recipient; it does not create another fee. An API key does not sign or broadcast a claim transaction.
+Fees build up in the contract until they are claimed. A claim sends them to the wallet selected for those earnings. It does not charge another trading fee or count the same earnings twice.
 
-The [Dune dashboard](https://dune.com/programmablehq/analytics) shows daily totals from supported `NativeFeesAccrued` events on stamped Robinhood pools. Unclaimed balances are included. LP fees, gas, liquidity deposits and historical fee models without those events are excluded.
+Our [Dune dashboard](https://dune.com/programmablehq/analytics) shows creator earnings from supported Custom Launch contracts, including fees that have not yet been claimed. Gas payments, liquidity deposits and separate pool fees are not included in that creator total.
 
 ## Module Mode
 
-Module Mode accounts for coin creator fees and module author rewards through its own contracts. Read the [Module Mode guide](../models/module-mode.md) for the configured recipients and management interface. Its Dune counters are separate from Custom Launch totals.
+You can choose a creator fee of up to **10%**. Your fee is separate from the shares for Programmable and module authors. The [fee guide](../economics.md#module-mode) shows the split, and the launch screen shows the fees for your coin before you confirm.
+
+Module authors earn their own rewards when their modules are used. If you build modules, see [Reusable modules](templates.md) for how to publish them and receive rewards.
 
 ## Classic on Ethereum
 
-Classic creator rewards come from the selected buy and sell transaction fees. Programmable's 0.1% share is included in that selected rate. For example, a 1% buy transaction fee assigns 0.9% to creator rewards and 0.1% to Programmable.
+Programmable's **0.10%** share is included in your selected trading fee. For example, a **1% fee** gives **0.90% to you** and **0.10% to Programmable**.
 
-Rewards accrue in ETH according to the recipient configuration. A creator can use the launch wallet, another wallet or a split between two and five unique wallets. Each beneficiary claims its allocation. Updating recipients does not move balances already accrued to earlier recipients.
+You can receive ETH rewards in one wallet or split them between two and five wallets. Each wallet claims its own share. Changing the recipients only affects future earnings; fees already earned stay with the original recipients.
 
-Read [fees and revenue](../economics.md) for the rates and accounting of each launch model. Earnings depend on qualifying transactions, not API preparation or publication of a token page.
+Read [Fees and revenue](../economics.md) for all launch fees and how Programmable uses its share.

--- a/docs/public/creators/templates.md
+++ b/docs/public/creators/templates.md
@@ -14,9 +14,9 @@ Every launched coin records the revisions and configuration it selected. A new s
 
 ## Earn from use
 
-Module rewards accrue when eligible modules are used by a coin that generates qualifying trading fees. The total author allocation is shared among the eligible module families selected for that launch. Adding multiple components from the same family does not create extra shares. [Fees and revenue](../economics.md) lists the fee policy and version-specific rates.
+You earn rewards when creators use your eligible module in a coin that trades. Our Module Mode fee policy reserves **0.20% (20 bps) in total for module authors**, shared among the eligible module families used by that coin. Multiple components from one family share the same reward allocation. Existing coins keep their original fee model, as explained in [Fees and revenue](../economics.md#module-mode).
 
-A contribution submission, review result or catalog listing does not itself generate revenue. Use the registered reward wallet and the supported claim interface to receive accrued rewards.
+Publishing a module makes it available for use. Earnings start when a coin using it generates trading fees. Claim your earnings to the reward wallet registered with your module.
 
 ## Custom projects
 

--- a/docs/public/economics.md
+++ b/docs/public/economics.md
@@ -1,57 +1,65 @@
 ---
-description: Trading fees, creator and module rewards, revenue allocation and accounting
+description: What we charge, who receives the fees and how we use our revenue
 ---
 
 # Fees and revenue
 
-Trading fees are percentages of the amount exchanged. One basis point, written as bps, is 0.01%; 20 bps is 0.20%. Network gas, initial purchases, liquidity deposits and module operating budgets are separate costs. The launch review shows the selected fees and required funding before wallet confirmation.
+Programmable earns a share of trading fees. Coin creators and module authors receive their own shares. We use half of our platform fee revenue to buy and burn V4, and keep the other half in the Programmable treasury.
+
+Fees are shown as percentages or basis points (bps): **10 bps is 0.10%, and 20 bps is 0.20%**. Gas, liquidity deposits and the funds needed to run a module are separate costs. You can see the fee breakdown before confirming a launch.
 
 ## Robinhood Custom Launches
 
-Native20 charges **20 bps (0.20%)** of gross native ETH once per successful buy or sell, rounded up to the next wei. The full 20 bps belongs to Programmable. A project's creator fee and its Uniswap pool fee are additional, so 0.20% is not an all-in maximum. A trade with 1 ETH of gross native value accrues 0.002 ETH for Programmable before any separate creator fee.
+Programmable charges **0.20% (20 bps)** on each buy and sell. The coin creator can set a separate fee, which belongs to them. The pool also has its own trading fee.
 
-The fee kernel credits PoolManager native claims to the fixed platform recipient `0xD88539d3c4C460136a733A3Fd60cf6BF269079da`. Anyone can trigger a claim, but payment goes only to that recipient. Creator rewards accrue separately to the configured creator recipient. A creator fee of zero produces no creator rewards, even when platform revenue accrues.
+On a trade worth **1 ETH**, the Programmable fee is **0.002 ETH**. Half of that, **0.001 ETH**, goes to V4 buybacks and burns. The other **0.001 ETH** goes to the treasury. Creator and pool fees are added separately.
 
-This model covers the supported Native20 paths for separate contracts and a shared token/hook contract. An API profile's fee requirement does not retroactively change another deployment's fee contract.
+If the creator sets their fee to 0%, they earn no creator fees from those trades.
 
 ## Module Mode
 
-Coin creators choose the supported creator fee, up to **10%**. That fee belongs to the coin creator. Platform and module author charges are additional, and any declared module operating budget is separate from trading fees.
+Coin creators choose their own trading fee, up to **10%**, and keep that fee. Our Module Mode fee policy adds **0.30% (30 bps)**, divided as follows:
 
-The Module Mode allocation policy is **10 bps (0.10%) for Programmable and 20 bps (0.20%) in total for the authors of eligible modules used by the coin**. For a launch using modules, this is 30 bps (0.30%) in addition to the coin creator's fee. The author allocation is shared among the eligible module families; it is not 20 bps per module. A module earns through qualifying use, not merely by being submitted or listed.
+| Recipient | Share of each trade |
+| --- | --- |
+| Programmable | 0.10% (10 bps) |
+| Authors of the modules used by the coin | 0.20% (20 bps) in total |
 
-### Contract versions
+The author share is divided between the eligible module families used by the coin. Adding more modules does not increase the total 0.20% author fee. Authors earn when their modules are used in coins that trade.
 
-Fee rates are bound to the deployed engine. The `module-native-v1` engine charges 20 bps in total: with eligible module families, 10 bps goes to Programmable and 10 bps is shared equally among those families. Without eligible families, the full 20 bps goes to the protocol recipient. Its creator fee supports 0% through 10% in one-percentage-point steps.
+For example, under this model, a **1% creator fee** plus the **0.30% platform and author fee** gives a **1.30% combined fee**. Any separate pool fee is additional.
 
-The 10/20 allocation policy requires a different engine release; it does not alter `module-native-v1` or the fees of its existing coins. Check the [active engine](https://programmable.market/api/module-mode), the launch review and the deployed fee contract for the rate that a particular coin charges. Module author rewards, coin creator rewards and Programmable revenue must remain separate balances.
+Existing coins keep the fees they launched with. The original Module Mode contract charges 0.20% in total: 0.10% for Programmable and 0.10% for module authors when eligible modules are used. Without eligible modules, that contract sends the full 0.20% to Programmable. Check the launch fee breakdown for the model that applies to your coin.
 
-## Protocol revenue allocation
+## How we use our revenue
 
-Programmable's revenue policy allocates **50% of net protocol revenue to V4 buybacks and burns** and **50% to the treasury**, with daily processing. Net protocol revenue is the share belonging to Programmable after creator, module author and other third-party liabilities have been separated.
+We split the fees that belong to Programmable equally:
 
-For Native20 Custom Launches, half of the 20 bps platform share is equivalent to 10 bps of the qualifying trading amount. Under the Module Mode 10 bps platform allocation, half is equivalent to 5 bps. Module author and coin creator rewards are not part of this allocation.
+| Use | Share of Programmable revenue |
+| --- | --- |
+| Buy V4 and burn it | 50% |
+| Programmable treasury | 50% |
 
-The allocation policy describes how revenue is assigned. Finalized claim, purchase and burn transactions establish what has actually been processed. A daily accounting schedule does not imply that every accrued amount has already been claimed or that a transaction occurs at an exact clock time. Earlier deployments and revenue processors retain their own contract rules.
+Buybacks and burns are processed daily. For every **1 ETH** Programmable earns in platform fees, **0.5 ETH** goes to buying and burning V4, and **0.5 ETH** stays in the treasury. Coin creator fees and module author rewards belong to those creators and authors, so they are not included in this split.
 
 ## V4 liquidity fees and burns
 
-Programmable's main V4/ETH pool has a separate LP fee. The project's liquidity position earns its proportional share in the input asset: ETH on buys and V4 on sells. The policy assigns collected V4 fees to daily burns. These token fees are separate from the ETH protocol revenue used to buy V4.
+Programmable also earns fees from its liquidity in the main V4/ETH pool. When someone buys V4, we receive ETH fees. When someone sells V4, we receive V4 tokens as fees. We burn the V4 tokens we collect each day.
 
-Read [V4 token](v4-token.md) for the contract identity, liquidity custody and the meaning of a burn for this token.
+These V4 fees are burned directly. We also buy V4 with the platform revenue described above and burn those tokens. The [V4 token page](v4-token.md) explains the token and its liquidity.
 
-## Analytics
+## Track the numbers
 
-The [Dune dashboard](https://dune.com/programmablehq/analytics) reports burns, Module Mode activity and Custom Launch activity. Custom Launch statistics distinguish the following:
+Our [Dune dashboard](https://dune.com/programmablehq/analytics) shows launches, earned fees and V4 burns. It refreshes every 24 hours.
 
-| Metric | Accounting |
+| Custom Launch metric | What it shows |
 | --- | --- |
-| Custom Launches | Finalized stamps from the canonical Custom V1 and V2 Routers, including reference launches. |
-| Custom Creator Rewards | ETH accrued to creators by `NativeFeesAccrued` for a stamped hook and its exact pool. |
-| Custom Protocol Revenue | ETH accrued to Programmable by those events, including unclaimed balances. |
+| Custom Launches | Confirmed launches through Programmable. |
+| Custom Creator Rewards | ETH earned by coin creators. |
+| Custom Protocol Revenue | ETH earned by Programmable. |
 
-Revenue is counted when earned. Claiming it later does not create new revenue. Gas, liquidity deposits, donations and LP fees are excluded from Custom protocol revenue. Historical fee models without the supported event are outside those ETH totals. The dashboard refreshes every 24 hours; the [Custom query](https://dune.com/queries/8631499) includes its finalized checkpoint and accounting rules.
+Earned fees include balances that have not yet been withdrawn. Withdrawing them does not count as new revenue. Gas payments and liquidity deposits are not revenue. The [Custom Launch query](https://dune.com/queries/8631499) lists the contracts and transactions included in those totals.
 
-## Ethereum fee models
+## Ethereum launches
 
-Ethereum Classic includes a 10 bps (0.10%) Programmable share in the creator-selected buy or sell fee. Ethereum Custom uses the fee policy attached to its exact profile and market path; fee-certified paths assign 10 bps separately from project hook fees. These historical and chain-specific contracts do not inherit Robinhood Native20 or Module Mode rates. Ordinary token transfers do not become pool swaps merely because a token has a trading fee.
+Classic on Ethereum includes Programmable's **0.10%** share within the creator's selected fee. For example, a 1% fee leaves 0.90% for the creator and 0.10% for Programmable. Ethereum Custom fees depend on the contract used; supported fee contracts charge 0.10% for Programmable in addition to project fees. Check the fee details for the coin you are launching or trading.

--- a/docs/public/models/custom.md
+++ b/docs/public/models/custom.md
@@ -26,7 +26,7 @@ The API key and client do not sign or broadcast. Material source, metadata, fund
 
 ## Fees and liquidity
 
-On Robinhood, Native20 charges **20 bps (0.20%)** of the gross native ETH amount per successful buy or sell for Programmable. Creator fees and the Uniswap pool fee are additional. Setting the creator buy and sell fees to 0 produces no creator fee accruals. [Fees and revenue](../economics.md) defines each fee path and the Dune metrics.
+On Robinhood, Programmable receives **0.20% (20 bps)** on each buy and sell. The creator's fee and the pool's trading fee are added separately. If the creator sets their fee to 0%, they earn no creator fees from those trades. [Fees and revenue](../economics.md) explains the split and includes a 1 ETH example.
 
 An ordinary pool needs a funded liquidity position. Initializing the pool does not supply that liquidity. A project using custom accounting, launch inventory or another reserve model must implement and verify its own settlement behavior. The selected API's funding rules still apply.
 

--- a/docs/public/models/module-mode.md
+++ b/docs/public/models/module-mode.md
@@ -35,11 +35,11 @@ Each launch records the exact module versions and configuration it used. Publish
 
 ## Fees and contributor rewards
 
-The launch review separates the coin creator's fee, the platform charge and any module operating budget. Creator fees can be set up to 10% under the active engine. Module author rewards accrue from qualifying use and are shared among the eligible module families selected for the coin.
+Coin creators can set a trading fee of up to **10%** and keep that fee. Our Module Mode fee policy adds **0.10% (10 bps) for Programmable** and **0.20% (20 bps) in total for module authors**. Authors share that 0.20% when their eligible modules are used by the coin.
 
-Fee contracts are versioned. The allocation policy is 10 bps for Programmable and 20 bps in total for module authors. The deployed `module-native-v1` engine retains its 20 bps total fee and 10/10 split when eligible modules are used. Read [Fees and revenue](../economics.md#module-mode) for the policy, deployed-version rules and treatment of launches without eligible modules.
+Existing coins keep their original fees. Check the launch screen for your coin's fee breakdown and any funds required to run its modules. [Fees and revenue](../economics.md#module-mode) explains the fee models and includes an example.
 
-The author and reward wallet are recorded with the module revision. Submission or review acceptance alone does not generate a payout.
+Module rewards go to the reward wallet registered with the module. Publishing a module alone does not earn fees; it needs to be used by a coin that trades.
 
 ## Build a module
 

--- a/docs/public/v4-token.md
+++ b/docs/public/v4-token.md
@@ -1,39 +1,39 @@
 ---
-description: The Programmable token on Robinhood Chain, its liquidity fees and burn policy
+description: The Programmable token, its trading fees and how buybacks and burns work
 ---
 
 # V4 token
 
-V4 is the Programmable token on Robinhood Chain. Identify it by the network and contract address rather than its name or ticker. The token has a fixed supply of one billion V4 with 18 decimals and no later mint function.
+V4 is Programmable's token on Robinhood Chain. It has a fixed supply of one billion tokens, and no more can be minted. Use the contract address below to identify the token.
 
-| Field | Value |
+| Detail | Value |
 | --- | --- |
 | Name and symbol | Programmable, V4 |
 | Network | Robinhood Chain Mainnet, chain ID `4663` |
 | Contract | [`0xC60bA256B44334A0Cd2C7242E98B88f031abB006`](https://robinhoodchain.blockscout.com/token/0xC60bA256B44334A0Cd2C7242E98B88f031abB006) |
 | Initial supply | 1,000,000,000 V4 |
-| Pool | [V4 / native ETH](https://dexscreener.com/robinhood/0x3df16f271060e4941c0386047def159f42e629dc0455db623c5b363eeacbcc1d) |
-| Source | [V4 token repository](https://github.com/programmablehq/programmable-v4-token) |
-| Analytics | [Programmable on Dune](https://dune.com/programmablehq/analytics) |
+| Pool | [V4 / ETH](https://dexscreener.com/robinhood/0x3df16f271060e4941c0386047def159f42e629dc0455db623c5b363eeacbcc1d) |
+| Source code | [V4 token repository](https://github.com/programmablehq/programmable-v4-token) |
+| Burns and activity | [Programmable on Dune](https://dune.com/programmablehq/analytics) |
 
 ## Liquidity and fees
 
-The canonical pool uses a 1% LP fee after its initial 30-second launch period. This is a pool fee, not a token transfer tax. It accrues to active liquidity positions according to their liquidity share.
+The V4/ETH pool charges a **1% trading fee**. Liquidity providers share these fees according to the liquidity they provide. Sending V4 between wallets does not incur this pool fee.
 
-Programmable's main liquidity position is NFT `1708785`, held by the [PositionFeesForwarder locker](https://robinhoodchain.blockscout.com/address/0x9f9424BbCCe8a865f70155fe40Fb22A103eBEc63). Its withdrawal lock is set to the maximum `uint256` block number. Fee collection leaves the position in place and forwards proceeds to its fixed recipient, `0x39544A7023081B56D7405c1af0bFaf72da7e24F6`.
+Programmable's liquidity is held in a [locked position](https://robinhoodchain.blockscout.com/address/0x9f9424BbCCe8a865f70155fe40Fb22A103eBEc63), identified by NFT `1708785`. We can collect the fees it earns while the liquidity stays locked.
 
-When someone buys V4 with ETH, the position earns ETH fees. When someone sells V4 for ETH, it earns V4 fees. Other liquidity providers earn their own shares; the project does not receive every fee paid by every position in the pool.
+When someone buys V4 with ETH, our position earns ETH fees. When someone sells V4, it earns V4 tokens as fees. Other liquidity providers receive their own shares.
 
 ## Buybacks and burns
 
-The revenue policy allocates half of Programmable's net platform revenue to V4 purchases and burns, with daily processing. This includes the platform share from Custom Launches and Module Mode after creator and module author rewards have been separated. The other half is allocated to the treasury. [Fees and revenue](economics.md) explains the rates and version-specific accounting.
+We use **50% of Programmable's platform fee revenue to buy V4 and burn it each day**. The other **50% stays in the treasury**. This includes our fees from Custom Launches and Module Mode. Creator fees and module author rewards belong to their recipients and are not used for these buybacks.
 
-V4 collected from the project's LP fees is also allocated to daily burns. More qualifying trading volume can generate more fee revenue and V4 available to burn, depending on trade direction and the position's liquidity share. Neither volume nor a burn determines a future token price or investor return.
+We also burn the V4 tokens collected from our liquidity fees each day. More trading in the main pool can generate more tokens to burn. [Fees and revenue](economics.md) explains how much each launch model charges and who receives it.
 
-Burns transfer V4 to `0x000000000000000000000000000000000000dEaD`, removing it from circulation. This ERC-20 has no supply-reducing burn function, so these transfers do not lower its onchain `totalSupply`. Report the burn-address balance separately from total supply and avoid counting the same transfer twice.
+Burning sends V4 to the address `0x000000000000000000000000000000000000dEaD`, removing those tokens from circulation. The token's reported total supply stays at one billion; burned tokens are counted separately.
 
-Use the [Dune dashboard](https://dune.com/programmablehq/analytics) to track recorded burns and the underlying transactions. Its daily refresh reports observed execution, which is separate from a revenue allocation policy or an unclaimed fee balance.
+You can track burns and the transactions behind them on our [Dune dashboard](https://dune.com/programmablehq/analytics), which refreshes every 24 hours.
 
-## Token holder rights
+## Holding V4
 
-Holding V4 does not represent equity in Programmable or a claim on protocol revenue. Buybacks and burns do not guarantee a price, liquidity, distribution to holders or return. Historical Ethereum tokens use different contract addresses and must not be combined with Robinhood V4 balances.
+V4 does not give holders company ownership or a right to receive platform revenue. Buybacks and burns do not guarantee a higher price or a return. The Robinhood V4 token is separate from Programmable's earlier Ethereum tokens.


### PR DESCRIPTION
The public fee and tokenomics pages used contract and accounting terminology where readers need the amounts, recipients and use of revenue. Rewrite those explanations in plain language with percentage tables and concrete ETH examples, and align the creator, module and overview pages.

The Module Mode policy remains 10 bps for Programmable and 20 bps total for module authors. Existing coin rates remain explicit. Daily buybacks and burns are described without an automation claim. Product writing guidance now distinguishes general explanations from exact API references.

Validation: 15 existing documentation tests passed; changed Markdown links, fee examples and formatting reviewed. This is a GitBook content update and does not change contracts or application runtime.
