### PR TITLE
Start module building with API key setup

### DIFF
--- a/app/developers/api-keys/page.tsx
+++ b/app/developers/api-keys/page.tsx
@@ -25,6 +25,7 @@ export default async function DeveloperApiKeysPage({
   return (
     <DeveloperApiKeys
       initialSection={developerApiKeysInitialSection(resolvedSearchParams)}
+      moduleBuilder={resolvedSearchParams.purpose === "modules"}
       agentSetupText={buildProgrammableAgentSetupTextV1(V4_API_PROFILE_VERSION)}
     />
   );

--- a/components/developer-api-keys.module.css
+++ b/components/developer-api-keys.module.css
@@ -225,3 +225,9 @@
 @media (forced-colors: active) { .primaryButton, .secondaryButton, .dangerButton, .keyList, .mutationConfirmation, .createPanel, .keyReveal, .walletGate, .sectionSwitch button, .expiryTrigger, .expiryMenu, .expiryOption, .connectionOptions { border: 1px solid CanvasText; } .keyStatus::before { forced-color-adjust: none; } }
 
 @media (max-width: 600px) { .hero h1 { font-size: 28px; line-height: 36px; } .intro { min-height: 40px; } }
+.workspace:is(details) { display: block; }
+.keySettingsSummary { align-items: center; border: 1px solid var(--api-line); border-radius: 12px; cursor: pointer; display: flex; font-size: 14px; gap: 16px; justify-content: space-between; list-style: none; min-height: 48px; padding: 12px 16px; }
+.keySettingsSummary::-webkit-details-marker { display: none; }
+.keySettingsSummary:focus-visible { outline: 2px solid #e786b2; outline-offset: 3px; }
+.workspace[open] > .keySettingsSummary { margin-bottom: 16px; }
+.workspace[open] > .keySettingsSummary svg { transform: rotate(180deg); }

--- a/components/developer-api-keys.tsx
+++ b/components/developer-api-keys.tsx
@@ -25,6 +25,7 @@ import {
 import styles from "@/components/developer-api-keys.module.css";
 import { AGENT_KEY_SCHEMA, AGENT_SCOPES, buildAgentConnection, buildAgentInstructions } from "@/lib/agent-connection";
 import { DeveloperLaunchHistory } from "@/components/developer-launch-history";
+import { ModuleBuilderPrompt } from "@/components/module-contribution-entry";
 import {
   DeveloperRobinhoodLaunch,
   RobinhoodFeePolicyDisclosure,
@@ -108,11 +109,13 @@ const readHydrated = () => true;
 const readServerHydrated = () => false;
 type ApiKeyLoadMode = "initial" | "refresh" | "mutation";
 type DeveloperApiKeysProps = Readonly<{
+  moduleBuilder?: boolean;
   initialSection?: ActiveSection;
   agentSetupText?: string;
   moduleAgentSetupText?: string;
 }>;
 type DeveloperApiKeysViewProps = Readonly<{
+  moduleBuilder?: boolean;
   account: `0x${string}` | null;
   authReady: boolean;
   connecting: boolean;
@@ -839,6 +842,7 @@ function ExpirySelect({
 }
 
 export function DeveloperApiKeys({
+  moduleBuilder = false,
   initialSection = "keys",
   agentSetupText,
   moduleAgentSetupText,
@@ -866,6 +870,7 @@ export function DeveloperApiKeys({
       getAccessToken={getAccessToken}
       getIdentityToken={getIdentityToken}
       initialSection={initialSection}
+      moduleBuilder={moduleBuilder}
       agentSetupText={agentSetupText}
       moduleAgentSetupText={moduleAgentSetupText}
       openWallet={openWallet}
@@ -879,6 +884,7 @@ export function DeveloperApiKeys({
 }
 
 export function DeveloperApiKeysView({
+  moduleBuilder = false,
   account,
   authReady,
   connecting,
@@ -959,6 +965,8 @@ export function DeveloperApiKeysView({
     (activeKeyPage - 1) * API_KEY_PAGE_SIZE,
     activeKeyPage * API_KEY_PAGE_SIZE,
   );
+  const moduleKey = moduleBuilder ? apiKeys.find((key) => keyStatus(key) === "Active" && moduleScopes.every((scope) => key.scopes.includes(scope))) : undefined;
+  const KeyWorkspace = moduleKey ? "details" : "div";
 
   const getAuthHeaders = useCallback(
     async (json = false) => {
@@ -1561,10 +1569,10 @@ export function DeveloperApiKeysView({
 
       <header className={styles.hero}>
         <div className={styles.heroCopy}>
-          <h1>{activeSection === "keys" ? "API keys" : activeSection === "launch" ? "Launch a hook" : "Your launches"}</h1>
+          <h1>{activeSection === "keys" ? moduleBuilder ? "Build a module" : "API keys" : activeSection === "launch" ? "Launch a hook" : "Your launches"}</h1>
           <p className={styles.intro}>
             {activeSection === "keys"
-              ? "Connect your AI builder."
+              ? moduleBuilder ? "Set up your API key, then copy your module prompt." : "Connect your AI builder."
               : activeSection === "launch"
                 ? "Upload the launch file from your builder."
                 : "Track progress and complete your wallet steps."}
@@ -1691,16 +1699,16 @@ export function DeveloperApiKeysView({
               {mutationResult.result.secretState === "delivered-once" ? (
                 <>
                   <p className={styles.revealWarning}>
-                    Copy the connection for your agent. It includes this secret key and the full guide. Save it privately; the key is shown once.
+                    {moduleBuilder ? "Save this key in your AI builder’s secure setup, then copy the prompt below. The key is shown once." : "Copy the connection for your agent. It includes this secret key and the full guide. Save it privately; the key is shown once."}
                     {mutationResult.operation === "rotate" ? " The previous key is revoked." : ""}
                   </p>
                   <div className={styles.secretRow}>
                     <code>{mutationResult.result.apiKeySecret}</code>
                     <div className={styles.secretActions}>
-                      <button className={styles.primaryButton} type="button" onClick={() => void copyConnection()}>
+                      {!moduleBuilder ? <button className={styles.primaryButton} type="button" onClick={() => void copyConnection()}>
                         {connectionCopyState === "copied" ? <Check size={16} aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         Copy connection
-                      </button>
+                      </button> : null}
                       <button
                         className={styles.secondaryButton}
                         type="button"
@@ -1744,8 +1752,11 @@ export function DeveloperApiKeysView({
             </div>
           ) : null}
 
+          {activeSection === "keys" && moduleKey && account ? <ModuleBuilderPrompt scopes={moduleKey.scopes} wallet={account} /> : null}
+
           {activeSection === "keys" ? (
-            <div className={styles.workspace}>
+            <KeyWorkspace className={styles.workspace}>
+              {moduleKey ? <summary className={styles.keySettingsSummary}>Manage API keys <ChevronDown size={16} aria-hidden="true" /></summary> : null}
               <section
                 className={`${styles.panel} ${styles.createPanel}`}
                 aria-labelledby="create-key-title"
@@ -2179,7 +2190,7 @@ export function DeveloperApiKeysView({
                   </p>
                 ) : null}
               </section>
-            </div>
+            </KeyWorkspace>
           ) : activeSection === "launch" ? (
             <DeveloperRobinhoodLaunch
               onOpenLaunch={openRobinhoodLaunchHistory}
@@ -2202,10 +2213,10 @@ export function DeveloperApiKeysView({
       )}
 
       <nav className={styles.resourceLinks} aria-label="Developer resources">
-        <button className={styles.guideAction} type="button" onClick={() => void copyAgentSetup()}>
+        {!moduleBuilder ? <button className={styles.guideAction} type="button" onClick={() => void copyAgentSetup()}>
           {setupCopyState === "copied" ? <Check size={16} aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
           Copy instructions
-        </button>
+        </button> : null}
         <Link href="/developers/modules">Build a module <ArrowRight size={16} aria-hidden="true" /></Link>
         <a href="/agents.md" target="_blank" rel="noreferrer">Agent guide <ExternalLink size={14} aria-hidden="true" /></a>
       </nav>

--- a/components/module-contribution-entry.module.css
+++ b/components/module-contribution-entry.module.css
@@ -16,12 +16,14 @@
 .back, .textLink, .resources a { align-items: center; border-radius: 8px; color: var(--module-muted); display: inline-flex; font-size: 14px; gap: 8px; line-height: 20px; min-height: 44px; text-decoration: none; }
 .workspace { background: var(--module-surface); border: 1px solid var(--module-line); border-radius: 16px; padding: 32px; }
 .header h1 { color: var(--module-ink); font-size: 32px; font-weight: 500; letter-spacing: -0.035em; line-height: 40px; margin: 0; text-wrap: balance; }
+.header h2 { color: var(--module-ink); font-size: 24px; font-weight: 500; letter-spacing: -0.025em; line-height: 32px; margin: 0; }
+.promptWorkspace { --module-ink: #f5f3ef; --module-muted: #aaa9a5; --module-line: #30302e; --module-surface: #151515; --module-accent: #e786b2; margin-block: 24px; }
 .header p { color: var(--module-muted); font-size: 14px; line-height: 20px; margin: 8px 0 24px; max-width: 580px; text-wrap: pretty; }
 .ideaField { display: grid; gap: 8px; }
 .ideaField > span { color: var(--module-muted); font-size: 14px; line-height: 20px; }
 .ideaField textarea { background: #181818; border: 1px solid #76716b; border-radius: 12px; color: var(--module-ink); font: inherit; font-size: 14px; line-height: 24px; min-height: 136px; padding: 12px 16px; resize: vertical; width: 100%; }
 .ideaField textarea::placeholder { color: #888884; }
-.actions { display: grid; gap: 12px; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); margin-top: 16px; max-width: 400px; }
+.actions { display: grid; gap: 12px; grid-template-columns: minmax(0, 1fr); margin-top: 16px; max-width: 200px; }
 .primaryAction, .secondaryAction { align-items: center; border: 1px solid var(--module-line); border-radius: 12px; display: inline-flex; font: inherit; font-size: 14px; font-weight: 500; gap: 8px; justify-content: center; line-height: 20px; min-height: 48px; padding: 12px 16px; text-decoration: none; white-space: nowrap; }
 .primaryAction { background: var(--module-accent); border-color: var(--module-accent); color: #1c1217; }
 .secondaryAction { background: transparent; border-color: #76716b; color: var(--module-ink); }
@@ -35,8 +37,8 @@
 .promptDetails pre { background: #000; border: 1px solid var(--module-line); border-radius: 12px; color: var(--module-muted); font-family: var(--font-instrument), sans-serif; font-size: 14px; line-height: 24px; margin: 8px 0 16px; overflow-wrap: anywhere; padding: 16px; white-space: pre-wrap; }
 .reviewNote { color: var(--module-muted); font-size: 14px; line-height: 20px; margin: 16px 0 0; text-wrap: pretty; }
 .resources { display: flex; flex-wrap: wrap; gap: 24px; margin-top: 16px; }
-.page :is(a, button, summary) { cursor: pointer; touch-action: manipulation; transition: color 120ms ease, background-color 120ms ease, border-color 120ms ease; }
-.page :is(a, button, summary, textarea):focus-visible { outline: 2px solid var(--module-accent); outline-offset: 3px; }
+:is(.page, .promptWorkspace) :is(a, button, summary) { cursor: pointer; touch-action: manipulation; transition: color 120ms ease, background-color 120ms ease, border-color 120ms ease; }
+:is(.page, .promptWorkspace) :is(a, button, summary, textarea):focus-visible { outline: 2px solid var(--module-accent); outline-offset: 3px; }
 @media (hover: hover) and (pointer: fine) {
 .page :is(.back, .textLink, .resources a, .promptDetails summary):hover { color: var(--module-ink); }
 .primaryAction:hover { background: #ee9fc2; border-color: #ee9fc2; }
@@ -54,5 +56,5 @@
   .copyStatus { min-height: 60px; }
 }
 
-@media (prefers-reduced-motion: reduce) { .page *, .page *::before, .page *::after { transition: none; } }
+@media (prefers-reduced-motion: reduce) { :is(.page, .promptWorkspace) *, :is(.page, .promptWorkspace) *::before, :is(.page, .promptWorkspace) *::after { transition: none; } }
 @media (forced-colors: active) { .workspace, .primaryAction, .secondaryAction, .ideaField textarea, .promptDetails pre { border: 1px solid CanvasText; } }

--- a/components/module-contribution-entry.tsx
+++ b/components/module-contribution-entry.tsx
@@ -7,10 +7,37 @@ import { buildAgentInstructions } from "@/lib/agent-connection";
 import styles from "@/components/module-contribution-entry.module.css";
 
 export function ModuleContributionEntry() {
+  return (
+    <div className={styles.page}>
+      <nav className={styles.navigation} aria-label="Module builder navigation">
+        <Link href="/launch/modules" className={styles.back}><ArrowLeft size={16} aria-hidden="true" /> Modules</Link>
+        <Link href="/profile?section=submissions#profile-modules-title" className={styles.textLink}>Submissions <ArrowRight size={16} aria-hidden="true" /></Link>
+      </nav>
+      <section className={styles.workspace} aria-labelledby="module-builder-title">
+        <header className={styles.header}>
+          <h1 id="module-builder-title">Build a module</h1>
+          <p>A module gives a coin a new ability. Set up your API key, then describe your idea and copy the prompt for your AI builder.</p>
+        </header>
+        <div className={styles.actions}>
+          <Link href="/developers/api-keys?purpose=modules" className={styles.primaryAction}>Get API key <ArrowRight size={16} aria-hidden="true" /></Link>
+        </div>
+        <p className={styles.reviewNote}>Your builder submits the module for review. Approval is required before publication.</p>
+      </section>
+      <nav className={styles.resources} aria-label="Module developer resources">
+        <Link href="/developer-reference/module-mode">Module docs <ArrowRight size={16} aria-hidden="true" /></Link>
+        <a href="/agents.md">Agent guide <ArrowRight size={16} aria-hidden="true" /></a>
+      </nav>
+    </div>
+  );
+}
+
+export function ModuleBuilderPrompt({ scopes, wallet }: { scopes: readonly string[]; wallet: string }) {
   const [idea, setIdea] = useState("");
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState("");
   const instructions = buildAgentInstructions({
+    scopes,
+    wallet,
     intent: idea.trim()
       ? `Build and submit a reusable Module Mode module. The module should do the following: ${idea.trim().replace(/\.+$/u, "")}`
       : "Build and submit a reusable Module Mode module. Ask me what my module should do before starting",
@@ -27,20 +54,10 @@ export function ModuleContributionEntry() {
   }
 
   return (
-    <div className={styles.page}>
-      <nav className={styles.navigation} aria-label="Module builder navigation">
-        <Link href="/launch/modules" className={styles.back}>
-          <ArrowLeft size={16} aria-hidden="true" /> Modules
-        </Link>
-        <Link href="/profile?section=submissions#profile-modules-title" className={styles.textLink}>
-          Submissions <ArrowRight size={16} aria-hidden="true" />
-        </Link>
-      </nav>
-
-      <section className={styles.workspace} aria-labelledby="module-builder-title">
+      <section className={`${styles.workspace} ${styles.promptWorkspace}`} aria-labelledby="module-prompt-title">
         <header className={styles.header}>
-          <h1 id="module-builder-title">Build a module</h1>
-          <p>A module gives a coin a new ability. Describe yours and let your AI builder create it.</p>
+          <h2 id="module-prompt-title">Your module</h2>
+          <p>Describe what your module should do.</p>
         </header>
 
         <label className={styles.ideaField} htmlFor="module-idea">
@@ -63,12 +80,9 @@ export function ModuleContributionEntry() {
             {copied ? <Check size={16} aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
             Copy prompt
           </button>
-          <Link href="/developers/api-keys?purpose=modules" className={styles.secondaryAction}>
-            Get API key <ArrowRight size={16} aria-hidden="true" />
-          </Link>
         </div>
         <p className={styles.copyStatus} role={error ? "alert" : "status"}>
-          {error || (copied ? "Prompt copied. Paste it into your AI builder." : "Paste the prompt into your AI builder. Connect the API key through its secure setup.")}
+          {error || (copied ? "Prompt copied. Paste it into your AI builder." : "Save your API key in your builder’s secure setup, then paste this prompt.")}
         </p>
 
         <details className={styles.promptDetails}>
@@ -79,10 +93,5 @@ export function ModuleContributionEntry() {
         <p className={styles.reviewNote}>Your builder submits the module for review. Approval is required before publication.</p>
       </section>
 
-      <nav className={styles.resources} aria-label="Module developer resources">
-        <Link href="/developer-reference/module-mode">Module docs <ArrowRight size={16} aria-hidden="true" /></Link>
-        <a href="/agents.md">Agent guide <ArrowRight size={16} aria-hidden="true" /></a>
-      </nav>
-    </div>
   );
 }

--- a/components/module-engine-builder.tsx
+++ b/components/module-engine-builder.tsx
@@ -134,7 +134,7 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
   const quoteShort = quoteAsset ? `${quoteAsset.slice(0, 6)}…${quoteAsset.slice(-4)}` : "Not chosen";
 
   return <div className={`${styles.page} ${engineStyles.root} ${engineStyles.builderRoot}`}>
-    <div className={engineStyles.pageTop}><a href="/launch"><ArrowLeft size={16} aria-hidden="true" />Back</a><span>Robinhood Chain</span></div>
+    <div className={engineStyles.pageTop}><a href="/launch"><ArrowLeft size={16} aria-hidden="true" />Back</a></div>
     {statusContent}
     {!template || !definition || !availability?.release ? <section className={engineStyles.emptyState}><h1>Create a coin</h1><p role="status">No modules available yet.{parsed.error || availability?.reason ? ` ${parsed.error ?? availability?.reason}` : ""}</p></section> : <>
       {availability.reason ? <p className={engineStyles.notice} role="status">{availability.reason}</p> : null}

--- a/components/module-mode-builder.tsx
+++ b/components/module-mode-builder.tsx
@@ -79,7 +79,7 @@ export interface ModuleModeBuilderProps {
   onEdit?: () => void;
 }
 
-export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = NATIVE_ENGINE_PROFILE, configurationContext = {}, launchAction, minimumInitialBuyWei, release, previewDescription, statusContent, versionContent, reviewContent, resultContent, onEdit }: Readonly<ModuleModeBuilderProps>) {
+export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = NATIVE_ENGINE_PROFILE, configurationContext = {}, launchAction, minimumInitialBuyWei, release, previewDescription, statusContent, reviewContent, resultContent, onEdit }: Readonly<ModuleModeBuilderProps>) {
   const { hydrated, viewChainId, setViewChainId } = useViewChain();
   useEffect(() => {
     if (!hydrated || viewChainId === 4663) return;
@@ -188,7 +188,7 @@ export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = N
 
   return (
     <div className={`${styles.page} ${styles.studio}`}>
-      <div className={styles.pageTop}><Link href="/launch" className={styles.backLink}><ArrowLeft size={16} aria-hidden="true" /> Launch</Link><span className={styles.network} aria-label="Launch network: Robinhood. Fee currency: ETH.">Robinhood <span aria-hidden="true">·</span> ETH</span></div>
+      <div className={styles.pageTop}><Link href="/launch" className={styles.backLink}><ArrowLeft size={16} aria-hidden="true" /> Launch</Link></div>
       {statusContent}
       <div className={resultContent ? styles.resultLayout : styles.layout}>
         {resultContent ? <section className={styles.formPanel}>{resultContent}</section> : review ? (
@@ -248,7 +248,6 @@ export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = N
                 {missingSelected.map((entry) => <div className={styles.unavailableModule} key={entry.id}><p><strong>{entry.title}</strong> is no longer in the current catalog. Your settings are kept; remove it to continue with another configuration.</p><button className={styles.textButton} type="button" onClick={() => remove(entry)}>Remove {entry.title}</button></div>)}
 
               </div>
-              {versionContent ? <details className={styles.setupDetails}><summary>Other coin setups<ChevronDown size={16} aria-hidden="true" /></summary><div>{versionContent}</div></details> : null}
             </section>
             <section className={styles.formSection} aria-labelledby="module-launch-title">
               <h2 id="module-launch-title" className={styles.liveRegion}>Launch settings</h2>

--- a/tests/developer-api-keys-ui.test.ts
+++ b/tests/developer-api-keys-ui.test.ts
@@ -335,7 +335,7 @@ describe("developer API key interface", () => {
   });
 
   it("keeps the first view compact and focused on key management", () => {
-    expect(apiKeysSource).toContain('activeSection === "keys" ? "API keys"');
+    expect(apiKeysSource).toContain('activeSection === "keys" ? moduleBuilder ? "Build a module" : "API keys"');
     expect(apiKeysSource).toContain('aria-label="Developer access view"');
     expect(apiKeysSource).toContain('aria-pressed={activeSection === "keys"}');
     expect(apiKeysSource).toContain('aria-pressed={activeSection === "history"}');


### PR DESCRIPTION
The coin builder now omits the redundant network badge and “Other coin setups” section. Module creation starts with API key setup. The idea field and Copy prompt action appear after a valid module-capable key is available, and existing keys can be reused. Key management collapses once a suitable key exists.

The prompt carries the idea, actual scopes, author wallet and canonical agent guide. It contains no API key. Existing key issuance, rotation, revocation and wallet transaction handlers retain their behavior.

Validation: scoped ESLint and existing component suites passed. Rendered desktop, 390 px and 320 px browser checks cover the key-first flow, existing-key reuse, synthetic key creation, prompt content, keyboard access, stable button size and overflow. No real credentials or wallet transactions were used. Required CI must pass before release.
