### PR TITLE
Bind Any Quote review to verified deployed host identity

### DIFF
--- a/config/module-engine/review-release.json
+++ b/config/module-engine/review-release.json
@@ -1,38 +1,50 @@
 {
-  "schemaVersion": "programmable.module-engine.release.v1",
-  "sourceVersion": "module-engine-v1",
-  "engineProfile": "programmable.module-engine-solidity@1",
   "chainId": 4663,
-  "sourceCommit": "17b64b6613108dbc6ffdf767607bde6ea33343cd",
-  "tokenCreationCodeHash": "0x445809d9f7a34e959de4a96dec1e1beddfb265755bf28c57c42744adea1128ef",
-  "economicsPolicyId": "0x781124e941c10961779bc0d3ce1606083d16e1af3a03dccbc10d362b81085cc2",
-  "finalityPolicy": "robinhood-ethereum-finalized-v1",
   "contracts": {
-    "tokenFactory": {
-      "address": "0x754e8c1ade3c6c4c863590a91f2ed020baf8e779",
-      "runtimeCodeHash": "0x9354ef051bafa1edccb95c91d999e31025c012ee8d93392a78a51d83594845f2"
+    "host": {
+      "address": "0xfc4752006da554f086ba75a336b3525b9de5ce1d",
+      "runtimeCodeHash": "0xb793455747d315c40c77431556f653bd3cafb0d2adb55218e87baa735ed02313"
     },
     "launchPolicy": {
       "address": "0xf3ff250759a66edc7893bba9d34daf4ba4ae4caa",
       "runtimeCodeHash": "0x1c485a64c77174e0b2a78adf2527128792180def26cbab2ca00fcfa74b73ba91"
     },
-    "registry": {
-      "address": "0x0082094ebeb3817cd78b2bc3725ca23b5720d884",
-      "runtimeCodeHash": "0x364028382d38d4d1d4994ad305e0538f72ef2f2360a0f671ae82912c44374fdd"
-    },
-    "host": {
-      "address": "0x4ee5822de7296df5959085b95762f8c1c63da614",
-      "runtimeCodeHash": "0x01e10e24635483dff1ddfab9ef3925d34f061f542714e13134042ed7b6129dc0"
-    },
     "ledger": {
-      "address": "0xd1a00fe1cf3a5fb2aab7d01513f3a9a0fa12f2b8",
-      "runtimeCodeHash": "0xc4123ca7d1adff7e0cadae9add95fc196325478ba89bd89360e7ebcb3e1ca401"
+      "address": "0xc6ec7c1b2edd91183e967a21c944d3dd6ff9a084",
+      "runtimeCodeHash": "0x04274a9f3daacee275f86fc2fdf817bd11a777c029d0990a3ffc51825eaba640"
+    },
+    "nativeRouteGuard": {
+      "address": "0x92c1d5735a89488a77841634c48d922cd3f2c0e4",
+      "runtimeCodeHash": "0x704f8f3c1903e1f15dd041b2dd29673a8c98bee9c87f645da90978c2315cf4ee"
     },
     "poolManager": {
       "address": "0x8366a39cc670b4001a1121b8f6a443a643e40951",
       "runtimeCodeHash": "0xbd3881180b547f5fe817545743cfb4343e96b1bc6640dcd70c106b0066e95626"
+    },
+    "registry": {
+      "address": "0x0082094ebeb3817cd78b2bc3725ca23b5720d884",
+      "runtimeCodeHash": "0x364028382d38d4d1d4994ad305e0538f72ef2f2360a0f671ae82912c44374fdd"
+    },
+    "sharedHook": {
+      "address": "0xcf533f717b787f6eb591498411aef8231366a0cc",
+      "runtimeCodeHash": "0x67720ca20962ddc3762c63d98b2dd900e268fc9ccc4b4306528ac09f630b12fa"
+    },
+    "tokenFactory": {
+      "address": "0x754e8c1ade3c6c4c863590a91f2ed020baf8e779",
+      "runtimeCodeHash": "0x9354ef051bafa1edccb95c91d999e31025c012ee8d93392a78a51d83594845f2"
+    },
+    "universalRouter": {
+      "address": "0x06afba43fd06227fa663b0daecf536f6eaa6bf99",
+      "runtimeCodeHash": "0xbe8e8191bb42d843c2e948a5a55772eaab864ce01e54dcd47c9d089170b302d5"
     }
   },
-  "startBlock": "57168845",
-  "releaseDigest": "0xed101352062708f9c783aaf7b52fb752d98c5a5a2b0c3955ed14ab7feefa5497"
+  "economicsPolicyId": "0xe5028630113d178a49b8fce74f39ed7b326081772695f9e3e2ffaacee81f504d",
+  "engineProfile": "robinhood-any-quote.shared-hook.v1",
+  "finalityPolicy": "robinhood-ethereum-finalized-v1",
+  "schemaVersion": "programmable.module-engine.release.v1",
+  "sourceCommit": "9824c23ca4954fde8b5f4861f2a537fd0600bbf7",
+  "sourceVersion": "module-engine-any-quote-v1",
+  "tokenCreationCodeHash": "0x445809d9f7a34e959de4a96dec1e1beddfb265755bf28c57c42744adea1128ef",
+  "startBlock": "59807048",
+  "releaseDigest": "0xac96d652e2043f34b3f736bad999ab673b17aa8750b5d62951e9ec928306273d"
 }


### PR DESCRIPTION
The Engine review service needs the actual deployed Any Quote host identity before it can validate and accept a template manifest. Install the identity collected from the successful Foundation transactions, with release digest `0xac96d652e2043f34b3f736bad999ab673b17aa8750b5d62951e9ec928306273d`, contract source `9824c23ca4954fde8b5f4861f2a537fd0600bbf7`, and start block `59807048`.

Only `config/module-engine/review-release.json` changes. Its bytes exactly match the collected identity, and the existing identity binder independently recomputes the same digest. Both receipts and all seven source records passed independent review, including full public Sourcify source, creation and runtime verification for the four new contracts. This identity configuration does not activate the Engine release or add a catalogue entry; Native review and historical configurations remain byte-identical.

Validation: 116 existing publication, catalogue and review-route tests passed. The first route run lacked tracked files in the sparse checkout; after materializing those existing files, all 56 route tests passed. `git diff --check` passed. Actual template review, registry approval, lifecycle and activation remain separate release steps.
