### PR TITLE
Show availability errors when no Engine release is loaded

### DIFF
--- a/components/module-engine-host.tsx
+++ b/components/module-engine-host.tsx
@@ -94,7 +94,7 @@ export function ModuleEngineHost({ releaseDigest, token, versions = [] }: { rele
   const working = ["checking", "signing", "pending"].includes(flow.phase) || checkingReceipt;
   const blocked = loading || Boolean(loadError) || !release || working || unresolved || requestPending
     || connecting || openingWallet || switchingNetwork || disconnecting || (Boolean(wallet?.account) && !authReady);
-  const blockedReason = loadError ?? (loading ? "Checking this template version…" : saved.error ?? (unresolved ? "Resolve the saved transaction below before sending another request." : working ? "Checking your transaction…" : requestPending ? "Complete the open wallet request before continuing." : undefined));
+  const blockedReason = loadError ?? (loading ? "Checking this template version…" : saved.error ?? (unresolved ? "Resolve the saved transaction below before sending another request." : working ? "Checking your transaction…" : requestPending ? "Complete the open wallet request before continuing." : !release ? availability.reason ?? "This template version is temporarily unavailable." : undefined));
 
   async function submit(prepared: PreparedModuleEngineTransaction): Promise<ModuleEngineReceiptResult> {
     if (busy.current || blocked) throw new Error(blockedReason ?? "This request is not available yet.");


### PR DESCRIPTION
When no Engine release is available, the builder could tell a disconnected user to resolve a pending wallet operation. It now shows the actual availability reason, or the existing unavailable-version message. Real saved transactions, pending work and open wallet requests retain their original priority.

Validation: 13 existing component/controller tests passed, plus nine focused state cases covering availability fallbacks and the preserved error priorities. The change is one line; submission guards and transaction behavior are unchanged.
