### PR TITLE
Use the published browser preference when cookie views lag

### DIFF
--- a/components/view-chain.tsx
+++ b/components/view-chain.tsx
@@ -51,13 +51,13 @@ function readViewChainCookie(): ViewChainId | null {
 }
 
 function readViewChainRevision(): string {
-  let stored: string | null = null;
   try {
-    stored = window.localStorage.getItem(VIEW_CHAIN_REVISION_STORAGE_KEY);
+    const stored = window.localStorage.getItem(VIEW_CHAIN_REVISION_STORAGE_KEY);
+    if (stored !== null) return stored;
   } catch {
     // The cookie still detects choices when browser storage is blocked.
   }
-  return JSON.stringify([readCookie(VIEW_CHAIN_REVISION_COOKIE_NAME), stored]);
+  return readCookie(VIEW_CHAIN_REVISION_COOKIE_NAME) ?? "";
 }
 
 function readStoredViewChain(): ViewChainId | null {
@@ -67,6 +67,21 @@ function readStoredViewChain(): ViewChainId | null {
     );
   } catch {
     return null;
+  }
+}
+
+function readBrowserViewChain(): ViewChainId | null {
+  // Storage events and their backing value share one publication source.
+  // Another renderer's cookie cache may still contain the previous choice.
+  return readStoredViewChain() ?? readViewChainCookie();
+}
+
+function storeViewChainValue(key: string, value: string) {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // A failed write must not leave an old value ahead of the updated cookie.
+    try { window.localStorage.removeItem(key); } catch { /* Storage is unavailable. */ }
   }
 }
 
@@ -86,14 +101,9 @@ function subscribeToViewChain(onStoreChange: () => void) {
 }
 
 function persistViewChain(viewChainId: ViewChainId) {
-  // Cross-tab subscribers read the cookie first. Make it current before the
-  // storage write can notify another browser process.
+  // Keep the cookie available for server rendering and blocked browser storage.
   document.cookie = serializeViewChainCookie(viewChainId);
-  try {
-    window.localStorage.setItem(VIEW_CHAIN_STORAGE_KEY, String(viewChainId));
-  } catch {
-    // A functional cookie remains available when browser storage is blocked.
-  }
+  storeViewChainValue(VIEW_CHAIN_STORAGE_KEY, String(viewChainId));
 
   window.dispatchEvent(
     new CustomEvent<ViewChainId>(VIEW_CHAIN_CHANGE_EVENT, {
@@ -111,7 +121,7 @@ export function ViewChainProvider({
 }>) {
   const getViewChainSnapshot = useCallback(
     (): ViewChainId | null =>
-      readViewChainCookie() ?? readStoredViewChain() ?? initialViewChainId,
+      readBrowserViewChain() ?? initialViewChainId,
     [initialViewChainId],
   );
   const getServerSnapshot = useCallback((): ViewChainId | null => null, []);
@@ -141,11 +151,7 @@ export function ViewChainProvider({
     // detect a newer choice even before its storage event or after a round trip.
     const revision = window.crypto.randomUUID();
     document.cookie = `${VIEW_CHAIN_REVISION_COOKIE_NAME}=${revision}; Path=/; SameSite=Lax`;
-    try {
-      window.localStorage.setItem(VIEW_CHAIN_REVISION_STORAGE_KEY, revision);
-    } catch {
-      // Keep the same cookie fallback as the browsing preference itself.
-    }
+    storeViewChainValue(VIEW_CHAIN_REVISION_STORAGE_KEY, revision);
     persistViewChain(nextViewChainId);
   }, []);
 
@@ -171,7 +177,7 @@ export function useViewChain(): ViewChainContextValue {
 
 function captureRouteEntry(chainId: ViewChainId | undefined) {
   if (typeof document === "undefined") return { chainId, revision: null, previousChain: null };
-  return { chainId, revision: readViewChainRevision(), previousChain: readViewChainCookie() ?? readStoredViewChain() };
+  return { chainId, revision: readViewChainRevision(), previousChain: readBrowserViewChain() };
 }
 
 /** Apply a route's initial preference without replacing a more recent choice. */
@@ -189,7 +195,7 @@ export function useRouteViewChain(chainId: ViewChainId | undefined): ViewChainCo
     const timer = window.setTimeout(() => {
       if (readViewChainRevision() !== revision) return;
       // Also respect a numeric preference written by an already open older tab.
-      if (previousChain !== null && (readViewChainCookie() ?? readStoredViewChain()) !== previousChain) return;
+      if (previousChain !== null && readBrowserViewChain() !== previousChain) return;
       setViewChainId(routeChainId);
     }, 0);
     return () => window.clearTimeout(timer);

--- a/tests/browser/fixtures/view-chain-scheduling.ts
+++ b/tests/browser/fixtures/view-chain-scheduling.ts
@@ -4,12 +4,26 @@ import type { EffectCallback } from "react";
 
 const deferredEntries = new Map<number, () => void>();
 const deferredStorage: StorageEvent[] = [];
+const receivedPreferences: (string | null)[] = [];
 const deferredEffects = new Set<{ effect: EffectCallback; cleanup: ReturnType<EffectCallback> }>();
 let nextTimer = -1;
 const parameters = new URLSearchParams(location.search);
 let holdEffects = parameters.get("holdViewChainEffect");
 let holdEntries = parameters.has("holdRouteEntry") || holdEffects === "route";
 let holdStorage = holdEntries || holdEffects === "provider";
+const nativeCookie = Object.getOwnPropertyDescriptor(Document.prototype, "cookie")!;
+let frozenCookie: string | null = null;
+let blockPreferenceWrites = false;
+const nativeSetItem = Storage.prototype.setItem;
+Storage.prototype.setItem = function (key: string, value: string) {
+  if (blockPreferenceWrites && key.startsWith("programmable:view-chain:")) throw new DOMException("Storage quota reached", "QuotaExceededError");
+  nativeSetItem.call(this, key, value);
+};
+Object.defineProperty(document, "cookie", {
+  configurable: true,
+  get: () => frozenCookie ?? nativeCookie.get!.call(document),
+  set: (value: string) => nativeCookie.set!.call(document, value),
+});
 
 export function deferViewChainEffect(effect: EffectCallback): ReturnType<EffectCallback> {
   const source = String(effect);
@@ -40,12 +54,17 @@ Object.defineProperty(window, "clearTimeout", { value: (id?: number) => {
 } });
 
 window.addEventListener("storage", (event) => {
+  if (event.key === "programmable:view-chain:v2") receivedPreferences.push(event.newValue);
   if (!holdStorage || !event.key?.startsWith("programmable:view-chain:")) return;
   event.stopImmediatePropagation();
   deferredStorage.push(event);
 }, true);
 
 const scheduling = {
+  freezeCookieReads: () => { frozenCookie = nativeCookie.get!.call(document); },
+  releaseCookieReads: () => { frozenCookie = null; },
+  receivedPreferences: () => [...receivedPreferences],
+  blockPreferenceWrites: () => { blockPreferenceWrites = true; },
   pendingPassiveEffects: () => deferredEffects.size,
   releasePassiveEffects: () => {
     holdEffects = null;

--- a/tests/browser/wallet-session.spec.ts
+++ b/tests/browser/wallet-session.spec.ts
@@ -255,6 +255,50 @@ test("an open module launch tab cannot undo another tab's browsing network choic
   }
 });
 
+test("the cookie remains usable when a new preference cannot replace existing browser storage", async ({ page }) => {
+  await open(page);
+  await page.getByRole("button", { name: "Browse Ethereum", exact: true }).click();
+  await expect(page.getByLabel("Selected browsing chain", { exact: true })).toHaveText("1");
+  await page.evaluate(() => window.__viewChainScheduling.blockPreferenceWrites());
+  await page.getByRole("button", { name: "Browse Robinhood", exact: true }).click();
+  await expect(page.getByLabel("Selected browsing chain", { exact: true })).toHaveText("4663");
+  expect(await page.evaluate(() => document.cookie)).toContain("programmable-view-chain-v2=4663");
+  expect(await page.evaluate(() => localStorage.getItem("programmable:view-chain:v2"))).toBeNull();
+  await expectMethods(page, []);
+});
+
+test("a receiving tab uses the published preference while its cookie view is still old", async ({ page }) => {
+  await open(page);
+  await page.getByRole("button", { name: "Browse Ethereum", exact: true }).click();
+  await expect(page.getByLabel("Selected browsing chain", { exact: true })).toHaveText("1");
+  await page.evaluate(() => window.__viewChainScheduling.freezeCookieReads());
+  const routeTab = await page.context().newPage();
+  const errors = browserErrors.get(page)!;
+  routeTab.on("pageerror", (error) => errors.push(error.message));
+  routeTab.on("console", (message) => { if (message.type() === "error") errors.push(message.text()); });
+  try {
+    await routeTab.goto(origin + "/launch/modules?holdRouteEntry=1");
+    await expect.poll(() => routeTab.evaluate(() => window.__viewChainScheduling.pendingEntries())).toBe(1);
+    await routeTab.evaluate(() => window.__viewChainScheduling.releaseEntries());
+    // A real cross-tab event has arrived, but this renderer's cookie cache has
+    // not caught up. The event's backing storage already has the new value.
+    await expect.poll(() => page.evaluate(() => window.__viewChainScheduling.receivedPreferences())).toContain("4663");
+    expect(await page.evaluate(() => localStorage.getItem("programmable:view-chain:v2"))).toBe("4663");
+    expect(await page.evaluate(() => document.cookie)).toContain("programmable-view-chain-v2=1");
+    await expect(routeTab.getByLabel("Selected browsing chain", { exact: true })).toHaveText("4663");
+    await expect(page.getByLabel("Selected browsing chain", { exact: true })).toHaveText("4663");
+    await page.evaluate(() => window.__viewChainScheduling.releaseCookieReads());
+    expect(await page.evaluate(() => document.cookie)).toContain("programmable-view-chain-v2=4663");
+    await expect(page.getByLabel("Selected browsing chain", { exact: true })).toHaveText("4663");
+    await expect(routeTab.getByLabel("Selected browsing chain", { exact: true })).toHaveText("4663");
+    await expectMethods(page, []);
+    await expectMethods(routeTab, []);
+  } finally {
+    await page.evaluate(() => window.__viewChainScheduling.releaseCookieReads());
+    await routeTab.close();
+  }
+});
+
 for (const phase of ["route", "provider"] as const) {
   test(`a delayed ${phase} passive effect cannot replace a choice made after the first render`, async ({ page }) => {
     await open(page);

--- a/tests/view-chain.test.ts
+++ b/tests/view-chain.test.ts
@@ -87,8 +87,9 @@ describe("view chain", () => {
 
     expect(provider).toContain("window.localStorage.getItem");
     expect(provider).toContain(
-      "readViewChainCookie() ?? readStoredViewChain() ?? initialViewChainId",
+      "readStoredViewChain() ?? readViewChainCookie()",
     );
+    expect(provider).toContain("readBrowserViewChain() ?? initialViewChainId");
     expect(provider).toContain('window.addEventListener("storage"');
     expect(provider).toContain("document.cookie = serializeViewChainCookie");
     expect(provider).not.toContain("useWallet");


### PR DESCRIPTION
A receiving tab could remain on Ethereum after a real storage event published Robinhood because its renderer still read an older cookie value. The current browser preference was already present in localStorage, but the snapshot preferred the stale cookie.

Client snapshots, route-entry comparisons and publication revisions now read from the storage source that sends the events. Cookies continue to support server rendering and storage fallback. The handler reads the current stored value instead of trusting an event payload, so an older event cannot restore an older choice. If a storage write fails, its old record is removed so it cannot override the updated fallback cookie. Existing preference formats, early route-entry guards and wallet/signing boundaries remain unchanged.

Validation:

- A deterministic regression freezes only the receiving renderer's cookie read while allowing a real cross-tab storage event. It failed on c6626e62 with the writer and storage at 4663 but the receiver at 1. It now passes, including both tabs remaining correct after the cookie view is released.
- A quota-failure case verifies that an existing stored preference cannot shadow the updated fallback cookie when writes fail.
- All 14 relevant browser cases pass, including the original cross-tab regression, both delayed passive effects and all nine route-entry cases.
- 33 related unit/source checks, TypeScript, targeted ESLint and `git diff --check` passed.

This addresses the receiving-side failure in [production Verify run 34356943758](https://github.com/programmablehq/PROGRAMMABLE/actions/runs/34356943758/job/102484010238). No assertion timeout or CI gate changed. The branch is prepared for integration-owner review and has not been merged or deployed.
