### PR TITLE
Allow Any Quote owner deployment continuation

### DIFF
--- a/contracts/scripts/module-engine/any-quote-deployment.test.mjs
+++ b/contracts/scripts/module-engine/any-quote-deployment.test.mjs
@@ -6,6 +6,7 @@ import { fixtures, params, addr } from '../module-mode/test-fixtures.mjs';
 import { buildPlan, digest, HOOK_FLAGS, HOOK_MASK } from '../module-mode/core.mjs';
 import { observeReceipt, walletRequest } from '../module-mode/rpc.mjs';
 import { operatorSourceProfile } from '../module-mode/operator.mjs';
+import { assertContinuationPlan } from '../module-mode/recovery.mjs';
 import { anyQuoteConstructorArguments, anyQuoteSourceCreation, anyQuoteSourceRequests } from './any-quote-evidence.mjs';
 import { assertAnyQuotePlan, assertAnyQuoteProfile, buildAnyQuotePlan, ANY_QUOTE_DEPLOYMENT_SCHEMA,
   ANY_QUOTE_REUSE_DOMAIN, ANY_QUOTE_ROUTER } from './any-quote-core.mjs';
@@ -113,6 +114,42 @@ test('existing manual operator selects only the exact Any Quote profile and pres
   assert.throws(() => walletRequest(plan, { ...observation, nonce: '44' }, ceilings), /nonce/);
   const mixed = structuredClone(plan); mixed.identityCandidate.sourceVersion = 'module-engine-v1'; assert.throws(() => operatorSourceProfile(mixed));
   const old = structuredClone(plan); old.schemaVersion = 'programmable.module-engine-deployment-plan.v1'; assert.throws(() => walletRequest(old, observation, ceilings), /Direct creation/);
+});
+test('Any Quote operator continuation retains the original plan and rejects changed source basis, rights, nonces or bytes', async () => {
+  const { plan: original, build, basis, parameters } = await fixture();
+  const before = structuredClone(original), sourceCommit = 'c'.repeat(40);
+  const basisBody = structuredClone(basis); delete basisBody.basisDigest;
+  basisBody.provenance.sourceCommit = sourceCommit;
+  const successorBasis = { ...basisBody, basisDigest: digest(basisBody.schemaVersion, basisBody) };
+  const current = await buildAnyQuotePlan({ ...build, sourceCommit, sourceTree: 'd'.repeat(40), buildDigest: h('operator-only-build') }, parameters, successorBasis);
+  const rehash = plan => {
+    if (plan.basis) { const body = { ...plan.basis }; delete body.basisDigest; plan.basis.basisDigest = digest(body.schemaVersion, body); }
+    const body = { ...plan }; delete body.planDigest; plan.planDigest = digest(body.schemaVersion, body); return plan;
+  };
+  assert.notEqual(current.planDigest, original.planDigest);
+  assert.equal(assertContinuationPlan(original, current), original);
+  assert.deepEqual(original, before, 'Original plan and its journal identity remain authoritative');
+  assert.deepEqual(current.steps, original.steps);
+  for (const mutate of [
+    p => { p.identityCandidate.sourceCommit = 'e'.repeat(40); },
+    p => { p.basis.provenance.sourceCommit = 'e'.repeat(40); },
+    p => { p.basis.schemaVersion = 'other-basis-domain'; },
+    p => { p.basis.previousRelease.releaseDigest = h('another-release'); },
+    p => { p.basis.registryOwner = addr(88); },
+    p => { p.steps[1].nonce = '44'; },
+    p => { p.steps[1].data += '00'; },
+    p => { p.contracts.nativeRouteGuard.address = addr(88); },
+    p => { p.economics.platformRecipient = addr(88); },
+    p => { delete p.basis; },
+  ]) {
+    const changed = structuredClone(current); mutate(changed); rehash(changed);
+    assert.throws(() => assertContinuationPlan(original, changed), /Continuation/);
+  }
+  const invalidDigest = structuredClone(current); invalidDigest.basis.basisDigest = h('invalid');
+  const body = { ...invalidDigest }; delete body.planDigest; invalidDigest.planDigest = digest(body.schemaVersion, body);
+  assert.throws(() => assertContinuationPlan(original, invalidDigest), /basis/);
+  const future = structuredClone(current); future.schemaVersion = 'programmable.module-engine-any-quote-deployment-plan.v2'; rehash(future);
+  assert.throws(() => assertContinuationPlan(future, future), /basis/, 'Unreviewed plan domains remain excluded');
 });
 test('direct Host receipt requires CREATE address, reserved nonce, wallet payload and all child runtimes', async () => {
   const { plan } = await fixture(), step = plan.steps[1], transactionHash = h('included-host'), blockHash = h('inclusion-block');

--- a/contracts/scripts/module-mode/recovery.mjs
+++ b/contracts/scripts/module-mode/recovery.mjs
@@ -11,7 +11,8 @@ export function assertContinuationPlan(original, current) {
   }
   const comparable = plan => {
     const body = Object.fromEntries(Object.entries(plan).filter(([key]) => !['sourceCommit', 'sourceTree', 'buildDigest', 'planDigest'].includes(key)));
-    const inheritedBasisRequired = ['programmable.module-mode-native-v2-deployment-plan.v1', 'programmable.module-engine-deployment-plan.v1'].includes(plan.schemaVersion);
+    const inheritedBasisRequired = ['programmable.module-mode-native-v2-deployment-plan.v1', 'programmable.module-engine-deployment-plan.v1',
+      'programmable.module-engine-any-quote-deployment-plan.v1'].includes(plan.schemaVersion);
     need(!inheritedBasisRequired || plan.basis, 'Continuation requires the inherited source basis');
     if (plan.basis !== undefined) {
       const { basisDigest, ...basis } = plan.basis;


### PR DESCRIPTION
An operator update after the Any Quote Guard deployment currently blocks the remaining Host step because the existing continuation validator omits the Any Quote v1 deployment-plan domain. Admit that exact domain so the updated operator can keep the original plan and journal while binding wallet authority to the current protected production source.

The inherited basis domain, digest and source provenance checks, full deployment comparison, source-generation and ancestor checks remain in place. Regression coverage uses the existing full Any Quote plan fixture and rejects rehashed changes to provenance, retained release, rights, nonce, calldata, Guard address, fee recipient and basis, plus an unknown future plan domain.

Validation: 39 operator, dispatch and Any Quote tests passed; ESLint on both changed files and git diff --check passed. No contract, transaction, receipt, retry or journal code changed.
