### PR TITLE
Fix BLOB website and X link icons

### DIFF
--- a/lib/server/robinhood-presentation.ts
+++ b/lib/server/robinhood-presentation.ts
@@ -319,7 +319,9 @@ export async function readRobinhoodPresentations(tokens: readonly RobinhoodLaunc
     }
     const supplemental = SUPPLEMENTAL_TOKEN_PRESENTATIONS[key];
     for (const link of supplemental?.links ?? []) {
-      if (!links.some(existing => existing.label === link.label || existing.url === link.url)) links.push(link);
+      const existing = links.findIndex(candidate => candidate.label === link.label || candidate.url === link.url);
+      if (existing === -1) links.push(link);
+      else links[existing] = link;
     }
     return {
       tokenAddress: token.tokenAddress,


### PR DESCRIPTION
BLOB's finalized launch already supplies its website and X URLs with the generic `Project link` label. Supplementary metadata skipped those duplicate URLs, leaving both buttons with the generic chain icon.

Replace a matching supplementary link so its explicit Website or X label reaches the existing card and detail icon component. No new icons or layout changes are required. Existing presentation tests, scoped ESLint and the diff check pass.
