### PR TITLE
Accept protected NVDA Module review artifacts

### DIFF
--- a/lib/module-mode/review-engine-contract.ts
+++ b/lib/module-mode/review-engine-contract.ts
@@ -5,7 +5,7 @@ import { compileOpenConfig } from "../../packages/classic-modules/src/open-confi
 import { nativeCanonicalJson, nativeJson } from "./native-catalog";
 import { encodeModuleEngineConfiguration, parseModuleEngineConfigurationAbi } from "../module-engine/configuration";
 import { reviewDigest as moduleReviewDigestV1, parseReviewSubject, type ReviewSubject as ModuleReviewSubjectV1 } from "./review-contract";
-import { MODULE_ENGINE_QUOTE_ENVIRONMENT_V1 } from "./review-engine-types";
+import { MODULE_ENGINE_QUOTE_ENVIRONMENT_V1, MODULE_ENGINE_QUOTE_NVDA_ENVIRONMENT_V1 } from "./review-engine-types";
 import { MODULE_ENGINE_BUILD_SCHEMA_V1, MODULE_ENGINE_PLAN_SCHEMA_V1, MODULE_ENGINE_PROFILE_V1, MODULE_ENGINE_CONFIGURATION_CODEC_V1, MODULE_ENGINE_CONTEXT_ABI_V1, MODULE_ENGINE_CONSTRUCTOR_ABI_V1, type ModuleEngineBuildArtifactV1, type ModuleEngineBuildPlanV1, type ModuleEngineContractArtifactV1, type ModuleEngineCompiledCaseV1, type ModuleEngineTestResultV1 } from "./review-engine-types";
 type ModuleDigestV1 = Hex;
 export const ENGINE_REVIEW_COMPILER = Object.freeze({version:"0.8.26+commit.8a97fa7a",binarySha256:"sha256:35ba6661f3bdaed995fc7af14c405502290cf681b3fd062fe8738cfdf6db14ed",imageDigest:"sha256:d8e448a56fc63242f70026718378bd4b00f8c82e78d20eefb199224a4d8e33d8"});
@@ -77,14 +77,16 @@ function subjectValid(subject: ModuleReviewSubjectV1) {
   exact(subject, ["submissionId", "principalId", "author", "requestDigest"]);
   need(UUID.test(subject.submissionId) && UUID.test(subject.principalId) && ADDRESS.test(subject.author) && DIGEST.test(subject.requestDigest), "MODULE_BUILD_SUBJECT_INVALID");
 }
+function testEnvironmentValid(value: unknown) {
+  const environment = exact(value, ["profile", "sourceDigest"]);
+  need([MODULE_ENGINE_QUOTE_ENVIRONMENT_V1, MODULE_ENGINE_QUOTE_NVDA_ENVIRONMENT_V1].some(installed =>
+    environment.profile === installed.profile && environment.sourceDigest === installed.sourceDigest), "MODULE_ENGINE_TEST_ENVIRONMENT_INVALID");
+}
 
 export function validateModuleEngineBuildPlanV1(value: unknown, subject: ModuleReviewSubjectV1): ModuleEngineBuildPlanV1 {
   subjectValid(subject);
   const p = exact(value, ["schemaVersion", "submissionId", "requestDigest", "engineComponentId", "configurationCodec", "configurationAbi", "immutableBindings", "operationPermissions", "moneyRights", "coinRights", "testEconomics", "executionGas", "cases", ...(Object.hasOwn(object(value), "testEnvironment") ? ["testEnvironment"] : [])]);
-  if(Object.hasOwn(p,"testEnvironment")) {
-    const environment=exact(p.testEnvironment,["profile","sourceDigest"]);
-    need(environment.profile===MODULE_ENGINE_QUOTE_ENVIRONMENT_V1.profile && environment.sourceDigest===MODULE_ENGINE_QUOTE_ENVIRONMENT_V1.sourceDigest,"MODULE_ENGINE_TEST_ENVIRONMENT_INVALID");
-  }
+  if(Object.hasOwn(p,"testEnvironment")) testEnvironmentValid(p.testEnvironment);
   need(p.schemaVersion === MODULE_ENGINE_PLAN_SCHEMA_V1 && p.submissionId === subject.submissionId && p.requestDigest === subject.requestDigest, "MODULE_ENGINE_SUBJECT_MISMATCH");
   need(p.configurationCodec === MODULE_ENGINE_CONFIGURATION_CODEC_V1, "MODULE_ENGINE_CODEC_UNSUPPORTED");
   parseModuleEngineConfigurationAbi(p.configurationAbi);
@@ -312,10 +314,7 @@ export function parseEngineReviewArtifact(value: unknown, subject: ModuleReviewS
   need(json(raw.reviewRequired)===json(MODULE_ENGINE_REVIEW_AREAS_V1),"MODULE_ENGINE_REVIEW_COVERAGE_INVALID");
   need(raw.configurationCodec===MODULE_ENGINE_CONFIGURATION_CODEC_V1,"MODULE_ENGINE_CODEC_UNSUPPORTED"); parseModuleEngineConfigurationAbi(raw.configurationAbi);
   const artifact=raw as unknown as ModuleEngineBuildArtifactV1;
-  if(Object.hasOwn(raw,"testEnvironment")) {
-    const environment=exact(raw.testEnvironment,["profile","sourceDigest"]);
-    need(environment.profile===MODULE_ENGINE_QUOTE_ENVIRONMENT_V1.profile && environment.sourceDigest===MODULE_ENGINE_QUOTE_ENVIRONMENT_V1.sourceDigest,"MODULE_ENGINE_TEST_ENVIRONMENT_INVALID");
-  }
+  if(Object.hasOwn(raw,"testEnvironment")) testEnvironmentValid(raw.testEnvironment);
   need(Array.isArray(artifact.cases) && artifact.cases.length>0 && artifact.cases.length<=16,"MODULE_ENGINE_CASES_INVALID");
   const engine=artifact.engine;
   need(engine && engine.abiHash===moduleReviewDigestV1("programmable.modules.abi.v1",engine.abi),"MODULE_ENGINE_ABI_INVALID");

--- a/lib/module-mode/review-engine-types.ts
+++ b/lib/module-mode/review-engine-types.ts
@@ -12,7 +12,11 @@ export const MODULE_ENGINE_QUOTE_ENVIRONMENT_V1 = Object.freeze({
   profile: "programmable.engine-quote-v4-v3@1",
   sourceDigest: "0xa0d03aa0af44d281907d91efb03805411b4f72831035b1fc3b4c63462ad0d39f",
 } as const);
-export type ModuleEngineTestEnvironmentV1 = typeof MODULE_ENGINE_QUOTE_ENVIRONMENT_V1;
+export const MODULE_ENGINE_QUOTE_NVDA_ENVIRONMENT_V1 = Object.freeze({
+  profile: "programmable.engine-quote-nvda-v4-v3@1",
+  sourceDigest: "0x99893b6a331147270eec445b65cbb3ee43265fb8aba36f72063c1542ef7ff41d",
+} as const);
+export type ModuleEngineTestEnvironmentV1 = typeof MODULE_ENGINE_QUOTE_ENVIRONMENT_V1 | typeof MODULE_ENGINE_QUOTE_NVDA_ENVIRONMENT_V1;
 export const MODULE_ENGINE_CONTEXT_ABI_V1 = [
   { name: "host", type: "address" }, { name: "launchId", type: "bytes32" },
   { name: "token", type: "address" }, { name: "creator", type: "address" },

--- a/tests/module-engine-review-route.test.ts
+++ b/tests/module-engine-review-route.test.ts
@@ -10,7 +10,7 @@ import { WEBSITE_ADMIN_WALLET } from "../lib/admin-access";
 import { computeModuleEngineHostManifestHash, computeModuleEngineReleaseDigest, type ModuleEngineCatalogDefinition } from "../lib/module-engine/catalog";
 import { createReviewedModuleEngineManifest } from "../lib/module-mode/review-engine-manifest";
 import type { ModuleEngineBuildArtifactV1, ModuleEngineBuildPlanV1 } from "../lib/module-mode/review-engine-types";
-import { MODULE_ENGINE_QUOTE_ENVIRONMENT_V1 } from "../lib/module-mode/review-engine-types";
+import { MODULE_ENGINE_QUOTE_ENVIRONMENT_V1, MODULE_ENGINE_QUOTE_NVDA_ENVIRONMENT_V1 } from "../lib/module-mode/review-engine-types";
 import { moduleEngineStandardInputV1, parseEngineReviewArtifact, validateModuleEngineBuildPlanV1, verifyModuleEngineBuildArtifactV1 } from "../lib/module-mode/review-engine-contract";
 import { parseReviewSubject, reviewDigest, type ReviewJob } from "../lib/module-mode/review-contract";
 import { computeModuleModeHostManifestHash, createModuleModeHostManifest, type ModuleModeHostReleaseIdentity } from "../lib/server/module-mode/catalog";
@@ -40,12 +40,50 @@ const nativeV2IdentityBytes = readFileSync(new URL("../config/module-mode/review
 const nativeV2Identity = JSON.parse(nativeV2IdentityBytes.toString()) as ModuleModeHostReleaseIdentity;
 
 describe("source-bound Quote dependency environment", () => {
+  const environments = [MODULE_ENGINE_QUOTE_ENVIRONMENT_V1, MODULE_ENGINE_QUOTE_NVDA_ENVIRONMENT_V1];
+  // Synthetic parser fixtures only; these digests are not protected-worker execution evidence.
+  const artifactWithEnvironment = (testEnvironment: unknown, planDigest = frozen.artifact.planDigest) => {
+    const { artifactDigest: _digest, ...contents } = frozen.artifact; void _digest;
+    const changed = { ...contents, testEnvironment, planDigest, tests: { ...contents.tests, planDigest } };
+    return { ...changed, artifactDigest: reviewDigest("programmable.modules.engine-build.v1", changed) };
+  };
   it("preserves the ordinary protected artifact and exact plan digest", () => {
     const subject=parseReviewSubject(frozen.subject), plan=validateModuleEngineBuildPlanV1(frozen.plan,subject);
     expect(reviewDigest("programmable.modules.engine-build-plan.v1",plan)).toBe(frozen.artifact.planDigest);
     expect(reviewDigest("programmable.modules.compiler-input.v1",moduleEngineStandardInputV1(frozen.source,subject,plan))).toBe(frozen.artifact.compiler.completeInputHash);
     expect(()=>verifyModuleEngineBuildArtifactV1(frozen.artifact as ModuleEngineBuildArtifactV1,subject,plan,frozen.source)).not.toThrow();
     expect(validateModuleEngineBuildPlanV1({...plan,testEnvironment:MODULE_ENGINE_QUOTE_ENVIRONMENT_V1},subject).testEnvironment).toEqual(MODULE_ENGINE_QUOTE_ENVIRONMENT_V1);
+  });
+  it.each(environments)("accepts the exact installed $profile in plans and bound artifacts", environment => {
+    const subject = parseReviewSubject(frozen.subject);
+    const plan = validateModuleEngineBuildPlanV1({ ...frozen.plan, testEnvironment: environment }, subject);
+    const artifact = artifactWithEnvironment(environment, reviewDigest("programmable.modules.engine-build-plan.v1", plan));
+    expect(plan.testEnvironment).toEqual(environment);
+    expect(parseEngineReviewArtifact(artifact, subject).testEnvironment).toEqual(environment);
+    expect(parseEngineReviewArtifact(artifact, subject, plan).testEnvironment).toEqual(environment);
+    expect(() => verifyModuleEngineBuildArtifactV1(artifact as ModuleEngineBuildArtifactV1, subject, plan, frozen.source)).not.toThrow();
+  });
+  it.each([
+    { ...MODULE_ENGINE_QUOTE_ENVIRONMENT_V1, sourceDigest: MODULE_ENGINE_QUOTE_NVDA_ENVIRONMENT_V1.sourceDigest },
+    { ...MODULE_ENGINE_QUOTE_NVDA_ENVIRONMENT_V1, sourceDigest: MODULE_ENGINE_QUOTE_ENVIRONMENT_V1.sourceDigest },
+    ...environments.flatMap(environment => [
+      { ...environment, profile: "programmable.engine-quote-uninstalled@1" },
+      { ...environment, sourceDigest: `0x${"00".repeat(32)}` },
+      { ...environment, rpcUrl: "https://caller.example.invalid" },
+      { ...environment, bytecode: "0x00" },
+      { ...environment, state: {} },
+    ]),
+  ])("rejects altered or cross-profile environment data in plans and artifacts %j", environment => {
+    const subject = parseReviewSubject(frozen.subject);
+    expect(() => validateModuleEngineBuildPlanV1({ ...frozen.plan, testEnvironment: environment }, subject)).toThrow();
+    expect(() => parseEngineReviewArtifact(artifactWithEnvironment(environment), subject)).toThrow();
+  });
+  it.each(environments)("rejects changing $profile after the plan was selected", environment => {
+    const subject = parseReviewSubject(frozen.subject);
+    const plan = validateModuleEngineBuildPlanV1({ ...frozen.plan, testEnvironment: environment }, subject);
+    const other = environments.find(installed => installed.profile !== environment.profile)!;
+    const artifact = artifactWithEnvironment(other, reviewDigest("programmable.modules.engine-build-plan.v1", plan));
+    expect(() => parseEngineReviewArtifact(artifact, subject, plan)).toThrow("MODULE_ENGINE_BUILD_PLAN_MISMATCH");
   });
   it.each([null,undefined,{},"quote",{...MODULE_ENGINE_QUOTE_ENVIRONMENT_V1,profile:"other"},{...MODULE_ENGINE_QUOTE_ENVIRONMENT_V1,sourceDigest:`0x${"00".repeat(32)}`},{...MODULE_ENGINE_QUOTE_ENVIRONMENT_V1,rpcUrl:"https://caller.example.invalid"},{...MODULE_ENGINE_QUOTE_ENVIRONMENT_V1,bytecode:"0x00"},{...MODULE_ENGINE_QUOTE_ENVIRONMENT_V1,state:{}}])("rejects caller-controlled environment data %j",value=>{
     expect(()=>validateModuleEngineBuildPlanV1({...frozen.plan,testEnvironment:value},parseReviewSubject(frozen.subject))).toThrow();


### PR DESCRIPTION
The Module admin and publication parsers currently reject every protected quote environment except the original WETH/general-quote profile. Accept the exact source-bound NVDA profile in both review plans and build artifacts so NVDA Pair can enter the normal protected review and publication flow after the backend release.

The original profile and digest stay unchanged. Both parsers share the same closed validation of the two installed profile/digest pairs; substituted digests, unknown profiles, caller-supplied environment fields, and plan/artifact mismatches remain rejected. This change grants no module approval and performs no deployment or wallet transaction.

Validation: 127 targeted review, publication, and admin tests passed; full TypeScript checking, scoped ESLint, and `git diff --check` passed. Backend counterpart: https://github.com/programmablehq/programmable-open-hook-v2-internal/pull/293.
