### PR TITLE
fix(module-mode): keep reviewed gas allowance stable during handoff

### DIFF
--- a/contracts/scripts/module-mode/publication-operator.test.mjs
+++ b/contracts/scripts/module-mode/publication-operator.test.mjs
@@ -5,11 +5,23 @@ import { decodeFunctionData, encodeFunctionResult, keccak256, parseAbi } from 'v
 import { hexQuantity } from './core.mjs';
 import { createPublicationPlan, assertPublicationPlan, bindPublicationModule, assertAuthenticatedOperationPlan, registryAbi, registryV2Abi } from './publication-plan.mjs';
 import { publicationFixture } from './publication-test-fixtures.mjs';
+import { lifecycleV2RpcFixture } from './lifecycle-v2-test-fixtures.mjs';
 import { publicationWalletRequest, assertPublicationRequest, observePublicationOperation, preparePublicationRequest, revalidatePublicationRequest, observePublicationReceipt, preparePublicationRetry } from './publication-rpc.mjs';
 import { startPublicationOperator } from './publication-operator.mjs';
 
 const ceilings = { maxGas: '2000000', maxFeePerGas: '1000', maxPriorityFeePerGas: '10', maxValue: '1000' };
 const h = n => `0x${n.toString(16).padStart(64, '0')}`;
+const reviewedLaunchCeilings = { maxGas: '4600000', maxFeePerGas: '800000000', maxPriorityFeePerGas: '10000000', maxValue: '400000000000000' };
+async function gasDriftFixture() {
+  const fixture = await lifecycleV2RpcFixture('launch', false);
+  let estimate = 4292099n, balance;
+  const providers = fixture.providers.map(provider => ({ ...provider, rpc(method, params) {
+    if (method === 'eth_estimateGas') return Promise.resolve(hexQuantity(estimate));
+    if (method === 'eth_getBalance' && balance !== undefined) return Promise.resolve(hexQuantity(balance));
+    return provider.rpc(method, params);
+  } }));
+  return { ...fixture, providers, setEstimate(value) { estimate = value; }, setBalance(value) { balance = value; } };
+}
 function rpcFixture() {
   const owner = '0x0000000000000000000000000000000000000001', registry = '0x0000000000000000000000000000000000000002', runtime = '0x600100';
   const family = h(4), wallet = '0x0000000000000000000000000000000000000003';
@@ -76,11 +88,54 @@ test('NativeV2 false/zero keeps the untouched default and NativeV1 cannot adopt 
   await assert.rejects(bindPublicationModule(v1.module, v1.identity, v1.owner));
 });
 test('wallet ceilings include ETH value and gas, with no automatic fee raise', () => {
-  const f = rpcFixture(); f.step.value = '1000'; const observation = { state: 'operation-simulated', stepIndex: 0, gasLimit: '100000', baseFeePerGas: '1', minimumBalance: '100001000', nonce: '1' };
-  const request = publicationWalletRequest(f.plan, observation, ceilings); assert.equal(request.value, '0x3e8');
-  assert.throws(() => publicationWalletRequest(f.plan, { ...observation, minimumBalance: '100000999' }, ceilings), /balance/);
+  const f = rpcFixture(); f.step.value = '1000'; const observation = { state: 'operation-simulated', stepIndex: 0, gasLimit: '100000', baseFeePerGas: '1', minimumBalance: '2000001000', nonce: '1' };
+  const request = publicationWalletRequest(f.plan, observation, ceilings); assert.equal(request.value, '0x3e8'); assert.equal(BigInt(request.gas), 2000000n);
+  assert.throws(() => publicationWalletRequest(f.plan, { ...observation, minimumBalance: '2000000999' }, ceilings), /balance/);
   assert.throws(() => publicationWalletRequest(f.plan, observation, { ...ceilings, maxValue: '999' }), /ETH value/);
   assert.throws(() => publicationWalletRequest(f.plan, observation, { ...ceilings, maxGas: '99999' }), /Gas estimate/);
+});
+test('fixed reviewed launch gas tolerates modest estimate drift without changing the armed or retry request', async () => {
+  const f = await gasDriftFixture(), prepared = await preparePublicationRequest(f.plan, 0, f.providers, reviewedLaunchCeilings), original = structuredClone(prepared);
+  assert.equal(prepared.observation.gasLimit, '4531704');
+  // Archived not-armed Native V2 observations: 4292099 -> 4292479 gas.
+  f.setEstimate(4292479n);
+  const fresh = await revalidatePublicationRequest(f.plan, prepared, f.providers, reviewedLaunchCeilings);
+  assert.equal(fresh.gasLimit, '4532103'); assert.equal(BigInt(prepared.request.gas), 4600000n);
+  assert.deepEqual(prepared, original);
+  const retry = await preparePublicationRetry(f.plan, { ...prepared, transactionHash: null }, f.providers, reviewedLaunchCeilings, prepared.requestDigest, 1);
+  assert.deepEqual(retry.request, original.request); assertPublicationRequest(f.plan, retry);
+  f.setEstimate(4357142n); // ceil(estimate * 1.05) + 25000 reaches the ceiling exactly.
+  assert.equal((await revalidatePublicationRequest(f.plan, prepared, f.providers, reviewedLaunchCeilings)).gasLimit, '4600000');
+  assert.deepEqual(prepared, original);
+});
+test('fixed reviewed launch gas still requires the full fresh buffer and balance for its maximum cost', async () => {
+  const f = await gasDriftFixture(), prepared = await preparePublicationRequest(f.plan, 0, f.providers, reviewedLaunchCeilings);
+  for (const estimate of [4357143n, 4600001n]) {
+    f.setEstimate(estimate); // The first raw estimate fits, but its unchanged buffer needs 4600001 gas.
+    await assert.rejects(preparePublicationRequest(f.plan, 0, f.providers, reviewedLaunchCeilings), /Gas estimate/);
+    await assert.rejects(revalidatePublicationRequest(f.plan, prepared, f.providers, reviewedLaunchCeilings), /Gas estimate/);
+    await assert.rejects(preparePublicationRetry(f.plan, { ...prepared, transactionHash: null }, f.providers, reviewedLaunchCeilings, prepared.requestDigest, 1), /Gas estimate/);
+  }
+  f.setEstimate(4292479n);
+  const maximumCost = BigInt(prepared.request.value) + 4600000n * BigInt(prepared.request.maxFeePerGas);
+  f.setBalance(maximumCost); await revalidatePublicationRequest(f.plan, prepared, f.providers, reviewedLaunchCeilings);
+  f.setBalance(maximumCost - 1n);
+  await assert.rejects(preparePublicationRequest(f.plan, 0, f.providers, reviewedLaunchCeilings), /balance/);
+  await assert.rejects(revalidatePublicationRequest(f.plan, prepared, f.providers, reviewedLaunchCeilings), /balance/);
+  await assert.rejects(preparePublicationRetry(f.plan, { ...prepared, transactionHash: null }, f.providers, reviewedLaunchCeilings, prepared.requestDigest, 1), /balance/);
+});
+test('fixed launch gas cannot replace reviewed gas, fees, value, nonce or calldata at arm or retry', async () => {
+  const f = await gasDriftFixture(), prepared = await preparePublicationRequest(f.plan, 0, f.providers, reviewedLaunchCeilings);
+  for (const change of [{ maxGas: '4599999' }, { maxGas: '4600001' }, { maxFeePerGas: '800000001' }, { maxPriorityFeePerGas: '10000001' }]) {
+    await assert.rejects(revalidatePublicationRequest(f.plan, prepared, f.providers, { ...reviewedLaunchCeilings, ...change }), /changed/);
+    await assert.rejects(preparePublicationRetry(f.plan, { ...prepared, transactionHash: null }, f.providers, { ...reviewedLaunchCeilings, ...change }, prepared.requestDigest, 1), /changed/);
+  }
+  for (const [key, value] of [['gas', '0x1'], ['nonce', '0x3'], ['value', '0x0'], ['data', '0x00'], ['maxFeePerGas', '0x1']]) {
+    assert.notEqual(value, prepared.request[key]);
+    const changed = structuredClone(prepared); changed.request[key] = value;
+    await assert.rejects(revalidatePublicationRequest(f.plan, changed, f.providers, reviewedLaunchCeilings), /digest differs/);
+    await assert.rejects(preparePublicationRetry(f.plan, { ...changed, transactionHash: null }, f.providers, reviewedLaunchCeilings, changed.requestDigest, 1), /digest differs/);
+  }
 });
 test('independent providers and no pending owner nonce are required', async () => {
   const f = rpcFixture(); await observePublicationOperation(f.plan, 0, f.providers);

--- a/contracts/scripts/module-mode/publication-rpc.mjs
+++ b/contracts/scripts/module-mode/publication-rpc.mjs
@@ -181,8 +181,9 @@ export function publicationWalletRequest(plan, observation, ceilings) {
   need(step && BigInt(step.value) <= BigInt(ceilings.maxValue), 'ETH value exceeds the owner reviewed ceiling');
   need(BigInt(observation.gasLimit) <= BigInt(ceilings.maxGas), 'Gas estimate exceeds the owner reviewed ceiling');
   need(priority <= maxFee && 2n * BigInt(observation.baseFeePerGas) + priority <= maxFee, 'Fee ceiling cannot cover the current base fee');
-  need(BigInt(observation.minimumBalance) >= BigInt(step.value) + BigInt(observation.gasLimit) * maxFee, 'Owner balance cannot cover ETH value and maximum gas cost');
-  return { chainId: '0x1237', from: plan.owner, to: step.to, value: hexQuantity(step.value), data: step.data, nonce: hexQuantity(observation.nonce), gas: hexQuantity(observation.gasLimit),
+  // Keep the full fresh estimate buffer within the fixed gas allowance shown to the owner.
+  need(BigInt(observation.minimumBalance) >= BigInt(step.value) + BigInt(ceilings.maxGas) * maxFee, 'Owner balance cannot cover ETH value and maximum gas cost');
+  return { chainId: '0x1237', from: plan.owner, to: step.to, value: hexQuantity(step.value), data: step.data, nonce: hexQuantity(observation.nonce), gas: hexQuantity(ceilings.maxGas),
     maxFeePerGas: hexQuantity(maxFee), maxPriorityFeePerGas: hexQuantity(priority), accessList: [], type: '0x2' };
 }
 export async function preparePublicationRequest(plan, stepIndex, providers, ceilings) {
@@ -202,8 +203,7 @@ export async function revalidatePublicationRequest(plan, prepared, providers, ce
   need(Date.now() >= prepared.issuedAt && prepared.expiresAt - Date.now() >= 60000, 'Owner request has expired');
   const fresh = await observePublicationOperation(plan, prepared.stepIndex, providers), next = publicationWalletRequest(plan, fresh, ceilings);
   if (isEngineOperationPlan(plan)) equalEngineSimulation(plan, prepared.stepIndex, fresh.simulatedResult, prepared.observation.simulatedResult);
-  for (const key of Object.keys(next).filter(key => key !== 'gas')) need(canonicalJson(next[key]) === canonicalJson(prepared.request[key]), `Owner request changed: ${key}`);
-  need(BigInt(next.gas) <= BigInt(prepared.request.gas), 'Fresh gas estimate exceeds the reviewed request');
+  for (const key of Object.keys(next)) need(canonicalJson(next[key]) === canonicalJson(prepared.request[key]), `Owner request changed: ${key}`);
   need(BigInt(fresh.minimumBalance) >= BigInt(prepared.request.value) + BigInt(prepared.request.gas) * BigInt(prepared.request.maxFeePerGas), 'Owner balance fell below value and maximum gas cost'); return fresh;
 }
 function receiptLogs(logs) {
@@ -278,8 +278,7 @@ export async function preparePublicationRetry(plan, entry, providers, ceilings, 
   assertPublicationRequest(plan, entry);
   const observation = await observePublicationOperation(plan, entry.stepIndex, providers), next = publicationWalletRequest(plan, observation, ceilings);
   if (isEngineOperationPlan(plan)) equalEngineSimulation(plan, entry.stepIndex, observation.simulatedResult, entry.observation.simulatedResult);
-  for (const key of Object.keys(next).filter(key => key !== 'gas')) need(canonicalJson(next[key]) === canonicalJson(entry.request[key]), `Retry wallet field changed: ${key}`);
-  need(BigInt(next.gas) <= BigInt(entry.request.gas), 'Retry estimate exceeds the original reviewed gas');
+  for (const key of Object.keys(next)) need(canonicalJson(next[key]) === canonicalJson(entry.request[key]), `Retry wallet field changed: ${key}`);
   need(BigInt(observation.minimumBalance) >= BigInt(entry.request.value) + BigInt(entry.request.gas) * BigInt(entry.request.maxFeePerGas), 'Retry is not funded for original gas plus value');
   const issuedAt = Date.now(), body = { planDigest: plan.planDigest, stepIndex: entry.stepIndex, request: entry.request, observation,
     issuedAt, expiresAt: issuedAt + 300000, retryAttempt, originalRequestDigest: entry.requestDigest };

--- a/docs/operations/module-mode-publication-operator.md
+++ b/docs/operations/module-mode-publication-operator.md
@@ -122,6 +122,14 @@ shows the sender, transaction recipient, resulting contract/token, function,
 arguments, exact ETH value, maximum gas cost and source commitments. It disables
 wallet actions in `--ui-check` mode and rejects cross-origin requests.
 
+For publication and Native/Engine lifecycle operations, `--max-gas` is the fixed
+gas allowance displayed and sent to the wallet. Preparation, arm and retry each
+require `ceil(max(provider estimates) * 1.05) + 25000` to fit within that allowance,
+and the balance must cover the exact ETH value plus `maxGas * maxFeePerGas`.
+Changing the allowance or fee fields requires a new preparation and owner review;
+an unresolved request can only be retried with its original wallet fields. The
+displayed maximum gas cost is a cap, not the transaction's actual cost.
+
 Record and verify each actual receipt before the next step. The server verifies
 all preceding recorded operations, exact transaction payload/nonce/gas fields,
 canonical inclusion, deployed runtime and registry post-state. Record/check are


### PR DESCRIPTION
Small block-dependent gas estimate increases could stop a Native V2 launch before the wallet handoff even when the reviewed gas allowance still had room. Publication and Native/Engine lifecycle requests now use the explicit reviewed `--max-gas` as their fixed wallet allowance. Every fresh simulation must still fit the existing 5% plus 25,000-gas reserve within that allowance, and preparation checks ETH value plus the full maximum gas cost. Arm and retry require all wallet fields, including gas, to match the prepared request.

Validation: reproduced the original failure; 49 focused Publication, Engine and Native lifecycle checks pass, including reserve and balance boundaries, modest estimate drift, and rejection of changed gas, fee, nonce or payload fields. ESLint and the pinned Gitleaks scan of this exact commit pass. The independent review of this commit found no issue.
