### PR TITLE
Fix Robinhood Custom analytics for BLOB and pool volume

### DIFF
--- a/docs/analytics/README.md
+++ b/docs/analytics/README.md
@@ -2,15 +2,35 @@
 
 [Public dashboard](https://dune.com/programmablehq/analytics) · [Dune query 8631499](https://dune.com/queries/8631499)
 
-The dashboard refreshes every 24 hours. The query includes a finalized block and timestamp so readers can distinguish refresh time from the chain checkpoint.
+The dashboard refreshes every four hours, configured in Dune on 2026-09-10. The query includes its indexed, finalized block and timestamp so readers can distinguish refresh time from the chain checkpoint. A successful launch does not force a dashboard refresh.
 
-`custom-launch-robinhood.sql` counts canonical V1 and V2 Launch Stamp Router events on chain 4663, including reference launches. It combines Dune history with a recent public RPC overlap, checks the chain and finalized head, and deduplicates logs by block hash, transaction hash and log index. RPC errors fail the query instead of supplying zero fees.
+`custom-launch-robinhood.sql` counts canonical V1 and both published V2 Launch Stamp Router deployments on chain 4663, including reference launches. The current MultiRole V2 router is `0x4b5Cec6E715C3bCd7e6837E9E307C40C9aCc2B2E`. It checks the public RPC chain ID and finalized head, then reads Dune logs through the latest Dune block at or below that head. Every metric uses this common checkpoint. Missing RPC/checkpoint data fails the query instead of supplying zero fees. `chain_finalized_block` separately exposes the chain head when Dune trails it.
 
 Fee events must come from a stamped hook and its exact pool at or after the launch block. Same-block initial-buy events can precede the stamp. An existence join prevents repeated launch references from multiplying fees. Module Mode fee events are excluded by launch provenance.
 
-The query decodes `NativeFeesAccrued(bytes32,address,bool,uint256,uint256,uint256)`. Gross native amount, platform fee and creator fee are separate uint256 values in wei. Only display columns convert to ETH. Native20 platform fees equal `ceil(grossNativeWei * 20 / 10000)` per successful trade; the aggregate is the sum of emitted fees, not a rounded estimate from total volume. Creator rewards are separate from the platform fee.
+Native20 earnings decode `NativeFeesAccrued(bytes32,address,bool,uint256,uint256,uint256)`. Gross native amount, platform fee and creator fee are separate uint256 values in wei. Only display columns convert to ETH. Native20 platform fees equal `ceil(grossNativeWei * 20 / 10000)` per successful trade; the aggregate is the sum of emitted fees, not a rounded estimate from total volume. Creator rewards are separate from the platform fee.
 
-Revenue is earned accrual, including unclaimed balances. Do not add `FeesRecorded` or `FeesClaimed` to it: they account for or withdraw the same fees. Gas, liquidity, donations and pool LP fees are excluded. Historical fee models without the supported event are outside the ETH totals. Add a separately verified event adapter before including another fee model or router.
+The separate BLOB adapter reads `FeesRecorded(uint256,uint256)` exclusively from its source-verified vault `0xC4b0AE2d8530ddD043c8124bf79297A17166Baf7`. The adapter is bound to BLOB's canonical router, combined token/hook `0x105f6435a4ab3C03C13d4a0dB67961344694d0CC`, pool and launch block. BLOB is explicitly excluded from the Native20 event path, so the two accounting sources cannot count its fees twice. This vault's fixed platform recipient is `0xD88539d3c4C460136a733A3Fd60cf6BF269079da`. BLOB's project taxes and game fees are outside this vault's creator-fee ledger and outside these fee totals.
+
+Revenue is earned accrual, including unclaimed balances. Do not add `FeesClaimed`: it withdraws already recorded fees. For Native20, do not also add the vault's `FeesRecorded` events. Gas, liquidity, donations and pool LP fees are excluded. Other fee models remain outside these totals until a verified adapter is added. `launches_without_observed_supported_fees` exposes launches with no observed supported fee events; it can include zero-activity launches and LP-only models, and is not a claim that those projects owe unpaid platform fees.
+
+`volume_eth`, `volume_wei` and `swaps` now use actual `PoolManager.Swap` events for canonically stamped native-ETH pools. A matching `Initialize` event establishes the native currency. Each pool execution is counted once using an existence join, including same-transaction first buys. Volume is the absolute native-side pool delta, not volume inferred from revenue. It excludes hook transfers outside the pool delta. The previous Native20 gross fee base remains available as `native20_gross_volume_wei`. Non-native, no-pool and other custom settlement volumes need separate models. V4's pool volume is included, while its LP fees remain outside platform revenue.
+
+## Verification on 2026-09-10
+
+The candidate ran successfully on Dune and returned checkpoint `59648445`, `2026-09-10 19:20:17 UTC`:
+
+| Metric | Exact result |
+| --- | --- |
+| Custom launch records, including references | 5 |
+| Supported platform earnings | 310799513208732103 wei |
+| ARBT platform earnings | 186849654838866631 wei |
+| BLOB platform earnings | 75636916217030532 wei |
+| Native pool volume | 1985248579789016263279 wei |
+
+ARBT and BLOB earnings were independently summed from complete, bounded RPC fee-log ranges. Each matched Dune exactly and reconciled to lifetime platform claims plus `platformAccrued()` at the same block. Public RPC logs and the Developer-documented historical RPC were used separately for log and historical state reads. Current vault runtime hashes matched the prior exact-source verification. These are snapshot verification values, not live balances.
+
+An independent, paced RPC scan also matched the actual pool volume and swap count at that block: ARBT had 2054 swaps and 93328835588635934262 wei of native-side volume; BLOB had 2229 swaps and 35486187719787992739 wei. RPC throttling was handled by honoring the provider's retry interval. The corrected SQL and coverage description were saved to the existing query 8631499, and the existing dashboard visibly returned 0.310800 ETH supported custom platform revenue and five launch records. No duplicate dashboard was created.
 
 Dashboard counters:
 

--- a/docs/analytics/custom-launch-robinhood.sql
+++ b/docs/analytics/custom-launch-robinhood.sql
@@ -1,115 +1,123 @@
--- Custom Launch on Robinhood Chain, source version custom-native20-v1.
--- Counts canonical V1 and V2 Launch Stamp Router events, including reference launches.
--- ETH earnings use NativeFeesAccrued from the stamped hook and its exact pool.
--- These are credited fees, including unclaimed balances, not treasury withdrawals.
--- Creator fees and the 20 bps Programmable allocation remain separate.
--- Gas, liquidity, donations, LP fees and fee claims are not new fee revenue.
--- Historical Custom fee models without this event are outside the ETH fee totals.
--- Dune history and the recent RPC overlap are deduplicated at a finalized cutoff.
-WITH dune_head AS (
-    SELECT greatest(BIGINT '50469365', coalesce(max(number) - 20000, BIGINT '50469365')) AS rpc_from
-    FROM robinhood.blocks
-    WHERE time >= current_timestamp - INTERVAL '2' DAY
-), batch AS (
-    SELECT documents
-    FROM dune_head
-    CROSS JOIN UNNEST(ARRAY[CAST(json_parse(http_post(
+-- Robinhood Custom analytics: Native20 and the verified BLOB fee-vault adapter.
+-- All amounts use one common Dune-indexed, chain-finalized checkpoint.
+-- Revenue is earned fees. Claims, LP fees, gas and transfers are not added to revenue.
+-- Volume is actual PoolManager native-side execution volume, counted once per Swap.
+-- Includes reference launches. Other fee mechanisms require a verified adapter.
+WITH rpc AS (
+    SELECT CAST(json_parse(http_post(
         'https://rpc.mainnet.chain.robinhood.com',
-        concat('[{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]},',
-               '{"jsonrpc":"2.0","id":2,"method":"eth_getBlockByNumber","params":["finalized",false]},',
-               '{"jsonrpc":"2.0","id":3,"method":"eth_getLogs","params":[{"fromBlock":"0x',
-               to_base(rpc_from, 16), '","toBlock":"finalized",',
-               '"topics":[["0x6cf479a102f1eebc9244f48f8d68f6aa52b4c5a4516318df58ba46614a5b14f2","0x4916167b998f441a46d1e4bc734a855746d34935136a4b3bc2575f7cf5682e1e","0xd4d0f5055e2337ff5463933dff69d06a57f6cc89503aed6e89d23c1bda23c94c"]]}]}]'),
+        '[{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]},{"jsonrpc":"2.0","id":2,"method":"eth_getBlockByNumber","params":["finalized",false]}]',
         ARRAY['Content-Type: application/json']
-    )) AS ARRAY(JSON))]) AS r(documents)
-), replies AS (
-    SELECT
-        element_at(filter(documents, d -> json_extract_scalar(d, '$.id') = '1'), 1) AS chain_reply,
-        element_at(filter(documents, d -> json_extract_scalar(d, '$.id') = '2'), 1) AS head_reply,
-        element_at(filter(documents, d -> json_extract_scalar(d, '$.id') = '3'), 1) AS logs_reply
-    FROM batch
-), rpc_response AS (
-    SELECT
-        CASE WHEN json_extract_scalar(chain_reply, '$.result') = '0x1237'
-                  AND json_extract_scalar(head_reply, '$.result.number') IS NOT NULL
-             THEN from_base(substr(json_extract_scalar(head_reply, '$.result.number'), 3), 16)
-             ELSE CAST('FINALIZED_ROBINHOOD_HEAD_UNAVAILABLE' AS BIGINT) END AS final_block,
-        from_base(substr(json_extract_scalar(head_reply, '$.result.timestamp'), 3), 16) AS final_timestamp,
-        CAST(json_parse(CASE WHEN substr(json_format(json_extract(logs_reply, '$.result')), 1, 1) = '['
-                            THEN json_format(json_extract(logs_reply, '$.result'))
-                            ELSE 'RPC_LOGS_UNAVAILABLE' END) AS ARRAY(JSON)) AS records
-    FROM replies
-), rpc_logs AS (
-    SELECT
-        from_base(substr(json_extract_scalar(document, '$.blockNumber'), 3), 16) AS block_number,
-        from_hex(substr(json_extract_scalar(document, '$.blockHash'), 3)) AS block_hash,
-        from_hex(substr(json_extract_scalar(document, '$.transactionHash'), 3)) AS tx_hash,
-        from_base(substr(json_extract_scalar(document, '$.logIndex'), 3), 16) AS log_index,
-        from_hex(substr(json_extract_scalar(document, '$.address'), 3)) AS contract_address,
-        from_hex(substr(json_extract_scalar(document, '$.topics[0]'), 3)) AS topic0,
-        from_hex(substr(json_extract_scalar(document, '$.topics[1]'), 3)) AS topic1,
-        from_hex(substr(json_extract_scalar(document, '$.topics[2]'), 3)) AS topic2,
-        from_hex(substr(json_extract_scalar(document, '$.topics[3]'), 3)) AS topic3,
-        from_hex(substr(json_extract_scalar(document, '$.data'), 3)) AS data,
-        final_block, final_timestamp
-    FROM rpc_response
-    CROSS JOIN UNNEST(concat(records, ARRAY[CAST(NULL AS JSON)])) AS r(document)
-    WHERE coalesce(json_extract_scalar(document, '$.removed'), 'false') = 'false'
-), stored_logs AS (
-    SELECT block_number, block_hash, tx_hash, "index" AS log_index,
-           contract_address, topic0, topic1, topic2, topic3, data,
-           CAST(NULL AS BIGINT) AS final_block, CAST(NULL AS BIGINT) AS final_timestamp
-    FROM robinhood.logs
-    WHERE block_time >= TIMESTAMP '2026-08-31 00:00:00'
-      AND block_number >= 50469365
-      AND topic0 IN (
-          0x6cf479a102f1eebc9244f48f8d68f6aa52b4c5a4516318df58ba46614a5b14f2,
-          0x4916167b998f441a46d1e4bc734a855746d34935136a4b3bc2575f7cf5682e1e,
-          0xd4d0f5055e2337ff5463933dff69d06a57f6cc89503aed6e89d23c1bda23c94c
-      )
-), combined AS (
-    SELECT * FROM stored_logs UNION ALL SELECT * FROM rpc_logs
-), ranked AS (
-    SELECT *, max(final_block) OVER () AS finalized_block,
-           max(final_timestamp) OVER () AS finalized_timestamp,
-           row_number() OVER (PARTITION BY block_hash, tx_hash, log_index ORDER BY block_number) AS duplicate_rank
-    FROM combined
-), logs AS (
-    SELECT * FROM ranked
-    WHERE duplicate_rank = 1 AND (block_number <= finalized_block OR block_number IS NULL)
+    )) AS ARRAY(JSON)) AS replies
+), chain_head AS (
+    SELECT CASE
+        WHEN json_extract_scalar(element_at(filter(replies, r -> json_extract_scalar(r, '$.id') = '1'), 1), '$.result') = '0x1237'
+        THEN from_base(substr(json_extract_scalar(element_at(filter(replies, r -> json_extract_scalar(r, '$.id') = '2'), 1), '$.result.number'), 3), 16)
+        ELSE CAST('WRONG_CHAIN_OR_RPC_UNAVAILABLE' AS BIGINT)
+    END AS chain_finalized_block
+    FROM rpc
+), checkpoint AS (
+    SELECT coalesce(max(b.number), CAST('FINALIZED_DUNE_CHECKPOINT_UNAVAILABLE' AS BIGINT)) AS finalized_block,
+           max(b.time) AS finalized_at, max(h.chain_finalized_block) AS chain_finalized_block
+    FROM robinhood.blocks b CROSS JOIN chain_head h
+    WHERE b.time >= current_timestamp - INTERVAL '1' DAY
+      AND b.number <= h.chain_finalized_block
 ), launches AS (
-    SELECT contract_address AS router, topic1 AS launch_id,
-           varbinary_substring(topic2, 13, 20) AS token,
-           varbinary_substring(topic3, 13, 20) AS hook,
-           varbinary_substring(data, 33, 32) AS pool_id,
-           block_number AS launch_block
-    FROM logs
-    WHERE varbinary_substring(data, 13, 20) = 0x8366a39cc670b4001a1121b8f6a443a643e40951
-      AND ((contract_address = 0x34965f2a2ee9254522232c32f02056e92be0c98a
-            AND topic0 = 0x6cf479a102f1eebc9244f48f8d68f6aa52b4c5a4516318df58ba46614a5b14f2)
-        OR (contract_address = 0x9fd629cd1eb47fb20813c2403153714b523f681e
-            AND topic0 = 0x4916167b998f441a46d1e4bc734a855746d34935136a4b3bc2575f7cf5682e1e))
-), trades AS (
-    SELECT l.* FROM logs l
-    WHERE l.topic0 = 0xd4d0f5055e2337ff5463933dff69d06a57f6cc89503aed6e89d23c1bda23c94c
-      AND EXISTS (
-          SELECT 1 FROM launches s
-          WHERE l.contract_address = s.hook AND l.topic1 = s.pool_id
-            AND l.block_number >= s.launch_block
-      )
-), totals AS (
-    SELECT count(*) AS swaps,
-           coalesce(sum(varbinary_to_uint256(varbinary_substring(data, 33, 32))), UINT256 '0') AS volume_wei,
-           coalesce(sum(varbinary_to_uint256(varbinary_substring(data, 65, 32))), UINT256 '0') AS protocol_wei,
-           coalesce(sum(varbinary_to_uint256(varbinary_substring(data, 97, 32))), UINT256 '0') AS creator_rewards_wei
-    FROM trades
+    SELECT l.contract_address AS router, l.topic1 AS launch_id,
+           varbinary_substring(l.topic2, 13, 20) AS token,
+           varbinary_substring(l.topic3, 13, 20) AS hook,
+           varbinary_substring(l.data, 33, 32) AS pool_id,
+           min(l.block_number) AS launch_block
+    FROM robinhood.logs l CROSS JOIN checkpoint c
+    WHERE l.block_time >= TIMESTAMP '2026-08-31 00:00:00'
+      AND l.block_number >= 50469365 AND l.block_number <= c.finalized_block
+      AND varbinary_length(l.data) = 96
+      AND varbinary_substring(l.data, 13, 20) = 0x8366a39cc670b4001a1121b8f6a443a643e40951
+      AND ((l.contract_address = 0x34965f2a2ee9254522232c32f02056e92be0c98a
+            AND l.topic0 = 0x6cf479a102f1eebc9244f48f8d68f6aa52b4c5a4516318df58ba46614a5b14f2)
+        OR (l.contract_address IN (0x9fd629cd1eb47fb20813c2403153714b523f681e,
+                                   0x4b5cec6e715c3bcd7e6837e9e307c40c9acc2b2e)
+            AND l.topic0 = 0x4916167b998f441a46d1e4bc734a855746d34935136a4b3bc2575f7cf5682e1e))
+    GROUP BY 1, 2, 3, 4, 5
+), native20_fees AS (
+    SELECT l.contract_address AS hook, l.topic1 AS pool_id, l.tx_hash, l."index" AS log_index,
+           varbinary_to_uint256(varbinary_substring(l.data, 33, 32)) AS gross_native_wei,
+           varbinary_to_uint256(varbinary_substring(l.data, 65, 32)) AS protocol_wei,
+           varbinary_to_uint256(varbinary_substring(l.data, 97, 32)) AS creator_wei
+    FROM robinhood.logs l CROSS JOIN checkpoint c
+    WHERE l.block_time >= TIMESTAMP '2026-08-31 00:00:00'
+      AND l.block_number >= 50469365 AND l.block_number <= c.finalized_block
+      AND l.topic0 = 0xd4d0f5055e2337ff5463933dff69d06a57f6cc89503aed6e89d23c1bda23c94c
+      AND varbinary_length(l.data) = 128
+      AND l.contract_address <> 0x105f6435a4ab3c03c13d4a0db67961344694d0cc
+      AND EXISTS (SELECT 1 FROM launches s
+                  WHERE l.contract_address = s.hook AND l.topic1 = s.pool_id AND l.block_number >= s.launch_block)
+), blob_adapter AS (
+    -- Exact finalized deployment and source-verified immutable fee-vault wiring, 2026-09-10.
+    -- This exception is a separate accounting adapter, not an assumption about arbitrary custom hooks.
+    SELECT 0xc4b0ae2d8530ddd043c8124bf79297a17166baf7 AS vault, launch_block
+    FROM launches
+    WHERE router = 0x4b5cec6e715c3bcd7e6837e9e307c40c9acc2b2e
+      AND token = 0x105f6435a4ab3c03c13d4a0db67961344694d0cc
+      AND hook = token
+      AND pool_id = 0xd4ec7c72641720f85b309c9ff9f3c61a3cd4c85fcef2bd416d35ebb00696847b
+), blob_fees AS (
+    SELECT varbinary_to_uint256(varbinary_substring(l.data, 1, 32)) AS protocol_wei,
+           varbinary_to_uint256(varbinary_substring(l.data, 33, 32)) AS creator_wei
+    FROM robinhood.logs l CROSS JOIN checkpoint c
+    WHERE l.block_time >= TIMESTAMP '2026-09-10 00:00:00'
+      AND l.block_number <= c.finalized_block
+      AND l.contract_address = 0xc4b0ae2d8530ddd043c8124bf79297a17166baf7
+      AND l.topic0 = 0x89aac707e63949a6b4f34ddf7059a674a7023add93e77158c2986b78edac6076
+      AND varbinary_length(l.data) = 64
+      AND EXISTS (SELECT 1 FROM blob_adapter a WHERE l.contract_address = a.vault AND l.block_number >= a.launch_block)
+), fees AS (
+    SELECT protocol_wei, creator_wei FROM native20_fees
+    UNION ALL
+    SELECT protocol_wei, creator_wei FROM blob_fees
+), native_pools AS (
+    SELECT DISTINCT s.pool_id, s.launch_block
+    FROM launches s
+    WHERE EXISTS (
+        SELECT 1 FROM robinhood.logs i CROSS JOIN checkpoint c
+        WHERE i.block_time >= TIMESTAMP '2026-08-31 00:00:00'
+          AND i.block_number <= c.finalized_block
+          AND i.contract_address = 0x8366a39cc670b4001a1121b8f6a443a643e40951
+          AND i.topic0 = 0xdd466e674ea557f56295e2d0218a125ea4b4f0f6f3307b95f85e6110838d6438
+          AND i.topic1 = s.pool_id
+          AND i.topic2 = 0x0000000000000000000000000000000000000000000000000000000000000000
+    )
+), pool_swaps AS (
+    SELECT l.tx_hash, l."index" AS log_index, l.topic1 AS pool_id,
+           CAST(abs(varbinary_to_int256(varbinary_substring(l.data, 1, 32))) AS UINT256) AS volume_wei
+    FROM robinhood.logs l CROSS JOIN checkpoint c
+    WHERE l.block_time >= TIMESTAMP '2026-08-31 00:00:00'
+      AND l.block_number >= 50469365 AND l.block_number <= c.finalized_block
+      AND l.contract_address = 0x8366a39cc670b4001a1121b8f6a443a643e40951
+      AND l.topic0 = 0x40e9cecb9f5f1f1c5b9c97dec2917b7ee92e57ba5563708daca94dd84ad7112f
+      AND varbinary_length(l.data) = 192
+      AND EXISTS (SELECT 1 FROM native_pools p WHERE l.topic1 = p.pool_id AND l.block_number >= p.launch_block)
+), fee_totals AS (
+    SELECT coalesce(sum(protocol_wei), UINT256 '0') AS protocol_wei,
+           coalesce(sum(creator_wei), UINT256 '0') AS creator_rewards_wei
+    FROM fees
+), swap_totals AS (
+    SELECT count(*) AS swaps, coalesce(sum(volume_wei), UINT256 '0') AS volume_wei FROM pool_swaps
 )
 SELECT (SELECT count(*) FROM launches) AS custom_launches,
-       CAST(creator_rewards_wei AS DOUBLE) / 1e18 AS creator_rewards_eth,
-       CAST(protocol_wei AS DOUBLE) / 1e18 AS protocol_revenue_eth,
-       CAST(creator_rewards_wei + protocol_wei AS DOUBLE) / 1e18 AS total_fees_eth,
-       CAST(volume_wei AS DOUBLE) / 1e18 AS volume_eth,
-       swaps, volume_wei, creator_rewards_wei, protocol_wei,
-       (SELECT max(finalized_block) FROM logs) AS finalized_block,
-       from_unixtime((SELECT max(finalized_timestamp) FROM logs)) AS finalized_at
-FROM totals
+       CAST(f.creator_rewards_wei AS DOUBLE) / 1e18 AS creator_rewards_eth,
+       CAST(f.protocol_wei AS DOUBLE) / 1e18 AS protocol_revenue_eth,
+       CAST(f.creator_rewards_wei + f.protocol_wei AS DOUBLE) / 1e18 AS total_fees_eth,
+       CAST(s.volume_wei AS DOUBLE) / 1e18 AS volume_eth,
+       s.swaps, s.volume_wei, f.creator_rewards_wei, f.protocol_wei,
+       c.finalized_block, c.finalized_at,
+       (SELECT coalesce(sum(protocol_wei), UINT256 '0') FROM native20_fees
+        WHERE hook = 0x94f6cef92a5363860de99836c968382f4410a0cc) AS arbt_protocol_wei,
+       (SELECT coalesce(sum(protocol_wei), UINT256 '0') FROM blob_fees) AS blob_protocol_wei,
+       (SELECT coalesce(sum(gross_native_wei), UINT256 '0') FROM native20_fees) AS native20_gross_volume_wei,
+       (SELECT count(*) FROM launches l WHERE NOT EXISTS (
+           SELECT 1 FROM native20_fees n WHERE n.hook = l.hook AND n.pool_id = l.pool_id
+       ) AND NOT EXISTS (SELECT 1 FROM blob_adapter b WHERE b.launch_block = l.launch_block
+           AND l.token = 0x105f6435a4ab3c03c13d4a0db67961344694d0cc)) AS launches_without_observed_supported_fees,
+       c.chain_finalized_block
+FROM fee_totals f CROSS JOIN swap_totals s CROSS JOIN checkpoint c


### PR DESCRIPTION
The existing Robinhood Custom analytics omitted BLOB's current MultiRole router and counted fees only from NativeFeesAccrued. Add the current router and an exact, source-verified BLOB vault adapter while preserving Native20 accounting and preventing double-counting.

Volume now comes from actual native-side PoolManager Swap amounts for stamped ETH pools. The previous Native20 gross fee base remains a separate column. All metrics share an indexed, finalized checkpoint; the description states coverage limits, including LP fees and project/game taxes.

Validation: the SQL ran successfully in Dune. At block 59648445, ARBT earnings of 186849654838866631 wei and BLOB earnings of 75636916217030532 wei matched complete RPC fee-log scans and reconciled to paid claims plus open vault balances. Independent RPC scans also matched both pools' swap counts and volume. git diff --check passed.

The corrected SQL and description are already saved to existing Dune query 8631499. The dashboard visibly shows 0.310800 ETH of supported custom platform earnings and five launch records, including references. Its schedule was changed to every four hours within the existing Dune quota. This PR synchronizes the repository source and documentation; it does not deploy the website.
