### PR TITLE
Fix module author profile links

### DIFF
--- a/components/module-library.tsx
+++ b/components/module-library.tsx
@@ -25,7 +25,7 @@ export function ModuleCategoryIcon({ category, size = 22 }: { category: ModuleCa
 
 export function ModuleAuthor({ entry }: { entry: ModuleModeCatalogEntry }) {
   const author = moduleDiscovery(entry).author;
-  return author ? <Link href={`/profile/${author}`} className={styles.author} title={`Module author ${author}`}>By {moduleAuthorLabel(entry)}</Link> : null;
+  return author ? <Link href={`/profile?account=${author}&chain=4663`} className={styles.author} title={`Module author ${author}`}>By {moduleAuthorLabel(entry)}</Link> : null;
 }
 
 export function ModuleLibrary({ catalog, selectedIds, onAdd, onRemove }: {


### PR DESCRIPTION
Module author links in the launch catalog currently navigate to `/profile/<address>`, which returns 404. Use the existing `/profile?account=<address>&chain=4663` route already used by module detail and token creator links, so catalog authors open their actual profile.

Validation: the public browser reproduced the old route's 404; the existing query route and its profile module API both return 200 with the author's two published modules. The change is one href line, with `git diff --check` passing. The normal PR checks and a rendered click after deployment remain the release checks.
