### PR TITLE
Fix source verification for quote-bound settlement launches

### DIFF
--- a/contracts/scripts/module-mode/launch-source-profiles.mjs
+++ b/contracts/scripts/module-mode/launch-source-profiles.mjs
@@ -164,8 +164,17 @@ export function engineResourceCommitment(identity, state) {
   need(p.launchData === '0x', 'Unsupported engine initialization resource data');
   let hash;
   if (manifest.catalogDefinition.interface === 'settlement-v1') {
-    const abi = parseAbiParameters('uint256,uint256'), [minimum, maximum] = decodeAbiParameters(abi, p.configuration);
-    need(same(encodeAbiParameters(abi, [minimum, maximum]), p.configuration) && minimum > 0n && maximum >= minimum
+    const definition = manifest.catalogDefinition;
+    // The protected publication binds these source bytes. A presentation interface alone does not select a new codec.
+    const quoteBound = definition.source.path === 'src/QuoteBoundSettlementV1.sol'
+      && definition.source.sha256 === 'bbf3d19c6244d1a9ad37ee33b2c147f11662475f72904f24c4d13be208797bcf';
+    if (quoteBound) equal(definition.configurationAbi, [
+      { path: ['quoteAsset'], type: 'address' }, { path: ['minimumWindow'], type: 'uint256' }, { path: ['maximumWindow'], type: 'uint256' },
+    ], 'Settlement configuration ABI differs from the reviewed source profile');
+    const abi = parseAbiParameters(quoteBound ? 'address,uint256,uint256' : 'uint256,uint256');
+    const values = decodeAbiParameters(abi, p.configuration), [minimum, maximum] = quoteBound ? values.slice(1) : values;
+    if (quoteBound) need(same(values[0], a.quoteAsset) && minimum === 60n && maximum === 30n * 86400n, 'Settlement quote/fixed windows differ');
+    need(same(encodeAbiParameters(abi, values), p.configuration) && minimum > 0n && maximum >= minimum
       && maximum <= 365n * 86400n && state.minimumWindow === minimum && state.maximumWindow === maximum, 'Settlement resources differ');
     hash = keccak256(encodeAbiParameters(parseAbiParameters('address,address,uint256,uint256'), [a.quoteAsset, a.creator, minimum, maximum]));
   } else if (manifest.catalogDefinition.interface === 'escrow-v1') {

--- a/contracts/scripts/module-mode/launch-source-profiles.test.mjs
+++ b/contracts/scripts/module-mode/launch-source-profiles.test.mjs
@@ -181,6 +181,35 @@ test('known settlement/escrow/quote resource hashes are exact; custom or extra r
   assert.throws(() => engineResourceCommitment(quote, { ...state, positionRecipient: a(1001) }), /resources hash/);
 });
 
+test('the published quote-bound settlement codec preserves its quote, fixed windows and exact source profile', async () => {
+  const catalog = JSON.parse(await readFile(new URL('../../../config/module-engine/catalog.json', import.meta.url)));
+  const definition = catalog.entries.find(entry => entry.template.manifest.manifest.catalogDefinition.id === 'quote-bound-settlement-v1')
+    .template.manifest.manifest.catalogDefinition;
+  const settlement = engineLaunchIdentity(engineLaunchFixture(), wire);
+  settlement.manifest.catalogDefinition = structuredClone(definition);
+  const abi = parseAbiParameters('address,uint256,uint256'), state = { minimumWindow: 60n, maximumWindow: 2592000n };
+  settlement.parameters.configuration = encodeAbiParameters(abi, [settlement.launch.quoteAsset, state.minimumWindow, state.maximumWindow]);
+  settlement.launch.resourcesHash = keccak256(encodeAbiParameters(parseAbiParameters('address,address,uint256,uint256'),
+    [settlement.launch.quoteAsset, settlement.launch.creator, state.minimumWindow, state.maximumWindow]));
+  assert.equal(engineResourceCommitment(settlement, state), settlement.launch.resourcesHash);
+  for (const change of [
+    value => { value.manifest.catalogDefinition.source.sha256 = '0'.repeat(64); },
+    value => { value.manifest.catalogDefinition.source.path = 'src/OtherSettlement.sol'; },
+    value => { value.manifest.catalogDefinition.configurationAbi[0].type = 'uint256'; },
+    value => { value.manifest.catalogDefinition.configurationAbi.reverse(); },
+    value => { value.parameters.configuration = encodeAbiParameters(abi, [a(999), 60n, 2592000n]); },
+    value => { value.parameters.configuration = encodeAbiParameters(abi, [value.launch.quoteAsset, 61n, 2592000n]); },
+    value => { value.parameters.configuration = encodeAbiParameters(abi, [value.launch.quoteAsset, 60n, 2592001n]); },
+    value => { value.parameters.configuration = encodeAbiParameters(parseAbiParameters('uint256,uint256'), [60n, 2592000n]); },
+    value => { value.parameters.configuration += '00'.repeat(32); },
+    value => { value.launch.resourcesHash = h(999); },
+  ]) {
+    const changed = structuredClone(settlement); change(changed);
+    assert.throws(() => engineResourceCommitment(changed, state), undefined, change.toString());
+  }
+  assert.throws(() => engineResourceCommitment(settlement, { ...state, maximumWindow: 2592001n }), /resources/);
+});
+
 test('the public Engine packet is verified by the same protected catalogue/build/manifest validators', async () => {
   const f = reviewedPublication();
   assert.equal(wire.verifyModuleEnginePublication(f).manifestHash, f.publication.template.manifestHash);


### PR DESCRIPTION
The scheduled launch-source verifier fails on the already published Funded settlement module because its wrapper encodes `(address,uint256,uint256)` while the verifier assumes the legacy `(uint256,uint256)` configuration. The first address word is treated as a request window, so the canonical roundtrip fails before source publication can advance the Engine checkpoint. Public receipt and canonical getter reads for M53SET show matching quote, 60-second minimum, 30-day maximum, and resource commitment.

Add an explicit adapter bound to the exact reviewed `QuoteBoundSettlementV1.sol` path and SHA-256 and its exact configuration ABI. It checks the quote and fixed windows, then retains the full canonical encoding, current getters, resource hash, and existing publication/runtime checks. The legacy two-field adapter remains unchanged.

Validation:

- Both existing launch-source test files: 23 passed, 1 unchanged compiler integration test skipped locally because `MODULE_MODE_SOLC` is unset.
- The new regression uses the checked-in published configuration and rejects a changed source/path, ABI type/order, quote, fixed window, encoding length, getter, or resource commitment.
- Node syntax checks and `git diff --check` passed.
- Public availability returned HTTP 200 with this template available; canonical `getRevision` returned enabled. No transaction or publication workflow was executed for this diagnosis.

Only the source-verification script and its test change. There are no website runtime importers or contract/catalog changes. The existing trusted classifier still requires Contracts and Interface CI; those gates are preserved. The failed scheduled scan must pass on the merged source before source-publication recovery is claimed.

Failure evidence: https://github.com/programmablehq/PROGRAMMABLE/actions/runs/34336364212
