### PR TITLE
Normalize the Engine token creator address during receipt verification

### DIFF
--- a/contracts/scripts/module-engine/operation-rpc.mjs
+++ b/contracts/scripts/module-engine/operation-rpc.mjs
@@ -61,8 +61,9 @@ async function boundLaunch(plan, step, providers, block, c, api) {
   await c.code(providers, { address: expected.engine, runtimeCodeHash: expected.engineCodeHash }, block);
   const tokenRuntime = bytes(c.same(await c.pair(providers, 'eth_getCode', [expected.token, block]), 'Engine token runtime')); need(tokenRuntime !== '0x', 'Engine token runtime missing');
   const parameters = launchStep(plan.action.kind === 'launch' ? plan : plan.action.launch.plan).arguments[0];
-  for (const [name, expectedValue] of [['name', parameters.name], ['symbol', parameters.symbol], ['creator', host], ['decimals', 18], ['totalSupply', 1000000000n * 10n ** 18n]])
+  for (const [name, expectedValue] of [['name', parameters.name], ['symbol', parameters.symbol], ['decimals', 18], ['totalSupply', 1000000000n * 10n ** 18n]])
     equal(await c.read(providers, expected.token, api.moduleEngineReadAbi, name, [], block), expectedValue, `Engine token ${name}`);
+  equal(address(await c.read(providers, expected.token, api.moduleEngineReadAbi, 'creator', [], block)), host, 'Engine token creator');
   const graffiti = keccak256(encodeAbiParameters(parseAbiParameters('string,address,bytes32'), ['programmable.module-engine.token.v1', expected.creator, parameters.creatorSalt]));
   equal(await c.read(providers, expected.token, api.moduleEngineReadAbi, 'graffiti', [], block), graffiti, 'Engine token graffiti');
   equal(address(await c.read(providers, pins.tokenFactory.address, api.moduleEngineReadAbi, 'getUERC20Address', [parameters.name, parameters.symbol, 18, host, graffiti], block)), expected.token, 'Factory token identity');

--- a/contracts/scripts/module-engine/wallet-operator.test.mjs
+++ b/contracts/scripts/module-engine/wallet-operator.test.mjs
@@ -2,9 +2,10 @@ import test from 'node:test';
 import { mkdtemp, chmod, readFile, rm } from 'node:fs/promises';
 import path from 'node:path';
 import { REPOSITORY_ROOT } from '../module-mode/build.mjs';
+import { canonicalJson, sha256 } from '../module-mode/core.mjs';
 import { armJournal, armRetryJournal, journalEntry, recordTransaction, recordReceipt } from '../module-mode/journal.mjs';
 import assert from 'node:assert/strict';
-import { decodeFunctionData, erc20Abi } from 'viem';
+import { decodeFunctionData, decodeFunctionResult, encodeFunctionData, encodeFunctionResult, erc20Abi } from 'viem';
 import { engineWalletFixture, engineWorld, a, h } from './wallet-test-fixtures.mjs';
 import { createEnginePublicationOperatorPlan, assertEnginePublicationOperatorPlan, assertCurrentEngineReview } from './publication-plan.mjs';
 import { createEngineLifecycleOperatorPlan, assertEngineLifecycleOperatorPlan } from './lifecycle-operator-plan.mjs';
@@ -123,6 +124,30 @@ test('Engine receipt rejects a changed wallet request, wrong network, missing/du
   const prepared = await preparePublicationRequest(next, 0, world.providers, ceilings), execution = await world.mine(prepared), receipt = world.receipts.get(execution.transactionHash);
   receipt.logs[0].data = `${receipt.logs[0].data.slice(0, -64)}${h(0).slice(2)}`;
   await assert.rejects(observePublicationReceipt(next, execution, world.providers), /result hash/);
+});
+test('Engine token creator normalizes ABI address casing and rejects a different address', async () => {
+  const f = await engineWalletFixture(), previousHost = f.identity.contracts.host.address, host = a(0xabcd);
+  const creatorResult = encodeFunctionResult({ abi: f.api.moduleEngineReadAbi, functionName: 'creator', result: host });
+  const decodedCreator = decodeFunctionResult({ abi: f.api.moduleEngineReadAbi, functionName: 'creator', data: creatorResult });
+  assert.notEqual(decodedCreator, host); assert.equal(decodedCreator.toLowerCase(), host);
+  // Rebind the existing synthetic review fixture to a Host whose ABI-decoded address has checksum capitals.
+  f.identity.contracts.host.address = host;
+  f.identity.releaseDigest = f.api.computeModuleEngineReleaseDigest(f.identity);
+  f.codes.set(host, f.codes.get(previousHost)); f.codes.delete(previousHost);
+  f.bundle.manifest = f.api.createReviewedModuleEngineManifest({ job: { artifact: f.artifact, plan: f.bundle.buildPlan },
+    descriptor: f.source.descriptor, release: f.identity, definition: f.definition.catalogDefinition, revision: f.definition.revision });
+  f.bundle.review.command.hostManifestHash = f.api.computeModuleEngineHostManifestHash(f.bundle.manifest);
+  const review = { ...f.bundle.review }; delete review.decisionDigest;
+  f.bundle.review.decisionDigest = `0x${sha256(canonicalJson({ domain: review.schemaVersion, value: review }))}`;
+  const plan = await createEngineLifecycleOperatorPlan(f), world = engineWorld(f, plan);
+  const entry = await world.mine(await preparePublicationRequest(plan, 0, world.providers, ceilings));
+  const evidence = await observePublicationReceipt(plan, entry, world.providers);
+  assert.equal(evidence.status, 'included-code-verified-unfinalized');
+  assert.equal(evidence.canary.token, plan.steps[0].expectation.token);
+  const creatorData = encodeFunctionData({ abi: f.api.moduleEngineReadAbi, functionName: 'creator' });
+  world.mutations.rpc = (method, params) => method === 'eth_call' && params[0].to === evidence.canary.token && params[0].data === creatorData
+    ? encodeFunctionResult({ abi: f.api.moduleEngineReadAbi, functionName: 'creator', result: a(0xabce) }) : undefined;
+  await assert.rejects(observePublicationReceipt(plan, entry, world.providers), /Engine token creator differs/);
 });
 test('Engine same server has a disabled inspection mode and retains the original wallet/source authority gate', async () => {
   const f = await engineWalletFixture(), plan = await createEngineLifecycleOperatorPlan(f);


### PR DESCRIPTION
The Engine receipt reader rejects a successful launch when viem returns the token's correct Host creator address in checksum casing and the reviewed plan stores it in lowercase. Normalize this one address getter with the existing address parser before the strict comparison.

The same failure was confirmed for a real included launch using both configured RPC providers. The original transaction and journal are retained for receipt reconciliation after this source fix; no launch replay is required.

Validation: the regression failed with the original error before the fix, then passed with the checksum Host. A genuinely different creator is still rejected. The existing atomic launch and exact-approval test also passed (2 targeted tests total); `git diff --check` passed. No contract, calldata, authorization or generic equality behavior changes.
