### PR TITLE
Add authenticated admin Module source corrections

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -476,6 +476,8 @@ jobs:
         run: node scripts/ci/contracts-ci.mjs verify-receipt
 
       - name: Verify the complete deterministic test partition
+        env:
+          ETHEREUM_RPC_URL: https://eth.drpc.org
         run: node scripts/ci/contracts-ci.mjs test 1
 
   contracts-tests-2:
@@ -514,6 +516,8 @@ jobs:
         run: node scripts/ci/contracts-ci.mjs verify-receipt
 
       - name: Verify the complete deterministic test partition
+        env:
+          ETHEREUM_RPC_URL: https://eth.drpc.org
         run: node scripts/ci/contracts-ci.mjs test 2
 
   contracts-release:

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -4,3 +4,5 @@
 # False positive: Solidity position-liquidity assignment, not an API credential.
 28fcea6ee143e5a259e50a3d22b50c744c2e9e54:contracts/src/MemeLaunchV4.sol:generic-api-key:316
 1ea44bd6b6552a51194a4f82c01d41abb9f87d89:contracts/src/MemeLaunchV4.sol:generic-api-key:316
+# False positive: public idempotency-key example in correction documentation.
+f2908f9f146ab634a7f6f54449c0bf8526c5c4b7:ops/module-mode-publication/README.md:generic-api-key:38

--- a/app/api/admin/modules/[id]/corrections/route.ts
+++ b/app/api/admin/modules/[id]/corrections/route.ts
@@ -1,0 +1,13 @@
+import { moduleReviewRoute } from "@/lib/server/module-mode/review-client";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+export async function POST(request: Request, context: { params: Promise<{ id: string }> }) {
+  return moduleReviewRoute(request, "correction", (await context.params).id);
+}
+
+export async function GET(request: Request, context: { params: Promise<{ id: string }> }) {
+  return moduleReviewRoute(request, "correction-status", (await context.params).id);
+}

--- a/lib/module-mode/review-contract.ts
+++ b/lib/module-mode/review-contract.ts
@@ -27,7 +27,12 @@ export interface ReviewQueueItem extends Omit<ReviewJob, "artifact" | "plan" | "
 export interface ReviewQueue { schemaVersion: "programmable.modules.website-review-queue.v1"; jobs: ReviewQueueItem[]; nextCursor: string | null }
 export interface ReviewSourceInfo { descriptor: OpenSourcePackage; packageId: Hex; familyId: Hex; files: { path: string; sha256: string; bytes: number }[] }
 export interface ReviewAttempt { attempt: number; event: "claimed" | "completed" | "failed" | "expired"; requestDigest: Hex; planDigest: Hex; workerIdentity: null | { sourceCommit: string; runId: string; runAttempt: string; workflowRef: string; identityDigest: Hex }; artifactDigest: Hex | null; errorCode: string | null; createdAt: string }
-export interface ReviewDetail { schemaVersion: "programmable.modules.website-review-detail.v1"; job: ReviewJob; decisions: ModuleReviewDecisionRecordV1[]; attempts: ReviewAttempt[]; source: ReviewSourceInfo }
+export interface ReviewSourceCorrection {
+  schemaVersion: "programmable.modules.source-correction-record.v1"; parentSubmissionId: string; submissionId: string;
+  principalId: string; author: string; rewardWallet: string; familyId: Hex; baseRequestDigest: Hex; requestDigest: Hex;
+  packageId: Hex; version: string; correctedBy: string; policyDigest: Hex; commandDigest: Hex; reason: string; createdAt: string; correctionDigest: Hex;
+}
+export interface ReviewDetail { schemaVersion: "programmable.modules.website-review-detail.v1"; job: ReviewJob; decisions: ModuleReviewDecisionRecordV1[]; attempts: ReviewAttempt[]; source: ReviewSourceInfo; sourceCorrection?: ReviewSourceCorrection | null }
 export interface ReviewManifestCheck { schemaVersion: "programmable.modules.website-manifest-check.v1"; submissionId: string; requestDigest: Hex; reviewRevision: number; artifactDigest: Hex; hostManifestHash: Hex }
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
@@ -53,6 +58,19 @@ export function parseReviewSubject(value: unknown): ReviewSubject {
   const r = reviewRecord(value, ["submissionId", "principalId", "author", "requestDigest"]);
   requireValue(isReviewId(r.submissionId) && isReviewId(r.principalId) && typeof r.author === "string" && ADDRESS.test(r.author) && isReviewDigest(r.requestDigest), "subject");
   return r as unknown as ReviewSubject;
+}
+export function parseReviewSourceCorrection(value: unknown): ReviewSourceCorrection {
+  const r = reviewRecord(value, ["schemaVersion", "parentSubmissionId", "submissionId", "principalId", "author", "rewardWallet", "familyId", "baseRequestDigest", "requestDigest", "packageId", "version", "correctedBy", "policyDigest", "commandDigest", "reason", "createdAt", "correctionDigest"]);
+  requireValue(r.schemaVersion === "programmable.modules.source-correction-record.v1" && isReviewId(r.parentSubmissionId)
+    && isReviewId(r.submissionId) && r.submissionId !== r.parentSubmissionId && isReviewId(r.principalId), "source correction subject");
+  for (const key of ["author", "rewardWallet", "correctedBy"] as const) requireValue(typeof r[key] === "string" && ADDRESS.test(r[key]), "source correction wallet");
+  for (const key of ["familyId", "baseRequestDigest", "requestDigest", "packageId", "policyDigest", "commandDigest", "correctionDigest"] as const) requireValue(isReviewDigest(r[key]), "source correction digest");
+  requireValue(typeof r.version === "string" && /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-pm\.[1-9][0-9]*$/u.test(r.version) && r.version.length <= 128
+    && typeof r.reason === "string" && r.reason.trim() === r.reason && !r.reason.includes("\0") && new TextEncoder().encode(r.reason).byteLength >= 10 && new TextEncoder().encode(r.reason).byteLength <= 4096
+    && r.correctedBy !== r.author && r.baseRequestDigest !== r.requestDigest && timestamp(r.createdAt), "source correction metadata");
+  const { correctionDigest, ...contents } = r;
+  requireValue(correctionDigest === reviewDigest("programmable.modules.source-correction-record.v1", contents), "source correction record digest");
+  return r as unknown as ReviewSourceCorrection;
 }
 export function parseReviewProgramAbi(value: unknown): ReviewProgramArgument[] {
   requireValue(Array.isArray(value) && value.length <= 128, "configuration ABI");

--- a/lib/server/module-mode/review-client.ts
+++ b/lib/server/module-mode/review-client.ts
@@ -9,7 +9,7 @@ import { isWebsiteAdminWallet } from "@/lib/admin-access";
 import configuredNativeReviewRelease from "@/config/module-mode/review-release.json";
 import configuredEngineReviewRelease from "@/config/module-engine/review-release.json";
 import { computeModuleModeReleaseDigest, moduleHash, moduleRecord, MODULE_MODE_SOURCE_VERSION_V2 } from "@/lib/module-mode/release";
-import { isReviewId, parseReviewAttempt, parseReviewJob, parseReviewPlan, reviewDigest, reviewRecord, parseReviewQueueItem, type ReviewDetail } from "@/lib/module-mode/review-contract";
+import { isReviewId, parseReviewAttempt, parseReviewJob, parseReviewPlan, parseReviewSourceCorrection, reviewDigest, reviewRecord, parseReviewQueueItem, type ReviewDetail } from "@/lib/module-mode/review-contract";
 import { nativeCanonicalJson } from "@/lib/module-mode/native-catalog";
 import { unsupportedManagementCapabilities } from "@/lib/module-mode/management-manifest";
 import { validateModuleSubmissionRequest, MODULE_TRANSPORT_LIMITS } from "@/packages/classic-modules/src/open-transport.mjs";
@@ -18,8 +18,9 @@ import { createWalletAdminBffAssertionV2, requireWalletAdminBffAssertionKeyV2 } 
 import { parseStrictJson } from "../projection-target/canonical-json";
 import { createModuleModeHostManifest, computeModuleModeHostManifestHash, type ModuleModeCatalogDefinition, type ModuleModeHostReleaseIdentity } from "./catalog";
 import { validateModuleReviewDecisionCommandV1, validateModuleReviewDecisionRecordV1 } from "./review-decision-wire-v1";
+import { bindModuleSourceCorrectionReceipt, isModuleCorrectionIdempotencyKey, MODULE_SOURCE_CORRECTION_LIMIT, parseModuleSourceCorrectionCommand, parseModuleSourceCorrectionReceipt, type ModuleSourceCorrectionCommand } from "./review-source-correction";
 
-type Operation = "list" | "detail" | "source" | "plan" | "manifest" | "decision";
+type Operation = "list" | "detail" | "source" | "plan" | "manifest" | "decision" | "correction" | "correction-status";
 const BACKEND_PATH = "/v1/wallet-admin/module-review";
 const HEADERS = { "Cache-Control": "no-store", "Content-Type": "application/json; charset=utf-8", "X-Content-Type-Options": "nosniff", Vary: "Authorization, X-Privy-Identity-Token" };
 const BROWSER_LIMIT = 3 * 1024 * 1024;
@@ -67,16 +68,17 @@ export function createModuleReviewClient(input: {
   const assertionKey = requireWalletAdminBffAssertionKeyV2(input.bffAssertionKeyV2, input.websiteToken);
   return { async handle(request: Request, operation: Operation, id?: string): Promise<Response> {
     try {
-      const mutation = ["plan", "manifest", "decision"].includes(operation);
+      const mutation = ["plan", "manifest", "decision", "correction"].includes(operation);
       if (request.method !== (mutation ? "POST" : "GET")) fail(405, "METHOD_NOT_ALLOWED");
       const url = new URL(request.url);
-      const allowedQuery = mutation ? [] : ["walletAddress", ...(operation === "list" ? ["cursor"] : [])];
+      const allowedQuery = mutation ? [] : ["walletAddress", ...(operation === "list" ? ["cursor"] : []), ...(operation === "correction-status" ? ["idempotencyKey"] : [])];
       if (url.hash || [...url.searchParams.keys()].some((key) => !allowedQuery.includes(key)) || [...url.searchParams.keys()].some((key) => url.searchParams.getAll(key).length !== 1)) fail(400, "MODULE_REVIEW_REQUEST_INVALID");
       if (operation !== "list" && !isReviewId(id)) fail(400, "MODULE_REVIEW_ID_INVALID");
       if (mutation) jsonHeader(request);
       const principal = await input.authenticator.authenticate(request);
-      const bodyBytes = mutation ? await bytes(request, BROWSER_LIMIT) : null;
-      const body = bodyBytes ? userInput(() => reviewRecord(parsed(bodyBytes, BROWSER_LIMIT))) : null;
+      const browserLimit = operation === "correction" ? MODULE_SOURCE_CORRECTION_LIMIT + 256 : BROWSER_LIMIT;
+      const bodyBytes = mutation ? await bytes(request, browserLimit) : null;
+      const body = bodyBytes ? userInput(() => reviewRecord(parsed(bodyBytes, browserLimit))) : null;
       const rawWallet = mutation ? body?.walletAddress : url.searchParams.get("walletAddress");
       if (typeof rawWallet !== "string" || !isAddress(rawWallet) || BigInt(rawWallet) === 0n) fail(400, "wallet_address_invalid");
       const wallet = getAddress(rawWallet).toLowerCase() as `0x${string}`;
@@ -115,7 +117,17 @@ export function createModuleReviewClient(input: {
         if (!Array.isArray(detail.decisions) || detail.decisions.length > 1000 || detail.decisions.some((decision) => !validateModuleReviewDecisionRecordV1(decision) || !same(decision.subject, job.subject))) fail(502, "MODULE_REVIEW_DECISION_INVALID");
         const attempts = detail.attempts ?? [];
         if (!Array.isArray(attempts) || attempts.length > 24) fail(502, "MODULE_REVIEW_ATTEMPTS_INVALID");
-        return { detail: { schemaVersion: "programmable.modules.website-review-detail.v1", job, decisions: detail.decisions as ReviewDetail["decisions"], attempts: attempts.map((item) => parseReviewAttempt(item, job.subject)), source: { descriptor: checked.request.descriptor, packageId: checked.packageId, familyId: checked.familyId, files: checked.request.files.map((file) => ({ path: file.path, sha256: file.sha256, bytes: Buffer.from(file.bytes, "base64").byteLength })) } }, sourceRaw: sourceResponse.raw };
+        let sourceCorrection: ReviewDetail["sourceCorrection"];
+        if (Object.hasOwn(detail, "sourceCorrection")) {
+          try { sourceCorrection = detail.sourceCorrection === null ? null : parseReviewSourceCorrection(detail.sourceCorrection); }
+          catch { fail(502, "MODULE_REVIEW_SOURCE_CORRECTION_INVALID"); }
+          if (sourceCorrection && (sourceCorrection.submissionId !== id || sourceCorrection.requestDigest !== job.subject.requestDigest
+            || sourceCorrection.principalId !== job.subject.principalId || sourceCorrection.author !== job.subject.author
+            || sourceCorrection.rewardWallet !== checked.request.descriptor.rewardWallet.toLowerCase() || sourceCorrection.familyId !== checked.familyId
+            || sourceCorrection.packageId !== checked.packageId || sourceCorrection.version !== checked.request.descriptor.version
+            || sourceCorrection.parentSubmissionId !== checked.request.supersedesSubmissionId)) fail(502, "MODULE_REVIEW_SOURCE_CORRECTION_INVALID");
+        }
+        return { detail: { schemaVersion: "programmable.modules.website-review-detail.v1", job, decisions: detail.decisions as ReviewDetail["decisions"], attempts: attempts.map((item) => parseReviewAttempt(item, job.subject)), source: { descriptor: checked.request.descriptor, packageId: checked.packageId, familyId: checked.familyId, files: checked.request.files.map((file) => ({ path: file.path, sha256: file.sha256, bytes: Buffer.from(file.bytes, "base64").byteLength })) }, ...(sourceCorrection === undefined ? {} : { sourceCorrection }) }, sourceRaw: sourceResponse.raw };
       };
       const validateManifest = (text: unknown, detail: ReviewDetail) => {
         if (typeof text !== "string" || Buffer.byteLength(text) > 2 * 1024 * 1024) fail(400, "MODULE_REVIEW_MANIFEST_REQUIRED");
@@ -159,6 +171,43 @@ export function createModuleReviewClient(input: {
       const { detail, sourceRaw } = await loadDetail();
       if (operation === "detail") return response(200, detail);
       if (operation === "source") return new Response(Uint8Array.from(sourceRaw), { headers: { ...HEADERS, "Content-Disposition": `attachment; filename="module-${id}.json"` } });
+      if (operation === "correction" || operation === "correction-status") {
+        const command = operation === "correction" ? userInput(() => {
+          reviewRecord(body, ["walletAddress", "command"]);
+          if (Buffer.byteLength(JSON.stringify(body!.command)) > MODULE_SOURCE_CORRECTION_LIMIT) fail(413, "MODULE_SOURCE_CORRECTION_TOO_LARGE");
+          return parseModuleSourceCorrectionCommand(body!.command);
+        }) : undefined;
+        const key = command?.idempotencyKey ?? url.searchParams.get("idempotencyKey");
+        if (!isModuleCorrectionIdempotencyKey(key)) fail(400, "MODULE_SOURCE_CORRECTION_KEY_INVALID");
+        const receiptFor = (upstream: { value: unknown; status: number }, expectedCommand?: ModuleSourceCorrectionCommand) => {
+          try {
+            const receipt = parseModuleSourceCorrectionReceipt(upstream.value);
+            if (![200, 201].includes(upstream.status) || receipt.created !== (upstream.status === 201)) fail(502, "MODULE_REVIEW_SOURCE_CORRECTION_INVALID");
+            bindModuleSourceCorrectionReceipt(receipt, detail, wallet, expectedCommand);
+            return receipt;
+          } catch { return fail(502, "MODULE_REVIEW_SOURCE_CORRECTION_INVALID"); }
+        };
+        // Resolve a committed attempt before checking a revision that may have advanced afterwards.
+        let previous: Awaited<ReturnType<typeof call>> | undefined;
+        try { previous = await call(`${BACKEND_PATH}/${id}/corrections?idempotencyKey=${encodeURIComponent(key)}`, "GET", undefined, 16_384); }
+        catch (error) { if (!(operation === "correction" && error instanceof ReviewHttpError && error.status === 404 && error.code === "MODULE_CORRECTION_NOT_FOUND")) throw error; }
+        if (previous) {
+          const receipt = receiptFor(previous);
+          if (command && receipt.sourceCorrection.commandDigest !== reviewDigest("programmable.modules.source-correction-command.v1", command)) fail(409, "MODULE_SOURCE_CORRECTION_IDEMPOTENCY_CONFLICT");
+          return response(200, command ? receiptFor(previous, command) : receipt);
+        }
+        if (!command || command.requestDigest !== detail.job.subject.requestDigest || command.expectedReviewRevision !== detail.job.reviewRevision) fail(409, "MODULE_REVIEW_REVISION_CONFLICT");
+        if (wallet === detail.job.subject.author) fail(403, "MODULE_REVIEW_SELF_DECISION_FORBIDDEN");
+        if (detail.sourceCorrection || !["awaiting_plan", "build_failed", "changes_requested", "built"].includes(detail.job.state)
+          || command.version === detail.source.descriptor.version) fail(409, "MODULE_CORRECTION_REVISION_CONFLICT");
+        const files = new Map(detail.source.files.map(file => [file.path, file]));
+        for (const change of command.files) {
+          const original = files.get(change.path);
+          if (change.expectedSha256 === null ? original !== undefined : original?.sha256 !== change.expectedSha256) fail(409, "MODULE_SOURCE_CORRECTION_SOURCE_CONFLICT");
+        }
+        const upstream = await call(`${BACKEND_PATH}/${id}/corrections`, "POST", command, 16_384);
+        return response(upstream.status, receiptFor(upstream, command));
+      }
       if (wallet === detail.job.subject.author) fail(403, "MODULE_REVIEW_SELF_DECISION_FORBIDDEN");
       if (operation === "plan") {
         userInput(() => reviewRecord(body, ["walletAddress", "expectedReviewRevision", "planJson"]));

--- a/lib/server/module-mode/review-source-correction.ts
+++ b/lib/server/module-mode/review-source-correction.ts
@@ -1,0 +1,81 @@
+import { isReviewDigest, parseReviewSourceCorrection, reviewDigest, reviewRecord, type ReviewDetail, type ReviewSourceCorrection } from "../../module-mode/review-contract";
+
+export const MODULE_SOURCE_CORRECTION_LIMIT = 262_144;
+export interface ModuleSourceCorrectionCommand {
+  schemaVersion: "programmable.modules.source-correction.v1";
+  expectedReviewRevision: number;
+  requestDigest: `0x${string}`;
+  version: string;
+  reason: string;
+  idempotencyKey: string;
+  files: { path: string; expectedSha256: string | null; sha256: string; edits: { offset: number; deleteBytes: number; insertBase64: string }[] }[];
+}
+export interface ModuleSourceCorrectionReceipt {
+  schemaVersion: "programmable.modules.source-correction-receipt.v1";
+  created: boolean;
+  sourceCorrection: ReviewSourceCorrection;
+  reviewStatus: "awaiting_plan";
+  approved: false;
+  available: false;
+}
+const HASH = /^[0-9a-f]{64}$/u;
+function need(value: unknown): asserts value { if (!value) throw new Error("Module source correction is invalid."); }
+function integer(value: unknown): value is number { return Number.isSafeInteger(value) && Number(value) >= 0 && !Object.is(value, -0); }
+export function isModuleCorrectionIdempotencyKey(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z0-9._:-]{16,128}$/u.test(value);
+}
+export function parseModuleSourceCorrectionCommand(value: unknown): ModuleSourceCorrectionCommand {
+  const r = reviewRecord(value, ["schemaVersion", "expectedReviewRevision", "requestDigest", "version", "reason", "idempotencyKey", "files"]);
+  need(Buffer.byteLength(JSON.stringify(r)) <= MODULE_SOURCE_CORRECTION_LIMIT);
+  need(r.schemaVersion === "programmable.modules.source-correction.v1" && integer(r.expectedReviewRevision) && isReviewDigest(r.requestDigest));
+  need(typeof r.version === "string" && /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-pm\.[1-9][0-9]*$/u.test(r.version) && r.version.length <= 128);
+  need(typeof r.reason === "string" && r.reason.trim() === r.reason && !r.reason.includes("\0") && Buffer.byteLength(r.reason) >= 10 && Buffer.byteLength(r.reason) <= 4096);
+  need(isModuleCorrectionIdempotencyKey(r.idempotencyKey));
+  need(Array.isArray(r.files) && r.files.length > 0 && r.files.length <= 16);
+  const paths = new Set<string>();
+  let totalEdits = 0; let insertedBytes = 0;
+  for (const raw of r.files) {
+    const f = reviewRecord(raw, ["path", "expectedSha256", "sha256", "edits"]);
+    need(typeof f.path === "string" && f.path.length > 0 && Buffer.byteLength(f.path) <= 1024 && !f.path.startsWith("/") && !/[\\\u0000]/u.test(f.path)
+      && f.path.split("/").every(part => part !== "" && part !== "." && part !== "..") && !paths.has(f.path));
+    paths.add(f.path);
+    need((f.expectedSha256 === null || (typeof f.expectedSha256 === "string" && HASH.test(f.expectedSha256))) && typeof f.sha256 === "string" && HASH.test(f.sha256) && f.sha256 !== f.expectedSha256);
+    need(Array.isArray(f.edits) && f.edits.length > 0 && f.edits.length <= 64);
+    totalEdits += f.edits.length; need(totalEdits <= 256);
+    let previousEnd = -1; let previousOffset = -1;
+    for (const rawEdit of f.edits) {
+      const edit = reviewRecord(rawEdit, ["offset", "deleteBytes", "insertBase64"]);
+      need(integer(edit.offset) && integer(edit.deleteBytes) && edit.offset >= previousEnd && edit.offset > previousOffset
+        && edit.offset + edit.deleteBytes <= 4 * 1024 * 1024 && typeof edit.insertBase64 === "string");
+      need(edit.insertBase64.length % 4 === 0 && /^[A-Za-z0-9+/]*={0,2}$/u.test(edit.insertBase64)
+        && Buffer.from(edit.insertBase64, "base64").toString("base64") === edit.insertBase64);
+      insertedBytes += Buffer.from(edit.insertBase64, "base64").byteLength; need(insertedBytes <= 128 * 1024);
+      need(edit.deleteBytes > 0 || edit.insertBase64.length > 0);
+      previousEnd = edit.offset + edit.deleteBytes;
+      previousOffset = edit.offset;
+      need(Number.isSafeInteger(previousEnd));
+    }
+    if (f.expectedSha256 === null) {
+      const insertion = reviewRecord(f.edits[0]);
+      need(f.edits.length === 1 && insertion.offset === 0 && insertion.deleteBytes === 0);
+    }
+  }
+  return r as unknown as ModuleSourceCorrectionCommand;
+}
+
+export function parseModuleSourceCorrectionReceipt(value: unknown): ModuleSourceCorrectionReceipt {
+  const r = reviewRecord(value, ["schemaVersion", "created", "sourceCorrection", "reviewStatus", "approved", "available"]);
+  need(r.schemaVersion === "programmable.modules.source-correction-receipt.v1" && typeof r.created === "boolean"
+    && r.reviewStatus === "awaiting_plan" && r.approved === false && r.available === false);
+  parseReviewSourceCorrection(r.sourceCorrection);
+  return r as unknown as ModuleSourceCorrectionReceipt;
+}
+export function bindModuleSourceCorrectionReceipt(receipt: ModuleSourceCorrectionReceipt, parent: ReviewDetail, wallet: string, command?: ModuleSourceCorrectionCommand): void {
+  const record = receipt.sourceCorrection;
+  need(record.parentSubmissionId === parent.job.subject.submissionId && record.principalId === parent.job.subject.principalId
+    && record.author === parent.job.subject.author && record.rewardWallet === parent.source.descriptor.rewardWallet.toLowerCase()
+    && record.familyId === parent.source.familyId && record.baseRequestDigest === parent.job.subject.requestDigest
+    && record.correctedBy === wallet && record.requestDigest !== parent.job.subject.requestDigest && record.packageId !== parent.source.packageId
+    && (command === undefined || (record.version === command.version && record.reason === command.reason
+      && record.commandDigest === reviewDigest("programmable.modules.source-correction-command.v1", command))));
+}

--- a/ops/module-mode-publication/README.md
+++ b/ops/module-mode-publication/README.md
@@ -8,6 +8,71 @@ not need a GitHub repository or a pull request. Publication is a separate operat
 The three commands are `manifest`, `prepare` and `export`. They never sign, send a transaction,
 publish a website or change the catalogue. `export` writes a reviewable local publication only after
 real Registry, contract-code, transaction and receipt checks pass on both reviewed RPC providers.
+The separate `correct-source` command records a bounded administrator correction as a new submission.
+It preserves the original source and attribution and starts a new review; it does not approve or publish.
+
+## Correct a submitted source package
+
+An authenticated administrator can apply a prepared small source correction without using the
+contributor's API key. Use the existing session-file workflow below. This command accepts source-byte
+edits, not a replacement author, reward wallet, family or review result. It only supports an original
+author submission; an existing platform correction cannot be corrected again through this version.
+
+```sh
+node ops/module-mode-publication/operator.mjs correct-source \
+  --submission 00000000-0000-4000-8000-000000000001 \
+  --correction-file /private/operator/correction.json \
+  --session-file /private/operator/session.json \
+  --output /private/operator/correction-run
+```
+
+The correction file contains exactly:
+
+```json
+{
+  "schemaVersion": "programmable.modules.source-correction.v1",
+  "expectedReviewRevision": 0,
+  "requestDigest": "0x…",
+  "version": "0.1.1-pm.1",
+  "reason": "Explain the concrete defect and the bounded correction.",
+  "idempotencyKey": "unique-correction-key-0001",
+  "files": [
+    {
+      "path": "src/Example.sol",
+      "expectedSha256": "original lowercase SHA-256 without 0x",
+      "sha256": "corrected lowercase SHA-256 without 0x",
+      "edits": [
+        { "offset": 0, "deleteBytes": 0, "insertBase64": "Ly8gRXhhbXBsZQo=" }
+      ]
+    }
+  ]
+}
+```
+
+All identifiers, hashes, offsets and source in that example are placeholders. Prepare the command
+against the live parent request and its current review revision. Offsets count bytes in each original
+file. Edits must be sorted and must not overlap. A new file uses `expectedSha256: null` and one
+insertion at offset zero. Existing files are never deleted. The complete command is limited to
+262,144 bytes, 16 changed files, 64 edits per file, 256 edits in total and 128 KiB of inserted bytes.
+The reason is trimmed text of 10 to 4,096 UTF-8 bytes; the idempotency key is 16 to 128 characters
+from `A-Za-z0-9._:-`. The platform version ends in `-pm.` followed by a positive integer.
+
+The backend reconstructs immutable source, changes only the descriptor version and source-file
+hashes, removes the old Git revision claim, and sets `supersedesSubmissionId` to the original submission.
+It records the actual authenticated editor, reason, parent identity, policy and correction digest
+separately. The author's principal, author wallet, reward wallet, family and all other descriptor
+fields remain unchanged. The parent must be unapproved, have no active build and belong to an author
+other than the correcting administrator. The new submission starts at `awaiting_plan`; previous build or approval
+results are not inherited. Admin detail exposes the verified `sourceCorrection` record.
+
+Before POST, the operator writes a private command and intent journal. It sends the command once,
+then verifies the stored receipt and newly fetched source, including every unchanged file and the
+original attribution. If a response is lost, it queries the receipt with the same idempotency key.
+Run the identical command with the same output directory to reconcile an interrupted run. An existing
+journal permits reads only; it never automatically sends another POST. Keep the original key and
+command while the outcome is unresolved. A missing `correction.complete.json` means verification is
+incomplete. A successful correction still needs a protected build, review, Registry admission and
+catalog publication through the normal process.
 
 ## Inputs and authority
 

--- a/ops/module-mode-publication/README.md
+++ b/ops/module-mode-publication/README.md
@@ -35,7 +35,7 @@ The correction file contains exactly:
   "requestDigest": "0x…",
   "version": "0.1.1-pm.1",
   "reason": "Explain the concrete defect and the bounded correction.",
-  "idempotencyKey": "unique-correction-key-0001",
+  "idempotencyKey": "<unique idempotency key>",
   "files": [
     {
       "path": "src/Example.sol",

--- a/ops/module-mode-publication/correction.ts
+++ b/ops/module-mode-publication/correction.ts
@@ -1,0 +1,167 @@
+import { constants } from "node:fs";
+import { lstat, mkdir, open, realpath, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { isReviewId, parseReviewJob, parseReviewSourceCorrection, reviewDigest, reviewRecord, type ReviewDetail } from "../../lib/module-mode/review-contract";
+import { nativeCanonicalJson } from "../../lib/module-mode/native-catalog";
+import { bindModuleSourceCorrectionReceipt, MODULE_SOURCE_CORRECTION_LIMIT, parseModuleSourceCorrectionCommand, parseModuleSourceCorrectionReceipt, type ModuleSourceCorrectionCommand, type ModuleSourceCorrectionReceipt } from "../../lib/server/module-mode/review-source-correction";
+import { MODULE_TRANSPORT_LIMITS, validateModuleSubmissionRequest, type ModuleSubmissionRequest } from "../../packages/classic-modules/src/open-transport.mjs";
+import { exactJson, ModulePublicationError, need, readOperatorSession, REVIEW_ORIGIN, same, type OperatorSession } from "./review";
+
+interface Submission { detail: ReviewDetail; source: ModuleSubmissionRequest; sourceBytes: Uint8Array }
+async function fileJson(file: string, maximum: number, privateFile = false): Promise<unknown> {
+  const handle = await open(file, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const info = await handle.stat();
+    need(info.isFile() && info.nlink === 1 && info.size <= maximum
+      && (!privateFile || (info.uid === process.getuid?.() && (info.mode & 0o077) === 0)), "Correction input must be a bounded regular file with the required permissions");
+    return exactJson(await handle.readFile(), maximum);
+  } finally { await handle.close(); }
+}
+async function responseBytes(response: Response, maximum: number): Promise<Uint8Array> {
+  need(!response.redirected && response.body && !response.headers.has("content-encoding")
+    && /^application\/json(?:\s*;|$)/iu.test(response.headers.get("content-type") ?? ""), "Correction endpoint returned an invalid response");
+  const reader = response.body.getReader(); const chunks: Uint8Array[] = []; let size = 0;
+  try {
+    for (;;) {
+      const item = await reader.read(); if (item.done) break;
+      size += item.value.byteLength; need(size <= maximum, "Correction response exceeds its byte limit"); chunks.push(item.value);
+    }
+    return Buffer.concat(chunks);
+  } catch (error) { await reader.cancel().catch(() => undefined); throw error; }
+  finally { reader.releaseLock(); }
+}
+function correctionClient(session: OperatorSession, fetchImpl: typeof fetch) {
+  const request = async (submissionId: string, suffix: string, payload?: unknown, maximum = 4 * 1024 * 1024) => {
+    need(isReviewId(submissionId), "Invalid correction submission identifier");
+    const url = new URL(`${REVIEW_ORIGIN}/api/admin/modules/${submissionId}${suffix}`);
+    if (payload === undefined) url.searchParams.set("walletAddress", session.walletAddress);
+    let response: Response;
+    try {
+      response = await fetchImpl(url, { method: payload === undefined ? "GET" : "POST", cache: "no-store", redirect: "error", signal: AbortSignal.timeout(30_000),
+        headers: { Accept: "application/json", "Accept-Encoding": "identity", Authorization: `Bearer ${session.accessToken}`,
+          ...(session.identityToken ? { "X-Privy-Identity-Token": session.identityToken } : {}), ...(payload === undefined ? {} : { "Content-Type": "application/json" }) },
+        ...(payload === undefined ? {} : { body: JSON.stringify({ walletAddress: session.walletAddress, command: payload }) }) });
+    } catch { throw new ModulePublicationError("Correction request did not return a confirmed result. Keep the original idempotency key and reconcile the existing output directory."); }
+    const raw = await responseBytes(response, response.ok ? maximum : 16_384);
+    const value = exactJson(raw, response.ok ? maximum : 16_384);
+    if (!response.ok) {
+      const error = reviewRecord(value).error;
+      const code = error && typeof error === "object" && !Array.isArray(error) ? (error as { code?: unknown }).code : null;
+      if (response.status === 404 && code === "MODULE_CORRECTION_NOT_FOUND" && suffix.startsWith("/corrections?")) return null;
+      throw new ModulePublicationError(`Correction endpoint rejected the request (${response.status}${typeof code === "string" && /^[A-Z_a-z0-9]{1,128}$/u.test(code) ? `, ${code}` : ""}).`);
+    }
+    return { value, raw, status: response.status };
+  };
+  return {
+    async read(submissionId: string): Promise<Submission> {
+      const [detailResponse, sourceResponse] = await Promise.all([request(submissionId, ""), request(submissionId, "/source", undefined, MODULE_TRANSPORT_LIMITS.requestBytes)]);
+      need(detailResponse?.status === 200 && sourceResponse?.status === 200, "Correction source read is unavailable");
+      const raw = reviewRecord(detailResponse.value);
+      need(raw.schemaVersion === "programmable.modules.website-review-detail.v1", "Correction detail format differs");
+      const job = parseReviewJob(raw.job);
+      const checked = validateModuleSubmissionRequest(sourceResponse.value);
+      need(checked.ok && job.subject.submissionId === submissionId && checked.requestDigest === job.subject.requestDigest
+        && checked.request.descriptor.author.toLowerCase() === job.subject.author, "Correction source does not bind its original author");
+      const metadata = reviewRecord(raw.source);
+      same(metadata.descriptor, checked.request.descriptor, "Correction source descriptor");
+      need(metadata.packageId === checked.packageId && metadata.familyId === checked.familyId, "Correction source identity differs");
+      const sourceCorrection = raw.sourceCorrection === undefined || raw.sourceCorrection === null ? null : parseReviewSourceCorrection(raw.sourceCorrection);
+      const detail = { ...raw, job, sourceCorrection } as unknown as ReviewDetail;
+      const closing = await request(submissionId, "");
+      need(closing?.status === 200, "Closing correction detail read is unavailable");
+      const fresh = reviewRecord(closing.value);
+      same(fresh.job, raw.job, "Concurrent correction review revision");
+      same(fresh.sourceCorrection ?? null, sourceCorrection, "Concurrent source correction");
+      return { detail, source: checked.request, sourceBytes: sourceResponse.raw };
+    },
+    async find(submissionId: string, key: string): Promise<ModuleSourceCorrectionReceipt | null> {
+      const result = await request(submissionId, `/corrections?idempotencyKey=${encodeURIComponent(key)}`, undefined, 16_384);
+      if (!result) return null;
+      need(result.status === 200, "Correction lookup status differs");
+      return parseModuleSourceCorrectionReceipt(result.value);
+    },
+    async submit(submissionId: string, command: ModuleSourceCorrectionCommand): Promise<ModuleSourceCorrectionReceipt> {
+      const result = await request(submissionId, "/corrections", command, 16_384);
+      need(result && [200, 201].includes(result.status), "Correction creation status differs");
+      return parseModuleSourceCorrectionReceipt(result.value);
+    },
+  };
+}
+function verifySource(parent: Submission, corrected: Submission, command: ModuleSourceCorrectionCommand, receipt: ModuleSourceCorrectionReceipt) {
+  const record = receipt.sourceCorrection;
+  same(corrected.detail.sourceCorrection, record, "Stored correction provenance");
+  need(corrected.detail.job.subject.submissionId === record.submissionId && corrected.detail.job.subject.requestDigest === record.requestDigest
+    && corrected.detail.job.subject.author === record.author && corrected.detail.job.subject.principalId === record.principalId
+    && corrected.detail.source.packageId === record.packageId && corrected.detail.source.familyId === record.familyId
+    && corrected.source.supersedesSubmissionId === record.parentSubmissionId, "Corrected submission identity differs");
+  const expectedFiles = new Map(parent.source.files.map(file => [file.path, { path: file.path, sha256: file.sha256 }]));
+  for (const change of command.files) expectedFiles.set(change.path, { path: change.path, sha256: change.sha256 });
+  const pinned = [...expectedFiles.values()].sort((a, b) => a.path < b.path ? -1 : a.path > b.path ? 1 : 0);
+  const expectedDescriptor = { ...parent.source.descriptor, version: command.version, source: { files: pinned } };
+  const correctedDescriptor = { ...corrected.source.descriptor, source: { ...corrected.source.descriptor.source,
+    files: [...corrected.source.descriptor.source.files].sort((a, b) => a.path < b.path ? -1 : a.path > b.path ? 1 : 0) } };
+  same(correctedDescriptor, expectedDescriptor, "Corrected descriptor and original attribution");
+  const changed = new Set(command.files.map(file => file.path));
+  const files = new Map(corrected.source.files.map(file => [file.path, file]));
+  for (const file of parent.source.files) if (!changed.has(file.path)) same(files.get(file.path), file, "Unchanged source bytes");
+}
+
+/** Uses the authenticated admin BFF only. A correction does not build, approve, sign or publish. */
+export async function runSourceCorrection(options: Record<string, string>, repositoryRoot: string, fetchImpl: typeof fetch = fetch) {
+  const command = parseModuleSourceCorrectionCommand(await fileJson(options["correction-file"], MODULE_SOURCE_CORRECTION_LIMIT));
+  need(isReviewId(options.submission), "Invalid correction submission identifier");
+  const session = await readOperatorSession(options["session-file"]);
+  const output = path.resolve(options.output);
+  const physicalParent = await realpath(path.dirname(output));
+  const parentStat = await lstat(physicalParent);
+  need(physicalParent === path.dirname(output) && parentStat.isDirectory() && parentStat.uid === process.getuid?.() && (parentStat.mode & 0o077) === 0, "Output parent must be a private owner-only real directory");
+  need(output !== path.resolve(repositoryRoot) && !output.startsWith(path.resolve(repositoryRoot) + path.sep), "Write correction evidence outside the source checkout");
+  const intent = { schemaVersion: "programmable.modules.source-correction-intent.v1", parentSubmissionId: options.submission,
+    walletAddress: session.walletAddress.toLowerCase(), commandDigest: reviewDigest("programmable.modules.source-correction-command.v1", command) };
+  let recovering = false;
+  try { await mkdir(output, { mode: 0o700 }); }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    const info = await lstat(output);
+    need(info.isDirectory() && !info.isSymbolicLink() && info.uid === process.getuid?.() && (info.mode & 0o077) === 0, "Correction output must remain a private real directory");
+    same(await fileJson(path.join(output, "intent.json"), 4096, true), intent, "Existing correction intent");
+    same(await fileJson(path.join(output, "command.json"), MODULE_SOURCE_CORRECTION_LIMIT, true), command, "Existing correction command");
+    recovering = true;
+  }
+  const write = (name: string, value: unknown) => writeFile(path.join(output, name), `${nativeCanonicalJson(value)}\n`, { flag: "wx", mode: 0o600 });
+  if (!recovering) { await write("intent.json", intent); await write("command.json", command); }
+  const client = correctionClient(session, fetchImpl);
+  const parent = await client.read(options.submission);
+  let receipt = await client.find(options.submission, command.idempotencyKey);
+  if (!receipt) {
+    need(!recovering, "No committed correction is visible yet. Reconcile this output directory again; keep its command and idempotency key unchanged.");
+    need(parent.detail.sourceCorrection == null && parent.detail.job.subject.author !== session.walletAddress.toLowerCase(), "Correction requires an independent administrator and an original author submission");
+    need(["awaiting_plan", "build_failed", "changes_requested", "built"].includes(parent.detail.job.state), "The parent submission must be unapproved and have no active build");
+    need(parent.detail.job.reviewRevision === command.expectedReviewRevision && parent.detail.job.subject.requestDigest === command.requestDigest, "Correction parent revision changed; prepare a new reviewed command before sending");
+    const originals = new Map(parent.source.files.map(file => [file.path, file.sha256]));
+    for (const change of command.files) need(change.expectedSha256 === null ? !originals.has(change.path) : originals.get(change.path) === change.expectedSha256, "Correction source hash differs from the current parent");
+    await write("request.pending.json", intent);
+    try { receipt = await client.submit(options.submission, command); }
+    catch (error) {
+      receipt = await client.find(options.submission, command.idempotencyKey);
+      if (!receipt) throw error;
+    }
+  }
+  bindModuleSourceCorrectionReceipt(receipt, parent.detail, session.walletAddress.toLowerCase(), command);
+  const corrected = await client.read(receipt.sourceCorrection.submissionId);
+  verifySource(parent, corrected, command, receipt);
+  const completion = { schemaVersion: "programmable.modules.source-correction-complete.v1", sourceCorrection: receipt.sourceCorrection,
+    sourceBytesVerified: true, approved: false, available: false };
+  for (const [name, value] of [["receipt.json", receipt], ["corrected-source.json", corrected.source], ["correction.complete.json", completion]] as const) {
+    try { await write(name, value); }
+    catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      const previous = await fileJson(path.join(output, name), MODULE_TRANSPORT_LIMITS.requestBytes, true);
+      if (name === "receipt.json") same(parseModuleSourceCorrectionReceipt(previous).sourceCorrection, receipt.sourceCorrection, "Existing correction receipt");
+      else same(previous, value, "Existing correction evidence");
+    }
+  }
+  console.log(JSON.stringify({ status: "source-correction-recorded", output, submissionId: receipt.sourceCorrection.submissionId,
+    parentSubmissionId: options.submission, version: receipt.sourceCorrection.version, author: receipt.sourceCorrection.author,
+    rewardWallet: receipt.sourceCorrection.rewardWallet, approved: false, available: false }));
+}

--- a/ops/module-mode-publication/main.ts
+++ b/ops/module-mode-publication/main.ts
@@ -1,4 +1,5 @@
 import { runEnginePublication } from "./main-engine";
+import { runSourceCorrection } from "./correction";
 import { readFile, mkdir, writeFile, lstat, realpath } from "node:fs/promises";
 import path from "node:path";
 import { moduleHash } from "../../lib/module-mode/release";
@@ -10,15 +11,17 @@ import { publicationRpc, readPublicationOwner, observePublicationReadback, type 
 
 interface Context { repositoryRoot: string; providers: () => Promise<(Omit<PublicationProvider, "rpc"> & { url: string })[]> }
 export async function run(args: string[], context: Context) {
-  const command = args.shift(); need(["manifest", "prepare", "export"].includes(command ?? ""), "Use manifest, prepare or export");
+  const command = args.shift(); need(["manifest", "prepare", "export", "correct-source"].includes(command ?? ""), "Use manifest, prepare, export or correct-source");
   const options: Record<string, string> = {};
-  const required = ["identity", "definition", "submission", "session-file", "output", ...(command === "export" ? ["transactions"] : [])];
-  const allowed = new Set([...required, "fee-eligibility"]);
+  const required = command === "correct-source" ? ["correction-file", "submission", "session-file", "output"]
+    : ["identity", "definition", "submission", "session-file", "output", ...(command === "export" ? ["transactions"] : [])];
+  const allowed = new Set([...required, ...(command === "correct-source" ? [] : ["fee-eligibility"])]);
   for (let i = 0; i < args.length; i += 2) {
     const key = args[i].slice(2);
     need(args[i].startsWith("--") && allowed.has(key) && args[i + 1] && !Object.hasOwn(options, key), "Unexpected or duplicate publication option"); options[key] = args[i + 1];
   }
   need(required.every(key => Object.hasOwn(options, key)), "Missing publication options");
+  if (command === "correct-source") return runSourceCorrection(options, context.repositoryRoot);
   const read = async (key: string, maximum = 2 * 1024 * 1024) => exactJson(await readFile(options[key]), maximum);
   const identity = await read("identity") as ModuleModeHostReleaseIdentity;
   const definition = await read("definition") as ModuleModeCatalogDefinition;

--- a/tests/fixtures/module-source-correction.ts
+++ b/tests/fixtures/module-source-correction.ts
@@ -1,0 +1,40 @@
+import { createHash } from "node:crypto";
+import { reviewDigest, type ReviewSourceCorrection } from "../../lib/module-mode/review-contract";
+import type { ModuleSourceCorrectionCommand, ModuleSourceCorrectionReceipt } from "../../lib/server/module-mode/review-source-correction";
+import { validateModuleSubmissionRequest } from "../../packages/classic-modules/src/open-transport.mjs";
+import { moduleReviewAdminFixture } from "./module-review-admin";
+
+// Synthetic API data only. None of these sources is built, accepted or sent to a real service.
+export function moduleSourceCorrectionFixture() {
+  const f = moduleReviewAdminFixture();
+  const file = f.source.files[0];
+  const inserted = Buffer.from("// Synthetic correction fixture only.\n");
+  const patched = Buffer.concat([inserted, Buffer.from(file.bytes, "base64")]);
+  const sha256 = createHash("sha256").update(patched).digest("hex");
+  const command: ModuleSourceCorrectionCommand = { schemaVersion: "programmable.modules.source-correction.v1", expectedReviewRevision: f.job.reviewRevision,
+    requestDigest: f.subject.requestDigest, version: "0.1.1-pm.1", reason: "Synthetic operator correction test only, never publish.", idempotencyKey: "synthetic:correction_v1.20260910",
+    files: [{ path: file.path, expectedSha256: file.sha256, sha256, edits: [{ offset: 0, deleteBytes: 0, insertBase64: inserted.toString("base64") }] }] };
+  const corrected = structuredClone(f.source);
+  corrected.descriptor.version = command.version;
+  corrected.descriptor.source = { files: corrected.descriptor.source.files.map(pin => pin.path === file.path ? { path: pin.path, sha256 } : pin) };
+  corrected.files = corrected.files.map(item => item.path === file.path ? { ...item, sha256, bytes: patched.toString("base64") } : item);
+  corrected.supersedesSubmissionId = f.subject.submissionId;
+  const checked = validateModuleSubmissionRequest(corrected); if (!checked.ok) throw new Error("Invalid correction fixture");
+  const contents: Omit<ReviewSourceCorrection, "correctionDigest"> = { schemaVersion: "programmable.modules.source-correction-record.v1",
+    parentSubmissionId: f.subject.submissionId, submissionId: "00000000-0000-4000-8000-000000000009", principalId: f.subject.principalId,
+    author: f.subject.author, rewardWallet: f.source.descriptor.rewardWallet.toLowerCase(), familyId: checked.familyId, baseRequestDigest: f.subject.requestDigest,
+    requestDigest: checked.requestDigest, packageId: checked.packageId, version: command.version, correctedBy: f.reviewer, policyDigest: f.policyDigest,
+    commandDigest: reviewDigest("programmable.modules.source-correction-command.v1", command), reason: command.reason, createdAt: f.job.updatedAt };
+  const record: ReviewSourceCorrection = { ...contents, correctionDigest: reviewDigest("programmable.modules.source-correction-record.v1", contents) };
+  const receipt: ModuleSourceCorrectionReceipt = { schemaVersion: "programmable.modules.source-correction-receipt.v1", created: true, sourceCorrection: record,
+    approved: false, available: false, reviewStatus: "awaiting_plan" };
+  const originalDetail = { schemaVersion: "programmable.modules.review-detail.v1", job: f.job, decisions: [], attempts: f.detail.attempts, sourceCorrection: null };
+  const correctedDetail = { schemaVersion: "programmable.modules.review-detail.v1", job: { ...f.job,
+    subject: { ...f.subject, submissionId: record.submissionId, requestDigest: record.requestDigest }, state: "awaiting_plan", reviewRevision: 0,
+    plan: null, planDigest: null, artifact: null, attempt: 0, lastError: null }, decisions: [], attempts: [], sourceCorrection: record };
+  const websiteDetail = { ...originalDetail, schemaVersion: "programmable.modules.website-review-detail.v1", source: f.detail.source };
+  const correctedWebsiteDetail = { ...correctedDetail, schemaVersion: "programmable.modules.website-review-detail.v1", source: {
+    descriptor: checked.request.descriptor, packageId: checked.packageId, familyId: checked.familyId,
+    files: checked.request.files.map(item => ({ path: item.path, sha256: item.sha256, bytes: Buffer.from(item.bytes, "base64").byteLength })) } };
+  return { ...f, command, corrected: checked.request, record, receipt, originalDetail, correctedDetail, websiteDetail, correctedWebsiteDetail };
+}

--- a/tests/module-source-correction-bff.test.ts
+++ b/tests/module-source-correction-bff.test.ts
@@ -1,0 +1,97 @@
+import { createHash, createHmac } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { createModuleReviewClient } from "../lib/server/module-mode/review-client";
+import type { WalletPrincipalAuthenticatorV1 } from "../lib/server/creator-article/wallet-principal.server";
+import { reviewDigest } from "../lib/module-mode/review-contract";
+import { moduleSourceCorrectionFixture } from "./fixtures/module-source-correction";
+
+vi.mock("server-only", () => ({}));
+const SERVICE = "service_" + "a".repeat(48), KEY = "assert_" + "b".repeat(48), TIME = "2026-09-06T02:00:00.000Z", NONCE = "abcdefghijklmnopqrstuv";
+function setup(options: { wallet?: string; linked?: boolean; committed?: boolean } = {}) {
+  const f = moduleSourceCorrectionFixture(); const wallet = options.wallet ?? f.reviewer;
+  let committed = options.committed ?? false;
+  const fetchBackend = vi.fn<typeof fetch>(async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname.endsWith("/corrections")) {
+      if (init?.method === "POST") { committed = true; return Response.json(f.receipt, { status: 201 }); }
+      return committed ? Response.json({ ...f.receipt, created: false }) : Response.json({ error: { code: "MODULE_CORRECTION_NOT_FOUND" } }, { status: 404 });
+    }
+    if (url.pathname.includes(f.record.submissionId)) return Response.json(url.pathname.endsWith("/source") ? f.corrected : f.correctedDetail);
+    return Response.json(url.pathname.endsWith("/source") ? f.source : f.originalDetail);
+  });
+  const client = createModuleReviewClient({ authenticator: { authenticate: vi.fn(async () => ({ privyUserId: "did:privy:correction-admin", privySessionId: "synthetic-correction-session", wallets: options.linked === false ? [] : [wallet] })) } as unknown as WalletPrincipalAuthenticatorV1,
+    backendBaseUrl: "https://review.example.invalid", websiteToken: SERVICE, bffAssertionKeyV2: KEY, fetchBackend, now: () => new Date(TIME), nonce: () => NONCE });
+  const post = (command: unknown = f.command, extra: object = {}) => new Request(`https://programmable.example/api/admin/modules/${f.subject.submissionId}/corrections`, { method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Bearer synthetic_browser_token", "X-Programmable-Bff-Assertion-Signature": "forged-browser-signature" }, body: JSON.stringify({ walletAddress: wallet, command, ...extra }) });
+  const read = (suffix = "", id = f.subject.submissionId) => new Request(`https://programmable.example/api/admin/modules/${id}${suffix}?walletAddress=${wallet}`);
+  return { ...f, client, fetchBackend, wallet, post, read };
+}
+describe("Module admin source correction BFF", () => {
+  it.each([{ linked: false }, { wallet: "0x2222222222222222222222222222222222222222" }])("requires the actual linked admin wallet before any upstream call: %j", async options => {
+    const f = setup(options); const response = await f.client.handle(f.post(), "correction", f.subject.submissionId);
+    expect(response.status).toBe(403); expect(f.fetchBackend).not.toHaveBeenCalled();
+  });
+  it("binds the exact correction bytes, method, target and authenticated editor while preserving attribution", async () => {
+    const f = setup(); const response = await f.client.handle(f.post(), "correction", f.subject.submissionId);
+    expect(response.status).toBe(201); expect(await response.json()).toEqual(f.receipt);
+    const posts = f.fetchBackend.mock.calls.filter(([, init]) => init?.method === "POST"); expect(posts).toHaveLength(1);
+    const [url, init] = posts[0]; const bytes = Buffer.from(init!.body as Uint8Array); const headers = new Headers(init!.headers);
+    expect(JSON.parse(bytes.toString())).toEqual(f.command); expect(String(url)).toBe(`https://review.example.invalid/v1/wallet-admin/module-review/${f.subject.submissionId}/corrections`);
+    const digest = `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+    const signed = `programmable.custom-launch-api.wallet-bff-assertion.v2\0POST\0/v1/wallet-admin/module-review/${f.subject.submissionId}/corrections\0did:privy:correction-admin\0${f.wallet}\0${TIME}\0${NONCE}\0${digest}`;
+    expect(headers.get("X-Programmable-Bff-Assertion-Signature")).toBe(`hmac-sha256:${createHmac("sha256", KEY).update(signed).digest("hex")}`);
+    expect(JSON.stringify(init)).not.toContain("synthetic_browser_token"); expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(f.receipt.sourceCorrection.author).not.toBe(f.wallet); expect(f.receipt.approved).toBe(false);
+  });
+  it.each(["attribution", "version", "revision", "hash", "unknownField"])("rejects changed %s before mutation", async kind => {
+    const f = setup(); const command = structuredClone(f.command) as unknown as Record<string, unknown>;
+    if (kind === "attribution") command.correctedBy = f.subject.author;
+    if (kind === "version") command.version = "0.1.1";
+    if (kind === "revision") command.expectedReviewRevision = 1;
+    if (kind === "hash") (command.files as { expectedSha256: string }[])[0].expectedSha256 = "b".repeat(64);
+    const response = await f.client.handle(f.post(command, kind === "unknownField" ? { accessToken: "do-not-forward" } : {}), "correction", f.subject.submissionId);
+    expect([400, 409]).toContain(response.status); expect(f.fetchBackend.mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(0);
+  });
+  it("rejects streamed oversized correction input before forwarding it", async () => {
+    const f = setup(); const response = await f.client.handle(f.post({ ...f.command, reason: "x".repeat(262_145) }), "correction", f.subject.submissionId);
+    expect(response.status).toBe(413); expect(f.fetchBackend).not.toHaveBeenCalled();
+  });
+  it("recovers a committed same-key correction even after the parent revision advances", async () => {
+    const f = setup({ committed: true }); f.originalDetail.job = { ...f.job, reviewRevision: f.job.reviewRevision + 3 };
+    const response = await f.client.handle(f.post(), "correction", f.subject.submissionId);
+    expect(response.status).toBe(200); expect((await response.json()).sourceCorrection).toEqual(f.record);
+    expect(f.fetchBackend.mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(0);
+    const conflict = await f.client.handle(f.post({ ...f.command, reason: "Another correction must not reuse the earlier idempotency key." }), "correction", f.subject.submissionId);
+    expect(conflict.status).toBe(409);
+  });
+  it("offers an authenticated reconciliation read and validates query selectors", async () => {
+    const f = setup({ committed: true });
+    const get = new Request(`${f.read("/corrections").url}&idempotencyKey=${encodeURIComponent(f.command.idempotencyKey)}`);
+    const response = await f.client.handle(get, "correction-status", f.subject.submissionId);
+    expect(response.status).toBe(200); expect((await response.json()).created).toBe(false);
+    const wrong = new Request(get.url + "&correctedBy=" + f.subject.author);
+    expect((await f.client.handle(wrong, "correction-status", f.subject.submissionId)).status).toBe(400);
+  });
+  it("rejects a correctly digested correction receipt that changes the original reward wallet", async () => {
+    const f = setup({ committed: true }); const { correctionDigest: _digest, ...contents } = f.record;
+    expect(_digest).toBe(f.receipt.sourceCorrection.correctionDigest);
+    const changed = { ...contents, rewardWallet: f.wallet };
+    f.receipt.sourceCorrection = { ...changed, correctionDigest: reviewDigest("programmable.modules.source-correction-record.v1", changed) };
+    const response = await f.client.handle(f.post(), "correction", f.subject.submissionId);
+    expect(response.status).toBe(502); expect(f.fetchBackend.mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(0);
+  });
+  it("does not accept a replay receipt whose version differs from the exact command", async () => {
+    const f = setup({ committed: true }); const { correctionDigest: _digest, ...contents } = f.record;
+    expect(_digest).toBe(f.receipt.sourceCorrection.correctionDigest);
+    const changed = { ...contents, version: "0.1.2-pm.1" };
+    f.receipt.sourceCorrection = { ...changed, correctionDigest: reviewDigest("programmable.modules.source-correction-record.v1", changed) };
+    const response = await f.client.handle(f.post(), "correction", f.subject.submissionId);
+    expect(response.status).toBe(502); expect(f.fetchBackend.mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(0);
+  });
+  it("exposes verified correction provenance in admin detail, bound to the new immutable source", async () => {
+    const f = setup(); const response = await f.client.handle(f.read("", f.record.submissionId), "detail", f.record.submissionId);
+    expect(response.status).toBe(200); expect((await response.json()).sourceCorrection).toEqual(f.record);
+    f.correctedDetail.sourceCorrection = { ...f.record, requestDigest: f.subject.requestDigest };
+    expect((await f.client.handle(f.read("", f.record.submissionId), "detail", f.record.submissionId)).status).toBe(502);
+  });
+});

--- a/tests/module-source-correction-operator.test.ts
+++ b/tests/module-source-correction-operator.test.ts
@@ -1,0 +1,92 @@
+import { mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { run } from "../ops/module-mode-publication/main";
+import { runSourceCorrection } from "../ops/module-mode-publication/correction";
+import { moduleSourceCorrectionFixture } from "./fixtures/module-source-correction";
+
+const directories: string[] = [];
+afterEach(async () => { vi.restoreAllMocks(); vi.unstubAllGlobals(); await Promise.all(directories.splice(0).map(dir => rm(dir, { recursive: true, force: true }))); });
+async function setup(mode: "success" | "lost-committed" | "lost-uncommitted" = "success") {
+  const f = moduleSourceCorrectionFixture();
+  const directory = await mkdtemp(path.join(await realpath(tmpdir()), "module-correction-test-")); directories.push(directory);
+  const sessionFile = path.join(directory, "session.json"), commandFile = path.join(directory, "command.json"), output = path.join(directory, "result");
+  const token = "synthetic_private_operator_session_20260910";
+  await writeFile(sessionFile, JSON.stringify({ walletAddress: f.reviewer, accessToken: token }), { mode: 0o600 });
+  await writeFile(commandFile, JSON.stringify(f.command), { mode: 0o600 });
+  const state = { committed: false };
+  const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+    const url = new URL(String(input));
+    expect(url.origin).toBe("https://programmable.market"); expect(url.pathname).toMatch(/^\/api\/admin\/modules\/[0-9a-f-]+(?:\/(?:source|corrections))?$/u);
+    expect(init).toMatchObject({ cache: "no-store", redirect: "error" }); expect(new Headers(init?.headers).get("Authorization")).toBe(`Bearer ${token}`);
+    if (url.pathname.endsWith("/corrections")) {
+      if (init?.method === "POST") {
+        expect(JSON.parse(String(init.body))).toEqual({ walletAddress: f.reviewer, command: f.command });
+        state.committed = mode !== "lost-uncommitted";
+        if (mode !== "success") throw new Error("Synthetic dropped response including credentials must never be logged: " + token);
+        return Response.json(f.receipt, { status: 201 });
+      }
+      return state.committed ? Response.json({ ...f.receipt, created: false }) : Response.json({ error: { code: "MODULE_CORRECTION_NOT_FOUND" } }, { status: 404 });
+    }
+    if (url.pathname.includes(f.record.submissionId)) return Response.json(url.pathname.endsWith("/source") ? f.corrected : f.correctedWebsiteDetail);
+    return Response.json(url.pathname.endsWith("/source") ? f.source : f.websiteDetail);
+  });
+  const options = { "correction-file": commandFile, "session-file": sessionFile, submission: f.subject.submissionId, output };
+  const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  return { ...f, directory, token, fetchImpl, options, state, log, context: { repositoryRoot: "/synthetic-source-checkout", providers: vi.fn(async () => { throw new Error("Correction must never contact an RPC provider"); }) } };
+}
+describe("Admin source correction operator", () => {
+  it("runs correct-source through the fixed authenticated BFF and verifies preserved attribution and exact new source", async () => {
+    const f = await setup(); const original = structuredClone(f.source);
+    vi.stubGlobal("fetch", f.fetchImpl);
+    const args = ["correct-source", ...Object.entries(f.options).flatMap(([key, value]) => ["--" + key, value])];
+    await run(args, f.context);
+    expect(f.context.providers).not.toHaveBeenCalled(); expect(f.source).toEqual(original);
+    const completion = JSON.parse(await readFile(path.join(f.options.output, "correction.complete.json"), "utf8"));
+    expect(completion).toMatchObject({ sourceCorrection: f.record, sourceBytesVerified: true, approved: false, available: false });
+    expect(JSON.parse(await readFile(path.join(f.options.output, "corrected-source.json"), "utf8"))).toEqual(f.corrected);
+    expect((await stat(path.join(f.options.output, "command.json"))).mode & 0o077).toBe(0);
+    expect(f.fetchImpl.mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(1);
+    expect(JSON.stringify(f.log.mock.calls)).not.toContain(f.token);
+  });
+  it("reconciles a lost POST response by its persisted receipt without sending a second correction", async () => {
+    const f = await setup("lost-committed");
+    await runSourceCorrection(f.options, f.context.repositoryRoot, f.fetchImpl);
+    expect(f.fetchImpl.mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(1);
+    const reads = f.fetchImpl.mock.calls.filter(([input, init]) => String(input).includes("/corrections?") && init?.method === "GET");
+    expect(reads).toHaveLength(2);
+    expect(JSON.parse(await readFile(path.join(f.options.output, "receipt.json"), "utf8"))).toMatchObject({ created: false, sourceCorrection: f.record });
+    expect(JSON.stringify(f.log.mock.calls)).not.toContain(f.token);
+  });
+  it("keeps an unresolved intent and only reconciles when the same output is resumed", async () => {
+    const f = await setup("lost-uncommitted");
+    await expect(runSourceCorrection(f.options, f.context.repositoryRoot, f.fetchImpl)).rejects.toThrow("did not return a confirmed result");
+    await expect(readFile(path.join(f.options.output, "correction.complete.json"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(runSourceCorrection(f.options, f.context.repositoryRoot, f.fetchImpl)).rejects.toThrow("No committed correction is visible yet");
+    expect(f.fetchImpl.mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(1);
+    f.state.committed = true;
+    await runSourceCorrection(f.options, f.context.repositoryRoot, f.fetchImpl);
+    expect(f.fetchImpl.mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(1);
+    expect(JSON.parse(await readFile(path.join(f.options.output, "correction.complete.json"), "utf8"))).toMatchObject({ sourceCorrection: f.record });
+  });
+  it("refuses to replace the command of a pending correction journal", async () => {
+    const f = await setup("lost-uncommitted");
+    await expect(runSourceCorrection(f.options, f.context.repositoryRoot, f.fetchImpl)).rejects.toThrow();
+    await writeFile(f.options["correction-file"], JSON.stringify({ ...f.command, reason: "A different correction cannot borrow the previous command journal." }));
+    const before = f.fetchImpl.mock.calls.length;
+    await expect(runSourceCorrection(f.options, f.context.repositoryRoot, f.fetchImpl)).rejects.toThrow("Existing correction intent");
+    expect(f.fetchImpl.mock.calls).toHaveLength(before);
+  });
+  it("does not mark a receipt complete when the fetched new source changes the reward wallet", async () => {
+    const f = await setup(); f.corrected.descriptor.rewardWallet = f.reviewer;
+    await expect(runSourceCorrection(f.options, f.context.repositoryRoot, f.fetchImpl)).rejects.toThrow("Correction source does not bind its original author");
+    await expect(readFile(path.join(f.options.output, "correction.complete.json"))).rejects.toMatchObject({ code: "ENOENT" });
+    expect(f.fetchImpl.mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(1);
+  });
+  it("rejects a stale parent before a network mutation", async () => {
+    const f = await setup(); f.websiteDetail.job = { ...f.job, reviewRevision: f.job.reviewRevision + 1 };
+    await expect(runSourceCorrection(f.options, f.context.repositoryRoot, f.fetchImpl)).rejects.toThrow("Correction parent revision changed");
+    expect(f.fetchImpl.mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Platform admins currently cannot record a small source fix without asking the original module author to submit another version. Add an authenticated correction route and operator that create a new reviewed-source candidate through the backend, preserve the author and reward wallet, and expose the actual editor provenance.

The operator journals the exact command, reconciles uncertain writes by idempotency key, and verifies the saved source and unchanged bytes. It does not build, accept or publish a module. The route stays unavailable until the matching backend and migration are installed.

The two contract-test shards now receive the public dRPC Ethereum endpoint. Their previous Publicnode fallback rejects archive reads with HTTP 403. This preserves the existing tests without giving PR code a provider credential.

Validation: 20 new BFF/operator checks and 122 existing admin/publication checks passed; TypeScript and ESLint passed. The 14 existing CI orchestration and fork-coverage checks passed, and the public RPC answered historical code, storage and call probes. Exact-head remote CI remains required.
