### PR TITLE
Make module reviews a compact single-screen inbox

### DIFF
--- a/app/admin/modules/page.tsx
+++ b/app/admin/modules/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { ModuleReviewAdminConsole } from "@/components/module-review-admin-console";
 
 export const metadata: Metadata = {
-  title: "Admin Dashboard · Programmable",
+  title: "Module reviews · Programmable",
   description: "Review module submissions and build evidence.",
   robots: { index: false, follow: false },
 };

--- a/components/module-review-admin-console.module.css
+++ b/components/module-review-admin-console.module.css
@@ -1,112 +1,254 @@
-.page { color: var(--text); padding: 44px 24px 100px; --review-line: color-mix(in srgb, var(--border) 86%, transparent); }
-.header { display: flex; align-items: end; justify-content: space-between; gap: 24px; padding-bottom: 28px; border-bottom: 1px solid var(--review-line); }
-.eyebrow { color: var(--muted); font-size: 12px; font-weight: 600; letter-spacing: .09em; text-transform: uppercase; margin: 0 0 12px; }
-.header h1 { font-size: clamp(36px, 5vw, 58px); font-weight: 520; letter-spacing: -.05em; line-height: 1.05; margin: 0; }
-.header > div > p:last-child { color: var(--muted); font-size: 16px; margin: 16px 0 0; }
-.textLink { color: var(--muted); display: inline-flex; align-items: center; gap: 8px; min-height: 44px; white-space: nowrap; font-size: 14px; text-decoration: none; }
-.textLink:hover { color: var(--text); }
-.toolbar { display: flex; align-items: center; justify-content: space-between; gap: 20px; margin: 22px 0; }
-.toolbar p { font-size: 14px; margin: 0; }
-.sessionExport { margin: 22px 0; }
-.sessionExport p { max-width: 66ch; margin: 8px 0 0; }
-.sessionExport [role=status]:empty { margin: 0; }
-.primary, .secondary, .iconButton, .textButton, .fileButton { font: inherit; cursor: pointer; display: inline-flex; justify-content: center; align-items: center; gap: 8px; min-height: 44px; }
-.primary, .secondary { border: 1px solid var(--review-line); border-radius: 8px; font-size: 14px; font-weight: 550; padding: 10px 15px; }
-.primary { background: var(--text); color: var(--canvas); border-color: var(--text); }
-.secondary { background: transparent; color: var(--text); }
-.primary:hover { opacity: .9; }
-.secondary:hover, .iconButton:hover { background: color-mix(in srgb, var(--text) 6%, transparent); }
+.page { --review-line: var(--border); --review-panel: var(--surface-raised); --review-subtle: var(--surface); --review-ease: cubic-bezier(.2,.65,.3,1); color: var(--text); padding: 32px 24px 80px; }
+:global(html[data-theme="dark"]) .page { --review-panel: #181818; --review-subtle: #1f1f1f; --muted: #b8b3ae; --review-line: #363432; }
+.header { display: flex; align-items: center; justify-content: space-between; gap: 24px; }
+.eyebrow { margin: 0 0 8px; font-size: 12px; line-height: 16px; font-weight: 600; color: var(--muted); letter-spacing: .08em; text-transform: uppercase; }
+.header h1 { margin: 0; font-size: 36px; line-height: 40px; font-weight: 550; letter-spacing: -.035em; }
+.header > div > p:last-child:not(.eyebrow) { color: var(--muted); font-size: 14px; line-height: 20px; }
+.toolbar { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin: 16px 0 24px; }
+.toolbar > p { margin: 0; color: var(--muted); font-size: 14px; line-height: 20px; }
+.tools { position: relative; flex-shrink: 0; z-index: 5; }
+.tools > summary { display: flex; align-items: center; justify-content: center; gap: 8px; min-height: 44px; border: 1px solid var(--review-line); border-radius: 8px; padding: 8px 12px; cursor: pointer; font-size: 14px; line-height: 20px; list-style: none; box-sizing: border-box; background: var(--review-panel); }
+.tools > summary::-webkit-details-marker { display: none; }
+.tools[open] > summary { background: var(--review-subtle); }
+.toolsMenu { position: absolute; right: 0; top: calc(100% + 8px); width: min(336px, calc(100vw - 48px)); padding: 16px; border: 1px solid var(--review-line); border-radius: 12px; background: var(--review-panel); box-shadow: 0 12px 32px #0002; }
+.textLink { color: var(--text); display: flex; align-items: center; justify-content: space-between; gap: 8px; min-height: 44px; font-size: 14px; text-decoration: none; }
+.sessionExport { margin: 12px 0 0; }
+.sessionExport p { max-width: 60ch; margin: 8px 0 0; }
+.sessionExport [role=status]:empty { display: none; }
+.sessionExport .secondary { width: 100%; }
+.primary, .secondary, .iconButton, .textButton, .fileButton, .backToInbox { font: inherit; cursor: pointer; display: inline-flex; justify-content: center; align-items: center; gap: 8px; min-height: 44px; transition: background-color 160ms var(--review-ease), border-color 160ms var(--review-ease), color 160ms var(--review-ease); }
+.primary, .secondary { border: 1px solid var(--review-line); border-radius: 8px; font-size: 14px; line-height: 20px; font-weight: 550; padding: 8px 16px; }
+.primary { background: var(--brand-pink-action); color: var(--brand-pink-ink); border-color: var(--brand-pink-action); font-size: 16px; line-height: 24px; }
+.secondary { background: var(--review-panel); color: var(--text); }
 .page button:disabled, .page fieldset:disabled { cursor: default; opacity: .5; }
-.page button:focus-visible, .page a:focus-visible, .page input:focus-visible, .page select:focus-visible, .page textarea:focus-visible, .page summary:focus-visible, .page pre:focus-visible { outline: 2px solid var(--brand-pink); outline-offset: 4px; }
-.workspace { display: grid; grid-template-columns: 292px minmax(0, 1fr); gap: 22px; align-items: start; }
-.inbox, .detail { border: 1px solid var(--review-line); background: var(--surface); border-radius: 12px; min-width: 0; }
-:global(html[data-theme="dark"]) .inbox, :global(html[data-theme="dark"]) .detail { --muted: #b3b0ad; }
-.inbox { overflow: hidden; }
-.inboxHeading { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; padding: 20px 18px 16px; }
-.inboxHeading h2 { font-size: 14px; font-weight: 600; margin: 0; }
-.inboxHeading > span { font-size: 12px; color: var(--muted); }
-.submissions { list-style: none; margin: 0; padding: 0; }
-.submission { width: 100%; background: transparent; border: 0; border-top: 1px solid var(--review-line); color: var(--text); cursor: pointer; text-align: left; padding: 17px 18px; display: grid; justify-items: start; gap: 7px; font: inherit; border-inline-start: 2px solid transparent; }
-.submission strong { font-size: 14px; font-weight: 550; overflow-wrap: anywhere; }
-.submission > .muted, .identifier { font-size: 12px; }
-.identifier { color: var(--muted); font-variant-numeric: tabular-nums; }
-.submission:hover { background: color-mix(in srgb, var(--text) 3%, transparent); }
-.submission[aria-current] { background: color-mix(in srgb, var(--text) 5%, transparent); border-inline-start-color: var(--brand-pink); }
-.badge { display: inline-flex; align-items: center; border: 1px solid var(--review-line); padding: 4px 7px; border-radius: 5px; color: var(--muted); font-size: 12px; line-height: 1.2; }
-.badge[data-state=built], .badge[data-state=accepted] { color: var(--text); }
+.page button:focus-visible, .page a:focus-visible, .page input:focus-visible, .page select:focus-visible, .page textarea:focus-visible, .page summary:focus-visible, .page pre:focus-visible { outline: 2px solid var(--brand-pink); outline-offset: 3px; }
+.workspace { display: grid; grid-template-columns: 328px minmax(0, 1fr); gap: 24px; align-items: start; }
+.inbox, .detail { border: 1px solid var(--review-line); background: var(--review-panel); border-radius: 16px; min-width: 0; }
+.inbox { position: sticky; top: 104px; overflow: hidden; }
+.inboxHeading { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; padding: 24px 20px 16px; }
+.inboxHeading h2 { font-size: 16px; line-height: 24px; font-weight: 550; margin: 0; }
+.inboxHeading > span { font-size: 12px; line-height: 16px; color: var(--muted); }
+.search, .fileSearch { display: flex; align-items: center; gap: 8px; min-height: 44px; padding: 0 12px; border: 1px solid var(--review-line); border-radius: 8px; color: var(--muted); background: var(--review-subtle); }
+.search { margin: 0 16px 8px; }
+.search input, .fileSearch input { min-width: 0; width: 100%; min-height: 44px; padding: 8px 0; box-sizing: border-box; border: 0; border-radius: 4px; background: transparent; color: var(--text); font: inherit; font-size: 16px; line-height: 24px; }
+.search input::placeholder, .fileSearch input::placeholder { color: var(--muted); opacity: 1; }
+.search > svg, .fileSearch > svg { flex-shrink: 0; }
+.filters { display: flex; gap: 4px; padding: 0 16px 12px; }
+.filters button { flex: 1; min-height: 44px; border: 0; border-radius: 8px; color: var(--muted); background: transparent; font: inherit; font-size: 14px; cursor: pointer; }
+.filters button[aria-pressed=true] { color: var(--text); background: var(--review-subtle); font-weight: 550; }
+.submissions { list-style: none; margin: 0; padding: 0 8px 8px; max-height: calc(100dvh - 414px); min-height: 240px; overflow-y: auto; overscroll-behavior: contain; scrollbar-width: thin; scrollbar-color: var(--review-line) transparent; }
+.submission { width: 100%; background: transparent; border: 1px solid transparent; border-radius: 8px; color: var(--text); cursor: pointer; text-align: left; padding: 16px 12px; display: grid; justify-items: start; gap: 8px; font: inherit; transition: background-color 150ms var(--review-ease), border-color 150ms var(--review-ease); }
+.submissionHeading { display: flex; align-items: center; justify-content: space-between; gap: 12px; width: 100%; min-width: 0; }
+.submissionHeading strong { font-size: 16px; line-height: 24px; font-weight: 550; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.submissionHeading > svg { flex-shrink: 0; color: var(--muted); }
+.submissionMeta { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; width: 100%; color: var(--muted); font-size: 12px; line-height: 16px; }
+.submissionMeta > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.submissionMeta time { flex-shrink: 0; }
+.submission[aria-current] { background: color-mix(in srgb, var(--brand-pink) 8%, var(--review-panel)); border-color: color-mix(in srgb, var(--brand-pink) 36%, var(--review-line)); }
+.submission[aria-current] .submissionHeading > svg { color: var(--brand-pink); }
+.badge { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: 12px; line-height: 16px; font-weight: 500; }
+.badge > span { width: 6px; height: 6px; background: currentColor; border-radius: 50%; flex-shrink: 0; }
+.badge[data-state=built], .badge[data-state=accepted] { color: var(--success); }
 .badge[data-state=build_failed], .badge[data-state=rejected] { color: var(--danger); }
-.pagination { border-top: 1px solid var(--review-line); display: flex; align-items: center; justify-content: space-between; padding: 7px 10px; }
-.pagination > span { font-size: 12px; color: var(--muted); }
-.iconButton { width: 44px; background: none; border: 0; border-radius: 6px; color: var(--text); }
-.detail { padding: 28px; }
-.detailTitle { font-size: 28px; letter-spacing: -.035em; line-height: 1.18; margin: 0; font-weight: 550; overflow-wrap: anywhere; }
-.detailTitle > span { color: var(--muted); font-size: 14px; font-weight: 400; letter-spacing: 0; white-space: nowrap; }
-.detailTitle:focus, .confirmation h4:focus { outline: none; }
-.detailMeta { display: flex; align-items: center; gap: 10px; margin: 14px 0 22px; color: var(--muted); font-size: 12px; flex-wrap: wrap; }
-.identities { display: grid; gap: 14px; margin: 0; }
-.hash { min-width: 0; margin: 12px 0; }
-.hash dt { color: var(--muted); font-size: 12px; margin-bottom: 6px; }
-.hash dd { font-family: var(--font-geist-mono, ui-monospace), monospace; font-size: 12px; line-height: 1.65; overflow-wrap: anywhere; margin: 0; }
-.section { margin-top: 28px; padding-top: 24px; border-top: 1px solid var(--review-line); }
-.section h3 { font-size: 16px; font-weight: 550; letter-spacing: -.01em; margin: 0 0 12px; }
-.section p { font-size: 14px; line-height: 1.6; }
-.sectionHeading { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.badge[data-state=awaiting_plan], .badge[data-state=changes_requested] { color: var(--warning); }
+.badge[data-state=running], .badge[data-state=queued] { color: var(--brand-pink); }
+.pagination { border-top: 1px solid var(--review-line); display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; }
+.pagination > span { font-size: 12px; line-height: 16px; color: var(--muted); }
+.iconButton { width: 44px; flex-shrink: 0; background: none; border: 0; border-radius: 8px; color: var(--muted); padding: 0; }
+.detail { padding: 32px; min-height: 576px; position: relative; }
+.detailHeading { display: flex; align-items: center; gap: 16px; min-width: 0; }
+.moduleMark, .emptyMark { display: grid; place-items: center; flex-shrink: 0; color: var(--brand-pink); background: color-mix(in srgb, var(--brand-pink) 9%, var(--review-panel)); border: 1px solid color-mix(in srgb, var(--brand-pink) 18%, var(--review-line)); }
+.moduleMark { width: 56px; height: 56px; border-radius: 12px; }
+.detailTitle { font-size: 24px; line-height: 32px; letter-spacing: -.025em; margin: 0; font-weight: 550; overflow-wrap: anywhere; }
+.detailTitle:focus { outline: none; }
+.detailVersion { display: flex; flex-wrap: wrap; gap: 8px; font-size: 14px; line-height: 20px; color: var(--muted); margin: 4px 0 0; }
+.detailMeta { display: flex; align-items: center; gap: 16px; margin: 24px 0; color: var(--muted); font-size: 12px; line-height: 16px; flex-wrap: wrap; }
+.detailTabs { display: flex; gap: 24px; border-bottom: 1px solid var(--review-line); margin-bottom: 24px; }
+.detailTabs button { position: relative; padding: 8px 0 16px; min-height: 48px; background: transparent; border: 0; font: inherit; font-size: 14px; line-height: 20px; color: var(--muted); cursor: pointer; }
+.detailTabs button[aria-pressed=true] { color: var(--text); font-weight: 550; }
+.detailTabs button[aria-pressed=true]::after { content: ""; position: absolute; inset: auto 0 -1px; height: 2px; background: var(--brand-pink); border-radius: 2px; }
+.overview h3, .section h3 { font-size: 16px; line-height: 24px; font-weight: 550; margin: 0 0 12px; }
+.description { font-size: 16px; line-height: 24px; color: var(--text-soft); margin: 0; max-width: 65ch; text-wrap: pretty; }
+.identities { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin: 24px 0; }
+.walletIdentity { min-width: 0; }
+.walletIdentity dt { color: var(--muted); font-size: 12px; line-height: 16px; }
+.walletIdentity dd { display: flex; align-items: center; gap: 4px; margin: 0; font-size: 14px; line-height: 20px; font-variant-numeric: tabular-nums; }
+.hash { min-width: 0; margin: 16px 0; }
+.hash dt { color: var(--muted); font-size: 12px; line-height: 16px; margin-bottom: 8px; }
+.hash dd { font-family: var(--font-plex-mono), monospace; font-size: 12px; line-height: 20px; overflow-wrap: anywhere; margin: 0; }
+.reviewProgress { display: grid; margin: 8px 0 24px; }
+.reviewProgress > div { display: flex; align-items: start; gap: 12px; padding: 12px 0; }
+.stepMark { display: grid; place-items: center; width: 32px; height: 32px; flex-shrink: 0; border: 1px solid var(--review-line); border-radius: 50%; color: var(--muted); }
+.reviewProgress [data-complete=true] .stepMark { color: var(--success); border-color: color-mix(in srgb, var(--success) 22%, var(--review-line)); background: color-mix(in srgb, var(--success) 7%, var(--review-panel)); }
+.reviewProgress strong { display: block; font-size: 14px; line-height: 20px; font-weight: 550; }
+.reviewProgress p { margin: 4px 0 0; color: var(--muted); font-size: 14px; line-height: 20px; }
+.overviewActions { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 24px; }
+.section { margin: 0; min-width: 0; }
+.section p { font-size: 14px; line-height: 24px; }
+.sectionHeading { display: flex; align-items: center; justify-content: space-between; gap: 16px; min-height: 44px; }
 .sectionHeading h3 { margin-bottom: 0; }
-.sectionHeading strong { font-size: 12px; overflow-wrap: anywhere; }
-.capabilities { list-style: none; margin: 14px 0; padding: 0; display: flex; flex-wrap: wrap; gap: 7px; }
-.capabilities li { padding: 5px 8px; border: 1px solid var(--review-line); border-radius: 5px; font-size: 12px; overflow-wrap: anywhere; }
-.disclosure { margin-top: 14px; border-top: 1px solid var(--review-line); }
-.disclosure summary { cursor: pointer; min-height: 44px; padding: 14px 0; font-size: 12px; line-height: 1.4; color: var(--muted); }
-.disclosure[open] summary { color: var(--text); }
-.disclosure pre, .sourceViewer pre { background: color-mix(in srgb, var(--surface) 75%, #000); border: 1px solid var(--review-line); border-radius: 6px; margin: 4px 0 14px; padding: 14px; max-height: 460px; overflow: auto; font-size: 12px; line-height: 1.65; tab-size: 2; }
-.files { list-style: none; margin: 16px 0; padding: 0; }
+.sectionHeading strong { font-size: 14px; line-height: 20px; overflow-wrap: anywhere; }
+.capabilities { list-style: none; margin: 16px 0; padding: 0; display: flex; flex-wrap: wrap; gap: 8px; }
+.capabilities li { padding: 8px; background: var(--review-subtle); border-radius: 4px; font-size: 12px; line-height: 16px; overflow-wrap: anywhere; }
+.disclosure { margin-top: 16px; border-top: 1px solid var(--review-line); }
+.disclosure summary { cursor: pointer; min-height: 44px; padding: 12px 0; font-size: 14px; line-height: 20px; color: var(--muted); box-sizing: border-box; }
+.disclosure[open] > summary { color: var(--text); }
+.disclosure pre, .sourceViewer pre { background: var(--review-subtle); border: 1px solid var(--review-line); border-radius: 8px; margin: 8px 0 16px; padding: 16px; max-height: 460px; overflow: auto; font-size: 12px; line-height: 20px; tab-size: 2; }
+.fileSearch { margin-top: 16px; }
+.files { list-style: none; margin: 16px 0; padding: 0; max-height: 360px; overflow: auto; scrollbar-width: thin; overscroll-behavior: contain; }
 .files li { display: flex; align-items: center; justify-content: space-between; gap: 12px; border-bottom: 1px solid var(--review-line); }
-.files li > span { color: var(--muted); font-size: 12px; white-space: nowrap; }
-.fileButton, .textButton { border: 0; background: none; color: var(--text); padding: 5px 0; font-size: 12px; text-align: left; justify-content: start; overflow-wrap: anywhere; }
-.fileButton:hover, .textButton:hover { text-decoration: underline; text-underline-offset: 4px; }
-.buildResult { display: flex; align-items: center; gap: 8px; }
+.files li > span { color: var(--muted); font-size: 12px; line-height: 16px; white-space: nowrap; padding-right: 8px; }
+.fileButton, .textButton { border: 0; background: none; color: var(--text); padding: 8px 0; font-size: 14px; line-height: 20px; text-align: left; justify-content: start; overflow-wrap: anywhere; }
+.fileButton { min-width: 0; flex: 1; padding-right: 8px; }
+.fileButton > svg { flex-shrink: 0; color: var(--muted); }
+.fileButton > span { overflow-wrap: anywhere; min-width: 0; }
+.sourceViewer { margin-top: 24px; }
+.buildResult { display: flex; align-items: center; gap: 8px; color: var(--success); }
+.checksEmpty { display: flex; align-items: start; gap: 16px; padding: 24px 0; color: var(--muted); }
+.checksEmpty svg { flex-shrink: 0; margin-top: 4px; }
+.checksEmpty h4 { margin: 0; color: var(--text); font-size: 16px; line-height: 24px; font-weight: 550; }
+.checksEmpty p { margin: 8px 0 0; }
 .testTable { max-width: 100%; overflow-x: auto; margin: 16px 0 8px; }
-.testTable table { width: 100%; border-collapse: collapse; font-size: 12px; text-align: left; white-space: nowrap; }
-.testTable th, .testTable td { padding: 9px 8px; border-bottom: 1px solid var(--review-line); }
+.testTable table { width: 100%; border-collapse: collapse; font-size: 12px; line-height: 20px; text-align: left; white-space: nowrap; }
+.testTable th, .testTable td { padding: 12px 8px; border-bottom: 1px solid var(--review-line); }
 .testTable th { color: var(--muted); font-weight: 450; }
-.testTable caption { text-align: left; margin-bottom: 10px; color: var(--muted); }
-.caption { overflow-wrap: anywhere; color: var(--muted); font-size: 12px !important; line-height: 1.6; }
+.testTable caption { text-align: left; margin-bottom: 12px; color: var(--muted); }
+.caption { overflow-wrap: anywhere; color: var(--muted); font-size: 12px; line-height: 20px; }
 .muted { color: var(--muted); }
-.note { background: color-mix(in srgb, var(--text) 4%, transparent); border-inline-start: 2px solid var(--review-line); padding: 12px 14px; font-size: 12px; line-height: 1.6; color: var(--muted); }
-.importField, .decisionFields { display: grid; gap: 10px; padding: 0; margin: 18px 0; border: 0; min-width: 0; }
-.importField label, .decisionFields > label { font-size: 12px; }
-.importField textarea, .decisionFields textarea, .decisionFields select { width: 100%; box-sizing: border-box; border: 1px solid var(--review-line); border-radius: 7px; background: var(--canvas); color: var(--text); padding: 12px; font: inherit; font-size: 14px; resize: vertical; min-height: 44px; }
-.importField textarea { font-family: ui-monospace, monospace; font-size: 12px; }
-.importField input[type=file] { font-size: 12px; color: var(--muted); max-width: 100%; }
-.importField input::file-selector-button { min-height: 44px; margin-right: 12px; border: 1px solid var(--review-line); background: transparent; color: var(--text); padding: 8px 12px; border-radius: 6px; cursor: pointer; }
-.decisionFields > .primary { justify-self: start; margin-top: 5px; }
-.decisionFields > .caption { margin: -3px 0 6px; }
-.checkbox { display: flex; align-items: center; gap: 10px; min-height: 44px; line-height: 1.5; cursor: pointer; }
-.checkbox input { width: 17px; height: 17px; accent-color: var(--brand-pink); flex-shrink: 0; }
-.confirmation { border: 1px solid var(--review-line); border-radius: 8px; padding: 20px; margin: 22px 0; background: color-mix(in srgb, var(--text) 3%, transparent); }
-.confirmation h4 { font-size: 20px; font-weight: 500; letter-spacing: -.025em; margin: 0 0 16px; }
+.note { background: var(--review-subtle); border: 1px solid var(--review-line); border-radius: 8px; padding: 16px; font-size: 14px; line-height: 24px; color: var(--muted); }
+.importField, .decisionFields { display: grid; gap: 12px; padding: 0; margin: 24px 0; border: 0; min-width: 0; }
+.importField label, .decisionFields > label { font-size: 14px; line-height: 20px; }
+.importField textarea, .decisionFields textarea, .decisionFields select { width: 100%; box-sizing: border-box; border: 1px solid var(--review-line); border-radius: 8px; background: var(--review-subtle); color: var(--text); padding: 12px; font: inherit; font-size: 16px; line-height: 24px; resize: vertical; min-height: 44px; }
+.importField textarea { font-family: var(--font-plex-mono), monospace; font-size: 12px; line-height: 20px; }
+.importField input[type=file] { font-size: 14px; color: var(--muted); max-width: 100%; }
+.importField input::file-selector-button { min-height: 44px; margin-right: 12px; border: 1px solid var(--review-line); background: var(--review-subtle); color: var(--text); padding: 8px 12px; border-radius: 8px; cursor: pointer; }
+.decisionFields > .primary { justify-self: start; margin-top: 8px; }
+.decisionFields > .caption { margin: 0 0 8px; }
+.checkbox { display: flex; align-items: center; gap: 12px; min-height: 44px; font-size: 14px; line-height: 24px; cursor: pointer; }
+.checkbox input { width: 20px; height: 20px; accent-color: var(--brand-pink); flex-shrink: 0; }
+.confirmation { border: 1px solid var(--review-line); border-radius: 12px; padding: 24px; margin: 24px 0; background: var(--review-subtle); }
+.confirmation h4 { font-size: 20px; line-height: 28px; font-weight: 550; margin: 0 0 16px; }
 .confirmReason { white-space: pre-wrap; overflow-wrap: anywhere; }
-.actions { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 18px; }
-.error { color: var(--danger); font-size: 14px; line-height: 1.6; overflow-wrap: anywhere; }
-.success { color: var(--text); font-size: 14px; line-height: 1.6; }
-.history { list-style: none; padding: 0; margin: 10px 0; display: grid; gap: 16px; }
-.history > li { border-inline-start: 1px solid var(--review-line); padding-left: 16px; min-width: 0; }
-.history strong { font-size: 12px; display: block; margin-bottom: 7px; }
-.history span { color: var(--muted); font-size: 12px; overflow-wrap: anywhere; }
-.gate { max-width: 600px; padding: 54px 0; }
-.gateMark { border: 1px solid var(--review-line); border-radius: 9px; color: var(--brand-pink); width: 42px; height: 42px; display: grid; place-items: center; margin-bottom: 28px; font-size: 17px; }
-.gate h2, .selectionEmpty h2 { font-size: 25px; font-weight: 500; letter-spacing: -.035em; margin: 0 0 12px; }
-.gate p, .selectionEmpty > p { font-size: 14px; color: var(--muted); line-height: 1.7; max-width: 52ch; }
-.gate > button { margin-top: 18px; }
-.empty { color: var(--muted); padding: 18px; font-size: 12px; line-height: 1.7; }
-.selectionEmpty { padding: 42px 10px 64px; }
-.selectionEmpty .note { margin-top: 36px; }
+.actions { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 16px; }
+.error { color: var(--danger); font-size: 14px; line-height: 24px; overflow-wrap: anywhere; }
+.success { color: var(--success); font-size: 14px; line-height: 24px; }
+.history { list-style: none; padding: 0; margin: 16px 0; display: grid; gap: 24px; }
+.history > li { border-inline-start: 2px solid var(--review-line); padding-left: 16px; min-width: 0; }
+.history strong { font-size: 16px; line-height: 24px; display: block; margin-bottom: 8px; font-weight: 550; }
+.history span { color: var(--muted); font-size: 12px; line-height: 20px; overflow-wrap: anywhere; }
+.gate { max-width: 600px; padding: 64px 0; }
+.gateMark { border: 1px solid var(--review-line); border-radius: 12px; color: var(--brand-pink); width: 56px; height: 56px; display: grid; place-items: center; margin-bottom: 24px; }
+.gate h2, .selectionEmpty h2 { font-size: 24px; line-height: 32px; font-weight: 550; letter-spacing: -.025em; margin: 0 0 12px; }
+.gate p, .selectionEmpty > p { font-size: 16px; color: var(--muted); line-height: 24px; max-width: 36ch; text-wrap: pretty; }
+.gate > button { margin-top: 16px; }
+.empty { display: grid; justify-items: start; padding: 24px; color: var(--muted); }
+.empty h3 { font-size: 16px; line-height: 24px; font-weight: 550; margin: 16px 0 0; color: var(--text); }
+.empty p { font-size: 14px; line-height: 20px; margin: 8px 0; }
+.selectionEmpty { min-height: 510px; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 24px; text-align: center; }
+.emptyMark { width: 80px; height: 80px; border-radius: 16px; margin-bottom: 24px; }
+.selectionEmpty p { margin: 0; }
+.queueSkeleton { padding: 8px 20px 24px; }
+.queueSkeleton > div { display: grid; gap: 12px; padding: 20px 0; }
+.queueSkeleton span:not(.srOnly) { display: block; height: 16px; width: 76%; border-radius: 4px; background: var(--review-subtle); }
+.queueSkeleton span:not(.srOnly):last-child { width: 45%; height: 12px; }
+.loadingDetail { color: var(--muted); font-size: 14px; line-height: 20px; margin: 0 0 16px; }
+.backToInbox { display: none; }
+.mobileDetailTools { display: none; }
 .srOnly { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
-@media (max-width: 900px) { .workspace { grid-template-columns: 250px minmax(0, 1fr); gap: 14px; } .detail { padding: 22px; } }
-@media (max-width: 700px) {
-  .page { padding: 28px 16px 70px; } .header { align-items: start; flex-direction: column; gap: 12px; } .header h1 { font-size: 40px; } .header > div > p:last-child { font-size: 14px; }
-  .workspace { grid-template-columns: minmax(0, 1fr); gap: 18px; } .submissions { max-height: 340px; overflow-y: auto; } .detail { padding: 22px 18px; } .detailTitle { font-size: 26px; }
-  .toolbar { gap: 10px; } .toolbar p { font-size: 12px; } .toolbar .muted { display: block; margin-top: 6px; } .sectionHeading { align-items: start; flex-wrap: wrap; }
-  .importField textarea, .decisionFields textarea, .decisionFields select { font-size: 16px; } .importField input[type=file] { font-size: 12px; } .confirmation { padding: 16px; }
-  .selectionEmpty { padding: 22px 0 32px; } .gate { padding: 36px 0; } .actions > button { flex: 1; } .hash dd { font-size: 12px; }
+@media (hover: hover) and (pointer: fine) {
+  .primary:not(:disabled):hover { background: var(--brand-pink-hover); border-color: var(--brand-pink-hover); }
+  .secondary:not(:disabled):hover, .iconButton:not(:disabled):hover, .tools > summary:hover { background: var(--review-subtle); }
+  .submission:not(:disabled):not([aria-current]):hover { background: var(--review-subtle); }
+  .textLink:hover, .textButton:hover, .fileButton:hover, .detailTabs button:hover { color: var(--brand-pink); }
+  .filters button:not([aria-pressed=true]):hover { color: var(--text); background: var(--review-subtle); }
+}
+@media (max-width: 1024px) { .workspace { grid-template-columns: 280px minmax(0, 1fr); gap: 16px; } .detail { padding: 24px; } .identities { grid-template-columns: 1fr; gap: 8px; } }
+@media (max-width: 760px) {
+  .page { padding: 24px 16px 64px; } .header { gap: 16px; } .header h1 { font-size: 30px; line-height: 36px; } .eyebrow { margin-bottom: 4px; }
+  .toolbar { margin: 16px 0; } .toolbar > p { max-width: 24ch; }
+  .workspace { grid-template-columns: minmax(0, 1fr); gap: 0; }
+  .inbox { position: static; } .submissions { max-height: none; min-height: 240px; }
+  .detail { display: none; padding: 24px 16px; min-height: 480px; }
+  .workspace[data-selected=true] .inbox { display: none; } .workspace[data-selected=true] .detail { display: block; }
+  .backToInbox { display: inline-flex; border: 0; background: transparent; color: var(--muted); padding: 0; margin: -8px 0 16px; font-size: 14px; line-height: 20px; }
+  .detailHeading { gap: 12px; align-items: start; } .moduleMark { width: 44px; height: 44px; border-radius: 8px; }
+  .detailTitle { font-size: 20px; line-height: 28px; } .detailVersion { font-size: 12px; line-height: 16px; gap: 4px 8px; }
+  .detailTabs { gap: 0; justify-content: space-between; margin-inline: -4px; } .detailTabs button { padding: 8px 4px 12px; min-height: 44px; }
+  .detailMeta { margin: 20px 0 12px; } .identities { grid-template-columns: 1fr 1fr; gap: 12px; }
+  .walletIdentity dd { font-size: 12px; line-height: 20px; gap: 0; } .walletIdentity .iconButton { width: 32px; min-width: 32px; }
+  .sectionHeading { align-items: start; flex-wrap: wrap; gap: 12px; } .sectionHeading .secondary { padding-inline: 12px; }
+  .importField textarea { font-size: 16px; line-height: 24px; } .confirmation { padding: 16px; }
+  .overviewActions { gap: 8px; } .overviewActions button { flex: 1; padding-inline: 12px; }
+  .gate { padding: 40px 0; } .actions > button { flex: 1; } .toolsMenu { width: min(320px, calc(100vw - 64px)); }
+}
+@media (max-width: 360px) { .header h1 { font-size: 24px; line-height: 32px; } .identities { grid-template-columns: 1fr; } .detail { padding-inline: 16px; } .overviewActions { flex-direction: column; } }
+@media (prefers-reduced-motion: reduce) { .page *, .page *::before, .page *::after { transition: none !important; scroll-behavior: auto !important; } }
+
+/* Keep the review inbox in one viewport; long evidence scrolls inside its panel. */
+:global(.app-frame):has(.page[data-module-review-page]) :global([data-site-footer]) { display: none; }
+:global(.app-frame):has(.page[data-module-review-page]) :global(.route-transition) { min-height: 0; }
+:global(.app-frame):has(.page[data-module-review-page]) :global(#main-content) { padding-bottom: 0; }
+.page[data-module-review-page] { height: calc(100dvh - var(--header-height)); display: flex; flex-direction: column; padding-block: 24px; box-sizing: border-box; overflow: hidden; }
+.page[data-module-review-page] > .header, .page[data-module-review-page] > .toolbar { flex-shrink: 0; }
+.page[data-module-review-page] > .header { margin-bottom: 24px; }
+.page[data-module-review-page] .inboxHeading { align-items: center; padding-block: 12px 8px; }
+.page[data-module-review-page] .workspace { flex: 1; min-height: 0; align-items: stretch; }
+.page[data-module-review-page] .inbox { position: static; display: flex; flex-direction: column; min-height: 0; }
+.page[data-module-review-page] .inboxHeading, .page[data-module-review-page] .search, .page[data-module-review-page] .filters, .page[data-module-review-page] .pagination { flex-shrink: 0; }
+.page[data-module-review-page] .submissions { flex: 1; min-height: 0; max-height: none; }
+.page[data-module-review-page] .detail { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+.page[data-module-review-page] .detailHeading, .page[data-module-review-page] .detailMeta, .page[data-module-review-page] .detailTabs, .page[data-module-review-page] .backToInbox { flex-shrink: 0; }
+.page[data-module-review-page] .editor { display: flex; flex-direction: column; flex: 1; min-height: 0; }
+.page[data-module-review-page] .editorBody { flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; padding: 4px; margin: -4px; scrollbar-width: thin; scrollbar-color: var(--review-line) transparent; overscroll-behavior: contain; }
+.page[data-module-review-page] .selectionEmpty { flex: 1; min-height: 0; }
+.page[data-module-review-page] .gate { overflow-y: auto; min-height: 0; }
+@media (max-width: 760px) {
+  .page[data-module-review-page] { padding-block: 16px; width: calc(100% - 24px); padding-inline: 0; }
+  .page[data-module-review-page] .detail { display: none; padding-block: 16px; }
+  .page[data-module-review-page] .workspace[data-selected=true] .inbox { display: none; }
+  .page[data-module-review-page] .workspace[data-selected=true] .detail { display: flex; }
+  .page[data-module-review-page] .toolbar { margin: 12px 0; }
+  .page[data-module-review-page] .detailHeading { gap: 12px; }
+  .page[data-module-review-page] > .header { margin-bottom: 16px; }
+  .page[data-module-review-page] .mobileDetailTools { display: flex; justify-content: space-between; align-items: center; flex-shrink: 0; margin: -8px -4px 8px 0; }
+  .page[data-module-review-page] .backToInbox { margin: 0; }
+}
+@media (max-height: 700px) and (min-width: 761px) {
+  .page[data-module-review-page] { padding-block: 16px; }
+  .page[data-module-review-page] .header h1 { font-size: 30px; line-height: 36px; }
+  .page[data-module-review-page] .toolbar { margin: 8px 0 16px; }
+  .page[data-module-review-page] .detail { padding: 24px; }
+  .page[data-module-review-page] .detailMeta { margin: 16px 0; }
+}
+
+/* Primary actions remain visible while supporting evidence scrolls. */
+.page[data-module-review-page] .overviewActions { flex-shrink: 0; margin: 16px 0 0; padding-top: 16px; border-top: 1px solid var(--review-line); }
+.page[data-module-review-page] .reviewProgress { grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; margin: 8px 0 16px; }
+.page[data-module-review-page] .reviewProgress > div { flex-direction: column; gap: 8px; padding: 0; }
+.page[data-module-review-page] .reviewProgress p { display: none; }
+.page[data-module-review-page] .toolsMenu { max-height: calc(100dvh - 220px); overflow-y: auto; }
+@media (max-width: 760px) {
+  .page[data-module-review-page] .overviewActions { margin-top: 12px; padding-top: 12px; }
+  .page[data-module-review-page] .reviewProgress { gap: 8px; }
+  .page[data-module-review-page] .reviewProgress strong { font-size: 12px; line-height: 16px; }
+}
+
+.page[data-module-review-page] .overviewActions .primary { white-space: nowrap; flex-grow: 1.2; }
+.page[data-module-review-page] .overviewActions .secondary { white-space: nowrap; }
+@media (min-width: 761px) { .page[data-module-review-page] .overviewActions .primary { flex-grow: 0; } }
+@media (max-width: 360px) {
+  .page[data-module-review-page] .overviewActions { flex-direction: row; }
+  .page[data-module-review-page] .overviewActions button { font-size: 14px; line-height: 20px; padding-inline: 8px; }
+}
+@media (max-height: 700px) and (max-width: 760px) {
+  .page[data-module-review-page] .eyebrow, .page[data-module-review-page] .toolbar > p { display: none; }
+  .page[data-module-review-page] .toolbar { justify-content: end; margin-block: 8px; }
+  .page[data-module-review-page] .detail { padding-block: 12px; }
+}
+@media (max-height: 540px) {
+  .page[data-module-review-page] { padding-block: 8px; }
+  .page[data-module-review-page] > .header { margin-bottom: 8px; }
+  .page[data-module-review-page] .detailMeta { margin-block: 8px; }
+  .page[data-module-review-page] .detailTabs { margin-bottom: 12px; }
+  .page[data-module-review-page] .overviewActions { margin-top: 8px; padding-top: 8px; }
 }

--- a/components/module-review-admin-console.tsx
+++ b/components/module-review-admin-console.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type FormEvent } from "react";
-import { ArrowDownToLine, ArrowLeft, ArrowRight, Check, RefreshCw } from "lucide-react";
+import { ArrowDownToLine, ArrowLeft, ArrowRight, Check, ChevronDown, Clipboard, Clock3, FileCode2, Inbox, Puzzle, RefreshCw, Search, Settings2, ShieldCheck } from "lucide-react";
 import { useWallet } from "@/components/wallet-provider";
 import { isWebsiteAdminWallet } from "@/lib/admin-access";
 import { isReviewDigest, parseReviewPlan, reviewStateLabel, type ModuleReviewDecisionCommandV1, type ModuleReviewDecisionRecordV1, type ReviewDetail, type ReviewManifestCheck, type ReviewQueue } from "@/lib/module-mode/review-contract";
@@ -34,9 +34,21 @@ function download(text: string, filename: string) {
     const link = document.createElement("a"); link.href = url; link.download = filename; link.click();
   } finally { window.setTimeout(() => URL.revokeObjectURL(url), 1000); }
 }
-function Status({ state }: { state: ReviewState }) { return <span className={styles.badge} data-state={state}>{reviewStateLabel(state)}</span>; }
+const dateFormat = new Intl.DateTimeFormat("en", { day: "numeric", month: "short", timeZone: "UTC" });
+function submittedDate(value: string) { return dateFormat.format(new Date(value)); }
+function Status({ state }: { state: ReviewState }) {
+  const label = ({ awaiting_plan: "Needs checks", queued: "Checks queued", running: "Checking", build_failed: "Checks failed" } as Partial<Record<ReviewState, string>>)[state] ?? reviewStateLabel(state);
+  return <span className={styles.badge} data-state={state}><span aria-hidden="true" />{label}</span>;
+}
 function Hash({ label, value }: { label: string; value: string }) { return <div className={styles.hash}><dt>{label}</dt><dd>{value}</dd></div>; }
 function JsonView({ title, value }: { title: string; value: unknown }) { return <details className={styles.disclosure}><summary>{title}</summary><pre tabIndex={0}>{json(value)}</pre></details>; }
+function WalletIdentity({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false);
+  const [failed, setFailed] = useState(false);
+  return <div className={styles.walletIdentity}><dt>{label}</dt><dd><span title={value}>{short(value)}</span><button type="button" className={styles.iconButton} aria-label={`Copy ${label.toLowerCase()}`} title="Copy address" onClick={() => {
+    void navigator.clipboard.writeText(value).then(() => { setCopied(true); setFailed(false); }, () => { setFailed(true); });
+  }}>{copied ? <Check size={16} aria-hidden="true" /> : <Clipboard size={16} aria-hidden="true" />}</button></dd><span className={failed ? styles.error : styles.srOnly} role="status">{failed ? `Copy unavailable. ${value}` : copied ? `${label} copied` : ""}</span></div>;
+}
 const AREA_LABELS: Record<string, string> = {
   "complete-constructor-accepted-configuration-range": "All accepted constructor configurations",
   "external-calls-and-mutable-dependencies": "External calls and mutable dependencies",
@@ -78,17 +90,22 @@ export function ModuleReviewAdminConsole() {
     }
     return asText ? text : JSON.parse(text);
   }, [account, getAccessToken, getIdentityToken]);
-  return <div className={`${styles.page} page-width`}>
+  return <div className={`${styles.page} page-width`} data-module-review-page>
     <header className={styles.header}>
-      <div><p className={styles.eyebrow}>Modules</p><h1>Admin Dashboard</h1></div>
-      <Link className={styles.textLink} href="/admin/partners">Partner access <ArrowRight size={15} aria-hidden="true" /></Link>
+      <div><p className={styles.eyebrow}>Admin</p><h1>Module reviews</h1></div>
+      <details className={styles.tools} onKeyDown={event => { if (event.key === "Escape") { event.currentTarget.open = false; event.currentTarget.querySelector("summary")?.focus(); } }}>
+        <summary><Settings2 size={17} aria-hidden="true" />Tools<ChevronDown size={14} aria-hidden="true" /></summary>
+        <div className={styles.toolsMenu}>
+          <Link className={styles.textLink} href="/admin/partners">Partner access <ArrowRight size={15} aria-hidden="true" /></Link>
+          {account && <PublicationSessionDownload ready={publicationReady} readSession={() => publicationSession.current}
+            getAccessToken={getAccessToken} getIdentityToken={getIdentityToken} />}
+        </div>
+      </details>
     </header>
     {account ? <>
-      <PublicationSessionDownload ready={publicationReady} readSession={() => publicationSession.current}
-        getAccessToken={getAccessToken} getIdentityToken={getIdentityToken} />
       <ModuleReviewWorkspace key={account} account={account} request={request} />
     </> : <section className={styles.gate}>
-      <div className={styles.gateMark} aria-hidden="true">M</div><h2>Admin wallet required</h2>
+      <div className={styles.gateMark} aria-hidden="true"><ShieldCheck size={24} /></div><h2>Connect your admin wallet</h2>
       <p>Connect the admin wallet to review submissions.</p>
       <button className={styles.primary} type="button" disabled={connecting} onClick={openWallet}>{connecting ? "Connecting…" : "Connect wallet"}</button>
     </section>}
@@ -137,9 +154,13 @@ export function ModuleReviewWorkspace({ account, request }: { account: string; r
   const [blocked, setBlocked] = useState(false);
   const [refresh, setRefresh] = useState(0);
   const [busy, setBusy] = useState(false);
+  const [queryText, setQueryText] = useState("");
+  const [filter, setFilter] = useState<"all" | "pending" | "approved">("all");
+  const [knownNames, setKnownNames] = useState<Record<string, { name: string; version: string }>>({});
   const lifetime = useRef<AbortController | null>(null);
   const selection = useRef(0);
   const heading = useRef<HTMLHeadingElement>(null);
+  const search = useRef<HTMLInputElement>(null);
   useEffect(() => { const controller = new AbortController(); lifetime.current = controller; return () => controller.abort(); }, []);
   const guardedRequest = useCallback<RequestReview>(async (...args) => {
     try { return await request(args[0], args[1], args[2] ?? lifetime.current?.signal, args[3]); }
@@ -164,28 +185,46 @@ export function ModuleReviewWorkspace({ account, request }: { account: string; r
     try {
       const value = await guardedRequest(`/${id}?walletAddress=${encodeURIComponent(account)}`) as ReviewDetail;
       if (value.schemaVersion !== "programmable.modules.website-review-detail.v1" || value.job.subject.submissionId !== id) throw new Error("The review detail response is invalid.");
-      if (selection.current === generation) { setDetail(value); window.requestAnimationFrame(() => heading.current?.focus()); }
+      if (selection.current === generation) {
+        setDetail(value);
+        setKnownNames(names => ({ ...names, [`${id}:${value.job.subject.requestDigest}`]: { name: value.source.descriptor.name, version: value.source.descriptor.version } }));
+        window.requestAnimationFrame(() => heading.current?.focus());
+      }
       return true;
     } catch (e) { if (selection.current === generation) setError(message(e)); return false; }
     finally { if (selection.current === generation) setDetailLoading(false); }
   }, [account, guardedRequest]);
   const current = detail?.job.subject.submissionId === selected ? detail : null;
+  const refreshQueue = () => { setLoading(true); setError(""); setRefresh(n => n + 1); if (selected) void loadDetail(selected); };
+  const jobs = queue?.jobs ?? [];
+  const visibleJobs = jobs.filter(job => {
+    const identity = job.sourceSummary ?? knownNames[`${job.subject.submissionId}:${job.subject.requestDigest}`];
+    const matchesState = filter === "all" || (filter === "approved" ? job.state === "accepted" : !["accepted", "rejected"].includes(job.state));
+    return matchesState && [identity?.name, identity?.version, job.subject.submissionId, job.subject.author].join(" ").toLowerCase().includes(queryText.trim().toLowerCase());
+  });
   return <>
-    <div className={styles.toolbar}><p>Private review inbox <span className={styles.muted}>· {short(account)}</span></p><button type="button" className={styles.secondary} disabled={loading || busy} onClick={() => { setLoading(true); setError(""); setRefresh(n => n + 1); if (selected) void loadDetail(selected); }}><RefreshCw size={14} aria-hidden="true" /> Refresh</button></div>
     {error && <p className={styles.error} role="alert">{error}</p>}
-    {blocked ? <section className={styles.gate}><h2>Review access required</h2><p>Use a wallet that is included in the module reviewer allowlist.</p></section> : <div className={styles.workspace}>
+    {blocked ? <section className={styles.gate}><h2>Review access required</h2><p>Connect an authorized admin wallet to continue.</p></section> : <div className={styles.workspace} data-selected={selected !== null}>
       <aside className={styles.inbox} aria-label="Module submissions" aria-busy={loading}>
-        <div className={styles.inboxHeading}><h2>Submissions</h2>{queue && <span>{queue.jobs.length} on this page</span>}</div>
-        {!queue && loading && <p className={styles.empty}>Loading submissions…</p>}
-        {queue?.jobs.length === 0 && <p className={styles.empty}>No submissions on this page. New API submissions appear here once they reach the review service.</p>}
-        <ul className={styles.submissions}>{queue?.jobs.map(job => <li key={job.subject.submissionId}><button type="button" className={styles.submission} aria-current={selected === job.subject.submissionId ? "true" : undefined} disabled={busy || loading} onClick={() => void loadDetail(job.subject.submissionId)}>
-          <strong>{job.build?.programName ?? "Module submission"}</strong><span className={styles.identifier}>{short(job.subject.submissionId)}</span><Status state={job.state} />
-          <span className={styles.muted}>{job.build ? `${job.build.caseCount} test ${job.build.caseCount === 1 ? "case" : "cases"} · ${job.build.testsPassed ? "Checks passed" : "Checks incomplete"}` : `Build attempt ${job.attempt}`}</span>
-        </button></li>)}</ul>
+        <div className={styles.inboxHeading}><h2>Submissions{queue && <span className={styles.srOnly}> · {queue.jobs.length} on this page</span>}</h2><button type="button" className={styles.iconButton} aria-label="Refresh" title="Refresh submissions" disabled={loading || busy} onClick={refreshQueue}><RefreshCw size={16} aria-hidden="true" /></button></div>
+        <label className={styles.search}><Search size={17} aria-hidden="true" /><span className={styles.srOnly}>Search this page by module, author or submission ID</span><input ref={search} type="search" placeholder="Search this page" value={queryText} onChange={event => setQueryText(event.target.value)} /></label>
+        <div className={styles.filters} aria-label="Filter submissions on this page">{([["all", "All"], ["pending", "Pending"], ["approved", "Approved"]] as const).map(([value, label]) => <button type="button" key={value} aria-pressed={filter === value} onClick={() => setFilter(value)}>{label}</button>)}</div>
+        {!queue && loading && <div className={styles.queueSkeleton} role="status"><span className={styles.srOnly}>Loading submissions</span>{[0, 1, 2, 3].map(item => <div key={item}><span /><span /></div>)}</div>}
+        {queue && visibleJobs.length === 0 && <div className={styles.empty}><Inbox size={24} aria-hidden="true" /><h3>{jobs.length ? "No matches on this page" : "No submissions yet"}</h3><p>{jobs.length ? "Try another name, filter or page." : "New module applications will appear here."}</p>{(queryText || filter !== "all") && <button type="button" className={styles.textButton} onClick={() => { setQueryText(""); setFilter("all"); }}>Clear filters</button>}</div>}
+        <ul className={styles.submissions}>{visibleJobs.map(job => {
+          const identity = job.sourceSummary ?? knownNames[`${job.subject.submissionId}:${job.subject.requestDigest}`];
+          return <li key={job.subject.submissionId}><button type="button" className={styles.submission} aria-current={selected === job.subject.submissionId ? "true" : undefined} disabled={busy || loading} onClick={() => void loadDetail(job.subject.submissionId)}>
+            <span className={styles.submissionHeading}><strong>{identity?.name ?? `Submission ${short(job.subject.submissionId)}`}</strong><ArrowRight size={15} aria-hidden="true" /></span>
+            <span className={styles.submissionMeta}><span>{identity ? `v${identity.version}` : `By ${short(job.subject.author)}`}</span><time dateTime={job.createdAt} title={job.createdAt}>{submittedDate(job.createdAt)}</time></span>
+            <Status state={job.state} />
+          </button></li>;
+        })}</ul>
         <div className={styles.pagination}><button className={styles.iconButton} aria-label="Previous page of submissions" disabled={!previous.length || busy || loading} onClick={() => { setLoading(true); setError(""); setCursor(previous.at(-1) ?? null); setPrevious(p => p.slice(0, -1)); }}><ArrowLeft size={17} /></button><span>Page {previous.length + 1}</span><button className={styles.iconButton} aria-label="Next page of submissions" disabled={!queue?.nextCursor || busy || loading} onClick={() => { setLoading(true); setError(""); setPrevious(p => [...p, cursor]); setCursor(queue!.nextCursor); }}><ArrowRight size={17} /></button></div>
       </aside>
       <section className={styles.detail} aria-busy={detailLoading} aria-label="Selected submission">
-        {detailLoading && <p className={styles.caption} role="status">Checking source and build evidence…</p>}{current ? <><h2 className={styles.detailTitle} ref={heading} tabIndex={-1}>{current.source.descriptor.name} <span>v{current.source.descriptor.version}</span></h2><ReviewEditor key={current.job.subject.submissionId} detail={current} account={account} request={guardedRequest} setParentBusy={setBusy} refresh={async () => { if (!await loadDetail(current.job.subject.submissionId)) throw new Error("The current review could not be refreshed."); setLoading(true); setRefresh(n => n + 1); }} /></> : <div className={styles.selectionEmpty}><p className={styles.eyebrow}>Source → Build → Decision</p><h2>Select a submission</h2><p>Each review keeps the submitted source, build results, and decision together.</p><p className={styles.note}>Review approval does not publish a module or approve it onchain.</p></div>}
+        {selected && <div className={styles.mobileDetailTools}><button type="button" className={styles.backToInbox} disabled={busy} onClick={() => { selection.current++; setSelected(null); setDetail(null); setDetailLoading(false); window.requestAnimationFrame(() => search.current?.focus()); }}><ArrowLeft size={17} aria-hidden="true" />All submissions</button><button type="button" className={styles.iconButton} aria-label="Refresh" title="Refresh submission" disabled={loading || busy} onClick={refreshQueue}><RefreshCw size={16} aria-hidden="true" /></button></div>}
+        {detailLoading && <p className={styles.loadingDetail} role="status">Loading submission…</p>}
+        {current ? <><div className={styles.detailHeading}><div className={styles.moduleMark}><Puzzle size={25} aria-hidden="true" /></div><div><h2 className={styles.detailTitle} ref={heading} tabIndex={-1}>{current.source.descriptor.name}</h2><p className={styles.detailVersion}>Version {current.source.descriptor.version}<span aria-hidden="true">·</span><time dateTime={current.job.createdAt}>Submitted {submittedDate(current.job.createdAt)}</time></p></div></div><ReviewEditor key={current.job.subject.submissionId} detail={current} account={account} request={guardedRequest} setParentBusy={setBusy} refresh={async () => { if (!await loadDetail(current.job.subject.submissionId)) throw new Error("The current review could not be refreshed."); setLoading(true); setRefresh(n => n + 1); }} /></> : !detailLoading && <div className={styles.selectionEmpty}><div className={styles.emptyMark}><Puzzle size={36} strokeWidth={1.4} aria-hidden="true" /></div><h2>Choose a module</h2><p>Open a submission to review its source, checks and next steps.</p></div>}
       </section>
     </div>}
   </>;
@@ -217,6 +256,8 @@ function ReviewEditor({ detail, account, request, refresh, setParentBusy }: { de
   const [receipt, setReceipt] = useState<ModuleReviewDecisionRecordV1 | null>(null);
   const [sourceText, setSourceText] = useState<string | null>(null);
   const [sourceFile, setSourceFile] = useState<string | null>(null);
+  const [fileQuery, setFileQuery] = useState("");
+  const [tab, setTab] = useState<"overview" | "source" | "checks" | "decision">("overview");
   const [seenRevision, setSeenRevision] = useState(job.reviewRevision);
   const operationLock = useRef(false);
   if (seenRevision !== job.reviewRevision) {
@@ -255,26 +296,39 @@ function ReviewEditor({ detail, account, request, refresh, setParentBusy }: { de
       artifactDigest: outcome === "accept" ? artifact!.artifactDigest : null, hostManifestHash: outcome === "accept" ? manifestCheck!.hostManifestHash : null, acknowledgedReviewAreas: outcome === "accept" ? areas : [] });
   };
   return <div className={styles.editor}>
-    <div className={styles.detailMeta}><Status state={job.state} /><span>Revision {job.reviewRevision}</span><span>Build attempt {job.attempt}</span></div>
-    <dl className={styles.identities}><Hash label="Author wallet" value={job.subject.author} /><Hash label="Reward wallet" value={source.descriptor.rewardWallet} /><Hash label="Submission" value={id} /></dl>
-    <section className={styles.section}><h3>What this module needs</h3><p>{source.descriptor.management.summary}</p><ul className={styles.capabilities}>{source.descriptor.requiresHost.map(capability => <li key={capability}>{capability}</li>)}</ul><JsonView title="Configuration, compatibility and management" value={{ configuration: source.descriptor.configuration, ports: source.descriptor.ports, constraints: source.descriptor.constraints, management: source.descriptor.management }} /></section>
-    <section className={styles.section}><div className={styles.sectionHeading}><h3>Submitted source</h3><button type="button" className={styles.secondary} disabled={busy !== null} onClick={() => void run("source", async () => download(await readSource(), `module-${id}.json`))}><ArrowDownToLine size={14} aria-hidden="true" /> Download source</button></div>
-      <ul className={styles.files}>{source.files.map(file => <li key={file.path}><button type="button" className={styles.fileButton} disabled={busy !== null} onClick={() => void run("source", async () => { await readSource(); setSourceFile(file.path); })}>{file.path}</button><span>{file.bytes.toLocaleString()} B</span></li>)}</ul>
+    <div className={styles.detailMeta}><Status state={job.state} /><span>{source.files.length} source files</span></div>
+    <nav className={styles.detailTabs} aria-label="Submission sections">{([["overview", "Overview"], ["source", "Source"], ["checks", "Checks"], ["decision", "Decision"]] as const).map(([value, label]) => <button type="button" key={value} aria-pressed={tab === value} onClick={() => setTab(value)}>{label}</button>)}</nav>
+    <div className={styles.editorBody}>
+    {tab === "overview" && <section className={styles.overview}>
+      <h3>About this module</h3><p className={styles.description}>{source.descriptor.management.summary}</p>
+      <dl className={styles.identities}><WalletIdentity label="Author wallet" value={job.subject.author} /><WalletIdentity label="Reward wallet" value={source.descriptor.rewardWallet} /></dl>
+      <div className={styles.reviewProgress} aria-label="Review progress">
+        <div data-complete="true"><span className={styles.stepMark}><Check size={16} aria-hidden="true" /></span><div><strong>Submission received</strong><p>Source and author recorded.</p></div></div>
+        <div data-complete={canApprove || job.state === "accepted"}><span className={styles.stepMark}>{canApprove || job.state === "accepted" ? <Check size={16} aria-hidden="true" /> : <FileCode2 size={17} aria-hidden="true" />}</span><div><strong>{canApprove || job.state === "accepted" ? "Build checks passed" : job.state === "build_failed" ? "Build needs attention" : ["queued", "running"].includes(job.state) ? "Build checks in progress" : "Build checks needed"}</strong><p>{artifact ? `${artifact.tests.cases.length} test ${artifact.tests.cases.length === 1 ? "case" : "cases"} recorded.` : ["queued", "running"].includes(job.state) ? "Refresh to see the latest result." : "Prepare a test plan for this module."}</p></div></div>
+        <div data-complete={job.state === "accepted" || job.state === "rejected"}><span className={styles.stepMark}>{terminal ? <Check size={16} aria-hidden="true" /> : <ShieldCheck size={17} aria-hidden="true" />}</span><div><strong>{job.state === "accepted" ? "Review approved" : job.state === "rejected" ? "Submission rejected" : job.state === "changes_requested" ? "Changes requested" : "Review decision"}</strong><p>{job.state === "accepted" ? "Ready for the separate publication process." : job.state === "rejected" || job.state === "changes_requested" ? "The decision is available to the author." : "Check the evidence and record your decision."}</p></div></div>
+      </div>
+
+      <details className={styles.disclosure}><summary>Technical details</summary><ul className={styles.capabilities}>{source.descriptor.requiresHost.map(capability => <li key={capability}>{capability}</li>)}</ul><dl><Hash label="Submission" value={id} /><Hash label="Request digest" value={job.subject.requestDigest} /><Hash label="Package ID" value={source.packageId} /><Hash label="Family ID" value={source.familyId} /></dl><p className={styles.caption}>Revision {job.reviewRevision} · Build attempt {job.attempt}</p><JsonView title="Configuration and management" value={{ configuration: source.descriptor.configuration, ports: source.descriptor.ports, constraints: source.descriptor.constraints, management: source.descriptor.management }} /></details>
+    </section>}
+    {tab === "source" && <section className={styles.section}><div className={styles.sectionHeading}><h3>Source files <span className={styles.muted}>{source.files.length}</span></h3><button type="button" className={styles.secondary} disabled={busy !== null} onClick={() => void run("source", async () => download(await readSource(), `module-${id}.json`))}><ArrowDownToLine size={16} aria-hidden="true" /> Download source</button></div>
+      <label className={styles.fileSearch}><Search size={17} aria-hidden="true" /><span className={styles.srOnly}>Find a source file</span><input type="search" value={fileQuery} onChange={event => setFileQuery(event.target.value)} placeholder="Find a file" /></label>
+      <ul className={styles.files}>{source.files.filter(file => file.path.toLowerCase().includes(fileQuery.toLowerCase())).map(file => <li key={file.path}><button type="button" className={styles.fileButton} disabled={busy !== null} onClick={() => void run("source", async () => { await readSource(); setSourceFile(file.path); })}><FileCode2 size={16} aria-hidden="true" /><span>{file.path}</span></button><span>{file.bytes.toLocaleString()} B</span></li>)}</ul>
+      {fileQuery && !source.files.some(file => file.path.toLowerCase().includes(fileQuery.toLowerCase())) && <p className={styles.caption}>No files match this search.</p>}
       {sourceFile && <div className={styles.sourceViewer}><div className={styles.sectionHeading}><strong>{sourceFile}</strong><button type="button" className={styles.textButton} onClick={() => setSourceFile(null)}>Close source</button></div><pre tabIndex={0}>{code}</pre></div>}
       <JsonView title="Source manifest and file hashes" value={source.descriptor} />
-    </section>
-    <section className={styles.section}><h3>Build evidence</h3>{artifact ? <><p className={styles.buildResult}><Check size={17} aria-hidden="true" /> {artifact.tests.allRequiredChecksPassed ? "Required build checks passed" : "Build checks are incomplete"}</p><p className={styles.muted}>{artifact.tests.cases.length} test {artifact.tests.cases.length === 1 ? "case" : "cases"} · Solidity {artifact.compiler.version} · {artifact.schemaVersion === "programmable.modules.engine-build.v1" ? `${artifact.executionGas.toLocaleString()} execution gas` : `${artifact.callbackGas.toLocaleString()} callback gas`}</p>
+    </section>}
+    {tab === "checks" && <section className={styles.section}><h3>Build checks</h3>{artifact ? <><p className={styles.buildResult}><Check size={17} aria-hidden="true" /> {artifact.tests.allRequiredChecksPassed ? "Required build checks passed" : "Build checks are incomplete"}</p><p className={styles.muted}>{artifact.tests.cases.length} test {artifact.tests.cases.length === 1 ? "case" : "cases"} · Solidity {artifact.compiler.version} · {artifact.schemaVersion === "programmable.modules.engine-build.v1" ? `${artifact.executionGas.toLocaleString()} execution gas` : `${artifact.callbackGas.toLocaleString()} callback gas`}</p>
       {artifact.schemaVersion === "programmable.modules.engine-build.v1" ? <div className={styles.testTable}><table><caption>Isolated engine test results</caption><thead><tr>{["Case", "Deploy", "Code", "Context", "Resources", "Initialize auth", "Execute auth", "Operations"].map(label => <th key={label}>{label}</th>)}</tr></thead><tbody>{artifact.tests.cases.map(test => <tr key={test.id}><th scope="row">{test.id}</th>{[test.deploymentMatched, test.codeHashMatched, test.contextMatched, test.resourcesMatched, test.unauthorizedInitializeReverted, test.unauthorizedExecuteReverted].map((flag, index) => <td key={index}>{flag === true ? "Pass" : flag === false ? "Fail" : "—"}</td>)}<td>{test.operations.length ? `${test.operations.filter(op => op.outcomeMatched && op.resultMatched && op.stateMatched && op.inputOutputBound && op.replayReverted && op.feesBacked).length}/${test.operations.length} passed` : "—"}</td></tr>)}</tbody></table></div> : <div className={styles.testTable}><table><caption>Isolated build test results</caption><thead><tr><th>Case</th><th>Deploy</th><th>Code</th><th>Binding</th><th>Trade auth</th><th>Action auth</th><th>Gas</th><th>Budget</th></tr></thead><tbody>{artifact.tests.cases.map((test, index) => <tr key={index}><th scope="row">{String(test.id)}</th>{["deploymentMatched", "codeHashMatched", "bindingMatched", "unauthorizedTradeReverted", "unauthorizedActionReverted", "callbackGasBound", "budgetIsolationChecked"].map(key => <td key={key}>{test[key] === true ? "Pass" : test[key] === false ? "Fail" : "—"}</td>)}</tr>)}</tbody></table></div>}<p className={styles.caption}>A dash means the check does not apply to that deployment case. Passing tests still requires a human source review.</p>
-      <JsonView title="Compiler, ABI, bytecode and complete test artifact" value={artifact} /></> : <p className={styles.muted}>No completed build artifact is attached to this revision.</p>}
+      <JsonView title="Compiler, ABI, bytecode and complete test artifact" value={artifact} /></> : <div className={styles.checksEmpty}><Clock3 size={24} aria-hidden="true" /><div><h4>{["queued", "running"].includes(job.state) ? "Checks are in progress" : "Checks have not passed yet"}</h4><p>{["queued", "running"].includes(job.state) ? "Refresh the submission to see the latest result." : "Import a reviewed test plan below to build and test this module."}</p></div></div>}
       {job.lastError && <p className={styles.error}>Last build error: {job.lastError}</p>}
       {detail.attempts.length > 0 && <details className={styles.disclosure}><summary>Worker runs and build history</summary><ol className={styles.history}>{detail.attempts.map((attempt, i) => <li key={i}><strong>Attempt {attempt.attempt} · {attempt.event}</strong><span>{attempt.createdAt}</span>{attempt.workerIdentity && <dl><Hash label="Worker source commit" value={attempt.workerIdentity.sourceCommit} /><Hash label="GitHub run / attempt" value={`${attempt.workerIdentity.runId} / ${attempt.workerIdentity.runAttempt}`} /><Hash label="Workflow" value={attempt.workerIdentity.workflowRef} /></dl>}{attempt.errorCode && <code>{attempt.errorCode}</code>}</li>)}</ol></details>}
-      <details className={styles.disclosure}><summary>Queue a reviewed build plan</summary><p>Import the operator plan for this exact submission. A new build clears the previous artifact and uses the fixed review worker.</p><ImportJson id="review-plan" label="Build plan JSON" value={planText} onChange={setPlanText} maximum={262144} disabled={active || !canQueue} /><button className={styles.secondary} type="button" disabled={active || !canQueue} onClick={() => void run("plan", async () => {
+      <details className={styles.disclosure} open={!artifact && canQueue}><summary>Build plan</summary><p>Import the reviewed plan for this submission. Starting a new build replaces the previous build result.</p><ImportJson id="review-plan" label="Build plan JSON" value={planText} onChange={setPlanText} maximum={262144} disabled={active || !canQueue} /><button className={styles.secondary} type="button" disabled={active || !canQueue} onClick={() => void run("plan", async () => {
         let plan; try { plan = parseReviewPlan(JSON.parse(planText), job.subject); } catch { throw new ReviewRequestError(400, "MODULE_REVIEW_PLAN_INVALID"); }
         await request(`/${id}/plan`, { expectedReviewRevision: job.reviewRevision, planJson: json(plan) }); setNotice("Build plan queued. Check the current status for worker results."); await refresh();
       }, true)}>{busy === "plan" ? "Queueing build…" : "Queue build"}</button>{!canQueue && <p className={styles.caption}>{self ? "An author cannot queue their own review build." : "A build can be queued when the submission needs a plan, failed, needs changes, or is ready for review."}</p>}</details>
-    </section>
+    </section>}
     {self && <p className={styles.note}>This is your submission. Another authorized reviewer must make the decision.</p>}
-    {!terminal && !self && !receipt && <section className={styles.section}><h3>Review decision</h3><p className={styles.muted}>Approval records the reviewed build and host manifest. Publication and onchain admission happen separately.</p>
+    {tab === "decision" && !terminal && !self && !receipt && <section className={styles.section}><h3>Review decision</h3><p className={styles.muted}>Record your review here. Publication and onchain approval follow separately.</p>
       <details className={styles.disclosure}><summary>Check a host manifest for approval</summary><p>The import must match this build, source configuration, website controls, and the configured host release.</p><ImportJson id="review-manifest" label="Host manifest JSON" value={manifestText} onChange={text => { setManifestText(text); setManifestCheck(null); setConfirmation(null); }} maximum={2 * 1024 * 1024} disabled={active} /><button type="button" className={styles.secondary} disabled={active || !artifact} onClick={() => void run("manifest", async () => {
         const value = await request(`/${id}/manifest`, { expectedReviewRevision: job.reviewRevision, hostManifestJson: manifestText }) as ReviewManifestCheck;
         if (value.schemaVersion !== "programmable.modules.website-manifest-check.v1" || value.submissionId !== id || value.reviewRevision !== job.reviewRevision || value.requestDigest !== job.subject.requestDigest || value.artifactDigest !== artifact?.artifactDigest || !isReviewDigest(value.hostManifestHash)) throw new Error("The checked manifest belongs to a different review.");
@@ -294,7 +348,8 @@ function ReviewEditor({ detail, account, request, refresh, setParentBusy }: { de
     {uncertain && <p className={styles.note}>The server may have recorded the action. Check the current review before submitting anything again.</p>}
     {(uncertain || receipt) && <button type="button" className={styles.secondary} disabled={busy !== null} onClick={() => void run("refresh", async () => { await refresh(); setUncertain(false); setConfirmation(null); setManifestCheck(null); })}>Check current review status</button>}
     {receipt && <dl><Hash label="Recorded decision digest" value={receipt.decisionDigest} /></dl>}
-    {detail.decisions.length > 0 && <section className={styles.section}><h3>Decision history</h3><ol className={styles.history}>{detail.decisions.map(decision => <li key={decision.decisionDigest}><strong>{decision.command.outcome === "accept" ? "Review approved" : decision.command.outcome === "reject" ? "Rejected" : "Changes requested"}</strong><span>{decision.decidedAt} · {short(decision.reviewerWallet)}</span><p>{decision.command.reason}</p><JsonView title="Canonical decision record" value={decision} /></li>)}</ol></section>}
-    <details className={styles.disclosure}><summary>Submission identity</summary><dl><Hash label="Request digest" value={job.subject.requestDigest} /><Hash label="Package ID" value={source.packageId} /><Hash label="Family ID" value={source.familyId} /></dl></details>
+    {tab === "decision" && detail.decisions.length > 0 && <section className={styles.section}><h3>Decision history</h3><ol className={styles.history}>{detail.decisions.map(decision => <li key={decision.decisionDigest}><strong>{decision.command.outcome === "accept" ? "Review approved" : decision.command.outcome === "reject" ? "Rejected" : "Changes requested"}</strong><span>{submittedDate(decision.decidedAt)} · {short(decision.reviewerWallet)}</span><p>{decision.command.reason}</p><JsonView title="Canonical decision record" value={decision} /></li>)}</ol></section>}
+    </div>
+    {tab === "overview" && (<div className={styles.overviewActions}><button type="button" className={styles.primary} onClick={() => setTab(canApprove || terminal || job.state === "changes_requested" ? "decision" : "checks")}>{terminal ? "View decision" : canApprove ? "Review module" : job.state === "changes_requested" ? "View feedback" : "Open checks"}<ArrowRight size={17} aria-hidden="true" /></button><button type="button" className={styles.secondary} onClick={() => setTab("source")}>View source</button></div>)}
   </div>;
 }

--- a/contracts/scripts/module-mode/launch-source-shared.ts
+++ b/contracts/scripts/module-mode/launch-source-shared.ts
@@ -4,7 +4,8 @@ export { moduleNativeLaunchAbiFor } from '../../../lib/module-mode/native-abi';
 export { bindActiveModuleEngineRelease } from '../../../lib/module-engine/catalog';
 export { bindModuleEngineCatalogFile, verifyModuleEnginePublication } from '../../../lib/server/module-engine/publication';
 export { readPublication } from '../../../lib/server/module-mode/catalog';
-export { moduleEngineStandardInputV1, materializeModuleEngineRuntimeV1 } from '../../../lib/module-mode/review-engine-contract';
+export { materializeModuleEngineRuntimeV1 } from '../../../lib/module-mode/review-engine-contract';
+export { moduleEngineStandardInputV1 } from '../../../lib/server/module-mode/review-engine-source';
 export { moduleEngineHostAbi, moduleEngineResourcesAbi, moduleEngineConstructorParameters, moduleEnginePlanParameters,
   ENGINE_LAUNCH_PARAMETERS } from '../../../lib/module-engine/index/abi-v1';
 export { reviewDigest } from '../../../lib/module-mode/review-contract';

--- a/contracts/scripts/module-mode/publication-shared.ts
+++ b/contracts/scripts/module-mode/publication-shared.ts
@@ -12,7 +12,7 @@ export { moduleEngineReleaseIdentity, computeModuleEngineHostManifestHash, MODUL
 export { compileModuleEngineLaunch, moduleEngineOperation } from '../../../lib/module-engine/operation-plan';
 export { createReviewedModuleEngineManifest } from '../../../lib/module-mode/review-engine-manifest';
 export { parseReviewSubject, parseReviewPlan, parseReviewArtifact } from '../../../lib/module-mode/review-contract';
-export { verifyModuleEngineBuildArtifactV1 } from '../../../lib/module-mode/review-engine-contract';
+export { verifyModuleEngineBuildArtifactV1 } from '../../../lib/server/module-mode/review-engine-source';
 export { validateModuleReviewDecisionRecordV1 } from '../../../lib/server/module-mode/review-decision-wire-v1';
 export { createEngineHostPreparation, prepareEnginePublication, engineRegistryRevision } from '../../../ops/module-mode-publication/core-engine';
 export { computeModuleEngineReleaseDigest } from '../../../lib/module-engine/catalog';

--- a/lib/module-mode/review-contract.ts
+++ b/lib/module-mode/review-contract.ts
@@ -23,7 +23,7 @@ export interface ReviewBuildArtifact {
   reviewRequired: string[]; approved: false; registryApproved: false; available: false; artifactDigest: Hex;
 }
 export interface ReviewJob { subject: ReviewSubject; state: ModuleReviewState; reviewRevision: number; plan: AnyReviewPlan | null; planDigest: Hex | null; artifact: AnyReviewBuildArtifact | null; attempt: number; lastError: string | null; createdAt: string; updatedAt: string }
-export interface ReviewQueueItem extends Omit<ReviewJob, "artifact" | "plan" | "planDigest"> { build: { artifactDigest: Hex; programName: string; testsPassed: boolean; caseCount: number } | null }
+export interface ReviewQueueItem extends Omit<ReviewJob, "artifact" | "plan" | "planDigest"> { sourceSummary?: { name: string; version: string } | null; build: { artifactDigest: Hex; programName: string; testsPassed: boolean; caseCount: number } | null }
 export interface ReviewQueue { schemaVersion: "programmable.modules.website-review-queue.v1"; jobs: ReviewQueueItem[]; nextCursor: string | null }
 export interface ReviewSourceInfo { descriptor: OpenSourcePackage; packageId: Hex; familyId: Hex; files: { path: string; sha256: string; bytes: number }[] }
 export interface ReviewAttempt { attempt: number; event: "claimed" | "completed" | "failed" | "expired"; requestDigest: Hex; planDigest: Hex; workerIdentity: null | { sourceCommit: string; runId: string; runAttempt: string; workflowRef: string; identityDigest: Hex }; artifactDigest: Hex | null; errorCode: string | null; createdAt: string }
@@ -163,10 +163,19 @@ export function summarizeReviewJob(job: ReviewJob): ReviewQueueItem {
   return { subject: job.subject, state: job.state, reviewRevision: job.reviewRevision, attempt: job.attempt, lastError: job.lastError, createdAt: job.createdAt, updatedAt: job.updatedAt, build: job.artifact ? { artifactDigest: job.artifact.artifactDigest, programName: job.artifact.schemaVersion === "programmable.modules.engine-build.v1" ? job.artifact.engine.contractName : job.artifact.program.contractName, testsPassed: job.artifact.tests.allRequiredChecksPassed, caseCount: job.artifact.tests.cases.length } : null };
 }
 export function parseReviewQueueItem(value: unknown): ReviewQueueItem {
-  const r = reviewRecord(value, JOB_KEYS); jobState(r);
+  const raw = reviewRecord(value);
+  const r = reviewRecord(raw, Object.hasOwn(raw, "sourceSummary") ? [...JOB_KEYS, "sourceSummary"] : JOB_KEYS); jobState(r);
   const subject = parseReviewSubject(r.subject);
   requireValue(r.plan === null && r.artifact === null && (r.planDigest === null || isReviewDigest(r.planDigest)), "lightweight queue entry");
-  return summarizeReviewJob({ ...r, subject } as unknown as ReviewJob);
+  const result = summarizeReviewJob({ ...r, subject } as unknown as ReviewJob);
+  if (r.sourceSummary !== undefined && r.sourceSummary !== null) {
+    const summary = reviewRecord(r.sourceSummary, ["name", "version"]);
+    const bytes = new TextEncoder();
+    requireValue(typeof summary.name === "string" && bytes.encode(summary.name).length >= 1 && bytes.encode(summary.name).length <= 512 &&
+      typeof summary.version === "string" && bytes.encode(summary.version).length >= 1 && bytes.encode(summary.version).length <= 128, "source summary");
+    result.sourceSummary = { name: summary.name, version: summary.version };
+  }
+  return result;
 }
 export function reviewStateLabel(state: ModuleReviewState) {
   return ({ awaiting_plan: "Needs build plan", queued: "Queued", running: "Building", built: "Ready for review", build_failed: "Build failed", changes_requested: "Changes requested", accepted: "Review approved", rejected: "Rejected" })[state];

--- a/lib/module-mode/review-engine-contract.ts
+++ b/lib/module-mode/review-engine-contract.ts
@@ -1,40 +1,13 @@
 // Pure validation of the protected backend engine profile. No source compilation or execution occurs here.
 import { bytesToHex, encodeAbiParameters, getContractAddress, hexToBytes, keccak256, parseAbi, toFunctionSelector, type Hex } from "viem";
-import { validateModuleSubmissionRequest } from "../../packages/classic-modules/src/open-transport.mjs";
-import { compileOpenConfig } from "../../packages/classic-modules/src/open-config.mjs";
 import { nativeCanonicalJson, nativeJson } from "./native-catalog";
-import { encodeModuleEngineConfiguration, parseModuleEngineConfigurationAbi } from "../module-engine/configuration";
+import { parseModuleEngineConfigurationAbi } from "../module-engine/configuration";
 import { reviewDigest as moduleReviewDigestV1, parseReviewSubject, type ReviewSubject as ModuleReviewSubjectV1 } from "./review-contract";
 import { MODULE_ENGINE_QUOTE_ENVIRONMENT_V1, MODULE_ENGINE_QUOTE_NVDA_ENVIRONMENT_V1 } from "./review-engine-types";
-import { MODULE_ENGINE_BUILD_SCHEMA_V1, MODULE_ENGINE_PLAN_SCHEMA_V1, MODULE_ENGINE_PROFILE_V1, MODULE_ENGINE_CONFIGURATION_CODEC_V1, MODULE_ENGINE_CONTEXT_ABI_V1, MODULE_ENGINE_CONSTRUCTOR_ABI_V1, type ModuleEngineBuildArtifactV1, type ModuleEngineBuildPlanV1, type ModuleEngineContractArtifactV1, type ModuleEngineCompiledCaseV1, type ModuleEngineTestResultV1 } from "./review-engine-types";
+import { MODULE_ENGINE_BUILD_SCHEMA_V1, MODULE_ENGINE_PLAN_SCHEMA_V1, MODULE_ENGINE_CONFIGURATION_CODEC_V1, MODULE_ENGINE_CONTEXT_ABI_V1, MODULE_ENGINE_CONSTRUCTOR_ABI_V1, type ModuleEngineBuildArtifactV1, type ModuleEngineBuildPlanV1, type ModuleEngineContractArtifactV1, type ModuleEngineCompiledCaseV1, type ModuleEngineTestResultV1 } from "./review-engine-types";
 type ModuleDigestV1 = Hex;
 export const ENGINE_REVIEW_COMPILER = Object.freeze({version:"0.8.26+commit.8a97fa7a",binarySha256:"sha256:35ba6661f3bdaed995fc7af14c405502290cf681b3fd062fe8738cfdf6db14ed",imageDigest:"sha256:d8e448a56fc63242f70026718378bd4b00f8c82e78d20eefb199224a4d8e33d8"});
-const NATIVE_SETTINGS_V1 = {optimizer:{enabled:true,runs:1000},evmVersion:"cancun",viaIR:true,metadata:{bytecodeHash:"none"}};
-const MODULE_REVIEW_LIMITS_V1 = {sourceBytes:4*1024*1024,standardJsonBytes:5242880,creationBytes:49152,runtimeBytes:24576,configBytes:16384,artifactBytes:2*1024*1024};
-const ENGINE_SOURCE_ALIASES = [
-  ["dependencies/scoped/openzeppelin/contracts/", "@openzeppelin/contracts/"],
-  ["dependencies/scoped/openzeppelin/uniswap-hooks/", "@openzeppelin/uniswap-hooks/"],
-  ["dependencies/scoped/uniswap/blocknumberish/", "@uniswap/blocknumberish/"],
-  ["dependencies/scoped/uniswap/liquidity-launcher/", "@uniswap/liquidity-launcher/"],
-  ["dependencies/scoped/uniswap/uerc20-factory/", "@uniswap/uerc20-factory/"],
-  ["dependencies/scoped/uniswap/v4-core/", "@uniswap/v4-core/"],
-  ["dependencies/scoped/uniswap/v4-periphery/", "@uniswap/v4-periphery/"],
-  ["dependencies/scoped/solady/src/", "@solady/src/"],
-] as const;
-function soliditySources(files: readonly {path:string;bytes:string}[]): Record<string,{content:string}> {
-  const sources: Record<string,{content:string}> = Object.create(null);
-  for (const f of files) if (f.path.endsWith(".sol")) sources[f.path]={content:new TextDecoder("utf-8",{fatal:true}).decode(Uint8Array.from(atob(f.bytes),c=>c.charCodeAt(0)))};
-  const prefix="dependencies/openzeppelin-contracts/contracts/";
-  for(const [path,source] of Object.entries(sources)) if(path.startsWith(prefix)) {const alias=`@openzeppelin/contracts/${path.slice(prefix.length)}`;need(!Object.hasOwn(sources,alias),"MODULE_BUILD_SOURCE_ALIAS_COLLISION");sources[alias]=source;}
-  for(const [path,source] of Object.entries(sources)) {
-    const match=ENGINE_SOURCE_ALIASES.find(([prefix])=>path.startsWith(prefix));
-    if(!match) continue;
-    const alias=`${match[1]}${path.slice(match[0].length)}`;
-    need(!Object.hasOwn(sources,alias),"MODULE_BUILD_SOURCE_ALIAS_COLLISION");
-    sources[alias]=source; delete sources[path];
-  }
-  return sources;
-}
+export const MODULE_REVIEW_LIMITS_V1 = {sourceBytes:4*1024*1024,standardJsonBytes:5242880,creationBytes:49152,runtimeBytes:24576,configBytes:16384,artifactBytes:2*1024*1024};
 export const MODULE_ENGINE_INTERFACE_V1 = parseAbi([
   "function contextHash() view returns(bytes32)",
   "function initialize(bytes launchData) returns(bytes32 resourcesHash)",
@@ -166,29 +139,11 @@ export function validateModuleEngineBuildPlanV1(value: unknown, subject: ModuleR
   return JSON.parse(json(value)) as ModuleEngineBuildPlanV1;
 }
 
-function sourceInput(source: unknown, subject: ModuleReviewSubjectV1, plan: ModuleEngineBuildPlanV1) {
-  need(new TextEncoder().encode(json(source)).length <= 24 * 1024 * 1024, "MODULE_BUILD_SOURCE_UNAVAILABLE");
-  const checked = validateModuleSubmissionRequest(source);
-  need(checked.ok && checked.requestDigest === subject.requestDigest && checked.request.descriptor.author.toLowerCase() === subject.author, "MODULE_BUILD_SOURCE_BINDING_INVALID");
-  need(checked.totalSourceBytes <= MODULE_REVIEW_LIMITS_V1.sourceBytes, "MODULE_BUILD_PROFILE_CAPACITY_EXCEEDED");
-  const target = checked.request.descriptor.components.find(c => c.id === plan.engineComponentId);
-  need(target && target.runtime === MODULE_ENGINE_PROFILE_V1, "MODULE_BUILD_ADAPTER_UNSUPPORTED");
-  need(/^[A-Za-z_$][A-Za-z0-9_$]{0,255}$/u.test(target.entrypoint), "MODULE_BUILD_ENTRYPOINT_INVALID");
-  const sources = soliditySources(checked.request.files);
-  need(Object.hasOwn(sources, target.sourcePath), "MODULE_BUILD_TARGET_MISSING");
-  const standard = { language: "Solidity", sources, settings: NATIVE_SETTINGS_V1 };
-  need(new TextEncoder().encode(json(standard)).length <= MODULE_REVIEW_LIMITS_V1.standardJsonBytes, "MODULE_BUILD_PROFILE_CAPACITY_EXCEEDED");
-  return { checked, target, standard };
-}
-/** Reuses the reviewed source closure/settings for source publication; grants no build or review authority. */
-export function moduleEngineStandardInputV1(source: unknown, subject: ModuleReviewSubjectV1, rawPlan: unknown) {
-  return sourceInput(source, subject, validateModuleEngineBuildPlanV1(rawPlan, subject)).standard;
-}
 function abiTypes(parameters: unknown): unknown {
   need(Array.isArray(parameters), "MODULE_ENGINE_ABI_INVALID");
   return parameters.map(p => { const item = object(p); return { type: item.type, ...(item.components === undefined ? {} : { components: abiTypes(item.components) }) }; });
 }
-function contractArtifact(raw: unknown, target: { id: string; sourcePath: string; entrypoint: string }, plan: ModuleEngineBuildPlanV1): ModuleEngineContractArtifactV1 {
+export function parseModuleEngineContractArtifactV1(raw: unknown, target: { id: string; sourcePath: string; entrypoint: string }, plan: ModuleEngineBuildPlanV1): ModuleEngineContractArtifactV1 {
   const output = object(raw);
   need(output.errors === undefined || Array.isArray(output.errors) && !output.errors.some(e => object(e).severity === "error"), "MODULE_BUILD_COMPILATION_FAILED");
   const contract = object(object(object(output.contracts)[target.sourcePath])[target.entrypoint]);
@@ -243,40 +198,6 @@ export function materializeModuleEngineRuntimeV1(engine: ModuleEngineContractArt
   }
   return bytesToHex(runtime);
 }
-function compiledCases(plan: ModuleEngineBuildPlanV1, source: ReturnType<typeof sourceInput>, engine: ModuleEngineContractArtifactV1): ModuleEngineCompiledCaseV1[] {
-  const descriptor = source.checked.request.descriptor;
-  return plan.cases.map(c => {
-    const configBytes = c.rawConfigBytes ?? encodeModuleEngineConfiguration(plan.configurationAbi, compileOpenConfig(descriptor.configuration, c.parameters, { roles: { author: descriptor.author, reward: descriptor.rewardWallet } }), descriptor.configuration);
-    const context = {
-      host: MODULE_ENGINE_REVIEW_HOST_V1,
-      launchId: moduleReviewDigestV1("programmable.modules.engine-review-launch.v1", { requestDigest: plan.requestDigest, caseId: c.id }),
-      token: c.token, creator: MODULE_ENGINE_REVIEW_ACTOR_V1, quoteAsset: c.quoteAsset, feeCollector: MODULE_ENGINE_REVIEW_HOST_V1,
-    };
-    const constructorArgs = encodeAbiParameters(MODULE_ENGINE_CONSTRUCTOR_ABI_V1, [context, configBytes]);
-    const runtimeBytecode = materializeModuleEngineRuntimeV1(engine, constructorArgs);
-    const initCode = `${engine.creationBytecode}${constructorArgs.slice(2)}` as `0x${string}`;
-    need((initCode.length - 2) / 2 <= MODULE_REVIEW_LIMITS_V1.creationBytes, "MODULE_ENGINE_INITCODE_TOO_LARGE");
-    return { ...c, context, contextHash: keccak256(encodeAbiParameters([{ type: "tuple", components: MODULE_ENGINE_CONTEXT_ABI_V1 }], [context])), configBytes, configHash: keccak256(configBytes), constructorArgs, constructorHash: keccak256(constructorArgs), initCodeHash: keccak256(initCode), runtimeBytecode, runtimeCodeHash: keccak256(runtimeBytecode) };
-  });
-}
-function compilerIdentity(standard: unknown) {
-  return { version: ENGINE_REVIEW_COMPILER.version, binarySha256: ENGINE_REVIEW_COMPILER.binarySha256, imageDigest: ENGINE_REVIEW_COMPILER.imageDigest, settingsHash: moduleReviewDigestV1("programmable.modules.compiler-settings.v1", NATIVE_SETTINGS_V1), completeInputHash: moduleReviewDigestV1("programmable.modules.compiler-input.v1", standard), reproducible: true as const };
-}
-function artifactContents(subject: ModuleReviewSubjectV1, plan: ModuleEngineBuildPlanV1, source: ReturnType<typeof sourceInput>, engine: ModuleEngineContractArtifactV1, tests: ModuleEngineTestResultV1) {
-  const descriptor = source.checked.request.descriptor;
-  const planDigest = moduleReviewDigestV1(MODULE_ENGINE_PLAN_SCHEMA_V1, plan), cases = compiledCases(plan, source, engine);
-  validateModuleEngineTestResultsV1(tests, subject.requestDigest, planDigest, cases);
-  return {
-    schemaVersion: MODULE_ENGINE_BUILD_SCHEMA_V1, authority: "programmable.module-review.engine-build.v1" as const, subject,
-    packageId: source.checked.packageId, familyId: source.checked.familyId, rewardWallet: descriptor.rewardWallet.toLowerCase(),
-    sourceManifestHash: moduleReviewDigestV1("programmable.modules.source-manifest.v1", descriptor), planDigest,
-    configurationSchemaHash: moduleReviewDigestV1("programmable.modules.configuration-schema.v1", descriptor.configuration),
-    configurationCodec: plan.configurationCodec, configurationAbi: plan.configurationAbi,
-    ...(plan.testEnvironment === undefined ? {} : { testEnvironment: plan.testEnvironment }),
-    compiler: compilerIdentity(source.standard), engine, executionGas: plan.executionGas, operationPermissions: plan.operationPermissions, moneyRights: plan.moneyRights, coinRights: plan.coinRights, testEconomics: plan.testEconomics, cases, tests,
-    reviewRequired: MODULE_ENGINE_REVIEW_AREAS_V1, approved: false as const, registryApproved: false as const, available: false as const,
-  };
-}
 export function validateModuleEngineTestResultsV1(results: ModuleEngineTestResultV1, requestDigest: ModuleDigestV1, planDigest: ModuleDigestV1, cases: readonly ModuleEngineCompiledCaseV1[]) {
   exact(results, ["schemaVersion", "requestDigest", "planDigest", "harnessDigest", "execution", "cases", "allRequiredChecksPassed"]);
   need(results.schemaVersion === "programmable.modules.engine-test-results.v1" && results.execution === "isolated-docker-anvil" && results.requestDigest === requestDigest && results.planDigest === planDigest && DIGEST.test(results.harnessDigest), "MODULE_ENGINE_TEST_SUBJECT_MISMATCH");
@@ -293,15 +214,6 @@ export function validateModuleEngineTestResultsV1(results: ModuleEngineTestResul
       need(o.id === c.operations[j]!.id && o.outcomeMatched === true && o.resultMatched === true && o.stateMatched === true && o.inputOutputBound === true && o.replayReverted === true && o.feesBacked === true, "MODULE_ENGINE_OPERATIONS_FAILED");
     });
   });
-}
-
-/** API-side reconstruction binds the authenticated worker result; no contributor code executes here. */
-export function verifyModuleEngineBuildArtifactV1(artifact: ModuleEngineBuildArtifactV1, subject: ModuleReviewSubjectV1, rawPlan: unknown, sourceRequest: unknown): void {
-  const plan = validateModuleEngineBuildPlanV1(rawPlan, subject), source = sourceInput(sourceRequest, subject, plan), value = artifact.engine;
-  const engine = contractArtifact({ contracts: { [source.target.sourcePath]: { [source.target.entrypoint]: { abi: value.abi, evm: { bytecode: { object: value.creationBytecode.slice(2) }, deployedBytecode: { object: value.runtimeTemplate.slice(2), immutableReferences: Object.fromEntries(value.immutableReferences.map(r => [r.id, r.ranges])) } } } } } }, source.target, plan);
-  const contents = artifactContents(subject, plan, source, engine, artifact.tests);
-  const expected = { ...contents, artifactDigest: moduleReviewDigestV1(MODULE_ENGINE_BUILD_SCHEMA_V1, contents) };
-  need(json(artifact) === json(expected) && new TextEncoder().encode(json(artifact)).length <= MODULE_REVIEW_LIMITS_V1.artifactBytes, "MODULE_REVIEW_BUILD_BINDING_INVALID");
 }
 
 /** DTO reader: byte identities and case evidence are checked before any UI or publisher consumes the build. */
@@ -324,7 +236,7 @@ export function parseEngineReviewArtifact(value: unknown, subject: ModuleReviewS
   if(plan) {
     need(json(artifact.testEnvironment ?? null)===json(plan.testEnvironment ?? null),"MODULE_ENGINE_BUILD_PLAN_MISMATCH");
     need(artifact.planDigest===moduleReviewDigestV1(MODULE_ENGINE_PLAN_SCHEMA_V1,plan) && artifact.executionGas===plan.executionGas && artifact.moneyRights===plan.moneyRights && artifact.coinRights===plan.coinRights && json(artifact.operationPermissions)===json(plan.operationPermissions) && json(artifact.testEconomics)===json(plan.testEconomics) && json(artifact.configurationAbi)===json(plan.configurationAbi),"MODULE_ENGINE_BUILD_PLAN_MISMATCH");
-    const rebuilt=contractArtifact({contracts:{[engine.sourcePath]:{[engine.contractName]:{abi:engine.abi,evm:{bytecode:{object:engine.creationBytecode.slice(2)},deployedBytecode:{object:engine.runtimeTemplate.slice(2),immutableReferences:Object.fromEntries(engine.immutableReferences.map(r=>[r.id,r.ranges]))}}}}}},{id:plan.engineComponentId,sourcePath:engine.sourcePath,entrypoint:engine.contractName},plan);
+    const rebuilt=parseModuleEngineContractArtifactV1({contracts:{[engine.sourcePath]:{[engine.contractName]:{abi:engine.abi,evm:{bytecode:{object:engine.creationBytecode.slice(2)},deployedBytecode:{object:engine.runtimeTemplate.slice(2),immutableReferences:Object.fromEntries(engine.immutableReferences.map(r=>[r.id,r.ranges]))}}}}}},{id:plan.engineComponentId,sourcePath:engine.sourcePath,entrypoint:engine.contractName},plan);
     need(json(engine)===json(rebuilt) && artifact.cases.length===plan.cases.length,"MODULE_ENGINE_BUILD_CONTRACT_MISMATCH");
   }
   for(const [i,c] of artifact.cases.entries()) {

--- a/lib/server/module-engine/publication.ts
+++ b/lib/server/module-engine/publication.ts
@@ -3,7 +3,8 @@ import { bindModuleEngineTemplate, computeModuleEngineHostManifestHash, type Mod
 import { nativeJson } from "@/lib/module-mode/native-catalog";
 import { moduleHash, moduleRecord } from "@/lib/module-mode/release";
 import { parseReviewSubject, type ReviewSubject } from "@/lib/module-mode/review-contract";
-import { parseEngineReviewArtifact, validateModuleEngineBuildPlanV1, verifyModuleEngineBuildArtifactV1 } from "@/lib/module-mode/review-engine-contract";
+import { parseEngineReviewArtifact, validateModuleEngineBuildPlanV1 } from "@/lib/module-mode/review-engine-contract";
+import { verifyModuleEngineBuildArtifactV1 } from "@/lib/server/module-mode/review-engine-source";
 import { createReviewedModuleEngineManifest } from "@/lib/module-mode/review-engine-manifest";
 import type { ModuleEngineBuildArtifactV1, ModuleEngineBuildPlanV1 } from "@/lib/module-mode/review-engine-types";
 import { validateModuleSubmissionRequest } from "@/packages/classic-modules/src/open-transport.mjs";

--- a/lib/server/module-mode/review-client.ts
+++ b/lib/server/module-mode/review-client.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { createReviewedModuleEngineManifest } from "@/lib/module-mode/review-engine-manifest";
-import { verifyModuleEngineBuildArtifactV1 } from "@/lib/module-mode/review-engine-contract";
+import { verifyModuleEngineBuildArtifactV1 } from "@/lib/server/module-mode/review-engine-source";
 import { bindModuleEngineReleaseIdentity, computeModuleEngineHostManifestHash, type ModuleEngineCatalogDefinition, type ModuleEngineRevisionDefinition } from "@/lib/module-engine/catalog";
 import { randomBytes } from "node:crypto";
 import { getAddress, isAddress } from "viem";

--- a/lib/server/module-mode/review-engine-source.ts
+++ b/lib/server/module-mode/review-engine-source.ts
@@ -1,0 +1,97 @@
+// Server and operator source reconstruction. Never imported by the browser review UI.
+import { encodeAbiParameters, keccak256 } from "viem";
+import { validateModuleSubmissionRequest } from "../../../packages/classic-modules/src/open-transport.mjs";
+import { compileOpenConfig } from "../../../packages/classic-modules/src/open-config.mjs";
+import { nativeCanonicalJson } from "../../module-mode/native-catalog";
+import { encodeModuleEngineConfiguration } from "../../module-engine/configuration";
+import { reviewDigest as moduleReviewDigestV1, type ReviewSubject as ModuleReviewSubjectV1 } from "../../module-mode/review-contract";
+import { ENGINE_REVIEW_COMPILER, MODULE_REVIEW_LIMITS_V1, MODULE_ENGINE_REVIEW_HOST_V1, MODULE_ENGINE_REVIEW_ACTOR_V1, MODULE_ENGINE_REVIEW_AREAS_V1, validateModuleEngineBuildPlanV1, parseModuleEngineContractArtifactV1, materializeModuleEngineRuntimeV1, validateModuleEngineTestResultsV1 } from "../../module-mode/review-engine-contract";
+import { MODULE_ENGINE_PROFILE_V1, MODULE_ENGINE_PLAN_SCHEMA_V1, MODULE_ENGINE_BUILD_SCHEMA_V1, MODULE_ENGINE_CONSTRUCTOR_ABI_V1, MODULE_ENGINE_CONTEXT_ABI_V1, type ModuleEngineBuildPlanV1, type ModuleEngineBuildArtifactV1, type ModuleEngineContractArtifactV1, type ModuleEngineCompiledCaseV1, type ModuleEngineTestResultV1 } from "../../module-mode/review-engine-types";
+const json = (value: unknown) => nativeCanonicalJson(value);
+function need(ok: unknown, code: string): asserts ok { if (!ok) throw new Error(code); }
+const NATIVE_SETTINGS_V1 = {optimizer:{enabled:true,runs:1000},evmVersion:"cancun",viaIR:true,metadata:{bytecodeHash:"none"}};
+const ENGINE_SOURCE_ALIASES = [
+  ["dependencies/scoped/openzeppelin/contracts/", "@openzeppelin/contracts/"],
+  ["dependencies/scoped/openzeppelin/uniswap-hooks/", "@openzeppelin/uniswap-hooks/"],
+  ["dependencies/scoped/uniswap/blocknumberish/", "@uniswap/blocknumberish/"],
+  ["dependencies/scoped/uniswap/liquidity-launcher/", "@uniswap/liquidity-launcher/"],
+  ["dependencies/scoped/uniswap/uerc20-factory/", "@uniswap/uerc20-factory/"],
+  ["dependencies/scoped/uniswap/v4-core/", "@uniswap/v4-core/"],
+  ["dependencies/scoped/uniswap/v4-periphery/", "@uniswap/v4-periphery/"],
+  ["dependencies/scoped/solady/src/", "@solady/src/"],
+] as const;
+function soliditySources(files: readonly {path:string;bytes:string}[]): Record<string,{content:string}> {
+  const sources: Record<string,{content:string}> = Object.create(null);
+  for (const f of files) if (f.path.endsWith(".sol")) sources[f.path]={content:new TextDecoder("utf-8",{fatal:true}).decode(Uint8Array.from(atob(f.bytes),c=>c.charCodeAt(0)))};
+  const prefix="dependencies/openzeppelin-contracts/contracts/";
+  for(const [path,source] of Object.entries(sources)) if(path.startsWith(prefix)) {const alias=`@openzeppelin/contracts/${path.slice(prefix.length)}`;need(!Object.hasOwn(sources,alias),"MODULE_BUILD_SOURCE_ALIAS_COLLISION");sources[alias]=source;}
+  for(const [path,source] of Object.entries(sources)) {
+    const match=ENGINE_SOURCE_ALIASES.find(([prefix])=>path.startsWith(prefix));
+    if(!match) continue;
+    const alias=`${match[1]}${path.slice(match[0].length)}`;
+    need(!Object.hasOwn(sources,alias),"MODULE_BUILD_SOURCE_ALIAS_COLLISION");
+    sources[alias]=source; delete sources[path];
+  }
+  return sources;
+}
+function sourceInput(source: unknown, subject: ModuleReviewSubjectV1, plan: ModuleEngineBuildPlanV1) {
+  need(new TextEncoder().encode(json(source)).length <= 24 * 1024 * 1024, "MODULE_BUILD_SOURCE_UNAVAILABLE");
+  const checked = validateModuleSubmissionRequest(source);
+  need(checked.ok && checked.requestDigest === subject.requestDigest && checked.request.descriptor.author.toLowerCase() === subject.author, "MODULE_BUILD_SOURCE_BINDING_INVALID");
+  need(checked.totalSourceBytes <= MODULE_REVIEW_LIMITS_V1.sourceBytes, "MODULE_BUILD_PROFILE_CAPACITY_EXCEEDED");
+  const target = checked.request.descriptor.components.find(c => c.id === plan.engineComponentId);
+  need(target && target.runtime === MODULE_ENGINE_PROFILE_V1, "MODULE_BUILD_ADAPTER_UNSUPPORTED");
+  need(/^[A-Za-z_$][A-Za-z0-9_$]{0,255}$/u.test(target.entrypoint), "MODULE_BUILD_ENTRYPOINT_INVALID");
+  const sources = soliditySources(checked.request.files);
+  need(Object.hasOwn(sources, target.sourcePath), "MODULE_BUILD_TARGET_MISSING");
+  const standard = { language: "Solidity", sources, settings: NATIVE_SETTINGS_V1 };
+  need(new TextEncoder().encode(json(standard)).length <= MODULE_REVIEW_LIMITS_V1.standardJsonBytes, "MODULE_BUILD_PROFILE_CAPACITY_EXCEEDED");
+  return { checked, target, standard };
+}
+/** Reuses the reviewed source closure/settings for source publication; grants no build or review authority. */
+export function moduleEngineStandardInputV1(source: unknown, subject: ModuleReviewSubjectV1, rawPlan: unknown) {
+  return sourceInput(source, subject, validateModuleEngineBuildPlanV1(rawPlan, subject)).standard;
+}
+function compiledCases(plan: ModuleEngineBuildPlanV1, source: ReturnType<typeof sourceInput>, engine: ModuleEngineContractArtifactV1): ModuleEngineCompiledCaseV1[] {
+  const descriptor = source.checked.request.descriptor;
+  return plan.cases.map(c => {
+    const configBytes = c.rawConfigBytes ?? encodeModuleEngineConfiguration(plan.configurationAbi, compileOpenConfig(descriptor.configuration, c.parameters, { roles: { author: descriptor.author, reward: descriptor.rewardWallet } }), descriptor.configuration);
+    const context = {
+      host: MODULE_ENGINE_REVIEW_HOST_V1,
+      launchId: moduleReviewDigestV1("programmable.modules.engine-review-launch.v1", { requestDigest: plan.requestDigest, caseId: c.id }),
+      token: c.token, creator: MODULE_ENGINE_REVIEW_ACTOR_V1, quoteAsset: c.quoteAsset, feeCollector: MODULE_ENGINE_REVIEW_HOST_V1,
+    };
+    const constructorArgs = encodeAbiParameters(MODULE_ENGINE_CONSTRUCTOR_ABI_V1, [context, configBytes]);
+    const runtimeBytecode = materializeModuleEngineRuntimeV1(engine, constructorArgs);
+    const initCode = `${engine.creationBytecode}${constructorArgs.slice(2)}` as `0x${string}`;
+    need((initCode.length - 2) / 2 <= MODULE_REVIEW_LIMITS_V1.creationBytes, "MODULE_ENGINE_INITCODE_TOO_LARGE");
+    return { ...c, context, contextHash: keccak256(encodeAbiParameters([{ type: "tuple", components: MODULE_ENGINE_CONTEXT_ABI_V1 }], [context])), configBytes, configHash: keccak256(configBytes), constructorArgs, constructorHash: keccak256(constructorArgs), initCodeHash: keccak256(initCode), runtimeBytecode, runtimeCodeHash: keccak256(runtimeBytecode) };
+  });
+}
+function compilerIdentity(standard: unknown) {
+  return { version: ENGINE_REVIEW_COMPILER.version, binarySha256: ENGINE_REVIEW_COMPILER.binarySha256, imageDigest: ENGINE_REVIEW_COMPILER.imageDigest, settingsHash: moduleReviewDigestV1("programmable.modules.compiler-settings.v1", NATIVE_SETTINGS_V1), completeInputHash: moduleReviewDigestV1("programmable.modules.compiler-input.v1", standard), reproducible: true as const };
+}
+function artifactContents(subject: ModuleReviewSubjectV1, plan: ModuleEngineBuildPlanV1, source: ReturnType<typeof sourceInput>, engine: ModuleEngineContractArtifactV1, tests: ModuleEngineTestResultV1) {
+  const descriptor = source.checked.request.descriptor;
+  const planDigest = moduleReviewDigestV1(MODULE_ENGINE_PLAN_SCHEMA_V1, plan), cases = compiledCases(plan, source, engine);
+  validateModuleEngineTestResultsV1(tests, subject.requestDigest, planDigest, cases);
+  return {
+    schemaVersion: MODULE_ENGINE_BUILD_SCHEMA_V1, authority: "programmable.module-review.engine-build.v1" as const, subject,
+    packageId: source.checked.packageId, familyId: source.checked.familyId, rewardWallet: descriptor.rewardWallet.toLowerCase(),
+    sourceManifestHash: moduleReviewDigestV1("programmable.modules.source-manifest.v1", descriptor), planDigest,
+    configurationSchemaHash: moduleReviewDigestV1("programmable.modules.configuration-schema.v1", descriptor.configuration),
+    configurationCodec: plan.configurationCodec, configurationAbi: plan.configurationAbi,
+    ...(plan.testEnvironment === undefined ? {} : { testEnvironment: plan.testEnvironment }),
+    compiler: compilerIdentity(source.standard), engine, executionGas: plan.executionGas, operationPermissions: plan.operationPermissions, moneyRights: plan.moneyRights, coinRights: plan.coinRights, testEconomics: plan.testEconomics, cases, tests,
+    reviewRequired: MODULE_ENGINE_REVIEW_AREAS_V1, approved: false as const, registryApproved: false as const, available: false as const,
+  };
+}
+/** API-side reconstruction binds the authenticated worker result; no contributor code executes here. */
+export function verifyModuleEngineBuildArtifactV1(artifact: ModuleEngineBuildArtifactV1, subject: ModuleReviewSubjectV1, rawPlan: unknown, sourceRequest: unknown): void {
+  const plan = validateModuleEngineBuildPlanV1(rawPlan, subject), source = sourceInput(sourceRequest, subject, plan), value = artifact.engine;
+  const engine = parseModuleEngineContractArtifactV1({ contracts: { [source.target.sourcePath]: { [source.target.entrypoint]: { abi: value.abi, evm: { bytecode: { object: value.creationBytecode.slice(2) }, deployedBytecode: { object: value.runtimeTemplate.slice(2), immutableReferences: Object.fromEntries(value.immutableReferences.map(r => [r.id, r.ranges])) } } } } } }, source.target, plan);
+  const contents = artifactContents(subject, plan, source, engine, artifact.tests);
+  const expected = { ...contents, artifactDigest: moduleReviewDigestV1(MODULE_ENGINE_BUILD_SCHEMA_V1, contents) };
+  need(json(artifact) === json(expected) && new TextEncoder().encode(json(artifact)).length <= MODULE_REVIEW_LIMITS_V1.artifactBytes, "MODULE_REVIEW_BUILD_BINDING_INVALID");
+}
+

--- a/ops/module-mode-publication/review.ts
+++ b/ops/module-mode-publication/review.ts
@@ -1,4 +1,4 @@
-import { verifyModuleEngineBuildArtifactV1 } from "../../lib/module-mode/review-engine-contract";
+import { verifyModuleEngineBuildArtifactV1 } from "../../lib/server/module-mode/review-engine-source";
 import type { ModuleEngineBuildArtifactV1, ModuleEngineBuildPlanV1 } from "../../lib/module-mode/review-engine-types";
 import { constants } from "node:fs";
 import { open } from "node:fs/promises";

--- a/tests/fixtures/module-review-admin-harness.tsx
+++ b/tests/fixtures/module-review-admin-harness.tsx
@@ -8,9 +8,12 @@ import { reviewDigest, summarizeReviewJob, type ModuleReviewDecisionCommandV1, t
 import type { moduleReviewAdminFixture } from "./module-review-admin";
 import styles from "../../components/module-review-admin-console.module.css";
 
+const NO_EXAMPLES: ReturnType<typeof moduleReviewAdminFixture>[] = [];
+
 /** Local rendering harness only. No authentication, network, database, review, or publication authority. */
-export function ModuleReviewAdminHarness({ fixture }: { fixture: ReturnType<typeof moduleReviewAdminFixture> }) {
+export function ModuleReviewAdminHarness({ fixture, examples = NO_EXAMPLES }: { fixture: ReturnType<typeof moduleReviewAdminFixture>; examples?: ReturnType<typeof moduleReviewAdminFixture>[] }) {
   const detail = useRef(structuredClone(fixture.detail));
+  const records = useRef([fixture, ...examples].map(item => structuredClone(item.detail)));
   const loseResponse = useRef(false);
   const [generation, setGeneration] = useState(0);
   const [requestCount, setRequestCount] = useState(0);
@@ -19,36 +22,45 @@ export function ModuleReviewAdminHarness({ fixture }: { fixture: ReturnType<type
   const [exportReady, setExportReady] = useState(true);
   const [tokenReads, setTokenReads] = useState(0);
   const request = useCallback<ComponentProps<typeof ModuleReviewWorkspace>["request"]>(async (path, body) => {
-    if (path.startsWith("?")) return { schemaVersion: "programmable.modules.website-review-queue.v1", jobs: [summarizeReviewJob(detail.current.job)], nextCursor: null };
-    if (path.includes("/source?")) return JSON.stringify(fixture.source);
-    if (path.endsWith("/manifest")) return { schemaVersion: "programmable.modules.website-manifest-check.v1", submissionId: fixture.subject.submissionId, requestDigest: fixture.subject.requestDigest, reviewRevision: detail.current.job.reviewRevision, artifactDigest: fixture.artifact.artifactDigest, hostManifestHash: fixture.manifestHash };
+    if (path.startsWith("?")) return { schemaVersion: "programmable.modules.website-review-queue.v1", jobs: records.current.map(record => {
+      const current = record.job.subject.submissionId === detail.current.job.subject.submissionId ? detail.current : record;
+      return { ...summarizeReviewJob(current.job), sourceSummary: { name: current.source.descriptor.name, version: current.source.descriptor.version } };
+    }), nextCursor: null };
+    const requested = [fixture, ...examples].find(item => path.startsWith(`/${item.subject.submissionId}`)) ?? fixture;
+    if (path.includes("/source?")) return JSON.stringify(requested.source);
+    if (path.endsWith("/manifest")) return { schemaVersion: "programmable.modules.website-manifest-check.v1", submissionId: requested.subject.submissionId, requestDigest: requested.subject.requestDigest, reviewRevision: detail.current.job.reviewRevision, artifactDigest: requested.artifact.artifactDigest, hostManifestHash: requested.manifestHash };
     if (path.endsWith("/plan")) {
       detail.current = { ...detail.current, job: { ...detail.current.job, state: "queued", reviewRevision: detail.current.job.reviewRevision + 1, artifact: null } };
       return { schemaVersion: "programmable.modules.review-plan-receipt.v1", job: detail.current.job, approved: false, available: false };
     }
     if (path.endsWith("/decisions")) {
       const command = (body as { command: ModuleReviewDecisionCommandV1 }).command;
-      const contents: Omit<ModuleReviewDecisionRecordV1, "decisionDigest"> = { schemaVersion: "programmable.modules.review-decision.v1", reviewerWallet: fixture.reviewer, policyDigest: fixture.policyDigest, subject: fixture.subject, command, decidedAt: "2026-09-06T02:00:00.000Z", available: false, registryApproved: false };
+      const contents: Omit<ModuleReviewDecisionRecordV1, "decisionDigest"> = { schemaVersion: "programmable.modules.review-decision.v1", reviewerWallet: fixture.reviewer, policyDigest: requested.policyDigest, subject: requested.subject, command, decidedAt: "2026-09-06T02:00:00.000Z", available: false, registryApproved: false };
       const decision = { ...contents, decisionDigest: reviewDigest("programmable.modules.review-decision.v1", contents) };
       detail.current = { ...detail.current, decisions: [...detail.current.decisions, decision], job: { ...detail.current.job, reviewRevision: detail.current.job.reviewRevision + 1, state: command.outcome === "accept" ? "accepted" : command.outcome === "reject" ? "rejected" : "changes_requested" } };
       setRequestCount(n => n + 1);
       if (loseResponse.current) throw new Error("Synthetic lost response after recording the decision.");
       return { schemaVersion: "programmable.modules.review-decision-receipt.v1", decision };
     }
+    const id = path.split("?")[0].slice(1);
+    const next = records.current.find(item => item.job.subject.submissionId === id);
+    if (next && detail.current.job.subject.submissionId !== id) {
+      records.current = records.current.map(item => item.job.subject.submissionId === detail.current.job.subject.submissionId ? detail.current : item);
+      detail.current = next;
+    }
     return structuredClone(detail.current);
-  }, [fixture]);
+  }, [fixture, examples]);
   const reset = (failed: boolean) => {
     detail.current = structuredClone(fixture.detail);
     if (failed) detail.current.job = { ...detail.current.job, state: "build_failed", lastError: "SYNTHETIC_BUILD_FAILURE", artifact: null };
     setRequestCount(0); setGeneration(n => n + 1);
   };
-  return <div className={`${styles.page} page-width`}>
-    <header className={styles.header}><div><p className={styles.eyebrow}>Local synthetic fixture · No real review authority</p><h1>Module review</h1><p>This page tests the review interface without a wallet, backend, or onchain action.</p></div></header>
-    <div className={styles.toolbar}>
+  return <div className={`${styles.page} page-width`} data-module-review-page>
+    <header className={styles.header}><div><p className={styles.eyebrow}>Admin · Local preview</p><h1>Module reviews</h1></div>
+    <details className={styles.tools}><summary>Preview controls</summary><div className={styles.toolsMenu}>
+      <p className={styles.caption}>Synthetic data. No real review authority.</p>
       <div className={styles.actions}><button className={styles.secondary} onClick={() => reset(false)}>Reset successful build</button><button className={styles.secondary} onClick={() => reset(true)}>Show failed build</button><label className={styles.checkbox}><input type="checkbox" onChange={event => { loseResponse.current = event.target.checked; }} />Lose decision response</label></div>
       <p role="status">Synthetic decisions sent: {requestCount}</p>
-    </div>
-    <ModuleReviewWorkspace key={generation} account={fixture.reviewer} request={request} />
     <section className={styles.section}>
       <h2>Local session-download fixture</h2>
       <p className={styles.note}>Downloaded files contain synthetic tokens with no authentication or publication authority. Delete these fixture files after the interface check.</p>
@@ -66,5 +78,7 @@ export function ModuleReviewAdminHarness({ fixture }: { fixture: ReturnType<type
       <p className={styles.caption}>Synthetic access-token reads: {tokenReads}</p>
     </section>
     <details className={styles.disclosure}><summary>Fixture host manifest</summary><pre>{JSON.stringify(fixture.manifest, null, 2)}</pre></details>
+    </div></details></header>
+    <ModuleReviewWorkspace key={generation} account={fixture.reviewer} request={request} />
   </div>;
 }

--- a/tests/fixtures/module-review-admin.ts
+++ b/tests/fixtures/module-review-admin.ts
@@ -10,7 +10,7 @@ import { a, h, moduleEvidenceFixture } from "./module-mode-evidence";
 import { WEBSITE_ADMIN_WALLET } from "../../lib/admin-access";
 
 // Synthetic parser and UI fixtures. Never deployment, worker, reviewer, or publication evidence.
-export function moduleReviewAdminFixture(author = a(900)) {
+export function moduleReviewAdminFixture(author = a(900), options: { name?: string; submissionId?: string } = {}) {
   const release = bindActiveModuleModeRelease(moduleEvidenceFixture().release);
   const files = [{ path: "README.md", text: "Synthetic module review fixture. Never publish or admit." },
     { path: "src/Program.sol", text: "// Synthetic parser fixture, not a deployable module.\ncontract Program {}\ncontract Factory {}\n" }].map(file => ({
@@ -18,7 +18,7 @@ export function moduleReviewAdminFixture(author = a(900)) {
   }));
   const schema = { type: "record" as const, fields: { capNative: { type: "uint" as const, bits: 128, min: "1", label: "Maximum buys" }, duration: { type: "uint" as const, bits: 64, min: "1", label: "Duration" } }, required: ["capNative", "duration"] };
   const source: ModuleSubmissionRequest = { format: "programmable.modules.submission.v0.1", files, descriptor: {
-    format: "programmable.classic.source-package.v0.1", name: "Synthetic opening cap", version: "1.0.0", author, rewardWallet: a(901), familySalt: h(902),
+    format: "programmable.classic.source-package.v0.1", name: options.name ?? "Synthetic opening cap", version: "1.0.0", author, rewardWallet: a(901), familySalt: h(902),
     source: { files: files.map(({ path, sha256 }) => ({ path, sha256 })) }, configuration: schema,
     components: [
       { id: "program", runtime: "programmable.module-native-runtime@1", sourcePath: "src/Program.sol", entrypoint: "Program" },
@@ -28,7 +28,7 @@ export function moduleReviewAdminFixture(author = a(900)) {
   } };
   const checked = validateModuleSubmissionRequest(source);
   if (!checked.ok) throw new Error(JSON.stringify(checked.errors));
-  const subject: ReviewSubject = { submissionId: "00000000-0000-4000-8000-000000000001", principalId: "00000000-0000-4000-8000-000000000002", author, requestDigest: checked.requestDigest };
+  const subject: ReviewSubject = { submissionId: options.submissionId ?? "00000000-0000-4000-8000-000000000001", principalId: "00000000-0000-4000-8000-000000000002", author, requestDigest: checked.requestDigest };
   const plan: ReviewPlan = { schemaVersion: "programmable.modules.native-build-plan.v1", submissionId: subject.submissionId, requestDigest: subject.requestDigest,
     programComponentId: "program", factoryComponentId: "factory", configurationCodec: "programmable.native-abi@1", programAbi: [{ path: ["capNative"], type: "uint128" }, { path: ["duration"], type: "uint64" }], callbackGas: 75000,
     cases: [{ id: "basic", parameters: { capNative: "1", duration: "60" }, budgetWei: "0", expectedDeployment: "success" }] };

--- a/tests/module-engine-publication.test.ts
+++ b/tests/module-engine-publication.test.ts
@@ -21,7 +21,8 @@ import type { PublicationProvider } from "../ops/module-mode-publication/rpc";
 import { computeModuleReviewDecisionDigestV1, type ModuleReviewDecisionRecordV1 } from "../lib/server/module-mode/review-decision-wire-v1";
 import { validateModuleSubmissionRequest } from "../packages/classic-modules/src/open-transport.mjs";
 import { createModuleReviewClient } from "../lib/server/module-mode/review-client";
-import { materializeModuleEngineRuntimeV1, moduleEngineStandardInputV1, verifyModuleEngineBuildArtifactV1 } from "../lib/module-mode/review-engine-contract";
+import { materializeModuleEngineRuntimeV1 } from "../lib/module-mode/review-engine-contract";
+import { moduleEngineStandardInputV1, verifyModuleEngineBuildArtifactV1 } from "../lib/server/module-mode/review-engine-source";
 import { createReviewedModuleEngineManifest } from "../lib/module-mode/review-engine-manifest";
 
 vi.mock("server-only", () => ({}));

--- a/tests/module-engine-review-route.test.ts
+++ b/tests/module-engine-review-route.test.ts
@@ -11,7 +11,8 @@ import { computeModuleEngineHostManifestHash, computeModuleEngineReleaseDigest, 
 import { createReviewedModuleEngineManifest } from "../lib/module-mode/review-engine-manifest";
 import type { ModuleEngineBuildArtifactV1, ModuleEngineBuildPlanV1 } from "../lib/module-mode/review-engine-types";
 import { MODULE_ENGINE_QUOTE_ENVIRONMENT_V1, MODULE_ENGINE_QUOTE_NVDA_ENVIRONMENT_V1 } from "../lib/module-mode/review-engine-types";
-import { moduleEngineStandardInputV1, parseEngineReviewArtifact, validateModuleEngineBuildPlanV1, verifyModuleEngineBuildArtifactV1 } from "../lib/module-mode/review-engine-contract";
+import { parseEngineReviewArtifact, validateModuleEngineBuildPlanV1 } from "../lib/module-mode/review-engine-contract";
+import { moduleEngineStandardInputV1, verifyModuleEngineBuildArtifactV1 } from "../lib/server/module-mode/review-engine-source";
 import { parseReviewSubject, reviewDigest, type ReviewJob } from "../lib/module-mode/review-contract";
 import { computeModuleModeHostManifestHash, createModuleModeHostManifest, type ModuleModeHostReleaseIdentity } from "../lib/server/module-mode/catalog";
 import { computeModuleReviewDecisionDigestV1, type ModuleReviewDecisionCommandV1, type ModuleReviewDecisionRecordV1 } from "../lib/server/module-mode/review-decision-wire-v1";

--- a/tests/module-review-admin-contract.test.ts
+++ b/tests/module-review-admin-contract.test.ts
@@ -27,6 +27,17 @@ describe("Private module review wire boundaries", () => {
   it("requires an artifact for built and accepted detail states", () => {
     const f = moduleReviewAdminFixture(); expect(() => parseReviewJob({ ...f.job, artifact: null })).toThrow("required build");
   });
+  it("accepts compact inbox names without accepting source bytes or relaxing detail fields", () => {
+    const f = moduleReviewAdminFixture();
+    const light = { ...f.job, plan: null, artifact: null };
+    const sourceSummary = { name: f.source.descriptor.name, version: f.source.descriptor.version };
+    expect(parseReviewQueueItem({ ...light, sourceSummary }).sourceSummary).toEqual(sourceSummary);
+    expect(parseReviewQueueItem({ ...light, sourceSummary: null }).sourceSummary).toBeUndefined();
+    expect(() => parseReviewQueueItem({ ...light, sourceSummary: { ...sourceSummary, bytes: "source" } })).toThrow();
+    expect(() => parseReviewQueueItem({ ...light, sourceSummary: { ...sourceSummary, name: "🧩".repeat(129) } })).toThrow();
+    expect(() => parseReviewQueueItem({ ...light, sourceSummary: { ...sourceSummary, version: "" } })).toThrow();
+    expect(() => parseReviewJob({ ...f.job, sourceSummary })).toThrow();
+  });
   it("rejects an artifact attached to a different submission", () => {
     const f = moduleReviewAdminFixture(); expect(() => parseReviewArtifact(f.artifact, { ...f.subject, submissionId: "00000000-0000-4000-8000-000000000003" })).toThrow("subject");
   });


### PR DESCRIPTION
Module submissions now stay in one screen: a searchable, paginated inbox on the left and a focused review panel on the right. Source, checks and decisions use separate sections; the main page stays fixed while long evidence scrolls inside its panel. Mobile uses a list/detail view with an explicit way back and visible primary actions.

Keep the existing manual review, confirmation and uncertain-response controls. Accept an optional compact source name/version from the queue API, with compatibility for the current response and verified names cached after opening a submission. Move Node-only source reconstruction into the server/operator directory so the browser review UI no longer imports the Node transport dependency.

Validation: 159 targeted review/parser/publication tests passed; final TypeScript and scoped ESLint passed. Root checked desktop and mobile screenshots, 320px and short-height layouts, search/filter/source paths, keyboard focus, explicit confirmation and recovery after a lost synthetic decision response. Zero browser console errors after reload. The temporary preview route is excluded from this change.
