### PR TITLE
Preserve newer network choices during route initialization

### DIFF
--- a/components/module-mode-builder.tsx
+++ b/components/module-mode-builder.tsx
@@ -12,7 +12,7 @@ import { ModulePickerDialog } from "@/components/module-picker-dialog";
 import { moduleCategory } from "@/lib/module-mode/library";
 import { ModuleSchemaField } from "@/components/module-mode-fields";
 import { ModuleModeImagePicker, moduleModeImageSource, type ModuleModeImageResource } from "@/components/module-mode-image";
-import { useViewChain } from "@/components/view-chain";
+import { useRouteViewChain } from "@/components/view-chain";
 import styles from "@/components/module-mode-builder.module.css";
 import {
   createModuleModeState,
@@ -82,13 +82,7 @@ export interface ModuleModeBuilderProps {
 }
 
 export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = NATIVE_ENGINE_PROFILE, configurationContext = {}, launchAction, minimumInitialBuyWei, release, previewDescription, statusContent, reviewContent, resultContent, onEdit }: Readonly<ModuleModeBuilderProps>) {
-  const { hydrated, setViewChainId } = useViewChain();
-  useEffect(() => {
-    if (!hydrated) return;
-    // Set the route preference once after hydration; other tabs may change it later.
-    const timer = window.setTimeout(() => setViewChainId(4663), 0);
-    return () => window.clearTimeout(timer);
-  }, [hydrated, setViewChainId]);
+  const { hydrated } = useRouteViewChain(4663);
   const [state, setState] = useState(createModuleModeState);
   const { expanded: detailsOpen, setExpanded: setDetailsOpen, toggle: toggleDetails, panelProps: detailsPanel } = useDisclosureState();
   const { expanded: feesOpen, setExpanded: setFeesOpen, toggle: toggleFees, panelProps: feesPanel } = useDisclosureState();

--- a/components/robinhood-launches-view.tsx
+++ b/components/robinhood-launches-view.tsx
@@ -8,7 +8,7 @@ import { ExploreChainSelector } from "@/components/explore-chain-selector";
 import { ExploreFilters } from "@/components/explore-filters";
 import { AnimatedMarketCap } from "@/components/animated-market-cap";
 import { ETHEREUM_EXPLORE_FILTERS, ETHEREUM_EXPLORE_MODES } from "@/lib/ethereum-explore";
-import { useViewChain, type ViewChainId } from "@/components/view-chain";
+import { useRouteViewChain, type ViewChainId } from "@/components/view-chain";
 import { MODULE_TOKEN_FALLBACK_IMAGE, RobinhoodCoinArtwork } from "@/components/robinhood-coin-artwork";
 import { RobinhoodProjectLinks } from "@/components/robinhood-project-links";
 import { rememberRobinhoodTokenPresentations } from "@/components/robinhood-presentation-cache";
@@ -121,14 +121,7 @@ export function RobinhoodLaunchesView({
   embedded = false,
   chainId,
 }: Readonly<{ embedded?: boolean; chainId?: ViewChainId }>) {
-  const { hydrated, viewChainId, setViewChainId } = useViewChain();
-
-  useEffect(() => {
-    if (!hydrated || chainId === undefined) return;
-    // The explicit route wins after the shared preference is restored.
-    const timer = window.setTimeout(() => setViewChainId(chainId), 0);
-    return () => window.clearTimeout(timer);
-  }, [chainId, hydrated, setViewChainId]);
+  const { hydrated, viewChainId } = useRouteViewChain(chainId);
 
   const selectedChain = chainId ?? viewChainId;
   return <IndexedLaunchList key={selectedChain} chainId={selectedChain} embedded={embedded} enabled={hydrated} />;

--- a/components/token-route-chain-sync.tsx
+++ b/components/token-route-chain-sync.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, type ReactNode } from "react";
+import { type ReactNode } from "react";
 
 import {
-  useViewChain,
+  useRouteViewChain,
   type ViewChainId,
 } from "@/components/view-chain";
 
@@ -14,14 +14,7 @@ export function TokenRouteChainSync({
   chainId: ViewChainId;
   children: ReactNode;
 }>) {
-  const { hydrated, setViewChainId } = useViewChain();
-
-  useEffect(() => {
-    if (!hydrated) return;
-    // Wait for the provider to finish restoring its saved preference first.
-    const timer = window.setTimeout(() => setViewChainId(chainId), 0);
-    return () => window.clearTimeout(timer);
-  }, [chainId, hydrated, setViewChainId]);
+  useRouteViewChain(chainId);
 
   return children;
 }

--- a/components/view-chain.tsx
+++ b/components/view-chain.tsx
@@ -32,15 +32,31 @@ type ViewChainContextValue = Readonly<{
 }>;
 
 const ViewChainContext = createContext<ViewChainContextValue | null>(null);
+const VIEW_CHAIN_REVISION_COOKIE_NAME = `${VIEW_CHAIN_COOKIE_NAME}-revision`;
+const VIEW_CHAIN_REVISION_STORAGE_KEY = `${VIEW_CHAIN_STORAGE_KEY}:revision`;
 
-function readViewChainCookie(): ViewChainId | null {
-  const encodedName = `${VIEW_CHAIN_COOKIE_NAME}=`;
+function readCookie(name: string): string | null {
+  const encodedName = `${name}=`;
   for (const cookiePart of document.cookie.split(";")) {
     const normalizedPart = cookiePart.trim();
     if (!normalizedPart.startsWith(encodedName)) continue;
-    return tryParseViewChainId(normalizedPart.slice(encodedName.length));
+    return normalizedPart.slice(encodedName.length);
   }
   return null;
+}
+
+function readViewChainCookie(): ViewChainId | null {
+  return tryParseViewChainId(readCookie(VIEW_CHAIN_COOKIE_NAME));
+}
+
+function readViewChainRevision(): string {
+  let stored: string | null = null;
+  try {
+    stored = window.localStorage.getItem(VIEW_CHAIN_REVISION_STORAGE_KEY);
+  } catch {
+    // The cookie still detects choices when browser storage is blocked.
+  }
+  return JSON.stringify([readCookie(VIEW_CHAIN_REVISION_COOKIE_NAME), stored]);
 }
 
 function readStoredViewChain(): ViewChainId | null {
@@ -117,6 +133,15 @@ export function ViewChainProvider({
   }, [hydrated, viewChainId]);
 
   const setViewChainId = useCallback((nextViewChainId: ViewChainId) => {
+    // Publish a distinct revision before the value. Pending route entry must
+    // detect a newer choice even before its storage event or after a round trip.
+    const revision = window.crypto.randomUUID();
+    document.cookie = `${VIEW_CHAIN_REVISION_COOKIE_NAME}=${revision}; Path=/; SameSite=Lax`;
+    try {
+      window.localStorage.setItem(VIEW_CHAIN_REVISION_STORAGE_KEY, revision);
+    } catch {
+      // Keep the same cookie fallback as the browsing preference itself.
+    }
     persistViewChain(nextViewChainId);
   }, []);
 
@@ -137,5 +162,26 @@ export function useViewChain(): ViewChainContextValue {
   if (!value) {
     throw new Error("useViewChain must be used within ViewChainProvider");
   }
+  return value;
+}
+
+/** Apply a route's initial preference without replacing a more recent choice. */
+export function useRouteViewChain(chainId: ViewChainId | undefined): ViewChainContextValue {
+  const value = useViewChain();
+  const { hydrated, setViewChainId } = value;
+
+  useEffect(() => {
+    if (!hydrated || chainId === undefined) return;
+    const revision = readViewChainRevision();
+    const previousChain = readViewChainCookie() ?? readStoredViewChain();
+    const timer = window.setTimeout(() => {
+      if (readViewChainRevision() !== revision) return;
+      // Also respect a numeric preference written by an already open older tab.
+      if (previousChain !== null && (readViewChainCookie() ?? readStoredViewChain()) !== previousChain) return;
+      setViewChainId(chainId);
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [chainId, hydrated, setViewChainId]);
+
   return value;
 }

--- a/components/view-chain.tsx
+++ b/components/view-chain.tsx
@@ -6,6 +6,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useState,
   useSyncExternalStore,
   type ReactNode,
 } from "react";
@@ -124,13 +125,16 @@ export function ViewChainProvider({
 
   useEffect(() => {
     if (!hydrated) return;
+    // Another tab may have changed the preference since this render committed.
+    const currentViewChainId = getViewChainSnapshot();
+    if (currentViewChainId === null) return;
     if (
-      readViewChainCookie() !== viewChainId ||
-      readStoredViewChain() !== viewChainId
+      readViewChainCookie() !== currentViewChainId ||
+      readStoredViewChain() !== currentViewChainId
     ) {
-      persistViewChain(viewChainId);
+      persistViewChain(currentViewChainId);
     }
-  }, [hydrated, viewChainId]);
+  }, [getViewChainSnapshot, hydrated, viewChainId]);
 
   const setViewChainId = useCallback((nextViewChainId: ViewChainId) => {
     // Publish a distinct revision before the value. Pending route entry must
@@ -165,23 +169,31 @@ export function useViewChain(): ViewChainContextValue {
   return value;
 }
 
+function captureRouteEntry(chainId: ViewChainId | undefined) {
+  if (typeof document === "undefined") return { chainId, revision: null, previousChain: null };
+  return { chainId, revision: readViewChainRevision(), previousChain: readViewChainCookie() ?? readStoredViewChain() };
+}
+
 /** Apply a route's initial preference without replacing a more recent choice. */
 export function useRouteViewChain(chainId: ViewChainId | undefined): ViewChainContextValue {
   const value = useViewChain();
   const { hydrated, setViewChainId } = value;
+  // Capture before the first passive effect, which may run after a visible
+  // background tab has already been superseded by a choice in another tab.
+  const [entry, setEntry] = useState(() => captureRouteEntry(chainId));
+  if (entry.chainId !== chainId) setEntry(captureRouteEntry(chainId));
 
   useEffect(() => {
-    if (!hydrated || chainId === undefined) return;
-    const revision = readViewChainRevision();
-    const previousChain = readViewChainCookie() ?? readStoredViewChain();
+    const { chainId: routeChainId, revision, previousChain } = entry;
+    if (!hydrated || routeChainId === undefined || revision === null) return;
     const timer = window.setTimeout(() => {
       if (readViewChainRevision() !== revision) return;
       // Also respect a numeric preference written by an already open older tab.
       if (previousChain !== null && (readViewChainCookie() ?? readStoredViewChain()) !== previousChain) return;
-      setViewChainId(chainId);
+      setViewChainId(routeChainId);
     }, 0);
     return () => window.clearTimeout(timer);
-  }, [chainId, hydrated, setViewChainId]);
+  }, [entry, hydrated, setViewChainId]);
 
   return value;
 }

--- a/tests/browser/fixtures/module-mode-operation-wallet.tsx
+++ b/tests/browser/fixtures/module-mode-operation-wallet.tsx
@@ -78,6 +78,7 @@ export function FixtureWallet({ children }: { children: ReactNode }) {
   return <Context.Provider value={{ wallet, openWallet: () => setWallet({ account, chainId: "0x1237" }) }}>{children}</Context.Provider>;
 }
 export const useViewChain = () => ({ hydrated: true, viewChainId: 4663, setViewChainId: () => {} });
+export const useRouteViewChain = useViewChain;
 export function useWallet() {
   const value = useContext(Context);
   return { ...value, authenticated: true, sessionReady: true, authReady: true, connecting: false, openingWallet: false, switchingNetwork: false, disconnecting: false,

--- a/tests/browser/fixtures/view-chain-scheduling.ts
+++ b/tests/browser/fixtures/view-chain-scheduling.ts
@@ -1,12 +1,27 @@
 // Fixture-only control of the real route callbacks and native storage events.
 // Nothing imports this file from the application.
-export {};
+import type { EffectCallback } from "react";
 
 const deferredEntries = new Map<number, () => void>();
 const deferredStorage: StorageEvent[] = [];
+const deferredEffects = new Set<{ effect: EffectCallback; cleanup: ReturnType<EffectCallback> }>();
 let nextTimer = -1;
-let holdEntries = new URLSearchParams(location.search).has("holdRouteEntry");
-let holdStorage = holdEntries;
+const parameters = new URLSearchParams(location.search);
+let holdEffects = parameters.get("holdViewChainEffect");
+let holdEntries = parameters.has("holdRouteEntry") || holdEffects === "route";
+let holdStorage = holdEntries || holdEffects === "provider";
+
+export function deferViewChainEffect(effect: EffectCallback): ReturnType<EffectCallback> {
+  const source = String(effect);
+  const kind = source.includes("readViewChainRevision") ? "route" : source.includes("persistViewChain") ? "provider" : null;
+  if (!kind || kind !== holdEffects) return effect();
+  const deferred = { effect, cleanup: undefined as ReturnType<EffectCallback> };
+  deferredEffects.add(deferred);
+  return () => {
+    deferredEffects.delete(deferred);
+    deferred.cleanup?.();
+  };
+}
 
 const nativeSetTimeout = window.setTimeout.bind(window);
 const nativeClearTimeout = window.clearTimeout.bind(window);
@@ -31,6 +46,13 @@ window.addEventListener("storage", (event) => {
 }, true);
 
 const scheduling = {
+  pendingPassiveEffects: () => deferredEffects.size,
+  releasePassiveEffects: () => {
+    holdEffects = null;
+    const effects = [...deferredEffects];
+    deferredEffects.clear();
+    for (const deferred of effects) deferred.cleanup = deferred.effect();
+  },
   pendingEntries: () => deferredEntries.size,
   pendingStorageEvents: () => deferredStorage.length,
   releaseEntries: () => {

--- a/tests/browser/fixtures/view-chain-scheduling.ts
+++ b/tests/browser/fixtures/view-chain-scheduling.ts
@@ -1,0 +1,54 @@
+// Fixture-only control of the real route callbacks and native storage events.
+// Nothing imports this file from the application.
+export {};
+
+const deferredEntries = new Map<number, () => void>();
+const deferredStorage: StorageEvent[] = [];
+let nextTimer = -1;
+let holdEntries = new URLSearchParams(location.search).has("holdRouteEntry");
+let holdStorage = holdEntries;
+
+const nativeSetTimeout = window.setTimeout.bind(window);
+const nativeClearTimeout = window.clearTimeout.bind(window);
+Object.defineProperty(window, "setTimeout", { value: (callback: TimerHandler, delay?: number, ...args: unknown[]) => {
+  if (holdEntries && delay === 0 && typeof callback === "function"
+    && /\bsetViewChainId\d*\(/.test(String(callback))) {
+    const id = nextTimer--;
+    deferredEntries.set(id, () => callback(...args));
+    return id;
+  }
+  return nativeSetTimeout(callback, delay, ...args);
+} });
+Object.defineProperty(window, "clearTimeout", { value: (id?: number) => {
+  if (id !== undefined && deferredEntries.delete(id)) return;
+  nativeClearTimeout(id);
+} });
+
+window.addEventListener("storage", (event) => {
+  if (!holdStorage || !event.key?.startsWith("programmable:view-chain:")) return;
+  event.stopImmediatePropagation();
+  deferredStorage.push(event);
+}, true);
+
+const scheduling = {
+  pendingEntries: () => deferredEntries.size,
+  pendingStorageEvents: () => deferredStorage.length,
+  releaseEntries: () => {
+    holdEntries = false;
+    const callbacks = [...deferredEntries.values()];
+    deferredEntries.clear();
+    for (const callback of callbacks) callback();
+  },
+  releaseStorageEvents: () => {
+    holdStorage = false;
+    for (const event of deferredStorage.splice(0)) {
+      window.dispatchEvent(new StorageEvent("storage", {
+        key: event.key, oldValue: event.oldValue, newValue: event.newValue,
+        storageArea: event.storageArea, url: event.url,
+      }));
+    }
+  },
+};
+
+declare global { interface Window { __viewChainScheduling: typeof scheduling } }
+window.__viewChainScheduling = scheduling;

--- a/tests/browser/fixtures/wallet-session-server.mjs
+++ b/tests/browser/fixtures/wallet-session-server.mjs
@@ -9,6 +9,7 @@ export async function createWalletSessionServer() {
   const bundled = await build({
     stdin: {
       contents: `
+        import './tests/browser/fixtures/view-chain-scheduling';
         import React, {useState} from 'react';
         import {createRoot} from 'react-dom/client';
         import {WalletProvider, WalletButton, useWallet} from './components/wallet-provider';
@@ -17,6 +18,7 @@ export async function createWalletSessionServer() {
         import {ModuleModeBuilder} from './components/module-mode-builder';
         import {moduleModeWalletStep} from './components/module-mode-wallet-state';
         import {TokenRouteChainSync} from './components/token-route-chain-sync';
+        import {RobinhoodLaunchesView} from './components/robinhood-launches-view';
         import {FixtureControls} from './tests/browser/fixtures/wallet-session-runtime';
         import './app/globals.css';
         import './app/interface.css';
@@ -63,6 +65,7 @@ export async function createWalletSessionServer() {
               description:'Local UI callback only. No transaction is prepared or sent.',
               onContinue:async () => setModuleContinuations(previous => previous + 1)}}/> : null}
             {location.pathname === '/token/ethereum' ? <TokenRouteChainSync chainId={1}><p>Ethereum token route</p></TokenRouteChainSync> : null}
+            {location.pathname === '/explore/robinhood' ? <RobinhoodLaunchesView chainId={4663}/> : null}
           </main>;
         }
         createRoot(document.getElementById('root')).render(<ViewChainProvider><WalletProvider><SiteHeader/><Consumer/></WalletProvider></ViewChainProvider>);
@@ -94,6 +97,12 @@ export async function createWalletSessionServer() {
   return createServer(async (request, response) => {
     const url = new URL(request.url, "http://localhost");
     if (url.pathname === "/favicon.ico") { response.writeHead(204); response.end(); return; }
+    if (url.pathname === "/api/explore/robinhood") {
+      response.setHeader("Content-Type", "application/json");
+      response.end(JSON.stringify({ chainId: 4663, status: "ready", updatedAt: null, items: [], presentations: [],
+        page: { number: 1, size: 50, totalItems: 0, totalPages: 0, hasMore: false } }));
+      return;
+    }
     if (sources.has(url.pathname)) {
       response.setHeader("Content-Type", url.pathname.endsWith(".css") ? "text/css" : "text/javascript");
       response.end(sources.get(url.pathname)); return;
@@ -108,7 +117,7 @@ export async function createWalletSessionServer() {
       } catch { response.writeHead(404); response.end(); }
       return;
     }
-    if (!["/profile", "/developers/api-keys", "/launch/modules", "/token/ethereum"].includes(url.pathname)) {
+    if (!["/profile", "/developers/api-keys", "/launch/modules", "/token/ethereum", "/explore/robinhood"].includes(url.pathname)) {
       response.writeHead(404); response.end(); return;
     }
     response.setHeader("Content-Type", "text/html");

--- a/tests/browser/fixtures/wallet-session-server.mjs
+++ b/tests/browser/fixtures/wallet-session-server.mjs
@@ -81,6 +81,14 @@ export async function createWalletSessionServer() {
     },
     external: ["/brand/*", "/fonts/*"],
     plugins: [{ name: "wallet-session-boundaries", setup(plugin) {
+      plugin.onResolve({ filter: /^react$/ }, (args) => args.importer === resolve(root, "components/view-chain.tsx")
+        ? { path: "view-chain-react", namespace: "view-chain-react" } : undefined);
+      plugin.onLoad({ filter: /.*/, namespace: "view-chain-react" }, () => ({
+        loader: "tsx", resolveDir: root,
+        contents: `export * from 'react'; import {useEffect as nativeEffect} from 'react';
+          import {deferViewChainEffect} from './tests/browser/fixtures/view-chain-scheduling';
+          export function useEffect(effect,deps){return nativeEffect(()=>deferViewChainEffect(effect),deps);}`,
+      }));
       plugin.onResolve({ filter: /^\.\/wallet-provider-runtime$/ }, () => ({ path: runtime }));
       plugin.onResolve({ filter: /^next\/(navigation|link|image)$/ }, (args) => ({ path: args.path, namespace: "fixture" }));
       plugin.onLoad({ filter: /.*/, namespace: "fixture" }, (args) => ({

--- a/tests/browser/wallet-session.spec.ts
+++ b/tests/browser/wallet-session.spec.ts
@@ -255,6 +255,40 @@ test("an open module launch tab cannot undo another tab's browsing network choic
   }
 });
 
+for (const phase of ["route", "provider"] as const) {
+  test(`a delayed ${phase} passive effect cannot replace a choice made after the first render`, async ({ page }) => {
+    await open(page);
+    const browse = (name: string) => page.getByRole("button", { name, exact: true }).click();
+    if (phase === "route") await browse("Browse Ethereum");
+    const delayedTab = await page.context().newPage();
+    const errors = browserErrors.get(page)!;
+    delayedTab.on("pageerror", (error) => errors.push(error.message));
+    delayedTab.on("console", (message) => { if (message.type() === "error") errors.push(message.text()); });
+    try {
+      await delayedTab.goto(origin + (phase === "route" ? "/launch/modules" : "/profile") + `?holdViewChainEffect=${phase}`);
+      await expect.poll(() => delayedTab.evaluate(() => window.__viewChainScheduling.pendingPassiveEffects())).toBe(1);
+      await expect(delayedTab.getByLabel("Selected browsing chain", { exact: true })).toHaveText(phase === "route" ? "1" : "4663");
+      if (phase === "route") await browse("Browse Robinhood");
+      await browse("Browse Ethereum");
+      await expect.poll(() => delayedTab.evaluate(() => window.__viewChainScheduling.pendingStorageEvents())).toBeGreaterThan(0);
+      expect(await delayedTab.evaluate(() => document.cookie)).toContain("programmable-view-chain-v2=1");
+      await delayedTab.evaluate(() => window.__viewChainScheduling.releasePassiveEffects());
+      if (phase === "route") {
+        await expect.poll(() => delayedTab.evaluate(() => window.__viewChainScheduling.pendingEntries())).toBe(1);
+        await delayedTab.evaluate(() => window.__viewChainScheduling.releaseEntries());
+      }
+      expect(await delayedTab.evaluate(() => localStorage.getItem("programmable:view-chain:v2"))).toBe("1");
+      await delayedTab.evaluate(() => window.__viewChainScheduling.releaseStorageEvents());
+      await expect(delayedTab.getByLabel("Selected browsing chain", { exact: true })).toHaveText("1");
+      await expect(page.getByLabel("Selected browsing chain", { exact: true })).toHaveText("1");
+      await expectMethods(page, []);
+      await expectMethods(delayedTab, []);
+    } finally {
+      await delayedTab.close();
+    }
+  });
+}
+
 for (const [path, routeChain] of [["/launch/modules", 4663], ["/token/ethereum", 1], ["/explore/robinhood", 4663]] as const) {
   for (const selection of ["one newer choice", "a newer choice returning to the initial value", "no newer choice"] as const) {
     test(`${path}: deferred route entry respects ${selection} before storage events arrive`, async ({ page }) => {

--- a/tests/browser/wallet-session.spec.ts
+++ b/tests/browser/wallet-session.spec.ts
@@ -255,6 +255,52 @@ test("an open module launch tab cannot undo another tab's browsing network choic
   }
 });
 
+for (const [path, routeChain] of [["/launch/modules", 4663], ["/token/ethereum", 1], ["/explore/robinhood", 4663]] as const) {
+  for (const selection of ["one newer choice", "a newer choice returning to the initial value", "no newer choice"] as const) {
+    test(`${path}: deferred route entry respects ${selection} before storage events arrive`, async ({ page }) => {
+      await open(page);
+      const otherChain = routeChain === 1 ? 4663 : 1;
+      const browse = (chain: number) => page.getByRole("button", { name: chain === 1 ? "Browse Ethereum" : "Browse Robinhood", exact: true }).click();
+      const initialChain = selection === "one newer choice" ? routeChain : otherChain;
+      await browse(initialChain);
+      const routeTab = await page.context().newPage();
+      const errors = browserErrors.get(page)!;
+      routeTab.on("pageerror", (error) => errors.push(error.message));
+      routeTab.on("console", (message) => { if (message.type() === "error") errors.push(message.text()); });
+      await routeTab.route("**/*", async (route) => {
+        const url = new URL(route.request().url());
+        if (url.origin === origin) return route.continue();
+        errors.push(`Unexpected external request from route fixture: ${url.origin}`);
+        await route.abort();
+      });
+      try {
+        await routeTab.goto(origin + path + "?holdRouteEntry=1");
+        await expect.poll(() => routeTab.evaluate(() => window.__viewChainScheduling.pendingEntries())).toBe(1);
+        await expect(routeTab.getByLabel("Selected browsing chain", { exact: true })).toHaveText(String(initialChain));
+        if (selection === "a newer choice returning to the initial value") await browse(routeChain);
+        if (selection !== "no newer choice") {
+          await browse(otherChain);
+          await expect.poll(() => routeTab.evaluate(() => window.__viewChainScheduling.pendingStorageEvents())).toBeGreaterThan(0);
+          // The shared cookie is current while the receiving tab has not handled
+          // any storage event. Returning to the same number must also cancel entry.
+          expect(await routeTab.evaluate(() => document.cookie)).toContain(`programmable-view-chain-v2=${otherChain}`);
+        }
+        await routeTab.evaluate(() => window.__viewChainScheduling.releaseEntries());
+        const expected = selection === "no newer choice" ? routeChain : otherChain;
+        expect(await routeTab.evaluate(() => localStorage.getItem("programmable:view-chain:v2"))).toBe(String(expected));
+        await routeTab.evaluate(() => window.__viewChainScheduling.releaseStorageEvents());
+        await expect(routeTab.getByLabel("Selected browsing chain", { exact: true })).toHaveText(String(expected));
+        await expect(page.getByLabel("Selected browsing chain", { exact: true })).toHaveText(String(expected));
+        await expectMethods(page, []);
+        await expectMethods(routeTab, []);
+        await expect(routeTab.getByLabel("Selected wallet network", { exact: true })).toHaveText("0x1237");
+      } finally {
+        await routeTab.close();
+      }
+    });
+  }
+}
+
 test("a denied clipboard offers the address for manual copy without asking to reconnect", async ({ page }, testInfo) => {
   await open(page);
   await page.getByRole("button", { name: "Disable clipboard", exact: true }).click();

--- a/tests/module-mode-launch-ui.test.tsx
+++ b/tests/module-mode-launch-ui.test.tsx
@@ -7,7 +7,10 @@ import { ModuleSchemaField } from "@/components/module-mode-fields";
 import { bindActiveModuleModeRelease, computeModuleModeReleaseDigest, MODULE_MODE_ECONOMICS_POLICY_V2 } from "@/lib/module-mode/release";
 import { moduleEvidenceFixture, a } from "./fixtures/module-mode-evidence";
 
-vi.mock("@/components/view-chain", () => ({ useViewChain: () => ({ hydrated: true, viewChainId: 4663, setViewChainId: vi.fn() }) }));
+vi.mock("@/components/view-chain", () => {
+  const useViewChain = () => ({ hydrated: true, viewChainId: 4663, setViewChainId: vi.fn() });
+  return { useViewChain, useRouteViewChain: useViewChain };
+});
 vi.mock("@/components/wallet-provider", () => ({ useWallet: vi.fn() }));
 
 const token = `0x${"12".repeat(20)}` as const;

--- a/tests/robinhood-explore-controls.test.tsx
+++ b/tests/robinhood-explore-controls.test.tsx
@@ -2,7 +2,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import { activeExploreFilterCount, DEFAULT_EXPLORE_FILTERS, sameRobinhoodExploreRequest } from "@/lib/robinhood-explore-filters";
 
-vi.mock("@/components/view-chain", () => ({ useViewChain: () => ({ hydrated: true, viewChainId: 4663, setViewChainId: vi.fn() }) }));
+vi.mock("@/components/view-chain", () => {
+  const useViewChain = () => ({ hydrated: true, viewChainId: 4663, setViewChainId: vi.fn() });
+  return { useViewChain, useRouteViewChain: useViewChain };
+});
 vi.mock("next/navigation", () => ({ usePathname: () => "/explore/robinhood", useRouter: () => ({ push: vi.fn() }) }));
 import { RobinhoodLaunchesView } from "@/components/robinhood-launches-view";
 

--- a/tests/view-chain.test.ts
+++ b/tests/view-chain.test.ts
@@ -104,7 +104,8 @@ describe("view chain", () => {
       "const getServerSnapshot = useCallback((): ViewChainId | null => null",
     );
     expect(provider).toContain("const hydrated = resolvedViewChainId !== null");
-    expect(provider).toContain("persistViewChain(viewChainId)");
+    expect(provider).toContain("const currentViewChainId = getViewChainSnapshot()");
+    expect(provider).toContain("persistViewChain(currentViewChainId)");
     expect(layout).not.toContain('from "next/headers"');
     expect(layout).not.toContain("cookies()");
     expect(resolvedLayout).toContain('import { cookies } from "next/headers"');


### PR DESCRIPTION
A visible Module Mode, token or explicit Explore route could overwrite a newer network choice when its deferred initialization finally ran. A delayed provider effect could also restore its old rendered value. For example, selecting Ethereum in a second tab could switch both tabs back to Robinhood when the first tab resumed.

All three routes now use one guarded entry hook. It captures the route's initial preference and publication revision during its first client render, before passive effects can be delayed. Each preference publication writes a distinct revision before its value, allowing a pending entry to recognize a newer choice before a storage event is delivered and after a switch away from and back to the same chain. Provider reconciliation reads the current preference when its effect executes rather than restoring an older render's value.

The existing numeric cookie and localStorage formats remain compatible. The revision is separate functional metadata with the same storage fallback. Wallet connection, transaction network checks and signing logic are unchanged.

Validation on the final source:

- 12 targeted browser cases passed: the original two-tab Module Mode regression, nine deterministic route-entry cases across the three routes, and separate delayed route-effect and provider-effect regressions.
- The fixture delays real production callbacks and storage-event delivery. Before the corresponding fixes, all six newer-choice timer cases failed and both passive-effect cases separately failed; normal route entry remains covered.
- The original regression retains its unchanged timing and checks both launch callbacks and the actual wallet network guard.
- 33 related unit and source-guard checks, full TypeScript, targeted ESLint and `git diff --check` passed.
- Existing test doubles expose the shared hook; the regressions themselves use the real provider and route components.

The investigation began with the failed cross-tab assertion in [Verify run 34352400491](https://github.com/programmablehq/PROGRAMMABLE/actions/runs/34352400491/job/102468696589). No timeout was increased and no CI gate was removed. This PR is prepared for integration-owner review and has not been merged or deployed.
