### PR TITLE
Complete private Module publication and personal canary execution

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -9,6 +9,8 @@ regexTarget = "line"
 paths = [
   '''^config/module-mode/robinhood\.preview\.json$''',
   '''^config/module-mode/historical-releases\.json$''',
+  '''^config/module-mode/review-release\.json$''',
+  '''^config/module-engine/review-release\.json$''',
 ]
 regexes = ['''^\s*"tokenCreationCodeHash": "0x445809d9f7a34e959de4a96dec1e1beddfb265755bf28c57c42744adea1128ef",\s*$''']
 

--- a/components/module-review-admin-console.module.css
+++ b/components/module-review-admin-console.module.css
@@ -7,6 +7,9 @@
 .textLink:hover { color: var(--text); }
 .toolbar { display: flex; align-items: center; justify-content: space-between; gap: 20px; margin: 22px 0; }
 .toolbar p { font-size: 14px; margin: 0; }
+.sessionExport { margin: 22px 0; }
+.sessionExport p { max-width: 66ch; margin: 8px 0 0; }
+.sessionExport [role=status]:empty { margin: 0; }
 .primary, .secondary, .iconButton, .textButton, .fileButton { font: inherit; cursor: pointer; display: inline-flex; justify-content: center; align-items: center; gap: 8px; min-height: 44px; }
 .primary, .secondary { border: 1px solid var(--review-line); border-radius: 8px; font-size: 14px; font-weight: 550; padding: 10px 15px; }
 .primary { background: var(--text); color: var(--canvas); border-color: var(--text); }

--- a/components/module-review-admin-console.tsx
+++ b/components/module-review-admin-console.tsx
@@ -6,6 +6,7 @@ import { ArrowDownToLine, ArrowLeft, ArrowRight, Check, RefreshCw } from "lucide
 import { useWallet } from "@/components/wallet-provider";
 import { isWebsiteAdminWallet } from "@/lib/admin-access";
 import { isReviewDigest, parseReviewPlan, reviewStateLabel, type ModuleReviewDecisionCommandV1, type ModuleReviewDecisionRecordV1, type ReviewDetail, type ReviewManifestCheck, type ReviewQueue } from "@/lib/module-mode/review-contract";
+import { createPublicationSessionExporter, type PublicationSession, type PublicationSessionExportResult } from "@/lib/module-mode/publication-session";
 import styles from "./module-review-admin-console.module.css";
 
 type RequestReview = (path: string, body?: unknown, signal?: AbortSignal, asText?: boolean) => Promise<unknown>;
@@ -29,8 +30,9 @@ function short(value: string) { return `${value.slice(0, 8)}…${value.slice(-6)
 function json(value: unknown) { return JSON.stringify(value, null, 2); }
 function download(text: string, filename: string) {
   const url = URL.createObjectURL(new Blob([text], { type: "application/json" }));
-  const link = document.createElement("a"); link.href = url; link.download = filename; link.click();
-  window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+  try {
+    const link = document.createElement("a"); link.href = url; link.download = filename; link.click();
+  } finally { window.setTimeout(() => URL.revokeObjectURL(url), 1000); }
 }
 function Status({ state }: { state: ReviewState }) { return <span className={styles.badge} data-state={state}>{reviewStateLabel(state)}</span>; }
 function Hash({ label, value }: { label: string; value: string }) { return <div className={styles.hash}><dt>{label}</dt><dd>{value}</dd></div>; }
@@ -44,11 +46,19 @@ const AREA_LABELS: Record<string, string> = {
 };
 
 export function ModuleReviewAdminConsole() {
-  const { authenticated, connecting, wallet, getAccessToken, getIdentityToken, openWallet } = useWallet();
+  const { authenticated, authReady, sessionReady, connecting, disconnecting, wallet, getAccessToken, getIdentityToken, openWallet } = useWallet();
   const account = authenticated && isWebsiteAdminWallet(wallet?.account)
     ? wallet?.account.toLowerCase() ?? null : null;
   const session = useRef(account);
   useLayoutEffect(() => { session.current = account; }, [account]);
+  const publicationSession = useRef<PublicationSession | null>(null);
+  const publicationReady = Boolean(account && authReady && sessionReady && !disconnecting);
+  useLayoutEffect(() => {
+    publicationSession.current = publicationReady && account ? Object.freeze({ walletAddress: account }) : null;
+    return () => { publicationSession.current = null; };
+    // WalletProvider replaces the identity-token capability when its session/token changes.
+    // Cleanup also cancels a pending export when the same wallet disconnects and reconnects.
+  }, [account, publicationReady, getAccessToken, getIdentityToken]);
   const request = useCallback<RequestReview>(async (path, body, signal, asText) => {
     const identity = await getIdentityToken().catch(() => null);
     const token = await getAccessToken();
@@ -73,12 +83,45 @@ export function ModuleReviewAdminConsole() {
       <div><p className={styles.eyebrow}>Modules</p><h1>Admin Dashboard</h1></div>
       <Link className={styles.textLink} href="/admin/partners">Partner access <ArrowRight size={15} aria-hidden="true" /></Link>
     </header>
-    {account ? <ModuleReviewWorkspace key={account} account={account} request={request} /> : <section className={styles.gate}>
+    {account ? <>
+      <PublicationSessionDownload ready={publicationReady} readSession={() => publicationSession.current}
+        getAccessToken={getAccessToken} getIdentityToken={getIdentityToken} />
+      <ModuleReviewWorkspace key={account} account={account} request={request} />
+    </> : <section className={styles.gate}>
       <div className={styles.gateMark} aria-hidden="true">M</div><h2>Admin wallet required</h2>
       <p>Connect the admin wallet to review submissions.</p>
       <button className={styles.primary} type="button" disabled={connecting} onClick={openWallet}>{connecting ? "Connecting…" : "Connect wallet"}</button>
     </section>}
   </div>;
+}
+
+export function PublicationSessionDownload({ ready, ...input }: {
+  ready: boolean;
+  readSession: () => PublicationSession | null;
+  getAccessToken: () => Promise<string | null>;
+  getIdentityToken: () => Promise<string | null>;
+}) {
+  const [exportSession] = useState(() => createPublicationSessionExporter());
+  const [status, setStatus] = useState<"idle" | "pending" | PublicationSessionExportResult>("idle");
+  const startDownload = async () => {
+    const initial = input.readSession();
+    if (!ready || initial === null) { setStatus("session-changed"); return; }
+    setStatus("pending");
+    const result = await exportSession({ ...input, download: text => download(text, "module-publication-session.json") });
+    if (result !== "busy") setStatus(input.readSession() === initial ? result : "session-changed");
+  };
+  const notice = status === "downloaded" ? "Download requested. Set owner-only file permissions before using the publication operator."
+    : status === "session-changed" ? "Your wallet session changed. Reconnect the admin wallet and try again."
+      : status === "unavailable" ? "The session file could not be downloaded. Reconnect the admin wallet and try again."
+        : status === "pending" ? "Preparing the private session file…" : "";
+  return <section className={styles.sessionExport} aria-label="Publication session">
+    <button className={styles.secondary} type="button" disabled={!ready || status === "pending"}
+      aria-describedby="publication-session-handling" onClick={event => { if (event.detail <= 1) void startDownload(); }}>
+      <ArrowDownToLine size={15} aria-hidden="true" />Download publication session
+    </button>
+    <p id="publication-session-handling" className={styles.caption}>Contains your login tokens. Keep this file private and outside the repository. Delete it when finished.</p>
+    <p className={styles.caption} role="status" aria-live="polite" aria-atomic="true">{notice}</p>
+  </section>;
 }
 
 // The authenticated host owns the request function. This workspace has no credential or authority of its own.

--- a/config/module-engine/README.md
+++ b/config/module-engine/README.md
@@ -3,8 +3,8 @@
 `robinhood.json` is deliberately `null`: no Engine source is activated by this change. `catalog.json`
 has no templates or source digest. There are no placeholder contracts, deployment proofs or reviews.
 
-`review-release.json` is also deliberately `null`. The existing private Module review BFF reads this
-server configuration for Engine manifest checks and acceptance. It accepts only the closed
+`review-release.json` contains the deployed, source-verified Core host identity. The existing private
+Module review BFF reads this server configuration for Engine manifest checks and acceptance. It accepts only the closed
 `ModuleEngineReleaseIdentity` wire with its exact digest, source commit, chain, profile and contract
 pins. Browser requests and submitted manifests cannot supply or replace this installed identity.
 Null blocks Engine manifest checks and acceptance; Native review and source/build review remain

--- a/config/module-engine/review-release.json
+++ b/config/module-engine/review-release.json
@@ -1,1 +1,38 @@
-null
+{
+  "schemaVersion": "programmable.module-engine.release.v1",
+  "sourceVersion": "module-engine-v1",
+  "engineProfile": "programmable.module-engine-solidity@1",
+  "chainId": 4663,
+  "sourceCommit": "17b64b6613108dbc6ffdf767607bde6ea33343cd",
+  "tokenCreationCodeHash": "0x445809d9f7a34e959de4a96dec1e1beddfb265755bf28c57c42744adea1128ef",
+  "economicsPolicyId": "0x781124e941c10961779bc0d3ce1606083d16e1af3a03dccbc10d362b81085cc2",
+  "finalityPolicy": "robinhood-ethereum-finalized-v1",
+  "contracts": {
+    "tokenFactory": {
+      "address": "0x754e8c1ade3c6c4c863590a91f2ed020baf8e779",
+      "runtimeCodeHash": "0x9354ef051bafa1edccb95c91d999e31025c012ee8d93392a78a51d83594845f2"
+    },
+    "launchPolicy": {
+      "address": "0xf3ff250759a66edc7893bba9d34daf4ba4ae4caa",
+      "runtimeCodeHash": "0x1c485a64c77174e0b2a78adf2527128792180def26cbab2ca00fcfa74b73ba91"
+    },
+    "registry": {
+      "address": "0x0082094ebeb3817cd78b2bc3725ca23b5720d884",
+      "runtimeCodeHash": "0x364028382d38d4d1d4994ad305e0538f72ef2f2360a0f671ae82912c44374fdd"
+    },
+    "host": {
+      "address": "0x4ee5822de7296df5959085b95762f8c1c63da614",
+      "runtimeCodeHash": "0x01e10e24635483dff1ddfab9ef3925d34f061f542714e13134042ed7b6129dc0"
+    },
+    "ledger": {
+      "address": "0xd1a00fe1cf3a5fb2aab7d01513f3a9a0fa12f2b8",
+      "runtimeCodeHash": "0xc4123ca7d1adff7e0cadae9add95fc196325478ba89bd89360e7ebcb3e1ca401"
+    },
+    "poolManager": {
+      "address": "0x8366a39cc670b4001a1121b8f6a443a643e40951",
+      "runtimeCodeHash": "0xbd3881180b547f5fe817545743cfb4343e96b1bc6640dcd70c106b0066e95626"
+    }
+  },
+  "startBlock": "57168845",
+  "releaseDigest": "0xed101352062708f9c783aaf7b52fb752d98c5a5a2b0c3955ed14ab7feefa5497"
+}

--- a/config/module-mode/README.md
+++ b/config/module-mode/README.md
@@ -1,0 +1,27 @@
+# Native Module source configuration
+
+`review-release.json` supplies the private Module review BFF with the independently adopted NativeV2
+identity from the actual deployment and source-verification output. Its release digest is
+`0xe81f122e0bd21e0984e21c71ffce56f315e82f22e485cc19e0e490d4d5b7bd49`, and its contract source is
+`17b64b6613108dbc6ffdf767607bde6ea33343cd`. The file is the exact 3401-byte identity output, SHA256
+`36100920548506582be173ef0aeef392b413602fc7f4490c1c758829097aae1e`.
+
+The server accepts only the closed NativeV1 or NativeV2 identity fields, with the exact source
+generation, chain, source commit, finality policy, contract pins and computed release digest. NativeV2
+also requires its exact economics policy. Browser requests and submitted manifests cannot select or
+replace this identity. `null` blocks Native manifest checking and acceptance; an invalid identity
+fails closed for those same operations. Source reads, build review and Engine review retain their
+independent paths and existing authentication.
+
+Installing a review identity precedes module publication and the lifecycle canary. It grants no
+reviewer or publisher authority and provides no lifecycle or activation proof. Acceptance still
+requires the exact successful protected source/build, current review revision, canonical host
+manifest, acknowledged review areas and existing independent reviewer authorization. NativeV2
+manifests also bind the explicit family fee-eligibility decision. An older NativeV1 accepted manifest
+does not become a NativeV2 approval when this file changes.
+
+`robinhood.preview.json`, `catalog.json` and `historical-releases.json` remain the existing public
+NativeV1 release, catalogue and historical configuration. The private review identity does not change
+their availability, launch permissions or the bindings of existing coins. Public activation still
+requires the original release, source, lifecycle, finality and publication checks. Active-release
+fields, proof digests, arbitrary URLs and request overrides are not accepted in the review identity.

--- a/config/module-mode/review-release.json
+++ b/config/module-mode/review-release.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": "programmable.module-mode-source.v2",
+  "sourceVersion": "module-native-v2",
+  "economicsPolicyId": "0x781124e941c10961779bc0d3ce1606083d16e1af3a03dccbc10d362b81085cc2",
+  "chainId": 4663,
+  "sourceCommit": "17b64b6613108dbc6ffdf767607bde6ea33343cd",
+  "minimumInitialBuyNative": "400000000000000",
+  "tokenCreationCodeHash": "0x445809d9f7a34e959de4a96dec1e1beddfb265755bf28c57c42744adea1128ef",
+  "finalityPolicy": "robinhood-ethereum-finalized-v1",
+  "contracts": {
+    "tokenFactory": {
+      "address": "0x754e8c1ade3c6c4c863590a91f2ed020baf8e779",
+      "runtimeCodeHash": "0x9354ef051bafa1edccb95c91d999e31025c012ee8d93392a78a51d83594845f2"
+    },
+    "positionPlanner": {
+      "address": "0x79a6281fc6910600b0aa73c0439266a6e9399de2",
+      "runtimeCodeHash": "0x1c2e74e2161589f3650fe2955e86da8890178a49b86ab7b742c6eeb80c9a2ae9"
+    },
+    "launchPolicy": {
+      "address": "0xf3ff250759a66edc7893bba9d34daf4ba4ae4caa",
+      "runtimeCodeHash": "0x1c485a64c77174e0b2a78adf2527128792180def26cbab2ca00fcfa74b73ba91"
+    },
+    "positionForwarderFactory": {
+      "address": "0xc9ec66eca31b8bee9479025eb5467bb2926d5e8d",
+      "runtimeCodeHash": "0xbe86703ef1ab24716bddcb5be981d224d891fe1336c68d4daf587cbc105b16d4"
+    },
+    "runtimeFactory": {
+      "address": "0xee5d8f7a17dd14ce86a5b8d745add285f88f9bb4",
+      "runtimeCodeHash": "0xf924c7114ee699300e86975829e109a69fdc3d3df2f3b8893cb83a4c4a7cceae"
+    },
+    "registry": {
+      "address": "0x56251ab2716d3fec1fa44a45acd6f489194360f0",
+      "runtimeCodeHash": "0x6d2e51502e5e4ff5d03562ff3c5fb4cc517953584651188d267206ee49e462ec"
+    },
+    "swapRouterFactory": {
+      "address": "0x22af538f3c7127fe31262bd0a66410f42c8d70e2",
+      "runtimeCodeHash": "0x0da797636dc67063cd494a21685b37b2b3fd61d8e00477d77825a61f1a2d9198"
+    },
+    "hook": {
+      "address": "0xe6d1b4951b4bd4fdcd1746a7d8fbff98a7fce0cc",
+      "runtimeCodeHash": "0xa0c41fbf23b09767c8aa6d54f0543cbc5f0741cd525bca44fb259061f9225633"
+    },
+    "rewardLedger": {
+      "address": "0x4bf80c62c9e9fb5c25f165070189dce957d01982",
+      "runtimeCodeHash": "0x30a1bf80146a303273cf57d36c4b6f4f934299353a1fcfda1b7f321b06462095"
+    },
+    "runtime": {
+      "address": "0x912e7dcae95c6585a0ecab7d53c5d5bc5e26b00a",
+      "runtimeCodeHash": "0x764c4731d4b54598a10ed03a2f0804289848c1910f2836f485ee832f1895655a"
+    },
+    "budgetVault": {
+      "address": "0xc67264f9b6f390c9b5ae6ac6ea3710d3c08171d4",
+      "runtimeCodeHash": "0xefef9bf90bc2a0bec08bbee3546bad80abb5e9f5cdaa0f6ae8fa463720415079"
+    },
+    "swapRouter": {
+      "address": "0x866f4ab06aa022d3f82447c43f493a7d98a990ff",
+      "runtimeCodeHash": "0xe19508a16c26315fa76dfb1abaae3f113d73af9c20d30ca62954b3ef2835b705"
+    },
+    "launcher": {
+      "address": "0x362dac28ac64ce11989a90e0da6715313e0162c5",
+      "runtimeCodeHash": "0x2f4f04402489d12b70b9dbc0ffb15b1bfceaef645b75b18102bc7b1c0af9b753"
+    },
+    "poolManager": {
+      "address": "0x8366a39cc670b4001a1121b8f6a443a643e40951",
+      "runtimeCodeHash": "0xbd3881180b547f5fe817545743cfb4343e96b1bc6640dcd70c106b0066e95626"
+    },
+    "positionManager": {
+      "address": "0x58daec3116aae6d93017baaea7749052e8a04fa7",
+      "runtimeCodeHash": "0xc873e135dc9aaec88489cfbad146b4cb49d6a32e0d80326377784b7ba17670b2"
+    }
+  },
+  "startBlock": "57167553",
+  "releaseDigest": "0xe81f122e0bd21e0984e21c71ffce56f315e82f22e485cc19e0e490d4d5b7bd49"
+}

--- a/contracts/scripts/module-engine/lifecycle-operator-plan.mjs
+++ b/contracts/scripts/module-engine/lifecycle-operator-plan.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { writeFile } from 'node:fs/promises';
+import { encodeFunctionData, erc20Abi } from 'viem';
+import { address, bytes, canonicalJson, exactKeys, hash, jsonSafe, need, uint } from '../module-mode/core.mjs';
+import { repositoryState } from '../module-mode/build.mjs';
+import { readCondition, readOperatorJson, ZERO_ADDRESS } from '../module-mode/publication-plan.mjs';
+import { publicationValidators } from '../module-mode/publication-shared.mjs';
+import { assertPublicationRequest } from '../module-mode/publication-rpc.mjs';
+import { bindEngineReview, enginePlanBody, equal, equalEngineLaunchPlan, ENGINE_LIFECYCLE_OPERATOR_SCHEMA } from './publication-plan.mjs';
+const ZERO_HASH = `0x${'0'.repeat(64)}`;
+export function optionalHash(value) { need(typeof value === 'string' && /^0x[0-9a-f]{64}$/.test(value), 'Canonical bytes32 required'); return value; }
+export function bindEngineIntent(intent, token, quote, actor, deadline, nonce, api) {
+  exactKeys(intent, ['operationId', 'recipient', 'inputAsset', 'inputAmount', 'outputAsset', 'minimumOutput', 'data'], 'Engine operation intent');
+  const asset = role => { need(['primary', 'quote', 'native'].includes(role), 'Explicit primary/quote/native asset role required'); return role === 'primary' ? token : role === 'quote' ? quote : ZERO_ADDRESS; };
+  return api.moduleEngineOperation({ operationId: hash(intent.operationId), recipient: address(intent.recipient), inputAsset: asset(intent.inputAsset), inputAmount: BigInt(uint(intent.inputAmount)),
+    outputAsset: asset(intent.outputAsset), minimumOutput: BigInt(uint(intent.minimumOutput)), data: bytes(intent.data) }, actor, BigInt(uint(deadline, 'deadline', true)), BigInt(uint(nonce)));
+}
+export function assertEnginePermission(revision, launch, operation, actor) {
+  const permission = revision.operationPermissions.find(p => p.operationId === operation.operationId);
+  need(permission && operation.actor === actor && (permission.authorization === 0 || (permission.authorization === 1 && actor === launch.creator)), 'Engine operation actor or creator authority differs');
+  const role = (asset, amount) => asset === ZERO_ADDRESS ? BigInt(amount) === 0n ? 0 : 4 : asset === launch.token ? 1 : asset === launch.quoteAsset ? 2 : -1;
+  const input = role(operation.inputAsset, operation.inputAmount), output = role(operation.outputAsset, operation.minimumOutput);
+  need(input >= 0 && output >= 0 && (permission.inputRoles & input) === input && (permission.outputRoles & output) === output, 'Engine asset roles exceed the accepted operation permission');
+  return permission;
+}
+function fundingSteps(action, owner, host, operation) {
+  exactKeys(action.funding, ['mode', 'expectedAllowance'], 'Exact engine funding'); uint(action.funding.expectedAllowance, 'expectedAllowance');
+  const erc20 = operation.inputAsset !== ZERO_ADDRESS && BigInt(operation.inputAmount) > 0n, mode = action.funding.mode;
+  if (!erc20) { need(mode === 'none' && action.funding.expectedAllowance === '0', 'No ERC20 approval is allowed for this operation'); return []; }
+  need(['existing', 'approve', 'reset-approve'].includes(mode), 'Select exact existing allowance or bounded approval');
+  const amount = operation.inputAmount.toString(), before = action.funding.expectedAllowance;
+  need(BigInt(amount) < (1n << 256n) - 1n, 'Unlimited ERC20 allowance is forbidden');
+  if (mode === 'existing') { need(before === amount, 'Existing allowance must equal the exact operation amount'); return []; }
+  need(mode === 'approve' ? before === '0' : BigInt(before) > 0n, 'Allowance reset mode differs from the reviewed existing allowance');
+  const approval = (amount, prior) => ({ kind: 'engine-approve', label: amount === '0' ? 'Reset the exact Host funding allowance' : 'Approve the exact next operation input', sender: owner,
+    to: operation.inputAsset, target: operation.inputAsset, value: '0', functionName: 'approve', arguments: [host, amount],
+    data: encodeFunctionData({ abi: erc20Abi, functionName: 'approve', args: [host, BigInt(amount)] }), approval: { spender: host, amount, previousAllowance: prior, operationId: operation.operationId },
+    preReads: [readCondition(operation.inputAsset, erc20Abi, 'allowance', [owner, host], BigInt(prior))],
+    postReads: [readCondition(operation.inputAsset, erc20Abi, 'allowance', [owner, host], BigInt(amount))], newCode: [] });
+  return [...(mode === 'reset-approve' ? [approval('0', before)] : []), approval(amount, '0')];
+}
+function quotePin(value) {
+  exactKeys(value, ['address', 'runtimeCodeHash', 'decimals'], 'Reviewed quote asset');
+  need(Number.isInteger(value.decimals) && value.decimals >= 0 && value.decimals <= 18, 'Quote decimals are unsupported');
+  return { address: address(value.address), runtimeCodeHash: hash(value.runtimeCodeHash), decimals: value.decimals };
+}
+export async function createEngineLifecycleOperatorPlan({ identity, owner, bundle, action, sourceState }) {
+  owner = address(owner); const checked = await bindEngineReview(bundle, identity), api = await publicationValidators(), m = checked.manifest.manifest, host = identity.contracts.host.address;
+  need(action && ['launch', 'execute'].includes(action.kind), 'Closed Engine launch/execute profile required');
+  let compiled, operation, expected, quote, reference = null;
+  if (action.kind === 'launch') {
+    exactKeys(action, ['kind', 'name', 'symbol', 'description', 'imageUri', 'socialLinks', 'quote', 'configuration', 'creatorSalt', 'engineSalt', 'launchData', 'creatorWallets', 'creatorSharesBps', 'buyCreatorFeeBps', 'sellCreatorFeeBps', 'initialOperation', 'deadline', 'funding'], 'Engine launch action');
+    quote = quotePin(action.quote); uint(action.deadline, 'deadline', true);
+    const input = { ...action, account: owner, quoteAsset: quote.address, creatorSalt: optionalHash(action.creatorSalt), engineSalt: optionalHash(action.engineSalt),
+      initialOperation: action.initialOperation === null ? undefined : ({ token, quoteAsset }) => bindEngineIntent(action.initialOperation, token, quoteAsset, owner, action.deadline, '0', api) };
+    compiled = await api.compileModuleEngineLaunch(input, identity, checked.manifest, quote.decimals, BigInt(action.deadline));
+    operation = compiled.initialOperation;
+    expected = { launchId: compiled.launchId, revisionId: m.revision.packageId, creator: owner, token: compiled.predictedToken, quoteAsset: quote.address, engine: compiled.engine,
+      engineCodeHash: compiled.engineCodeHash, constructorHash: compiled.constructorHash, initCodeHash: compiled.initCodeHash, configurationHash: compiled.configurationHash,
+      planHash: compiled.planHash, buyCreatorFeeBps: compiled.buyCreatorFeeBps, sellCreatorFeeBps: compiled.sellCreatorFeeBps };
+    need(operation.inputAsset !== expected.token || operation.inputAmount === 0n, 'The uncreated primary token cannot pre-fund its own launch');
+
+  } else {
+    exactKeys(action, ['kind', 'launch', 'intent', 'nonce', 'deadline', 'funding'], 'Engine execute action');
+    reference = action.launch; exactKeys(reference, ['plan', 'entry', 'evidence'], 'Original Engine launch reference');
+    need(reference.plan?.schemaVersion === ENGINE_LIFECYCLE_OPERATOR_SCHEMA && reference.plan.action?.kind === 'launch', 'Reference must be an original Engine launch plan');
+    await assertEngineLifecycleOperatorPlan(reference.plan); equal(reference.plan.identity, identity, 'Referenced release');
+    equal(reference.plan.bundle.manifest, bundle.manifest, 'Referenced reviewed engine manifest');
+    assertPublicationRequest(reference.plan, reference.entry); const launchStep = reference.plan.steps[reference.entry.stepIndex];
+    need(launchStep?.kind === 'engine-launch' && reference.entry.transactionHash === reference.evidence?.transaction?.hash && reference.evidence.status === 'included-code-verified-unfinalized'
+      && reference.evidence.sourceKind === 'module-engine-v1' && reference.evidence.planDigest === reference.plan.planDigest, 'Original bound engine launch receipt required');
+    expected = launchStep.expectation; quote = reference.plan.action.quote;
+    equalEngineLaunchPlan(reference.evidence.canary, reference.entry.observation.simulatedResult, 'Referenced simulated/actual Engine launch');
+    for (const [key, value] of Object.entries(expected)) equal(reference.evidence.canary[key], value, `Referenced launch ${key}`);
+    operation = bindEngineIntent(action.intent, expected.token, expected.quoteAsset, owner, action.deadline, action.nonce, api);
+  }
+  if (operation.operationId !== ZERO_HASH) assertEnginePermission(m.revision, expected, operation, owner);
+  const steps = fundingSteps(action, owner, host, operation), params = compiled?.parameters;
+  steps.push({ kind: action.kind === 'launch' ? 'engine-launch' : 'engine-execute', label: action.kind === 'launch' ? `Launch ${params.symbol} with ${m.catalogDefinition.title}` : `Execute ${operation.operationId}`,
+    sender: owner, to: host, target: expected.token, value: operation.inputAsset === ZERO_ADDRESS ? operation.inputAmount.toString() : '0',
+    functionName: action.kind, arguments: jsonSafe(action.kind === 'launch' ? [params] : [expected.launchId, operation]),
+    data: encodeFunctionData({ abi: api.moduleEngineHostAbi, functionName: action.kind, args: action.kind === 'launch' ? [params] : [expected.launchId, operation] }),
+    deadline: action.deadline, expectation: expected, operation: jsonSafe(operation), preReads: [], postReads: [],
+    newCode: action.kind === 'launch' ? [{ address: expected.engine, runtimeCodeHash: expected.engineCodeHash }] : [] });
+  // Approval UI displays the same already-derived operation, recipient, bound token and exact maximum allowance.
+  for (const step of steps) if (step.kind === 'engine-approve') { step.expectation = expected; step.operation = jsonSafe(operation); step.deadline = action.deadline; }
+  return enginePlanBody(ENGINE_LIFECYCLE_OPERATOR_SCHEMA, identity, owner, checked, bundle, sourceState, { action, steps });
+}
+export async function assertEngineLifecycleOperatorPlan(plan) {
+  const rebuilt = await createEngineLifecycleOperatorPlan({ ...plan, sourceState: plan }); equal(plan, rebuilt, 'Engine lifecycle owner plan'); return plan;
+}
+async function main(argv) {
+  const options = {}; let candidate = false;
+  for (let i = 0; i < argv.length; i++) { const key = argv[i]; if (key === '--candidate') { need(!candidate, 'Duplicate candidate'); candidate = true; continue; }
+    need(['--identity', '--bundle', '--owner', '--action', '--output'].includes(key) && !options[key] && argv[i + 1] && !argv[i + 1].startsWith('--'), 'Expected --identity FILE --bundle FILE --owner ADDRESS --action FILE --output FILE [--candidate]'); options[key] = argv[++i]; }
+  need(Object.keys(options).length === 5, 'All Engine lifecycle inputs are required'); const state = await repositoryState(); need(candidate || state.sourceClean, 'Clean operator source required');
+  const plan = await createEngineLifecycleOperatorPlan({ identity: await readOperatorJson(options['--identity']), bundle: await readOperatorJson(options['--bundle']), owner: options['--owner'], action: await readOperatorJson(options['--action']), sourceState: { ...state, sourceClean: !candidate && state.sourceClean } });
+  await writeFile(options['--output'], `${canonicalJson(plan)}\n`, { flag: 'wx', mode: 0o600 });
+  console.log(JSON.stringify({ authority: 'preparation-only', planDigest: plan.planDigest, steps: plan.steps.length, sourceClean: plan.sourceClean }));
+}
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main(process.argv.slice(2)).catch(error => { console.error(error.message); process.exitCode = 1; });

--- a/contracts/scripts/module-engine/operation-rpc.mjs
+++ b/contracts/scripts/module-engine/operation-rpc.mjs
@@ -1,0 +1,202 @@
+import { decodeEventLog, decodeFunctionResult, encodeAbiParameters, encodeEventTopics, erc20Abi, keccak256, parseAbiParameters } from 'viem';
+import { address, bytes, hash, jsonSafe, need } from '../module-mode/core.mjs';
+import { publicationValidators } from '../module-mode/publication-shared.mjs';
+import { ZERO_ADDRESS, registryAbi } from '../module-mode/publication-plan.mjs';
+import { ENGINE_PUBLICATION_OPERATOR_SCHEMA, equal, equalEngineLaunchPlan } from './publication-plan.mjs';
+import { assertEnginePermission } from './lifecycle-operator-plan.mjs';
+const ZERO_HASH = `0x${'0'.repeat(64)}`;
+const optionalAddress = v => v.toLowerCase() === ZERO_ADDRESS ? ZERO_ADDRESS : address(v);
+const qty = v => BigInt(v);
+function launchShape(raw) {
+  const out = {};
+  for (const key of ['launchId', 'revisionId', 'engineCodeHash', 'constructorHash', 'initCodeHash', 'configurationHash', 'planHash', 'resourcesHash']) out[key] = hash(raw[key], key);
+  for (const key of ['creator', 'token', 'quoteAsset', 'engine']) out[key] = address(raw[key], key);
+  for (const key of ['buyCreatorFeeBps', 'sellCreatorFeeBps']) { need(Number.isInteger(raw[key]) && raw[key] >= 0 && raw[key] <= 1000, 'Invalid creator fee'); out[key] = raw[key]; }
+  return out;
+}
+async function releaseBindings(plan, providers, block, c, api) {
+  const pins = plan.identity.contracts, host = pins.host.address, ledger = pins.ledger.address;
+  need(c.quantity(block) >= BigInt(plan.identity.startBlock), 'Engine release start block not reached');
+  const read = (to, name, args = [], abi = api.moduleEngineReadAbi) => c.read(providers, to, abi, name, args, block);
+  equal(await read(host, 'SOURCE_VERSION', [], api.moduleEngineHostAbi), api.MODULE_ENGINE_SOURCE_ID, 'Engine source version');
+  for (const name of ['registry', 'ledger', 'tokenFactory', 'launchPolicy']) equal(address(await read(host, name, [], api.moduleEngineHostAbi)), pins[name].address, `Engine ${name}`);
+  for (const [name, role] of [['hook', 'host'], ['registry', 'registry'], ['poolManager', 'poolManager']]) equal(address(await read(ledger, name)), pins[role].address, `Engine ledger ${name}`);
+  equal(await read(ledger, 'ECONOMICS_POLICY_ID'), plan.identity.economicsPolicyId, 'Engine economics policy');
+  need(await read(ledger, 'PROTOCOL_FEE_BPS') === 10 && await read(ledger, 'AUTHOR_POOL_FEE_BPS') === 20, 'Engine fee policy constants differ');
+  const owner = address(await read(pins.registry.address, 'owner'));
+  if (plan.schemaVersion === ENGINE_PUBLICATION_OPERATOR_SCHEMA) need(owner === plan.owner, 'Current Registry EOA owner differs');
+}
+async function revisionBindings(plan, providers, block, c, api, absent = false, historical = false) {
+  const m = plan.bundle.manifest.manifest, host = plan.identity.contracts.host.address, engine = m.source.engine;
+  const result = await c.read(providers, host, api.moduleEngineHostAbi, 'getRevision', [m.revision.packageId], block);
+  need(Array.isArray(result) && result.length === 4, 'Invalid Engine revision getter');
+  const expected = api.engineRegistryRevision({ manifest: plan.bundle.manifest, manifestHash: api.computeModuleEngineHostManifestHash(plan.bundle.manifest) });
+  if (absent) {
+    need(result[0].creationCodeHash === ZERO_HASH && result[0].manifestHash === ZERO_HASH && result[0].enabled === false && result.slice(1).every(v => v.length === 0), 'Engine revision already exists; immutable admission cannot be retried as new');
+    return;
+  }
+  const r = { ...result[0], fixedQuoteAsset: optionalAddress(result[0].fixedQuoteAsset) };
+  // Disabled revisions still govern already-launched coins; only new launches require enabled=true.
+  if (historical || plan.action?.kind === 'execute') expected.enabled = r.enabled;
+  equal(r, expected, 'Immutable Engine revision'); equal(result[1], engine.immutableRuntimeOffsets, 'Engine runtime immutable offsets');
+  equal(result[2], engine.immutableConstructorOffsets, 'Engine constructor offsets'); equal(result[3], m.revision.eligibleFamilies, 'Engine fee families');
+  for (const permission of m.revision.operationPermissions) equal(await c.read(providers, host, api.moduleEngineHostAbi, 'permission', [m.revision.packageId, permission.operationId], block), permission, 'Actual Engine operation permission');
+}
+async function familyBindings(plan, providers, block, c, api) {
+  const m = plan.bundle.manifest.manifest, source = plan.bundle.source.descriptor;
+  const family = await c.read(providers, plan.identity.contracts.registry.address, api.moduleEngineReadAbi, 'families', [m.revision.familyId], block);
+  equal(family.map(address => optionalAddress(address)), [address(source.author), address(source.rewardWallet)], 'Engine family author and reward');
+  for (const id of m.revision.eligibleFamilies) {
+    const family = await c.read(providers, plan.identity.contracts.registry.address, api.moduleEngineReadAbi, 'families', [id], block); family.forEach(v => address(v));
+  }
+}
+function launchStep(plan) { return plan.steps.find(s => s.kind === 'engine-launch'); }
+function launchContext(plan, expected) { return { host: plan.identity.contracts.host.address, launchId: expected.launchId, token: expected.token, creator: expected.creator, quoteAsset: expected.quoteAsset, feeCollector: plan.identity.contracts.host.address }; }
+async function boundLaunch(plan, step, providers, block, c, api) {
+  const pins = plan.identity.contracts, host = pins.host.address, expected = step.expectation;
+  const actual = launchShape(await c.read(providers, host, api.moduleEngineHostAbi, 'getLaunch', [expected.launchId], block));
+  for (const [key, value] of Object.entries(expected)) equal(actual[key], value, `Engine launch ${key}`);
+  equal(await c.read(providers, host, api.moduleEngineHostAbi, 'launchIdOf', [expected.token], block), expected.launchId, 'Token launch registration');
+  equal(await c.read(providers, host, api.moduleEngineHostAbi, 'engineLaunchId', [expected.engine], block), expected.launchId, 'Engine launch registration');
+  await c.code(providers, { address: expected.engine, runtimeCodeHash: expected.engineCodeHash }, block);
+  const tokenRuntime = bytes(c.same(await c.pair(providers, 'eth_getCode', [expected.token, block]), 'Engine token runtime')); need(tokenRuntime !== '0x', 'Engine token runtime missing');
+  const parameters = launchStep(plan.action.kind === 'launch' ? plan : plan.action.launch.plan).arguments[0];
+  for (const [name, expectedValue] of [['name', parameters.name], ['symbol', parameters.symbol], ['creator', host], ['decimals', 18], ['totalSupply', 1000000000n * 10n ** 18n]])
+    equal(await c.read(providers, expected.token, api.moduleEngineReadAbi, name, [], block), expectedValue, `Engine token ${name}`);
+  const graffiti = keccak256(encodeAbiParameters(parseAbiParameters('string,address,bytes32'), ['programmable.module-engine.token.v1', expected.creator, parameters.creatorSalt]));
+  equal(await c.read(providers, expected.token, api.moduleEngineReadAbi, 'graffiti', [], block), graffiti, 'Engine token graffiti');
+  equal(address(await c.read(providers, pins.tokenFactory.address, api.moduleEngineReadAbi, 'getUERC20Address', [parameters.name, parameters.symbol, 18, host, graffiti], block)), expected.token, 'Factory token identity');
+  equal(await c.read(providers, expected.engine, api.moduleEngineReadAbi, 'contextHash', [], block), keccak256(encodeAbiParameters(parseAbiParameters(api.ENGINE_CONTEXT), [launchContext(plan, expected)])), 'Engine instance context');
+  const platform = plan.bundle.manifest.manifest.revision.eligibleFamilies.length ? 30 : 10;
+  equal(await c.read(providers, pins.ledger.address, api.moduleEngineReadAbi, 'platformFeeBps', [expected.launchId], block), platform, 'Launch-bound platform fee');
+  const creators = await c.read(providers, pins.ledger.address, api.moduleEngineLedgerAbi, 'creatorRecipients', [expected.launchId], block);
+  equal(creators[0].map(address), parameters.creatorWallets, 'Launch creator recipients'); equal(creators[1], parameters.creatorSharesBps, 'Launch creator shares');
+  for (const buy of [true, false]) equal(await c.read(providers, host, api.moduleEngineHostAbi, 'feeTerms', [expected.launchId, buy], block), [platform, buy ? parameters.buyCreatorFeeBps : parameters.sellCreatorFeeBps], 'Engine fee terms');
+  equal(await c.read(providers, host, api.moduleEngineHostAbi, 'fixedConfigurationHash', [expected.launchId], block), plan.bundle.manifest.manifest.revision.fixedConfigurationHash, 'Host fixed configuration admission');
+  return { actual, tokenRuntimeCodeHash: keccak256(tokenRuntime) };
+}
+async function nonceAndFunding(plan, step, providers, block, c, api, approvalStep) {
+  const op = step.operation, host = plan.identity.contracts.host.address;
+  if (op.operationId === ZERO_HASH) return;
+  assertEnginePermission(plan.bundle.manifest.manifest.revision, step.expectation, op, plan.owner);
+  equal(await c.read(providers, host, api.moduleEngineHostAbi, 'nonces', [step.expectation.launchId, plan.owner], block), qty(op.nonce), 'Engine actor nonce');
+  if (op.inputAsset !== ZERO_ADDRESS && BigInt(op.inputAmount) > 0n) {
+    need(BigInt(await c.read(providers, op.inputAsset, erc20Abi, 'balanceOf', [plan.owner], block)) >= BigInt(op.inputAmount), 'Insufficient balance in the exact Engine input asset');
+    if (!approvalStep) equal(await c.read(providers, op.inputAsset, erc20Abi, 'allowance', [plan.owner, host], block), BigInt(op.inputAmount), 'Exact Host allowance');
+  }
+}
+export async function assertEngineOperationPreflight(plan, stepIndex, providers, block, c) {
+  const api = await publicationValidators(), step = plan.steps[stepIndex]; await releaseBindings(plan, providers, block.number, c, api);
+  // A reset's zero allowance is superseded by the later exact approval. The original
+  // server still verifies each predecessor's receipt at its own canonical inclusion block.
+  const latestPostReads = new Map();
+  for (const previous of plan.steps.slice(0, stepIndex)) for (const read of previous.postReads) latestPostReads.set(`${read.to}:${read.data}`, read);
+  await c.readConditions(providers, [...latestPostReads.values()], block.number);
+  await c.readConditions(providers, step.preReads, block.number);
+  if (plan.schemaVersion === ENGINE_PUBLICATION_OPERATOR_SCHEMA) {
+    await revisionBindings(plan, providers, block.number, c, api, true);
+    if (step.kind === 'engine-revision') await familyBindings(plan, providers, block.number, c, api);
+    return;
+  }
+  const launching = plan.action.kind === 'launch', quote = launching ? plan.action.quote : plan.action.launch.plan.action.quote;
+  await c.code(providers, quote, block.number);
+  equal(await c.read(providers, quote.address, erc20Abi, 'decimals', [], block.number), quote.decimals, 'Actual quote asset decimals');
+  await revisionBindings(plan, providers, block.number, c, api);
+  if (launching) {
+    const p = launchStep(plan).arguments[0], expected = step.expectation;
+    const graffiti = keccak256(encodeAbiParameters(parseAbiParameters('string,address,bytes32'), ['programmable.module-engine.token.v1', plan.owner, p.creatorSalt]));
+    const prediction = await c.read(providers, plan.identity.contracts.host.address, api.moduleEngineHostAbi, 'predictTokenAddress', [p.name, p.symbol, plan.owner, p.creatorSalt], block.number);
+    equal([address(prediction[0]), prediction[1]], [expected.token, graffiti], 'Actual Host token prediction');
+    for (const target of [expected.token, expected.engine]) {
+      need(c.same(await c.pair(providers, 'eth_getCode', [target, block.number]), 'Engine target vacancy') === '0x', 'Engine target is already deployed; reconcile its receipt');
+      need(c.quantity(c.same(await c.pair(providers, 'eth_getTransactionCount', [target, block.number]), 'Engine target nonce')) === 0n, 'Engine CREATE2 target has a nonzero nonce');
+    }
+    await familyBindings(plan, providers, block.number, c, api);
+  } else {
+    const reference = plan.action.launch;
+    const original = await c.observeReceipt(reference.plan, reference.entry, providers);
+    equal(original, reference.evidence, 'Canonical original Engine launch evidence');
+    const live = await boundLaunch(plan, step, providers, block.number, c, api);
+    equal(live.actual, reference.evidence.canary, 'Existing Engine launch identity');
+  }
+  await nonceAndFunding(plan, step, providers, block.number, c, api, step.kind === 'engine-approve');
+}
+export async function bindEngineSimulation(plan, step, simulation) {
+  const api = await publicationValidators();
+  if (step.kind === 'engine-family') {
+    equal(decodeFunctionResult({ abi: registryAbi, functionName: 'registerReviewedFamily', data: simulation }), plan.bundle.manifest.manifest.revision.familyId, 'Simulated Engine family'); return null;
+  }
+  if (step.kind === 'engine-revision') { need(simulation === '0x', 'Engine admission returned unexpected data'); return null; }
+  if (step.kind === 'engine-approve') { need(simulation === '0x' || decodeFunctionResult({ abi: erc20Abi, functionName: 'approve', data: simulation }) === true, 'Token rejected exact Host approval'); return null; }
+  if (step.kind === 'engine-launch') {
+    const result = launchShape(decodeFunctionResult({ abi: api.moduleEngineHostAbi, functionName: 'launch', data: simulation }));
+    for (const [key, value] of Object.entries(step.expectation)) equal(result[key], value, `Simulated Engine ${key}`); return result;
+  }
+  need(step.kind === 'engine-execute', 'Unsupported engine simulation profile');
+  const result = bytes(decodeFunctionResult({ abi: api.moduleEngineHostAbi, functionName: 'execute', data: simulation })); need(result.length <= 65536 * 2 + 2, 'Engine result exceeds bounds'); return { result, resultHash: keccak256(result) };
+}
+function events(receipt, target, name, abi) {
+  return receipt.logs.filter(l => l.address === target).flatMap(log => {
+    let parsed; try { parsed = decodeEventLog({ abi, data: log.data, topics: log.topics, strict: true }); } catch { return []; }
+    if (parsed.eventName !== name) return [];
+    need(!log.removed && log.transactionHash === receipt.transactionHash && log.blockHash === receipt.blockHash && log.blockNumber === receipt.blockNumber, 'Engine event inclusion differs');
+    equal(encodeEventTopics({ abi, eventName: name, args: parsed.args }), log.topics, 'Canonical Engine event topics');
+    const fields = abi.find(item => item.type === 'event' && item.name === name).inputs.filter(i => !i.indexed);
+    equal(encodeAbiParameters(fields, fields.map(f => parsed.args[f.name])), log.data, 'Canonical Engine event payload'); return [parsed.args];
+  });
+}
+function one(receipt, target, name, abi) { const found = events(receipt, target, name, abi); need(found.length === 1, `Expected exactly one ${name} event`); return found[0]; }
+async function operationReceipt(plan, step, receipt, providers, c, api) {
+  const op = step.operation, host = plan.identity.contracts.host.address;
+  if (op.operationId === ZERO_HASH) { need(events(receipt, host, 'EngineOperationExecuted', api.moduleEngineHostAbi).length === 0, 'Unexpected Engine initial operation'); return null; }
+  const event = one(receipt, host, 'EngineOperationExecuted', api.moduleEngineHostAbi);
+  for (const [key, expected] of Object.entries({ launchId: step.expectation.launchId, operationId: op.operationId, actor: plan.owner, recipient: op.recipient,
+    nonce: BigInt(op.nonce), inputAsset: op.inputAsset, inputAmount: BigInt(op.inputAmount), outputAsset: op.outputAsset })) equal(typeof event[key] === 'string' ? event[key].toLowerCase() : event[key], expected, `Engine operation ${key}`);
+  need(event.outputAmount >= BigInt(op.minimumOutput), 'Engine output is below the reviewed minimum');
+  // Approved engines can return market/state-dependent bytes. The canonical Host event
+  // attests the actual result; the signed output floor, assets and funding are the limits.
+  hash(event.resultHash, 'Actual Engine result hash');
+  equal(await c.read(providers, host, api.moduleEngineHostAbi, 'nonces', [step.expectation.launchId, plan.owner], receipt.blockNumber), BigInt(op.nonce) + 1n, 'Consumed Engine actor nonce');
+  if (op.inputAsset !== ZERO_ADDRESS && BigInt(op.inputAmount) > 0n) equal(await c.read(providers, op.inputAsset, erc20Abi, 'allowance', [plan.owner, host], receipt.blockNumber), 0n, 'Consumed exact Engine allowance');
+  return jsonSafe(event);
+}
+export async function finishEngineReceipt(plan, entry, providers, receipt, transaction, pins, c) {
+  const api = await publicationValidators(), step = plan.steps[entry.stepIndex], host = plan.identity.contracts.host.address;
+  await releaseBindings(plan, providers, receipt.blockNumber, c, api); let canary = null, operation = null, tokenRuntimeCodeHash = null;
+  if (plan.schemaVersion === ENGINE_PUBLICATION_OPERATOR_SCHEMA) {
+    await familyBindings(plan, providers, receipt.blockNumber, c, api);
+    if (step.kind === 'engine-revision') {
+      await revisionBindings(plan, providers, receipt.blockNumber, c, api, false, true);
+      const event = one(receipt, host, 'EngineRevisionApproved', api.moduleEngineHostAbi), m = plan.bundle.manifest.manifest;
+      equal(event.revisionId, m.revision.packageId, 'Admitted Engine revision'); equal(event.familyId, m.revision.familyId, 'Admitted Engine family');
+      const expected = api.engineRegistryRevision({ manifest: plan.bundle.manifest, manifestHash: api.computeModuleEngineHostManifestHash(plan.bundle.manifest) });
+      equal({ ...event.revision, fixedQuoteAsset: optionalAddress(event.revision.fixedQuoteAsset) }, expected, 'Exact Engine revision event');
+    }
+  } else if (step.kind !== 'engine-approve') {
+    await revisionBindings(plan, providers, receipt.blockNumber, c, api, false, true);
+    ({ actual: canary, tokenRuntimeCodeHash } = await boundLaunch(plan, step, providers, receipt.blockNumber, c, api));
+    if (step.kind === 'engine-launch') {
+      equalEngineLaunchPlan(canary, entry.observation.simulatedResult, 'Actual/simulated Engine launch');
+      const event = one(receipt, host, 'EngineLaunchBound', api.moduleEngineHostAbi);
+      for (const [key, value] of Object.entries({ ...step.expectation, runtimeCodeHash: step.expectation.engineCodeHash, resourcesHash: canary.resourcesHash, economicsPolicyId: plan.identity.economicsPolicyId }).filter(([key]) => !['engineCodeHash', 'buyCreatorFeeBps', 'sellCreatorFeeBps'].includes(key))) equal(typeof event[key] === 'string' ? event[key].toLowerCase() : event[key], value, `Engine launch event ${key}`);
+      const parameters = one(receipt, host, 'EngineLaunchParametersBound', api.moduleEngineHostAbi);
+      equal(parameters.launchId, canary.launchId, 'Engine parameter launch'); equal(parameters.encodedParameters, encodeAbiParameters(api.moduleEngineLaunchParameters, [step.arguments[0]]), 'Exact Engine launch parameters');
+    } else equal(canary, plan.action.launch.evidence.canary, 'Executed Engine launch identity');
+    operation = await operationReceipt(plan, step, receipt, providers, c, api);
+  } else {
+    // Receipt uses the same bounded asset/runtime/allowance. It never grants launch membership to an approval.
+    const quote = plan.action.kind === 'launch' ? plan.action.quote : plan.action.launch.plan.action.quote;
+    await c.code(providers, quote, receipt.blockNumber);
+    if (step.to === step.expectation.token) ({ tokenRuntimeCodeHash } = await boundLaunch(plan, step, providers, receipt.blockNumber, c, api));
+  }
+  need((await c.pair(providers, 'eth_getBlockByNumber', [receipt.blockNumber, false])).every(b => b?.hash === receipt.blockHash), 'Engine receipt anchor changed during verification');
+  return { status: 'included-code-verified-unfinalized', sourceKind: 'module-engine-v1', chainId: 4663, planDigest: plan.planDigest, releaseDigest: plan.identity.releaseDigest,
+    stepIndex: entry.stepIndex, kind: step.kind, transaction, receipt, contracts: pins, canary, operation, tokenRuntimeCodeHash, providers: c.publicBindings(providers) };
+}
+
+export function equalEngineSimulation(plan, stepIndex, actual, expected) {
+  if (plan.steps[stepIndex].kind === 'engine-launch') equalEngineLaunchPlan(actual, expected, 'Engine revalidation launch plan');
+  else if (plan.steps[stepIndex].kind !== 'engine-execute') equal(actual, expected, 'Engine revalidation result');
+  // execute was freshly simulated by the pinned Host with the unchanged signed
+  // input/recipient/minimumOutput/deadline. Its returned bytes are not a limit.
+}

--- a/contracts/scripts/module-engine/publication-plan.mjs
+++ b/contracts/scripts/module-engine/publication-plan.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { writeFile } from 'node:fs/promises';
+import { encodeFunctionData } from 'viem';
+import { address, canonicalJson, digest, exactKeys, jsonSafe, need } from '../module-mode/core.mjs';
+import { repositoryState } from '../module-mode/build.mjs';
+import { publicationValidators } from '../module-mode/publication-shared.mjs';
+import { readOperatorJson, readCondition, registryAbi, ZERO_ADDRESS } from '../module-mode/publication-plan.mjs';
+
+export const ENGINE_PUBLICATION_OPERATOR_SCHEMA = 'programmable.module-engine-publication-owner-plan.v1';
+export const ENGINE_LIFECYCLE_OPERATOR_SCHEMA = 'programmable.module-engine-lifecycle-owner-plan.v1';
+export const isEngineOperationPlan = plan => [ENGINE_PUBLICATION_OPERATOR_SCHEMA, ENGINE_LIFECYCLE_OPERATOR_SCHEMA].includes(plan?.schemaVersion);
+export function equal(a, b, label) { need(canonicalJson(jsonSafe(a)) === canonicalJson(jsonSafe(b)), `${label} differs`); }
+// Resources (for example a position NFT ID) can advance between simulation and mining.
+// The immutable plan is exact; each actual resourcesHash must instead match its canonical Host event/getter.
+export function equalEngineLaunchPlan(actual, expected, label) {
+  const withoutResources = value => Object.fromEntries(Object.entries(value).filter(([key]) => key !== 'resourcesHash'));
+  equal(withoutResources(actual), withoutResources(expected), label);
+}
+export async function bindEngineIdentity(identity) {
+  const api = await publicationValidators(), result = api.moduleEngineReleaseIdentity(identity);
+  equal(identity, result, 'Immutable engine release');
+  return result;
+}
+/** Local consistency only. Authenticated current acceptance is checked separately before every wallet handoff. */
+export async function bindEngineReview(bundle, identity) {
+  exactKeys(bundle, ['source', 'manifest', 'review', 'artifact', 'buildPlan'], 'Engine accepted bundle');
+  const api = await publicationValidators(); await bindEngineIdentity(identity);
+  const source = api.validateModuleSubmissionRequest(bundle.source); need(source.ok, 'Invalid engine source package');
+  need(api.validateModuleReviewDecisionRecordV1(bundle.review), 'Invalid engine review decision');
+  const review = bundle.review, subject = api.parseReviewSubject(review.subject), artifact = api.parseReviewArtifact(bundle.artifact, subject), buildPlan = api.parseReviewPlan(bundle.buildPlan, subject);
+  need(artifact.schemaVersion === 'programmable.modules.engine-build.v1' && buildPlan.schemaVersion === 'programmable.modules.engine-build-plan.v1', 'Protected engine profile required');
+  api.verifyModuleEngineBuildArtifactV1(artifact, subject, buildPlan, source.request);
+  need(review.command.outcome === 'accept' && review.command.artifactDigest === artifact.artifactDigest
+    && review.reviewerWallet !== subject.author && artifact.reviewRequired.every(area => review.command.acknowledgedReviewAreas.includes(area)), 'Complete independent engine acceptance required');
+  const definition = { profile: 'programmable.module-engine-solidity@1', catalogDefinition: bundle.manifest.manifest.catalogDefinition, revision: bundle.manifest.manifest.revision };
+  const manifest = api.createReviewedModuleEngineManifest({ job: { artifact, plan: buildPlan }, descriptor: source.request.descriptor, release: identity,
+    definition: definition.catalogDefinition, revision: definition.revision });
+  equal(manifest, bundle.manifest, 'Reviewed engine manifest'); const manifestHash = api.computeModuleEngineHostManifestHash(manifest);
+  need(review.command.hostManifestHash === manifestHash && source.requestDigest === subject.requestDigest && source.request.descriptor.author.toLowerCase() === subject.author,
+    'Engine acceptance/source binding differs');
+  return { source: source.request, artifact, buildPlan, review, manifest, manifestHash, definition, revision: api.engineRegistryRevision({ manifest, manifestHash }),
+    reviewAuthority: address(review.reviewerWallet), familyId: source.familyId, packageId: source.packageId };
+}
+export async function assertAuthenticatedEngineOperationPlan(plan, sessionFile) {
+  need(typeof sessionFile === 'string' && sessionFile.length > 0, 'Private reviewer session file required for engine operations');
+  const api = await publicationValidators(), session = await api.readOperatorSession(sessionFile);
+  need(address(session.walletAddress) === plan.reviewAuthority, 'Engine reviewer session differs; the operation actor is a separate wallet');
+  const current = await api.createAuthenticatedReviewReader(session).read(plan.bundle.review.subject.submissionId);
+  await assertCurrentEngineReview(plan, current);
+}
+/** Only genuine objects from the existing authenticated reader pass acceptedDecision/prepareEnginePublication. */
+export async function assertCurrentEngineReview(plan, current) {
+  const api = await publicationValidators(), checked = await bindEngineReview(plan.bundle, plan.identity), decision = api.acceptedDecision(current);
+  equal(decision, plan.bundle.review, 'Current authenticated engine decision'); equal(current.source, plan.bundle.source, 'Current authenticated engine source');
+  equal(current.artifact, plan.bundle.artifact, 'Current protected engine artifact'); equal(current.job.plan, plan.bundle.buildPlan, 'Current protected engine build plan');
+  const publication = api.prepareEnginePublication(current, plan.identity, checked.definition, plan.owner);
+  equal(publication.manifest, checked.manifest, 'Authenticated engine host manifest');
+  if (plan.schemaVersion === ENGINE_PUBLICATION_OPERATOR_SCHEMA) for (const step of plan.steps) {
+    const call = publication.calls.find(call => call.action === step.functionName);
+    need(call && call.from === plan.owner && call.to === step.to && call.data === step.data && BigInt(call.value) === BigInt(step.value), 'Canonical engine publication call differs');
+  }
+}
+export function enginePlanBody(schemaVersion, identity, owner, checked, bundle, sourceState, fields) {
+  need(/^[0-9a-f]{40}$/.test(sourceState.sourceCommit) && /^[0-9a-f]{40}$/.test(sourceState.sourceTree) && typeof sourceState.sourceClean === 'boolean', 'Exact operator source state required');
+  const body = jsonSafe({ schemaVersion, chainId: 4663, sourceCommit: sourceState.sourceCommit, sourceTree: sourceState.sourceTree, sourceClean: sourceState.sourceClean,
+    identity, owner, reviewAuthority: checked.reviewAuthority, bundle, ...fields });
+  return { ...body, planDigest: digest(schemaVersion, body) };
+}
+export async function createEnginePublicationOperatorPlan({ identity, owner, bundle, familyState, sourceState }) {
+  owner = address(owner); const checked = await bindEngineReview(bundle, identity), api = await publicationValidators();
+  need(['absent', 'existing'].includes(familyState), 'Explicit absent/existing family state required; quorum verifies it');
+  const { manifest, revision, source, familyId, packageId } = checked, engine = manifest.manifest.source.engine, r = manifest.manifest.revision;
+  const registry = identity.contracts.registry.address, host = identity.contracts.host.address;
+  const author = address(source.descriptor.author), reward = address(source.descriptor.rewardWallet);
+  const familyRead = readCondition(registry, registryAbi, 'families', [familyId], [author, reward]), steps = [];
+  if (familyState === 'absent') {
+    const args = [author, source.descriptor.familySalt, reward, checked.artifact.subject.requestDigest];
+    steps.push({ kind: 'engine-family', label: `Register ${r.familyId} contributor family`, sender: owner, to: registry, target: registry, value: '0',
+      functionName: 'registerReviewedFamily', arguments: args, data: encodeFunctionData({ abi: registryAbi, functionName: 'registerReviewedFamily', args }),
+      preReads: [readCondition(registry, registryAbi, 'families', [familyId], [ZERO_ADDRESS, ZERO_ADDRESS])], postReads: [familyRead], newCode: [] });
+  }
+  const args = [packageId, revision, engine.immutableRuntimeOffsets, engine.immutableConstructorOffsets, r.operationPermissions, r.eligibleFamilies];
+  steps.push({ kind: 'engine-revision', label: `Admit ${manifest.manifest.catalogDefinition.title}`, sender: owner, to: host, target: host, value: '0',
+    functionName: 'approveRevision', arguments: args, data: encodeFunctionData({ abi: api.moduleEngineHostAbi, functionName: 'approveRevision', args }),
+    preReads: [familyRead], postReads: [], newCode: [] });
+  return enginePlanBody(ENGINE_PUBLICATION_OPERATOR_SCHEMA, identity, owner, checked, bundle, sourceState, { familyState, steps });
+}
+export async function assertEnginePublicationOperatorPlan(plan) {
+  const rebuilt = await createEnginePublicationOperatorPlan({ ...plan, sourceState: plan }); equal(plan, rebuilt, 'Engine publication owner plan'); return plan;
+}
+async function main(argv) {
+  const command = argv.shift(), options = {}; let candidate = false;
+  const keys = command === 'bundle' ? ['identity', 'definition', 'submission', 'session-file', 'output'] : ['identity', 'bundle', 'owner', 'family-state', 'output'];
+  need(['bundle', 'prepare'].includes(command), 'Expected bundle or prepare');
+  for (let i = 0; i < argv.length; i++) { const key = argv[i]; if (key === '--candidate' && command === 'prepare') { need(!candidate, 'Duplicate candidate'); candidate = true; continue; }
+    need(keys.includes(key.slice(2)) && !options[key.slice(2)] && argv[i + 1] && !argv[i + 1].startsWith('--'), 'Unknown, duplicate or missing engine publication argument'); options[key.slice(2)] = argv[++i]; }
+  need(Object.keys(options).length === keys.length, `Required: ${keys.map(k => `--${k}`).join(' ')}`);
+  const identity = await readOperatorJson(options.identity); let output;
+  if (command === 'bundle') {
+    const api = await publicationValidators(), session = await api.readOperatorSession(options['session-file']);
+    const review = await api.createAuthenticatedReviewReader(session).read(options.submission), accepted = api.acceptedDecision(review);
+    need(address(session.walletAddress) === address(accepted.reviewerWallet), 'Use the accepted reviewer session');
+    const host = api.createEngineHostPreparation(review, identity, await readOperatorJson(options.definition));
+    output = { source: review.source, manifest: host.manifest, review: accepted, artifact: review.artifact, buildPlan: review.job.plan };
+    await bindEngineReview(output, identity);
+  } else {
+    const state = await repositoryState(); need(candidate || state.sourceClean, 'Clean operator source required');
+    output = await createEnginePublicationOperatorPlan({ identity, bundle: await readOperatorJson(options.bundle), owner: options.owner, familyState: options['family-state'], sourceState: { ...state, sourceClean: !candidate && state.sourceClean } });
+  }
+  await writeFile(options.output, `${canonicalJson(output)}\n`, { flag: 'wx', mode: 0o600 });
+  console.log(JSON.stringify({ authority: 'preparation-only', ...(output.planDigest ? { planDigest: output.planDigest, steps: output.steps.length, sourceClean: output.sourceClean } : { manifestHash: (await publicationValidators()).computeModuleEngineHostManifestHash(output.manifest) }) }));
+}
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main(process.argv.slice(2)).catch(() => { console.error('Engine publication preparation failed; no wallet authority or output was granted.'); process.exitCode = 1; });

--- a/contracts/scripts/module-engine/quote-evidence.mjs
+++ b/contracts/scripts/module-engine/quote-evidence.mjs
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { address, canonicalJson, hash, need } from '../module-mode/core.mjs';
 import { journalEntry } from '../module-mode/journal.mjs';
 import { evidenceBytes, evidenceDigest, sourcifyVerificationRequests } from '../module-mode/evidence.mjs';
-import { SOURCIFY_BASE, boundedPublicJson, exactJson, sourcifyNeedsRecompilation, sourcifyPreflight, validateSourcifySource } from '../module-mode/source-readback.mjs';
+import { SOURCIFY_BASE, SOURCIFY_QUOTE_PLANNER_AUXDATA_PROFILE, boundedPublicJson, exactJson, sourcifyNeedsRecompilation, sourcifyPreflight, validateSourcifySource } from '../module-mode/source-readback.mjs';
 import { recompileSourcifyInput } from '../module-mode/source-recompile.mjs';
 import { assertQuoteProfile, QUOTE_DEPLOYMENT_SCHEMA, QUOTE_ROLES, quoteInfrastructureIdentity } from './quote-core.mjs';
 import { assertQuoteWethProxyObservation, observeQuoteReceipt } from './quote-rpc.mjs';
@@ -100,7 +100,8 @@ export async function collectQuoteSource(plan, build, deployment, previousRaw, f
     const creation = quoteSourceCreation(plan, role, deployment), url = `${SOURCIFY_BASE}/v2/contract/4663/${plan.contracts[role].address}?fields=all`;
     const { raw, value } = await boundedPublicJson(url, fetchImpl);
     const recompilation = sourcifyNeedsRecompilation(build.standardInputs[role], value) ? await recompileSourcifyInput(value, build.standardInputs[role]) : undefined;
-    const verified = validateSourcifySource({ plan, build, role, constructorArguments: quoteConstructorArguments(plan, role), creation, recompilation }, value);
+    const verified = validateSourcifySource({ plan, build, role, constructorArguments: quoteConstructorArguments(plan, role), creation, recompilation,
+      ...(role === 'positionPlanner' ? { compilerAuxdataProfile: SOURCIFY_QUOTE_PLANNER_AUXDATA_PROFILE } : {}) }, value);
     records.push({ ...verified, url, responseBytesDigest: evidenceDigest(raw) });
   }
   return { schemaVersion: QUOTE_SOURCE_SCHEMA, chainId: 4663, sourceVersion: plan.identityCandidate.sourceVersion,

--- a/contracts/scripts/module-engine/wallet-operator.test.mjs
+++ b/contracts/scripts/module-engine/wallet-operator.test.mjs
@@ -1,0 +1,195 @@
+import test from 'node:test';
+import { mkdtemp, chmod, readFile, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { REPOSITORY_ROOT } from '../module-mode/build.mjs';
+import { armJournal, armRetryJournal, journalEntry, recordTransaction, recordReceipt } from '../module-mode/journal.mjs';
+import assert from 'node:assert/strict';
+import { decodeFunctionData, erc20Abi } from 'viem';
+import { engineWalletFixture, engineWorld, a, h } from './wallet-test-fixtures.mjs';
+import { createEnginePublicationOperatorPlan, assertEnginePublicationOperatorPlan, assertCurrentEngineReview } from './publication-plan.mjs';
+import { createEngineLifecycleOperatorPlan, assertEngineLifecycleOperatorPlan } from './lifecycle-operator-plan.mjs';
+import { assertAuthenticatedOperationPlan } from '../module-mode/publication-plan.mjs';
+import { assertOperationPlan, startPublicationOperator } from '../module-mode/publication-operator.mjs';
+import { preparePublicationRequest, revalidatePublicationRequest, preparePublicationRetry, observePublicationReceipt, observePublicationOperation } from '../module-mode/publication-rpc.mjs';
+const ceilings = { maxGas: '2000000', maxFeePerGas: '1000', maxPriorityFeePerGas: '10', maxValue: '10000' };
+async function launched(initial = false) {
+  const f = await engineWalletFixture({ initial }), plan = await createEngineLifecycleOperatorPlan(f), world = engineWorld(f, plan); let entry, evidence;
+  for (let i = 0; i < plan.steps.length; i++) {
+    const prepared = await preparePublicationRequest(plan, i, world.providers, ceilings);
+    entry = await world.mine(prepared); evidence = await observePublicationReceipt(plan, entry, world.providers);
+  }
+  return { f, plan, world, entry, evidence };
+}
+function executeAction(f, reference, { permission = 2, actor = f.owner, nonce = '0', amount = '2' } = {}) {
+  const grant = f.artifact.operationPermissions[permission];
+  return { kind: 'execute', launch: reference, intent: { operationId: grant.operationId, recipient: actor, inputAsset: permission === 2 ? 'quote' : 'native', inputAmount: permission === 2 ? amount : '0',
+    outputAsset: permission === 3 ? 'quote' : 'native', minimumOutput: permission === 3 ? '1' : '0', data: h(2) }, nonce, deadline: f.action.deadline, funding: { mode: permission === 2 ? 'approve' : 'none', expectedAllowance: '0' } };
+}
+test('Engine publication reuses actual accepted manifest/calls and separates operator source, contract source, reviewer and owner', async () => {
+  const f = await engineWalletFixture(), owner = a(993), plan = await createEnginePublicationOperatorPlan({ ...f, owner, familyState: 'absent' });
+  assert.equal(plan.owner, owner); assert.equal(plan.reviewAuthority, f.reviewer); assert.notEqual(plan.sourceCommit, plan.identity.sourceCommit);
+  assert.deepEqual(plan.steps.map(s => s.kind), ['engine-family', 'engine-revision']);
+  assert.ok(plan.steps.every(s => s.value === '0')); await assertOperationPlan(plan); await assertEnginePublicationOperatorPlan(plan);
+  await assertCurrentEngineReview(plan, await f.current());
+  const current = await f.current(); await assert.rejects(assertCurrentEngineReview(plan, structuredClone(current)), /authenticated/);
+  await assert.rejects(assertAuthenticatedOperationPlan(plan), /session file/);
+  f.detail.job.state = 'rejected'; await assert.rejects(async () => assertCurrentEngineReview(plan, await f.current()));
+});
+test('Engine owner plan rejects altered acceptance/build/calldata, unknown profile, excess keys and private activation claims', async () => {
+  const f = await engineWalletFixture();
+  for (const mutate of [b => { b.review.command.hostManifestHash = h(15); }, b => { b.artifact.engine.creationBytecode += '00'; }, b => { b.manifest.manifest.revision.moneyRights = 7; }]) {
+    const bundle = structuredClone(f.bundle); mutate(bundle); await assert.rejects(createEnginePublicationOperatorPlan({ ...f, bundle, familyState: 'existing' }));
+  }
+  const plan = await createEnginePublicationOperatorPlan({ ...f, familyState: 'existing' });
+  for (const mutate of [p => { p.steps[0].data += '00'; }, p => { p.enabled = true; }, p => { p.reviewAuthority = a(3); }, p => { p.identity.status = 'active'; }]) {
+    const changed = structuredClone(plan); mutate(changed); await assert.rejects(assertOperationPlan(changed));
+  }
+  await assert.rejects(assertOperationPlan({ ...plan, schemaVersion: 'invented-engine-profile' }), /Unknown/);
+});
+test('Engine family/admission transport verifies the actual owner, both providers, absence and exact admitted getters/event', async () => {
+  const f = await engineWalletFixture(), plan = await createEnginePublicationOperatorPlan({ ...f, owner: f.reviewer, familyState: 'absent' }), w = engineWorld(f, plan, { published: false });
+  w.mutations.registryOwner = a(995); await assert.rejects(observePublicationOperation(plan, 0, w.providers), /Registry EOA owner/); delete w.mutations.registryOwner;
+  for (let i = 0; i < plan.steps.length; i++) {
+    const prepared = await preparePublicationRequest(plan, i, w.providers, ceilings); const entry = await w.mine(prepared), receipt = await observePublicationReceipt(plan, entry, w.providers);
+    assert.equal(receipt.sourceKind, 'module-engine-v1'); assert.equal(receipt.status, 'included-code-verified-unfinalized');
+  }
+  await assert.rejects(observePublicationOperation(plan, 1, w.providers), /already exists/);
+  const estimates = w.methods.filter(c => c.method === 'eth_estimateGas'); assert.ok(estimates.length >= 4 && estimates.every(c => c.params[1]?.startsWith('0x')));
+  assert.deepEqual(new Set(estimates.map(c => c.provider)), new Set([0, 1]));
+});
+test('Engine launch uses the shared pure codec and exact bounded ERC20 approval before its atomic initial operation', async () => {
+  const f = await engineWalletFixture({ initial: true }), plan = await createEngineLifecycleOperatorPlan(f); await assertEngineLifecycleOperatorPlan(plan);
+  assert.deepEqual(plan.steps.map(s => s.kind), ['engine-approve', 'engine-launch']);
+  const approval = decodeFunctionData({ abi: erc20Abi, data: plan.steps[0].data }); assert.deepEqual(approval.args, [f.identity.contracts.host.address, 2n]);
+  const launch = decodeFunctionData({ abi: f.api.moduleEngineHostAbi, data: plan.steps[1].data });
+  assert.equal(launch.functionName, 'launch'); assert.equal(launch.args[0].initialOperation.inputAmount, 2n); assert.equal(launch.args[0].initialOperation.nonce, 0n);
+  assert.equal(plan.steps[1].value, '0'); assert.equal(plan.owner, f.owner); assert.notEqual(plan.owner, f.reviewer);
+  const w = engineWorld(f, plan); await assert.rejects(observePublicationOperation(plan, 1, w.providers), /allowance|allowance.*differs/i);
+  const entry = await w.mine(await preparePublicationRequest(plan, 0, w.providers, ceilings)); await observePublicationReceipt(plan, entry, w.providers);
+  const prepared = await preparePublicationRequest(plan, 1, w.providers, ceilings); await revalidatePublicationRequest(plan, prepared, w.providers, ceilings);
+  const actual = await observePublicationReceipt(plan, await w.mine(prepared), w.providers);
+  assert.equal(actual.operation.nonce, '0'); assert.equal(actual.canary.planHash, plan.steps[1].expectation.planHash); assert.equal(w.state.allowance, '0');
+  assert.ok(!w.methods.some(c => c.method === 'eth_call' && c.params[0].data.startsWith('0x') && (() => { try { return decodeFunctionData({ abi: f.api.moduleEngineReadAbi, data: c.params[0].data }).functionName === 'familyFeeEligibility'; } catch { return false; } })()));
+});
+test('Engine funding is exact, with explicit zero-reset and no unlimited, unrelated or stand-alone approval', async () => {
+  const f = await engineWalletFixture({ initial: true });
+  for (const funding of [{ mode: 'existing', expectedAllowance: '3' }, { mode: 'approve', expectedAllowance: '2' }, { mode: 'none', expectedAllowance: '0' }]) await assert.rejects(createEngineLifecycleOperatorPlan({ ...f, action: { ...f.action, funding } }));
+  const reset = await createEngineLifecycleOperatorPlan({ ...f, action: { ...f.action, funding: { mode: 'reset-approve', expectedAllowance: '4' } } });
+  assert.deepEqual(reset.steps.filter(s => s.kind === 'engine-approve').map(s => s.approval.amount), ['0', '2']);
+  const world = engineWorld(f, reset); world.state.allowance = '4'; world.sync();
+  for (let i = 0; i < reset.steps.length; i++) { const entry = await world.mine(await preparePublicationRequest(reset, i, world.providers, ceilings)); await observePublicationReceipt(reset, entry, world.providers); }
+  for (const mutate of [a => { a.initialOperation.inputAsset = a.quote.address; }, a => { a.initialOperation.actor = f.reviewer; }, a => { a.kind = 'approve'; }, a => { a.initialOperation.minimumOutput = '-1'; }, a => { a.initialOperation.inputAmount = ((1n << 256n) - 1n).toString(); }]) {
+    const action = structuredClone(f.action); mutate(action); await assert.rejects(createEngineLifecycleOperatorPlan({ ...f, action }));
+  }
+});
+test('Engine execute binds original launch receipt, exact Host nonce, immutable permission and creator-only authority', async () => {
+  const { f, plan, world, entry, evidence } = await launched(true), reference = { plan, entry, evidence };
+  const actor = a(996), action = executeAction(f, reference, { actor, nonce: '0' });
+  const next = await createEngineLifecycleOperatorPlan({ ...f, owner: actor, action }); world.setPlan(next);
+  for (let i = 0; i < next.steps.length; i++) { const e = await world.mine(await preparePublicationRequest(next, i, world.providers, ceilings)); const result = await observePublicationReceipt(next, e, world.providers); assert.equal(result.sourceKind, 'module-engine-v1'); }
+  assert.equal(world.state.actorNonce[actor], '1'); assert.equal(world.state.actorNonce[f.owner], '1');
+  const creatorOnly = executeAction(f, reference, { permission: 3, actor, nonce: '1' });
+  await assert.rejects(createEngineLifecycleOperatorPlan({ ...f, owner: actor, action: creatorOnly }), /creator authority/);
+  const authorized = await createEngineLifecycleOperatorPlan({ ...f, action: executeAction(f, reference, { permission: 3, nonce: '1' }) }); world.setPlan(authorized);
+  const prepared = await preparePublicationRequest(authorized, 0, world.providers, ceilings);
+  const fulfilled = await observePublicationReceipt(authorized, await world.mine(prepared), world.providers); assert.equal(fulfilled.operation.outputAmount, '1');
+  const forged = structuredClone(reference); forged.evidence.canary.planHash = h(888);
+  await assert.rejects(createEngineLifecycleOperatorPlan({ ...f, action: executeAction(f, forged) }), /Referenced/);
+});
+test('Engine nonce, deadline, wallet ceilings, quote code and provider disagreement fail before arming', async () => {
+  const f = await engineWalletFixture(), plan = await createEngineLifecycleOperatorPlan(f), w = engineWorld(f, plan);
+  await assert.rejects(preparePublicationRequest(plan, 0, [w.providers[0], w.providers[0]], ceilings), /quorum/);
+  w.mutations.pending = true; await assert.rejects(preparePublicationRequest(plan, 0, w.providers, ceilings), /pending/); delete w.mutations.pending;
+  await assert.rejects(preparePublicationRequest(plan, 0, w.providers, { ...ceilings, maxGas: '1' }), /Gas estimate/);
+  w.mutations.balance = '0x0'; await assert.rejects(preparePublicationRequest(plan, 0, w.providers, ceilings), /balance/); delete w.mutations.balance;
+  const request = await preparePublicationRequest(plan, 0, w.providers, ceilings);
+  const retry = await preparePublicationRetry(plan, { ...request, transactionHash: null }, w.providers, ceilings, request.requestDigest, 1); assert.deepEqual(retry.request, request.request);
+  w.state.eoaNonce = '9'; w.sync(); await assert.rejects(revalidatePublicationRequest(plan, request, w.providers, ceilings), /nonce/); w.state.eoaNonce = '1'; w.sync();
+  w.mutations.rpc = (method, params, provider) => method === 'eth_getCode' && params[0] === f.quote.address && provider === 1 ? '0x6002' : undefined;
+  await assert.rejects(preparePublicationRequest(plan, 0, w.providers, ceilings), /disagreement/); delete w.mutations.rpc;
+  const stale = await createEngineLifecycleOperatorPlan({ ...f, action: { ...f.action, deadline: '1' } });
+  await assert.rejects(preparePublicationRequest(stale, 0, w.providers, ceilings), /deadline/);
+});
+test('Engine receipt rejects a changed wallet request, wrong network, missing/duplicate/altered parameter event and absent result hash', async () => {
+  const { f, plan, world, entry } = await launched();
+  for (const patch of [{ nonce: '0x99' }, { value: '0x1' }, { input: '0x' }, { from: a(1) }]) { world.mutations.tx = patch; await assert.rejects(observePublicationReceipt(plan, entry, world.providers)); }
+  delete world.mutations.tx; world.mutations.chain = '0x1'; await assert.rejects(observePublicationReceipt(plan, entry, world.providers), /chain/); delete world.mutations.chain;
+  const r = world.receipts.get(entry.transactionHash), original = structuredClone(r.logs);
+  for (const logs of [original.slice(0, 1), [...original, original[1]], original.map((l,i) => i === 1 ? { ...l, data: `${l.data}00` } : l), original.map((l,i) => i === 1 ? { ...l, removed: true } : l)]) {
+    r.logs = logs; await assert.rejects(observePublicationReceipt(plan, entry, world.providers));
+  }
+  r.logs = original; const evidence = await observePublicationReceipt(plan, entry, world.providers);
+  const next = await createEngineLifecycleOperatorPlan({ ...f, action: executeAction(f, { plan, entry, evidence }, { permission: 0 }) }); world.setPlan(next);
+  const prepared = await preparePublicationRequest(next, 0, world.providers, ceilings), execution = await world.mine(prepared), receipt = world.receipts.get(execution.transactionHash);
+  receipt.logs[0].data = `${receipt.logs[0].data.slice(0, -64)}${h(0).slice(2)}`;
+  await assert.rejects(observePublicationReceipt(next, execution, world.providers), /result hash/);
+});
+test('Engine same server has a disabled inspection mode and retains the original wallet/source authority gate', async () => {
+  const f = await engineWalletFixture(), plan = await createEngineLifecycleOperatorPlan(f);
+  await assert.rejects(startPublicationOperator({ plan, port: 18883, reviewedPlanDigest: plan.planDigest }), /clean-source/);
+  const { server, url } = await startPublicationOperator({ plan, uiCheck: true, port: 18883 });
+  try {
+    const page = await (await fetch(url)).text(), token = page.match(/name="operator-token" content="([a-f0-9]+)"/)[1];
+    const headers = { origin: url, 'x-module-operator-token': token, 'content-type': 'application/json' };
+    const state = await (await fetch(`${url}/state`, { method: 'POST', headers, body: '{}' })).json();
+    assert.equal(state.owner, f.owner); assert.equal(state.contractSourceCommit, f.identity.sourceCommit); assert.equal(state.sourceCommit, f.sourceState.sourceCommit);
+    assert.equal((await fetch(`${url}/arm`, { method: 'POST', headers, body: '{}' })).status, 400);
+  } finally { await new Promise(resolve => server.close(resolve)); }
+});
+
+test('Engine resource IDs may advance but their actual Host event and getter must agree with the exact signed plan', async () => {
+  const f = await engineWalletFixture(), plan = await createEngineLifecycleOperatorPlan(f), world = engineWorld(f, plan);
+  const prepared = await preparePublicationRequest(plan, 0, world.providers, ceilings);
+  world.mutations.resourcesHash = h(2222);
+  await revalidatePublicationRequest(plan, prepared, world.providers, ceilings);
+  const entry = await world.mine(prepared), evidence = await observePublicationReceipt(plan, entry, world.providers);
+  assert.equal(evidence.canary.resourcesHash, h(2222)); assert.equal(evidence.canary.planHash, prepared.observation.simulatedResult.planHash);
+  assert.notEqual(evidence.canary.resourcesHash, prepared.observation.simulatedResult.resourcesHash);
+  await createEngineLifecycleOperatorPlan({ ...f, action: executeAction(f, { plan, entry, evidence }, { permission: 0 }) });
+});
+test('Engine grant keeps zero-valued ERC20 roles meaningful and actor nonce independent of the EOA nonce', async () => {
+  const { f, plan, world, entry, evidence } = await launched(), reference = { plan, entry, evidence };
+  const action = executeAction(f, reference, { permission: 0 }); action.intent.inputAsset = 'quote';
+  await assert.rejects(createEngineLifecycleOperatorPlan({ ...f, action }), /asset roles/);
+  const next = await createEngineLifecycleOperatorPlan({ ...f, action: executeAction(f, reference, { permission: 0 }) }); world.setPlan(next);
+  const prepared = await preparePublicationRequest(next, 0, world.providers, ceilings);
+  world.state.actorNonce[f.owner] = '1'; world.sync();
+  await assert.rejects(revalidatePublicationRequest(next, prepared, world.providers, ceilings), /actor nonce/);
+  world.state.actorNonce[f.owner] = '0'; world.state.enabled = false; world.sync(true);
+  // Existing launches remain operable after the reviewed revision is disabled for new launches.
+  await revalidatePublicationRequest(next, prepared, world.providers, ceilings);
+});
+
+test('Engine handoff uses the original durable unknown-outcome journal and same-nonce retry with no write/sign RPC', async () => {
+  const f = await engineWalletFixture(), plan = await createEngineLifecycleOperatorPlan(f), world = engineWorld(f, plan);
+  const directory = await mkdtemp(path.join(path.dirname(REPOSITORY_ROOT), '.engine-operator-journal-test-')); await chmod(directory, 0o700);
+  try {
+    const prepared = await preparePublicationRequest(plan, 0, world.providers, ceilings);
+    await armJournal(directory, prepared, { evidenceClass: 'synthetic-test-only' });
+    const pending = await journalEntry(directory, plan.planDigest, 0); assert.equal(pending.state, 'wallet-requested-outcome-unknown'); assert.equal(pending.transactionHash, null);
+    await assert.rejects(armJournal(directory, prepared, {}), /exist/i);
+    const retry = await preparePublicationRetry(plan, pending, world.providers, ceilings, pending.requestDigest, 1);
+    await armRetryJournal(directory, retry, { evidenceClass: 'synthetic-test-only' }); assert.deepEqual(retry.request, pending.request);
+    const mined = await world.mine(prepared); await recordTransaction(directory, plan.planDigest, 0, mined.transactionHash);
+    const entry = await journalEntry(directory, plan.planDigest, 0), evidence = await observePublicationReceipt(plan, entry, world.providers);
+    await recordReceipt(directory, plan.planDigest, 0, evidence);
+    assert.equal(JSON.parse(await readFile(path.join(directory, `${plan.planDigest}-0.receipt.json`))).sourceKind, 'module-engine-v1');
+    await assert.rejects(recordTransaction(directory, plan.planDigest, 0, h(999999)), /different transaction/);
+    const count = world.methods.length;
+    for (const method of ['eth_sendTransaction', 'eth_sendRawTransaction', 'eth_sign', 'personal_sign', 'debug_traceCall', 'anvil_impersonateAccount']) await assert.rejects(world.providers[0].rpc(method, []), /read-only inventory/);
+    assert.equal(world.methods.length, count);
+  } finally { await rm(directory, { recursive: true, force: true }); }
+});
+
+test('Engine execution permits state-dependent results while enforcing the exact signed output minimum', async () => {
+  const { f, plan, world, entry, evidence } = await launched();
+  const next = await createEngineLifecycleOperatorPlan({ ...f, action: executeAction(f, { plan, entry, evidence }, { permission: 3 }) }); world.setPlan(next);
+  const prepared = await preparePublicationRequest(next, 0, world.providers, ceilings), execution = await world.mine(prepared), receipt = world.receipts.get(execution.transactionHash);
+  const original = receipt.logs[0].data;
+  receipt.logs[0].data = `${original.slice(0, -64)}${h(12345).slice(2)}`;
+  const observed = await observePublicationReceipt(next, execution, world.providers);
+  assert.equal(observed.operation.resultHash, h(12345)); assert.equal(observed.operation.outputAmount, '1');
+  // outputAmount is the penultimate non-indexed word; actual output below one is rejected.
+  receipt.logs[0].data = `${original.slice(0, -128)}${h(0).slice(2)}${original.slice(-64)}`;
+  await assert.rejects(observePublicationReceipt(next, execution, world.providers), /below the reviewed minimum/);
+});

--- a/contracts/scripts/module-engine/wallet-test-fixtures.mjs
+++ b/contracts/scripts/module-engine/wallet-test-fixtures.mjs
@@ -1,0 +1,164 @@
+// Explicit synthetic provider/review doubles. Never deployment, acceptance or wallet evidence.
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { decodeFunctionData, encodeAbiParameters, encodeEventTopics, encodeFunctionResult, erc20Abi, keccak256, parseAbiParameters } from 'viem';
+import { REPOSITORY_ROOT } from '../module-mode/build.mjs';
+import { canonicalJson, hexQuantity, jsonSafe, sha256 } from '../module-mode/core.mjs';
+import { publicationValidators } from '../module-mode/publication-shared.mjs';
+import { registryAbi, ZERO_ADDRESS } from '../module-mode/publication-plan.mjs';
+import { rpcClient } from '../module-mode/rpc.mjs';
+export const h = n => `0x${BigInt(n).toString(16).padStart(64, '0')}`;
+export const a = n => `0x${BigInt(n).toString(16).padStart(40, '0')}`;
+const reviewDigest = (domain, value) => `0x${sha256(canonicalJson({ domain, value }))}`;
+export async function engineWalletFixture({ initial = false, fixed = false } = {}) {
+  const frozen = JSON.parse(await readFile(path.join(REPOSITORY_ROOT, 'tests/fixtures/module-engine-review-build.json'), 'utf8'));
+  if (frozen.evidenceClass !== 'synthetic-parser-fixture-not-review-or-publication-authority') throw new Error('Synthetic fixture boundary differs');
+  const api = await publicationValidators(), source = frozen.source, artifact = frozen.artifact, buildPlan = frozen.plan, subject = frozen.subject;
+  const reviewer = a(991), actor = a(992), codes = new Map();
+  const contracts = Object.fromEntries(['host', 'registry', 'tokenFactory', 'launchPolicy', 'ledger', 'poolManager'].map((role, i) => {
+    const address = a(900 + i), runtime = `0x60${(i + 1).toString(16).padStart(2, '0')}`; codes.set(address, runtime); return [role, { address, runtimeCodeHash: keccak256(runtime) }];
+  }));
+  const base = { schemaVersion: 'programmable.module-engine.release.v1', sourceVersion: 'module-engine-v1', engineProfile: 'programmable.module-engine-solidity@1', chainId: 4663,
+    sourceCommit: '1'.repeat(40), startBlock: '1', tokenCreationCodeHash: h(994), economicsPolicyId: keccak256(new TextEncoder().encode('programmable.module-mode.native-economics.v2')),
+    finalityPolicy: 'robinhood-ethereum-finality-v1', contracts };
+  // Reuse an existing fixture's exact finality spelling, not a made-up policy authority.
+  const native = JSON.parse(await readFile(path.join(REPOSITORY_ROOT, 'config/module-mode/historical-releases.json'), 'utf8'));
+  const findPolicy = value => value && typeof value === 'object' ? value.finalityPolicy ?? Object.values(value).map(findPolicy).find(Boolean) : undefined;
+  base.finalityPolicy = findPolicy(native);
+  const identity = { ...base, releaseDigest: api.computeModuleEngineReleaseDigest(base) };
+  const quote = { address: a(0x1002), runtimeCodeHash: keccak256('0x600100'), decimals: 18 }; codes.set(quote.address, '0x600100');
+  const definition = { profile: 'programmable.module-engine-solidity@1', catalogDefinition: { id: 'operator-fixture', title: 'Synthetic engine operator', summary: 'Synthetic local test.', detail: 'Never publication authority.', version: source.descriptor.version,
+    interface: 'custom-v1', source: source.descriptor.source.files[0], schema: source.descriptor.configuration, defaults: { cap: '5' }, configurationAbi: artifact.configurationAbi, constraints: [] },
+    revision: { packageId: artifact.packageId, familyId: artifact.familyId, fixedQuoteAsset: fixed ? quote.address : ZERO_ADDRESS, fixedConfigurationHash: fixed ? artifact.cases[0].configHash : h(0),
+      initialOperationId: initial ? artifact.operationPermissions[2].operationId : h(0), executionGas: artifact.executionGas, moneyRights: artifact.moneyRights, coinRights: 0, operationPermissions: artifact.operationPermissions, eligibleFamilies: [artifact.familyId] } };
+  const manifest = api.createReviewedModuleEngineManifest({ job: { artifact, plan: buildPlan }, descriptor: source.descriptor, release: identity, definition: definition.catalogDefinition, revision: definition.revision });
+  const record = { schemaVersion: 'programmable.modules.review-decision.v1', reviewerWallet: reviewer, policyDigest: h(997), subject,
+    command: { schemaVersion: 'programmable.modules.review-command.v1', submissionId: subject.submissionId, requestDigest: subject.requestDigest, expectedReviewRevision: 2, outcome: 'accept',
+      reason: 'Synthetic operator tests only; no real authority.', artifactDigest: artifact.artifactDigest, hostManifestHash: api.computeModuleEngineHostManifestHash(manifest), acknowledgedReviewAreas: artifact.reviewRequired },
+    decidedAt: '2026-09-07T01:11:00.000Z', registryApproved: false, available: false };
+  const review = { ...record, decisionDigest: reviewDigest(record.schemaVersion, record) };
+  const bundle = { source, manifest, review, artifact, buildPlan };
+  const worker = { sourceCommit: 'a'.repeat(40), runId: '123', runAttempt: '1', workflowRef: 'programmablehq/programmable-open-hook-v2-internal/.github/workflows/protected-module-review-v1.yml@refs/heads/main' };
+  const job = { subject, state: 'accepted', reviewRevision: 3, plan: buildPlan, planDigest: artifact.planDigest, artifact, attempt: 1, lastError: null, createdAt: '2026-09-07T01:00:00.000Z', updatedAt: '2026-09-07T01:10:00.000Z' };
+  const attempt = { attempt: 1, requestDigest: subject.requestDigest, planDigest: artifact.planDigest, errorCode: null };
+  const detail = { schemaVersion: 'programmable.modules.website-review-detail.v1', job, decisions: [review], attempts: [
+    { ...attempt, event: 'claimed', artifactDigest: null, workerIdentity: { ...worker, identityDigest: reviewDigest('programmable.modules.worker-identity.v1', worker) }, createdAt: job.createdAt },
+    { ...attempt, event: 'completed', artifactDigest: artifact.artifactDigest, workerIdentity: null, createdAt: job.updatedAt },
+  ] };
+  const fakeFetch = async (url, init) => { if (!String(url).startsWith('https://programmable.market/api/admin/modules/') || init.method !== 'GET' || init.redirect !== 'error') throw new Error('Unexpected fixture HTTP authority'); return Response.json(String(url).includes('/source?') ? source : detail); };
+  const current = () => api.createAuthenticatedReviewReader({ walletAddress: reviewer, accessToken: 'synthetic_operator_test_session_1234' }, fakeFetch).read(subject.submissionId);
+  const initialOperation = initial ? { operationId: artifact.operationPermissions[2].operationId, recipient: actor, inputAsset: 'quote', inputAmount: '2', outputAsset: 'native', minimumOutput: '0', data: h(2) } : null;
+  const action = { kind: 'launch', name: 'Synthetic operator coin', symbol: 'OPTEST', description: 'Local test only.', imageUri: '', socialLinks: {}, quote,
+    configuration: { cap: '5' }, creatorSalt: h(1100), engineSalt: h(1101), launchData: '0x', creatorWallets: [actor], creatorSharesBps: [10000], buyCreatorFeeBps: 100, sellCreatorFeeBps: 100,
+    initialOperation, deadline: String(Math.floor(Date.now() / 1000) + 600), funding: { mode: initial ? 'approve' : 'none', expectedAllowance: '0' } };
+  return { api, source, artifact, bundle, definition, identity, reviewer, owner: actor, sourceState: { sourceCommit: 'a'.repeat(40), sourceTree: 'b'.repeat(40), sourceClean: false }, action, quote, codes, current, detail };
+}
+
+export function engineWorld(f, initialPlan, { published = true } = {}) {
+  const { api } = f, methods = [], pins = f.identity.contracts, host = pins.host.address;
+  let head = 256n, nextHash = 2000, currentPlan = initialPlan;
+  const initial = { family: published, revision: published, enabled: true, allowance: '0', actorNonce: {}, eoaNonce: '1', launched: null, engineRuntime: null };
+  let state = structuredClone(initial); const states = new Map(), blocks = new Map(), txs = new Map(), receipts = new Map();
+  const save = () => { const number = hexQuantity(head); states.set(number, structuredClone(state)); blocks.set(number, { number, hash: h(head), timestamp: hexQuantity(Math.floor(Date.now() / 1000)), baseFeePerGas: '0x1', transactions: [...txs].filter(([, tx]) => tx.blockNumber === number).map(([hash]) => hash) }); }; save();
+  const mutations = {};
+  const revision = api.engineRegistryRevision({ manifest: f.bundle.manifest, manifestHash: api.computeModuleEngineHostManifestHash(f.bundle.manifest) });
+  const absent = Object.fromEntries(Object.entries(revision).map(([key, v]) => [key, typeof v === 'boolean' ? false : typeof v === 'number' ? 0 : key === 'fixedQuoteAsset' ? ZERO_ADDRESS : h(0)]));
+  const lookup = block => block && block !== 'latest' && block !== 'pending' ? states.get(block) : state;
+  const expected = () => currentPlan.steps.at(-1).expectation;
+  const originalPlan = () => currentPlan.action?.kind === 'execute' ? currentPlan.action.launch.plan : currentPlan;
+  const p = () => originalPlan().steps.find(s => s.kind === 'engine-launch')?.arguments[0];
+  const result = encodeAbiParameters(parseAbiParameters('uint256'), [17n]);
+  const simulationRecord = () => ({ ...expected(), resourcesHash: mutations.resourcesHash ?? h(1999) });
+  const eventLog = (name, args, txHash, block) => {
+    const shape = api.moduleEngineHostAbi.find(item => item.type === 'event' && item.name === name), fields = shape.inputs.filter(i => !i.indexed);
+    return { address: host, data: encodeAbiParameters(fields, fields.map(i => args[i.name])), topics: encodeEventTopics({ abi: api.moduleEngineHostAbi, eventName: name, args }),
+      blockNumber: block.number, blockHash: block.hash, transactionHash: txHash, transactionIndex: '0x0', logIndex: '0x0', removed: false };
+  };
+  const rpc = async (method, params, provider) => {
+    methods.push({ method, params, provider }); if (mutations.rpc) { const value = mutations.rpc(method, params, provider); if (value !== undefined) return value; }
+    const s = lookup(method === 'eth_call' ? params[1] : method === 'eth_getCode' ? params[1] : undefined);
+    if (method === 'eth_chainId') return mutations.chain ?? '0x1237';
+    if (method === 'eth_getBlockByNumber') return params[0] === 'latest' ? blocks.get(hexQuantity(head)) : blocks.get(params[0]);
+    if (method === 'eth_getCode') {
+      if (params[0] === s.launched?.engine) return s.engineRuntime;
+      if (params[0] === s.launched?.token) return '0x601100';
+      return f.codes.get(params[0]) ?? '0x';
+    }
+    if (method === 'eth_getTransactionCount') return f.codes.has(params[0]) || [expected()?.token, expected()?.engine].includes(params[0]) ? '0x0' : hexQuantity(params[1] === 'pending' && mutations.pending ? BigInt(state.eoaNonce) + 1n : state.eoaNonce);
+    if (method === 'eth_getBalance') return mutations.balance ?? '0xffffffffffffffff';
+    if (method === 'eth_estimateGas') return mutations.gas ?? '0x186a0';
+    if (method === 'eth_getTransactionByHash') { const tx = txs.get(params[0]); return tx && mutations.tx ? { ...tx, ...mutations.tx } : tx; }
+    if (method === 'eth_getTransactionReceipt') return receipts.get(params[0]) ?? null;
+    if (method !== 'eth_call') throw new Error(`Unexpected synthetic RPC ${method}`);
+    const { to, data } = params[0]; let decoded, abi;
+    for (const candidate of [api.moduleEngineHostAbi, api.moduleEngineReadAbi, api.moduleEngineLedgerAbi, registryAbi, erc20Abi]) { try { decoded = decodeFunctionData({ abi: candidate, data }); abi = candidate; break; } catch {} }
+    if (!decoded) throw new Error('Unknown synthetic call'); const { functionName: fn, args = [] } = decoded;
+    let value;
+    if (fn === 'SOURCE_VERSION') value = api.MODULE_ENGINE_SOURCE_ID;
+    else if (['tokenFactory', 'launchPolicy', 'registry', 'ledger'].includes(fn)) value = pins[fn].address;
+    else if (fn === 'hook') value = host;
+    else if (fn === 'poolManager') value = pins.poolManager.address;
+    else if (fn === 'owner') value = mutations.registryOwner ?? f.reviewer;
+    else if (fn === 'ECONOMICS_POLICY_ID') value = f.identity.economicsPolicyId;
+    else if (fn === 'PROTOCOL_FEE_BPS') value = 10;
+    else if (fn === 'AUTHOR_POOL_FEE_BPS') value = 20;
+    else if (fn === 'families') value = s.family ? [f.source.descriptor.author, f.source.descriptor.rewardWallet] : [ZERO_ADDRESS, ZERO_ADDRESS];
+    else if (fn === 'getRevision') value = s.revision ? [{ ...revision, enabled: s.enabled }, f.artifact.engine.immutableRuntimeOffsets, f.artifact.engine.immutableConstructorOffsets, f.definition.revision.eligibleFamilies] : [absent, [], [], []];
+    else if (fn === 'permission') value = f.artifact.operationPermissions.find(p => p.operationId === args[1]);
+    else if (fn === 'getLaunch') value = s.launched;
+    else if (fn === 'launchIdOf' || fn === 'engineLaunchId') value = s.launched.launchId;
+    else if (fn === 'nonces') value = BigInt(s.actorNonce[args[1].toLowerCase()] ?? '0');
+    else if (fn === 'decimals') value = 18;
+    else if (fn === 'balanceOf') value = 1000000n;
+    else if (fn === 'allowance') value = BigInt(s.allowance);
+    else if (fn === 'approve') value = true;
+    else if (fn === 'name') value = p().name;
+    else if (fn === 'symbol') value = p().symbol;
+    else if (fn === 'creator') value = host;
+    else if (fn === 'totalSupply') value = 1000000000n * 10n ** 18n;
+    else if (fn === 'graffiti') value = keccak256(encodeAbiParameters(parseAbiParameters('string,address,bytes32'), ['programmable.module-engine.token.v1', s.launched.creator, p().creatorSalt]));
+    else if (fn === 'getUERC20Address') value = s.launched.token;
+    else if (fn === 'contextHash') value = keccak256(encodeAbiParameters(parseAbiParameters(api.ENGINE_CONTEXT), [{ host, launchId: s.launched.launchId, token: s.launched.token, creator: s.launched.creator, quoteAsset: s.launched.quoteAsset, feeCollector: host }]));
+    else if (fn === 'predictTokenAddress') value = [expected().token, keccak256(encodeAbiParameters(parseAbiParameters('string,address,bytes32'), ['programmable.module-engine.token.v1', currentPlan.owner, p().creatorSalt]))];
+    else if (fn === 'fixedConfigurationHash') value = f.definition.revision.fixedConfigurationHash;
+    else if (fn === 'platformFeeBps') value = 30;
+    else if (fn === 'feeTerms') value = [30, args[1] ? p().buyCreatorFeeBps : p().sellCreatorFeeBps];
+    else if (fn === 'creatorRecipients') value = [p().creatorWallets, p().creatorSharesBps, 0n];
+    else if (fn === 'launch') value = simulationRecord();
+    else if (fn === 'execute') value = result;
+    else if (fn === 'registerReviewedFamily') value = f.artifact.familyId;
+    else if (fn === 'approveRevision') return '0x';
+    else throw new Error(`Unhandled synthetic getter ${fn} at ${to}`);
+    return encodeFunctionResult({ abi, functionName: fn, result: value });
+  };
+  const providers = [0, 1].map(i => ({ role: i ? 'secondary' : 'primary', providerId: `synthetic-${i}`, trustDomain: `fixture-${i}.invalid`, authentication: 'fixture', endpointCommitment: `sha256:${h(i + 400).slice(2)}`,
+    rpc: rpcClient(`https://provider-${i}.invalid`, `fixture-${i}`, async (_url, init) => { const request = JSON.parse(init.body); return Response.json({ jsonrpc: '2.0', id: request.id, result: await rpc(request.method, request.params, i) }); }) }));
+  return { providers, methods, mutations, blocks, receipts, txs, get state() { return state; }, setPlan(plan) { currentPlan = plan; }, sync(advance = false) { if (advance) head++; save(); },
+    async mine(prepared, plan = currentPlan) {
+      currentPlan = plan; const step = plan.steps[prepared.stepIndex], txHash = h(nextHash++); head++;
+      state.eoaNonce = (BigInt(state.eoaNonce) + 1n).toString();
+      if (step.kind === 'engine-family') state.family = true;
+      if (step.kind === 'engine-revision') state.revision = true;
+      if (step.kind === 'engine-approve') state.allowance = step.approval.amount;
+      if (step.kind === 'engine-launch') {
+        state.launched = simulationRecord();
+        const parameters = step.arguments[0], context = { host, launchId: state.launched.launchId, token: state.launched.token, creator: plan.owner, quoteAsset: f.quote.address, feeCollector: host };
+        const constructorArgs = encodeAbiParameters(api.moduleEngineConstructorParameters, [context, parameters.configuration]);
+        state.engineRuntime = api.materializeModuleEngineRuntime(f.artifact.engine.runtimeTemplate, constructorArgs, f.artifact.engine.immutableRuntimeOffsets, f.artifact.engine.immutableConstructorOffsets);
+      }
+      const op = step.operation;
+      if (['engine-launch', 'engine-execute'].includes(step.kind) && op.operationId !== h(0)) { state.actorNonce[plan.owner] = (BigInt(op.nonce) + 1n).toString(); if (op.inputAsset !== ZERO_ADDRESS && BigInt(op.inputAmount) > 0n) state.allowance = '0'; }
+      save(); const block = blocks.get(hexQuantity(head)), tx = { ...prepared.request, input: prepared.request.data, hash: txHash, blockNumber: block.number, blockHash: block.hash };
+      txs.set(txHash, tx); block.transactions.push(txHash); const logs = [];
+      if (step.kind === 'engine-revision') logs.push(eventLog('EngineRevisionApproved', { revisionId: f.artifact.packageId, familyId: f.artifact.familyId, revision }, txHash, block));
+      if (step.kind === 'engine-launch') {
+        logs.push(eventLog('EngineLaunchBound', { ...state.launched, runtimeCodeHash: state.launched.engineCodeHash, economicsPolicyId: f.identity.economicsPolicyId }, txHash, block));
+        logs.push(eventLog('EngineLaunchParametersBound', { launchId: state.launched.launchId, encodedParameters: encodeAbiParameters(api.moduleEngineLaunchParameters, [step.arguments[0]]) }, txHash, block));
+      }
+      if (['engine-launch', 'engine-execute'].includes(step.kind) && op.operationId !== h(0)) logs.push(eventLog('EngineOperationExecuted', { ...op, nonce: BigInt(op.nonce), inputAmount: BigInt(op.inputAmount), launchId: state.launched.launchId, outputAmount: BigInt(op.minimumOutput), resultHash: keccak256(result) }, txHash, block));
+      logs.forEach((l,i) => { l.logIndex = hexQuantity(i); });
+      receipts.set(txHash, { transactionHash: txHash, blockNumber: block.number, blockHash: block.hash, status: '0x1', gasUsed: '0x186a0', transactionIndex: '0x0', logs });
+      return { ...jsonSafe(prepared), transactionHash: txHash };
+    },
+  };
+}

--- a/contracts/scripts/module-mode/lifecycle-plan.mjs
+++ b/contracts/scripts/module-mode/lifecycle-plan.mjs
@@ -18,12 +18,33 @@ export function predictLifecycleToken(identity, owner, action) {
     [action.name, action.symbol, 18, identity.contracts.launcher.address, graffiti]));
   return { token: getCreate2Address({ from: identity.contracts.tokenFactory.address, salt, bytecodeHash: identity.tokenCreationCodeHash }).toLowerCase(), graffiti };
 }
-/** Exact 9a native-hook/runtime formulas. Configuration bytes and creator fee rates are inside the recipe. */
-export function lifecycleLaunchCommitments(identity, owner, action, families, selections, token) {
+/** Released hook/runtime formulas. V2 additionally commits each selection's reviewed eligibility. */
+export function lifecycleLaunchCommitments(identity, owner, action, families, selections, token, feeEligibility = []) {
   const pins = identity.contracts;
   const poolId = keccak256(encodeAbiParameters(parseAbiParameters('address,address,uint24,int24,address'),
     ['0x0000000000000000000000000000000000000000', token, 0, 200, pins.hook.address]));
-  const recipeHash = keccak256(encodeAbiParameters(parseAbiParameters(`string,uint256,address,address,uint16,uint16,bytes32[],${SELECTIONS}`),
+  let recipeHash, economics;
+  if (identity.sourceVersion === 'module-native-v2') {
+    need(feeEligibility.length === selections.length && families.length === selections.length, 'Reviewed eligibility for every V2 selection required');
+    const reviews = new Map();
+    const selectionEligibilityHashes = feeEligibility.map((review, index) => {
+      exactKeys(review, ['eligible', 'reviewDigest'], 'Reviewed V2 fee eligibility');
+      const reviewDigest = bytes(review.reviewDigest);
+      need(typeof review.eligible === 'boolean' && reviewDigest.length === 66 && (!review.eligible || BigInt(reviewDigest) !== 0n), 'Invalid reviewed V2 fee eligibility');
+      const family = hash(families[index]);
+      if (reviews.has(family)) same(reviews.get(family), review, 'Same-family fee eligibility');
+      reviews.set(family, review);
+      return keccak256(encodeAbiParameters(parseAbiParameters('bytes32,bool,bytes32'), [family, review.eligible, review.reviewDigest]));
+    });
+    families = [...reviews.entries()].filter(([, review]) => review.eligible).map(([family]) => family).sort();
+    need(families.length <= 8 && (action.canaryKind === 'plain' ? families.length === 0 : families.length > 0), 'V2 module canary requires one to eight eligible families');
+    economics = { economicsPolicyId: identity.economicsPolicyId, protocolFeeBps: 10, authorPoolFeeBps: families.length ? 20 : 0,
+      platformFeeBps: families.length ? 30 : 10, selectionEligibilityHashes,
+      selectionEligible: feeEligibility.map(review => review.eligible), selectionReviewDigests: feeEligibility.map(review => review.reviewDigest) };
+    recipeHash = keccak256(encodeAbiParameters(parseAbiParameters(`string,uint256,address,address,bytes32,bytes32[],uint16,uint16,bytes32[],${SELECTIONS}`),
+      ['programmable.module-mode.native-recipe.v2', 4663n, pins.hook.address, pins.registry.address, identity.economicsPolicyId,
+        selectionEligibilityHashes, action.creatorFeeBps, action.creatorFeeBps, families, selections]));
+  } else recipeHash = keccak256(encodeAbiParameters(parseAbiParameters(`string,uint256,address,address,uint16,uint16,bytes32[],${SELECTIONS}`),
     ['programmable.module-mode.native-recipe.v1', 4663n, pins.hook.address, pins.registry.address, action.creatorFeeBps, action.creatorFeeBps, families, selections]));
   const programHash = keccak256(encodeAbiParameters(parseAbiParameters(`bytes32,${SELECTIONS}`), [keccak256(toHex('programmable.module-mode.native-program.v1')), selections]));
   const launchKey = keccak256(encodeAbiParameters(parseAbiParameters('bytes32,uint256,address,address,(address source,address launchWallet,address token,address poolManager,bytes32 poolId,bytes32 recipeHash,bytes32 programHash)'),
@@ -33,7 +54,7 @@ export function lifecycleLaunchCommitments(identity, owner, action, families, se
   const creatorConfigurationHash = keccak256(encodeAbiParameters(parseAbiParameters('address[],uint16[]'), [action.creatorWallets, action.creatorSharesBps]));
   return { poolId, recipeHash, programHash, launchKey, metadataHash, creatorConfigurationHash, creatorFeeBps: action.creatorFeeBps,
     creatorWallets: action.creatorWallets.map(value => address(value)), creatorSharesBps: action.creatorSharesBps,
-    selections: jsonSafe(selections), families };
+    selections: jsonSafe(selections), families, ...(economics ? economics : {}) };
 }
 /** Local consistency checks never turn receipt JSON into chain authority; the live observer re-reads this hash. */
 export async function bindLifecycleLaunchReference(reference, identity, owner, modules, canaryKind, token) {
@@ -56,11 +77,13 @@ export async function bindLifecycleLaunchReference(reference, identity, owner, m
   return step.expectation;
 }
 export async function createLifecyclePlan({ identity, owner, modules = [], action, sourceState }) {
-  await bindIdentity(identity); owner = address(owner); need(Array.isArray(modules) && modules.length <= 8, 'At most eight reviewed modules per canary');
+  await bindIdentity(identity); owner = address(owner); const v2 = identity.sourceVersion === 'module-native-v2';
+  need(Array.isArray(modules) && modules.length <= (v2 ? 16 : 8), 'Reviewed module count exceeds the native source limit');
   const checked = []; for (const input of modules) checked.push(await bindPublicationModule(input, identity, owner));
-  need(new Set(checked.map(m => m.familyId)).size === checked.length, 'Duplicate module family');
-  checked.sort((a, b) => a.familyId.localeCompare(b.familyId));
+  need(new Set(checked.map(m => v2 ? m.packageId : m.familyId)).size === checked.length, v2 ? 'Duplicate module package' : 'Duplicate module family');
+  checked.sort((a, b) => a.familyId.localeCompare(b.familyId) || a.packageId.localeCompare(b.packageId));
   const api = await publicationValidators(), pins = identity.contracts;
+  const launchAbi = api.moduleNativeLaunchAbiFor(identity), readAbi = api.moduleNativeReadAbiFor(identity);
   const preReads = checked.map(module => readCondition(pins.registry.address, registryAbi, 'getRevision', [module.packageId], {
     familyId: module.familyId, factory: module.factory, factoryCodeHash: module.factoryCodeHash, moduleCodeHash: module.moduleCodeHash,
     manifestHash: module.manifestHash, callbackGas: module.callbackGas, enabled: true,
@@ -95,20 +118,29 @@ export async function createLifecyclePlan({ identity, owner, modules = [], actio
     need(BigInt(uint(action.initialBuyNative, 'initial buy', true)) >= BigInt(identity.minimumInitialBuyNative), 'Initial buy is below the released minimum');
     uint(action.minimumTokenOut, 'minimum token output', true); uint(action.deadline, 'deadline', true);
     const predicted = predictLifecycleToken(identity, owner, action);
-    const commitments = lifecycleLaunchCommitments(identity, owner, action, checked.map(item => item.familyId), selections, predicted.token);
+    const commitments = lifecycleLaunchCommitments(identity, owner, action, checked.map(item => item.familyId), selections, predicted.token, checked.map(item => item.feeEligibility));
+    if (v2) {
+      for (const family of new Set(checked.map(item => item.familyId))) {
+        const review = checked.find(item => item.familyId === family).feeEligibility;
+        preReads.push(readCondition(pins.registry.address, readAbi, 'familyFeeEligibility', [family], [review.eligible, review.reviewDigest]));
+      }
+      preReads.push(readCondition(pins.hook.address, readAbi, 'previewRecipe', [action.creatorFeeBps, action.creatorFeeBps, selections], [commitments.recipeHash, commitments.families]));
+    }
     const parameters = { name: action.name, symbol: action.symbol, buyCreatorFeeBps: action.creatorFeeBps, sellCreatorFeeBps: action.creatorFeeBps,
       creatorSalt: action.creatorSalt, metadata: action.metadata, creatorWallets: action.creatorWallets, creatorSharesBps: action.creatorSharesBps,
-      modules: selections, moduleFunding: funding, initialBuyNative: BigInt(action.initialBuyNative), minimumInitialTokenOut: BigInt(action.minimumTokenOut), deadline: BigInt(action.deadline) };
+      modules: selections, moduleFunding: funding, initialBuyNative: BigInt(action.initialBuyNative), minimumInitialTokenOut: BigInt(action.minimumTokenOut), deadline: BigInt(action.deadline),
+      ...(v2 ? { expectedRecipeHash: commitments.recipeHash } : {}) };
     step = { kind: 'launch', label: `Launch ${action.canaryKind} canary ${action.name}`, sender: owner, to: pins.launcher.address,
       value: (BigInt(action.initialBuyNative) + funding.reduce((a, b) => a + b, 0n)).toString(), target: predicted.token, functionName: 'launch', arguments: jsonSafe(parameters),
-      data: encodeFunctionData({ abi: api.moduleNativeLaunchAbi, functionName: 'launch', args: [parameters] }),
-      result: null, preReads: [...preReads, readCondition(pins.launcher.address, api.moduleNativeLaunchAbi, 'predictTokenAddress', [action.name, action.symbol, owner, action.creatorSalt], [predicted.token, predicted.graffiti])],
+      data: encodeFunctionData({ abi: launchAbi, functionName: 'launch', args: [parameters] }),
+      result: null, preReads: [...preReads, readCondition(pins.launcher.address, launchAbi, 'predictTokenAddress', [action.name, action.symbol, owner, action.creatorSalt], [predicted.token, predicted.graffiti])],
       postReads: [], newCode: [], requiredCode, deadline: action.deadline,
       expectation: { ...commitments, fundingHash: keccak256(encodeAbiParameters(parseAbiParameters('uint256[]'), [funding])), totalFunding: funding.reduce((a, b) => a + b, 0n).toString(), canaryKind: action.canaryKind, token: predicted.token, initialBuyNative: action.initialBuyNative, minimumTokenOut: action.minimumTokenOut } };
-  } else if (['buy', 'approve', 'sell'].includes(action.kind)) {
-    exactKeys(action, action.kind === 'approve' ? ['kind', 'canaryKind', 'token', 'amount', 'tokenCodeHash', 'launch'] : ['kind', 'canaryKind', 'token', 'amount', 'minimumOut', 'deadline', 'tokenCodeHash', 'launch'], 'Trade action');
+  } else if (['buy', 'approve', 'sell', ...(v2 ? ['buyExactOutput', 'sellExactOutput'] : [])].includes(action.kind)) {
+    const exactOutput = action.kind.endsWith('ExactOutput'), isBuy = action.kind.startsWith('buy');
+    exactKeys(action, action.kind === 'approve' ? ['kind', 'canaryKind', 'token', 'amount', 'tokenCodeHash', 'launch'] : ['kind', 'canaryKind', 'token', 'amount', exactOutput ? 'maximumInput' : 'minimumOut', 'deadline', 'tokenCodeHash', 'launch'], 'Trade action');
     need(['plain', 'modules'].includes(action.canaryKind) && (action.canaryKind === 'plain' ? checked.length === 0 : checked.length > 0), 'Trade canary kind differs from modules');
-    const token = address(action.token), amount = BigInt(uint(action.amount, 'exact input amount', true));
+    const token = address(action.token), amount = BigInt(uint(action.amount, exactOutput ? 'exact output amount' : 'exact input amount', true));
     const launchExpectation = await bindLifecycleLaunchReference(action.launch, identity, owner, modules, action.canaryKind, token);
     need(amount < 1n << 127n, 'Amount exceeds native engine amount bound'); requiredCode.push({ address: token, runtimeCodeHash: hash(action.tokenCodeHash) });
     if (action.kind === 'approve') {
@@ -116,16 +148,18 @@ export async function createLifecyclePlan({ identity, owner, modules = [], actio
       step = { kind: 'approve', label: `Approve exactly ${amount} token units for the native router`, sender: owner, to: token, value: '0', target: token,
         functionName: 'approve', arguments: jsonSafe(args), data: encodeFunctionData({ abi: api.moduleNativeApprovalAbi, functionName: 'approve', args }),
         result: encodeFunctionResult({ abi: api.moduleNativeApprovalAbi, functionName: 'approve', result: true }), preReads, requiredCode, newCode: [],
-        postReads: [readCondition(token, api.moduleNativeReadAbi, 'allowance', [owner, pins.swapRouter.address], amount)], expectation: { ...launchExpectation, token, canaryKind: action.canaryKind } };
+        postReads: [readCondition(token, readAbi, 'allowance', [owner, pins.swapRouter.address], amount)], expectation: { ...launchExpectation, token, canaryKind: action.canaryKind } };
     } else {
-      uint(action.minimumOut, 'minimum output', true); uint(action.deadline, 'deadline', true);
-      const args = [token, action.kind === 'buy', -amount, BigInt(action.minimumOut), owner, BigInt(action.deadline)];
-      step = { kind: action.kind, label: `${action.kind === 'buy' ? 'Buy' : 'Sell'} ${action.canaryKind} canary`, sender: owner, to: pins.swapRouter.address,
-        value: action.kind === 'buy' ? amount.toString() : '0', target: token, functionName: 'swap', arguments: jsonSafe(args),
+      const limit = uint(exactOutput ? action.maximumInput : action.minimumOut, exactOutput ? 'maximum input' : 'minimum output', true); uint(action.deadline, 'deadline', true);
+      if (exactOutput) need(BigInt(limit) < 1n << 127n, 'Maximum input exceeds native engine amount bound');
+      const args = [token, isBuy, exactOutput ? amount : -amount, BigInt(limit), owner, BigInt(action.deadline)];
+      step = { kind: action.kind, label: `${isBuy ? 'Buy' : 'Sell'} ${action.canaryKind} canary${exactOutput ? ' with exact output' : ''}`, sender: owner, to: pins.swapRouter.address,
+        value: isBuy ? (exactOutput ? limit : amount.toString()) : '0', target: token, functionName: 'swap', arguments: jsonSafe(args),
         data: encodeFunctionData({ abi: api.moduleNativeRouterAbi, functionName: 'swap', args }), result: null, preReads, postReads: [], newCode: [], requiredCode,
-        deadline: action.deadline, expectation: { ...launchExpectation, token, canaryKind: action.canaryKind, amount: amount.toString(), minimumOut: action.minimumOut } };
+        deadline: action.deadline, expectation: { ...launchExpectation, token, canaryKind: action.canaryKind, amount: amount.toString(),
+          ...(exactOutput ? { maximumInput: limit } : { minimumOut: action.minimumOut }) } };
     }
-  } else throw new Error('Only native launch, buy, exact approval and sell operations are supported');
+  } else throw new Error('Unsupported native lifecycle operation for this source version');
   const body = { schemaVersion: LIFECYCLE_OPERATOR_SCHEMA, chainId: 4663, sourceCommit: sourceState.sourceCommit, sourceTree: sourceState.sourceTree,
     sourceClean: sourceState.sourceClean, identity, owner, modules, action, steps: [step] };
   return { ...body, planDigest: digest(LIFECYCLE_OPERATOR_SCHEMA, body) };

--- a/contracts/scripts/module-mode/lifecycle-plan.test.mjs
+++ b/contracts/scripts/module-mode/lifecycle-plan.test.mjs
@@ -1,11 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { decodeFunctionData, encodeAbiParameters, encodeFunctionResult, encodeFunctionData, keccak256, parseAbi, parseAbiParameters } from 'viem';
+import { decodeFunctionData, encodeAbiParameters, encodeFunctionResult, encodeFunctionData, keccak256, parseAbi, parseAbiParameters, toHex } from 'viem';
 import { hexQuantity } from './core.mjs';
-import { createLifecyclePlan, assertLifecyclePlan, createLifecycleCollectorPlan, bindLifecycleLaunchReference } from './lifecycle-plan.mjs';
+import { createLifecyclePlan, assertLifecyclePlan, createLifecycleCollectorPlan, bindLifecycleLaunchReference, lifecycleLaunchCommitments } from './lifecycle-plan.mjs';
 import { publicationFixture, launchAction } from './publication-test-fixtures.mjs';
+import { publicationV2Fixture, nativeLaunchReference, lifecycleV2RpcFixture } from './lifecycle-v2-test-fixtures.mjs';
 import { publicationValidators } from './publication-shared.mjs';
-import { observePublicationOperation } from './publication-rpc.mjs';
+import { observePublicationOperation, preparePublicationRequest, observePublicationReceipt, revalidatePublicationRequest } from './publication-rpc.mjs';
 import { registryAbi } from './publication-plan.mjs';
 const h = n => `0x${n.toString(16).padStart(64, '0')}`;
 async function launchReference(f, selected = false, changes = {}) {
@@ -186,4 +187,136 @@ test('collector plan includes only actual bound distinct operation receipt recor
   canaries[1].buy.evidence.transaction.hash = canaries[0].buy.evidence.transaction.hash;
   assert.throws(() => createLifecycleCollectorPlan(f.identity, canaries), /Duplicate/);
   canaries[0].launch.evidence.status = 'pending'; assert.throws(() => createLifecycleCollectorPlan(f.identity, canaries), /Actual bound/);
+});
+
+const v2Ceilings = { maxGas: '2000000', maxFeePerGas: '1000', maxPriorityFeePerGas: '10', maxValue: '1000000000000000' };
+
+test('V2 plain launch uses the released selector and preview-bound 10/0 recipe, keeping contract source distinct', async () => {
+  const f = await publicationV2Fixture(), api = await publicationValidators(), action = launchAction(f);
+  const plan = await createLifecyclePlan({ ...f, modules: [], action, sourceState: { ...f.sourceState, sourceCommit: 'c'.repeat(40) } });
+  await assertLifecyclePlan(plan);
+  const step = plan.steps[0], call = decodeFunctionData({ abi: api.moduleNativeLaunchAbiFor(f.identity), data: step.data });
+  assert.equal(call.functionName, 'launch'); assert.equal(call.args[0].expectedRecipeHash, step.expectation.recipeHash);
+  assert.equal(step.expectation.platformFeeBps, 10); assert.equal(step.expectation.authorPoolFeeBps, 0);
+  assert.deepEqual(step.expectation.selectionEligibilityHashes, []); assert.deepEqual(step.expectation.families, []);
+  const expected = keccak256(encodeAbiParameters(parseAbiParameters('string,uint256,address,address,bytes32,bytes32[],uint16,uint16,bytes32[],(bytes32 packageId,address factory,bytes32 factoryCodeHash,bytes32 moduleCodeHash,uint32 callbackGas,bytes config)[]'),
+    ['programmable.module-mode.native-recipe.v2', 4663n, f.identity.contracts.hook.address, f.identity.contracts.registry.address,
+      keccak256(toHex('programmable.module-mode.native-economics.v2')), [], 0, 0, [], []]));
+  assert.equal(step.expectation.recipeHash, expected);
+  assert.equal(step.preReads.filter(read => read.functionName === 'previewRecipe').length, 1);
+  assert.equal(plan.sourceCommit, 'c'.repeat(40)); assert.equal(plan.identity.sourceCommit, f.identity.sourceCommit);
+  const legacy = await publicationFixture(), old = await createLifecyclePlan({ ...legacy, modules: [], action: launchAction(legacy) });
+  assert.notEqual(step.data.slice(0, 10), old.steps[0].data.slice(0, 10));
+  const changed = structuredClone(plan); changed.steps[0].arguments.expectedRecipeHash = h(99);
+  await assert.rejects(assertLifecyclePlan(changed), /plan differs/);
+});
+
+test('V2 module recipe commits the accepted eligibility digest and rejects an unaccepted or ineligible replacement', async () => {
+  const f = await publicationV2Fixture(), plan = await createLifecyclePlan({ ...f, modules: [f.module], action: launchAction(f, true) });
+  await assertLifecyclePlan(plan);
+  const step = plan.steps[0], review = f.module.manifest.manifest.runtimeBinding.feeEligibility;
+  assert.deepEqual(step.expectation.selectionEligible, [true]);
+  assert.deepEqual(step.expectation.selectionReviewDigests, [review.reviewDigest]);
+  assert.deepEqual(step.expectation.selectionEligibilityHashes, [keccak256(encodeAbiParameters(parseAbiParameters('bytes32,bool,bytes32'), [f.artifact.familyId, true, review.reviewDigest]))]);
+  assert.deepEqual(step.expectation.families, [f.artifact.familyId]); assert.equal(step.expectation.platformFeeBps, 30);
+  assert.equal(step.preReads.filter(read => read.functionName === 'familyFeeEligibility').length, 1);
+  const tampered = structuredClone(f.module); tampered.manifest.manifest.runtimeBinding.feeEligibility.reviewDigest = h(999);
+  await assert.rejects(createLifecyclePlan({ ...f, modules: [tampered], action: launchAction(f, true) }));
+  const changed = await publicationV2Fixture({ eligible: true, reviewDigest: h(908) });
+  const changedPlan = await createLifecyclePlan({ ...changed, modules: [changed.module], action: launchAction(changed, true) });
+  assert.notEqual(changedPlan.steps[0].expectation.recipeHash, step.expectation.recipeHash);
+  const rejected = await publicationV2Fixture({ eligible: false, reviewDigest: h(0) });
+  await assert.rejects(createLifecyclePlan({ ...rejected, modules: [rejected.module], action: launchAction(rejected, true) }), /eligible families/);
+});
+
+test('V2 per-selection reviews deduplicate eligible families without losing repeated-family commitments', async () => {
+  const f = await publicationV2Fixture(), launch = await nativeLaunchReference(f, true), step = launch.plan.steps[0];
+  const family = f.artifact.familyId, review = f.module.manifest.manifest.runtimeBinding.feeEligibility;
+  const selections = [step.expectation.selections[0], { ...step.expectation.selections[0], packageId: h(55), config: '0x1234' }];
+  const commitment = lifecycleLaunchCommitments(f.identity, f.owner, launch.plan.action, [family, family], selections, step.target, [review, review]);
+  assert.deepEqual(commitment.families, [family]); assert.deepEqual(commitment.selectionEligible, [true, true]);
+  assert.equal(commitment.selectionEligibilityHashes.length, 2); assert.equal(commitment.authorPoolFeeBps, 20);
+  assert.notEqual(commitment.recipeHash, step.expectation.recipeHash);
+  assert.throws(() => lifecycleLaunchCommitments(f.identity, f.owner, launch.plan.action, [family, family], selections, step.target,
+    [review, { eligible: false, reviewDigest: h(909) }]), /Same-family fee eligibility/);
+  assert.throws(() => lifecycleLaunchCommitments(f.identity, f.owner, launch.plan.action, [family], [selections[0]], step.target,
+    [{ eligible: true, reviewDigest: h(0) }]), /Invalid reviewed/);
+});
+
+test('V2 launch preparation and revalidation enforce independent policy and the same reviewed preview', async () => {
+  const fixture = await lifecycleV2RpcFixture('launch', true);
+  const prepared = await preparePublicationRequest(fixture.plan, 0, fixture.providers, v2Ceilings);
+  for (const [fault, message] of [['policy', /economics policy/], ['protocol', /economics rates/], ['authors', /economics rates/],
+    ['eligibility-pre', /familyFeeEligibility binding/], ['preview-recipe', /previewRecipe binding/]]) {
+    fixture.faults.add(fault);
+    await assert.rejects(revalidatePublicationRequest(fixture.plan, prepared, fixture.providers, v2Ceilings), message);
+    fixture.faults.delete(fault);
+  }
+  const api = await publicationValidators(), selector = encodeFunctionData({ abi: api.moduleNativeReadV2Abi, functionName: 'ECONOMICS_POLICY_ID' });
+  for (const role of ['launcher', 'hook', 'swapRouter', 'rewardLedger']) {
+    const calls = fixture.reads.filter(read => read.method === 'eth_call' && read.params[0].to === fixture.plan.identity.contracts[role].address && read.params[0].data === selector);
+    assert.ok(calls.length >= 2 && calls.every(call => call.params[1] === '0x110'));
+  }
+});
+
+for (const kind of ['buy', 'sell', 'buyExactOutput', 'sellExactOutput']) test(`V2 ${kind} binds funding, exact side, output bounds and actual trade receipt`, async () => {
+  const fixture = await lifecycleV2RpcFixture(kind), { plan, providers } = fixture, api = await publicationValidators();
+  const exactOutput = kind.endsWith('ExactOutput'), isBuy = kind.startsWith('buy');
+  const decoded = decodeFunctionData({ abi: api.moduleNativeRouterAbi, data: plan.steps[0].data });
+  assert.equal(decoded.args[1], isBuy); assert.equal(decoded.args[2], exactOutput ? 10000n : -10000n);
+  assert.equal(decoded.args[3], exactOutput ? 20000n : 20n); assert.equal(decoded.args[4].toLowerCase(), plan.owner);
+  assert.equal(plan.steps[0].value, isBuy ? exactOutput ? '20000' : '10000' : '0');
+  const prepared = await preparePublicationRequest(plan, 0, providers, v2Ceilings);
+  if (exactOutput) {
+    assert.equal(prepared.observation.simulatedResult.maximumInput, '20000');
+    assert.equal(prepared.observation.simulatedResult.refundNative, isBuy ? '5000' : '0');
+  }
+  const entry = fixture.include(prepared), evidence = await observePublicationReceipt(plan, entry, providers);
+  assert.equal(evidence.status, 'included-code-verified-unfinalized');
+  if (exactOutput) assert.equal(evidence.trade.refundNative, isBuy ? '5000' : '0');
+  for (const [paid, received] of exactOutput ? [[20001n, 10000n], [15000n, 9999n], [15000n, 10001n], [0n, 10000n]] : [[9999n, 100n], [10000n, 19n]]) {
+    fixture.setAmounts(paid, received);
+    await assert.rejects(observePublicationOperation(plan, 0, providers), /Swap amounts differ/);
+    await assert.rejects(observePublicationReceipt(plan, entry, providers), /Swap amounts differ/);
+  }
+  fixture.setAmounts(exactOutput ? 15000n : 10000n, exactOutput ? 10000n : 100n);
+  for (const fault of ['event-sign', 'event-side', 'event-recipient']) {
+    fixture.faults.add(fault); await assert.rejects(observePublicationReceipt(plan, entry, providers), /Trade event identity|Swap amounts differ/); fixture.faults.delete(fault);
+  }
+});
+
+test('V2 maximum input is explicit and bounded; V1 exact-output requests remain rejected', async () => {
+  const f = await publicationV2Fixture(), launch = await nativeLaunchReference(f);
+  const action = { kind: 'buyExactOutput', canaryKind: 'plain', token: launch.plan.steps[0].target, tokenCodeHash: h(7),
+    amount: '10000', maximumInput: '20000', deadline: launch.plan.action.deadline, launch };
+  for (const maximumInput of ['0', (1n << 127n).toString()]) await assert.rejects(createLifecyclePlan({ ...f, modules: [], action: { ...action, maximumInput } }), /maximum input|Maximum input/);
+  const wrongField = { ...action, minimumOut: '1' }; delete wrongField.maximumInput;
+  await assert.rejects(createLifecyclePlan({ ...f, modules: [], action: wrongField }), /Trade action/);
+  const legacy = await publicationFixture();
+  await assert.rejects(createLifecyclePlan({ ...legacy, modules: [], action }), /Unsupported native lifecycle/);
+});
+
+test('V2 receipt binds the exact eligibility event and immutable pool/ledger snapshot for both canaries', async () => {
+  for (const selected of [false, true]) {
+    const fixture = await lifecycleV2RpcFixture('launch', selected), { plan, providers } = fixture;
+    const prepared = await preparePublicationRequest(plan, 0, providers, v2Ceilings), entry = fixture.include(prepared);
+    assert.equal((await observePublicationReceipt(plan, entry, providers)).status, 'included-code-verified-unfinalized');
+    for (const [fault, message] of [['missing-economics', /exactly one NativeEconomicsBound/], ['duplicate-economics', /exactly one NativeEconomicsBound/],
+      ['event-policy', /economics event/], ['event-protocol', /economics event/], ['event-authors', /economics event/], ['event-families', /economics event/],
+      ['event-eligible', /economics event/], ['event-review', /economics event/], ['pool-fee', /pool or ledger fee/], ['ledger-fee', /pool or ledger fee/],
+      ['snapshot-eligible', /eligibility snapshot/], ['snapshot-review', /eligibility snapshot/], ['components', /fee components/], ['protocol-pips', /fee components/], ['lp-pips', /fee components/]]) {
+      fixture.faults.add(fault); await assert.rejects(observePublicationReceipt(plan, entry, providers), message); fixture.faults.delete(fault);
+    }
+  }
+});
+
+test('V2 subsequent trades keep the launch eligibility snapshot and exact sell approval', async () => {
+  const fixture = await lifecycleV2RpcFixture('approve', true), { plan, providers } = fixture, api = await publicationValidators();
+  const decoded = decodeFunctionData({ abi: api.moduleNativeApprovalAbi, data: plan.steps[0].data });
+  assert.deepEqual(decoded.args, [plan.identity.contracts.swapRouter.address, 10000n]);
+  assert.equal(plan.steps[0].value, '0');
+  assert.equal(plan.steps[0].preReads.filter(read => ['familyFeeEligibility', 'previewRecipe'].includes(read.functionName)).length, 0);
+  const prepared = await preparePublicationRequest(plan, 0, providers, v2Ceilings), entry = fixture.include(prepared);
+  assert.equal((await observePublicationReceipt(plan, entry, providers)).status, 'included-code-verified-unfinalized');
+  fixture.faults.add('snapshot-review'); await assert.rejects(observePublicationReceipt(plan, entry, providers), /eligibility snapshot/);
 });

--- a/contracts/scripts/module-mode/lifecycle-v2-test-fixtures.mjs
+++ b/contracts/scripts/module-mode/lifecycle-v2-test-fixtures.mjs
@@ -1,0 +1,133 @@
+// Synthetic parser/RPC fixtures only. No chain, reviewer, deployment or lifecycle authority.
+import { decodeFunctionData, encodeAbiParameters, encodeEventTopics, encodeFunctionResult, getAbiItem, keccak256, parseAbi } from 'viem';
+import { hexQuantity } from './core.mjs';
+import { publicationFixture, launchAction } from './publication-test-fixtures.mjs';
+import { publicationValidators } from './publication-shared.mjs';
+import { createLifecyclePlan } from './lifecycle-plan.mjs';
+import { registryAbi } from './publication-plan.mjs';
+export const h = n => `0x${n.toString(16).padStart(64, '0')}`;
+const stateAbi = parseAbi([
+  'function creatorRecipients(bytes32 poolId) view returns (address[] wallets,uint16[] sharesBps,uint256 adminRevision)',
+  'function instances(bytes32 launchKey) view returns ((bytes32 instanceId,bytes32 packageId,bytes32 configHash,address factory,bytes32 factoryCodeHash,address module,bytes32 moduleCodeHash,uint32 callbackGas)[])',
+  'function launchBinding(bytes32 launchKey) view returns ((address source,address launchWallet,address token,address poolManager,bytes32 poolId,bytes32 recipeHash,bytes32 programHash))',
+]);
+export async function publicationV2Fixture(feeEligibility = { eligible: true, reviewDigest: h(907) }) {
+  return publicationFixture(feeEligibility);
+}
+export async function nativeLaunchReference(f, selected = false) {
+  const plan = await createLifecyclePlan({ ...f, modules: selected ? [f.module] : [], action: launchAction(f, selected) }), step = plan.steps[0];
+  const transaction = { hash: h(100), from: f.owner, to: step.to, input: step.data, value: hexQuantity(step.value), nonce: '0x1', chainId: '0x1237', type: '0x2',
+    gas: '0x100000', maxFeePerGas: '0x3e8', maxPriorityFeePerGas: '0xa', blockHash: h(200), blockNumber: '0x100' };
+  const receipt = { transactionHash: transaction.hash, blockHash: transaction.blockHash, blockNumber: transaction.blockNumber, status: '0x1', gasUsed: '0x80000', transactionIndex: '0x0', logs: [] };
+  return { plan, evidence: { status: 'included-code-verified-unfinalized', chainId: 4663, planDigest: plan.planDigest, releaseDigest: f.identity.releaseDigest,
+    stepIndex: 0, kind: 'launch', transaction, receipt } };
+}
+export async function lifecycleV2RpcFixture(kind = 'launch', selected = false) {
+  const f = await publicationV2Fixture(), api = await publicationValidators(), runtime = '0x600100';
+  const launch = await nativeLaunchReference(f, selected);
+  const exactOutput = kind.endsWith('ExactOutput'), isBuy = kind === 'launch' || kind.startsWith('buy');
+  const action = kind === 'launch' ? launch.plan.action : { kind, canaryKind: selected ? 'modules' : 'plain', token: launch.plan.steps[0].target, launch,
+    tokenCodeHash: keccak256(runtime), amount: '10000',
+    ...(kind === 'approve' ? {} : { [exactOutput ? 'maximumInput' : 'minimumOut']: exactOutput ? '20000' : '20', deadline: launch.plan.action.deadline }) };
+  const originalPlan = kind === 'launch' ? launch.plan : await createLifecyclePlan({ ...f, modules: selected ? [f.module] : [], action });
+  // Observation fixtures substitute only their synthetic runtime pins; no source authority is claimed.
+  const plan = structuredClone(originalPlan);
+  for (const pin of Object.values(plan.identity.contracts)) pin.runtimeCodeHash = keccak256(runtime);
+  const pins = plan.identity.contracts, step = plan.steps[0], expected = step.expectation, faults = new Set(), reads = [];
+  let request, included = false, input = exactOutput ? 15000n : kind === 'launch' ? BigInt(expected.initialBuyNative) : 10000n;
+  let output = exactOutput ? 10000n : kind === 'launch' ? 2000n : 100n;
+  const latest = { number: '0x110', hash: h(210), timestamp: hexQuantity(Math.floor(Date.now() / 1000)), baseFeePerGas: '0x1' };
+  const mined = { ...latest, number: '0x111', hash: h(211) }, txHash = h(101);
+  const nativeRecord = { launchId: h(300), launchWallet: f.owner, token: step.target, poolId: expected.poolId, recipeHash: expected.recipeHash,
+    hook: pins.hook.address, positionRecipient: f.owner, positionTokenId: 1n, initialBuyNative: BigInt(expected.initialBuyNative),
+    initialBuyTokens: 2000n, runtime: pins.runtime.address, launchKey: expected.launchKey };
+  const instances = expected.selections.map((selection, index) => ({ instanceId: h(index + 501), packageId: selection.packageId, configHash: keccak256(selection.config),
+    factory: selection.factory, factoryCodeHash: selection.factoryCodeHash, module: `0x${(index + 701).toString(16).padStart(40, '0')}`,
+    moduleCodeHash: selection.moduleCodeHash, callbackGas: selection.callbackGas }));
+  const log = (emitter, abi, eventName, args, index) => {
+    const event = getAbiItem({ abi, name: eventName }), values = event.inputs.filter(item => !item.indexed);
+    return { address: emitter, topics: encodeEventTopics({ abi, eventName, args }), data: encodeAbiParameters(values, values.map(item => args[item.name])),
+      transactionHash: txHash, blockHash: mined.hash, blockNumber: mined.number, transactionIndex: '0x0', logIndex: hexQuantity(index), removed: false };
+  };
+  const receipt = () => {
+    const logs = [], add = (emitter, abi, name, args) => logs.push(log(emitter, abi, name, args, logs.length));
+    if (kind === 'launch') {
+      add(pins.launcher.address, api.moduleNativeLaunchAbiFor(plan.identity), 'ModuleNativeConfigurationBound', {
+        launchId: nativeRecord.launchId, metadataHash: expected.metadataHash, creatorConfigurationHash: expected.creatorConfigurationHash, economicsHash: h(303) });
+      add(pins.launcher.address, api.moduleNativeLaunchAbiFor(plan.identity), 'ModuleNativeProgramBound', {
+        launchId: nativeRecord.launchId, launchKey: expected.launchKey, runtime: pins.runtime.address, fundingHash: expected.fundingHash, totalFunding: BigInt(expected.totalFunding) });
+      if (!faults.has('missing-economics')) add(pins.hook.address, api.moduleNativeReadV2Abi, 'NativeEconomicsBound', {
+        poolId: expected.poolId, economicsPolicyId: faults.has('event-policy') ? h(777) : plan.identity.economicsPolicyId,
+        protocolFeeBps: faults.has('event-protocol') ? 20 : 10, authorPoolFeeBps: faults.has('event-authors') ? 10 : expected.authorPoolFeeBps,
+        eligibleFamilies: faults.has('event-families') ? [h(778)] : expected.families,
+        selectionEligible: faults.has('event-eligible') ? [false] : expected.selectionEligible,
+        selectionReviewDigests: faults.has('event-review') ? [h(779)] : expected.selectionReviewDigests });
+      if (faults.has('duplicate-economics')) logs.push({ ...logs[2], logIndex: hexQuantity(logs.length) });
+    }
+    if (kind !== 'approve') add(pins.swapRouter.address, api.moduleNativeRouterAbi, 'NativeTradeCompleted', {
+      poolId: expected.poolId, actor: f.owner, recipient: faults.has('event-recipient') ? pins.registry.address : f.owner,
+      isBuy: faults.has('event-side') ? !isBuy : isBuy, amountSpecified: faults.has('event-sign') ? (exactOutput ? -10000n : 10000n)
+        : exactOutput ? 10000n : kind === 'launch' ? -BigInt(expected.initialBuyNative) : -10000n,
+      nativeAmount: isBuy ? input : output, tokenAmount: isBuy ? output : input });
+    return { transactionHash: txHash, blockHash: mined.hash, blockNumber: mined.number, status: '0x1', gasUsed: '0x10000', transactionIndex: '0x0', logs };
+  };
+  const rpc = async (method, params) => {
+    reads.push({ method, params });
+    if (method === 'eth_chainId') return '0x1237';
+    if (method === 'eth_getBlockByNumber') {
+      if (params[0] === '0x100') return { ...latest, number: '0x100', hash: launch.evidence.transaction.blockHash, transactions: [launch.evidence.transaction.hash] };
+      return { ...(params[0] === '0x111' ? mined : latest), transactions: params[0] === '0x111' ? [txHash] : [] };
+    }
+    if (method === 'eth_getTransactionByHash') {
+      if (params[0] === launch.evidence.transaction.hash) return launch.evidence.transaction;
+      return { ...request, hash: txHash, input: request.data, blockHash: mined.hash, blockNumber: mined.number };
+    }
+    if (method === 'eth_getTransactionReceipt') return params[0] === launch.evidence.transaction.hash ? launch.evidence.receipt : receipt();
+    if (method === 'eth_getCode') {
+      if (params[0] === f.owner || (kind === 'launch' && params[0] === step.target && !included)) return '0x';
+      if (params[0] === expected.selections[0]?.factory) return f.artifact.factory.runtimeBytecode;
+      if (params[0] === instances[0]?.module) return f.artifact.program.runtimeBytecode;
+      return runtime;
+    }
+    if (method === 'eth_getTransactionCount') return params[0] === step.target ? '0x0' : '0x2';
+    if (method === 'eth_getBalance') return '0xffffffffffffffff';
+    if (method === 'eth_estimateGas') return '0x186a0';
+    if (method === 'eth_call') {
+      const { to, data } = params[0];
+      if (data === step.data) {
+        if (kind === 'launch') return encodeFunctionResult({ abi: api.moduleNativeLaunchAbiFor(plan.identity), functionName: 'launch', result: nativeRecord });
+        if (kind === 'approve') return step.result;
+        return encodeFunctionResult({ abi: api.moduleNativeRouterAbi, functionName: 'swap', result: isBuy ? [input, output] : [output, input] });
+      }
+      const condition = [...step.preReads, ...step.postReads].find(value => value.data === data && value.to === to);
+      if (condition) {
+        if (faults.has('eligibility-pre') && condition.functionName === 'familyFeeEligibility') return '0x00';
+        if (faults.has('preview-recipe') && condition.functionName === 'previewRecipe') return '0x00';
+        return condition.result;
+      }
+      const abi = [...api.moduleNativeReadV2Abi, ...api.moduleNativeLaunchAbiFor(plan.identity), ...stateAbi, ...registryAbi];
+      const decoded = decodeFunctionData({ abi, data }), fn = decoded.functionName;
+      const respond = result => encodeFunctionResult({ abi, functionName: fn, result });
+      if (fn === 'owner') return respond(f.owner);
+      if (fn === 'ECONOMICS_POLICY_ID') return respond(faults.has('policy') ? h(790) : plan.identity.economicsPolicyId);
+      if (fn === 'PROTOCOL_FEE_BPS') return respond(faults.has('protocol') ? 20 : 10);
+      if (fn === 'AUTHOR_POOL_FEE_BPS') return respond(faults.has('authors') ? 10 : 20);
+      if (fn === 'getLaunch') return respond(nativeRecord);
+      if (fn === 'poolConfig') return respond([pins.launcher.address, f.owner, pins.swapRouter.address, pins.swapRouter.runtimeCodeHash,
+        expected.creatorFeeBps, expected.creatorFeeBps, expected.recipeHash, expected.launchKey, faults.has('pool-fee') ? 20 : expected.platformFeeBps]);
+      if (fn === 'platformFeeBps') return respond(faults.has('ledger-fee') ? 20 : expected.platformFeeBps);
+      if (fn === 'eligibilitySnapshot') return respond([faults.has('snapshot-eligible') ? [false] : expected.selectionEligible,
+        faults.has('snapshot-review') ? [h(792)] : expected.selectionReviewDigests]);
+      if (fn === 'feeComponents') return respond([expected.creatorFeeBps, faults.has('components') ? 20 : expected.platformFeeBps, faults.has('protocol-pips') ? 1001 : 0, faults.has('lp-pips') ? 1 : 0]);
+      if (fn === 'launchBinding') return respond({ source: pins.launcher.address, launchWallet: f.owner,
+        token: step.target, poolManager: pins.poolManager.address, poolId: expected.poolId, recipeHash: expected.recipeHash, programHash: expected.programHash });
+      if (fn === 'instances') return respond(instances);
+      if (fn === 'creatorRecipients') return respond([expected.creatorWallets, expected.creatorSharesBps, 0n]);
+    }
+    throw new Error('Unexpected synthetic V2 lifecycle read');
+  };
+  const providers = [0, 1].map(i => ({ providerId: `native-v2-${i}`, trustDomain: `native-v2-${i}.invalid`, role: i ? 'secondary' : 'primary',
+    authentication: 'fixture', endpointCommitment: `sha256:${h(80 + i).slice(2)}`, rpc }));
+  return { f, plan, providers, faults, reads, txHash, originalPlan, setAmounts(paid, received) { input = paid; output = received; },
+    include(prepared) { request = prepared.request; included = true; return { ...prepared, transactionHash: txHash }; } };
+}

--- a/contracts/scripts/module-mode/publication-operator.mjs
+++ b/contracts/scripts/module-mode/publication-operator.mjs
@@ -14,10 +14,14 @@ import { reviewedProviders } from './rpc.mjs';
 import { PUBLICATION_PLAN_SCHEMA, assertPublicationPlan, assertAuthenticatedOperationPlan, readOperatorJson } from './publication-plan.mjs';
 import { LIFECYCLE_OPERATOR_SCHEMA, assertLifecyclePlan } from './lifecycle-plan.mjs';
 import { preparePublicationRequest, preparePublicationRetry, revalidatePublicationRequest, observePublicationReceipt, observePublicationOperation } from './publication-rpc.mjs';
+import { ENGINE_PUBLICATION_OPERATOR_SCHEMA, ENGINE_LIFECYCLE_OPERATOR_SCHEMA, assertEnginePublicationOperatorPlan } from '../module-engine/publication-plan.mjs';
+import { assertEngineLifecycleOperatorPlan } from '../module-engine/lifecycle-operator-plan.mjs';
 const directory = path.dirname(fileURLToPath(import.meta.url));
 export async function assertOperationPlan(plan) {
   if (plan.schemaVersion === PUBLICATION_PLAN_SCHEMA) return assertPublicationPlan(plan);
   if (plan.schemaVersion === LIFECYCLE_OPERATOR_SCHEMA) return assertLifecyclePlan(plan);
+  if (plan.schemaVersion === ENGINE_PUBLICATION_OPERATOR_SCHEMA) return assertEnginePublicationOperatorPlan(plan);
+  if (plan.schemaVersion === ENGINE_LIFECYCLE_OPERATOR_SCHEMA) return assertEngineLifecycleOperatorPlan(plan);
   throw new Error('Unknown module publication or lifecycle operation plan');
 }
 async function body(req) { let size = 0; const chunks = []; for await (const chunk of req) { size += chunk.length; need(size <= 4096, 'Request exceeds limit'); chunks.push(chunk); } return exactJson(size ? Buffer.concat(chunks) : Buffer.from('{}'), 'Operator request'); }

--- a/contracts/scripts/module-mode/publication-operator.test.mjs
+++ b/contracts/scripts/module-mode/publication-operator.test.mjs
@@ -1,3 +1,4 @@
+import '../module-engine/wallet-operator.test.mjs';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { decodeFunctionData, encodeFunctionResult, keccak256, parseAbi } from 'viem';

--- a/contracts/scripts/module-mode/publication-operator.test.mjs
+++ b/contracts/scripts/module-mode/publication-operator.test.mjs
@@ -1,8 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { encodeFunctionResult, keccak256, parseAbi } from 'viem';
+import { decodeFunctionData, encodeFunctionResult, keccak256, parseAbi } from 'viem';
 import { hexQuantity } from './core.mjs';
-import { createPublicationPlan, assertPublicationPlan, bindPublicationModule, assertAuthenticatedOperationPlan, registryAbi } from './publication-plan.mjs';
+import { createPublicationPlan, assertPublicationPlan, bindPublicationModule, assertAuthenticatedOperationPlan, registryAbi, registryV2Abi } from './publication-plan.mjs';
 import { publicationFixture } from './publication-test-fixtures.mjs';
 import { publicationWalletRequest, assertPublicationRequest, observePublicationOperation, preparePublicationRequest, revalidatePublicationRequest, observePublicationReceipt, preparePublicationRetry } from './publication-rpc.mjs';
 import { startPublicationOperator } from './publication-operator.mjs';
@@ -45,6 +45,34 @@ test('missing acceptance, changed artifact and supplied salt fail closed', async
     const changed = structuredClone(f.module); mutate(changed); await assert.rejects(bindPublicationModule(changed, f.identity, f.owner));
   }
   await assert.rejects(assertAuthenticatedOperationPlan({ modules: [f.module], owner: f.owner }, undefined), /session file/);
+});
+test('NativeV2 owner plan records exactly the accepted family fee review and verifies its getter before admission', async () => {
+  const feeEligibility = { eligible: true, reviewDigest: h(101) }, f = await publicationFixture(feeEligibility);
+  const checked = await bindPublicationModule(f.module, f.identity, f.owner);
+  assert.deepEqual(checked.feeEligibility, feeEligibility);
+  const plan = await createPublicationPlan({ ...f, modules: [f.module] });
+  assert.deepEqual(plan.steps.map(step => step.kind), ['factory', 'family', 'feeEligibility', 'revision']);
+  const fee = plan.steps[2];
+  assert.equal(fee.sender, f.owner); assert.equal(fee.to, f.identity.contracts.registry.address); assert.equal(fee.value, '0');
+  assert.deepEqual(decodeFunctionData({ abi: registryV2Abi, data: fee.data }), { functionName: 'setFamilyFeeEligibility', args: [checked.familyId, true, feeEligibility.reviewDigest] });
+  assert.equal(fee.preReads[1].result, encodeFunctionResult({ abi: registryV2Abi, functionName: 'familyFeeEligibility', result: [false, h(0)] }));
+  assert.equal(fee.postReads[0].result, encodeFunctionResult({ abi: registryV2Abi, functionName: 'familyFeeEligibility', result: [true, feeEligibility.reviewDigest] }));
+  assert.deepEqual(plan.steps[3].preReads.at(-1), fee.postReads[0]);
+  assert.deepEqual(plan.steps[3].postReads.at(-1), fee.postReads[0]); await assertPublicationPlan(plan);
+  for (const change of [b => { b.feeEligibility.eligible = false; }, b => { b.feeEligibility.reviewDigest = h(102); }, b => { delete b.feeEligibility; }]) {
+    const changed = structuredClone(f.module); change(changed.manifest.manifest.runtimeBinding);
+    await assert.rejects(bindPublicationModule(changed, f.identity, f.owner));
+  }
+  const tampered = structuredClone(plan); tampered.steps[2].postReads = [];
+  await assert.rejects(assertPublicationPlan(tampered), /plan differs/);
+});
+test('NativeV2 false/zero keeps the untouched default and NativeV1 cannot adopt an eligibility field', async () => {
+  const f = await publicationFixture({ eligible: false, reviewDigest: h(0) });
+  const plan = await createPublicationPlan({ ...f, modules: [f.module] });
+  assert.deepEqual(plan.steps.map(step => step.kind), ['factory', 'family', 'revision']);
+  assert.equal(plan.steps[2].postReads.at(-1).functionName, 'familyFeeEligibility'); await assertPublicationPlan(plan);
+  const v1 = await publicationFixture(); v1.module.manifest.manifest.runtimeBinding.feeEligibility = { eligible: false, reviewDigest: h(0) };
+  await assert.rejects(bindPublicationModule(v1.module, v1.identity, v1.owner));
 });
 test('wallet ceilings include ETH value and gas, with no automatic fee raise', () => {
   const f = rpcFixture(); f.step.value = '1000'; const observation = { state: 'operation-simulated', stepIndex: 0, gasLimit: '100000', baseFeePerGas: '1', minimumBalance: '100001000', nonce: '1' };

--- a/contracts/scripts/module-mode/publication-plan.mjs
+++ b/contracts/scripts/module-mode/publication-plan.mjs
@@ -16,7 +16,12 @@ export const registryAbi = parseAbi([
   'function approveRevision(bytes32 packageId,bytes32 familyId,address factory,bytes32 moduleCodeHash,bytes32 manifestHash,uint32 callbackGas)',
   'function getRevision(bytes32 packageId) view returns ((bytes32 familyId,address factory,bytes32 factoryCodeHash,bytes32 moduleCodeHash,bytes32 manifestHash,uint32 callbackGas,bool enabled))',
 ]);
+export const registryV2Abi = [...registryAbi, ...parseAbi([
+  'function familyFeeEligibility(bytes32 familyId) view returns (bool eligible,bytes32 reviewDigest)',
+  'function setFamilyFeeEligibility(bytes32 familyId,bool eligible,bytes32 reviewDigest)',
+])];
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const ZERO_HASH = `0x${'0'.repeat(64)}`;
 function equal(a, b, name) { need(canonicalJson(a) === canonicalJson(b), `${name} differs`); }
 export function readCondition(to, abi, functionName, args, result) {
   return { to, functionName, data: encodeFunctionData({ abi, functionName, args }), result: encodeFunctionResult({ abi, functionName, result }) };
@@ -30,15 +35,16 @@ export async function bindPublicationModule(input, identity, owner) {
   exactKeys(input, ['source', 'manifest', 'review', 'artifact', 'factorySalt'], 'Module publication input');
   const api = await publicationValidators(), source = api.validateModuleSubmissionRequest(input.source);
   need(source.ok, 'Source package is invalid');
-  const { manifest, review, artifact } = input, binding = manifest?.manifest?.runtimeBinding;
+  const { manifest, review, artifact } = input, binding = manifest?.manifest?.runtimeBinding, v2 = identity.sourceVersion === 'module-native-v2';
   need(binding && review?.command?.outcome === 'accept', 'Actual accepted review record and host manifest are required');
   need(address(review.reviewerWallet) === owner, 'Accepted reviewer differs from the owner publishing this plan');
   const manifestHash = api.computeModuleModeHostManifestHash(manifest);
   const entry = { ...manifest.manifest.catalogDefinition, status: 'available', nativeBinding: {
     ...Object.fromEntries(['familyId', 'packageId', 'factory', 'factoryCodeHash', 'moduleCodeHash', 'callbackGas'].map(key => [key, binding[key]])),
+    ...(v2 ? { feeEligibility: binding.feeEligibility } : {}),
     manifestHash, reviewDigest: review.decisionDigest,
   } };
-  api.verifyModuleModePublication({ release: identity, publication: { entry, requestDigest: source.requestDigest, review }, ...input });
+  const verified = api.verifyModuleModePublication({ release: identity, publication: { entry, requestDigest: source.requestDigest, review }, ...input });
   const { artifactDigest, ...contents } = artifact;
   need(artifact.schemaVersion === 'programmable.modules.native-build.v1' && artifact.authority === 'programmable.module-review.native-build.v1'
     && artifactDigest === `0x${sha256(canonicalJson({ domain: artifact.schemaVersion, value: contents }))}`
@@ -66,6 +72,7 @@ export async function bindPublicationModule(input, identity, owner) {
   return { title: manifest.manifest.catalogDefinition.title, packageId: source.packageId, familyId: source.familyId, author: address(descriptor.author), familySalt: hash(descriptor.familySalt),
     rewardWallet: address(descriptor.rewardWallet), requestDigest: source.requestDigest, manifestHash, reviewDigest: review.decisionDigest, artifactDigest,
     factory: predicted, factorySalt: hash(input.factorySalt), factoryCodeHash: factory.runtimeCodeHash, moduleCodeHash: program.runtimeCodeHash, callbackGas: binding.callbackGas,
+    ...(v2 ? { feeEligibility: verified.nativeBinding.feeEligibility } : {}),
     factoryCreationBytecode: factory.creationBytecode, factoryRuntimeBytecode: factory.runtimeBytecode };
 }
 export async function createPublicationPlan({ identity, owner, modules, sourceState }) {
@@ -85,13 +92,23 @@ export async function createPublicationPlan({ identity, owner, modules, sourceSt
       result: encodeFunctionResult({ abi: registryAbi, functionName: 'registerReviewedFamily', result: item.familyId }),
       preReads: [readCondition(registry, registryAbi, 'families', [item.familyId], [ZERO_ADDRESS, ZERO_ADDRESS])],
       postReads: [readCondition(registry, registryAbi, 'families', [item.familyId], [item.author, item.rewardWallet])], newCode: [] });
+    const feeReads = item.feeEligibility ? [readCondition(registry, registryV2Abi, 'familyFeeEligibility', [item.familyId],
+      [item.feeEligibility.eligible, item.feeEligibility.reviewDigest])] : [];
+    if (item.feeEligibility && item.feeEligibility.reviewDigest !== ZERO_HASH) {
+      const feeArgs = [item.familyId, item.feeEligibility.eligible, item.feeEligibility.reviewDigest];
+      steps.push({ kind: 'feeEligibility', label: `Record ${item.title} reviewed family fee eligibility`, sender: owner, to: registry, value: '0', target: registry, packageId: item.packageId,
+        functionName: 'setFamilyFeeEligibility', arguments: jsonSafe(feeArgs), data: encodeFunctionData({ abi: registryV2Abi, functionName: 'setFamilyFeeEligibility', args: feeArgs }), result: '0x',
+        preReads: [readCondition(registry, registryAbi, 'families', [item.familyId], [item.author, item.rewardWallet]),
+          readCondition(registry, registryV2Abi, 'familyFeeEligibility', [item.familyId], [false, ZERO_HASH])],
+        postReads: feeReads, newCode: [] });
+    }
     const revision = { familyId: item.familyId, factory: item.factory, factoryCodeHash: item.factoryCodeHash, moduleCodeHash: item.moduleCodeHash,
       manifestHash: item.manifestHash, callbackGas: item.callbackGas, enabled: true };
     const revisionArgs = [item.packageId, item.familyId, item.factory, item.moduleCodeHash, item.manifestHash, item.callbackGas];
     steps.push({ kind: 'revision', label: `Admit ${item.title} revision`, sender: owner, to: registry, value: '0', target: registry, packageId: item.packageId,
       functionName: 'approveRevision', arguments: jsonSafe(revisionArgs), data: encodeFunctionData({ abi: registryAbi, functionName: 'approveRevision', args: revisionArgs }), result: '0x',
-      preReads: [readCondition(registry, registryAbi, 'families', [item.familyId], [item.author, item.rewardWallet])],
-      postReads: [readCondition(registry, registryAbi, 'getRevision', [item.packageId], revision)], newCode: [] });
+      preReads: [readCondition(registry, registryAbi, 'families', [item.familyId], [item.author, item.rewardWallet]), ...feeReads],
+      postReads: [readCondition(registry, registryAbi, 'getRevision', [item.packageId], revision), ...feeReads], newCode: [] });
   }
   const body = { schemaVersion: PUBLICATION_PLAN_SCHEMA, chainId: 4663, sourceCommit: sourceState.sourceCommit, sourceTree: sourceState.sourceTree,
     sourceClean: sourceState.sourceClean, identity, owner, modules, steps };
@@ -112,7 +129,7 @@ export async function assertAuthenticatedOperationPlan(plan, sessionFile) {
     const current = await reader.read(input.review.subject.submissionId), decision = api.acceptedDecision(current);
     equal(decision, input.review, 'Current authenticated review decision');
     equal(current.source, input.source, 'Current authenticated source'); equal(current.artifact, input.artifact, 'Current protected worker artifact');
-    const host = api.createHostPreparation(current, plan.identity, input.manifest.manifest.catalogDefinition);
+    const host = api.createHostPreparation(current, plan.identity, input.manifest.manifest.catalogDefinition, input.manifest.manifest.runtimeBinding.feeEligibility);
     equal(host.manifest, input.manifest, 'Canonical authenticated host manifest'); equal(host.salt, input.factorySalt, 'Canonical factory salt');
   }
 }

--- a/contracts/scripts/module-mode/publication-plan.mjs
+++ b/contracts/scripts/module-mode/publication-plan.mjs
@@ -8,6 +8,8 @@ import { repositoryState } from './build.mjs';
 import { exactJson } from './source-readback.mjs';
 import { publicationValidators } from './publication-shared.mjs';
 
+import { isEngineOperationPlan, assertAuthenticatedEngineOperationPlan } from '../module-engine/publication-plan.mjs';
+
 export const PUBLICATION_PLAN_SCHEMA = 'programmable.module-mode-publication-owner-plan.v1';
 export const registryAbi = parseAbi([
   'function owner() view returns (address)',
@@ -120,6 +122,7 @@ export async function assertPublicationPlan(plan) {
 }
 /** The existing fixed-origin private BFF reader is the only runtime review authority. Local JSON is a consistency input. */
 export async function assertAuthenticatedOperationPlan(plan, sessionFile) {
+  if (isEngineOperationPlan(plan)) return assertAuthenticatedEngineOperationPlan(plan, sessionFile);
   if (!plan.modules.length) return;
   need(typeof sessionFile === 'string' && sessionFile.length > 0, 'Private reviewer session file required for module operations');
   const api = await publicationValidators(), session = await api.readOperatorSession(sessionFile);

--- a/contracts/scripts/module-mode/publication-rpc.mjs
+++ b/contracts/scripts/module-mode/publication-rpc.mjs
@@ -2,6 +2,8 @@ import { decodeEventLog, decodeFunctionResult, encodeAbiParameters, encodeFuncti
 import { OFFICIAL, address, bytes, canonicalJson, digest, exactKeys, hash, hexQuantity, jsonSafe, need, uint } from './core.mjs';
 import { registryAbi, ZERO_ADDRESS } from './publication-plan.mjs';
 import { publicationValidators } from './publication-shared.mjs';
+import { isEngineOperationPlan } from '../module-engine/publication-plan.mjs';
+import { assertEngineOperationPreflight, bindEngineSimulation, equalEngineSimulation, finishEngineReceipt } from '../module-engine/operation-rpc.mjs';
 const canaryStateAbi = parseAbi([
   'function creatorRecipients(bytes32 poolId) view returns (address[] wallets,uint16[] sharesBps,uint256 adminRevision)',
   'function instances(bytes32 launchKey) view returns ((bytes32 instanceId,bytes32 packageId,bytes32 configHash,address factory,bytes32 factoryCodeHash,address module,bytes32 moduleCodeHash,uint32 callbackGas)[])',
@@ -129,20 +131,23 @@ async function assertCanaryToken(plan, step, providers, block) {
 export async function observePublicationOperation(plan, stepIndex, providers) {
   const step = plan.steps[stepIndex]; need(step, 'Unknown operation step'); const block = await blockSnapshot(providers);
   await Promise.all(Object.values(plan.identity.contracts).map(pin => code(providers, pin, block.number)));
-  await assertV2Policy(plan, providers, block.number);
-  if (step.kind === 'factory') await code(providers, OFFICIAL.deterministicDeployer, block.number);
-  const owner = await read(providers, plan.identity.contracts.registry.address, registryAbi, 'owner', [], block.number);
-  need(address(owner) === plan.owner, 'Registry review authority differs');
-  for (const previous of plan.steps.slice(0, stepIndex)) {
-    for (const pin of previous.newCode) await code(providers, pin, block.number);
-    await readConditions(providers, previous.postReads, block.number);
+  if (isEngineOperationPlan(plan)) await assertEngineOperationPreflight(plan, stepIndex, providers, block, engineRpcContext());
+  else {
+    await assertV2Policy(plan, providers, block.number);
+    if (step.kind === 'factory') await code(providers, OFFICIAL.deterministicDeployer, block.number);
+    const owner = await read(providers, plan.identity.contracts.registry.address, registryAbi, 'owner', [], block.number);
+    need(address(owner) === plan.owner, 'Registry review authority differs');
+    for (const previous of plan.steps.slice(0, stepIndex)) {
+      for (const pin of previous.newCode) await code(providers, pin, block.number);
+      await readConditions(providers, previous.postReads, block.number);
+    }
+    for (const pin of step.requiredCode ?? []) await code(providers, pin, block.number);
+    await readConditions(providers, step.preReads, block.number);
+    if (['factory', 'launch'].includes(step.kind)) {
+      need(same(await pair(providers, 'eth_getCode', [step.target, block.number]), 'target vacancy') === '0x', 'Target is already deployed; reconcile its actual receipt');
+      need(operationQuantity(same(await pair(providers, 'eth_getTransactionCount', [step.target, block.number]), 'target nonce')) === 0n, 'CREATE2 target has a nonzero nonce');
+    } else if (TRADES.includes(step.kind) || step.kind === 'approve') await assertCanaryToken(plan, step, providers, block.number);
   }
-  for (const pin of step.requiredCode ?? []) await code(providers, pin, block.number);
-  await readConditions(providers, step.preReads, block.number);
-  if (['factory', 'launch'].includes(step.kind)) {
-    need(same(await pair(providers, 'eth_getCode', [step.target, block.number]), 'target vacancy') === '0x', 'Target is already deployed; reconcile its actual receipt');
-    need(operationQuantity(same(await pair(providers, 'eth_getTransactionCount', [step.target, block.number]), 'target nonce')) === 0n, 'CREATE2 target has a nonzero nonce');
-  } else if (TRADES.includes(step.kind) || step.kind === 'approve') await assertCanaryToken(plan, step, providers, block.number);
   if (step.deadline) {
     const remaining = BigInt(step.deadline) - operationQuantity(block.timestamp); need(remaining >= 120n && remaining <= 3600n, 'Canary deadline must be between two minutes and one hour from the observed block');
   }
@@ -153,13 +158,14 @@ export async function observePublicationOperation(plan, stepIndex, providers) {
   const call = { from: plan.owner, to: step.to, value: hexQuantity(step.value), data: step.data };
   const simulation = bytes(same(await pair(providers, 'eth_call', [call, block.number]), 'operation simulation'));
   const api = await publicationValidators(); let decoded = null;
-  if (step.result !== null) need(simulation === step.result, 'Operation simulation returned an unexpected result');
+  if (isEngineOperationPlan(plan)) decoded = await bindEngineSimulation(plan, step, simulation);
+  else if (step.result !== null) need(simulation === step.result, 'Operation simulation returned an unexpected result');
   else if (step.kind === 'launch') decoded = jsonSafe(bindLaunchRecord(plan, step, decodeFunctionResult({ abi: api.moduleNativeLaunchAbiFor(plan.identity), functionName: 'launch', data: simulation }), true));
   else {
     const amounts = decodeFunctionResult({ abi: api.moduleNativeRouterAbi, functionName: 'swap', data: simulation });
     decoded = jsonSafe(bindTradeAmounts(plan, step, amounts[0], amounts[1]));
   }
-  const estimates = (await pair(providers, 'eth_estimateGas', [call])).map(operationQuantity), high = estimates[0] > estimates[1] ? estimates[0] : estimates[1], low = estimates[0] < estimates[1] ? estimates[0] : estimates[1];
+  const estimates = (await pair(providers, 'eth_estimateGas', isEngineOperationPlan(plan) ? [call, block.number] : [call])).map(operationQuantity), high = estimates[0] > estimates[1] ? estimates[0] : estimates[1], low = estimates[0] < estimates[1] ? estimates[0] : estimates[1];
   need(high - low <= 1000n + high / 10000n, 'Provider gas estimates disagree');
   need((await pair(providers, 'eth_getBlockByNumber', [block.number, false])).every(value => value?.hash === block.hash), 'Snapshot was reorganized');
   return { state: 'operation-simulated', stepIndex, blockNumber: operationQuantity(block.number).toString(), blockHash: block.hash,
@@ -195,6 +201,7 @@ export async function revalidatePublicationRequest(plan, prepared, providers, ce
   assertPublicationRequest(plan, prepared);
   need(Date.now() >= prepared.issuedAt && prepared.expiresAt - Date.now() >= 60000, 'Owner request has expired');
   const fresh = await observePublicationOperation(plan, prepared.stepIndex, providers), next = publicationWalletRequest(plan, fresh, ceilings);
+  if (isEngineOperationPlan(plan)) equalEngineSimulation(plan, prepared.stepIndex, fresh.simulatedResult, prepared.observation.simulatedResult);
   for (const key of Object.keys(next).filter(key => key !== 'gas')) need(canonicalJson(next[key]) === canonicalJson(prepared.request[key]), `Owner request changed: ${key}`);
   need(BigInt(next.gas) <= BigInt(prepared.request.gas), 'Fresh gas estimate exceeds the reviewed request');
   need(BigInt(fresh.minimumBalance) >= BigInt(prepared.request.value) + BigInt(prepared.request.gas) * BigInt(prepared.request.maxFeePerGas), 'Owner balance fell below value and maximum gas cost'); return fresh;
@@ -206,7 +213,9 @@ function receiptLogs(logs) {
     transactionIndex: log.transactionIndex, logIndex: log.logIndex, removed: log.removed ?? false }));
 }
 export async function observePublicationReceipt(plan, entry, providers) {
-  requirePair(providers); assertPublicationRequest(plan, entry); const step = plan.steps[entry.stepIndex], transactionHash = hash(entry.transactionHash);
+  requirePair(providers); assertPublicationRequest(plan, entry);
+  if (isEngineOperationPlan(plan)) need((await pair(providers, 'eth_chainId', [])).every(value => operationQuantity(value) === 4663n), 'Wrong Engine receipt chain');
+  const step = plan.steps[entry.stepIndex], transactionHash = hash(entry.transactionHash);
   const txs = await pair(providers, 'eth_getTransactionByHash', [transactionHash]); need(txs.every(Boolean), 'Transaction is not observed by both providers');
   const tx = same(txs.map(transactionView), 'transaction');
   for (const key of ['from', 'to', 'value', 'nonce', 'chainId', 'type', 'gas', 'maxFeePerGas', 'maxPriorityFeePerGas']) need(tx[key] === entry.request[key], `Wallet changed ${key}`);
@@ -218,6 +227,7 @@ export async function observePublicationReceipt(plan, entry, providers) {
   need((await pair(providers, 'eth_getBlockByNumber', [receipt.blockNumber, false])).every(b => b?.hash === receipt.blockHash && b.transactions.includes(transactionHash)), 'Receipt is not canonical');
   const pins = [...Object.values(plan.identity.contracts), ...plan.steps.slice(0, entry.stepIndex + 1).flatMap(s => s.newCode), ...(step.requiredCode ?? [])];
   await Promise.all(pins.map(pin => code(providers, pin, receipt.blockNumber))); await readConditions(providers, step.postReads, receipt.blockNumber);
+  if (isEngineOperationPlan(plan)) return finishEngineReceipt(plan, entry, providers, receipt, tx, pins, engineRpcContext());
   await assertV2Policy(plan, providers, receipt.blockNumber);
   let canary = null;
   if (step.kind === 'launch' || step.kind === 'approve' || TRADES.includes(step.kind)) canary = jsonSafe(await assertCanaryToken(plan, step, providers, receipt.blockNumber));
@@ -267,6 +277,7 @@ export async function preparePublicationRetry(plan, entry, providers, ceilings, 
     && Number.isSafeInteger(retryAttempt) && retryAttempt > 0, 'An explicit unresolved same-request retry is required');
   assertPublicationRequest(plan, entry);
   const observation = await observePublicationOperation(plan, entry.stepIndex, providers), next = publicationWalletRequest(plan, observation, ceilings);
+  if (isEngineOperationPlan(plan)) equalEngineSimulation(plan, entry.stepIndex, observation.simulatedResult, entry.observation.simulatedResult);
   for (const key of Object.keys(next).filter(key => key !== 'gas')) need(canonicalJson(next[key]) === canonicalJson(entry.request[key]), `Retry wallet field changed: ${key}`);
   need(BigInt(next.gas) <= BigInt(entry.request.gas), 'Retry estimate exceeds the original reviewed gas');
   need(BigInt(observation.minimumBalance) >= BigInt(entry.request.value) + BigInt(entry.request.gas) * BigInt(entry.request.maxFeePerGas), 'Retry is not funded for original gas plus value');
@@ -274,3 +285,6 @@ export async function preparePublicationRetry(plan, entry, providers, ceilings, 
     issuedAt, expiresAt: issuedAt + 300000, retryAttempt, originalRequestDigest: entry.requestDigest };
   return { ...body, requestDigest: digest('programmable.module-mode-owner-retry.v1', body) };
 }
+
+// Reuse the existing quorum and receipt transport; Engine contributes only its closed contract semantics.
+function engineRpcContext() { return { pair, same, code, read, readConditions, publicBindings, quantity: operationQuantity, observeReceipt: observePublicationReceipt }; }

--- a/contracts/scripts/module-mode/publication-rpc.mjs
+++ b/contracts/scripts/module-mode/publication-rpc.mjs
@@ -8,6 +8,8 @@ const canaryStateAbi = parseAbi([
   'function launchBinding(bytes32 launchKey) view returns ((address source,address launchWallet,address token,address poolManager,bytes32 poolId,bytes32 recipeHash,bytes32 programHash))',
 ]);
 const REQUEST_DOMAIN = 'programmable.module-mode-publication-owner-request.v1';
+const TRADES = ['buy', 'sell', 'buyExactOutput', 'sellExactOutput'];
+const isV2 = plan => plan.identity.sourceVersion === 'module-native-v2';
 export function operationQuantity(value) { need(typeof value === 'string' && /^0x(?:0|[1-9a-f][0-9a-f]*)$/i.test(value), 'Invalid RPC quantity'); return BigInt(value); }
 const pair = (providers, method, params) => Promise.all(providers.map(provider => provider.rpc(method, params)));
 function same(values, label) { need(canonicalJson(values[0]) === canonicalJson(values[1]), `Provider disagreement: ${label}`); return values[0]; }
@@ -30,6 +32,30 @@ async function readConditions(providers, reads, block) {
 }
 async function read(providers, target, abi, functionName, args, block) {
   return decodeFunctionResult({ abi, functionName, data: bytes(same(await pair(providers, 'eth_call', [{ to: target, data: encodeFunctionData({ abi, functionName, args }) }, block]), functionName)) });
+}
+async function assertV2Policy(plan, providers, block) {
+  if (!isV2(plan)) return;
+  const api = await publicationValidators(), abi = api.moduleNativeReadV2Abi, pins = plan.identity.contracts;
+  for (const role of ['launcher', 'hook', 'swapRouter', 'rewardLedger']) need(
+    await read(providers, pins[role].address, abi, 'ECONOMICS_POLICY_ID', [], block) === plan.identity.economicsPolicyId,
+    `Native V2 ${role} economics policy differs`);
+  for (const role of ['hook', 'rewardLedger']) need(
+    await read(providers, pins[role].address, abi, 'PROTOCOL_FEE_BPS', [], block) === 10
+    && await read(providers, pins[role].address, abi, 'AUTHOR_POOL_FEE_BPS', [], block) === 20,
+    `Native V2 ${role} economics rates differ`);
+}
+/** Amount/refund semantics of the exact runtime-pinned router, shared by simulation and receipt checks. */
+function bindTradeAmounts(plan, step, nativeAmount, tokenAmount, specified) {
+  const isBuy = step.kind === 'launch' || step.kind.startsWith('buy'), exactOutput = step.kind.endsWith('ExactOutput');
+  need(!exactOutput || isV2(plan), 'Exact-output lifecycle requires Native V2');
+  const amount = BigInt(step.kind === 'launch' ? step.expectation.initialBuyNative : step.expectation.amount);
+  const limit = BigInt(step.kind === 'launch' ? step.expectation.minimumTokenOut : exactOutput ? step.expectation.maximumInput : step.expectation.minimumOut);
+  const paid = isBuy ? nativeAmount : tokenAmount, received = isBuy ? tokenAmount : nativeAmount;
+  need(nativeAmount > 0n && tokenAmount > 0n && (specified === undefined || specified === (exactOutput ? amount : -amount))
+    && (exactOutput ? received === amount && paid <= limit : paid === amount && received >= limit), 'Swap amounts differ from reviewed input/output bounds');
+  // Launch additionally funds its explicitly reviewed module budgets; router trades do not.
+  if (step.kind !== 'launch') need(BigInt(step.value) === (isBuy ? exactOutput ? limit : amount : 0n), 'Swap ETH funding differs from the reviewed bound');
+  return { nativeAmount, tokenAmount, ...(exactOutput ? { maximumInput: limit, refundNative: isBuy ? limit - nativeAmount : 0n } : {}) };
 }
 function poolId(plan, token) { return keccak256(encodeAbiParameters(parseAbiParameters('address,address,uint24,int24,address'), [ZERO_ADDRESS, token, 0, 200, plan.identity.contracts.hook.address])); }
 function bindLaunchRecord(plan, step, result, initial = false) {
@@ -62,12 +88,26 @@ async function assertLaunchReference(plan, providers, block) {
 async function assertCanaryToken(plan, step, providers, block) {
   const api = await publicationValidators(), pins = plan.identity.contracts, expected = step.expectation;
   await assertLaunchReference(plan, providers, block);
-  const result = await read(providers, pins.launcher.address, api.moduleNativeLaunchAbi, 'getLaunch', [step.target], block);
+  const result = await read(providers, pins.launcher.address, api.moduleNativeLaunchAbiFor(plan.identity), 'getLaunch', [step.target], block);
   bindLaunchRecord(plan, step, result, step.kind === 'launch');
-  const config = await read(providers, pins.hook.address, api.moduleNativeReadAbi, 'poolConfig', [result.poolId], block);
+  const readAbi = api.moduleNativeReadAbiFor(plan.identity);
+  const config = await read(providers, pins.hook.address, readAbi, 'poolConfig', [result.poolId], block);
   need(address(config[0]) === pins.launcher.address && address(config[1]) === plan.owner && address(config[2]) === pins.swapRouter.address
     && config[3] === pins.swapRouter.runtimeCodeHash && Number(config[4]) === expected.creatorFeeBps && Number(config[5]) === expected.creatorFeeBps
     && config[6] === expected.recipeHash && config[7] === expected.launchKey, 'Canary pool fees or recipe differ');
+  if (isV2(plan)) {
+    need(config[8] === expected.platformFeeBps
+      && await read(providers, pins.rewardLedger.address, readAbi, 'platformFeeBps', [result.poolId], block) === expected.platformFeeBps,
+    'Native V2 pool or ledger fee differs from the launch snapshot');
+    const snapshot = await read(providers, pins.hook.address, readAbi, 'eligibilitySnapshot', [result.poolId], block);
+    need(canonicalJson(snapshot[0]) === canonicalJson(expected.selectionEligible)
+      && canonicalJson(snapshot[1]) === canonicalJson(expected.selectionReviewDigests), 'Native V2 selection eligibility snapshot differs');
+    if (step.kind === 'launch' || TRADES.includes(step.kind)) {
+      const components = await read(providers, pins.hook.address, readAbi, 'feeComponents', [result.poolId, step.kind === 'launch' || step.kind.startsWith('buy')], block);
+      need(components[0] === expected.creatorFeeBps && components[1] === expected.platformFeeBps
+        && components[2] >= 0 && components[2] <= 1000 && components[3] === 0, 'Native V2 fee components differ');
+    }
+  }
   const binding = await read(providers, pins.runtime.address, canaryStateAbi, 'launchBinding', [expected.launchKey], block);
   need(address(binding.source) === pins.launcher.address && address(binding.launchWallet) === plan.owner && address(binding.token) === step.target
     && address(binding.poolManager) === pins.poolManager.address && binding.poolId === expected.poolId && binding.recipeHash === expected.recipeHash
@@ -89,6 +129,7 @@ async function assertCanaryToken(plan, step, providers, block) {
 export async function observePublicationOperation(plan, stepIndex, providers) {
   const step = plan.steps[stepIndex]; need(step, 'Unknown operation step'); const block = await blockSnapshot(providers);
   await Promise.all(Object.values(plan.identity.contracts).map(pin => code(providers, pin, block.number)));
+  await assertV2Policy(plan, providers, block.number);
   if (step.kind === 'factory') await code(providers, OFFICIAL.deterministicDeployer, block.number);
   const owner = await read(providers, plan.identity.contracts.registry.address, registryAbi, 'owner', [], block.number);
   need(address(owner) === plan.owner, 'Registry review authority differs');
@@ -101,7 +142,7 @@ export async function observePublicationOperation(plan, stepIndex, providers) {
   if (['factory', 'launch'].includes(step.kind)) {
     need(same(await pair(providers, 'eth_getCode', [step.target, block.number]), 'target vacancy') === '0x', 'Target is already deployed; reconcile its actual receipt');
     need(operationQuantity(same(await pair(providers, 'eth_getTransactionCount', [step.target, block.number]), 'target nonce')) === 0n, 'CREATE2 target has a nonzero nonce');
-  } else if (['buy', 'approve', 'sell'].includes(step.kind)) await assertCanaryToken(plan, step, providers, block.number);
+  } else if (TRADES.includes(step.kind) || step.kind === 'approve') await assertCanaryToken(plan, step, providers, block.number);
   if (step.deadline) {
     const remaining = BigInt(step.deadline) - operationQuantity(block.timestamp); need(remaining >= 120n && remaining <= 3600n, 'Canary deadline must be between two minutes and one hour from the observed block');
   }
@@ -113,11 +154,10 @@ export async function observePublicationOperation(plan, stepIndex, providers) {
   const simulation = bytes(same(await pair(providers, 'eth_call', [call, block.number]), 'operation simulation'));
   const api = await publicationValidators(); let decoded = null;
   if (step.result !== null) need(simulation === step.result, 'Operation simulation returned an unexpected result');
-  else if (step.kind === 'launch') decoded = jsonSafe(bindLaunchRecord(plan, step, decodeFunctionResult({ abi: api.moduleNativeLaunchAbi, functionName: 'launch', data: simulation }), true));
+  else if (step.kind === 'launch') decoded = jsonSafe(bindLaunchRecord(plan, step, decodeFunctionResult({ abi: api.moduleNativeLaunchAbiFor(plan.identity), functionName: 'launch', data: simulation }), true));
   else {
     const amounts = decodeFunctionResult({ abi: api.moduleNativeRouterAbi, functionName: 'swap', data: simulation });
-    need(amounts[step.kind === 'buy' ? 0 : 1] === BigInt(step.expectation.amount) && amounts[step.kind === 'buy' ? 1 : 0] >= BigInt(step.expectation.minimumOut), 'Swap simulation differs from exact input or minimum output');
-    decoded = jsonSafe({ nativeAmount: amounts[0], tokenAmount: amounts[1] });
+    decoded = jsonSafe(bindTradeAmounts(plan, step, amounts[0], amounts[1]));
   }
   const estimates = (await pair(providers, 'eth_estimateGas', [call])).map(operationQuantity), high = estimates[0] > estimates[1] ? estimates[0] : estimates[1], low = estimates[0] < estimates[1] ? estimates[0] : estimates[1];
   need(high - low <= 1000n + high / 10000n, 'Provider gas estimates disagree');
@@ -178,12 +218,13 @@ export async function observePublicationReceipt(plan, entry, providers) {
   need((await pair(providers, 'eth_getBlockByNumber', [receipt.blockNumber, false])).every(b => b?.hash === receipt.blockHash && b.transactions.includes(transactionHash)), 'Receipt is not canonical');
   const pins = [...Object.values(plan.identity.contracts), ...plan.steps.slice(0, entry.stepIndex + 1).flatMap(s => s.newCode), ...(step.requiredCode ?? [])];
   await Promise.all(pins.map(pin => code(providers, pin, receipt.blockNumber))); await readConditions(providers, step.postReads, receipt.blockNumber);
+  await assertV2Policy(plan, providers, receipt.blockNumber);
   let canary = null;
-  if (['launch', 'buy', 'approve', 'sell'].includes(step.kind)) canary = jsonSafe(await assertCanaryToken(plan, step, providers, receipt.blockNumber));
+  if (step.kind === 'launch' || step.kind === 'approve' || TRADES.includes(step.kind)) canary = jsonSafe(await assertCanaryToken(plan, step, providers, receipt.blockNumber));
   if (step.kind === 'launch') {
     const api = await publicationValidators(), events = [];
     for (const log of receipt.logs.filter(log => log.address === plan.identity.contracts.launcher.address)) {
-      try { events.push(decodeEventLog({ abi: api.moduleNativeLaunchAbi, data: log.data, topics: log.topics, strict: true })); } catch { /* Unrelated launcher events are not configuration evidence. */ }
+      try { events.push(decodeEventLog({ abi: api.moduleNativeLaunchAbiFor(plan.identity), data: log.data, topics: log.topics, strict: true })); } catch { /* Unrelated launcher events are not configuration evidence. */ }
     }
     const one = name => { const found = events.filter(event => event.eventName === name); need(found.length === 1, `Expected exactly one ${name} event`); return found[0].args; };
     const configuration = one('ModuleNativeConfigurationBound'), program = one('ModuleNativeProgramBound');
@@ -191,22 +232,34 @@ export async function observePublicationReceipt(plan, entry, providers) {
       && configuration.creatorConfigurationHash === step.expectation.creatorConfigurationHash, 'Canary metadata or creator allocation event differs');
     need(program.launchId === canary.launchId && program.launchKey === step.expectation.launchKey && address(program.runtime) === plan.identity.contracts.runtime.address
       && program.fundingHash === step.expectation.fundingHash && program.totalFunding === BigInt(step.expectation.totalFunding), 'Canary funding event differs');
+    if (isV2(plan)) {
+      const economics = receipt.logs.filter(log => log.address === plan.identity.contracts.hook.address).flatMap(log => {
+        try { const event = decodeEventLog({ abi: api.moduleNativeReadV2Abi, data: log.data, topics: log.topics, strict: true });
+          return event.eventName === 'NativeEconomicsBound' ? [event.args] : []; } catch { return []; }
+      });
+      need(economics.length === 1, 'Expected exactly one NativeEconomicsBound event');
+      const event = economics[0], expected = step.expectation;
+      need(event.poolId === expected.poolId && event.economicsPolicyId === expected.economicsPolicyId
+        && event.protocolFeeBps === 10 && event.authorPoolFeeBps === expected.authorPoolFeeBps
+        && canonicalJson(event.eligibleFamilies) === canonicalJson(expected.families)
+        && canonicalJson(event.selectionEligible) === canonicalJson(expected.selectionEligible)
+        && canonicalJson(event.selectionReviewDigests) === canonicalJson(expected.selectionReviewDigests), 'Native V2 economics event differs from the reviewed recipe');
+    }
   }
-  if (['launch', 'buy', 'sell'].includes(step.kind)) {
+  let trade;
+  if (step.kind === 'launch' || TRADES.includes(step.kind)) {
     const api = await publicationValidators(), events = [];
     need(Array.isArray(receipt.logs) && receipt.logs.length <= 4096, 'Receipt logs are unavailable or exceed bounds');
     for (const log of receipt.logs.filter(log => log.address?.toLowerCase() === plan.identity.contracts.swapRouter.address)) {
       try { const event = decodeEventLog({ abi: api.moduleNativeRouterAbi, data: log.data, topics: log.topics, strict: true }); if (event.eventName === 'NativeTradeCompleted') events.push(event.args); } catch { /* Other router events are not trade evidence. */ }
     }
-    need(events.length === 1, 'Expected exactly one native trade event'); const event = events[0], isBuy = step.kind !== 'sell';
+    need(events.length === 1, 'Expected exactly one native trade event'); const event = events[0], isBuy = step.kind === 'launch' || step.kind.startsWith('buy');
     need(event.poolId === poolId(plan, step.target) && address(event.actor) === plan.owner && address(event.recipient) === plan.owner && event.isBuy === isBuy, 'Trade event identity differs');
-    const amount = BigInt(step.kind === 'launch' ? step.expectation.initialBuyNative : step.expectation.amount);
-    const minimum = BigInt(step.kind === 'launch' ? step.expectation.minimumTokenOut : step.expectation.minimumOut);
-    need(event.amountSpecified === -amount && (isBuy ? event.nativeAmount : event.tokenAmount) === amount && (isBuy ? event.tokenAmount : event.nativeAmount) >= minimum, 'Trade event amounts differ');
+    trade = jsonSafe(bindTradeAmounts(plan, step, event.nativeAmount, event.tokenAmount, event.amountSpecified));
   }
   need((await pair(providers, 'eth_getBlockByNumber', [receipt.blockNumber, false])).every(b => b?.hash === receipt.blockHash), 'Receipt anchor changed during verification');
   return { status: 'included-code-verified-unfinalized', chainId: 4663, planDigest: plan.planDigest, releaseDigest: plan.identity.releaseDigest, stepIndex: entry.stepIndex,
-    kind: step.kind, transaction: tx, receipt, contracts: pins, canary, providers: publicBindings(providers) };
+    kind: step.kind, transaction: tx, receipt, contracts: pins, canary, providers: publicBindings(providers), ...(isV2(plan) && trade ? { trade } : {}) };
 }
 
 export async function preparePublicationRetry(plan, entry, providers, ceilings, reviewedRequestDigest, retryAttempt) {

--- a/contracts/scripts/module-mode/publication-shared.ts
+++ b/contracts/scripts/module-mode/publication-shared.ts
@@ -6,3 +6,14 @@ export { moduleNativeLaunchAbi, moduleNativeRouterAbi, moduleNativeApprovalAbi, 
   moduleNativeLaunchAbiFor, moduleNativeReadAbiFor, moduleNativeReadV2Abi } from '../../../lib/module-mode/native-abi';
 export { createAuthenticatedReviewReader, readOperatorSession, acceptedDecision } from '../../../ops/module-mode-publication/review';
 export { createHostPreparation } from '../../../ops/module-mode-publication/core';
+// Engine operators use identity/manifest-only pure planning. No active public release is fabricated.
+export { moduleEngineHostAbi, moduleEngineReadAbi, moduleEngineLedgerAbi, moduleEngineLaunchParameters, moduleEnginePlanParameters, moduleEngineConstructorParameters, ENGINE_CONTEXT } from '../../../lib/module-engine/abi';
+export { moduleEngineReleaseIdentity, computeModuleEngineHostManifestHash, MODULE_ENGINE_SOURCE_ID } from '../../../lib/module-engine/catalog';
+export { compileModuleEngineLaunch, moduleEngineOperation } from '../../../lib/module-engine/operation-plan';
+export { createReviewedModuleEngineManifest } from '../../../lib/module-mode/review-engine-manifest';
+export { parseReviewSubject, parseReviewPlan, parseReviewArtifact } from '../../../lib/module-mode/review-contract';
+export { verifyModuleEngineBuildArtifactV1 } from '../../../lib/module-mode/review-engine-contract';
+export { validateModuleReviewDecisionRecordV1 } from '../../../lib/server/module-mode/review-decision-wire-v1';
+export { createEngineHostPreparation, prepareEnginePublication, engineRegistryRevision } from '../../../ops/module-mode-publication/core-engine';
+export { computeModuleEngineReleaseDigest } from '../../../lib/module-engine/catalog';
+export { materializeModuleEngineRuntime } from '../../../lib/module-engine/operation-plan';

--- a/contracts/scripts/module-mode/publication-shared.ts
+++ b/contracts/scripts/module-mode/publication-shared.ts
@@ -2,6 +2,7 @@
 export { computeModuleModeReleaseDigest } from '../../../lib/module-mode/release';
 export { createModuleModeHostManifest, computeModuleModeHostManifestHash, verifyModuleModePublication } from '../../../lib/server/module-mode/catalog';
 export { validateModuleSubmissionRequest } from '../../../packages/classic-modules/src/open-transport.mjs';
-export { moduleNativeLaunchAbi, moduleNativeRouterAbi, moduleNativeApprovalAbi, moduleNativeReadAbi } from '../../../lib/module-mode/native-abi';
+export { moduleNativeLaunchAbi, moduleNativeRouterAbi, moduleNativeApprovalAbi, moduleNativeReadAbi,
+  moduleNativeLaunchAbiFor, moduleNativeReadAbiFor, moduleNativeReadV2Abi } from '../../../lib/module-mode/native-abi';
 export { createAuthenticatedReviewReader, readOperatorSession, acceptedDecision } from '../../../ops/module-mode-publication/review';
 export { createHostPreparation } from '../../../ops/module-mode-publication/core';

--- a/contracts/scripts/module-mode/publication-test-fixtures.mjs
+++ b/contracts/scripts/module-mode/publication-test-fixtures.mjs
@@ -8,7 +8,7 @@ import { REPOSITORY_ROOT } from './build.mjs';
 import { OFFICIAL, canonicalJson, sha256 } from './core.mjs';
 import { publicationValidators } from './publication-shared.mjs';
 let fixtureModule;
-export async function publicationFixture() {
+export async function publicationFixture(feeEligibility) {
   if (!fixtureModule) {
     const result = await build({ absWorkingDir: REPOSITORY_ROOT, stdin: { contents: "export { moduleReviewAdminFixture } from './tests/fixtures/module-review-admin';", resolveDir: REPOSITORY_ROOT, loader: 'ts' },
       write: false, bundle: true, platform: 'node', target: 'node24', format: 'esm', packages: 'external', treeShaking: true, tsconfig: path.join(REPOSITORY_ROOT, 'tsconfig.json'), logLevel: 'silent' });
@@ -18,10 +18,11 @@ export async function publicationFixture() {
   }
   const f = fixtureModule.moduleReviewAdminFixture(), api = await publicationValidators();
   const identity = { ...f.release, contracts: { ...f.release.contracts, poolManager: OFFICIAL.poolManager, positionManager: OFFICIAL.positionManager } };
+  if (feeEligibility) Object.assign(identity, { schemaVersion: 'programmable.module-mode-source.v2', sourceVersion: 'module-native-v2', economicsPolicyId: keccak256(toHex('programmable.module-mode.native-economics.v2')) });
   identity.releaseDigest = api.computeModuleModeReleaseDigest(identity);
   const factorySalt = keccak256(toHex('synthetic-test-factory-salt'));
   const factory = getCreate2Address({ from: OFFICIAL.deterministicDeployer.address, salt: factorySalt, bytecode: f.artifact.factory.creationBytecode }).toLowerCase();
-  const manifest = api.createModuleModeHostManifest({ release: identity, definition: f.definition, nativeBinding: { ...f.binding, factory }, descriptor: f.source.descriptor });
+  const manifest = api.createModuleModeHostManifest({ release: identity, definition: f.definition, nativeBinding: { ...f.binding, factory, ...(feeEligibility ? { feeEligibility } : {}) }, descriptor: f.source.descriptor });
   const contents = { schemaVersion: 'programmable.modules.review-decision.v1', reviewerWallet: f.reviewer, policyDigest: f.policyDigest, subject: f.subject,
     command: { schemaVersion: 'programmable.modules.review-command.v1', submissionId: f.subject.submissionId, requestDigest: f.subject.requestDigest, expectedReviewRevision: 2,
       outcome: 'accept', reason: 'Synthetic operator test only. Never reviewer authority.', artifactDigest: f.artifact.artifactDigest,

--- a/contracts/scripts/module-mode/source-readback.mjs
+++ b/contracts/scripts/module-mode/source-readback.mjs
@@ -5,6 +5,8 @@ import { address, bytes, canonicalJson, hash, need } from './core.mjs';
 
 export const SOURCIFY_BASE = 'https://sourcify.dev/server';
 export const SOURCIFY_COMPILER = '0.8.26+commit.8a97fa7a';
+export const SOURCIFY_QUOTE_PLANNER_AUXDATA_PROFILE = 'quote-planner-solc-0.8.26-v1';
+const SOLC_VERSION_AUXDATA = '0xa164736f6c634300081a000a';
 export function exactJson(raw, label) {
   return parseStrictJson(decodeExactUtf8(raw, label), { maximumBytes: raw.length });
 }
@@ -67,8 +69,40 @@ function publicationSettings(input, value, artifact, recompilation, role) {
   equal({ ...value.stdJsonInput, settings: expected }, { ...input, settings: expected }, `${role}: Sourcify standard input differs`);
 }
 
+function quotePlannerAuxdataProfile(plan, role, profile, artifact, input, metadata, constructorArguments) {
+  const target = { 'src/StockPairedPositionPlannerV3.sol': 'StockPairedPositionPlannerV3' };
+  need(profile === SOURCIFY_QUOTE_PLANNER_AUXDATA_PROFILE && role === 'positionPlanner'
+    && plan.schemaVersion === 'programmable.module-engine-quote-deployment-plan.v1' && plan.chainId === 4663
+    && plan.identityCandidate?.schemaVersion === 'programmable.module-engine-quote-infrastructure.v1'
+    && plan.identityCandidate.sourceVersion === 'module-engine-quote-v1' && plan.identityCandidate.chainId === 4663,
+  'Exact Quote Planner source profile required for compiler auxdata');
+  equal(artifact.compilationTarget, target, 'Quote Planner compilation target differs');
+  const compilerSettings = { optimizer: { enabled: true, runs: 1000 }, evmVersion: 'cancun', viaIR: true, metadata: { bytecodeHash: 'none' } };
+  equal(settings(input.settings), compilerSettings, 'Quote Planner compiler settings differ');
+  need(metadata?.compiler?.version === SOURCIFY_COMPILER, 'Quote Planner compiler metadata version differs');
+  equal(metadata.settings, { ...compilerSettings, compilationTarget: target, libraries: {}, remappings: [] }, 'Quote Planner compiler metadata settings differ');
+  need(constructorArguments === '0x', 'Quote Planner cannot have constructor arguments');
+  empty(artifact.deployedBytecode.immutableReferences, 'Quote Planner cannot have immutable replacements');
+  need(bytes(artifact.deployedBytecode.object) === bytes(plan.contracts[role].runtime), 'Quote Planner complete runtime differs from its compiled template');
+}
+
+function exactSolcVersionAuxdata(code, compiled, role, label) {
+  const auxdata = code.cborAuxdata;
+  need(auxdata && typeof auxdata === 'object' && !Array.isArray(auxdata), `${role}: ${label} compiler auxdata map required`);
+  const entries = Object.entries(auxdata);
+  need(entries.length === 1 && /^[1-9][0-9]*$/.test(entries[0][0]), `${role}: ${label} must describe one compiler trailer`);
+  const [, entry] = entries[0];
+  need(entry && typeof entry === 'object' && !Array.isArray(entry), `${role}: ${label} compiler auxdata entry required`);
+  equal(Object.keys(entry).sort(), ['offset', 'value'], `${role}: ${label} compiler auxdata fields differ`);
+  const offset = (compiled.length - SOLC_VERSION_AUXDATA.length) / 2;
+  need(offset >= 0 && Number.isSafeInteger(entry.offset) && entry.offset === offset
+    && bytes(entry.value) === SOLC_VERSION_AUXDATA && compiled.slice(2 + offset * 2) === SOLC_VERSION_AUXDATA.slice(2)
+    && bytes(code.onchainBytecode).slice(2 + offset * 2) === SOLC_VERSION_AUXDATA.slice(2),
+  `${role}: ${label} compiler trailer must exactly match the terminal compiled and onchain bytes`);
+}
+
 /** Independent complete-byte comparison. Provider `match` is preserved as such, never relabelled `exact_match`. */
-export function validateSourcifySource({ plan, build, role, constructorArguments, creation, recompilation }, value) {
+export function validateSourcifySource({ plan, build, role, constructorArguments, creation, recompilation, compilerAuxdataProfile }, value) {
   const artifact = build.artifacts[role], pin = plan.contracts[role], input = build.standardInputs[role];
   need(artifact && pin && input, 'Unknown Sourcify target');
   const [file, name] = Object.entries(artifact.compilationTarget)[0];
@@ -94,8 +128,13 @@ export function validateSourcifySource({ plan, build, role, constructorArguments
   const onchainCreation = `${compiledCreation}${constructorArguments.slice(2)}`;
   need(bytes(c.recompiledBytecode) === compiledCreation && bytes(c.onchainBytecode) === onchainCreation
     && bytes(r.recompiledBytecode) === compiledRuntime && bytes(r.onchainBytecode) === pin.runtime, `${role}: complete creation/runtime bytes differ`);
+  if (compilerAuxdataProfile !== undefined) quotePlannerAuxdataProfile(plan, role, compilerAuxdataProfile, artifact, input,
+    build.compilerMetadata?.[role] ?? artifact.metadata, constructorArguments);
   for (const [label, code] of [['creation', c], ['runtime', r]]) {
-    empty(code.cborAuxdata, `${role}: unexpected ${label} CBOR transformation`);
+    // Auxdata describes compiler bytes; it never authorizes a transformation or an ignored range.
+    // Native/Core/default profiles retain their original empty-CBOR requirement.
+    if (compilerAuxdataProfile !== undefined) exactSolcVersionAuxdata(code, label === 'creation' ? compiledCreation : compiledRuntime, role, label);
+    else empty(code.cborAuxdata, `${role}: unexpected ${label} CBOR transformation`);
     empty(code.linkReferences, `${role}: unexpected ${label} library link`);
   }
   const expectedCreationTransforms = constructorArguments === '0x' ? [] : [{ type: 'insert', offset: (compiledCreation.length - 2) / 2, reason: 'constructorArguments' }];
@@ -122,7 +161,7 @@ export function validateSourcifySource({ plan, build, role, constructorArguments
   return { role, address: pin.address, runtimeCodeHash: pin.runtimeCodeHash, constructorArguments,
     sourcePaths: Object.keys(input.sources).sort(), sourceCommit: plan.sourceCommit, provider: 'sourcify-v2',
     providerMatch: value.match, creationMatch: value.creationMatch, runtimeMatch: value.runtimeMatch,
-    providerClassification: 'NO_CBOR_PROVIDER_MATCH', independentByteComparison: 'exact-complete-creation-and-runtime',
+    providerClassification: compilerAuxdataProfile === undefined ? 'NO_CBOR_PROVIDER_MATCH' : 'NO_METADATA_HASH_PROVIDER_MATCH', independentByteComparison: 'exact-complete-creation-and-runtime',
     transformationPolicy: 'constructor-arguments-and-compiled-immutables-only', creationTransactionHash: creation.transactionHash,
     creationBytecodeHash: keccak256(onchainCreation), recompiledRuntimeCodeHash: keccak256(compiledRuntime),
     matchId: value.matchId, verifiedAt: value.verifiedAt };

--- a/contracts/scripts/module-mode/source-readback.test.mjs
+++ b/contracts/scripts/module-mode/source-readback.test.mjs
@@ -26,6 +26,150 @@ function context(role = 'positionForwarderFactory') {
       transformations: transforms, transformationValues: transforms.length ? { immutables } : {} } };
   return { expected: { plan, build: sourceBuild, role, constructorArguments: args, creation }, value };
 }
+
+// Synthetic bytecode fixture carrying the exact solc-only trailer observed in the reviewed Quote
+// Planner. It is not a deployment/compilation proof; the actual archived readback is checked separately.
+function quotePlannerContext() {
+  const role = 'positionPlanner', file = 'src/StockPairedPositionPlannerV3.sol', name = 'StockPairedPositionPlannerV3';
+  const trailer = 'a164736f6c634300081a000a', runtime = `0x6001600055${trailer}`, creationCode = `0x6002600055${runtime.slice(2)}`;
+  const settings = { optimizer: { enabled: true, runs: 1000 }, evmVersion: 'cancun', viaIR: true, metadata: { bytecodeHash: 'none' } };
+  const sources = { [file]: { content: '// synthetic fixture, never deployed\n' } }, compilationTarget = { [file]: name };
+  const metadata = { compiler: { version: '0.8.26+commit.8a97fa7a' },
+    settings: { ...structuredClone(settings), compilationTarget, libraries: {}, remappings: [] } };
+  const artifact = { abi: [], compilationTarget, metadata, bytecode: { object: creationCode, linkReferences: {} },
+    deployedBytecode: { object: runtime, linkReferences: {}, immutableReferences: {} } };
+  const creation = { transactionHash: txHash, blockNumber: '123', transactionIndex: '2', transactionSender: addr(1) };
+  const pin = { address: addr(991), runtime, runtimeCodeHash: keccak256(runtime) };
+  const bytecode = code => ({ recompiledBytecode: code, onchainBytecode: code,
+    cborAuxdata: { 1: { offset: (code.length - 2 - trailer.length) / 2, value: `0x${trailer}` } },
+    linkReferences: {}, transformations: [], transformationValues: {} });
+  const value = { chainId: '4663', address: pin.address, match: 'match', creationMatch: 'match', runtimeMatch: 'match',
+    matchId: '12', verifiedAt: '2026-09-07T22:11:31Z',
+    compilation: { language: 'Solidity', compiler: 'solc', compilerVersion: '0.8.26+commit.8a97fa7a',
+      compilerSettings: structuredClone(settings), name, fullyQualifiedName: `${file}:${name}` },
+    stdJsonInput: { language: 'Solidity', sources: structuredClone(sources), settings: structuredClone(settings) },
+    sources: structuredClone(sources), metadata: structuredClone(metadata), abi: [], deployment: { ...creation, deployer: creation.transactionSender },
+    creationBytecode: bytecode(creationCode), runtimeBytecode: { ...bytecode(runtime), immutableReferences: {} } };
+  const expected = { role, constructorArguments: '0x', creation, compilerAuxdataProfile: 'quote-planner-solc-0.8.26-v1',
+    plan: { schemaVersion: 'programmable.module-engine-quote-deployment-plan.v1', chainId: 4663, sourceCommit: plan.sourceCommit,
+      identityCandidate: { schemaVersion: 'programmable.module-engine-quote-infrastructure.v1', sourceVersion: 'module-engine-quote-v1', chainId: 4663 },
+      contracts: { [role]: pin } },
+    build: { artifacts: { [role]: artifact }, compilerMetadata: { [role]: structuredClone(metadata) },
+      standardInputs: { [role]: { language: 'Solidity', sources, settings: { ...structuredClone(settings), outputSelection: { [file]: { [name]: ['abi'] } } } } } } };
+  return { expected, value };
+}
+
+test('Quote Planner compiler CBOR describes an identical terminal version marker without transformations', () => {
+  const { expected, value } = quotePlannerContext(), result = validateSourcifySource(expected, value);
+  assert.equal(result.providerClassification, 'NO_METADATA_HASH_PROVIDER_MATCH');
+  assert.equal(result.providerMatch, 'match');
+  assert.equal(result.independentByteComparison, 'exact-complete-creation-and-runtime');
+  assert.equal(result.runtimeCodeHash, expected.plan.contracts.positionPlanner.runtimeCodeHash);
+  assert.equal(result.transformationPolicy, 'constructor-arguments-and-compiled-immutables-only');
+  // Provider-local auxdata ids do not change the bound byte range or its exact bytes.
+  value.creationBytecode.cborAuxdata = { 7: value.creationBytecode.cborAuxdata[1] };
+  assert.equal(validateSourcifySource(expected, value).creationBytecodeHash, result.creationBytecodeHash);
+});
+
+test('Quote Planner CBOR cannot mask changed bytes, nonterminal regions or provider transformations', () => {
+  const mutations = [
+    v => { v.creationBytecode.recompiledBytecode += '00'; }, v => { v.creationBytecode.onchainBytecode += '00'; },
+    v => { v.runtimeBytecode.recompiledBytecode += '00'; }, v => { v.runtimeBytecode.onchainBytecode += '00'; },
+    v => { v.runtimeBytecode.onchainBytecode = `0x61${v.runtimeBytecode.onchainBytecode.slice(4)}`; },
+    v => { v.runtimeBytecode.onchainBytecode = `${v.runtimeBytecode.onchainBytecode.slice(0, -2)}0b`; },
+    ...['creationBytecode', 'runtimeBytecode'].flatMap(kind => [
+      v => { v[kind].cborAuxdata = {}; }, v => { v[kind].cborAuxdata = null; }, v => { v[kind].cborAuxdata = []; },
+      v => { v[kind].cborAuxdata[2] = structuredClone(v[kind].cborAuxdata[1]); },
+      v => { v[kind].cborAuxdata = { unexpected: v[kind].cborAuxdata[1] }; },
+      v => { v[kind].cborAuxdata[1].extra = true; }, v => { v[kind].cborAuxdata[1].offset--; },
+      v => { v[kind].cborAuxdata[1].offset = -1; }, v => { v[kind].cborAuxdata[1].offset = 0.5; },
+      v => { v[kind].cborAuxdata[1].offset = Number.MAX_SAFE_INTEGER; },
+      v => { v[kind].cborAuxdata[1].value = '0xa164736f6c634300081b000a'; },
+      v => { v[kind].cborAuxdata[1].value = '0x000a'; },
+      v => { v[kind].transformations.push({ id: '1', type: 'replace', offset: v[kind].cborAuxdata[1].offset, reason: 'cborAuxdata' }); },
+      v => { v[kind].transformationValues.cborAuxdata = { 1: v[kind].cborAuxdata[1].value }; },
+      v => { v[kind].linkReferences = { unexpected: {} }; },
+    ]),
+  ];
+  for (const mutate of mutations) {
+    const { expected, value } = quotePlannerContext(); mutate(value);
+    assert.throws(() => validateSourcifySource(expected, value), undefined, mutate.toString());
+  }
+});
+
+test('Quote Planner full-byte equality still rejects embedded CBOR, a different compiler marker and an uncompiled runtime', () => {
+  for (const kind of ['creationBytecode', 'runtimeBytecode']) for (const embedded of [true, false]) {
+    const { expected, value } = quotePlannerContext(), artifact = expected.build.artifacts.positionPlanner;
+    const code = value[kind], old = code.recompiledBytecode;
+    const changed = embedded ? `${old}00` : old.replace('a164736f6c634300081a000a', 'a164736f6c634300081b000a');
+    artifact[kind === 'creationBytecode' ? 'bytecode' : 'deployedBytecode'].object = changed;
+    code.recompiledBytecode = changed; code.onchainBytecode = changed;
+    if (!embedded) code.cborAuxdata[1].value = '0xa164736f6c634300081b000a';
+    if (kind === 'runtimeBytecode') {
+      expected.plan.contracts.positionPlanner.runtime = changed;
+      expected.plan.contracts.positionPlanner.runtimeCodeHash = keccak256(changed);
+    }
+    // Even equality of every complete source/onchain byte cannot turn an inner byte range or a
+    // compiler marker inconsistent with the full metadata into this profile's terminal auxdata.
+    assert.throws(() => validateSourcifySource(expected, value), /compiler trailer/);
+  }
+  const { expected, value } = quotePlannerContext();
+  const changed = `0x61${value.runtimeBytecode.onchainBytecode.slice(4)}`;
+  value.runtimeBytecode.onchainBytecode = changed;
+  expected.plan.contracts.positionPlanner.runtime = changed;
+  expected.plan.contracts.positionPlanner.runtimeCodeHash = keccak256(changed);
+  assert.throws(() => validateSourcifySource(expected, value), /complete runtime differs from its compiled template/);
+});
+
+test('Quote Planner CBOR opt-in requires its exact source profile, target and compiler metadata', () => {
+  const mutations = [
+    ({ expected }) => { delete expected.compilerAuxdataProfile; },
+    ({ expected }) => { expected.compilerAuxdataProfile = 'allow-cbor'; },
+    ({ expected }) => { expected.plan.schemaVersion = 'programmable.module-mode-deployment-plan.v1'; },
+    ...['module-native-v1', 'module-native-v2', 'module-engine-v1'].map(version => ({ expected }) => { expected.plan.identityCandidate.sourceVersion = version; }),
+    ({ expected }) => { expected.plan.identityCandidate.schemaVersion = 'programmable.module-engine.release.v1'; },
+    ({ expected }) => { expected.plan.identityCandidate.chainId = 1; },
+    ({ expected, value }) => {
+      const old = expected.role; expected.role = 'converter';
+      for (const entries of [expected.plan.contracts, expected.build.artifacts, expected.build.standardInputs, expected.build.compilerMetadata]) {
+        entries.converter = entries[old]; delete entries[old];
+      }
+      value.creationBytecode.cborAuxdata = {}; value.runtimeBytecode.cborAuxdata = {};
+    },
+    ({ expected, value }) => {
+      const target = { 'src/Other.sol': 'Other' };
+      expected.build.artifacts.positionPlanner.compilationTarget = target;
+      for (const metadata of [expected.build.artifacts.positionPlanner.metadata, expected.build.compilerMetadata.positionPlanner, value.metadata]) metadata.settings.compilationTarget = target;
+      value.compilation.name = 'Other'; value.compilation.fullyQualifiedName = 'src/Other.sol:Other';
+    },
+    ({ expected, value }) => {
+      for (const metadata of [expected.build.artifacts.positionPlanner.metadata, expected.build.compilerMetadata.positionPlanner, value.metadata]) metadata.compiler.version = '0.8.27+commit.40a35a09';
+    },
+    ...[
+      s => { s.metadata.appendCBOR = false; }, s => { s.metadata.appendCBOR = true; }, s => { s.metadata.bytecodeHash = 'ipfs'; },
+      s => { s.viaIR = false; }, s => { s.optimizer.runs = 999; }, s => { s.evmVersion = 'paris'; },
+    ].map(mutate => ({ expected, value }) => {
+      for (const settings of [expected.build.standardInputs.positionPlanner.settings, expected.build.artifacts.positionPlanner.metadata.settings,
+        expected.build.compilerMetadata.positionPlanner.settings, value.compilation.compilerSettings, value.stdJsonInput.settings, value.metadata.settings]) mutate(settings);
+    }),
+  ];
+  for (const mutate of mutations) {
+    const fixture = quotePlannerContext(); mutate(fixture);
+    assert.throws(() => validateSourcifySource(fixture.expected, fixture.value), undefined, mutate.toString());
+  }
+});
+
+test('Native and Core readbacks keep the existing no-CBOR default and reject the Quote opt-in', () => {
+  for (const sourceProfile of [undefined, 'module-native-v1', 'module-native-v2', 'module-engine-v1']) {
+    const { expected, value } = context(); expected.sourceProfile = sourceProfile;
+    assert.equal(validateSourcifySource(expected, value).providerClassification, 'NO_CBOR_PROVIDER_MATCH');
+    expected.compilerAuxdataProfile = 'quote-planner-solc-0.8.26-v1';
+    assert.throws(() => validateSourcifySource(expected, value), /Quote Planner/);
+    delete expected.compilerAuxdataProfile;
+    value.runtimeBytecode.cborAuxdata = { 1: { offset: 0, value: '0xa164736f6c634300081a000a' } };
+    assert.throws(() => validateSourcifySource(expected, value), /unexpected runtime CBOR/);
+  }
+});
 test('Sourcify binds all bytes while honestly retaining the no-CBOR provider match', () => {
   for (const role of ['positionForwarderFactory', 'tokenFactory']) {
     const { expected, value } = context(role); const result = validateSourcifySource(expected, value);

--- a/docs/operations/module-mode-publication-operator.md
+++ b/docs/operations/module-mode-publication-operator.md
@@ -69,13 +69,21 @@ wallet requests. Manifest construction before acceptance remains available throu
 the existing canonical `manifest` command. The wallet plan itself requires the
 real accepted decision.
 
-For each selected module, the plan has three sequential operations:
+For each selected Native V1 module, the plan has three sequential operations:
 
 1. Deploy its no-argument factory with the canonical salt and exact protected
    worker creation bytes. Both providers must report vacant code and zero nonce.
 2. Register the new contributor family with the API-authenticated author, fixed
    family salt, reward wallet and immutable source request digest.
 3. Admit the package revision with its exact factory/code/manifest/callback pins.
+
+Native V2 publication requires an explicit `--fee-eligibility` JSON tuple chosen
+before acceptance. The accepted manifest binds `eligible` and `reviewDigest`.
+A nonzero digest produces the existing owner-only `setFamilyFeeEligibility` call
+before revision admission; false/zero keeps the untouched default. Publication
+checks the exact `familyFeeEligibility` getter, and a supplied setter transaction
+must match owner, calldata, canonical receipt and event. Native V1 keeps its
+original inputs and calls.
 
 This first-family operator deliberately refuses to overwrite or transfer an
 existing family, revision or deployment. Existing-family revision workflows and
@@ -146,7 +154,26 @@ This wallet operator does not publish those artifacts or enable launches.
 canary uses an empty module array and 0% creator fee. The module canary uses the
 actual accepted modules and a positive whole-percent creator fee, for example
 100 bps, so the backend can prove both creator and contributor accrual. The
-platform fee remains the deployed 20 bps in both cases.
+platform fee is 20 bps for Native V1. Native V2 binds its separate economics
+policy: 10 bps protocol plus a 20 bps author pool only when the launch contains
+an eligible family. Its plain canary therefore has 10 bps and its module canary
+has 30 bps in total platform fees; creator fees remain separate.
+
+V2 obtains each selection's `feeEligibility` from its accepted, hash-bound host
+manifest. The caller cannot supply an alternative eligibility field in the
+action. Before launch, both providers must return that exact family eligibility
+and the hook's matching `previewRecipe`. The V2 recipe includes the economics
+policy and the hash of every selected family, eligibility flag and review digest.
+Eligible families are sorted and deduplicated; repeated selections of one family
+do not multiply its author allocation. V2 permits up to 16 distinct packages and
+eight eligible families. V1 retains its eight distinct-family bound.
+
+The V2 launch calldata includes the derived `expectedRecipeHash`. A changed
+eligibility review blocks preparation or the final arm refresh instead of
+silently changing the wallet payload. After inclusion, the operator checks the
+exact `NativeEconomicsBound` event and the hook's saved per-selection snapshot,
+pool fee and ledger fee. Later operations use that saved launch snapshot, so a
+later registry eligibility decision is not substituted into an existing pool.
 
 A launch action has this shape; all amounts are decimal base-unit strings and the
 addresses, salt, names, expiry and configuration must be deliberately selected:
@@ -196,6 +223,34 @@ must be positive, and the recipient is always the reviewed owner. Both providers
 must confirm that the token belongs to that owner's native launcher record. The
 receipt must contain the matching native trade event and amounts.
 
+Native V2 also supports the two exact-output canary operations:
+
+```ts
+{
+  kind: "buyExactOutput" | "sellExactOutput", canaryKind: "plain" | "modules",
+  token: Address, tokenCodeHash: Hex,
+  amount: string, maximumInput: string, deadline: string,
+  launch: { plan: originalLaunchPlan, evidence: verifiedLaunchReceipt }
+}
+```
+
+Here `amount` is the positive exact requested output, in token units for a buy or
+wei for a sell. `maximumInput` is the positive input ceiling in the other asset.
+Both values must be below the released native engine's signed amount bound.
+An exact-output buy sends exactly `maximumInput` wei. The runtime-pinned router
+atomically refunds `maximumInput - nativeAmount` to the caller and preserves its
+pre-existing balance. An exact-output sell sends no ETH and requires a separate
+token approval covering the chosen maximum input. Unspent approved tokens remain
+with the owner; they are not an ETH refund.
+
+Simulation and receipt checks require the exact output and an actual positive
+input no larger than the ceiling. V2 evidence reports `refundNative` calculated
+from the exact input ceiling and verified router result/event. This calculation
+uses the pinned router's successful atomic settlement semantics; it is not an
+independent wallet-balance-difference observation. The operator never raises a
+ceiling or changes an expired deadline. V1 operation plans retain their original
+exact-input behavior.
+
 Embed the original complete launch plan and its actual verified receipt output as
 JSON objects in `launch`; filenames or locally invented receipt claims are not
 accepted. Every subsequent operation re-reads that transaction and its canonical
@@ -230,6 +285,29 @@ It binds distinct tokens and six distinct transaction hashes to the same release
 The backend native lifecycle collector must then independently re-observe these
 receipts, module instances, fee accounting and Ethereum-finalized checkpoints.
 Only its separate validated artifact can satisfy the lifecycle activation gate.
+
+For Native V2, keep five operation records per canary: `launch`, `buy`, `sell`,
+`buyExactOutput`, and `sellExactOutput`. Preserve original creator recipients
+until this complete proof is collected. The existing V2 reference converter
+requires all ten actual transactions and the V2 economics event:
+
+```sh
+node contracts/scripts/module-native-v2/lifecycle.mjs \
+  --identity "$MODULE_RELEASE_IDENTITY" \
+  --canaries "$MODULE_ACTUAL_V2_CANARIES" \
+  --output "$MODULE_LIFECYCLE_PLAN" \
+  --source-root "$MODULE_CLEAN_CONTRACT_SOURCE_ROOT"
+```
+
+The operation plan's `sourceCommit` names the current reviewed operator source.
+Its `identity.sourceCommit` continues to name the actually deployed contracts.
+The unchanged wallet source-authority helper requires the operation plan to match
+the clean current production commit and its fresh hosted Verify evidence. The
+wallet builder has no source-root override. The later V2 lifecycle converter's
+existing `--source-root` selects the clean contract source for its mandatory
+identity/build comparison. It produces transaction references only; the original
+backend collector still independently verifies receipts, fees and Ethereum
+finality before activation.
 
 ## Existing management flow
 

--- a/docs/operations/module-mode-publication-operator.md
+++ b/docs/operations/module-mode-publication-operator.md
@@ -333,3 +333,205 @@ the hosted interface test gate. Tests use synthetic parser/RPC records and never
 serve as source, review, deployment or lifecycle evidence. Rendered desktop/mobile
 wallet-page QA remains an integration-owner check with `--ui-check`, followed by
 actual simulation and owner-confirmed receipts during release.
+
+## Private Engine publication and lifecycle
+
+The same personal operator also accepts the closed
+`programmable.module-engine-publication-owner-plan.v1` and
+`programmable.module-engine-lifecycle-owner-plan.v1` profiles. These are private
+wallet plans for an actual collected Engine release identity. They do not create
+an active release or an available template. The ordinary website client still
+requires its authenticated active release and catalog.
+
+Keep the two source identities separate: `identity.sourceCommit` identifies the
+already deployed contracts; the outer `sourceCommit` and `sourceTree` identify the
+clean production operator checkout and its successful hosted verification. A
+later operator fix does not relabel previously deployed contracts. The existing
+`assertSourceAuthority`, provider custody transport, explicit gas/value ceilings,
+pre-send journal, same-request retry, receipt and MetaMask confirmation are shared
+with Native operations.
+
+The accepted reviewer session belongs to `reviewAuthority`, taken from the exact
+accepted decision. The wallet that pays and sends is `owner`. Publication requires
+that wallet to be the **current Registry owner**, read from both providers. A
+launch or execute wallet is an **operation actor** and need not own the Registry
+or be the reviewer. Creator-only operations additionally require the actual
+Host launch creator. EOA transaction nonce and Host per-launch/per-actor nonce
+are separate checks.
+
+### Accepted Engine bundle and owner admission
+
+Use the existing protected build and accepted decision. Fetch their canonical
+bundle through the original fixed-origin authenticated reader; this command only
+reads the accepted submission and writes a new private file:
+
+```sh
+node contracts/scripts/module-engine/publication-plan.mjs bundle \
+  --identity "$ENGINE_COLLECTED_IDENTITY" \
+  --definition "$ENGINE_PUBLICATION_DEFINITION" \
+  --submission "$ENGINE_ACCEPTED_SUBMISSION_ID" \
+  --session-file "$MODULE_REVIEW_SESSION" \
+  --output "$ENGINE_ACCEPTED_BUNDLE"
+```
+
+`--definition` is the existing Engine publication definition from
+`ops/module-mode-publication`: `{ profile, catalogDefinition, revision }`. The
+output has exactly `{ source, manifest, review, artifact, buildPlan }`. Local
+copies are consistency inputs; they never replace the current authenticated
+Accepted revision or protected worker proof. The live server re-fetches that
+proof before starting, preparing, and arming each request. Revocation, a changed
+review/build/manifest, an unauthenticated cloned object, or a different reviewer
+session blocks the handoff.
+
+```sh
+node contracts/scripts/module-engine/publication-plan.mjs prepare \
+  --identity "$ENGINE_COLLECTED_IDENTITY" \
+  --bundle "$ENGINE_ACCEPTED_BUNDLE" \
+  --owner "$ENGINE_CURRENT_REGISTRY_OWNER" \
+  --family-state absent \
+  --output "$ENGINE_PUBLICATION_OWNER_PLAN"
+```
+
+`absent` produces `registerReviewedFamily` then Host `approveRevision`. Use
+`existing` only to reuse an already registered family with the exact accepted
+author and reward wallet; it produces only the Host admission. The two providers
+verify the chosen state. The revision must be absent, and its creation/runtime
+hashes, immutable maps, operation permissions, money/coin rights, fixed quote CA,
+fixed configuration, required initial operation and fee-family list come from the
+same accepted manifest and original publication ABI. No factory is deployed and
+no existing revision is overwritten or re-enabled.
+
+For each step use the **existing** commands above, substituting this plan:
+
+```sh
+node contracts/scripts/module-mode/publication-operator.mjs observe \
+  --plan "$ENGINE_PUBLICATION_OWNER_PLAN" --step "$ENGINE_STEP"
+
+node contracts/scripts/module-mode/publication-operator.mjs serve \
+  --plan "$ENGINE_PUBLICATION_OWNER_PLAN" --step "$ENGINE_STEP" --port 8787 \
+  --session-file "$MODULE_REVIEW_SESSION" --journal "$MODULE_PUBLICATION_JOURNAL" \
+  --reviewed-plan-digest "$ENGINE_REVIEWED_PLAN_DIGEST" \
+  --verify-run-id "$MODULE_VERIFY_RUN_ID" --verify-run-attempt "$MODULE_VERIFY_RUN_ATTEMPT" \
+  --max-gas "$OWNER_MAX_GAS" --max-fee-per-gas-wei "$OWNER_MAX_FEE_WEI" \
+  --priority-fee-per-gas-wei "$OWNER_PRIORITY_FEE_WEI" --max-value-wei 0
+```
+
+The UI shows the decoded target/function/arguments, value, chain and source before
+MetaMask. The owner confirms each exact request personally. `record` and `receipt`
+use the same original journal commands; a received wallet hash is never treated
+as verified inclusion. Export afterward through the original
+`ops/module-mode-publication/operator.mjs export`, supplying its actual
+`{family: hash|null, revision: hash}`. Export still does not activate a catalog.
+
+### Host launch and exact funding
+
+Prepare a launch action JSON with these exact keys (all addresses, salts, integer
+amounts, configuration and deadline are real reviewed inputs):
+
+```ts
+{
+  kind: "launch",
+  name: string, symbol: string, description: string,
+  imageUri: string, socialLinks: ModuleSocialLinks,
+  quote: { address: Address, runtimeCodeHash: Hex, decimals: number },
+  configuration: OpenConfigValue,
+  creatorSalt: Hex, engineSalt: Hex, launchData: Hex,
+  creatorWallets: Address[], creatorSharesBps: number[],
+  buyCreatorFeeBps: number, sellCreatorFeeBps: number,
+  initialOperation: EngineIntent | null,
+  deadline: string,
+  funding: { mode: "none" | "existing" | "approve" | "reset-approve", expectedAllowance: string }
+}
+```
+
+An `EngineIntent` has exactly `{ operationId, recipient, inputAsset, inputAmount,
+outputAsset, minimumOutput, data }`. Assets are the symbolic roles `"primary"`,
+`"quote"`, or `"native"`; the planner substitutes the predicted/actual primary
+token, exact quote CA, or zero address. Decimal amount strings are raw token/wei
+units. `data` is the accepted engine operation's ABI-encoded payload, displayed in
+the reviewed Host operation. The existing pure intent helpers in
+`lib/module-engine/client.ts` define deposit, withdrawal, quote trade, settlement
+request, fulfill and refund data. Their operation IDs must be admitted by the
+actual Host revision; a display label supplies no permission.
+
+```sh
+node contracts/scripts/module-engine/lifecycle-operator-plan.mjs \
+  --identity "$ENGINE_COLLECTED_IDENTITY" --bundle "$ENGINE_ACCEPTED_BUNDLE" \
+  --owner "$ENGINE_OPERATION_ACTOR" --action "$ENGINE_LAUNCH_ACTION" \
+  --output "$ENGINE_LAUNCH_OWNER_PLAN"
+```
+
+The common pure planner compiles the SDK schema bindings and constraints, enforces
+fixed quote/configuration, derives factory token CREATE2, constructor/runtime
+patches, engine CREATE2 and full Host plan hash, and encodes the actual Host ABI.
+A quote engine uses its required hook-address flags. The quote runtime and decimals
+are independently read before every handoff. The Engine Host V1's immutable
+`eligibleFamilies` list governs its Ledger V2 10/30 bps policy; its reused Registry
+V1 has no Native V2 `familyFeeEligibility` getter.
+
+Use `none` when there is no positive ERC20 input. `existing` requires allowance
+**exactly equal** to the operation input. `approve` requires a zero prior allowance
+and adds one exact approval. `reset-approve` requires the explicit positive prior
+allowance and adds a zero reset followed by that exact approval. The allowance is
+always for the fixed Host and next reviewed input asset/amount; an unlimited,
+unrelated, or stand-alone approval is rejected. The initial operation executes
+atomically inside Host `launch`, with actor nonce zero. ETH value equals only its
+native input; ERC20 funding sends zero ETH. Each preceding approval has its own
+wallet confirmation and canonical journal receipt before launch can proceed.
+
+Use the same `observe`/`serve`/`record`/`receipt` commands with this plan and its
+returned step indexes, owner-reviewed fee ceilings and exact `--max-value-wei`.
+The deadline must remain 120–3600 seconds from the common provider block. The
+Host enforces a deadline for an actual operation; an empty-initial-operation launch
+and ERC20 approvals have only the pre-handoff expiry check, not an onchain expiry. Expired
+plans must be prepared and reviewed again; an unresolved armed request must first
+be reconciled, never bypassed by silently replacing its plan or nonce.
+
+### Existing coin operations and D10 references
+
+An execute action has exactly:
+
+```ts
+{
+  kind: "execute",
+  launch: { plan: OriginalEngineLaunchOwnerPlan, entry: OriginalJournalEntry, evidence: OriginalReceiptEvidence },
+  intent: EngineIntent,
+  nonce: string, deadline: string,
+  funding: { mode: "none" | "existing" | "approve" | "reset-approve", expectedAllowance: string }
+}
+```
+
+Use the **launch step** from the original plan, including the initial operation
+if it had one. `journalEntry(journalDirectory, launchPlan.planDigest, launchStep)`
+from the unchanged `module-mode/journal.mjs` returns its original armed request
+and recorded transaction hash. Its `.receipt.json` supplies `evidence`. These
+three existing JSON values can be embedded locally into the action file without
+changing any journal file. The planner re-derives the original plan and binds
+its exact request; the observer independently re-reads both providers' actual
+transaction, canonical receipt, Engine events and getters. A Native receipt or
+an invented launch reference cannot supply membership.
+
+Run the same `lifecycle-operator-plan.mjs` command with this action and its actual
+actor. The required Host actor nonce is a raw decimal string in the reviewed
+action. It is re-read independently of the EOA nonce before every send. Input
+balance, exact allowance, permission roles even for zero amounts, creator-only
+rights, engine runtime, source release and launch plan all remain bound. A
+revision disabled for new launches retains its existing operation rights.
+
+The receipt verifies `EngineLaunchBound`, `EngineLaunchParametersBound` and
+`EngineOperationExecuted`, with exact canonical event encoding and original
+transaction fields. Output must meet the signed minimum. The canonical Host event attests the actual
+execute result hash; opaque result bytes may change with market or engine state,
+so the simulated result is not mislabeled as an execution limit. The pinned engine
+enforces its reviewed quote route and ETH fee floors as part of each call. Resource IDs may advance between simulation
+and inclusion; the actual resources hash is tied to the successful Host event and
+getter, while creation/configuration/plan bytes remain exact. Successful ERC20
+inputs must consume the exact allowance. Evidence is explicitly
+`sourceKind:"module-engine-v1"`, `included-code-verified-unfinalized`; Native event
+identity, Ethereum finality, public indexing and activation are not inferred.
+
+Feed actual `canary.launchId`, launch transaction and manifest hash, plus each
+actual operation's transaction/operationId/actor/nonce, into the already existing
+`contracts/scripts/module-engine/lifecycle-plan.mjs` reference format for its
+collector. A plan, local simulation, wallet hash or this operator receipt does
+not replace that final lifecycle collection or the separate D10 release gates.

--- a/lib/module-engine/client.ts
+++ b/lib/module-engine/client.ts
@@ -1,15 +1,15 @@
 import { concatHex, decodeAbiParameters, decodeEventLog, decodeFunctionResult, encodeAbiParameters, encodeEventTopics, encodeFunctionData, erc20Abi, getCreate2Address, keccak256, parseAbi, parseAbiParameters, toHex, type Abi, type Address, type Hex, type TransactionReceipt } from "viem";
 import { compileOpenConfig, type OpenConfigValue } from "@/packages/classic-modules/src/open-config.mjs";
-import { evaluateOpenConstraints } from "@/packages/classic-modules/src/open-constraints.mjs";
-import { validateTokenImage } from "@/lib/module-mode/builder";
 import { createModuleNativeClient, type ModuleNativeClient, type ModuleNativeWalletTransaction } from "@/lib/module-mode/native-client";
 import { nativeCanonicalJson } from "@/lib/module-mode/native-catalog";
 import { moduleAddress, moduleBytes, moduleHash, moduleRecord, moduleUint } from "@/lib/module-mode/release";
-import { MODULE_DEFAULT_TOKEN_IMAGE, moduleTokenMetadata, type ModuleSocialLinks } from "@/lib/module-mode/token-metadata";
-import { MAX_TOKEN_DESCRIPTION_BYTES, MAX_TOKEN_NAME_BYTES } from "@/lib/metadata-policy";
-import { ENGINE_CONTEXT, moduleEngineAuthorWalletAbi, moduleEngineConstructorParameters, moduleEngineHostAbi, moduleEngineLaunchParameters, moduleEngineLedgerAbi, moduleEnginePlanParameters, moduleEngineReadAbi, moduleEngineTradeLimitsParameters } from "./abi";
+import type { ModuleSocialLinks } from "@/lib/module-mode/token-metadata";
+import { ENGINE_CONTEXT, moduleEngineAuthorWalletAbi, moduleEngineHostAbi, moduleEngineLaunchParameters, moduleEngineLedgerAbi, moduleEnginePlanParameters, moduleEngineReadAbi, moduleEngineTradeLimitsParameters } from "./abi";
 import { bindActiveModuleEngineRelease, bindModuleEngineTemplate, ENGINE_ZERO_ADDRESS as ZERO, ENGINE_ZERO_HASH as ZERO_HASH, MODULE_ENGINE_CONTRACTS, MODULE_ENGINE_SOURCE_ID, moduleEngineOptionalHash, parseModuleEngineAvailability, type ModuleEngineAvailability, type ModuleEnginePermission, type ModuleEngineRelease, type ModuleEngineTemplate } from "./catalog";
 import { encodeModuleEngineConfiguration } from "./configuration";
+
+import { compileModuleEngineLaunch, moduleEngineOperation as operationFor } from "./operation-plan";
+export { materializeModuleEngineRuntime, predictModuleEngineAddress } from "./operation-plan";
 
 export type ModuleEngineClient = ModuleNativeClient;
 export const createModuleEngineClient = createModuleNativeClient;
@@ -153,10 +153,6 @@ async function approvalRequired(client: ModuleEngineClient, block: BoundBlock, t
   need(uint(balance, "input balance") >= amount, "Insufficient balance in the exact input asset.");
   const currentAllowance = uint(allowance, "input allowance"); return currentAllowance < amount ? { kind: "approval-required", token, spender, amount, currentAllowance } : null;
 }
-function operationFor(intent: ModuleEngineOperationIntent, account: Address, expiresAt: bigint, nonce: bigint): ModuleEngineOperation {
-  return { operationId: moduleHash(intent.operationId, "operationId"), actor: account, recipient: moduleAddress(intent.recipient, "recipient"), inputAsset: moduleAddress(intent.inputAsset, "inputAsset", true), inputAmount: uint(intent.inputAmount, "inputAmount"), outputAsset: moduleAddress(intent.outputAsset, "outputAsset", true), minimumOutput: uint(intent.minimumOutput, "minimumOutput"), deadline: expiresAt, nonce, data: moduleBytes(intent.data, "operation.data", 16_384) };
-}
-function emptyOperation(): ModuleEngineOperation { return { operationId: ZERO_HASH, actor: ZERO, recipient: ZERO, inputAsset: ZERO, inputAmount: 0n, outputAsset: ZERO, minimumOutput: 0n, deadline: 0n, nonce: 0n, data: "0x" }; }
 async function simulate(client: ModuleEngineClient, block: BoundBlock, transaction: ModuleNativeWalletTransaction, returnsNothing = false) {
   const request = { account: transaction.from, to: transaction.to, data: transaction.data, value: BigInt(transaction.value), blockNumber: block.blockNumber };
   const [result, gasEstimate] = await Promise.all([client.call(request), client.estimateGas(request)]);
@@ -174,20 +170,6 @@ export interface PrepareModuleEngineLaunchInput {
   initialOperation?: (identity: { token: Address; quoteAsset: Address }) => ModuleEngineOperationIntent;
   deadlineSeconds?: number;
 }
-export function materializeModuleEngineRuntime(template: Hex, constructorArgs: Hex, runtimeOffsets: readonly number[], constructorOffsets: readonly number[]): Hex {
-  need(runtimeOffsets.length === constructorOffsets.length, "Immutable map lengths differ."); let runtime = template; let previous = -32;
-  runtimeOffsets.forEach((offset, i) => { const binding = constructorOffsets[i]; need(Number.isInteger(offset) && offset >= previous + 32 && offset * 2 + 66 <= runtime.length && Number.isInteger(binding) && binding >= 0 && binding % 32 === 0 && binding * 2 + 66 <= constructorArgs.length, "Immutable mapping is out of bounds.");
-    const start = offset * 2 + 2; need(runtime.slice(start, start + 64) === "0".repeat(64), "Immutable slot is not zero."); runtime = `${runtime.slice(0, start)}${constructorArgs.slice(2 + binding * 2, 66 + binding * 2)}${runtime.slice(start + 64)}` as Hex; previous = offset; }); return runtime;
-}
-export function predictModuleEngineAddress(host: Address, creator: Address, engineSalt: Hex, launchId: Hex, initCodeHash: Hex) { return getCreate2Address({ from: host, salt: keccak256(encodeAbiParameters(parseAbiParameters("address,bytes32,bytes32"), [creator, engineSalt, launchId])), bytecodeHash: initCodeHash }).toLowerCase() as Address; }
-async function minedSalt(host: Address, creator: Address, base: Hex, launchId: Hex, initCodeHash: Hex) {
-  for (let i = 0n; i < 262_144n; i++) {
-    const salt = toHex((BigInt(base) + i) % (1n << 256n), { size: 32 }), address = predictModuleEngineAddress(host, creator, salt, launchId, initCodeHash);
-    if ((BigInt(address) & 0x3fffn) === 0x2080n) return { salt, address };
-    if (i % 2048n === 2047n) await new Promise<void>(resolve => setTimeout(resolve, 0));
-  }
-  throw new Error("Module engine: No valid hook address found. Change the engine salt and prepare again.");
-}
 export async function prepareModuleEngineLaunch(input: PrepareModuleEngineLaunchInput): Promise<PreparedModuleEngineLaunch | ModuleEngineApprovalRequired> {
   const availability = active(input.availability), account = moduleAddress(input.account, "account"), release = freeze(availability.release);
   const rawTemplate = availability.templates.find(item => item.manifest.manifest.catalogDefinition.id === input.templateId); need(rawTemplate, "Template is not in the current catalog.");
@@ -195,41 +177,22 @@ export async function prepareModuleEngineLaunch(input: PrepareModuleEngineLaunch
   const quoteAsset = moduleAddress(input.quoteAsset, "quoteAsset"); if (m.revision.fixedQuoteAsset !== ZERO) same(quoteAsset, m.revision.fixedQuoteAsset, "Fixed quote asset");
   const quoteCode = await input.client.getCode({ address: quoteAsset, blockNumber: block.blockNumber }); need(quoteCode && quoteCode !== "0x", "Quote asset is not a deployed token.");
   const quoteDecimals = Number(await read(input.client, quoteAsset, "decimals", [], block.blockNumber)); need(Number.isInteger(quoteDecimals) && quoteDecimals >= 0 && quoteDecimals <= 18, "Quote decimals are unsupported.");
-  const name = input.name.trim(), symbol = input.symbol.trim(); need(name.length > 0 && new TextEncoder().encode(name).length <= MAX_TOKEN_NAME_BYTES && /^[A-Za-z0-9]{1,11}$/.test(symbol), "Check the token name and symbol.");
-  need(new TextEncoder().encode(input.description).length <= MAX_TOKEN_DESCRIPTION_BYTES, "Description is too long.");
-  const imageUri = input.imageUri || MODULE_DEFAULT_TOKEN_IMAGE; need(!validateTokenImage({ kind: "uri", uri: imageUri, contentVerified: false }), "Use a public HTTPS token image.");
-  const config = compileOpenConfig(m.catalogDefinition.schema, input.configuration, { roles: { launchWallet: account }, assets: { quote: { chainId: "4663", address: quoteAsset, decimals: quoteDecimals } } });
-  const constraints = evaluateOpenConstraints(m.catalogDefinition.constraints, { self: { schema: m.catalogDefinition.schema, value: config.value } }); need(constraints.ok, constraints.violations[0]?.message ?? "Configuration constraints failed.");
-  const configuration = encodeModuleEngineConfiguration(m.catalogDefinition.configurationAbi, config, m.catalogDefinition.schema), configurationHash = keccak256(configuration); need(configuration.length <= 16_384 * 2 + 2, "Configuration is too large.");
-  if (m.revision.fixedConfigurationHash !== ZERO_HASH) same(configurationHash, m.revision.fixedConfigurationHash, "Fixed configuration");
-  const host = release.contracts.host.address, creatorSalt = moduleEngineOptionalHash(input.creatorSalt, "creatorSalt");
-  const predicted = await read(input.client, host, "predictTokenAddress", [name, symbol, account, creatorSalt], block.blockNumber, moduleEngineHostAbi) as readonly [Address, Hex];
-  const graffiti = keccak256(encodeAbiParameters(parseAbiParameters("string,address,bytes32"), ["programmable.module-engine.token.v1", account, creatorSalt])); same(predicted[1], graffiti, "Token graffiti");
-  const predictedToken = getCreate2Address({ from: release.contracts.tokenFactory.address, salt: keccak256(encodeAbiParameters(parseAbiParameters("string,string,uint8,address,bytes32"), [name, symbol, 18, host, graffiti])), bytecodeHash: release.tokenCreationCodeHash }).toLowerCase() as Address;
-  same(predicted[0], predictedToken, "Predicted token"); need(predictedToken !== quoteAsset, "Primary and quote assets must differ.");
-  const launchId = keccak256(encodeAbiParameters(parseAbiParameters("uint256,address,address,bytes32,bytes32"), [4663n, host, predictedToken, m.revision.packageId, configurationHash]));
-  const context = contextFor(release, { launchId, token: predictedToken, creator: account, quoteAsset }), constructorArgs = encodeAbiParameters(moduleEngineConstructorParameters, [context, configuration]);
-  const constructorHash = keccak256(constructorArgs), initCodeHash = keccak256(concatHex([m.source.engine.creationBytecode, constructorArgs]));
-  need((m.source.engine.creationBytecode.length + constructorArgs.length - 4) / 2 <= 49_152, "Engine init code exceeds the chain limit.");
-  const engineCodeHash = keccak256(materializeModuleEngineRuntime(m.source.engine.runtimeTemplate, constructorArgs, m.source.engine.immutableRuntimeOffsets, m.source.engine.immutableConstructorOffsets));
-  const initialSalt = moduleEngineOptionalHash(input.engineSalt, "engineSalt"); const engineIdentity = m.catalogDefinition.interface === "quote-v1" ? await minedSalt(host, account, initialSalt, launchId, initCodeHash) : { salt: initialSalt, address: predictModuleEngineAddress(host, account, initialSalt, launchId, initCodeHash) };
-  const expiresAt = deadline(block.timestamp, input.deadlineSeconds), initialOperation = input.initialOperation ? operationFor(input.initialOperation({ token: predictedToken, quoteAsset }), account, expiresAt, 0n) : emptyOperation();
-  same(initialOperation.operationId, m.revision.initialOperationId, "Required initial operation");
+  const expiresAt = deadline(block.timestamp, input.deadlineSeconds);
+  const compiled = await compileModuleEngineLaunch(input, release, template.manifest, quoteDecimals, expiresAt);
+  const { parameters, graffiti, predictedToken, launchId, configurationHash, constructorHash, initCodeHash, engineCodeHash, initialOperation, buyCreatorFeeBps, sellCreatorFeeBps, planHash } = compiled;
+  const host = release.contracts.host.address, engineIdentity = { address: compiled.engine };
+  const predicted = await read(input.client, host, "predictTokenAddress", [parameters.name, parameters.symbol, account, parameters.creatorSalt], block.blockNumber, moduleEngineHostAbi) as readonly [Address, Hex];
+  same(predicted[1], graffiti, "Token graffiti"); same(predicted[0], predictedToken, "Predicted token");
   if (initialOperation.operationId !== ZERO_HASH) { const required = await validateOperation(input.client, block, { launchId, revisionId: m.revision.packageId, creator: account, token: predictedToken, quoteAsset }, initialOperation, account); if (required) return required; }
-  need(input.creatorWallets.length > 0 && input.creatorWallets.length <= 16 && input.creatorWallets.length === input.creatorSharesBps.length && input.creatorSharesBps.every(value => Number.isInteger(value) && value > 0 && value <= 10_000) && input.creatorSharesBps.reduce((sum, value) => sum + value, 0) === 10_000, "Creator shares must total 100%.");
-  const creatorWallets = input.creatorWallets.map(wallet => moduleAddress(wallet, "creatorWallet")); need(new Set(creatorWallets).size === creatorWallets.length, "Creator recipients must be unique.");
-  const buyCreatorFeeBps = fee(input.buyCreatorFeeBps), sellCreatorFeeBps = fee(input.sellCreatorFeeBps);
-  const parameters = { name, symbol, creatorSalt, revisionId: m.revision.packageId, quoteAsset, configuration, creationCode: m.source.engine.creationBytecode, runtimeTemplate: m.source.engine.runtimeTemplate, engineSalt: engineIdentity.salt, launchData: moduleBytes(input.launchData ?? "0x", "launchData", 16_384), metadata: moduleTokenMetadata(input.description, imageUri, input.socialLinks), creatorWallets, creatorSharesBps: [...input.creatorSharesBps], buyCreatorFeeBps, sellCreatorFeeBps, initialOperation };
-  const planHash = keccak256(encodeAbiParameters(moduleEnginePlanParameters, [4663n, host, account, parameters]));
-  const transaction = tx(account, host, encodeFunctionData({ abi: moduleEngineHostAbi, functionName: "launch", args: [parameters] }), initialOperation.inputAsset === ZERO ? initialOperation.inputAmount : 0n, "launch", `Launch ${symbol} with ${m.catalogDefinition.title}`);
+  const transaction = tx(account, host, encodeFunctionData({ abi: moduleEngineHostAbi, functionName: "launch", args: [parameters] }), initialOperation.inputAsset === ZERO ? initialOperation.inputAmount : 0n, "launch", `Launch ${parameters.symbol} with ${m.catalogDefinition.title}`);
   const simulated = await simulate(input.client, block, transaction), result = launchRecord(decodeFunctionResult({ abi: moduleEngineHostAbi, functionName: "launch", data: simulated.data }));
   for (const [key, expected] of Object.entries({ launchId, revisionId: m.revision.packageId, token: predictedToken, creator: account, quoteAsset, engine: engineIdentity.address, engineCodeHash, constructorHash, initCodeHash, configurationHash, planHash })) same(result[key as keyof ModuleEngineLaunchRecord], expected, `Simulated ${key}`);
-  const snapshots = await Promise.all(m.revision.eligibleFamilies.map(family => read(input.client, release.contracts.registry.address, "familyFeeEligibility", [family], block.blockNumber)));
-  const platformFeeBps = snapshots.some(snapshot => Array.isArray(snapshot) && snapshot[0] === true) ? 30 : 10;
+  // Host V1 admits its immutable reviewed family list into Ledger V2. Its reused Registry V1
+  // has no Native V2 familyFeeEligibility getter; the list itself selects the 10/30 bps policy.
+  const platformFeeBps = m.revision.eligibleFamilies.length > 0 ? 30 : 10;
   const prepared: PreparedModuleEngineLaunch = { sourceKind: "module-engine-v1", kind: "launch", account, releaseDigest: release.releaseDigest, blockNumber: block.blockNumber, expiresAt, gasEstimate: simulated.gasEstimate, transaction: { ...transaction, gas: toHex(simulated.gasEstimate * 12n / 10n) }, predictedToken, engine: engineIdentity.address, launchId, revisionId: m.revision.packageId, planHash, configurationHash, engineCodeHash, quoteAsset, quoteDecimals, initialOperation, platformFeeBps, buyCreatorFeeBps, sellCreatorFeeBps };
   return bind(prepared, { client: input.client, release, refresh: async () => {
     const current = await assertModuleEngineRelease({ client: input.client, release }); need(current.timestamp <= expiresAt, "Launch preview expired."); await assertTemplate(input.client, current, template, true);
-    const currentSnapshots = await Promise.all(m.revision.eligibleFamilies.map(family => read(input.client, release.contracts.registry.address, "familyFeeEligibility", [family], current.blockNumber))); equal(currentSnapshots, snapshots, "Fee eligibility review snapshot");
     if (initialOperation.operationId !== ZERO_HASH) need(!await validateOperation(input.client, current, { ...result }, initialOperation, account), "Initial funding approval changed.");
     const fresh = await simulate(input.client, current, transaction); const currentLaunch = launchRecord(decodeFunctionResult({ abi: moduleEngineHostAbi, functionName: "launch", data: fresh.data }));
     for (const key of ["launchId", "planHash", "token", "engine", "engineCodeHash", "configurationHash"] as const) same(currentLaunch[key], result[key], `Current launch ${key}`);

--- a/lib/module-engine/operation-plan.ts
+++ b/lib/module-engine/operation-plan.ts
@@ -1,0 +1,74 @@
+import { concatHex, encodeAbiParameters, getCreate2Address, keccak256, parseAbiParameters, toHex, type Address, type Hex } from "viem";
+import { compileOpenConfig, type OpenConfigValue } from "@/packages/classic-modules/src/open-config.mjs";
+import { evaluateOpenConstraints } from "@/packages/classic-modules/src/open-constraints.mjs";
+import { validateTokenImage } from "@/lib/module-mode/builder";
+import { moduleAddress, moduleBytes, moduleHash, moduleUint } from "@/lib/module-mode/release";
+import { MODULE_DEFAULT_TOKEN_IMAGE, moduleTokenMetadata, type ModuleSocialLinks } from "@/lib/module-mode/token-metadata";
+import { MAX_TOKEN_DESCRIPTION_BYTES, MAX_TOKEN_NAME_BYTES } from "@/lib/metadata-policy";
+import { moduleEngineConstructorParameters, moduleEnginePlanParameters } from "./abi";
+import { computeModuleEngineHostManifestHash, moduleEngineReleaseIdentity, moduleEngineOptionalHash, ENGINE_ZERO_ADDRESS as ZERO, ENGINE_ZERO_HASH as ZERO_HASH, type ModuleEngineHostManifest, type ModuleEngineReleaseIdentity } from "./catalog";
+import { encodeModuleEngineConfiguration } from "./configuration";
+import type { ModuleEngineOperation, ModuleEngineOperationIntent } from "./client";
+function need(condition: unknown, message: string): asserts condition { if (!condition) throw new Error(`Module engine: ${message}`); }
+function same(actual: string, expected: string, label: string) { need(actual.toLowerCase() === expected.toLowerCase(), `${label} differs.`); }
+function uint(value: unknown, label: string) { return BigInt(moduleUint(typeof value === "bigint" ? value.toString() : value, label)); }
+function fee(value: unknown) { need(typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 1000 && value % 100 === 0, "Creator fees must be whole percentages from 0% to 10%."); return value; }
+export function moduleEngineOperation(intent: ModuleEngineOperationIntent, account: Address, expiresAt: bigint, nonce: bigint): ModuleEngineOperation {
+  return { operationId: moduleHash(intent.operationId, "operationId"), actor: moduleAddress(account, "actor"), recipient: moduleAddress(intent.recipient, "recipient"), inputAsset: moduleAddress(intent.inputAsset, "inputAsset", true), inputAmount: uint(intent.inputAmount, "inputAmount"), outputAsset: moduleAddress(intent.outputAsset, "outputAsset", true), minimumOutput: uint(intent.minimumOutput, "minimumOutput"), deadline: uint(expiresAt, "deadline"), nonce: uint(nonce, "nonce"), data: moduleBytes(intent.data, "operation.data", 16_384) };
+}
+function emptyOperation(): ModuleEngineOperation { return { operationId: ZERO_HASH, actor: ZERO, recipient: ZERO, inputAsset: ZERO, inputAmount: 0n, outputAsset: ZERO, minimumOutput: 0n, deadline: 0n, nonce: 0n, data: "0x" }; }
+export interface ModuleEngineLaunchInputs {
+  account: Address; quoteAsset: Address; name: string; symbol: string; description: string; imageUri?: string; socialLinks?: ModuleSocialLinks;
+  configuration: OpenConfigValue; creatorSalt: Hex; engineSalt: Hex; launchData?: Hex;
+  creatorWallets: readonly Address[]; creatorSharesBps: readonly number[]; buyCreatorFeeBps: number; sellCreatorFeeBps: number;
+  initialOperation?: (identity: { token: Address; quoteAsset: Address }) => ModuleEngineOperationIntent;
+}
+export function materializeModuleEngineRuntime(template: Hex, constructorArgs: Hex, runtimeOffsets: readonly number[], constructorOffsets: readonly number[]): Hex {
+  need(runtimeOffsets.length === constructorOffsets.length, "Immutable map lengths differ."); let runtime = template; let previous = -32;
+  runtimeOffsets.forEach((offset, i) => { const binding = constructorOffsets[i]; need(Number.isInteger(offset) && offset >= previous + 32 && offset * 2 + 66 <= runtime.length && Number.isInteger(binding) && binding >= 0 && binding % 32 === 0 && binding * 2 + 66 <= constructorArgs.length, "Immutable mapping is out of bounds.");
+    const start = offset * 2 + 2; need(runtime.slice(start, start + 64) === "0".repeat(64), "Immutable slot is not zero."); runtime = `${runtime.slice(0, start)}${constructorArgs.slice(2 + binding * 2, 66 + binding * 2)}${runtime.slice(start + 64)}` as Hex; previous = offset; }); return runtime;
+}
+export function predictModuleEngineAddress(host: Address, creator: Address, engineSalt: Hex, launchId: Hex, initCodeHash: Hex) { return getCreate2Address({ from: host, salt: keccak256(encodeAbiParameters(parseAbiParameters("address,bytes32,bytes32"), [creator, engineSalt, launchId])), bytecodeHash: initCodeHash }).toLowerCase() as Address; }
+async function minedSalt(host: Address, creator: Address, base: Hex, launchId: Hex, initCodeHash: Hex) {
+  for (let i = 0n; i < 262_144n; i++) {
+    const salt = toHex((BigInt(base) + i) % (1n << 256n), { size: 32 }), address = predictModuleEngineAddress(host, creator, salt, launchId, initCodeHash);
+    if ((BigInt(address) & 0x3fffn) === 0x2080n) return { salt, address };
+    if (i % 2048n === 2047n) await new Promise<void>(resolve => setTimeout(resolve, 0));
+  }
+  throw new Error("Module engine: No valid hook address found. Change the engine salt and prepare again.");
+}
+/** Pure deterministic planning only. It grants no review, availability, RPC or wallet authority. */
+export async function compileModuleEngineLaunch(input: ModuleEngineLaunchInputs, releaseValue: ModuleEngineReleaseIdentity, manifest: ModuleEngineHostManifest, quoteDecimals: number, expiresAt: bigint) {
+  const release = moduleEngineReleaseIdentity(releaseValue), account = moduleAddress(input.account, "account"), quoteAsset = moduleAddress(input.quoteAsset, "quoteAsset");
+  computeModuleEngineHostManifestHash(manifest);
+  need(manifest.manifest.release.releaseDigest === release.releaseDigest, "Manifest release differs.");
+  const m = manifest.manifest;
+  if (m.revision.fixedQuoteAsset !== ZERO) same(quoteAsset, m.revision.fixedQuoteAsset, "Fixed quote asset");
+  need(Number.isInteger(quoteDecimals) && quoteDecimals >= 0 && quoteDecimals <= 18, "Quote decimals are unsupported.");
+  const name = input.name.trim(), symbol = input.symbol.trim(); need(name.length > 0 && new TextEncoder().encode(name).length <= MAX_TOKEN_NAME_BYTES && /^[A-Za-z0-9]{1,11}$/.test(symbol), "Check the token name and symbol.");
+  need(new TextEncoder().encode(input.description).length <= MAX_TOKEN_DESCRIPTION_BYTES, "Description is too long.");
+  const imageUri = input.imageUri || MODULE_DEFAULT_TOKEN_IMAGE; need(!validateTokenImage({ kind: "uri", uri: imageUri, contentVerified: false }), "Use a public HTTPS token image.");
+  const config = compileOpenConfig(m.catalogDefinition.schema, input.configuration, { roles: { launchWallet: account }, assets: { quote: { chainId: "4663", address: quoteAsset, decimals: quoteDecimals } } });
+  const constraints = evaluateOpenConstraints(m.catalogDefinition.constraints, { self: { schema: m.catalogDefinition.schema, value: config.value } }); need(constraints.ok, constraints.violations[0]?.message ?? "Configuration constraints failed.");
+  const configuration = encodeModuleEngineConfiguration(m.catalogDefinition.configurationAbi, config, m.catalogDefinition.schema), configurationHash = keccak256(configuration); need(configuration.length <= 16_384 * 2 + 2, "Configuration is too large.");
+  if (m.revision.fixedConfigurationHash !== ZERO_HASH) same(configurationHash, m.revision.fixedConfigurationHash, "Fixed configuration");
+  const host = release.contracts.host.address, creatorSalt = moduleEngineOptionalHash(input.creatorSalt, "creatorSalt");
+  const graffiti = keccak256(encodeAbiParameters(parseAbiParameters("string,address,bytes32"), ["programmable.module-engine.token.v1", account, creatorSalt]));
+  const predictedToken = getCreate2Address({ from: release.contracts.tokenFactory.address, salt: keccak256(encodeAbiParameters(parseAbiParameters("string,string,uint8,address,bytes32"), [name, symbol, 18, host, graffiti])), bytecodeHash: release.tokenCreationCodeHash }).toLowerCase() as Address;
+  need(predictedToken !== quoteAsset, "Primary and quote assets must differ.");
+  const launchId = keccak256(encodeAbiParameters(parseAbiParameters("uint256,address,address,bytes32,bytes32"), [4663n, host, predictedToken, m.revision.packageId, configurationHash]));
+  const context = { host, launchId, token: predictedToken, creator: account, quoteAsset, feeCollector: host }, constructorArgs = encodeAbiParameters(moduleEngineConstructorParameters, [context, configuration]);
+  const constructorHash = keccak256(constructorArgs), initCodeHash = keccak256(concatHex([m.source.engine.creationBytecode, constructorArgs]));
+  need((m.source.engine.creationBytecode.length + constructorArgs.length - 4) / 2 <= 49_152, "Engine init code exceeds the chain limit.");
+  const engineCodeHash = keccak256(materializeModuleEngineRuntime(m.source.engine.runtimeTemplate, constructorArgs, m.source.engine.immutableRuntimeOffsets, m.source.engine.immutableConstructorOffsets));
+  const initialSalt = moduleEngineOptionalHash(input.engineSalt, "engineSalt"); const engineIdentity = m.catalogDefinition.interface === "quote-v1" ? await minedSalt(host, account, initialSalt, launchId, initCodeHash) : { salt: initialSalt, address: predictModuleEngineAddress(host, account, initialSalt, launchId, initCodeHash) };
+  const initialOperation = input.initialOperation ? moduleEngineOperation(input.initialOperation({ token: predictedToken, quoteAsset }), account, expiresAt, 0n) : emptyOperation();
+  same(initialOperation.operationId, m.revision.initialOperationId, "Required initial operation");
+  need(input.creatorWallets.length > 0 && input.creatorWallets.length <= 16 && input.creatorWallets.length === input.creatorSharesBps.length && input.creatorSharesBps.every(value => Number.isInteger(value) && value > 0 && value <= 10_000) && input.creatorSharesBps.reduce((sum, value) => sum + value, 0) === 10_000, "Creator shares must total 100%.");
+  const creatorWallets = input.creatorWallets.map(wallet => moduleAddress(wallet, "creatorWallet")); need(new Set(creatorWallets).size === creatorWallets.length, "Creator recipients must be unique.");
+  const buyCreatorFeeBps = fee(input.buyCreatorFeeBps), sellCreatorFeeBps = fee(input.sellCreatorFeeBps);
+  const parameters = { name, symbol, creatorSalt, revisionId: m.revision.packageId, quoteAsset, configuration, creationCode: m.source.engine.creationBytecode, runtimeTemplate: m.source.engine.runtimeTemplate, engineSalt: engineIdentity.salt, launchData: moduleBytes(input.launchData ?? "0x", "launchData", 16_384), metadata: moduleTokenMetadata(input.description, imageUri, input.socialLinks), creatorWallets, creatorSharesBps: [...input.creatorSharesBps], buyCreatorFeeBps, sellCreatorFeeBps, initialOperation };
+  const planHash = keccak256(encodeAbiParameters(moduleEnginePlanParameters, [4663n, host, account, parameters]));
+  return { parameters, graffiti, predictedToken, launchId, configurationHash, constructorArgs, constructorHash, initCodeHash, engineCodeHash,
+    context, engine: engineIdentity.address, planHash, quoteAsset, quoteDecimals, expiresAt, initialOperation, buyCreatorFeeBps, sellCreatorFeeBps };
+}

--- a/lib/module-mode/publication-session.ts
+++ b/lib/module-mode/publication-session.ts
@@ -1,0 +1,47 @@
+import { isWebsiteAdminWallet } from "../admin-access";
+
+/** A fresh object for each authenticated wallet/session generation. Contains no credentials. */
+export type PublicationSession = Readonly<{ walletAddress: string }>;
+export type PublicationSessionExportResult = "downloaded" | "busy" | "session-changed" | "unavailable";
+type ExportInput = Readonly<{
+  readSession: () => PublicationSession | null;
+  getIdentityToken: () => Promise<string | null>;
+  getAccessToken: () => Promise<string | null>;
+  download: (json: string) => void;
+}>;
+const tokenPattern = /^[A-Za-z0-9_.-]{20,16384}$/u;
+
+/** Local serialization only. The original operator still authenticates every private BFF read. */
+export function createPublicationSessionExporter() {
+  let pending = false;
+  return async (input: ExportInput): Promise<PublicationSessionExportResult> => {
+    // This lock is synchronous, before token access or the first await.
+    if (pending) return "busy";
+    pending = true;
+    try {
+      const session = input.readSession();
+      if (!session || !isWebsiteAdminWallet(session.walletAddress)) return "session-changed";
+      const isCurrent = () => input.readSession() === session && isWebsiteAdminWallet(session.walletAddress);
+      if (!isCurrent()) return "session-changed";
+      // Identity tokens are optional in the existing operator format.
+      const identityToken = await input.getIdentityToken().catch(() => null);
+      if (!isCurrent()) return "session-changed";
+      const accessToken = await input.getAccessToken();
+      if (!isCurrent()) return "session-changed";
+      if (typeof accessToken !== "string" || !tokenPattern.test(accessToken)
+        || (identityToken !== null && (typeof identityToken !== "string" || !tokenPattern.test(identityToken)))) return "unavailable";
+      const text = JSON.stringify({ walletAddress: session.walletAddress.toLowerCase(), accessToken,
+        ...(identityToken === null ? {} : { identityToken }) });
+      // Match readOperatorSession's closed JSON, token bounds and complete file-size limit.
+      if (new TextEncoder().encode(text).byteLength > 32_768) return "unavailable";
+      if (!isCurrent()) return "session-changed";
+      input.download(text);
+      return "downloaded";
+    } catch {
+      // SDK errors may contain credentials. Only fixed result codes leave this helper.
+      return "unavailable";
+    } finally {
+      pending = false;
+    }
+  };
+}

--- a/lib/server/module-mode/review-client.ts
+++ b/lib/server/module-mode/review-client.ts
@@ -6,8 +6,9 @@ import { bindModuleEngineReleaseIdentity, computeModuleEngineHostManifestHash, t
 import { randomBytes } from "node:crypto";
 import { getAddress, isAddress } from "viem";
 import { isWebsiteAdminWallet } from "@/lib/admin-access";
-import configuredRelease from "@/config/module-mode/robinhood.preview.json";
+import configuredNativeReviewRelease from "@/config/module-mode/review-release.json";
 import configuredEngineReviewRelease from "@/config/module-engine/review-release.json";
+import { computeModuleModeReleaseDigest, moduleHash, moduleRecord, MODULE_MODE_SOURCE_VERSION_V2 } from "@/lib/module-mode/release";
 import { isReviewId, parseReviewAttempt, parseReviewJob, parseReviewPlan, reviewDigest, reviewRecord, parseReviewQueueItem, type ReviewDetail } from "@/lib/module-mode/review-contract";
 import { nativeCanonicalJson } from "@/lib/module-mode/native-catalog";
 import { unsupportedManagementCapabilities } from "@/lib/module-mode/management-manifest";
@@ -43,6 +44,18 @@ async function bytes(input: Request | Response, maximum: number) {
 }
 function parsed(value: Uint8Array, maximum: number) { return parseStrictJson(new TextDecoder("utf-8", { fatal: true }).decode(value), { maximumBytes: maximum, maximumDepth: 40 }); }
 function jsonHeader(input: Request | Response) { if (input.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() !== "application/json") fail(415, "MODULE_REVIEW_JSON_REQUIRED"); }
+
+/** Closed server identity only; installing it does not authorize review or public activation. */
+export function bindModuleModeReviewReleaseIdentity(value: unknown): ModuleModeHostReleaseIdentity {
+  // The existing digest binder validates both generations, every pin and the V2 economics policy.
+  // It also rejects accessors before the source-version read below.
+  const digest = computeModuleModeReleaseDigest(value);
+  const r = moduleRecord(value, ["schemaVersion", "sourceVersion", "chainId", "sourceCommit", "startBlock",
+    "minimumInitialBuyNative", "tokenCreationCodeHash", "finalityPolicy", "contracts", "releaseDigest",
+    ...((value as { sourceVersion: unknown }).sourceVersion === MODULE_MODE_SOURCE_VERSION_V2 ? ["economicsPolicyId"] : [])], "review.releaseIdentity");
+  if (moduleHash(r.releaseDigest, "review.releaseDigest") !== digest) throw new Error("Native review release identity differs.");
+  return r as unknown as ModuleModeHostReleaseIdentity;
+}
 
 export function createModuleReviewClient(input: {
   authenticator: WalletPrincipalAuthenticatorV1; backendBaseUrl: string; websiteToken: string; bffAssertionKeyV2: string;
@@ -120,8 +133,9 @@ export function createModuleReviewClient(input: {
           if (!same(raw, expected)) fail(400, "MODULE_REVIEW_MANIFEST_BUILD_MISMATCH");
           return computeModuleEngineHostManifestHash(expected);
         }
-        const release = input.releaseIdentity ?? configuredRelease;
-        if (!release || typeof release !== "object" || typeof (release as { releaseDigest?: unknown }).releaseDigest !== "string") fail(409, "MODULE_REVIEW_HOST_RELEASE_UNAVAILABLE");
+        if (input.releaseIdentity === null || input.releaseIdentity === undefined) fail(409, "MODULE_REVIEW_HOST_RELEASE_UNAVAILABLE");
+        // Keep Native configuration failures local to Native manifest checks and acceptance.
+        const release = bindModuleModeReviewReleaseIdentity(input.releaseIdentity);
         const raw = userInput(() => parsed(Buffer.from(text), 2 * 1024 * 1024));
         const manifest = reviewRecord(reviewRecord(raw).manifest);
         const binding = reviewRecord(manifest.runtimeBinding);
@@ -129,7 +143,7 @@ export function createModuleReviewClient(input: {
           ...(Object.hasOwn(binding, "feeEligibility") ? { feeEligibility: binding.feeEligibility } : {}) };
         const artifact = detail.job.artifact;
         if (nativeBinding.familyId !== artifact.familyId || nativeBinding.packageId !== artifact.packageId || nativeBinding.factoryCodeHash !== artifact.factory.runtimeCodeHash || nativeBinding.moduleCodeHash !== artifact.program.runtimeCodeHash || nativeBinding.callbackGas !== artifact.callbackGas) fail(400, "MODULE_REVIEW_MANIFEST_BUILD_MISMATCH");
-        const expected = userInput(() => createModuleModeHostManifest({ release: release as ModuleModeHostReleaseIdentity, definition: manifest.catalogDefinition as ModuleModeCatalogDefinition, nativeBinding: nativeBinding as Parameters<typeof createModuleModeHostManifest>[0]["nativeBinding"], descriptor: detail.source.descriptor }));
+        const expected = userInput(() => createModuleModeHostManifest({ release, definition: manifest.catalogDefinition as ModuleModeCatalogDefinition, nativeBinding: nativeBinding as Parameters<typeof createModuleModeHostManifest>[0]["nativeBinding"], descriptor: detail.source.descriptor }));
         const plan = detail.job.plan;
         if (!plan || plan.configurationCodec !== "programmable.native-abi@1" || artifact.configurationCodec !== plan.configurationCodec || !same(plan.programAbi, artifact.programAbi) || !same(expected.manifest.configuration.abiMapping, plan.programAbi) || !same(expected.manifest.catalogDefinition.programAbi, plan.programAbi)) fail(400, "MODULE_REVIEW_MANIFEST_ABI_MISMATCH");
         if (!same(raw, expected) || unsupportedManagementCapabilities(expected.manifest.management).length) fail(400, "MODULE_REVIEW_MANIFEST_INVALID");
@@ -186,7 +200,7 @@ export function createModuleReviewClient(input: {
 let client: ReturnType<typeof createModuleReviewClient> | undefined;
 export async function moduleReviewRoute(request: Request, operation: Operation, id?: string) {
   try {
-    client ??= createModuleReviewClient({ authenticator: createPrivyWalletPrincipalAuthenticatorV1(), backendBaseUrl: process.env.PROGRAMMABLE_CUSTOM_LAUNCH_API_BASE_URL ?? "", websiteToken: process.env.PROGRAMMABLE_CUSTOM_LAUNCH_WEBSITE_TOKEN ?? "", bffAssertionKeyV2: process.env.PROGRAMMABLE_CUSTOM_LAUNCH_BFF_ASSERTION_KEY_V2 ?? "", fetchBackend: fetch, engineReleaseIdentity: configuredEngineReviewRelease });
+    client ??= createModuleReviewClient({ authenticator: createPrivyWalletPrincipalAuthenticatorV1(), backendBaseUrl: process.env.PROGRAMMABLE_CUSTOM_LAUNCH_API_BASE_URL ?? "", websiteToken: process.env.PROGRAMMABLE_CUSTOM_LAUNCH_WEBSITE_TOKEN ?? "", bffAssertionKeyV2: process.env.PROGRAMMABLE_CUSTOM_LAUNCH_BFF_ASSERTION_KEY_V2 ?? "", fetchBackend: fetch, releaseIdentity: configuredNativeReviewRelease, engineReleaseIdentity: configuredEngineReviewRelease });
     return await client.handle(request, operation, id);
   } catch { return response(503, { error: { code: "MODULE_REVIEW_SERVICE_UNAVAILABLE" } }); }
 }

--- a/ops/module-mode-publication/README.md
+++ b/ops/module-mode-publication/README.md
@@ -19,6 +19,11 @@ real Registry, contract-code, transaction and receipt checks pass on both review
   `programAbi` must exactly equal the tested plan and build artifact. Both declare
   `configurationCodec: "programmable.native-abi@1"`; no alphabetically ordered generic encoding
   is silently substituted for the program's reviewed argument order.
+- `--fee-eligibility`: required only for a `module-native-v2` identity. Supply a JSON file containing
+  exactly `{ "eligible": true, "reviewDigest": "0x…" }`, using the actual family review digest.
+  The reviewer chooses this tuple before manifest acceptance. The complete manifest hash covers it;
+  `prepare` and `export` require the same accepted value. The operator creates no eligibility or digest
+  default. NativeV1 and Engine publication reject this option.
 - `--submission`: the UUID returned by module submission.
 - `--session-file`: an existing administrator's Privy session in a local owner-only regular file:
   `{ "walletAddress": "0x…", "accessToken": "…", "identityToken": "…" }`.
@@ -94,6 +99,16 @@ operator; it never prints endpoints or credentials.
    is absent. For an existing family, verify its author and current reward wallet; do not overwrite it.
 3. Admit the immutable package revision with its factory/code/manifest/callback pins.
 
+NativeV2 inserts `setFamilyFeeEligibility(familyId, eligible, reviewDigest)` between family registration
+and revision admission when the reviewed digest is nonzero. The call uses the existing Registry owner,
+zero ETH value and exactly the eligibility covered by the accepted manifest. It cannot choose fee rates.
+The explicit `false`/zero-digest tuple retains the untouched RegistryV2 default without a setter call;
+the contract rejects zero digests in that setter. An explicit `false` with a nonzero review digest is
+recorded as reviewed ineligibility. Reuse an existing exact family review instead of overwriting it.
+The owner-plan command in `contracts/scripts/module-mode/publication-plan.mjs` derives the same tuple
+from the accepted manifest, checks the default before a new eligibility write, and checks the exact
+getter before and after revision admission.
+
 These are unsigned operation templates, not armed wallet requests. Simulate each operation immediately
 before signing, check the connected wallet and chain, and inspect the actual gas quote. Do not replay a
 transaction whose submission outcome is unknown. An existing revision is never overwritten or
@@ -109,6 +124,11 @@ Create a private transaction file with the actual hashes:
 ```
 
 Use `family: null` only when the family already existed with the exact author and current reward wallet.
+For NativeV2, the transaction file also requires `feeEligibility`: the actual setter transaction hash,
+or `null` for an existing exact review or the untouched false/zero default. Export always checks the
+current `familyFeeEligibility` getter on both providers. A supplied setter hash must match the exact
+owner, calldata, canonical successful receipt and `FamilyFeeEligibilityReviewed` event. A changed
+eligibility or review digest stops export. NativeV1 retains its original three transaction fields.
 Run the same command with `export`, a new output directory, and
 `--transactions /private/operator/transactions.json`.
 
@@ -149,7 +169,7 @@ submitted Solidity is treated only as data and is never executed by this publica
 ## Executable Engine profile
 
 The same `manifest`, `prepare`, and `export` commands also handle an authenticated
-`programmable.modules.engine-build.v1` result. Native publication keeps its existing
+`programmable.modules.engine-build.v1` result. NativeV1 publication keeps its existing
 wire, compiler profile, command arguments, session handling and registry calls.
 There is no additional intake, publisher identity, or source-selected host command.
 

--- a/ops/module-mode-publication/README.md
+++ b/ops/module-mode-publication/README.md
@@ -32,6 +32,16 @@ real Registry, contract-code, transaction and receipt checks pass on both review
 - `--output`: a new directory under an existing private `0700` parent outside the repository.
   The operator never overwrites an earlier result.
 
+Use the normal wallet login at `https://programmable.market/admin/modules`. With the authenticated
+admin wallet connected, select **Download publication session**. The explicit action downloads
+`module-publication-session.json` in the format above using the current wallet session. A session
+change during token retrieval cancels the download. This file contains login tokens; keep it outside
+the repository, do not share it, and delete it when finished. Browsers cannot set the operator's
+required owner-only filesystem permissions. Move the download into your existing private operator
+directory and run `chmod 600 /private/operator/module-publication-session.json` before passing that
+path to `--session-file`. Use your actual local path. If the session expires, reconnect normally and
+download a fresh file. The download grants no additional role, accepts no review, and signs no transaction.
+
 The fixed-origin website BFF `/api/admin/modules/<id>` and `/source` authenticate the current session,
 bind its linked wallet and use the existing signed BFF-v2 request to the private review API. The backend
 enforces its reviewer allowlist. Source and accepted decisions come from this live read on every run.

--- a/ops/module-mode-publication/core.ts
+++ b/ops/module-mode-publication/core.ts
@@ -1,6 +1,6 @@
 import { encodeAbiParameters, encodeFunctionData, getCreate2Address, keccak256, parseAbi, parseAbiParameters, toHex, type Address, type Hex } from "viem";
 import { moduleAddress, computeModuleModeReleaseDigest } from "../../lib/module-mode/release";
-import { nativeJson, type NativeModuleModeCatalogEntry } from "../../lib/module-mode/native-catalog";
+import { bindNativeFeeEligibility, nativeJson, type NativeModuleModeCatalogEntry } from "../../lib/module-mode/native-catalog";
 import { createModuleModeHostManifest, computeModuleModeHostManifestHash, verifyModuleModePublication, type ModuleModeCatalogDefinition, type ModuleModeHostReleaseIdentity, type ModuleModeCatalogPublication } from "../../lib/server/module-mode/catalog";
 import { validateModuleSubmissionRequest } from "../../packages/classic-modules/src/open-transport.mjs";
 import { acceptedDecision, need, requireNativeReview, reviewDigest, same, type AuthenticatedReview } from "./review";
@@ -16,11 +16,21 @@ export const REGISTRY_ABI = parseAbi([
   "function getRevision(bytes32 packageId) view returns ((bytes32 familyId,address factory,bytes32 factoryCodeHash,bytes32 moduleCodeHash,bytes32 manifestHash,uint32 callbackGas,bool enabled) revision)",
   "event RevisionApproved(bytes32 indexed packageId,bytes32 indexed familyId,(bytes32 familyId,address factory,bytes32 factoryCodeHash,bytes32 moduleCodeHash,bytes32 manifestHash,uint32 callbackGas,bool enabled) revision)",
 ]);
-export interface PublicationCall { action: "deployFactory" | "registerReviewedFamily" | "approveRevision"; chainId: 4663; from: Address; to: Address; value: "0x0"; data: Hex }
-export function createHostPreparation(review: AuthenticatedReview, releaseValue: ModuleModeHostReleaseIdentity, definition: ModuleModeCatalogDefinition) {
+export const REGISTRY_V2_ABI = [...REGISTRY_ABI, ...parseAbi([
+  "function familyFeeEligibility(bytes32 familyId) view returns (bool eligible,bytes32 reviewDigest)",
+  "function setFamilyFeeEligibility(bytes32 familyId,bool eligible,bytes32 reviewDigest)",
+  "event FamilyFeeEligibilityReviewed(bytes32 indexed familyId,bool eligible,bytes32 indexed reviewDigest,address indexed reviewer)",
+])] as const;
+export interface PublicationCall { action: "deployFactory" | "registerReviewedFamily" | "setFamilyFeeEligibility" | "approveRevision"; chainId: 4663; from: Address; to: Address; value: "0x0"; data: Hex }
+export function createHostPreparation(review: AuthenticatedReview, releaseValue: ModuleModeHostReleaseIdentity, definition: ModuleModeCatalogDefinition, feeEligibilityValue?: unknown) {
   requireNativeReview(review);
   const release = nativeJson(releaseValue) as ModuleModeHostReleaseIdentity;
   need(release.releaseDigest === computeModuleModeReleaseDigest(release), "Release identity digest differs");
+  const v2 = release.sourceVersion === "module-native-v2";
+  need(v2 || feeEligibilityValue === undefined, "Fee eligibility requires the NativeV2 release");
+  need(!v2 || feeEligibilityValue !== undefined, "NativeV2 requires an explicit family fee eligibility review");
+  // This is an explicit proposal before review. Only acceptance of its complete manifest authorizes publication.
+  const feeEligibility = v2 ? bindNativeFeeEligibility(nativeJson(feeEligibilityValue)) : undefined;
   const source = validateModuleSubmissionRequest(review.source); need(source.ok, "Invalid source submission");
   need(definition.source.path === review.artifact.program.sourcePath, "Published source is not the reviewed program component");
   const reviewedPlan = reviewRecord(review.job.plan), reviewedArtifact = reviewRecord(review.artifact);
@@ -31,15 +41,16 @@ export function createHostPreparation(review: AuthenticatedReview, releaseValue:
     [keccak256(toHex("programmable.module-mode.factory.v1")), 4663n, release.releaseDigest, source.packageId]));
   const factory = getCreate2Address({ from: CREATE2_DEPLOYER.address, salt, bytecodeHash: review.artifact.factory.creationCodeHash }).toLowerCase() as Address;
   const nativeBinding = { familyId: source.familyId, packageId: source.packageId, factory,
-    factoryCodeHash: review.artifact.factory.runtimeCodeHash, moduleCodeHash: review.artifact.program.runtimeCodeHash, callbackGas: review.artifact.callbackGas };
+    factoryCodeHash: review.artifact.factory.runtimeCodeHash, moduleCodeHash: review.artifact.program.runtimeCodeHash, callbackGas: review.artifact.callbackGas,
+    ...(feeEligibility ? { feeEligibility } : {}) };
   const manifest = createModuleModeHostManifest({ release, definition, nativeBinding, descriptor: source.request.descriptor });
   return { schemaVersion: "programmable.module-mode-host-preparation.v1" as const, status: "review-required" as const, release,
     requestDigest: source.requestDigest, artifactDigest: review.artifact.artifactDigest, salt, nativeBinding, manifest,
     manifestHash: computeModuleModeHostManifestHash(manifest) };
 }
-export function prepareModulePublication(review: AuthenticatedReview, release: ModuleModeHostReleaseIdentity, definition: ModuleModeCatalogDefinition, reviewAuthority: Address) {
+export function prepareModulePublication(review: AuthenticatedReview, release: ModuleModeHostReleaseIdentity, definition: ModuleModeCatalogDefinition, reviewAuthority: Address, feeEligibilityValue?: unknown) {
   requireNativeReview(review);
-  const host = createHostPreparation(review, release, definition), decision = acceptedDecision(review);
+  const host = createHostPreparation(review, release, definition, feeEligibilityValue), decision = acceptedDecision(review);
   const owner = moduleAddress(reviewAuthority, "registry.owner");
   need(decision.command.hostManifestHash === host.manifestHash, "Acceptance covers another host manifest");
   const entry: NativeModuleModeCatalogEntry = { ...definition, status: "available", nativeBinding: { ...host.nativeBinding, manifestHash: host.manifestHash, reviewDigest: decision.decisionDigest } };
@@ -51,6 +62,9 @@ export function prepareModulePublication(review: AuthenticatedReview, release: M
     { ...base, action: "deployFactory", to: CREATE2_DEPLOYER.address, data: `${host.salt}${review.artifact.factory.creationBytecode.slice(2)}` },
     { ...base, action: "registerReviewedFamily", to: registry, data: encodeFunctionData({ abi: REGISTRY_ABI, functionName: "registerReviewedFamily",
       args: [moduleAddress(review.source.descriptor.author, "author"), review.source.descriptor.familySalt, moduleAddress(review.source.descriptor.rewardWallet, "reward"), review.job.subject.requestDigest] }) },
+    ...(host.nativeBinding.feeEligibility && BigInt(host.nativeBinding.feeEligibility.reviewDigest) !== 0n ? [{ ...base,
+      action: "setFamilyFeeEligibility" as const, to: registry, data: encodeFunctionData({ abi: REGISTRY_V2_ABI, functionName: "setFamilyFeeEligibility",
+        args: [host.nativeBinding.familyId, host.nativeBinding.feeEligibility.eligible, host.nativeBinding.feeEligibility.reviewDigest] }) }] : []),
     { ...base, action: "approveRevision", to: registry, data: encodeFunctionData({ abi: REGISTRY_ABI, functionName: "approveRevision",
       args: [host.nativeBinding.packageId, host.nativeBinding.familyId, host.nativeBinding.factory, host.nativeBinding.moduleCodeHash, host.manifestHash, host.nativeBinding.callbackGas] }) },
   ];
@@ -59,12 +73,13 @@ export function prepareModulePublication(review: AuthenticatedReview, release: M
     submissionId: review.job.subject.submissionId, reviewRevision: review.job.reviewRevision, requestDigest: host.requestDigest,
     artifactDigest: host.artifactDigest, reviewDigest: decision.decisionDigest, reviewAuthority: owner, manifest: host.manifest, publication, calls,
     preconditions: { family: "register only if absent; otherwise require exact author and current reward wallet",
+      ...(host.nativeBinding.feeEligibility ? { feeEligibility: "require the exact accepted family eligibility snapshot; false/zero stays the untouched RegistryV2 default; reuse an existing exact review without changing it" } : {}),
       revision: "immutable; never overwrite or automatically re-enable", factory: "deploy only if vacant; existing exact code still requires the actual deployment transaction",
       transactions: "Each call must be simulated immediately before signing. This file is not an armed wallet request." } };
   return { ...contents, planDigest: reviewDigest("programmable.module-mode-publication-plan.v1", contents) };
 }
 export type PublicationPlan = ReturnType<typeof prepareModulePublication>;
 export function assertPublicationPlan(plan: PublicationPlan, review: AuthenticatedReview) {
-  const expected = prepareModulePublication(review, plan.release, plan.manifest.manifest.catalogDefinition, plan.reviewAuthority);
+  const expected = prepareModulePublication(review, plan.release, plan.manifest.manifest.catalogDefinition, plan.reviewAuthority, plan.publication.entry.nativeBinding.feeEligibility);
   same(plan, expected, "Publication plan");
 }

--- a/ops/module-mode-publication/main.ts
+++ b/ops/module-mode-publication/main.ts
@@ -12,15 +12,17 @@ interface Context { repositoryRoot: string; providers: () => Promise<(Omit<Publi
 export async function run(args: string[], context: Context) {
   const command = args.shift(); need(["manifest", "prepare", "export"].includes(command ?? ""), "Use manifest, prepare or export");
   const options: Record<string, string> = {};
-  const allowed = new Set(["identity", "definition", "submission", "session-file", "output", ...(command === "export" ? ["transactions"] : [])]);
+  const required = ["identity", "definition", "submission", "session-file", "output", ...(command === "export" ? ["transactions"] : [])];
+  const allowed = new Set([...required, "fee-eligibility"]);
   for (let i = 0; i < args.length; i += 2) {
     const key = args[i].slice(2);
     need(args[i].startsWith("--") && allowed.has(key) && args[i + 1] && !Object.hasOwn(options, key), "Unexpected or duplicate publication option"); options[key] = args[i + 1];
   }
-  need(Object.keys(options).length === allowed.size, "Missing publication options");
+  need(required.every(key => Object.hasOwn(options, key)), "Missing publication options");
   const read = async (key: string, maximum = 2 * 1024 * 1024) => exactJson(await readFile(options[key]), maximum);
   const identity = await read("identity") as ModuleModeHostReleaseIdentity;
   const definition = await read("definition") as ModuleModeCatalogDefinition;
+  const feeEligibility = options["fee-eligibility"] === undefined ? undefined : await read("fee-eligibility", 4096);
   const reader = createAuthenticatedReviewReader(await readOperatorSession(options["session-file"]));
   const review = await reader.read(options.submission);
   const output = path.resolve(options.output);
@@ -29,24 +31,27 @@ export async function run(args: string[], context: Context) {
   need(physicalParent === path.dirname(output) && parentStat.isDirectory() && parentStat.uid === process.getuid?.() && (parentStat.mode & 0o077) === 0, "Output parent must be a private owner-only real directory");
   need(!output.startsWith(path.resolve(context.repositoryRoot) + path.sep), "Write operator evidence outside the source checkout");
   if (review.artifact.schemaVersion === "programmable.modules.engine-build.v1") {
+    need(feeEligibility === undefined, "Fee eligibility input is only supported by NativeV2 publication");
     return runEnginePublication({command:command!,identity,definition,review,reader,output,providers:context.providers,
       readTransactions:()=>read("transactions",16_384)});
   }
-  const host = createHostPreparation(review, identity, definition);
+  const host = createHostPreparation(review, identity, definition, feeEligibility);
   let plan: ReturnType<typeof prepareModulePublication> | undefined;
   let evidence: Awaited<ReturnType<typeof observePublicationReadback>> | undefined;
   if (command !== "manifest") {
     acceptedDecision(review);
     const providers = (await context.providers()).map(({ url, ...binding }) => ({ ...binding, rpc: publicationRpc(url) }));
     const owner = await readPublicationOwner(host.release, providers);
-    plan = prepareModulePublication(review, host.release, definition, owner);
+    plan = prepareModulePublication(review, host.release, definition, owner, feeEligibility);
     if (command === "export") {
       const raw = await read("transactions", 16_384) as Record<string, unknown>;
-      need(raw && Object.keys(raw).sort().join(",") === "factory,family,revision", "Expected factory, family and revision transaction hashes");
-      const transactions = { factory: moduleHash(raw.factory, "factory.transaction"), family: raw.family === null ? null : moduleHash(raw.family, "family.transaction"), revision: moduleHash(raw.revision, "revision.transaction") };
+      const v2 = identity.sourceVersion === "module-native-v2";
+      need(raw && Object.keys(raw).sort().join(",") === (v2 ? "factory,family,feeEligibility,revision" : "factory,family,revision"), v2 ? "Expected factory, family, feeEligibility and revision transaction hashes" : "Expected factory, family and revision transaction hashes");
+      const transactions = { factory: moduleHash(raw.factory, "factory.transaction"), family: raw.family === null ? null : moduleHash(raw.family, "family.transaction"), revision: moduleHash(raw.revision, "revision.transaction"),
+        ...(v2 ? { feeEligibility: raw.feeEligibility === null ? null : moduleHash(raw.feeEligibility, "feeEligibility.transaction") } : {}) };
       evidence = await observePublicationReadback(plan, review, providers, transactions);
       const fresh = await reader.read(options.submission);
-      same(prepareModulePublication(fresh, host.release, definition, owner), plan, "Review changed during onchain readback");
+      same(prepareModulePublication(fresh, host.release, definition, owner, feeEligibility), plan, "Review changed during onchain readback");
     }
   }
   // No output exists until every requested read/validation has passed. Never overwrite a package or run.

--- a/ops/module-mode-publication/review.ts
+++ b/ops/module-mode-publication/review.ts
@@ -61,6 +61,12 @@ function bindSource(job: ReviewJob, sourceBytes: Uint8Array): { source: ModuleSu
   need(artifact.packageId === checked.packageId && artifact.familyId === checked.familyId && artifact.rewardWallet === source.descriptor.rewardWallet.toLowerCase(), "Build package identity differs");
   need(artifact.sourceManifestHash === reviewDigest("programmable.modules.source-manifest.v1", source.descriptor)
     && artifact.configurationSchemaHash === reviewDigest("programmable.modules.configuration-schema.v1", source.descriptor.configuration), "Build source manifest differs");
+  if (artifact.schemaVersion === "programmable.modules.engine-build.v1") {
+    need(job.plan.schemaVersion === "programmable.modules.engine-build-plan.v1", "Engine build plan required");
+    // The Engine verifier binds the exact compiler/image/settings and its scoped source aliases.
+    verifyModuleEngineBuildArtifactV1(artifact, job.subject, job.plan, source);
+    return { source, artifact };
+  }
   const sources: Record<string, { content: string }> = Object.create(null);
   for (const file of source.files) if (file.path.endsWith(".sol")) sources[file.path] = { content: new TextDecoder("utf-8", { fatal: true }).decode(Buffer.from(file.bytes, "base64")) };
   // Must match the protected builder's fixed alias inventory; package build scripts/config are inert.
@@ -73,11 +79,6 @@ function bindSource(job: ReviewJob, sourceBytes: Uint8Array): { source: ModuleSu
   same(artifact.compiler, { ...NATIVE_COMPILER,
     settingsHash: reviewDigest("programmable.modules.compiler-settings.v1", NATIVE_SETTINGS),
     completeInputHash: reviewDigest("programmable.modules.compiler-input.v1", { language: "Solidity", sources, settings: NATIVE_SETTINGS }), reproducible: true }, "Pinned compiler/input");
-  if (artifact.schemaVersion === "programmable.modules.engine-build.v1") {
-    need(job.plan.schemaVersion === "programmable.modules.engine-build-plan.v1", "Engine build plan required");
-    verifyModuleEngineBuildArtifactV1(artifact, job.subject, job.plan, source);
-    return { source, artifact };
-  }
   need(job.plan.schemaVersion === "programmable.modules.native-build-plan.v1", "Native build plan required");
   const nativePlan = job.plan;
   for (const role of ["factory", "program"] as const) {

--- a/ops/module-mode-publication/rpc.ts
+++ b/ops/module-mode-publication/rpc.ts
@@ -1,6 +1,7 @@
 import { decodeEventLog, decodeFunctionResult, encodeFunctionData, keccak256, type Address, type Hex } from "viem";
 import { moduleAddress, moduleBytes, moduleHash } from "../../lib/module-mode/release";
-import { CREATE2_DEPLOYER, REGISTRY_ABI, assertPublicationPlan, type PublicationPlan, type PublicationCall } from "./core";
+import { CREATE2_DEPLOYER, REGISTRY_ABI, REGISTRY_V2_ABI, assertPublicationPlan, type PublicationPlan, type PublicationCall } from "./core";
+import { bindNativeFeeEligibility } from "../../lib/module-mode/native-catalog";
 import { need, same, exactJson, acceptedDecision, type AuthenticatedReview } from "./review";
 
 export interface PublicationProvider { providerId: string; trustDomain: string; endpointCommitment: string; rpc(method: string, parameters: unknown[]): Promise<unknown> }
@@ -35,9 +36,9 @@ export async function code(providers: PublicationProvider[], address: Address, b
   const value = moduleBytes(await equalRead(providers, "eth_getCode", [address, block]), "publication.code");
   need(value !== "0x" && keccak256(value) === hash, "Runtime code differs from the pinned reviewed artifact");
 }
-async function getter(providers: PublicationProvider[], target: Address, name: "owner" | "families" | "getRevision", args: readonly Hex[], block: Hex) {
-  const data = encodeFunctionData({ abi: REGISTRY_ABI, functionName: name, args: args as never });
-  return decodeFunctionResult({ abi: REGISTRY_ABI, functionName: name, data: moduleBytes(await equalRead(providers, "eth_call", [{ to: target, data }, block]), "publication.getter", 4096) });
+async function getter(providers: PublicationProvider[], target: Address, name: "owner" | "families" | "getRevision" | "familyFeeEligibility", args: readonly Hex[], block: Hex): Promise<unknown> {
+  const data = encodeFunctionData({ abi: REGISTRY_V2_ABI, functionName: name, args: args as never });
+  return decodeFunctionResult({ abi: REGISTRY_V2_ABI, functionName: name, data: moduleBytes(await equalRead(providers, "eth_call", [{ to: target, data }, block]), "publication.getter", 4096) });
 }
 export async function snapshot(providers: PublicationProvider[]) {
   quorum(providers);
@@ -102,10 +103,25 @@ async function checkReceipt(plan: PublicationPlan, call: PublicationCall, txHash
     });
     need(matches.length === 1, "Exact Registry admission event missing");
   }
+  if (call.action === "setFamilyFeeEligibility") {
+    need(Array.isArray(receipt.logs), "Fee eligibility review event missing");
+    const binding = plan.publication.entry.nativeBinding;
+    const matches = receipt.logs.filter(raw => {
+      const log = record(raw); if (String(log.address).toLowerCase() !== call.to || log.removed === true) return false;
+      try {
+        const parsed = decodeEventLog({ abi: REGISTRY_V2_ABI, eventName: "FamilyFeeEligibilityReviewed", data: log.data as Hex, topics: log.topics as [Hex, ...Hex[]], strict: true });
+        return parsed.args.familyId === binding.familyId && parsed.args.eligible === binding.feeEligibility?.eligible
+          && parsed.args.reviewDigest === binding.feeEligibility.reviewDigest && moduleAddress(parsed.args.reviewer, "eligibility.reviewer") === call.from;
+      } catch { return false; }
+    });
+    need(matches.length === 1, "Exact Registry fee eligibility review event missing");
+  }
   return { action: call.action, transaction: tx, receipt };
 }
-export async function observePublicationReadback(plan: PublicationPlan, review: AuthenticatedReview, providers: PublicationProvider[], transactions: { factory: Hex; family: Hex | null; revision: Hex }) {
+export async function observePublicationReadback(plan: PublicationPlan, review: AuthenticatedReview, providers: PublicationProvider[], transactions: { factory: Hex; family: Hex | null; revision: Hex; feeEligibility?: Hex | null }) {
   assertPublicationPlan(plan, review); acceptedDecision(review); const block = await snapshot(providers);
+  const v2 = plan.release.sourceVersion === "module-native-v2";
+  need(Object.hasOwn(transactions, "feeEligibility") === v2, "Fee eligibility transaction field differs from the native generation");
   for (const pin of Object.values(plan.release.contracts)) await code(providers, pin.address, block.number, pin.runtimeCodeHash);
   await code(providers, CREATE2_DEPLOYER.address, block.number, CREATE2_DEPLOYER.runtimeCodeHash);
   need(moduleAddress(await getter(providers, plan.release.contracts.registry.address, "owner", [], block.number), "publication.owner") === plan.reviewAuthority, "Registry authority changed");
@@ -116,9 +132,16 @@ export async function observePublicationReadback(plan: PublicationPlan, review: 
     [moduleAddress(review.source.descriptor.author, "author"), moduleAddress(review.source.descriptor.rewardWallet, "reward")], "Registered family author/reward wallet");
   const revision = await getter(providers, plan.release.contracts.registry.address, "getRevision", [binding.packageId], block.number);
   same(normalizedRevision(revision), expectedRevision(plan), "Current immutable Registry revision");
-  const selected = [[plan.calls[0], moduleHash(transactions.factory, "factory.transaction")],
-    ...(transactions.family === null ? [] : [[plan.calls[1], moduleHash(transactions.family, "family.transaction")]]),
-    [plan.calls[2], moduleHash(transactions.revision, "revision.transaction")]] as [PublicationCall, Hex][];
+  if (v2) {
+    const value = await getter(providers, plan.release.contracts.registry.address, "familyFeeEligibility", [binding.familyId], block.number) as readonly unknown[];
+    same(bindNativeFeeEligibility({ eligible: value[0], reviewDigest: value[1] }), binding.feeEligibility, "Current Registry family fee eligibility");
+    if (BigInt(binding.feeEligibility!.reviewDigest) === 0n) need(transactions.feeEligibility === null, "Untouched fee eligibility has no setter transaction");
+  }
+  const operation = (action: PublicationCall["action"]) => { const call = plan.calls.find(item => item.action === action); need(call, "Publication operation missing"); return call; };
+  const selected: [PublicationCall, Hex][] = [[operation("deployFactory"), moduleHash(transactions.factory, "factory.transaction")],
+    ...(transactions.family === null ? [] : [[operation("registerReviewedFamily"), moduleHash(transactions.family, "family.transaction")] as [PublicationCall, Hex]]),
+    ...(v2 && transactions.feeEligibility !== null ? [[operation("setFamilyFeeEligibility"), moduleHash(transactions.feeEligibility, "feeEligibility.transaction")] as [PublicationCall, Hex]] : []),
+    [operation("approveRevision"), moduleHash(transactions.revision, "revision.transaction")]];
   need(new Set(selected.map(([, hash]) => hash)).size === selected.length, "Repeated publication transaction");
   const receipts = [];
   for (const [call, hash] of selected) receipts.push(await checkReceipt(plan, call, hash, providers, block.number));
@@ -126,5 +149,6 @@ export async function observePublicationReadback(plan: PublicationPlan, review: 
   return { schemaVersion: "programmable.module-mode-publication-readback.v1" as const, status: "canonical-inclusion-verified" as const,
     finality: "separate-robinhood-ethereum-finality-proof-required" as const, chainId: 4663, releaseDigest: plan.release.releaseDigest, planDigest: plan.planDigest,
     packageId: binding.packageId, reviewDigest: plan.reviewDigest, block, factory: { address: binding.factory, runtimeCodeHash: binding.factoryCodeHash },
+    ...(v2 ? { feeEligibility: binding.feeEligibility } : {}),
     revision: expectedRevision(plan), receipts, providers: providers.map(p => ({ providerId: p.providerId, trustDomain: p.trustDomain, endpointCommitment: p.endpointCommitment })), observedAt: new Date().toISOString() };
 }

--- a/tests/fixtures/module-review-admin-harness.md
+++ b/tests/fixtures/module-review-admin-harness.md
@@ -49,3 +49,17 @@ Verified in the rendered local application on 6 September 2026:
 
 The full authenticated production path, installed review worker, real database writes, publication,
 and onchain admission require their independent integration evidence. This fixture proves none of them.
+
+The local session-download section exercises the actual **Download publication session** control with
+clearly synthetic tokens. Its files cannot authenticate to the private review service. Use the
+authenticated-session checkbox to check the disabled state and the session-change checkbox to cancel
+token retrieval before any download. With both a ready session and no simulated change, keyboard
+Enter/Space should request one local JSON download and announce the status. Do not print the file
+contents in screenshots or console output; delete the synthetic download when finished.
+
+For the release check, the integration owner uses the normal `/admin/modules` route: the action is
+absent without the authenticated admin wallet, remains disabled while the wallet session is settling,
+and downloads only through an explicit click. Check desktop and 390/320-pixel widths, visible keyboard
+focus, the live status, rapid repeated activation, wallet/session changes, and the browser console.
+The application cannot apply filesystem permissions to downloads; the operator README explains the
+required owner-only permissions. No authenticated production check is claimed by the local fixture.

--- a/tests/fixtures/module-review-admin-harness.tsx
+++ b/tests/fixtures/module-review-admin-harness.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useCallback, useRef, useState, type ComponentProps } from "react";
-import { ModuleReviewWorkspace } from "../../components/module-review-admin-console";
+import { ModuleReviewWorkspace, PublicationSessionDownload } from "../../components/module-review-admin-console";
+import { WEBSITE_ADMIN_WALLET } from "../../lib/admin-access";
+import type { PublicationSession } from "../../lib/module-mode/publication-session";
 import { reviewDigest, summarizeReviewJob, type ModuleReviewDecisionCommandV1, type ModuleReviewDecisionRecordV1 } from "../../lib/module-mode/review-contract";
 import type { moduleReviewAdminFixture } from "./module-review-admin";
 import styles from "../../components/module-review-admin-console.module.css";
@@ -12,6 +14,10 @@ export function ModuleReviewAdminHarness({ fixture }: { fixture: ReturnType<type
   const loseResponse = useRef(false);
   const [generation, setGeneration] = useState(0);
   const [requestCount, setRequestCount] = useState(0);
+  const exportSession = useRef<PublicationSession | null>(Object.freeze({ walletAddress: WEBSITE_ADMIN_WALLET }));
+  const changeExportSession = useRef(false);
+  const [exportReady, setExportReady] = useState(true);
+  const [tokenReads, setTokenReads] = useState(0);
   const request = useCallback<ComponentProps<typeof ModuleReviewWorkspace>["request"]>(async (path, body) => {
     if (path.startsWith("?")) return { schemaVersion: "programmable.modules.website-review-queue.v1", jobs: [summarizeReviewJob(detail.current.job)], nextCursor: null };
     if (path.includes("/source?")) return JSON.stringify(fixture.source);
@@ -43,6 +49,22 @@ export function ModuleReviewAdminHarness({ fixture }: { fixture: ReturnType<type
       <p role="status">Synthetic decisions sent: {requestCount}</p>
     </div>
     <ModuleReviewWorkspace key={generation} account={fixture.reviewer} request={request} />
+    <section className={styles.section}>
+      <h2>Local session-download fixture</h2>
+      <p className={styles.note}>Downloaded files contain synthetic tokens with no authentication or publication authority. Delete these fixture files after the interface check.</p>
+      <label className={styles.checkbox}><input type="checkbox" checked={exportReady} onChange={event => {
+        exportSession.current = event.target.checked ? Object.freeze({ walletAddress: WEBSITE_ADMIN_WALLET }) : null;
+        setExportReady(event.target.checked);
+      }} />Authenticated fixture session</label>
+      <label className={styles.checkbox}><input type="checkbox" onChange={event => { changeExportSession.current = event.target.checked; }} />Change session during token retrieval</label>
+      <PublicationSessionDownload ready={exportReady} readSession={() => exportSession.current}
+        getIdentityToken={async () => {
+          if (changeExportSession.current) exportSession.current = Object.freeze({ walletAddress: WEBSITE_ADMIN_WALLET });
+          return "synthetic_identity_token_no_authority";
+        }}
+        getAccessToken={async () => { setTokenReads(n => n + 1); return "synthetic_access_token_no_authority"; }} />
+      <p className={styles.caption}>Synthetic access-token reads: {tokenReads}</p>
+    </section>
     <details className={styles.disclosure}><summary>Fixture host manifest</summary><pre>{JSON.stringify(fixture.manifest, null, 2)}</pre></details>
   </div>;
 }

--- a/tests/module-engine-client.test.ts
+++ b/tests/module-engine-client.test.ts
@@ -16,6 +16,25 @@ describe("isolated engine source and transaction bindings", () => {
   it("keeps ERC20 asset roles meaningful for zero amounts", async () => { const f = fixture(); await expect(prepareModuleEngineOperation({ ...f, account: ACCOUNT, token: TOKEN, intent: { ...f.intent, inputAmount: 0n, outputAsset: TOKEN, minimumOutput: 0n } })).rejects.toThrow("asset roles"); });
   it("rejects creator-only authority that is merely declared by a UI", async () => { const f = fixture(); f.template.manifest.manifest.revision.operationPermissions[0].authorization = 1; f.template.manifestHash = computeModuleEngineHostManifestHash(f.template.manifest); f.state.authorization = 1; await expect(prepareModuleEngineOperation({ ...f, account: addr(89), token: TOKEN })).rejects.toThrow("Creator-only"); });
   it("prepares a real launch plan and byte-identical reviewed transaction", async () => { const f = fixture(); const result = await prepareModuleEngineLaunch(f.launchInput); expect(result.kind).toBe("launch"); if (result.kind !== "launch") throw new Error(); expect(result.transaction.to).toBe(f.host); expect(result.transaction.value).toBe("0x0"); expect(result.quoteDecimals).toBe(6); const decoded = decodeFunctionData({ abi: moduleEngineHostAbi, data: result.transaction.data }); expect(decoded.functionName).toBe("launch"); expect(result.planHash).toBe(keccak256(encodeAbiParameters(moduleEnginePlanParameters, [4663n, f.host, ACCOUNT, decoded.args![0] as never]))); expect(await revalidateModuleEngineTransaction(result, ACCOUNT)).toBe(result.transaction); await expect(revalidateModuleEngineTransaction(result, ACCOUNT)).rejects.toThrow("fresh"); });
+  it("uses Host V1's admitted family list for Ledger V2 fees without calling a Native V2 Registry getter", async () => {
+    const f = fixture(), families = [hash(11)];
+    f.template.manifest.manifest.revision.eligibleFamilies = families;
+    f.template.manifestHash = computeModuleEngineHostManifestHash(f.template.manifest);
+    const reader = vi.mocked(f.client.readContract).getMockImplementation()!;
+    vi.mocked(f.client.readContract).mockImplementation(async input => {
+      if (input.functionName === "familyFeeEligibility") throw new Error("Registry V1 has no such selector");
+      const result = await reader(input);
+      return input.functionName === "getRevision" ? [...(result as unknown[]).slice(0, 3), families] : result;
+    });
+    const prepared = await prepareModuleEngineLaunch(f.launchInput);
+    expect(prepared.kind).toBe("launch"); if (prepared.kind !== "launch") throw new Error();
+    expect(prepared.platformFeeBps).toBe(30);
+    await expect(revalidateModuleEngineTransaction(prepared, ACCOUNT)).resolves.toEqual(prepared.transaction);
+    expect(f.client.readContract).not.toHaveBeenCalledWith(expect.objectContaining({ functionName: "familyFeeEligibility" }));
+    const plain = fixture(), plainPrepared = await prepareModuleEngineLaunch(plain.launchInput);
+    expect(plainPrepared.kind === "launch" && plainPrepared.platformFeeBps).toBe(10);
+    await expect(prepareModuleEngineLaunch({ ...plain.launchInput, availability: { ...plain.availability, release: { ...plain.release, enabled: false } } as never })).rejects.toThrow("active");
+  });
   it("rejects a fixed quote override and a fixed configuration override", async () => { const f = fixture(); f.template.manifest.manifest.revision.fixedQuoteAsset = addr(80); f.template.manifestHash = computeModuleEngineHostManifestHash(f.template.manifest); await expect(prepareModuleEngineLaunch(f.launchInput)).rejects.toThrow("Fixed quote"); f.template.manifest.manifest.revision.fixedQuoteAsset = ZERO; f.template.manifest.manifest.revision.fixedConfigurationHash = hash(88); f.template.manifestHash = computeModuleEngineHostManifestHash(f.template.manifest); await expect(prepareModuleEngineLaunch(f.launchInput)).rejects.toThrow("Fixed configuration"); });
   it("applies all constructor patches and rejects overlaps or partial words", () => { const template = `0x${"00".repeat(64)}6000` as Hex, args = `0x${"11".repeat(32)}${"22".repeat(32)}` as Hex; expect(materializeModuleEngineRuntime(template, args, [0, 32], [32, 0])).toBe(`0x${"22".repeat(32)}${"11".repeat(32)}6000`); expect(() => materializeModuleEngineRuntime(template, args, [0, 16], [0, 32])).toThrow("bounds"); expect(() => materializeModuleEngineRuntime(template, args, [0], [1])).toThrow("bounds"); });
   it("requires a nonzero ETH fee floor and preserves actual quote/primary directions", () => { expect(() => moduleEngineTradeIntent({ buy: true, token: TOKEN, quoteAsset: QUOTE, recipient: ACCOUNT, inputAmount: 1n, minimumOutput: 1n, minimumEthFees: 0n, conversionRoute: "0x" })).toThrow("positive"); const sell = moduleEngineTradeIntent({ buy: false, token: TOKEN, quoteAsset: QUOTE, recipient: ACCOUNT, inputAmount: 8n, minimumOutput: 4n, minimumEthFees: 2n, conversionRoute: "0x" }); expect(sell.inputAsset).toBe(TOKEN); expect(sell.outputAsset).toBe(QUOTE); });

--- a/tests/module-engine-publication.test.ts
+++ b/tests/module-engine-publication.test.ts
@@ -1,4 +1,5 @@
 import { mkdtemp, mkdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { run } from "../ops/module-mode-publication/main";
@@ -12,26 +13,53 @@ import { MODULE_ENGINE_CONTRACTS, MODULE_ENGINE_SOURCE_ID, computeModuleEngineRe
 import { ENGINE_REVISION, moduleEngineHostAbi, moduleEngineReadAbi } from "../lib/module-engine/abi";
 import { parseReviewJob, parseReviewPlan, reviewDigest, type ReviewJob, type ReviewAttempt } from "../lib/module-mode/review-contract";
 import type { ModuleEngineBuildArtifactV1, ModuleEngineBuildPlanV1 } from "../lib/module-mode/review-engine-types";
-import { createAuthenticatedReviewReader, requireAuthenticatedReview } from "../ops/module-mode-publication/review";
+import { MODULE_ENGINE_CONTEXT_ABI_V1, MODULE_ENGINE_CONSTRUCTOR_ABI_V1 } from "../lib/module-mode/review-engine-types";
+import { createAuthenticatedReviewReader, NATIVE_SETTINGS, requireAuthenticatedReview } from "../ops/module-mode-publication/review";
 import { createEngineHostPreparation, prepareEnginePublication, type EnginePublicationDefinition, type EnginePublicationPlan } from "../ops/module-mode-publication/core-engine";
 import { observeEnginePublicationReadback, readEnginePublicationOwner } from "../ops/module-mode-publication/rpc-engine";
 import type { PublicationProvider } from "../ops/module-mode-publication/rpc";
 import { computeModuleReviewDecisionDigestV1, type ModuleReviewDecisionRecordV1 } from "../lib/server/module-mode/review-decision-wire-v1";
 import { validateModuleSubmissionRequest } from "../packages/classic-modules/src/open-transport.mjs";
 import { createModuleReviewClient } from "../lib/server/module-mode/review-client";
-import { verifyModuleEngineBuildArtifactV1 } from "../lib/module-mode/review-engine-contract";
+import { materializeModuleEngineRuntimeV1, moduleEngineStandardInputV1, verifyModuleEngineBuildArtifactV1 } from "../lib/module-mode/review-engine-contract";
 import { createReviewedModuleEngineManifest } from "../lib/module-mode/review-engine-manifest";
 
 vi.mock("server-only", () => ({}));
 const reviewer = WEBSITE_ADMIN_WALLET.toLowerCase() as Address;
 // Exact backend-owned compiler fixture; worker receipts and authentication here are synthetic test doubles.
 // Never submit, review, publish, or sign these fixtures.
-async function fixture() {
+const scopedPrefixes = ["openzeppelin/contracts/", "openzeppelin/uniswap-hooks/", "uniswap/blocknumberish/", "uniswap/liquidity-launcher/", "uniswap/uerc20-factory/", "uniswap/v4-core/", "uniswap/v4-periphery/", "solady/src/"];
+async function fixture(scopedAliases = false) {
   expect(frozen.evidenceClass).toBe("synthetic-parser-fixture-not-review-or-publication-authority");
-  const source = structuredClone(frozen.source), checked = validateModuleSubmissionRequest(source);
+  const source = structuredClone(frozen.source);
+  if (scopedAliases) {
+    // Same eight scoped source paths as the existing source-alias fixture; no compiler is run.
+    const content = "// exact source bytes\npragma solidity 0.8.26;\n", sha256 = createHash("sha256").update(content).digest("hex");
+    for (const prefix of scopedPrefixes) {
+      const path = `dependencies/scoped/${prefix}Probe.sol`;
+      source.files.push({ path, sha256, encoding: "base64", bytes: Buffer.from(content).toString("base64") }); source.descriptor.source.files.push({ path, sha256 });
+    }
+  }
+  const checked = validateModuleSubmissionRequest(source);
   if (!checked.ok) throw new Error("Invalid test source");
-  const subject = { ...frozen.subject, requestDigest: checked.requestDigest }, plan = structuredClone(frozen.plan) as ModuleEngineBuildPlanV1;
-  const artifact = structuredClone(frozen.artifact) as ModuleEngineBuildArtifactV1;
+  const subject = { ...frozen.subject, requestDigest: checked.requestDigest }, plan = { ...structuredClone(frozen.plan), requestDigest: checked.requestDigest } as ModuleEngineBuildPlanV1;
+  let artifact = structuredClone(frozen.artifact) as ModuleEngineBuildArtifactV1;
+  if (scopedAliases) {
+    // Rebind only synthetic fixture identities/instances to its extended source inventory.
+    const cases = artifact.cases.map(c => {
+      const context = { ...c.context, launchId: reviewDigest("programmable.modules.engine-review-launch.v1", { requestDigest: checked.requestDigest, caseId: c.id }) };
+      const constructorArgs = encodeAbiParameters(MODULE_ENGINE_CONSTRUCTOR_ABI_V1, [context, c.configBytes]), runtimeBytecode = materializeModuleEngineRuntimeV1(artifact.engine, constructorArgs);
+      return { ...c, context, contextHash: keccak256(encodeAbiParameters([{ type: "tuple", components: MODULE_ENGINE_CONTEXT_ABI_V1 }], [context])), constructorArgs,
+        constructorHash: keccak256(constructorArgs), initCodeHash: keccak256(`${artifact.engine.creationBytecode}${constructorArgs.slice(2)}`), runtimeBytecode, runtimeCodeHash: keccak256(runtimeBytecode) };
+    });
+    const planDigest = reviewDigest("programmable.modules.engine-build-plan.v1", plan), { artifactDigest: _old, ...original } = artifact; void _old;
+    const contents = { ...original, subject, packageId: checked.packageId, familyId: checked.familyId, planDigest, cases,
+      sourceManifestHash: reviewDigest("programmable.modules.source-manifest.v1", source.descriptor),
+      compiler: { ...artifact.compiler, completeInputHash: reviewDigest("programmable.modules.compiler-input.v1", moduleEngineStandardInputV1(source, subject, plan)) },
+      tests: { ...artifact.tests, requestDigest: checked.requestDigest, planDigest, cases: artifact.tests.cases.map((c, i) => ({ ...c, constructorHash: cases[i].constructorHash, runtimeCodeHash: cases[i].runtimeCodeHash })) } };
+    artifact = { ...contents, artifactDigest: reviewDigest("programmable.modules.engine-build.v1", contents) };
+    verifyModuleEngineBuildArtifactV1(artifact, subject, plan, source);
+  }
   const job: ReviewJob = { subject, state: "built", reviewRevision: 2, plan, planDigest: artifact.planDigest, artifact, attempt: 1, lastError: null, createdAt: "2026-09-07T01:00:00.000Z", updatedAt: "2026-09-07T01:10:00.000Z" };
   const identityFields = { sourceCommit: "a".repeat(40), runId: "123", runAttempt: "1", workflowRef: "programmablehq/programmable-open-hook-v2-internal/.github/workflows/protected-module-review-v1.yml@refs/heads/main" };
   const base = { attempt: 1, requestDigest: subject.requestDigest, planDigest: artifact.planDigest, errorCode: null };
@@ -98,6 +126,33 @@ function providers(f: Awaited<ReturnType<typeof fixture>>, plan: EnginePublicati
 }
 
 describe("Engine publication through the existing authenticated operator", () => {
+  it("reads all eight scoped source aliases through the authenticated reader and canonical accepted publication", async () => {
+    const f = await fixture(true), input = moduleEngineStandardInputV1(f.source, f.subject, f.plan);
+    for (const prefix of scopedPrefixes) {
+      expect(input.sources[`@${prefix}Probe.sol`].content).toBe("// exact source bytes\npragma solidity 0.8.26;\n");
+      expect(Object.hasOwn(input.sources, `dependencies/scoped/${prefix}Probe.sol`)).toBe(false);
+    }
+    const accepted = await f.accept(), publication = prepareEnginePublication(accepted, f.release, f.definition, reviewer);
+    expect(publication.manifest).toEqual(f.host.manifest);
+    expect(publication.calls.map(call => call.action)).toEqual(["registerReviewedFamily", "approveRevision"]);
+    expect(() => requireAuthenticatedReview(structuredClone(accepted))).toThrow("authenticated");
+  });
+  it.each(["input", "compiler", "image", "settings", "reproducible", "worker"])("keeps scoped Engine %s provenance exact after profile dispatch", async field => {
+    const f = await fixture(true), compiler = f.artifact.compiler as unknown as Record<string, unknown>;
+    if (field === "input") {
+      const sources = Object.fromEntries(f.source.files.filter(file => file.path.endsWith(".sol")).map(file => [file.path, { content: Buffer.from(file.bytes, "base64").toString("utf8") }]));
+      compiler.completeInputHash = reviewDigest("programmable.modules.compiler-input.v1", { language: "Solidity", sources, settings: NATIVE_SETTINGS });
+    }
+    if (field === "compiler") compiler.binarySha256 = `sha256:${"11".repeat(32)}`;
+    if (field === "image") compiler.imageDigest = `sha256:${"11".repeat(32)}`;
+    if (field === "settings") compiler.settingsHash = h(90);
+    if (field === "reproducible") compiler.reproducible = false;
+    if (field === "worker") {
+      const identity = { ...f.detail.attempts[0].workerIdentity!, workflowRef: "unreviewed-workflow" }, { identityDigest: _old, ...contents } = identity; void _old;
+      f.detail.attempts[0].workerIdentity = { ...contents, identityDigest: reviewDigest("programmable.modules.worker-identity.v1", contents) };
+    }
+    f.redigest(); await expect(f.reader.read(f.subject.submissionId)).rejects.toThrow();
+  });
   it("reads the exact backend engine build and prepares the complete Host admission without availability", async () => {
     const f = await fixture(); expect(parseReviewJob(f.job)).toEqual(f.job);
     expect(() => prepareEnginePublication(f.built, f.release, f.definition, reviewer)).toThrow("accepted");

--- a/tests/module-engine-review-route.test.ts
+++ b/tests/module-engine-review-route.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { validateModuleSubmissionRequest } from "../packages/classic-modules/src/open-transport.mjs";
 import frozen from "./fixtures/module-engine-review-build.json";
 import configuredNativeRelease from "../config/module-mode/robinhood.preview.json";
@@ -14,16 +15,23 @@ import { moduleEngineStandardInputV1, parseEngineReviewArtifact, validateModuleE
 import { parseReviewSubject, reviewDigest, type ReviewJob } from "../lib/module-mode/review-contract";
 import { computeModuleModeHostManifestHash, createModuleModeHostManifest, type ModuleModeHostReleaseIdentity } from "../lib/server/module-mode/catalog";
 import { computeModuleReviewDecisionDigestV1, type ModuleReviewDecisionCommandV1, type ModuleReviewDecisionRecordV1 } from "../lib/server/module-mode/review-decision-wire-v1";
+import { computeModuleModeReleaseDigest } from "../lib/module-mode/release";
 
-const installed = vi.hoisted(() => ({ engine: null as unknown, authenticate: vi.fn() }));
+const installed = vi.hoisted(() => ({ engine: null as unknown, native: null as unknown, authenticate: vi.fn() }));
 vi.mock("server-only", () => ({}));
 vi.mock("@/config/module-engine/review-release.json", () => ({ get default() { return installed.engine; } }));
+vi.mock("@/config/module-mode/review-release.json", () => ({ get default() { return installed.native; } }));
 vi.mock("@/lib/server/creator-article/wallet-principal.server", () => ({
   createPrivyWalletPrincipalAuthenticatorV1: () => ({ authenticate: installed.authenticate }),
   WalletPrincipalAuthenticationErrorV1: class extends Error {},
 }));
 
 const reviewer = WEBSITE_ADMIN_WALLET.toLowerCase() as `0x${string}`;
+const nativeIdentityKeys = ["schemaVersion", "sourceVersion", "chainId", "sourceCommit", "startBlock",
+  "minimumInitialBuyNative", "tokenCreationCodeHash", "finalityPolicy", "contracts", "releaseDigest"];
+const nativeV1Identity = Object.fromEntries(nativeIdentityKeys.map(key => [key, configuredNativeRelease[key as keyof typeof configuredNativeRelease]]));
+const nativeV2IdentityBytes = readFileSync(new URL("../config/module-mode/review-release.json", import.meta.url));
+const nativeV2Identity = JSON.parse(nativeV2IdentityBytes.toString()) as ModuleModeHostReleaseIdentity;
 
 describe("source-bound Quote dependency environment", () => {
   it("preserves the ordinary protected artifact and exact plan digest", () => {
@@ -107,7 +115,7 @@ function routeSetup(f: Pick<ReturnType<typeof engineReviewFixture>, "source" | "
 }
 
 beforeEach(() => {
-  vi.resetModules(); installed.engine = null;
+  vi.resetModules(); installed.engine = null; installed.native = structuredClone(nativeV1Identity);
   installed.authenticate.mockReset().mockResolvedValue({ privyUserId: "did:privy:test-reviewer", privySessionId: "test-session", wallets: [reviewer] });
   vi.stubEnv("PROGRAMMABLE_CUSTOM_LAUNCH_API_BASE_URL", "https://review.example.invalid");
   vi.stubEnv("PROGRAMMABLE_CUSTOM_LAUNCH_WEBSITE_TOKEN", serviceToken);
@@ -167,5 +175,113 @@ describe("installed Engine review identity at the actual admin BFF routes", () =
     const hash = computeModuleModeHostManifestHash(manifest);
     expect((await route.manifest(manifest)).status).toBe(200);
     expect((await route.accept(manifest, hash)).status).toBe(201);
+  });
+});
+
+describe("installed Native review identity at the actual admin BFF routes", () => {
+  function nativeReviewFixture(release = nativeV2Identity) {
+    const f = moduleReviewAdminFixture();
+    // Only the adopted host identity is actual. Source/build/eligibility are synthetic test inputs.
+    const binding = { ...f.binding, ...(release.sourceVersion === "module-native-v2"
+      ? { feeEligibility: { eligible: true, reviewDigest: `0x${"7".repeat(64)}` as const } } : {}) };
+    const manifest = createModuleModeHostManifest({ release, definition: f.definition, nativeBinding: binding, descriptor: f.source.descriptor });
+    return { ...f, manifest, manifestHash: computeModuleModeHostManifestHash(manifest) };
+  }
+
+  it("installs the exact adopted NativeV2 identity without public activation fields", async () => {
+    const { bindModuleModeReviewReleaseIdentity } = await import("../lib/server/module-mode/review-client");
+    expect(nativeV2IdentityBytes.byteLength).toBe(3401);
+    expect(createHash("sha256").update(nativeV2IdentityBytes).digest("hex")).toBe("36100920548506582be173ef0aeef392b413602fc7f4490c1c758829097aae1e");
+    expect(bindModuleModeReviewReleaseIdentity(nativeV2Identity)).toEqual(nativeV2Identity);
+    expect(nativeV2Identity.releaseDigest).toBe("0xe81f122e0bd21e0984e21c71ffce56f315e82f22e485cc19e0e490d4d5b7bd49");
+    expect(nativeV2Identity.sourceCommit).toBe("17b64b6613108dbc6ffdf767607bde6ea33343cd");
+    expect(nativeV2Identity).not.toHaveProperty("enabled");
+    expect(nativeV2Identity).not.toHaveProperty("lifecycleEvidenceDigest");
+    expect(bindModuleModeReviewReleaseIdentity(nativeV1Identity)).toEqual(nativeV1Identity);
+    expect(configuredNativeRelease.sourceVersion).toBe("module-native-v1");
+  });
+
+  it("uses the separately installed V2 identity for manifest checking and authenticated acceptance", async () => {
+    installed.native = nativeV2Identity;
+    const f = nativeReviewFixture(), route = routeSetup(f);
+    expect((await route.manifest(f.manifest)).status).toBe(200);
+    expect((await route.accept(f.manifest, f.manifestHash)).status).toBe(201);
+    const writes = route.backend.mock.calls.filter(([, init]) => init?.method === "POST");
+    expect(writes).toHaveLength(1);
+    expect(String(writes[0][0])).toBe(`https://review.example.invalid/v1/wallet-admin/module-review/${f.subject.submissionId}/decisions`);
+    const headers = new Headers(writes[0][1]?.headers);
+    expect(headers.get("Authorization")).toBe(`Bearer ${serviceToken}`);
+    expect(headers.get("X-Programmable-Bff-Assertion-Signature")).toMatch(/^hmac-sha256:[a-f0-9]{64}$/);
+    expect(installed.authenticate).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps an absent Native slot closed without blocking the original source download", async () => {
+    installed.native = null;
+    const f = nativeReviewFixture(), route = routeSetup(f);
+    for (const result of [await route.manifest(f.manifest), await route.accept(f.manifest, f.manifestHash)]) {
+      expect(result.status).toBe(409);
+      expect(await result.json()).toEqual({ error: { code: "MODULE_REVIEW_HOST_RELEASE_UNAVAILABLE" } });
+    }
+    const { GET } = await import("../app/api/admin/modules/[id]/source/route");
+    const result = await GET(new Request(`https://programmable.market/api/admin/modules/${f.subject.submissionId}/source?walletAddress=${reviewer}`), { params: Promise.resolve({ id: f.subject.submissionId }) });
+    expect(result.status).toBe(200); expect(await result.json()).toEqual(f.source);
+    expect(route.backend.mock.calls.every(([, init]) => init?.method === "GET")).toBe(true);
+  });
+
+  it.each(["sourceVersion", "schemaVersion", "sourceCommit", "chainId", "economicsPolicyId", "missingEconomics", "sourceUrl", "activation", "proof", "pin", "duplicatePin", "accessor"])("rejects invalid installed Native %s before acceptance", async field => {
+    const release = structuredClone(nativeV2Identity) as unknown as Record<string, unknown>;
+    if (field === "sourceVersion") release.sourceVersion = "module-native-v3";
+    if (field === "schemaVersion") release.schemaVersion = "programmable.module-mode-source.v1";
+    if (field === "sourceCommit") release.sourceCommit = "f".repeat(40);
+    if (field === "chainId") release.chainId = 1;
+    if (field === "economicsPolicyId") release.economicsPolicyId = `0x${"8".repeat(64)}`;
+    if (field === "missingEconomics") delete release.economicsPolicyId;
+    if (field === "sourceUrl") release.sourceUrl = "https://caller.example.invalid/source.json";
+    if (field === "activation") { release.enabled = true; release.status = "active"; }
+    if (field === "proof") release.lifecycleEvidenceDigest = `0x${"8".repeat(64)}`;
+    const pins = release.contracts as Record<string, { address: string; runtimeCodeHash: string }>;
+    if (field === "pin") pins.registry.runtimeCodeHash = `0x${"8".repeat(64)}`;
+    if (field === "duplicatePin") pins.registry.address = pins.hook.address;
+    const accessor = vi.fn(() => "module-native-v2");
+    if (field === "accessor") Object.defineProperty(release, "sourceVersion", { enumerable: true, get: accessor });
+    installed.native = release;
+    const f = nativeReviewFixture(), route = routeSetup(f);
+    for (const result of [await route.manifest(f.manifest), await route.accept(f.manifest, f.manifestHash)]) {
+      expect(result.status).toBe(503);
+      expect(await result.json()).toEqual({ error: { code: "MODULE_REVIEW_SERVICE_UNAVAILABLE" } });
+    }
+    expect(accessor).not.toHaveBeenCalled();
+    expect(route.backend.mock.calls.every(([, init]) => init?.method === "GET")).toBe(true);
+  });
+
+  it("rejects V1 manifests, caller release overrides and a correctly rehashed alternate V2 source", async () => {
+    installed.native = nativeV2Identity;
+    const f = nativeReviewFixture(), route = routeSetup(f);
+    const v1 = nativeReviewFixture(nativeV1Identity as ModuleModeHostReleaseIdentity);
+    expect((await route.manifest(v1.manifest)).status).toBe(400);
+    expect((await route.manifest(f.manifest, { releaseIdentity: nativeV2Identity })).status).toBe(400);
+    const changedRelease = { ...nativeV2Identity, sourceCommit: "e".repeat(40) };
+    changedRelease.releaseDigest = computeModuleModeReleaseDigest(changedRelease);
+    const changed = nativeReviewFixture(changedRelease);
+    expect((await route.manifest(changed.manifest)).status).toBe(400);
+    expect((await route.accept(changed.manifest, changed.manifestHash)).status).toBe(400);
+    expect(route.backend.mock.calls.every(([, init]) => init?.method === "GET")).toBe(true);
+  });
+
+  it("rechecks the exact V2 fee-eligibility tuple on acceptance", async () => {
+    installed.native = nativeV2Identity;
+    const f = nativeReviewFixture(), route = routeSetup(f), changed = structuredClone(f.manifest);
+    expect((await route.manifest(f.manifest)).status).toBe(200);
+    changed.manifest.runtimeBinding.feeEligibility = { eligible: false, reviewDigest: `0x${"0".repeat(64)}` };
+    expect((await route.accept(changed, f.manifestHash)).status).toBe(400);
+    expect(route.backend.mock.calls.every(([, init]) => init?.method === "GET")).toBe(true);
+  });
+
+  it.each([null, { sourceVersion: "invalid" }])("preserves Engine checking and acceptance when Native configuration is %j", async native => {
+    installed.native = native;
+    const f = engineReviewFixture(); installed.engine = f.release;
+    const route = routeSetup(f);
+    expect((await route.manifest(f.manifest)).status).toBe(200);
+    expect((await route.accept(f.manifest, f.manifestHash)).status).toBe(201);
   });
 });

--- a/tests/module-mode-publication.test.ts
+++ b/tests/module-mode-publication.test.ts
@@ -1,16 +1,20 @@
 import { createHash } from "node:crypto";
 import { fileURLToPath } from "node:url";
+import { mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { decodeFunctionData, encodeAbiParameters, encodeEventTopics, encodeFunctionResult, keccak256, parseAbiParameters, type Hex } from "viem";
 import { moduleReviewAdminFixture } from "./fixtures/module-review-admin";
 import { a, h } from "./fixtures/module-mode-evidence";
-import { computeModuleModeReleaseDigest } from "../lib/module-mode/release";
+import { computeModuleModeReleaseDigest, MODULE_MODE_ECONOMICS_POLICY_V2 } from "../lib/module-mode/release";
 import { reviewDigest, type ReviewAttempt } from "../lib/module-mode/review-contract";
 import { computeModuleReviewDecisionDigestV1, type ModuleReviewDecisionRecordV1 } from "../lib/server/module-mode/review-decision-wire-v1";
 import { moduleSubmissionFromPack, validateModuleSubmissionRequest, type ModuleSubmissionRequest } from "../packages/classic-modules/src/open-transport.mjs";
 import { loadOpenSourcePackage } from "../packages/classic-modules/src/open-package-io.mjs";
 import { createAuthenticatedReviewReader, NATIVE_COMPILER, NATIVE_SETTINGS, requireAuthenticatedReview, acceptedDecision } from "../ops/module-mode-publication/review";
-import { CREATE2_DEPLOYER, REGISTRY_ABI, createHostPreparation, prepareModulePublication } from "../ops/module-mode-publication/core";
+import { CREATE2_DEPLOYER, REGISTRY_ABI, REGISTRY_V2_ABI, createHostPreparation, prepareModulePublication } from "../ops/module-mode-publication/core";
+import { run } from "../ops/module-mode-publication/main";
 import { observePublicationReadback, publicationRpc, readPublicationOwner, type PublicationProvider } from "../ops/module-mode-publication/rpc";
 
 // Synthetic parser/RPC evidence only. Never upload these fixtures or treat them as review or chain proof.
@@ -19,7 +23,7 @@ function workerIdentity(overrides: Partial<Omit<NonNullable<ReviewAttempt["worke
     workflowRef: "programmablehq/programmable-open-hook-v2-internal/.github/workflows/protected-module-review-v1.yml@refs/heads/main", ...overrides };
   return { ...fields, identityDigest: reviewDigest("programmable.modules.worker-identity.v1", fields) };
 }
-async function fixture() {
+async function fixture(feeEligibility?: { eligible: boolean; reviewDigest: Hex }) {
   const f = moduleReviewAdminFixture();
   const source = structuredClone(f.source);
   for (const c of source.descriptor.components) c.runtime = "programmable.native-solidity@1";
@@ -44,6 +48,7 @@ async function fixture() {
     { ...attempt, event: "completed", artifactDigest: artifact.artifactDigest, workerIdentity: null, createdAt: detail.job.updatedAt },
   ];
   const release = structuredClone(f.release);
+  if (feeEligibility) Object.assign(release, { schemaVersion: "programmable.module-mode-source.v2", sourceVersion: "module-native-v2", economicsPolicyId: MODULE_MODE_ECONOMICS_POLICY_V2 });
   const codes = new Map<string, Hex>(); let index = 0;
   for (const pin of Object.values(release.contracts)) { const code = `0x60${(++index).toString(16).padStart(2, "0")}` as Hex; (pin as { runtimeCodeHash: Hex }).runtimeCodeHash = keccak256(code); codes.set(pin.address, code); }
   (release as { releaseDigest: Hex }).releaseDigest = computeModuleModeReleaseDigest(release);
@@ -54,7 +59,7 @@ async function fixture() {
   });
   const reader = createAuthenticatedReviewReader({ walletAddress: f.reviewer, accessToken: "test_fixture_session_0123456789" }, fetchImpl);
   const built = await reader.read(subject.submissionId);
-  const host = createHostPreparation(built, release, f.definition);
+  const host = createHostPreparation(built, release, f.definition, feeEligibility);
   const accept = async () => {
     const contents: Omit<ModuleReviewDecisionRecordV1, "decisionDigest"> = { schemaVersion: "programmable.modules.review-decision.v1", subject,
       reviewerWallet: f.reviewer, policyDigest: f.policyDigest, decidedAt: new Date().toISOString(), registryApproved: false, available: false,
@@ -65,7 +70,7 @@ async function fixture() {
     detail.job.state = "accepted"; detail.job.reviewRevision++;
     return reader.read(subject.submissionId);
   };
-  return { ...f, source, subject, artifact, detail, release, codes, reader, fetchImpl, built, host, accept, digestArtifact };
+  return { ...f, source, subject, artifact, detail, release, codes, reader, fetchImpl, built, host, accept, digestArtifact, feeEligibility };
 }
 
 // Real SDK source inventory with synthetic review/build evidence, never protected-worker authority.
@@ -111,13 +116,21 @@ async function starterFixture(changeSource?: (source: ModuleSubmissionRequest) =
 }
 
 function providers(f: Awaited<ReturnType<typeof fixture>>, plan: ReturnType<typeof prepareModulePublication>) {
-  const transactions = { factory: h(70), family: h(71), revision: h(72) };
-  const block = { number: "0x100", hash: h(50), timestamp: `0x${Math.floor(Date.now() / 1000).toString(16)}`, transactions: Object.values(transactions) };
+  const transactions = { factory: h(70), family: h(71), revision: h(72),
+    ...(f.feeEligibility ? { feeEligibility: BigInt(f.feeEligibility.reviewDigest) !== 0n ? h(73) : null } : {}) };
+  const block = { number: "0x100", hash: h(50), timestamp: `0x${Math.floor(Date.now() / 1000).toString(16)}`, transactions: Object.values(transactions).filter(Boolean) };
   const b = plan.publication.entry.nativeBinding;
   const revision = { familyId: b.familyId, factory: b.factory, factoryCodeHash: b.factoryCodeHash, moduleCodeHash: b.moduleCodeHash, manifestHash: b.manifestHash, callbackGas: b.callbackGas, enabled: true };
-  const map = new Map(Object.values(transactions).map((hash, i) => [hash, plan.calls[i]]));
+  const map = new Map<Hex, (typeof plan.calls)[number]>();
+  for (const [key, action] of [["factory", "deployFactory"], ["family", "registerReviewedFamily"], ["revision", "approveRevision"], ["feeEligibility", "setFamilyFeeEligibility"]] as const) {
+    const hash = transactions[key]; if (hash) map.set(hash, plan.calls.find(call => call.action === action)!);
+  }
   const log = { address: plan.release.contracts.registry.address, topics: encodeEventTopics({ abi: REGISTRY_ABI, eventName: "RevisionApproved", args: { packageId: b.packageId, familyId: b.familyId } }),
     data: encodeAbiParameters(parseAbiParameters("(bytes32 familyId,address factory,bytes32 factoryCodeHash,bytes32 moduleCodeHash,bytes32 manifestHash,uint32 callbackGas,bool enabled)"), [revision]), removed: false };
+  const eligibility = f.feeEligibility ? { ...f.feeEligibility } : undefined;
+  const feeLog = eligibility ? { address: plan.release.contracts.registry.address,
+    topics: encodeEventTopics({ abi: REGISTRY_V2_ABI, eventName: "FamilyFeeEligibilityReviewed", args: { familyId: b.familyId, reviewDigest: eligibility.reviewDigest, reviewer: f.reviewer } }),
+    data: encodeAbiParameters([{ type: "bool" }], [eligibility.eligible]), removed: false } : undefined;
   const rpc = vi.fn(async (method: string, params: unknown[]): Promise<unknown> => {
     if (method === "eth_chainId") return "0x1237";
     if (method === "eth_getBlockByNumber") return block;
@@ -127,18 +140,19 @@ function providers(f: Awaited<ReturnType<typeof fixture>>, plan: ReturnType<type
       return f.codes.get(String(params[0])) ?? "0x";
     }
     if (method === "eth_call") {
-      const decoded = decodeFunctionData({ abi: REGISTRY_ABI, data: (params[0] as { data: Hex }).data });
+      const decoded = decodeFunctionData({ abi: REGISTRY_V2_ABI, data: (params[0] as { data: Hex }).data });
       if (decoded.functionName === "owner") return encodeFunctionResult({ abi: REGISTRY_ABI, functionName: "owner", result: f.reviewer });
       if (decoded.functionName === "families") return encodeFunctionResult({ abi: REGISTRY_ABI, functionName: "families", result: [f.source.descriptor.author as Hex, f.source.descriptor.rewardWallet as Hex] });
       if (decoded.functionName === "getRevision") return encodeFunctionResult({ abi: REGISTRY_ABI, functionName: "getRevision", result: revision });
+      if (decoded.functionName === "familyFeeEligibility" && eligibility) return encodeFunctionResult({ abi: REGISTRY_V2_ABI, functionName: "familyFeeEligibility", result: [eligibility.eligible, eligibility.reviewDigest] });
     }
     const hash = params[0] as Hex, call = map.get(hash)!;
     if (method === "eth_getTransactionByHash") return { hash, from: call.from, to: call.to, input: call.data, value: call.value, chainId: "0x1237", blockHash: block.hash, blockNumber: block.number };
-    if (method === "eth_getTransactionReceipt") return { transactionHash: hash, blockHash: block.hash, blockNumber: block.number, status: "0x1", transactionIndex: "0x0", logs: call.action === "approveRevision" ? [log] : [] };
+    if (method === "eth_getTransactionReceipt") return { transactionHash: hash, blockHash: block.hash, blockNumber: block.number, status: "0x1", transactionIndex: "0x0", logs: call.action === "approveRevision" ? [log] : call.action === "setFamilyFeeEligibility" ? [feeLog] : [] };
     throw new Error("Unexpected fixture RPC");
   });
   const result: PublicationProvider[] = [0, 1].map(i => ({ providerId: `fixture${i}`, trustDomain: `independent${i}.invalid`, endpointCommitment: `sha256:${h(i + 11).slice(2)}`, rpc }));
-  return { providers: result, transactions, block, revision, rpc, log };
+  return { providers: result, transactions, block, revision, rpc, log, eligibility, feeLog };
 }
 
 describe("Generic module publication authority and binding", () => {
@@ -212,6 +226,90 @@ describe("Generic module publication authority and binding", () => {
     await expect(f.reader.read(f.subject.submissionId)).rejects.not.toThrow("credential-canary-private");
     f.fetchImpl.mockImplementation(async () => new Response(null, { status: 302, headers: { location: "https://other.invalid" } }));
     await expect(f.reader.read(f.subject.submissionId)).rejects.toThrow("Authenticated module review read failed");
+  });
+});
+
+describe("NativeV2 publication fee review", () => {
+  it("requires explicit eligibility and the current acceptance of that exact manifest", async () => {
+    const eligibility = { eligible: true, reviewDigest: h(1001) }, f = await fixture(eligibility);
+    expect(f.host.nativeBinding.feeEligibility).toEqual(eligibility);
+    expect(f.host.manifest.manifest.runtimeBinding.feeEligibility).toEqual(eligibility);
+    expect(() => createHostPreparation(f.built, f.release, f.definition)).toThrow("explicit family fee eligibility");
+    expect(() => createHostPreparation(f.built, f.release, f.definition, { eligible: true, reviewDigest: h(0) })).toThrow();
+    expect(() => createHostPreparation(f.built, f.release, f.definition, { ...eligibility, feeBps: 30 })).toThrow();
+    expect(() => prepareModulePublication(f.built, f.release, f.definition, f.reviewer, eligibility)).toThrow("Current accepted");
+    const reviewed = await f.accept(), plan = prepareModulePublication(reviewed, f.release, f.definition, f.reviewer, eligibility);
+    expect(plan.calls.map(call => call.action)).toEqual(["deployFactory", "registerReviewedFamily", "setFamilyFeeEligibility", "approveRevision"]);
+    expect(plan.publication.entry.nativeBinding.feeEligibility).toEqual(eligibility);
+    const call = plan.calls[2];
+    expect(call).toMatchObject({ from: f.reviewer, to: f.release.contracts.registry.address, value: "0x0", chainId: 4663 });
+    expect(decodeFunctionData({ abi: REGISTRY_V2_ABI, data: call.data })).toEqual({ functionName: "setFamilyFeeEligibility", args: [f.host.nativeBinding.familyId, true, eligibility.reviewDigest] });
+    for (const changed of [{ ...eligibility, eligible: false }, { ...eligibility, reviewDigest: h(1002) }]) {
+      expect(() => prepareModulePublication(reviewed, f.release, f.definition, f.reviewer, changed)).toThrow("another host manifest");
+    }
+    const v1 = await fixture();
+    expect(v1.host.nativeBinding).not.toHaveProperty("feeEligibility");
+    expect(() => createHostPreparation(v1.built, v1.release, v1.definition, eligibility)).toThrow("NativeV2");
+  });
+  it.each([h(0), h(1003)])("keeps a reviewed false eligibility and handles digest %s without inventing a fee grant", async reviewDigest => {
+    const eligibility = { eligible: false, reviewDigest }, f = await fixture(eligibility), reviewed = await f.accept();
+    const plan = prepareModulePublication(reviewed, f.release, f.definition, f.reviewer, eligibility), p = providers(f, plan);
+    expect(plan.calls.some(call => call.action === "setFamilyFeeEligibility")).toBe(BigInt(reviewDigest) !== 0n);
+    const evidence = await observePublicationReadback(plan, reviewed, p.providers, p.transactions);
+    expect(evidence.feeEligibility).toEqual(eligibility);
+    expect(evidence.receipts).toHaveLength(BigInt(reviewDigest) === 0n ? 3 : 4);
+    if (BigInt(reviewDigest) === 0n) await expect(observePublicationReadback(plan, reviewed, p.providers, { ...p.transactions, feeEligibility: h(73) })).rejects.toThrow("no setter transaction");
+  });
+  it("checks the exact current getter, owner transaction and eligibility event before export", async () => {
+    const eligibility = { eligible: true, reviewDigest: h(1004) }, f = await fixture(eligibility), reviewed = await f.accept();
+    const plan = prepareModulePublication(reviewed, f.release, f.definition, f.reviewer, eligibility), p = providers(f, plan);
+    expect((await observePublicationReadback(plan, reviewed, p.providers, p.transactions)).receipts).toHaveLength(4);
+    expect((await observePublicationReadback(plan, reviewed, p.providers, { ...p.transactions, feeEligibility: null })).receipts).toHaveLength(3);
+    await expect(observePublicationReadback(plan, reviewed, p.providers, { factory: h(70), family: h(71), revision: h(72) })).rejects.toThrow("transaction field");
+    p.eligibility!.eligible = false;
+    await expect(observePublicationReadback(plan, reviewed, p.providers, p.transactions)).rejects.toThrow("Current Registry family fee eligibility");
+    Object.assign(p.eligibility!, eligibility, { reviewDigest: h(1005) });
+    await expect(observePublicationReadback(plan, reviewed, p.providers, p.transactions)).rejects.toThrow("Current Registry family fee eligibility");
+    Object.assign(p.eligibility!, eligibility); p.feeLog!.removed = true;
+    await expect(observePublicationReadback(plan, reviewed, p.providers, p.transactions)).rejects.toThrow("fee eligibility review event");
+    p.feeLog!.removed = false;
+    const rpc = p.rpc.getMockImplementation()!;
+    p.rpc.mockImplementation(async (method, params) => {
+      const value = await rpc(method, params);
+      return method === "eth_getTransactionByHash" && params[0] === h(73) ? { ...(value as object), from: a(1006) } : value;
+    });
+    await expect(observePublicationReadback(plan, reviewed, p.providers, p.transactions)).rejects.toThrow("Included transaction differs");
+  });
+  it("passes the explicit fee input through the existing manifest and authenticated export CLI", async () => {
+    const eligibility = { eligible: true, reviewDigest: h(1007) }, f = await fixture(eligibility), reviewed = await f.accept();
+    const plan = prepareModulePublication(reviewed, f.release, f.definition, f.reviewer, eligibility), p = providers(f, plan);
+    const directory = await mkdtemp(path.join(await realpath(tmpdir()), "module-publication-v2-"));
+    const filenames: Record<string, string> = {};
+    for (const [key, value] of Object.entries({ identity: f.release, definition: f.definition, "fee-eligibility": eligibility,
+      "session-file": { walletAddress: f.reviewer, accessToken: "test_fixture_session_0123456789" }, transactions: p.transactions })) {
+      filenames[key] = path.join(directory, `${key}.json`); await writeFile(filenames[key], JSON.stringify(value), { mode: 0o600 });
+    }
+    const providerUrls = ["https://fixture-a.invalid", "https://fixture-b.invalid"];
+    vi.stubGlobal("fetch", async (url: string | URL | Request, init?: RequestInit) => {
+      if (String(url).startsWith("https://programmable.market/")) return f.fetchImpl(url, init);
+      expect(providerUrls).toContain(String(url));
+      const request = JSON.parse(init!.body as string);
+      return Response.json({ jsonrpc: "2.0", id: request.id, result: await p.rpc(request.method, request.params) });
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const context = { repositoryRoot: fileURLToPath(new URL("..", import.meta.url)), providers: async () => p.providers.map((provider, i) => ({
+      providerId: provider.providerId, trustDomain: provider.trustDomain, endpointCommitment: provider.endpointCommitment, url: providerUrls[i],
+    })) };
+    const common = ["--identity", filenames.identity, "--definition", filenames.definition, "--submission", f.subject.submissionId, "--session-file", filenames["session-file"]];
+    try {
+      await expect(run(["manifest", ...common, "--output", path.join(directory, "missing")], context)).rejects.toThrow("explicit family fee eligibility");
+      await run(["manifest", ...common, "--fee-eligibility", filenames["fee-eligibility"], "--output", path.join(directory, "manifest")], context);
+      expect(JSON.parse(await readFile(path.join(directory, "manifest/manifest.json"), "utf8"))).toEqual(f.host.manifest);
+      await run(["export", ...common, "--fee-eligibility", filenames["fee-eligibility"], "--transactions", filenames.transactions, "--output", path.join(directory, "export")], context);
+      const evidence = JSON.parse(await readFile(path.join(directory, "export/publication-evidence.json"), "utf8"));
+      expect(evidence.feeEligibility).toEqual(eligibility); expect(evidence.receipts).toHaveLength(4);
+      expect(JSON.parse(await readFile(path.join(directory, "export/export.complete.json"), "utf8"))).toMatchObject({ websitePublished: false, ethereumFinalityProven: false });
+    } finally { vi.unstubAllGlobals(); log.mockRestore(); await rm(directory, { recursive: true, force: true }); }
   });
 });
 

--- a/tests/module-review-admin-bff.test.ts
+++ b/tests/module-review-admin-bff.test.ts
@@ -20,6 +20,11 @@ const TIME = "2026-09-06T02:00:00.000Z";
 const NONCE = "abcdefghijklmnopqrstuv";
 // Real immutable host pins with an explicit pending lifecycle, independent of production activation.
 const pendingRelease = { ...configuredRelease, enabled: false, status: "preview", lifecycleEvidenceDigest: null };
+function reviewIdentity(release: ModuleModeHostReleaseIdentity) {
+  return Object.fromEntries(["schemaVersion", "sourceVersion", "chainId", "sourceCommit", "startBlock",
+    "minimumInitialBuyNative", "tokenCreationCodeHash", "finalityPolicy", "contracts", "releaseDigest",
+    ...(release.sourceVersion === "module-native-v2" ? ["economicsPolicyId"] : [])].map(key => [key, release[key as keyof ModuleModeHostReleaseIdentity]]));
+}
 function setup(options: { wallet?: string; author?: `0x${string}`; release?: boolean | "pending" } = {}) {
   const f = moduleReviewAdminFixture(options.author); const wallet = options.wallet ?? f.reviewer;
   const authenticate = vi.fn(async () => ({ privyUserId: "did:privy:test-reviewer", privySessionId: "session-review", wallets: [wallet] }));
@@ -38,7 +43,7 @@ function setup(options: { wallet?: string; author?: `0x${string}`; release?: boo
     return Response.json(path.endsWith(f.subject.submissionId) ? detail : queue);
   });
   const client = createModuleReviewClient({ authenticator: { authenticate } as WalletPrincipalAuthenticatorV1, backendBaseUrl: "https://review.example.invalid", websiteToken: WEBSITE_TOKEN, bffAssertionKeyV2: ASSERTION_KEY, fetchBackend, now: () => new Date(TIME), nonce: () => NONCE,
-    releaseIdentity: options.release === "pending" ? pendingRelease : options.release === false ? { enabled: false, status: "preview", releaseDigest: null } : f.release });
+    releaseIdentity: options.release === false ? null : reviewIdentity(options.release === "pending" ? pendingRelease as ModuleModeHostReleaseIdentity : f.release) });
   const read = (suffix = "") => new Request(`https://programmable.example/api/admin/modules${suffix}?walletAddress=${wallet}`, { headers: { Authorization: "Bearer browser-private-token", "X-Programmable-Bff-Assertion-Signature": "forged-browser-value" } });
   const post = (suffix: string, body: object) => new Request(`https://programmable.example/api/admin/modules/${f.subject.submissionId}/${suffix}`, { method: "POST", headers: { "Content-Type": "application/json", Authorization: "Bearer browser-private-token" }, body: JSON.stringify({ walletAddress: wallet, ...body }) });
   const command = (outcome: ModuleReviewDecisionCommandV1["outcome"] = "accept"): ModuleReviewDecisionCommandV1 => ({ schemaVersion: "programmable.modules.review-command.v1", submissionId: f.subject.submissionId, requestDigest: f.subject.requestDigest, expectedReviewRevision: 2, outcome, reason: "Synthetic review test only. Do not publish this fixture.", artifactDigest: outcome === "accept" ? f.artifact.artifactDigest : null, hostManifestHash: outcome === "accept" ? f.manifestHash : null, acknowledgedReviewAreas: outcome === "accept" ? f.artifact.reviewRequired : [] });

--- a/tests/module-review-admin-contract.test.ts
+++ b/tests/module-review-admin-contract.test.ts
@@ -1,6 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
 import { parseReviewArtifact, parseReviewAttempt, parseReviewJob, parseReviewPlan, parseReviewProgramAbi, parseReviewQueueItem, reviewDigest } from "../lib/module-mode/review-contract";
+import { createPublicationSessionExporter, type PublicationSession } from "../lib/module-mode/publication-session";
+import { WEBSITE_ADMIN_WALLET } from "../lib/admin-access";
+import { readOperatorSession } from "../ops/module-mode-publication/review";
+import { ModuleReviewAdminConsole } from "../components/module-review-admin-console";
 import { moduleReviewAdminFixture } from "./fixtures/module-review-admin";
+
+const walletFixture = vi.hoisted(() => ({ authenticated: false, authReady: true, sessionReady: true, disconnecting: false,
+  connecting: false, wallet: { account: "0x79879fe6f00c0986Ca521eA6F5b276b5E28b1b9C" },
+  getAccessToken: vi.fn(async () => "synthetic_access_token_no_authority"),
+  getIdentityToken: vi.fn(async () => "synthetic_identity_token_no_authority"), openWallet: vi.fn() }));
+vi.mock("../components/wallet-provider", () => ({ useWallet: () => walletFixture }));
 
 function redigest<T extends { artifactDigest: string }>(value: T) { const { artifactDigest: _old, ...body } = value; void _old; return { ...body, artifactDigest: reviewDigest("programmable.modules.native-build.v1", body) }; }
 describe("Private module review wire boundaries", () => {
@@ -60,5 +75,85 @@ describe("Private module review wire boundaries", () => {
     const f = moduleReviewAdminFixture(); expect(parseReviewAttempt(f.detail.attempts[0], f.subject)).toEqual(f.detail.attempts[0]);
     expect(() => parseReviewAttempt({ ...f.detail.attempts[0], leaseToken: "private" }, f.subject)).toThrow();
     expect(() => parseReviewAttempt({ ...f.detail.attempts[0], workerIdentity: { ...f.detail.attempts[0].workerIdentity, runId: "javascript:bad" } }, f.subject)).toThrow();
+  });
+});
+
+describe("Explicit private publication session download", () => {
+  const access = "synthetic_access_token_no_authority";
+  const identity = "synthetic_identity_token_no_authority";
+  function fixture() {
+    let session: PublicationSession | null = Object.freeze({ walletAddress: WEBSITE_ADMIN_WALLET });
+    const input = { readSession: () => session, getAccessToken: vi.fn<() => Promise<string | null>>(async () => access),
+      getIdentityToken: vi.fn<() => Promise<string | null>>(async () => identity), download: vi.fn<(json: string) => void>() };
+    return { input, changeSession: (next: PublicationSession | null) => { session = next; } };
+  }
+
+  it.each([true, false])("round-trips the closed original owner-only file (identity token: %s)", async includeIdentity => {
+    const f = fixture(); if (!includeIdentity) f.input.getIdentityToken.mockResolvedValue(null);
+    expect(await createPublicationSessionExporter()(f.input)).toBe("downloaded");
+    expect(f.input.download).toHaveBeenCalledTimes(1);
+    const text = f.input.download.mock.calls[0][0];
+    const expected = { walletAddress: WEBSITE_ADMIN_WALLET.toLowerCase(), accessToken: access,
+      ...(includeIdentity ? { identityToken: identity } : {}) };
+    expect(JSON.parse(text)).toEqual(expected);
+    const directory = await mkdtemp(path.join(tmpdir(), "module-session-synthetic-"));
+    try {
+      const file = path.join(directory, "session.json"); await writeFile(file, text, { mode: 0o600, flag: "wx" });
+      expect(await readOperatorSession(file)).toEqual(expected);
+    } finally { await rm(directory, { recursive: true, force: true }); }
+  });
+
+  it.each(["identity", "access"])("cancels a new session of the same account during the %s await", async stage => {
+    const f = fixture();
+    const change = () => f.changeSession(Object.freeze({ walletAddress: WEBSITE_ADMIN_WALLET }));
+    if (stage === "identity") f.input.getIdentityToken.mockImplementation(async () => { change(); return identity; });
+    else f.input.getAccessToken.mockImplementation(async () => { change(); return access; });
+    expect(await createPublicationSessionExporter()(f.input)).toBe("session-changed");
+    expect(f.input.download).not.toHaveBeenCalled();
+    if (stage === "identity") expect(f.input.getAccessToken).not.toHaveBeenCalled();
+  });
+
+  it.each([null, { walletAddress: "0x1111111111111111111111111111111111111111" }])("does not retrieve tokens without the current admin session: %j", async session => {
+    const f = fixture(); f.changeSession(session);
+    expect(await createPublicationSessionExporter()(f.input)).toBe("session-changed");
+    expect(f.input.getIdentityToken).not.toHaveBeenCalled(); expect(f.input.getAccessToken).not.toHaveBeenCalled();
+    expect(f.input.download).not.toHaveBeenCalled();
+  });
+
+  it("locks synchronously before token retrieval and releases after completion", async () => {
+    const f = fixture(), run = createPublicationSessionExporter();
+    let release!: (value: string) => void;
+    f.input.getIdentityToken.mockReturnValue(new Promise(resolve => { release = resolve; }));
+    const first = run(f.input), second = run(f.input);
+    expect(await second).toBe("busy"); expect(f.input.getIdentityToken).toHaveBeenCalledTimes(1);
+    release(identity); expect(await first).toBe("downloaded"); expect(f.input.download).toHaveBeenCalledTimes(1);
+    expect(await run(f.input)).toBe("downloaded"); expect(f.input.download).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects missing, malformed or oversized tokens and never returns SDK error details", async () => {
+    const run = createPublicationSessionExporter();
+    for (const token of [null, "short", `${access}\n${identity}`]) {
+      const f = fixture(); f.input.getAccessToken.mockResolvedValue(token);
+      expect(await run(f.input)).toBe("unavailable"); expect(f.input.download).not.toHaveBeenCalled();
+    }
+    const f = fixture(); f.input.getAccessToken.mockResolvedValue("a".repeat(16_384)); f.input.getIdentityToken.mockResolvedValue("b".repeat(16_384));
+    expect(await run(f.input)).toBe("unavailable"); expect(f.input.download).not.toHaveBeenCalled();
+    f.input.getAccessToken.mockRejectedValue(new Error(`${access} ${identity}`));
+    expect(await run(f.input)).toBe("unavailable"); expect(f.input.download).not.toHaveBeenCalled();
+  });
+
+  it("renders the action only for the authenticated admin and never renders token content", () => {
+    try {
+      walletFixture.authenticated = false;
+      expect(renderToStaticMarkup(createElement(ModuleReviewAdminConsole))).not.toContain("Download publication session");
+      walletFixture.authenticated = true;
+      walletFixture.wallet.account = "0x1111111111111111111111111111111111111111";
+      expect(renderToStaticMarkup(createElement(ModuleReviewAdminConsole))).not.toContain("Download publication session");
+      walletFixture.wallet.account = WEBSITE_ADMIN_WALLET;
+      const html = renderToStaticMarkup(createElement(ModuleReviewAdminConsole));
+      expect(html).toContain("Download publication session"); expect(html).toContain("Contains your login tokens.");
+      expect(html).toContain('role="status"'); expect(html).not.toContain(access); expect(html).not.toContain(identity);
+      expect(walletFixture.getAccessToken).not.toHaveBeenCalled(); expect(walletFixture.getIdentityToken).not.toHaveBeenCalled();
+    } finally { walletFixture.authenticated = false; walletFixture.wallet.account = WEBSITE_ADMIN_WALLET; }
   });
 });


### PR DESCRIPTION
The private Module release flow could not publish Engine revisions or execute their canaries through the existing personal wallet operator. The operator now supports Engine family/revision admission, atomic initial operations and subsequent operations with bounded funding, while preserving fresh authenticated review, source/CI, journal, two-provider and receipt checks. The admin console provides an explicit private session download through its existing wallet login.

The change also binds private Native V2 and Core review slots to their deployed identities, completes Native V2 publication and exact-output canary plans, and recognizes the exact Solidity 0.8.26 metadata trailer during Quote source verification. Engine review reconstructs the correct scoped source aliases; RegistryV1 launches use the immutable Host revision fee-family list. A narrow existing Gitleaks hash allowlist covers the same verified public bytecode pin in the two private review identity files.

Validation: independent reviews completed with the scoped-source reader finding fixed and closed; existing targeted suites passed (48 operator checks, 17 Engine client checks, 108 reader/source checks and 68 admin/session checks), TypeScript and scoped lint passed. Rendered local browser QA covered 1440/390/320 CSS pixels, 44px controls, Tab/Enter/Space, one download on double-click, cancellation after session changes, the unauthenticated admin gate, and console review. Three synthetic downloads were checked and removed; no actual session credentials were used. The regular hosted Verify run must pass on this final PR head.

Contract deployments and source observations remain pinned to production 17b64b66. The operator code receives its own production source identity after merge. Actual review acceptance, wallet confirmations, lifecycle finality, indexing and public activation remain required; this change does not mark releases or modules available.
