### PR TITLE
Reject stale wallet sessions after network verification

### DIFF
--- a/components/wallet-provider.tsx
+++ b/components/wallet-provider.tsx
@@ -2075,6 +2075,7 @@ function PrivyWalletBridge({
           if (!isCurrentSession()) throw new Error("The wallet session changed. Reconnect and try again.");
         },
       });
+      if (!isCurrentSession()) return false;
       const walletAtVerification = walletRequestSessionRef.current.walletCapability;
       if (connectedWallet.walletClientType !== "privy" && connectedWallet.walletClientType !== "privy-v2") {
         const accounts = await provider.request({ method: "eth_accounts" });


### PR DESCRIPTION
If a user signs out between network verification completing and its caller resuming, an embedded wallet could report a successful network switch for the expired session. Recheck the active wallet session immediately after the asynchronous verification before recording the network or returning success.

Validation: 38 related wallet tests and scoped ESLint passed. The change adds one guard to the network recovery from #760 and preserves all provider/account checks.
