### PR TITLE
Fix Robinhood wallet network checks and account reconnect recovery

### DIFF
--- a/components/module-mode-wallet-state.tsx
+++ b/components/module-mode-wallet-state.tsx
@@ -2,6 +2,7 @@ import { sha256, type Address, type Hex } from "viem";
 import { useCallback, useMemo, useSyncExternalStore } from "react";
 
 import { ROBINHOOD_CHAIN_ID } from "@/lib/chains";
+import { walletChainIdsEqual } from "@/lib/wallet-chain-id";
 import type { ModuleModeDraft } from "@/lib/module-mode/builder";
 import type { ModuleNativeWalletTransaction, PreparedModuleNativeTransaction } from "@/lib/module-mode/native-client";
 import type { PreparedModuleEngineTransaction } from "@/lib/module-engine/client";
@@ -59,7 +60,7 @@ export interface ModuleModeWalletSnapshot {
 }
 
 export function isModuleModeChain(chainId: string | undefined) {
-  return Boolean(chainId && /^(?:0x[0-9a-f]+|[1-9]\d*)$/i.test(chainId) && BigInt(chainId) === 4663n);
+  return walletChainIdsEqual(chainId, ROBINHOOD_CHAIN_ID);
 }
 
 export function moduleModeWalletStep(wallet: ModuleModeWalletSnapshot): "connect" | "switch" | "prepare" {

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -1266,6 +1266,12 @@ function PrivyWalletBridge({
   const [sessionSuppressed, setSessionSuppressed] = useState(false);
   const [accountSwitchRequested, setAccountSwitchRequested] = useState(false);
   const [walletAccountMismatch, setWalletAccountMismatch] = useState(false);
+  const [verifiedWalletNetwork, setVerifiedWalletNetwork] = useState<{
+    userId: string;
+    account: string;
+    chainId: string;
+    walletSnapshot: object;
+  } | null>(null);
   const [switchingNetwork, setSwitchingNetwork] = useState(false);
   const networkSwitchPendingRef = useRef(false);
   const [error, setError] = useState("");
@@ -1299,6 +1305,7 @@ function PrivyWalletBridge({
       applicantRefreshUserGate.invalidate();
       setSessionSuppressed(false);
       setWalletAccountMismatch(false);
+      setVerifiedWalletNetwork(null);
       setError("");
       setWalletLoginStatus("");
       setDialogOpen(false);
@@ -1540,11 +1547,14 @@ function PrivyWalletBridge({
       return null;
     }
 
+    const verified = verifiedWalletNetwork !== null && verifiedWalletNetwork.userId === user?.id
+      && verifiedWalletNetwork.account.toLowerCase() === connectedWalletAddress.toLowerCase()
+      && verifiedWalletNetwork.walletSnapshot === connectedWallet;
     return {
       account: connectedWalletAddress,
-      chainId: normalizeChainId(connectedWalletChainId),
+      chainId: verified ? verifiedWalletNetwork.chainId : normalizeChainId(connectedWalletChainId),
     };
-  }, [connectedWalletAddress, connectedWalletChainId]);
+  }, [connectedWallet, connectedWalletAddress, connectedWalletChainId, user?.id, verifiedWalletNetwork]);
   const walletLinked = Boolean(connectedWallet && ownedWalletAddresses.has(connectedWallet.address.toLowerCase()));
   const walletSessionGenerationRef = useRef(0);
   const walletRequestSessionRef = useRef({
@@ -1969,6 +1979,7 @@ function PrivyWalletBridge({
     applicantRefreshUserGate.invalidate();
     settleWalletLoginAttempt();
     setDisconnecting(true);
+    setVerifiedWalletNetwork(null);
     setError("");
     const markDisconnectFailed = () => {
       const outcome = getWalletDisconnectOutcome(false);
@@ -2064,6 +2075,7 @@ function PrivyWalletBridge({
           if (!isCurrentSession()) throw new Error("The wallet session changed. Reconnect and try again.");
         },
       });
+      const walletAtVerification = walletRequestSessionRef.current.walletCapability;
       if (connectedWallet.walletClientType !== "privy" && connectedWallet.walletClientType !== "privy-v2") {
         const accounts = await provider.request({ method: "eth_accounts" });
         if (!isCurrentSession()) return false;
@@ -2072,6 +2084,14 @@ function PrivyWalletBridge({
           setError("The active wallet changed. Reconnect and try again.");
           return false;
         }
+      }
+      // Switching to an already active network need not emit chainChanged.
+      // Use the verified readback only while this SDK snapshot and wallet still match.
+      if (walletAtVerification !== null) {
+        setVerifiedWalletNetwork({
+          userId: expectedUser, account: expectedAccount,
+          chainId: target.chainHex, walletSnapshot: walletAtVerification,
+        });
       }
       return true;
     } catch (cause) {

--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -67,6 +67,8 @@ import {
 } from "@/lib/custom-launch/robinhood-funding-review-v1";
 import { parseLocalProfile } from "@/lib/profile/local-profile";
 import { robinhoodChain } from "@/lib/chains";
+import { normalizeWalletChainId, walletChainIdsEqual } from "@/lib/wallet-chain-id";
+import { getWalletProviderOnChain } from "@/lib/wallet-network";
 import {
   assertMainTokenMigrationTransaction,
   type MainTokenMigrationPermitSignature,
@@ -616,7 +618,7 @@ export function getWalletLoginErrorMessage(errorCode: string) {
     return "";
   }
   if (errorCode === "linked_to_another_user") {
-    return "This wallet belongs to another account. Sign out, then sign in with that wallet.";
+    return "This wallet is linked to another account. Switch accounts to use it.";
   }
 
   return "Unable to connect wallet. Try again.";
@@ -787,14 +789,7 @@ function shortenAddress(address: string) {
 }
 
 function normalizeChainId(chainId: string) {
-  if (chainId.startsWith("eip155:")) {
-    const decimalId = Number(chainId.slice("eip155:".length));
-    return Number.isSafeInteger(decimalId)
-      ? `0x${decimalId.toString(16)}`
-      : chainId;
-  }
-
-  return chainId.toLowerCase();
+  return normalizeWalletChainId(chainId) ?? chainId.toLowerCase();
 }
 
 function isEthereumAddress(address: string): address is `0x${string}` {
@@ -808,10 +803,7 @@ export async function assertExternalWalletAuthorityCurrent(input: Readonly<{
   request: (method: "eth_chainId" | "eth_accounts") => Promise<unknown>;
 }>): Promise<void> {
   const providerChainId = await input.request("eth_chainId");
-  if (
-    typeof providerChainId !== "string"
-    || normalizeChainId(providerChainId) !== normalizeChainId(input.expectedChainId)
-  ) {
+  if (!walletChainIdsEqual(providerChainId, input.expectedChainId)) {
     throw new Error(`The wallet is not connected to ${input.networkName}`);
   }
 
@@ -1272,6 +1264,8 @@ function PrivyWalletBridge({
   const [loginPending, setLoginPending] = useState(false);
   const [walletLoginStatus, setWalletLoginStatus] = useState("");
   const [sessionSuppressed, setSessionSuppressed] = useState(false);
+  const [accountSwitchRequested, setAccountSwitchRequested] = useState(false);
+  const [walletAccountMismatch, setWalletAccountMismatch] = useState(false);
   const [switchingNetwork, setSwitchingNetwork] = useState(false);
   const networkSwitchPendingRef = useRef(false);
   const [error, setError] = useState("");
@@ -1280,15 +1274,17 @@ function PrivyWalletBridge({
     userId: string;
     address: string;
   } | null>(null);
-  const sdkSessionRef = useRef({ ready, authenticated, userId: user?.id ?? null, sessionSuppressed, disconnecting });
+  const sdkSessionRef = useRef({ ready, authenticated, user, userId: user?.id ?? null, sessionSuppressed, disconnecting });
   useLayoutEffect(() => {
-    sdkSessionRef.current = { ready, authenticated, userId: user?.id ?? null, sessionSuppressed, disconnecting };
-  }, [authenticated, disconnecting, ready, sessionSuppressed, user?.id]);
+    sdkSessionRef.current = { ready, authenticated, user, userId: user?.id ?? null, sessionSuppressed, disconnecting };
+  }, [authenticated, disconnecting, ready, sessionSuppressed, user]);
   const walletLoginIntentRef = useRef<"login" | "connect" | "link" | null>(null);
+  const walletConnectionAttemptRef = useRef<{ userId: string } | null>(null);
   const walletLoginAttemptGateRef = useRef(createWalletLoginAttemptGate());
   const walletLoginLeaseRef = useRef<BrowserWalletLoginLease | null>(null);
   const settleWalletLoginAttempt = useCallback(() => {
     walletLoginIntentRef.current = null;
+    walletConnectionAttemptRef.current = null;
     walletLoginAttemptGateRef.current.settle();
     walletLoginLeaseRef.current?.release();
     walletLoginLeaseRef.current = null;
@@ -1302,6 +1298,7 @@ function PrivyWalletBridge({
       }
       applicantRefreshUserGate.invalidate();
       setSessionSuppressed(false);
+      setWalletAccountMismatch(false);
       setError("");
       setWalletLoginStatus("");
       setDialogOpen(false);
@@ -1326,23 +1323,61 @@ function PrivyWalletBridge({
   });
   const { generateSiweMessage, loginWithSiwe } = useLoginWithSiwe();
   const { connectWallet } = useConnectWallet({
-    onSuccess: ({ wallet: reconnectedWallet }) => {
+    onSuccess: async ({ wallet: reconnectedWallet }) => {
+      const attempt = walletConnectionAttemptRef.current;
+      if (!attempt || walletLoginIntentRef.current !== "connect") return;
+      const isCurrentAttempt = () => {
+        const session = sdkSessionRef.current;
+        return walletConnectionAttemptRef.current === attempt
+          && session.ready && session.authenticated && session.userId === attempt.userId
+          && !session.sessionSuppressed && !session.disconnecting;
+      };
+      const discardStaleAttempt = () => {
+        if (walletConnectionAttemptRef.current === attempt) settleWalletLoginAttempt();
+      };
+      if (!isCurrentAttempt()) {
+        discardStaleAttempt();
+        return;
+      }
+      const ownsWallet = (accountUser: RefreshableApplicantUserV1 | null | undefined) =>
+        accountUser?.id === attempt.userId && accountUser.linkedAccounts.some((account) =>
+          account.type === "wallet" && account.chainType === "ethereum"
+          && account.address?.toLowerCase() === reconnectedWallet.address.toLowerCase());
+      let owned = ownsWallet(sdkSessionRef.current.user);
+      if (!owned) {
+        try {
+          // A restored session can still contain the account's old linked-wallet list.
+          // Reuse the shared refresh gate so reconnect cannot flood Privy's user endpoint.
+          const refreshedUser = await applicantRefreshUserGate.refresh(applicantAuthorityKeyRef.current);
+          if (!isCurrentAttempt()) { discardStaleAttempt(); return; }
+          owned = ownsWallet(refreshedUser);
+        } catch {
+          if (!isCurrentAttempt()) { discardStaleAttempt(); return; }
+          settleWalletLoginAttempt();
+          setError("Unable to verify your account. Try connecting again.");
+          setDialogOpen(true);
+          return;
+        }
+      }
       settleWalletLoginAttempt();
-      const owned = user?.linkedAccounts.some((account) =>
-        account.type === "wallet"
-        && account.chainType === "ethereum"
-        && account.address.toLowerCase() === reconnectedWallet.address.toLowerCase());
-      if (!owned || !user) {
-        setError("Connect a wallet linked to this account, or sign out to use another account.");
+      if (!owned) {
+        setWalletAccountMismatch(true);
+        setError("This wallet is not linked to your signed-in account.");
         setDialogOpen(true);
         return;
       }
-      setSelectedWallet({ userId: user.id, address: reconnectedWallet.address });
+      setSelectedWallet({ userId: attempt.userId, address: reconnectedWallet.address });
+      setWalletAccountMismatch(false);
       setError("");
       setDialogOpen(false);
     },
     onError: (errorCode) => {
+      if (walletLoginIntentRef.current !== "connect") return;
+      const attempt = walletConnectionAttemptRef.current;
+      const session = sdkSessionRef.current;
       settleWalletLoginAttempt();
+      if (!attempt || session.userId !== attempt.userId
+        || !session.authenticated || session.sessionSuppressed || session.disconnecting) return;
       const message = getWalletLoginErrorMessage(errorCode);
       if (!message) return;
       setError(message);
@@ -1353,6 +1388,7 @@ function PrivyWalletBridge({
     onSuccess: ({ user: linkedUser, linkedAccount }) => {
       settleWalletLoginAttempt();
       applicantRefreshUserGate.invalidate();
+      setWalletAccountMismatch(false);
       if (linkedAccount.type === "wallet" && isEthereumAddress(linkedAccount.address)) {
         setSelectedWallet({ userId: linkedUser.id, address: linkedAccount.address });
       }
@@ -1361,6 +1397,7 @@ function PrivyWalletBridge({
     },
     onError: (errorCode) => {
       settleWalletLoginAttempt();
+      setWalletAccountMismatch(errorCode === "linked_to_another_user");
       const message = getWalletLoginErrorMessage(errorCode);
       if (!message) return;
 
@@ -1828,9 +1865,11 @@ function PrivyWalletBridge({
   }, [activeAuthenticated, authenticated, githubConnected, linkGithub, login, ready, user]);
 
   const connectAccountWallet = useCallback((link: boolean) => {
-    if (!providerSettled || !activeAuthenticated || privyModalOpen) return;
+    if (!providerSettled || !activeAuthenticated || !user || privyModalOpen) return;
     if (!walletLoginAttemptGateRef.current.tryStart()) return;
     walletLoginIntentRef.current = link ? "link" : "connect";
+    walletConnectionAttemptRef.current = { userId: user.id };
+    setWalletAccountMismatch(false);
     setLoginPending(true);
     setError("");
     setWalletLoginStatus("");
@@ -1861,12 +1900,13 @@ function PrivyWalletBridge({
         : "Unable to connect wallet. Try again.");
       setDialogOpen(true);
     });
-  }, [activeAuthenticated, connectWallet, linkWallet, privyModalOpen, providerSettled, settleWalletLoginAttempt, user?.id]);
+  }, [activeAuthenticated, connectWallet, linkWallet, privyModalOpen, providerSettled, settleWalletLoginAttempt, user]);
   const addWallet = useCallback(() => connectAccountWallet(true), [connectAccountWallet]);
   const reconnectWallet = useCallback(() => connectAccountWallet(false), [connectAccountWallet]);
 
   const openWallet = useCallback(() => {
     setError("");
+    setWalletAccountMismatch(false);
 
     const action = getWalletOpenAction(sessionAction, wallet !== null, hasLinkedWallet);
 
@@ -1969,6 +2009,27 @@ function PrivyWalletBridge({
     }
   }, [applicantRefreshUserGate, authenticated, logout, settleWalletLoginAttempt, wallets]);
 
+  const switchAccount = useCallback(() => {
+    if (disconnecting || accountSwitchRequested) return;
+    setAccountSwitchRequested(true);
+    void disconnect().then((succeeded) => {
+      if (!succeeded) setAccountSwitchRequested(false);
+    });
+  }, [accountSwitchRequested, disconnect, disconnecting]);
+
+  useEffect(() => {
+    // Privy's logout promise can resolve before it clears the current user.
+    // Opening login earlier silently reuses that account and recreates the loop.
+    if (!accountSwitchRequested || !ready || authenticated || user
+      || sessionSuppressed || disconnecting) return;
+    const timeout = window.setTimeout(() => {
+      setAccountSwitchRequested(false);
+      setWalletAccountMismatch(false);
+      startLogin();
+    }, 0);
+    return () => window.clearTimeout(timeout);
+  }, [accountSwitchRequested, authenticated, disconnecting, ready, sessionSuppressed, startLogin, user]);
+
   const switchWalletNetwork = useCallback(async (expectedChainId?: string) => {
     if (!connectedWallet || !wallet || !ownerUserId || networkSwitchPendingRef.current) return false;
     const expectedAccount = wallet.account.toLowerCase();
@@ -1997,19 +2058,12 @@ function PrivyWalletBridge({
     setError("");
 
     try {
-      await connectedWallet.switchChain(target.chain.id);
-      if (!isCurrentSession()) return false;
-      const provider = await connectedWallet.getEthereumProvider();
-      if (!isCurrentSession()) return false;
-      const connectedChainId = await provider.request({ method: "eth_chainId" });
-      if (!isCurrentSession()) return false;
-      if (
-        typeof connectedChainId !== "string"
-        || normalizeChainId(connectedChainId) !== target.chainHex
-      ) {
-        setError(`Unable to verify ${target.name}. Try again.`);
-        return false;
-      }
+      const provider = await getWalletProviderOnChain({
+        wallet: connectedWallet, chainId: target.chain.id, networkName: target.name,
+        assertCurrentSession: () => {
+          if (!isCurrentSession()) throw new Error("The wallet session changed. Reconnect and try again.");
+        },
+      });
       if (connectedWallet.walletClientType !== "privy" && connectedWallet.walletClientType !== "privy-v2") {
         const accounts = await provider.request({ method: "eth_accounts" });
         if (!isCurrentSession()) return false;
@@ -2075,7 +2129,7 @@ function PrivyWalletBridge({
       };
 
       try {
-        if (wallet.chainId !== target.chainHex) {
+        if (isEmbeddedWallet && wallet.chainId !== target.chainHex) {
           await connectedWallet.switchChain(target.chain.id);
           assertCurrentSession();
         }
@@ -2111,16 +2165,9 @@ function PrivyWalletBridge({
           });
         }
 
-        const provider = await connectedWallet.getEthereumProvider();
-        const providerChainId = await provider.request({
-          method: "eth_chainId",
+        const provider = await getWalletProviderOnChain({
+          wallet: connectedWallet, chainId: target.chain.id, networkName: target.name, assertCurrentSession,
         });
-        if (
-          typeof providerChainId !== "string" ||
-          normalizeChainId(providerChainId) !== target.chainHex
-        ) {
-          throw new Error(`The wallet is not connected to ${target.name}`);
-        }
         assertCurrentSession();
         return await sendLocked(async () => {
           const hash = await provider.request({
@@ -2258,14 +2305,17 @@ function PrivyWalletBridge({
       });
       const boundWallet = connectedWallet;
       const account = wallet.account;
+      const expectedGeneration = walletSessionGenerationRef.current;
       let walletRequestAttempted = false;
       let enginePreparationPending = false;
       const isEmbeddedWallet = boundWallet.walletClientType === "privy" || boundWallet.walletClientType === "privy-v2";
       const assertCurrentSession = () => {
         const current = walletRequestSessionRef.current;
-        if (!current.authenticated || current.privyUserId !== sessionSubject
+        if (walletSessionGenerationRef.current !== expectedGeneration
+          || !current.authenticated || current.privyUserId !== sessionSubject
           || current.account?.toLowerCase() !== account.toLowerCase()
-          || current.walletCapability !== boundWallet) {
+          || current.walletCapability?.getEthereumProvider !== boundWallet.getEthereumProvider
+          || current.walletCapability?.switchChain !== boundWallet.switchChain) {
           throw new Error("The selected wallet changed. Review the transaction again");
         }
       };
@@ -2276,7 +2326,10 @@ function PrivyWalletBridge({
           execute: async () => {
             try {
               assertCurrentSession();
-              const provider = await boundWallet.getEthereumProvider();
+              const provider = await getWalletProviderOnChain({
+                wallet: boundWallet, chainId: robinhoodChain.id,
+                networkName: robinhoodChain.name, assertCurrentSession,
+              });
               const assertAuthority = async () => {
                 assertCurrentSession();
                 await assertExternalWalletAuthorityCurrent({
@@ -2939,10 +2992,7 @@ function PrivyWalletBridge({
       const providerChainId = await provider.request({
         method: "eth_chainId",
       });
-      if (
-        typeof providerChainId !== "string" ||
-        normalizeChainId(providerChainId) !== appChainHex
-      ) {
+      if (!walletChainIdsEqual(providerChainId, appChainHex)) {
         throw new Error(`Switch your wallet to ${appNetworkName}`);
       }
 
@@ -2986,10 +3036,7 @@ function PrivyWalletBridge({
     const providerChainId = await provider.request({
       method: "eth_chainId",
     });
-    if (
-      typeof providerChainId !== "string" ||
-      normalizeChainId(providerChainId) !== appChainHex
-    ) {
+    if (!walletChainIdsEqual(providerChainId, appChainHex)) {
       throw new Error(`Switch your wallet to ${appNetworkName}`);
     }
 
@@ -3018,10 +3065,7 @@ function PrivyWalletBridge({
     const providerChainId = await provider.request({
       method: "eth_chainId",
     });
-    if (
-      typeof providerChainId !== "string" ||
-      normalizeChainId(providerChainId) !== appChainHex
-    ) {
+    if (!walletChainIdsEqual(providerChainId, appChainHex)) {
       throw new Error(`Switch your wallet to ${appNetworkName}`);
     }
 
@@ -3049,8 +3093,8 @@ function PrivyWalletBridge({
       authenticated: activeAuthenticated,
       hasSession,
       connecting:
-        loginPending || (!providerSettled && !providerTimedOut),
-      openingWallet: loginPending || autoAction !== null,
+        loginPending || (accountSwitchRequested && !providerTimedOut) || (!providerSettled && !providerTimedOut),
+      openingWallet: loginPending || (accountSwitchRequested && !providerTimedOut) || autoAction !== null,
       disconnecting,
       switchingNetwork,
       preloadWallet: () => undefined,
@@ -3089,6 +3133,7 @@ function PrivyWalletBridge({
       readTradeBalances,
     }),
     [
+      accountSwitchRequested,
       activeAuthenticated,
       autoAction,
       avatarDataUrl,
@@ -3160,6 +3205,7 @@ function PrivyWalletBridge({
           hasLinkedWallet={hasLinkedWallet}
           sessionReady={providerSettled}
           disconnecting={disconnecting}
+          accountMismatch={walletAccountMismatch}
           error={error}
           status={walletLoginStatus}
           walletOptions={walletOptions}
@@ -3167,6 +3213,7 @@ function PrivyWalletBridge({
           onReconnectWallet={reconnectWallet}
           onClose={() => setDialogOpen(false)}
           onLogout={disconnect}
+          onSwitchAccount={switchAccount}
           onRetryLogin={openWallet}
           onSelectWallet={(account) => {
             if (!user) return;
@@ -3302,6 +3349,7 @@ function WalletDialog({
   hasLinkedWallet,
   sessionReady,
   disconnecting,
+  accountMismatch,
   error,
   status,
   walletOptions,
@@ -3309,6 +3357,7 @@ function WalletDialog({
   onReconnectWallet,
   onClose,
   onLogout,
+  onSwitchAccount,
   onRetryLogin,
   onSelectWallet,
 }: {
@@ -3318,6 +3367,7 @@ function WalletDialog({
   hasLinkedWallet: boolean;
   sessionReady: boolean;
   disconnecting: boolean;
+  accountMismatch: boolean;
   error: string;
   status: string;
   walletOptions: readonly WalletState[];
@@ -3325,6 +3375,7 @@ function WalletDialog({
   onReconnectWallet: () => void;
   onClose: () => void;
   onLogout: () => Promise<boolean>;
+  onSwitchAccount: () => void;
   onRetryLogin: () => void;
   onSelectWallet: (account: `0x${string}`) => void;
 }) {
@@ -3416,11 +3467,18 @@ function WalletDialog({
             disabled={disconnecting}
             onClick={!sessionReady
               ? () => window.location.reload()
-              : wallet ? error ? onReconnectWallet : onAddWallet : connect}
+              : accountMismatch ? onSwitchAccount
+                : wallet ? error ? onReconnectWallet : onAddWallet : connect}
           >
-            {!sessionReady ? "Reload page" : wallet ? error ? "Reconnect wallet" : "Add wallet" : "Connect wallet"}
+            {!sessionReady ? "Reload page" : accountMismatch ? "Switch account"
+              : wallet ? error ? "Reconnect wallet" : "Add wallet" : "Connect wallet"}
           </button>
-          {hasSession ? (
+          {accountMismatch && sessionReady ? (
+            <button className={styles.signOut} type="button" disabled={disconnecting} onClick={onReconnectWallet}>
+              Connect linked wallet
+            </button>
+          ) : null}
+          {hasSession && !accountMismatch ? (
             <button
               className={styles.signOut}
               type="button"

--- a/lib/wallet-chain-id.ts
+++ b/lib/wallet-chain-id.ts
@@ -1,0 +1,28 @@
+const decimalChainIdPattern = /^[1-9][0-9]*$/;
+const hexChainIdPattern = /^0x[0-9a-f]+$/i;
+
+/** Parse provider and SDK chain IDs without coercing unrelated values. */
+export function parseWalletChainId(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value > 0 ? value : null;
+  }
+  if (typeof value !== "string" || value.trim() !== value) return null;
+
+  const isCaip = value.startsWith("eip155:");
+  const reference = isCaip ? value.slice("eip155:".length) : value;
+  if (!decimalChainIdPattern.test(reference)
+    && (isCaip || !hexChainIdPattern.test(reference))) return null;
+
+  const chainId = Number(reference);
+  return Number.isSafeInteger(chainId) && chainId > 0 ? chainId : null;
+}
+
+export function normalizeWalletChainId(value: unknown): `0x${string}` | null {
+  const chainId = parseWalletChainId(value);
+  return chainId === null ? null : `0x${chainId.toString(16)}`;
+}
+
+export function walletChainIdsEqual(left: unknown, right: unknown): boolean {
+  const chainId = parseWalletChainId(left);
+  return chainId !== null && chainId === parseWalletChainId(right);
+}

--- a/lib/wallet-network.ts
+++ b/lib/wallet-network.ts
@@ -1,0 +1,79 @@
+import { normalizeWalletChainId, parseWalletChainId, walletChainIdsEqual } from "@/lib/wallet-chain-id";
+
+export type WalletNetworkProvider = {
+  request: (input:
+    | { method: "eth_chainId" }
+    | { method: "wallet_switchEthereumChain"; params: [{ chainId: `0x${string}` }] }
+  ) => Promise<unknown>;
+};
+
+const NETWORK_READBACK_TIMEOUT_MS = 2_000;
+const NETWORK_READBACK_INTERVAL_MS = 200;
+
+function beforeDeadline<T>(request: () => Promise<T>, deadline: number, failure: () => Error): Promise<T> {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) return Promise.reject(failure());
+  let timeout: ReturnType<typeof setTimeout>;
+  const expired = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => reject(failure()), remaining);
+  });
+  let response: Promise<T>;
+  try {
+    response = request();
+  } catch (error) {
+    clearTimeout(timeout!);
+    return Promise.reject(error);
+  }
+  return Promise.race([response, expired]).finally(() => clearTimeout(timeout!));
+}
+
+export async function getWalletProviderOnChain<TProvider extends WalletNetworkProvider>(input: Readonly<{
+  wallet: {
+    chainId: unknown;
+    getEthereumProvider: () => Promise<TProvider>;
+    switchChain: (chainId: number) => Promise<unknown>;
+  };
+  chainId: number;
+  assertCurrentSession: () => void;
+  networkName: string;
+}>): Promise<TProvider> {
+  const { wallet, assertCurrentSession } = input;
+  const chainId = parseWalletChainId(input.chainId);
+  const chainHex = normalizeWalletChainId(input.chainId);
+  const wrongNetwork = () => new Error(`The wallet is not connected to ${input.networkName}`);
+
+  try {
+    assertCurrentSession();
+    if (chainId === null || chainHex === null) throw new Error("The requested wallet network is invalid");
+    const provider = await wallet.getEthereumProvider();
+    assertCurrentSession();
+    const currentChainId = await provider.request({ method: "eth_chainId" });
+    assertCurrentSession();
+    if (walletChainIdsEqual(currentChainId, chainId) && walletChainIdsEqual(wallet.chainId, chainId)) return provider;
+
+    if (walletChainIdsEqual(wallet.chainId, chainId)) {
+      // An SDK cache can already show the target and skip its own switch request.
+      await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: chainHex }] });
+    } else {
+      await wallet.switchChain(chainId);
+    }
+    assertCurrentSession();
+
+    const deadline = Date.now() + NETWORK_READBACK_TIMEOUT_MS;
+    const switchedProvider = await beforeDeadline(() => wallet.getEthereumProvider(), deadline, wrongNetwork);
+    assertCurrentSession();
+    while (Date.now() < deadline) {
+      const observedChainId = await beforeDeadline(
+        () => switchedProvider.request({ method: "eth_chainId" }), deadline, wrongNetwork,
+      );
+      assertCurrentSession();
+      if (walletChainIdsEqual(observedChainId, chainId)) return switchedProvider;
+      await new Promise<void>((resolve) => setTimeout(resolve, Math.min(NETWORK_READBACK_INTERVAL_MS, Math.max(0, deadline - Date.now()))));
+      assertCurrentSession();
+    }
+    throw wrongNetwork();
+  } catch (error) {
+    assertCurrentSession();
+    throw error;
+  }
+}

--- a/tests/browser/fixtures/wallet-session-runtime.tsx
+++ b/tests/browser/fixtures/wallet-session-runtime.tsx
@@ -22,7 +22,7 @@ type FixtureWallet = {
   isConnected: () => Promise<boolean>;
   switchChain: (chainId: number) => Promise<void>;
   disconnect: () => Promise<void>;
-  getEthereumProvider: () => Promise<{ request: (input: { method: string }) => Promise<string | string[]> }>;
+  getEthereumProvider: () => Promise<{ request: (input: { method: string; params?: unknown[] }) => Promise<string | number | string[] | null> }>;
 };
 type FixtureState = {
   ready: boolean;
@@ -37,7 +37,9 @@ type FixtureState = {
   delayedNetworkSwitch: boolean;
   waitingNetworkSwitches: number;
   providerAccountOverride: string | null;
-  providerChainOverride: string | null;
+  providerChainOverride: string | number | null;
+  refreshedUser: FixtureUser | null;
+  delayedUserRefresh: boolean;
   delayedLogoutReadback: boolean;
   clipboardMode: "native" | "denied" | "delayed";
   waitingClipboardWrites: number;
@@ -61,11 +63,19 @@ const pendingNetworkSwitches: { resolve: () => void; reject: (error: Error) => v
 function wallet(address: string, linked = true, connectedAt = 1, initialChain = "eip155:4663"): FixtureWallet {
   let networkChain = initialChain;
   const provider = {
-    request: async ({ method }: { method: string }) => {
+    request: async ({ method, params }: { method: string; params?: unknown[] }) => {
       record(method, { address });
       if (method === "eth_chainId") return state.providerChainOverride
         ?? `0x${Number(networkChain.slice("eip155:".length)).toString(16)}`;
       if (method === "eth_accounts") return [state.providerAccountOverride ?? address];
+      if (method === "wallet_switchEthereumChain") {
+        const chainId = (params?.[0] as { chainId: string }).chainId;
+        networkChain = `eip155:${Number(chainId)}`;
+        update({ providerChainOverride: null, wallets: state.wallets.map((candidate) =>
+          candidate.getEthereumProvider === getEthereumProvider ? { ...candidate, chainId: networkChain } : candidate) });
+        await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+        return null;
+      }
       return forbidden();
     },
   };
@@ -107,6 +117,7 @@ let state: FixtureState = {
   isOpen: false, calls: [], delayedLocks: false, waitingLocks: 0,
   delayedNetworkSwitch: false, waitingNetworkSwitches: 0,
   providerAccountOverride: null, providerChainOverride: null,
+  refreshedUser: null, delayedUserRefresh: false,
   delayedLogoutReadback: false,
   clipboardMode: "native", waitingClipboardWrites: 0,
 };
@@ -215,7 +226,14 @@ const logout = async () => {
 };
 const getAccessToken = async () => null;
 export const getIdentityToken = async () => null;
-const refreshUser = async () => state.user;
+const pendingUserRefreshes: (() => void)[] = [];
+const refreshUser = async () => {
+  record("refreshUser");
+  const refreshed = state.refreshedUser ?? state.user;
+  if (state.delayedUserRefresh) await new Promise<void>((resolve) => pendingUserRefreshes.push(resolve));
+  if (refreshed?.id === state.user?.id) update({ user: refreshed });
+  return refreshed;
+};
 const reauthorize = async () => { record("reauthorize"); };
 
 export function PrivyProvider({ children }: { children: ReactNode }) { return children; }
@@ -246,6 +264,7 @@ function chooseScenario(scenario: string) {
   const base = {
     ready: true, authenticated: true, walletsReady: true, isOpen: false, calls: [],
     providerAccountOverride: null, providerChainOverride: null,
+    refreshedUser: null, delayedUserRefresh: false,
     delayedLogoutReadback: false,
   };
   switch (scenario) {
@@ -319,6 +338,12 @@ export function FixtureControls() {
     }}>Resolve clipboard</button>
     <output aria-label="Pending clipboard writes">{current.waitingClipboardWrites}</output>
     <button onClick={() => update({ delayedLogoutReadback: true })}>Delay logout readback</button>
+    <button onClick={() => update({ refreshedUser: alphaBoth })}>Link wallet B on server</button>
+    <button onClick={() => update({ delayedUserRefresh: true })}>Delay user refresh</button>
+    <button onClick={() => {
+      update({ delayedUserRefresh: false });
+      pendingUserRefreshes.splice(0).forEach((resolve) => resolve());
+    }}>Finish user refresh</button>
     <button onClick={() => update({ authenticated: false, user: null, delayedLogoutReadback: false })}>Finish logout readback</button>
     <button onClick={() => update({ wallets: state.wallets.map((candidate) => wallet(
       candidate.address, candidate.linked, candidate.connectedAt + 1, candidate.chainId,
@@ -346,6 +371,14 @@ export function FixtureControls() {
     }}>Reject network switch</button>
     <button onClick={() => update({ providerAccountOverride: accountC })}>Return a different provider account</button>
     <button onClick={() => update({ providerChainOverride: "0x1237" })}>Return the wrong provider network</button>
+    <button onClick={() => update({ providerChainOverride: "0x1" })}>Simulate stale Robinhood cache</button>
+    <label>Provider chain format <select aria-label="Provider chain format" defaultValue="hex" onChange={(event) => {
+      const formats: Record<string, string | number | null> = { hex: null, decimal: "1", number: 1, padded: "0x0001", caip: "eip155:1" };
+      update({ providerChainOverride: formats[event.target.value] });
+    }}>
+      <option value="hex">Hex</option><option value="decimal">Decimal</option>
+      <option value="number">Number</option><option value="padded">Padded hex</option><option value="caip">CAIP</option>
+    </select></label>
     <output aria-label="Pending network switches">{current.waitingNetworkSwitches}</output>
     <output aria-label="SDK calls">{JSON.stringify(current.calls)}</output>
     <output aria-label="SDK user">{current.user?.id ?? "anonymous"}</output>
@@ -357,6 +390,11 @@ export function FixtureControls() {
         update({ wallets: [connected], isOpen: false });
         connectCallbacks.onSuccess({ wallet: connected });
       }}>Complete wallet A reconnect</button>
+      <button onClick={() => {
+        const connected = wallet(accountB, false);
+        update({ wallets: [connected], isOpen: false });
+        connectCallbacks.onSuccess({ wallet: connected });
+      }}>Complete wallet B reconnect</button>
       <button onClick={() => {
         update({ isOpen: false });
         linkCallbacks.onError("linked_to_another_user");

--- a/tests/browser/fixtures/wallet-session-runtime.tsx
+++ b/tests/browser/fixtures/wallet-session-runtime.tsx
@@ -40,6 +40,7 @@ type FixtureState = {
   providerChainOverride: string | number | null;
   refreshedUser: FixtureUser | null;
   delayedUserRefresh: boolean;
+  publishNetworkChanges: boolean;
   delayedLogoutReadback: boolean;
   clipboardMode: "native" | "denied" | "delayed";
   waitingClipboardWrites: number;
@@ -97,8 +98,10 @@ function wallet(address: string, linked = true, connectedAt = 1, initialChain = 
       networkChain = `eip155:${chainId}`;
       // Privy 3.35.2 rewraps its connector wallet on chainChanged. The public
       // object changes, while connection methods survive the object spread.
-      update({ wallets: state.wallets.map((candidate) => candidate.getEthereumProvider === getEthereumProvider
-        ? { ...candidate, chainId: networkChain } : candidate) });
+      if (state.publishNetworkChanges) {
+        update({ wallets: state.wallets.map((candidate) => candidate.getEthereumProvider === getEthereumProvider
+          ? { ...candidate, chainId: networkChain } : candidate) });
+      }
       await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
     },
     disconnect: async () => { record("disconnect-provider", { address }); },
@@ -118,6 +121,7 @@ let state: FixtureState = {
   delayedNetworkSwitch: false, waitingNetworkSwitches: 0,
   providerAccountOverride: null, providerChainOverride: null,
   refreshedUser: null, delayedUserRefresh: false,
+  publishNetworkChanges: true,
   delayedLogoutReadback: false,
   clipboardMode: "native", waitingClipboardWrites: 0,
 };
@@ -265,6 +269,7 @@ function chooseScenario(scenario: string) {
     ready: true, authenticated: true, walletsReady: true, isOpen: false, calls: [],
     providerAccountOverride: null, providerChainOverride: null,
     refreshedUser: null, delayedUserRefresh: false,
+    publishNetworkChanges: true,
     delayedLogoutReadback: false,
   };
   switch (scenario) {
@@ -372,6 +377,7 @@ export function FixtureControls() {
     <button onClick={() => update({ providerAccountOverride: accountC })}>Return a different provider account</button>
     <button onClick={() => update({ providerChainOverride: "0x1237" })}>Return the wrong provider network</button>
     <button onClick={() => update({ providerChainOverride: "0x1" })}>Simulate stale Robinhood cache</button>
+    <button onClick={() => update({ providerChainOverride: "0x1237", publishNetworkChanges: false })}>Keep the SDK network label stale</button>
     <label>Provider chain format <select aria-label="Provider chain format" defaultValue="hex" onChange={(event) => {
       const formats: Record<string, string | number | null> = { hex: null, decimal: "1", number: 1, padded: "0x0001", caip: "eip155:1" };
       update({ providerChainOverride: formats[event.target.value] });

--- a/tests/browser/fixtures/wallet-session-server.mjs
+++ b/tests/browser/fixtures/wallet-session-server.mjs
@@ -32,8 +32,8 @@ export async function createWalletSessionServer() {
           const moduleWalletStep = moduleModeWalletStep({account:value.wallet?.account, chainId:value.wallet?.chainId,
             authenticated:value.authenticated, sessionReady:value.sessionReady});
           const [networkResults, setNetworkResults] = useState([]);
-          const switchNetwork = () => {
-            void value.switchNetwork('1').then(
+          const switchNetwork = (chainId = '1') => {
+            void value.switchNetwork(chainId).then(
               result => setNetworkResults(previous => [...previous, result]),
               () => setNetworkResults(previous => [...previous, 'rejected']),
             );
@@ -58,7 +58,8 @@ export async function createWalletSessionServer() {
             <output aria-label="Module continue calls">{moduleContinuations}</output>
             <output aria-label="Module wallet step">{moduleWalletStep}</output>
             <button onClick={value.openWallet}>Open account</button>
-            <button onClick={switchNetwork}>Request Ethereum wallet network</button>
+            <button onClick={() => switchNetwork()}>Request Ethereum wallet network</button>
+            <button onClick={() => switchNetwork('4663')}>Request Robinhood wallet network</button>
             <button onClick={() => void value.disconnect({showDialogOnFailure:false})}>Sign out of app</button>
             <FixtureControls/>
             {location.pathname === '/launch/modules' ? <ModuleModeBuilder launchAction={{label:'Continue module fixture',

--- a/tests/browser/wallet-session.spec.ts
+++ b/tests/browser/wallet-session.spec.ts
@@ -482,8 +482,9 @@ for (const width of [1440, 390, 320]) {
     await expectMethods(page, ["linkWallet"]);
     await expect(page.getByRole("dialog")).toHaveCount(1);
     await page.getByRole("button", { name: "Reject linking foreign account", exact: true }).click();
-    await expect(dialog.getByRole("alert")).toHaveText("This wallet belongs to another account. Sign out, then sign in with that wallet.");
-    await expect(dialog.getByRole("button", { name: "Reconnect wallet", exact: true })).toBeVisible();
+    await expect(dialog.getByRole("alert")).toHaveText("This wallet is linked to another account. Switch accounts to use it.");
+    await expect(dialog.getByRole("button", { name: "Switch account", exact: true })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Connect linked wallet", exact: true })).toBeVisible();
     await page.keyboard.press("Escape");
     await expect(dialog).toHaveCount(0);
   });
@@ -514,7 +515,61 @@ test("only an authenticated account without a linked wallet starts the SDK link 
   await expectMethods(page, ["linkWallet"]);
   await expect(page.getByRole("dialog")).toHaveCount(1);
   await page.getByRole("button", { name: "Reject linking foreign account", exact: true }).click();
-  await expect(page.getByRole("alert")).toHaveText("This wallet belongs to another account. Sign out, then sign in with that wallet.");
+  await expect(page.getByRole("alert")).toHaveText("This wallet is linked to another account. Switch accounts to use it.");
+});
+
+for (const width of [1440, 390]) {
+  test(`an unlinked wallet can switch accounts without a reconnect loop at ${width}px`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width, height: 844 });
+    await open(page, "/launch/modules");
+    await scenario(page, "linked-disconnected");
+    await page.getByRole("button", { name: "Delay logout readback", exact: true }).click();
+    await page.getByRole("button", { name: "Open account", exact: true }).click();
+    await page.getByRole("button", { name: "Complete wallet B reconnect", exact: true }).click();
+    const dialog = page.getByRole("dialog", { name: "Connect wallet", exact: true });
+    await expect(dialog.getByRole("alert")).toHaveText("This wallet is not linked to your signed-in account.");
+    await expect(page.getByLabel("Selected account", { exact: true })).toHaveText("none");
+    await expectMethods(page, ["connectWallet", "refreshUser"]);
+    expect(await dialog.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+    await page.screenshot({ path: testInfo.outputPath(`wallet-account-recovery-${width}.png`) });
+    await dialog.getByRole("button", { name: "Switch account", exact: true }).click();
+    await expect(page.getByLabel("Session authenticated", { exact: true })).toHaveText("false");
+    expect((await calls(page)).filter((call) => call.method === "login")).toHaveLength(0);
+    await page.getByRole("button", { name: "Finish logout readback", exact: true }).click();
+    await expect(page.getByRole("dialog", { name: "SDK wallet dialog", exact: true })).toBeVisible();
+    expect((await calls(page)).filter((call) => call.method === "login")).toHaveLength(1);
+    await page.getByRole("button", { name: "Complete wallet B login", exact: true }).click();
+    await expect(page.getByLabel("Selected account", { exact: true })).toHaveText(accountB);
+    await expect(page.getByRole("alert")).toHaveCount(0);
+    await expect(page.getByLabel("Wallet busy", { exact: true })).toHaveText("false");
+  });
+}
+
+test("reconnecting refreshes stale account ownership before reporting a mismatch", async ({ page }) => {
+  await open(page);
+  await scenario(page, "linked-disconnected");
+  await page.getByRole("button", { name: "Link wallet B on server", exact: true }).click();
+  await page.getByRole("button", { name: "Open account", exact: true }).click();
+  await page.getByRole("button", { name: "Complete wallet B reconnect", exact: true }).click();
+  await expect(page.getByLabel("Selected account", { exact: true })).toHaveText(accountB);
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expectMethods(page, ["connectWallet", "refreshUser"]);
+});
+
+test("an ownership refresh cannot revive a previous user's reconnect attempt", async ({ page }) => {
+  await open(page);
+  await scenario(page, "linked-disconnected");
+  await page.getByRole("button", { name: "Link wallet B on server", exact: true }).click();
+  await page.getByRole("button", { name: "Delay user refresh", exact: true }).click();
+  await page.getByRole("button", { name: "Open account", exact: true }).click();
+  await page.getByRole("button", { name: "Complete wallet B reconnect", exact: true }).click();
+  await expectMethods(page, ["connectWallet", "refreshUser"]);
+  await page.getByRole("button", { name: "Change SDK user, keep old wallets", exact: true }).click();
+  await page.getByRole("button", { name: "Finish user refresh", exact: true }).click();
+  await expect(page.getByLabel("Wallet busy", { exact: true })).toHaveText("false");
+  await expect(page.getByLabel("Selected account", { exact: true })).toHaveText("none");
+  await expect(page.getByLabel("SDK user", { exact: true })).toHaveText("fixture-user-beta");
+  await expect(page.getByRole("dialog")).toHaveCount(0);
 });
 
 test("the SDK modal suppresses an existing application wallet dialog", async ({ page }) => {
@@ -708,6 +763,30 @@ test("a normal network update can replace the SDK wrapper while preserving its c
   expect(methods.filter((method) => method === "switchChain")).toHaveLength(1);
   expect(methods).toEqual(expect.arrayContaining(["eth_chainId", "eth_accounts"]));
   expect(methods).not.toContain("forbidden-wallet-operation");
+});
+
+for (const format of ["decimal", "number", "padded", "caip"]) {
+  test(`network switching accepts the provider's ${format} chain ID without changing wallet ownership`, async ({ page }) => {
+    await open(page);
+    await page.getByLabel("Provider chain format", { exact: true }).selectOption(format);
+    await page.getByRole("button", { name: "Request Ethereum wallet network", exact: true }).click();
+    await expectNetworkResults(page, [true]);
+    await expect(page.getByLabel("Selected account", { exact: true })).toHaveText(accountA);
+    expect((await calls(page)).some((call) => call.method === "eth_accounts")).toBe(true);
+  });
+}
+
+test("a stale Robinhood SDK cache switches the actual provider before reporting success", async ({ page }) => {
+  await open(page, "/launch/modules");
+  await page.getByRole("button", { name: "Simulate stale Robinhood cache", exact: true }).click();
+  await expect(page.getByLabel("Module wallet step", { exact: true })).toHaveText("prepare");
+  await page.getByRole("button", { name: "Request Robinhood wallet network", exact: true }).click();
+  await expectNetworkResults(page, [true]);
+  const methods = (await calls(page)).map((call) => call.method);
+  expect(methods.filter((method) => method === "wallet_switchEthereumChain")).toHaveLength(1);
+  expect(methods).not.toContain("switchChain");
+  expect(methods).not.toContain("forbidden-wallet-operation");
+  await expect(page.getByLabel("Selected account", { exact: true })).toHaveText(accountA);
 });
 
 test("duplicate requests do not open a second SDK network switch", async ({ page }) => {

--- a/tests/browser/wallet-session.spec.ts
+++ b/tests/browser/wallet-session.spec.ts
@@ -789,6 +789,19 @@ test("a stale Robinhood SDK cache switches the actual provider before reporting 
   await expect(page.getByLabel("Selected account", { exact: true })).toHaveText(accountA);
 });
 
+test("verified network readback updates Module Mode even without an SDK chainChanged event", async ({ page }) => {
+  await open(page, "/launch/modules");
+  await scenario(page, "unsupported-network");
+  await page.getByRole("button", { name: "Keep the SDK network label stale", exact: true }).click();
+  await expect(page.getByLabel("Module wallet step", { exact: true })).toHaveText("switch");
+  await page.getByRole("button", { name: "Request Robinhood wallet network", exact: true }).click();
+  await expectNetworkResults(page, [true]);
+  await expect(page.getByLabel("Selected wallet network", { exact: true })).toHaveText("0x1237");
+  await expect(page.getByLabel("Module wallet step", { exact: true })).toHaveText("prepare");
+  await page.getByRole("button", { name: "Replace connected wallet capability", exact: true }).click();
+  await expect(page.getByLabel("Module wallet step", { exact: true })).toHaveText("switch");
+});
+
 test("duplicate requests do not open a second SDK network switch", async ({ page }) => {
   await open(page);
   await beginDelayedNetworkSwitch(page);

--- a/tests/wallet-chain-id.test.ts
+++ b/tests/wallet-chain-id.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeWalletChainId, parseWalletChainId, walletChainIdsEqual } from "@/lib/wallet-chain-id";
+
+describe("wallet chain IDs", () => {
+  it("recognizes the same Robinhood chain from provider and SDK representations", () => {
+    const variants = [4663, "4663", "0x1237", "0x01237", "0X1237", "eip155:4663"];
+    for (const value of variants) {
+      expect(parseWalletChainId(value)).toBe(4663);
+      expect(normalizeWalletChainId(value)).toBe("0x1237");
+      for (const other of variants) expect(walletChainIdsEqual(value, other)).toBe(true);
+    }
+  });
+
+  it("preserves positive chain IDs across the safe integer range", () => {
+    for (const chainId of [1, 10, 11155111, Number.MAX_SAFE_INTEGER]) {
+      const hex = `0x${chainId.toString(16)}`;
+      for (const value of [chainId, String(chainId), hex.toUpperCase(), `eip155:${chainId}`]) {
+        expect(parseWalletChainId(value)).toBe(chainId);
+        expect(normalizeWalletChainId(value)).toBe(hex);
+        expect(walletChainIdsEqual(value, chainId)).toBe(true);
+      }
+    }
+  });
+
+  it("never treats a different valid chain as Robinhood", () => {
+    for (const value of [1, "1", "0x1", "eip155:1", 4664, "0x1238"]) {
+      expect(walletChainIdsEqual(value, 4663)).toBe(false);
+      expect(walletChainIdsEqual("eip155:4663", value)).toBe(false);
+    }
+  });
+
+  it("rejects malformed, nonpositive and unsafe IDs instead of rounding or coercing", () => {
+    const invalid: unknown[] = [
+      null, undefined, true, false, {}, [], [4663], 4663n,
+      { toString: () => "4663", valueOf: () => 4663 },
+      0, -0, -1, 4663.5, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY,
+      Number.MAX_SAFE_INTEGER + 1, Number.MAX_VALUE,
+      "", "0", "00", "04663", "-4663", "+4663", "4663.0", "4.663e3", "4663n",
+      "4663garbage", "4663\u0000", "0b1001000110111", "0o11067", "0x", "0x0", "0x0000", "0x123g",
+      "9007199254740992", "9007199254740993", "0x20000000000000", "eip155:9007199254740992",
+      "eip155:", "eip155:0", "eip155:04663", "eip155:0x1237", "eip155:4663:extra", "EIP155:4663", "other:4663",
+    ];
+    for (const value of invalid) {
+      expect(parseWalletChainId(value)).toBeNull();
+      expect(normalizeWalletChainId(value)).toBeNull();
+      expect(walletChainIdsEqual(value, 4663)).toBe(false);
+      expect(walletChainIdsEqual(4663, value)).toBe(false);
+      expect(walletChainIdsEqual(value, value)).toBe(false);
+    }
+  });
+
+  it("rejects surrounding or internal whitespace in every string format", () => {
+    for (const value of ["4663", "0x1237", "eip155:4663"]) {
+      for (const whitespace of [" ", "\t", "\n", "\r\n", "\u00a0", "\u2028", "\ufeff"]) {
+        for (const malformed of [`${whitespace}${value}`, `${value}${whitespace}`, `${value.slice(0, 2)}${whitespace}${value.slice(2)}`]) {
+          expect(parseWalletChainId(malformed)).toBeNull();
+          expect(walletChainIdsEqual(malformed, 4663)).toBe(false);
+        }
+      }
+    }
+    expect(parseWalletChainId("eip155: 4663")).toBeNull();
+    expect(parseWalletChainId("eip155:\n4663")).toBeNull();
+  });
+});

--- a/tests/wallet-login-lock.test.ts
+++ b/tests/wallet-login-lock.test.ts
@@ -111,7 +111,7 @@ describe("wallet login lock", () => {
       /onError: \(errorCode\) => \{\s+settleWalletLoginAttempt\(\);/u,
     );
     expect(provider).toContain(
-      "loginPending || (!providerSettled && !providerTimedOut)",
+      "loginPending || (accountSwitchRequested && !providerTimedOut) || (!providerSettled && !providerTimedOut)",
     );
     expect(provider).not.toContain("walletLoginExpiryTimerRef");
     expect(provider).toContain('? "Opening wallet"');

--- a/tests/wallet-network.test.ts
+++ b/tests/wallet-network.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getWalletProviderOnChain, type WalletNetworkProvider } from "@/lib/wallet-network";
+
+const target = { chainId: 4663, networkName: "Robinhood Chain" };
+type Request = Parameters<WalletNetworkProvider["request"]>[0];
+
+function fixture(cachedChainId = "eip155:1") {
+  let providerChainId: unknown = "0x1";
+  let active = true;
+  const provider = {
+    request: vi.fn(async (input: Request): Promise<unknown> => {
+      if (input.method === "eth_chainId") return providerChainId;
+      providerChainId = input.params[0].chainId;
+      return null;
+    }),
+  };
+  const wallet = {
+    chainId: cachedChainId,
+    getEthereumProvider: vi.fn(async () => provider),
+    switchChain: vi.fn(async (chainId: number) => { providerChainId = chainId; }),
+  };
+  const assertCurrentSession = vi.fn(() => {
+    if (!active) throw new Error("Wallet session changed");
+  });
+  return {
+    wallet, provider, assertCurrentSession,
+    setProviderChain(chainId: unknown) { providerChainId = chainId; },
+    changeSession() { active = false; },
+  };
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe("wallet provider network recovery", () => {
+  it("returns without a prompt when the provider and SDK already agree on the target", async () => {
+    const state = fixture("eip155:4663");
+    state.setProviderChain(4663);
+    await expect(getWalletProviderOnChain({ ...target, ...state })).resolves.toBe(state.provider);
+    expect(state.wallet.getEthereumProvider).toHaveBeenCalledOnce();
+    expect(state.wallet.switchChain).not.toHaveBeenCalled();
+    expect(state.provider.request.mock.calls).toEqual([[{ method: "eth_chainId" }]]);
+  });
+
+  it("asks the SDK to synchronize when only its cached chain is wrong", async () => {
+    const state = fixture();
+    state.setProviderChain("0x1237");
+    await expect(getWalletProviderOnChain({ ...target, ...state })).resolves.toBe(state.provider);
+    expect(state.wallet.switchChain).toHaveBeenCalledExactlyOnceWith(4663);
+    expect(state.wallet.getEthereumProvider).toHaveBeenCalledTimes(2);
+    expect(state.provider.request.mock.calls).toEqual([[{ method: "eth_chainId" }], [{ method: "eth_chainId" }]]);
+  });
+
+  it("switches the actual provider when the SDK target cache would skip the request", async () => {
+    const state = fixture("eip155:4663");
+    // This matches Privy's cached-target early return: it cannot change the provider.
+    state.wallet.switchChain.mockImplementation(async () => {});
+    await expect(getWalletProviderOnChain({ ...target, ...state })).resolves.toBe(state.provider);
+    expect(state.wallet.switchChain).not.toHaveBeenCalled();
+    expect(state.wallet.getEthereumProvider).toHaveBeenCalledTimes(2);
+    expect(state.provider.request.mock.calls).toEqual([
+      [{ method: "eth_chainId" }],
+      [{ method: "wallet_switchEthereumChain", params: [{ chainId: "0x1237" }] }],
+      [{ method: "eth_chainId" }],
+    ]);
+  });
+
+  it("uses the SDK for a different cached chain and verifies its newly returned provider", async () => {
+    const state = fixture();
+    const switchedProvider = { request: vi.fn<WalletNetworkProvider["request"]>(async () => "0x1237") };
+    state.wallet.getEthereumProvider.mockResolvedValueOnce(state.provider).mockResolvedValue(switchedProvider);
+    await expect(getWalletProviderOnChain({ ...target, ...state })).resolves.toBe(switchedProvider);
+    expect(state.wallet.switchChain).toHaveBeenCalledExactlyOnceWith(4663);
+    expect(state.provider.request.mock.calls).toEqual([[{ method: "eth_chainId" }]]);
+    expect(switchedProvider.request.mock.calls).toEqual([[{ method: "eth_chainId" }]]);
+  });
+
+  it("waits for provider convergence after the switch promise resolves", async () => {
+    vi.useFakeTimers();
+    const state = fixture();
+    state.wallet.switchChain.mockImplementation(async () => {
+      setTimeout(() => state.setProviderChain("0x01237"), 350);
+    });
+    const ready = getWalletProviderOnChain({ ...target, ...state });
+    await vi.advanceTimersByTimeAsync(400);
+    await expect(ready).resolves.toBe(state.provider);
+    expect(state.wallet.switchChain).toHaveBeenCalledOnce();
+    expect(state.provider.request.mock.calls.length).toBe(4);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each(["eip155:1", "eip155:4663"])("preserves wallet rejection for cached chain %s", async (cachedChain) => {
+    const state = fixture(cachedChain);
+    const rejection = Object.assign(new Error("User rejected the network switch"), { code: 4001 });
+    state.wallet.switchChain.mockRejectedValue(rejection);
+    state.provider.request.mockImplementation(async (input) => {
+      if (input.method === "eth_chainId") return "0x1";
+      throw rejection;
+    });
+    await expect(getWalletProviderOnChain({ ...target, ...state })).rejects.toBe(rejection);
+    expect(state.wallet.getEthereumProvider).toHaveBeenCalledOnce();
+  });
+
+  it.each(["0x1", "garbage"])("stops within the readback budget when the provider remains %s", async (chain) => {
+    vi.useFakeTimers();
+    const state = fixture();
+    state.wallet.switchChain.mockImplementation(async () => state.setProviderChain(chain));
+    const failure = expect(getWalletProviderOnChain({ ...target, ...state })).rejects.toThrow("The wallet is not connected to Robinhood Chain");
+    await vi.advanceTimersByTimeAsync(2_000);
+    await failure;
+    expect(state.wallet.switchChain).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("bounds a readback request that never returns", async () => {
+    vi.useFakeTimers();
+    const state = fixture();
+    state.provider.request.mockResolvedValueOnce("0x1").mockImplementation(() => new Promise(() => {}));
+    const failure = expect(getWalletProviderOnChain({ ...target, ...state })).rejects.toThrow("The wallet is not connected to Robinhood Chain");
+    await vi.advanceTimersByTimeAsync(2_000);
+    await failure;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not prompt if the session changes during the initial provider read", async () => {
+    const state = fixture();
+    state.provider.request.mockImplementation(async () => {
+      state.changeSession();
+      return "0x1";
+    });
+    await expect(getWalletProviderOnChain({ ...target, ...state })).rejects.toThrow("Wallet session changed");
+    expect(state.wallet.switchChain).not.toHaveBeenCalled();
+    expect(state.provider.request).toHaveBeenCalledOnce();
+  });
+
+  it("does not reuse a provider after the session changes during the switch", async () => {
+    const state = fixture();
+    state.wallet.switchChain.mockImplementation(async () => state.changeSession());
+    await expect(getWalletProviderOnChain({ ...target, ...state })).rejects.toThrow("Wallet session changed");
+    expect(state.wallet.getEthereumProvider).toHaveBeenCalledOnce();
+  });
+
+  it("stops polling when the session changes while waiting for convergence", async () => {
+    vi.useFakeTimers();
+    const state = fixture();
+    state.wallet.switchChain.mockImplementation(async () => {});
+    const failure = expect(getWalletProviderOnChain({ ...target, ...state })).rejects.toThrow("Wallet session changed");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(state.provider.request).toHaveBeenCalledTimes(2);
+    state.changeSession();
+    await vi.advanceTimersByTimeAsync(200);
+    await failure;
+    expect(state.provider.request).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("rejects an invalid target before requesting a provider", async () => {
+    const state = fixture();
+    await expect(getWalletProviderOnChain({ ...target, ...state, chainId: Number.NaN })).rejects.toThrow("network is invalid");
+    expect(state.wallet.getEthereumProvider).not.toHaveBeenCalled();
+  });
+});

--- a/tests/wallet-request-lock.test.ts
+++ b/tests/wallet-request-lock.test.ts
@@ -140,7 +140,11 @@ describe("production wallet request lock", () => {
     const refreshedAuthority = entrypoint.indexOf("await assertAuthority();", validation);
     expect(authority).toBeGreaterThan(lock); expect(validation).toBeGreaterThan(authority);
     expect(refreshedAuthority).toBeGreaterThan(validation); expect(entrypoint.indexOf('method: "eth_sendTransaction"')).toBeGreaterThan(refreshedAuthority);
-    expect(entrypoint).toContain("current.walletCapability !== boundWallet"); expect(entrypoint).toContain("walletRequestAttempted: false");
+    expect(entrypoint).toContain("walletSessionGenerationRef.current !== expectedGeneration");
+    expect(entrypoint).toContain("current.walletCapability?.getEthereumProvider !== boundWallet.getEthereumProvider");
+    expect(entrypoint).toContain("current.walletCapability?.switchChain !== boundWallet.switchChain");
+    expect(entrypoint).toContain("walletRequestAttempted: false");
+    expect(entrypoint.indexOf("await getWalletProviderOnChain({")).toBeGreaterThan(lock);
     expect(entrypoint).not.toContain("switchChain(");
   });
 

--- a/tests/wallet-state.test.ts
+++ b/tests/wallet-state.test.ts
@@ -564,6 +564,18 @@ describe("wallet recovery state", () => {
     expect(getIdentityToken).toHaveBeenCalledTimes(1);
   });
 
+  it.each([4663, "4663", "0x1237", "0x01237", "eip155:4663"])("accepts Robinhood provider chain ID %s before a wallet action", async (chainId) => {
+    const request = vi.fn(async (method: "eth_chainId" | "eth_accounts") =>
+      method === "eth_chainId" ? chainId : [`0x${"a".repeat(40)}`]);
+    await expect(subject.assertExternalWalletAuthorityCurrent({
+      expectedAccount: `0x${"a".repeat(40)}`,
+      expectedChainId: "0x1237",
+      networkName: "Robinhood Chain",
+      request,
+    })).resolves.toBeUndefined();
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["eth_chainId", "eth_accounts"]);
+  });
+
   it("fails closed when an external provider mutates chain before a wallet action", async () => {
     const request = vi.fn(async (method: "eth_chainId" | "eth_accounts") =>
       method === "eth_chainId"
@@ -928,6 +940,6 @@ describe("wallet recovery state", () => {
     expect(walletProvider.getWalletOpenAction(pending, false, true)).toBe("wait");
     expect(walletProvider.getWalletOpenAction("manage", false, true)).toBe("reconnect");
     expect(subject.getWalletLoginErrorMessage("linked_to_another_user"))
-      .toBe("This wallet belongs to another account. Sign out, then sign in with that wallet.");
+      .toBe("This wallet is linked to another account. Switch accounts to use it.");
   });
 });


### PR DESCRIPTION
Wallets could report Robinhood as connected in the launch UI and then fail the final authority check because the provider returned a numeric, decimal, or padded chain ID. The network switch could also trust a stale SDK cache and skip the actual provider switch. Use one strict chain-ID parser and verify the provider's current network, including bounded readback after a switch, before continuing a Module Mode or classic transaction.

Reconnecting now refreshes stale account ownership before reporting a mismatch. A wallet belonging to a different account offers a direct Switch account action, which waits for the SDK to clear the old session before opening login. Session changes invalidate pending reconnects and transaction authority. Module Mode accepts SDK wrapper replacement on a chain update while still checking the underlying wallet capability and session generation.

Validation covers provider ID formats, stale network caches, delayed network readback, rejected switches, stale account ownership, logout readback, account changes during pending work, and desktop/mobile recovery controls. Browser fixtures use the production wallet provider and prohibit signing or transaction submission. No real wallet transactions are required for these checks.
