### PR TITLE
Finish private Any Quote flow and bounded pool discovery

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -386,6 +386,14 @@ paths = [
 regexes = ['''(?i)^0x15fca474b23cafe775120b1fafbcff0e7a827af2$''']
 
 [[allowlists]]
+description = "Robinhood visibility test pins the public Any Quote release canary token address"
+targetRules = ["generic-api-key"]
+condition = "AND"
+regexTarget = "match"
+paths = ['''^tests/robinhood-website-index\.test\.ts$''']
+regexes = ['''^tokenAddress:\s*"0xb36271399c031ce270e0d1eed5f26dcd08367119"$''']
+
+[[allowlists]]
 description = "Attested Robinhood 4.1 clean-room proof pins its public predicted token address"
 targetRules = ["generic-api-key"]
 condition = "AND"

--- a/app/launch/modules/page.tsx
+++ b/app/launch/modules/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
 import { ModuleModeLaunchHost } from "@/components/module-mode-launch-host";
 import { ModuleEngineHost } from "@/components/module-engine-host";
-import { readModuleEngineLaunchVersions } from "@/lib/server/module-engine/catalog";
+import { readModuleEngineAvailability, readModuleEngineLaunchVersions } from "@/lib/server/module-engine/catalog";
+import { parseModuleEngineAvailability } from "@/lib/module-engine/catalog";
+import { isModuleEngineAnyQuoteRelease } from "@/lib/module-engine/profile";
+import reviewedAnyQuoteRelease from "@/config/module-engine/review-release.json";
 import { notFound } from "next/navigation";
 import { parseModuleModePageSelection } from "@/lib/module-mode/release-selection";
 import { readModuleModeLaunchVersions } from "@/lib/server/module-mode/launch-profiles";
@@ -16,8 +19,19 @@ export const metadata: Metadata = {
 export default async function ModuleModePage({ searchParams }: { searchParams: Promise<Record<string, string | string[] | undefined>> }) {
   let selection;
   try { selection = parseModuleModePageSelection(await searchParams); } catch { notFound(); }
-  const results = await Promise.allSettled([readModuleModeLaunchVersions(), readModuleEngineLaunchVersions()]);
-  const versions = results.flatMap(result => result.status === "fulfilled" ? result.value : []);
+  const [nativeVersions, engineVersions, currentEngine] = await Promise.allSettled([
+    readModuleModeLaunchVersions(), readModuleEngineLaunchVersions(), readModuleEngineAvailability(),
+  ]);
+  const versions = [nativeVersions, engineVersions].flatMap(result => result.status === "fulfilled" ? result.value : []);
   if (selection.sourceKind === "module-engine-v1") return <ModuleEngineHost releaseDigest={selection.releaseDigest} versions={versions} />;
-  return <ModuleModeLaunchHost releaseDigest={selection.releaseDigest} versions={versions} />;
+  let anyQuoteReleaseDigest;
+  if (currentEngine.status === "fulfilled") {
+    try {
+      const { release, templates } = parseModuleEngineAvailability(currentEngine.value);
+      // The review identity only selects the entry; current public authority must independently admit it.
+      if (release && isModuleEngineAnyQuoteRelease(release) && release.releaseDigest === reviewedAnyQuoteRelease.releaseDigest
+        && templates.some(template => template.manifest.manifest.catalogDefinition.interface === "quote-shared-v1")) anyQuoteReleaseDigest = release.releaseDigest;
+    } catch { /* Unavailable or unbound engine sources never create a launch entry. */ }
+  }
+  return <ModuleModeLaunchHost releaseDigest={selection.releaseDigest} versions={versions} anyQuoteReleaseDigest={anyQuoteReleaseDigest} />;
 }

--- a/components/module-mode-builder.tsx
+++ b/components/module-mode-builder.tsx
@@ -76,12 +76,13 @@ export interface ModuleModeBuilderProps {
   previewDescription?: string;
   statusContent?: ReactNode;
   versionContent?: ReactNode;
+  moduleLaunchContent?: ReactNode;
   reviewContent?: ReactNode;
   resultContent?: ReactNode;
   onEdit?: () => void;
 }
 
-export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = NATIVE_ENGINE_PROFILE, configurationContext = {}, launchAction, minimumInitialBuyWei, release, previewDescription, statusContent, reviewContent, resultContent, onEdit }: Readonly<ModuleModeBuilderProps>) {
+export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = NATIVE_ENGINE_PROFILE, configurationContext = {}, launchAction, minimumInitialBuyWei, release, previewDescription, statusContent, moduleLaunchContent, reviewContent, resultContent, onEdit }: Readonly<ModuleModeBuilderProps>) {
   const { hydrated } = useRouteViewChain(4663);
   const [state, setState] = useState(createModuleModeState);
   const { expanded: detailsOpen, setExpanded: setDetailsOpen, toggle: toggleDetails, panelProps: detailsPanel } = useDisclosureState();
@@ -292,6 +293,7 @@ export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = N
         </aside> : null}
       </div>
       {pickerOpen ? <ModulePickerDialog animateOpen={pickerPointer} title="Add modules" description="Modules are upgrades for your coin. Pick the features you want." onClose={() => setPickerOpen(false)}>
+        {moduleLaunchContent}
         <ModuleLibrary catalog={catalog} selectedIds={state.selectedModules} onAdd={add} onRemove={remove}
           feePolicyFor={release ? entry => moduleModeFeePolicy(release, state.selectedModules.includes(entry.id) ? selected : [...selected, entry]) : undefined} />
       </ModulePickerDialog> : null}

--- a/components/module-mode-launch-host.tsx
+++ b/components/module-mode-launch-host.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ArrowUpRight, Check, Copy, LoaderCircle, RefreshCw } from "lucide-react";
+import { ArrowRight, ArrowUpRight, Check, Copy, LoaderCircle, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useId, useMemo, useRef, useState, useSyncExternalStore, useTransition, type FormEvent } from "react";
 import { formatUnits, toHex, type Address, type Hex } from "viem";
 
@@ -65,7 +65,7 @@ function assertDraftAvailability(draft: ModuleModeDraft, current: ModuleModeAvai
   }
 }
 
-export function ModuleModeLaunchHost({ releaseDigest, versions = [] }: { releaseDigest?: string; versions?: readonly ModuleModeLaunchVersion[] }) {
+export function ModuleModeLaunchHost({ releaseDigest, versions = [], anyQuoteReleaseDigest }: { releaseDigest?: string; versions?: readonly ModuleModeLaunchVersion[]; anyQuoteReleaseDigest?: Hex }) {
   const router = useRouter();
   const [changingVersion, startVersionChange] = useTransition();
   const requestedRelease = useRef(releaseDigest);
@@ -234,6 +234,11 @@ export function ModuleModeLaunchHost({ releaseDigest, versions = [] }: { release
 
   return <ModuleModeBuilder
     release={release}
+    moduleLaunchContent={anyQuoteReleaseDigest ? <ModuleModeAnyQuoteLaunchEntry disabled={working || requestPending || hasSubmission || changingVersion} onSelect={() => {
+      if (working || requestPending || hasSubmission || changingVersion) return;
+      operation.current += 1; setFlow({ phase: "idle" });
+      startVersionChange(() => router.push(`/launch/modules${moduleModeReleaseQuery({ sourceKind: "module-engine-v1", releaseDigest: anyQuoteReleaseDigest })}`, { scroll: false }));
+    }} /> : undefined}
     versionContent={versions.length > 1 ? <div className={styles.field}><label htmlFor="module-launch-version">Module version</label><select id="module-launch-version" value={releaseDigest ?? availability?.release?.releaseDigest ?? versions[0]?.releaseDigest} disabled={working || requestPending || hasSubmission || changingVersion} onChange={event => {
       const version = versions.find(candidate => candidate.releaseDigest === event.target.value);
       if (!version || working || requestPending || hasSubmission) return;
@@ -269,6 +274,14 @@ export function ModuleModeLaunchHost({ releaseDigest, versions = [] }: { release
       onRecover={recoveryOperation?.kind === "launch" && recoveryOperation.sourceKind !== "module-engine-v1" ? transactionHash => void checkRecoveredReceipt(transactionHash) : undefined}
     /> : undefined}
   />;
+}
+
+export function ModuleModeAnyQuoteLaunchEntry({ disabled, onSelect }: { disabled: boolean; onSelect: () => void }) {
+  return <section className={styles.catalogRow} aria-labelledby="module-any-quote-title"><div>
+    <h3 id="module-any-quote-title">Any Quote LP</h3>
+    <p>Start a coin paired with a compatible token of your choice. Trade with ETH.</p>
+    <button type="button" className={styles.textButton} disabled={disabled} onClick={onSelect}>Use Any Quote LP <ArrowRight size={16} aria-hidden="true" /></button>
+  </div></section>;
 }
 
 export function ModuleModeLaunchResult({ phase, token, symbol, transactionHash, message, checking = false, onCheck, onRecover }: {

--- a/config/module-engine/index-releases.json
+++ b/config/module-engine/index-releases.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": "programmable.module-engine.index-releases.v1",
+  "releases": []
+}

--- a/contracts/scripts/module-engine/shared.ts
+++ b/contracts/scripts/module-engine/shared.ts
@@ -1,6 +1,7 @@
 // Use the canonical six-role Engine wire; no submitted contributor code is imported or executed.
 export { MODULE_ENGINE_RELEASE_SCHEMA, MODULE_ENGINE_SOURCE_VERSION, MODULE_ENGINE_SOURCE_ID,
-  MODULE_ENGINE_PROFILE, MODULE_ENGINE_CONTRACTS, computeModuleEngineReleaseDigest, bindModuleEngineReleaseIdentity } from '../../../lib/module-engine/catalog';
+  MODULE_ENGINE_PROFILE, MODULE_ENGINE_CONTRACTS, computeModuleEngineReleaseDigest, bindModuleEngineReleaseIdentity,
+  bindActiveModuleEngineRelease } from '../../../lib/module-engine/catalog';
 export { MODULE_ENGINE_ANY_QUOTE_SOURCE_VERSION, MODULE_ENGINE_ANY_QUOTE_SOURCE_ID, MODULE_ENGINE_ANY_QUOTE_PROFILE,
   MODULE_ENGINE_ANY_QUOTE_CONTRACTS, MODULE_ENGINE_ANY_QUOTE_ECONOMICS_POLICY_ID,
   MODULE_ENGINE_ANY_QUOTE_CONFIGURATION_SCHEMA_ID, MODULE_ENGINE_ANY_QUOTE_PLATFORM_RECIPIENT,

--- a/lib/module-engine/any-quote/discovery.server.ts
+++ b/lib/module-engine/any-quote/discovery.server.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { decodeEventLog, keccak256, pad, parseAbi, stringToHex, toHex, type Address, type Hex } from "viem";
-import { agreedTradeRpcV1 } from "@/lib/server/custom-launch/routed-trade-rpc-v1";
+import { canonicalBrowserJsonV2 } from "@/lib/custom-launch/browser-authority-v2";
+import { agreedTradeRpcV1, type TradeRpcV1 } from "@/lib/server/custom-launch/routed-trade-rpc-v1";
 import { anyQuotePoolIdV1 } from "./route";
 import {
   ANY_QUOTE_INFRASTRUCTURE, ANY_QUOTE_NATIVE, AnyQuoteErrorV1, anyQuoteAddressV1, anyQuoteSameAddressV1,
@@ -14,9 +15,9 @@ export const ANY_QUOTE_V4_START_BLOCK = 9070n;
 export const ANY_QUOTE_V4_MAX_POOL_CANDIDATES = 64;
 const MAX_LOG_REQUESTS = 24;
 const MAX_RANGE_SPLITS = 2;
+const MAX_VERIFICATION_BLOCKS = 10_000n;
 const initializeAbi = parseAbi(["event Initialize(bytes32 indexed id,address indexed currency0,address indexed currency1,uint24 fee,int24 tickSpacing,address hooks,uint160 sqrtPriceX96,int24 tick)"]);
 const initializeTopic = keccak256(stringToHex("Initialize(bytes32,address,address,uint24,int24,address,uint160,int24)"));
-type AgreedRpc = ReturnType<typeof agreedTradeRpcV1>;
 type PoolRecord = AnyQuoteV4PoolCandidateV1 & { blockNumber: string; blockHash: Hex; logIndex: string; sqrtPriceX96: string; tick: number };
 const invalid = (): never => { throw new AnyQuoteErrorV1("V4_DISCOVERY_RESPONSE_INVALID"); };
 const quantity = (value: unknown) => typeof value === "string" && /^0x[0-9a-f]{1,64}$/i.test(value) ? BigInt(value) : invalid();
@@ -82,32 +83,69 @@ export function parseAnyQuoteV4DiscoveryV1(value: unknown): AnyQuoteV4DiscoveryV
   } catch { return invalid(); }
 }
 
-/** Bounded, request-local index reader. Direct native pools cost one indexed query in the
- * normal case. Range-limited providers get at most two bisections; failures never mean no market.
- * Buy/sell and intermediate searches reuse results at this exact canonical checkpoint. */
-export function createAnyQuoteV4InitializeDiscoveryV1(input: { checkpoint: AnyQuoteCheckpointV1; agreed: AgreedRpc }) {
+/** A full-range response from one provider supplies discovery hints only. Both original
+ * providers must independently agree on every hinted log in bounded canonical block ranges.
+ * This verifies candidates, not index completeness; absent hints never prove no market.
+ * Buy/sell and intermediate searches share one checkpoint, cache and request budget. */
+export function createAnyQuoteV4InitializeDiscoveryV1(input: { checkpoint: AnyQuoteCheckpointV1; rpcs: readonly [TradeRpcV1, TradeRpcV1] }) {
   const toBlock = BigInt(input.checkpoint.number);
   if (toBlock < ANY_QUOTE_V4_START_BLOCK) throw new AnyQuoteErrorV1("V4_DISCOVERY_CHECKPOINT_UNAVAILABLE");
   let requests = 0;
+  let incompleteCoverage = false;
+  const agreed = agreedTradeRpcV1(input.rpcs);
   const cache = new Map<string, Promise<PoolRecord[]>>();
-  const readRange = async (currency: Address, otherCurrency: Address | undefined, topics: readonly (Hex | null)[], fromBlock: bigint, end: bigint, depth = 0): Promise<PoolRecord[]> => {
+  const reserveRequest = () => {
     if (++requests > MAX_LOG_REQUESTS) throw new AnyQuoteErrorV1("V4_DISCOVERY_REQUEST_LIMIT");
-    try {
-      return await input.agreed("eth_getLogs", [{ address: ANY_QUOTE_INFRASTRUCTURE.poolManager, fromBlock: toHex(fromBlock), toBlock: toHex(end), topics }],
-        value => parseAnyQuoteV4InitializeV1(value, { currency, otherCurrency, fromBlock, toBlock: end }));
-    } catch (error) {
-      const code = error && typeof error === "object" && "code" in error ? String(error.code) : "";
-      if (code === "TRADE_PROVIDER_DISAGREEMENT") throw new AnyQuoteErrorV1("V4_DISCOVERY_PROVIDER_DISAGREEMENT");
-      if (depth >= MAX_RANGE_SPLITS || fromBlock === end) throw new AnyQuoteErrorV1("V4_DISCOVERY_PROVIDER_UNAVAILABLE");
-      const middle = (fromBlock + end) / 2n;
-      const parts = await Promise.all([
-        readRange(currency, otherCurrency, topics, fromBlock, middle, depth + 1),
-        readRange(currency, otherCurrency, topics, middle + 1n, end, depth + 1),
-      ]);
-      const result = parts.flat();
-      if (result.length > ANY_QUOTE_V4_MAX_POOL_CANDIDATES) throw new AnyQuoteErrorV1("V4_DISCOVERY_CANDIDATE_LIMIT");
-      return result;
+  };
+  const requireSame = (a: PoolRecord[], b: PoolRecord[]) => {
+    if (canonicalBrowserJsonV2(a) !== canonicalBrowserJsonV2(b)) throw new AnyQuoteErrorV1("V4_DISCOVERY_PROVIDER_DISAGREEMENT");
+  };
+  const filter = (topics: readonly (Hex | null)[], fromBlock: bigint, end: bigint) =>
+    [{ address: ANY_QUOTE_INFRASTRUCTURE.poolManager, fromBlock: toHex(fromBlock), toBlock: toHex(end), topics }];
+  const verifyHints = async (hints: PoolRecord[], currency: Address, otherCurrency: Address | undefined, topics: readonly (Hex | null)[]) => {
+    incompleteCoverage = true;
+    // A single-provider empty result may prompt an intermediate search, never an incompatibility verdict.
+    const windows: PoolRecord[][] = [];
+    for (const hint of [...hints].sort((a, b) => Number(BigInt(a.blockNumber) - BigInt(b.blockNumber)))) {
+      const last = windows.at(-1);
+      if (last && BigInt(hint.blockNumber) - BigInt(last[0].blockNumber) < MAX_VERIFICATION_BLOCKS) last.push(hint);
+      else windows.push([hint]);
     }
+    if (requests + windows.length > MAX_LOG_REQUESTS) throw new AnyQuoteErrorV1("V4_DISCOVERY_REQUEST_LIMIT");
+    const result: PoolRecord[] = [];
+    for (let start = 0; start < windows.length; start += 4) result.push(...(await Promise.all(windows.slice(start, start + 4).map(async window => {
+      reserveRequest();
+      const fromBlock = BigInt(window[0].blockNumber), end = BigInt(window[window.length - 1].blockNumber);
+      let verified: PoolRecord[];
+      try {
+        verified = await agreed("eth_getLogs", filter(topics, fromBlock, end),
+          value => parseAnyQuoteV4InitializeV1(value, { currency, otherCurrency, fromBlock, toBlock: end }));
+      } catch (error) {
+        const code = error && typeof error === "object" && "code" in error ? String(error.code) : "";
+        throw new AnyQuoteErrorV1(code === "TRADE_PROVIDER_DISAGREEMENT" ? "V4_DISCOVERY_PROVIDER_DISAGREEMENT" : "V4_DISCOVERY_PROVIDER_UNAVAILABLE");
+      }
+      requireSame(verified, window.sort((a, b) => a.poolId.localeCompare(b.poolId)));
+      return verified;
+    }))).flat());
+    return result.sort((a, b) => a.poolId.localeCompare(b.poolId));
+  };
+  const readRange = async (currency: Address, otherCurrency: Address | undefined, topics: readonly (Hex | null)[], fromBlock: bigint, end: bigint, depth = 0): Promise<PoolRecord[]> => {
+    reserveRequest();
+    const responses = await Promise.allSettled(input.rpcs.map(rpc => rpc("eth_getLogs", filter(topics, fromBlock, end))));
+    // Invalid successful responses are terminal, not provider outages eligible for fallback.
+    const records = responses.map(response => response.status === "fulfilled"
+      ? parseAnyQuoteV4InitializeV1(response.value, { currency, otherCurrency, fromBlock, toBlock: end }) : null);
+    if (records[0] !== null && records[1] !== null) { requireSame(records[0], records[1]); return records[0]; }
+    const hints = records[0] ?? records[1];
+    if (hints !== null) return verifyHints(hints, currency, otherCurrency, topics);
+    if (depth >= MAX_RANGE_SPLITS || fromBlock === end) throw new AnyQuoteErrorV1("V4_DISCOVERY_PROVIDER_UNAVAILABLE");
+    const middle = (fromBlock + end) / 2n;
+    const result = (await Promise.all([
+      readRange(currency, otherCurrency, topics, fromBlock, middle, depth + 1),
+      readRange(currency, otherCurrency, topics, middle + 1n, end, depth + 1),
+    ])).flat();
+    if (result.length > ANY_QUOTE_V4_MAX_POOL_CANDIDATES) throw new AnyQuoteErrorV1("V4_DISCOVERY_CANDIDATE_LIMIT");
+    return result;
   };
   const pools = (currency: Address, otherCurrency?: Address): Promise<PoolRecord[]> => {
     const key = `${currency.toLowerCase()}:${otherCurrency?.toLowerCase() ?? "*"}`;
@@ -127,5 +165,6 @@ export function createAnyQuoteV4InitializeDiscoveryV1(input: { checkpoint: AnyQu
     }
     return pending;
   };
-  return { nativePools: (currency: Address) => pools(currency, ANY_QUOTE_NATIVE), adjacentPools: (currency: Address) => pools(currency) };
+  return { nativePools: (currency: Address) => pools(currency, ANY_QUOTE_NATIVE), adjacentPools: (currency: Address) => pools(currency),
+    hasIncompleteCoverage: () => incompleteCoverage };
 }

--- a/lib/module-engine/any-quote/readiness.server.ts
+++ b/lib/module-engine/any-quote/readiness.server.ts
@@ -104,7 +104,7 @@ async function context(options: AnyQuoteReadinessOptionsV1) {
   ]);
   let discovery: ReturnType<typeof createAnyQuoteV4InitializeDiscoveryV1> | undefined;
   return { now, checkpoint, block, code, call, pin,
-    discovery: () => discovery ??= createAnyQuoteV4InitializeDiscoveryV1({ checkpoint, agreed }) };
+    discovery: () => discovery ??= createAnyQuoteV4InitializeDiscoveryV1({ checkpoint, rpcs }) };
 }
 type Context = Awaited<ReturnType<typeof context>>;
 
@@ -228,7 +228,7 @@ async function discoverNativeV4(input: DiscoveryInput, ctx: Context) {
     ? [anyQuoteV4CandidateHopV1(first, ANY_QUOTE_NATIVE), anyQuoteV4CandidateHopV1(pool, intermediate)]
     : [anyQuoteV4CandidateHopV1(pool, quote), anyQuoteV4CandidateHopV1(first, intermediate)]));
   const routed = await chooseNativeCandidate(paths, input, ctx, "uniswap-v4-initialize");
-  if (!routed) throw new AnyQuoteErrorV1("NATIVE_V4_EXECUTABLE_ROUTE_UNAVAILABLE");
+  if (!routed) throw new AnyQuoteErrorV1(discovery.hasIncompleteCoverage() ? "V4_DISCOVERY_PROVIDER_UNAVAILABLE" : "NATIVE_V4_EXECUTABLE_ROUTE_UNAVAILABLE");
   return routed;
 }
 

--- a/lib/module-engine/any-quote/readiness.server.ts
+++ b/lib/module-engine/any-quote/readiness.server.ts
@@ -93,7 +93,18 @@ async function context(options: AnyQuoteReadinessOptionsV1) {
     const abi: Abi = parseAbi([signature]), functionName = /^function ([A-Za-z0-9_]+)/.exec(signature)?.[1];
     if (!functionName) throw new AnyQuoteErrorV1("INVALID_READ_CALL");
     const data = encodeFunctionData({ abi, functionName, args });
-    return cached(`call:${to.toLowerCase()}:${data}`, async () => decodeFunctionResult({ abi, functionName, data: await agreed("eth_call", [{ to, data }, block], bytes) }));
+    return cached(`call:${to.toLowerCase()}:${data}`, async () => {
+      let malformed = false;
+      const encoded = await agreed("eth_call", [{ to, data }, block], value => {
+        try { return bytes(value); } catch (error) { malformed = true; throw error; }
+      }).catch(error => {
+        if (malformed) throw new AnyQuoteErrorV1("RPC_RESPONSE_INVALID");
+        if (error && typeof error === "object" && "code" in error && error.code === "TRADE_PROVIDER_DISAGREEMENT") throw new AnyQuoteErrorV1("TRADE_PROVIDER_DISAGREEMENT");
+        throw error;
+      });
+      try { return decodeFunctionResult({ abi, functionName, data: encoded }); }
+      catch { throw new AnyQuoteErrorV1("RPC_RESPONSE_INVALID"); }
+    });
   };
   const pin = async (address: Address, hash: Hex) => {
     if (keccak256(await code(address)).toLowerCase() !== hash.toLowerCase()) throw new AnyQuoteErrorV1("INFRASTRUCTURE_RUNTIME_MISMATCH");
@@ -176,14 +187,23 @@ async function quoteHops(hops: readonly AnyQuoteAmmHopV1[], amountIn: bigint, ct
 
 type DiscoveryInput = { tokenIn: Address; tokenOut: Address; amountIn: bigint };
 type V4Hop = Extract<AnyQuoteAmmHopV1, { protocol: "V4" }>;
+type NativeCandidate = { route: AnyQuoteExternalRouteV1; spot: AnyQuoteRationalV1 };
+type CandidateQualification = (candidate: NativeCandidate) => Promise<void>;
 async function boundedMap<T, R>(values: readonly T[], read: (value: T) => Promise<R>) {
   const result: PromiseSettledResult<R>[] = [];
   for (let start = 0; start < values.length; start += 4) result.push(...await Promise.allSettled(values.slice(start, start + 4).map(read)));
   return result;
 }
+function requireCandidateProviderIntegrity(outcomes: readonly PromiseSettledResult<unknown>[]) {
+  for (const result of outcomes) if (result.status === "rejected") {
+    const code = result.reason && typeof result.reason === "object" && "code" in result.reason ? String(result.reason.code) : "";
+    if (code === "TRADE_PROVIDER_DISAGREEMENT") throw new AnyQuoteErrorV1("TRADE_PROVIDER_DISAGREEMENT");
+    if (code === "RPC_RESPONSE_INVALID") throw result.reason;
+  }
+}
 
 async function chooseNativeCandidate(paths: readonly (readonly V4Hop[])[], input: DiscoveryInput, ctx: Context,
-  provider: "uniswap-v4-initialize" | "uniswap-v4-discovery") {
+  provider: "uniswap-v4-initialize" | "uniswap-v4-discovery", qualify?: CandidateQualification) {
   if (paths.length > ANY_QUOTE_V4_MAX_POOL_CANDIDATES) throw new AnyQuoteErrorV1("V4_DISCOVERY_CANDIDATE_LIMIT");
   const buy = anyQuoteSameAddressV1(input.tokenIn, ANY_QUOTE_WETH);
   const outcomes = await boundedMap(paths, async hops => {
@@ -204,15 +224,27 @@ async function chooseNativeCandidate(paths: readonly (readonly V4Hop[])[], input
     return { route: { ...route, evidenceHash: anyQuoteEvidenceHashV1({ ...route, evidenceHash: undefined }) },
       spot: spots.reduce(multiplyAnyQuoteRationalsV1, anyQuoteRationalV1(1n, 1n)) };
   });
-  return outcomes.flatMap(value => value.status === "fulfilled" ? [value.value] : [])
-    .sort((a, b) => BigInt(a.route.amountOut) > BigInt(b.route.amountOut) ? -1 : BigInt(a.route.amountOut) < BigInt(b.route.amountOut) ? 1 : a.route.evidenceHash.localeCompare(b.route.evidenceHash))[0] ?? null;
+  requireCandidateProviderIntegrity(outcomes);
+  const ordered = outcomes.flatMap(value => value.status === "fulfilled" ? [value.value] : [])
+    .sort((a, b) => BigInt(a.route.amountOut) > BigInt(b.route.amountOut) ? -1 : BigInt(a.route.amountOut) < BigInt(b.route.amountOut) ? 1 : a.route.evidenceHash.localeCompare(b.route.evidenceHash));
+  let qualificationError: AnyQuoteErrorV1 | null = null;
+  for (const candidate of ordered) {
+    try { await qualify?.(candidate); return { candidate, qualificationError: null }; }
+    catch (error) {
+      // Only measured policy failures may select another candidate. Provider or malformed-data
+      // failures must remain inconclusive, even when another pool could return a quote.
+      if (!(error instanceof AnyQuoteErrorV1) || !["MARKET_PRICE_IMPACT_TOO_HIGH", "MARKET_DEPTH_UNAVAILABLE", "REFERENCE_MARKET_PRICE_DISAGREEMENT"].includes(error.code)) throw error;
+      qualificationError ??= error;
+    }
+  }
+  return { candidate: null, qualificationError };
 }
 
-async function discoverNativeV4(input: DiscoveryInput, ctx: Context) {
+async function discoverNativeV4(input: DiscoveryInput, ctx: Context, qualify?: CandidateQualification) {
   const buy = anyQuoteSameAddressV1(input.tokenIn, ANY_QUOTE_WETH), quote = buy ? input.tokenOut : input.tokenIn;
   const discovery = ctx.discovery(), nativePools = await discovery.nativePools(quote);
-  const direct = await chooseNativeCandidate(nativePools.map(pool => [anyQuoteV4CandidateHopV1(pool, buy ? ANY_QUOTE_NATIVE : quote)]), input, ctx, "uniswap-v4-initialize");
-  if (direct) return direct;
+  const direct = await chooseNativeCandidate(nativePools.map(pool => [anyQuoteV4CandidateHopV1(pool, buy ? ANY_QUOTE_NATIVE : quote)]), input, ctx, "uniswap-v4-initialize", qualify);
+  if (direct.candidate) return direct.candidate;
   const adjacent = await discovery.adjacentPools(quote);
   const inspected = await boundedMap(adjacent, async pool => {
     const hop = anyQuoteV4CandidateHopV1(pool, quote);
@@ -220,6 +252,7 @@ async function discoverNativeV4(input: DiscoveryInput, ctx: Context) {
     await inspectHop(hop, ctx);
     return { pool, intermediate: hop.tokenOut };
   });
+  requireCandidateProviderIntegrity(inspected);
   const live = inspected.flatMap(value => value.status === "fulfilled" && value.value ? [value.value] : []);
   const intermediates = [...new Set(live.map(value => value.intermediate))];
   if (intermediates.length > 8) throw new AnyQuoteErrorV1("V4_DISCOVERY_INTERMEDIATE_LIMIT");
@@ -227,19 +260,20 @@ async function discoverNativeV4(input: DiscoveryInput, ctx: Context) {
   const paths = live.flatMap(({ pool, intermediate }) => (native.get(intermediate) ?? []).map(first => buy
     ? [anyQuoteV4CandidateHopV1(first, ANY_QUOTE_NATIVE), anyQuoteV4CandidateHopV1(pool, intermediate)]
     : [anyQuoteV4CandidateHopV1(pool, quote), anyQuoteV4CandidateHopV1(first, intermediate)]));
-  const routed = await chooseNativeCandidate(paths, input, ctx, "uniswap-v4-initialize");
-  if (!routed) throw new AnyQuoteErrorV1(discovery.hasIncompleteCoverage() ? "V4_DISCOVERY_PROVIDER_UNAVAILABLE" : "NATIVE_V4_EXECUTABLE_ROUTE_UNAVAILABLE");
-  return routed;
+  const routed = await chooseNativeCandidate(paths, input, ctx, "uniswap-v4-initialize", qualify);
+  if (!routed.candidate) throw routed.qualificationError ?? direct.qualificationError
+    ?? new AnyQuoteErrorV1(discovery.hasIncompleteCoverage() ? "V4_DISCOVERY_PROVIDER_UNAVAILABLE" : "NATIVE_V4_EXECUTABLE_ROUTE_UNAVAILABLE");
+  return routed.candidate;
 }
 
-async function discover(input: DiscoveryInput, ctx: Context, options: AnyQuoteReadinessOptionsV1) {
+async function discover(input: DiscoveryInput, ctx: Context, options: AnyQuoteReadinessOptionsV1, qualify?: CandidateQualification) {
   if (anyQuoteSameAddressV1(input.tokenIn, input.tokenOut) && anyQuoteSameAddressV1(input.tokenIn, ANY_QUOTE_WETH)) {
     const value: AnyQuoteExternalRouteV1 = { provider: "weth-identity", chainId: 4663, ...input,
       amountIn: input.amountIn.toString(), amountOut: input.amountIn.toString(), hops: [], checkpoint: ctx.checkpoint,
       validUntil: (ctx.now + ROUTE_LIFETIME).toString(), evidenceHash: "0x" };
     return { route: { ...value, evidenceHash: anyQuoteEvidenceHashV1(value) }, spot: anyQuoteRationalV1(1n, 1n) };
   }
-  if (!options.discoverExternalRoute && (!options.apiKey || !/^[\x21-\x7e]{16,512}$/.test(options.apiKey))) return discoverNativeV4(input, ctx);
+  if (!options.discoverExternalRoute && (!options.apiKey || !/^[\x21-\x7e]{16,512}$/.test(options.apiKey))) return discoverNativeV4(input, ctx, qualify);
   const raw = options.discoverExternalRoute ? await options.discoverExternalRoute(input) : await fetchJson(QUOTE_URL, options, {
     type: "EXACT_INPUT", amount: input.amountIn.toString(), tokenInChainId: 4663, tokenOutChainId: 4663,
     tokenIn: input.tokenIn, tokenOut: input.tokenOut, swapper: PROBE_OWNER, recipient: PROBE_OWNER,
@@ -248,17 +282,19 @@ async function discover(input: DiscoveryInput, ctx: Context, options: AnyQuoteRe
   });
   if (raw && typeof raw === "object" && "schema" in raw) {
     const discovered = parseAnyQuoteV4DiscoveryV1(raw);
-    const result = await chooseNativeCandidate(discovered.routes, input, ctx, "uniswap-v4-discovery");
-    if (!result) throw new AnyQuoteErrorV1("NATIVE_V4_EXECUTABLE_ROUTE_UNAVAILABLE");
-    return result;
+    const result = await chooseNativeCandidate(discovered.routes, input, ctx, "uniswap-v4-discovery", qualify);
+    if (!result.candidate) throw result.qualificationError ?? new AnyQuoteErrorV1("NATIVE_V4_EXECUTABLE_ROUTE_UNAVAILABLE");
+    return result.candidate;
   }
   const parsed = parseAnyQuoteExternalRouteV1(raw, { ...input, checkpoint: ctx.checkpoint, validUntil: ctx.now + ROUTE_LIFETIME });
   requireAnyQuoteNativeUnlockRouteV1(parsed, anyQuoteSameAddressV1(input.tokenIn, ANY_QUOTE_WETH) ? "buy" : "sell");
   const spots = await Promise.all(parsed.hops.map(hop => inspectHop(hop, ctx)));
   const amountOut = await quoteHops(parsed.hops, input.amountIn, ctx);
   const route = { ...parsed, amountOut: amountOut.toString() };
-  return { route: { ...route, evidenceHash: anyQuoteEvidenceHashV1({ ...route, evidenceHash: undefined }) },
+  const candidate = { route: { ...route, evidenceHash: anyQuoteEvidenceHashV1({ ...route, evidenceHash: undefined }) },
     spot: spots.reduce(multiplyAnyQuoteRationalsV1, anyQuoteRationalV1(1n, 1n)) };
+  await qualify?.(candidate);
+  return candidate;
 }
 
 export function validateAnyQuoteFeedRoundV1(input: { roundId: bigint; answer: bigint; updatedAt: bigint; answeredInRound: bigint; decimals: number; heartbeatSeconds: number; now: bigint }) {
@@ -357,18 +393,30 @@ export async function assessAnyQuoteAssetV1(input: { quoteAsset: string; probeEt
     const referenceEth = 10n ** 18n * BigInt(ethPrice.usd.denominator) / BigInt(ethPrice.usd.numerator);
     const probe = input.probeEthAmount ?? referenceEth;
     if (probe <= 0n || probe > 10n ** 19n) throw new AnyQuoteErrorV1("INVALID_PROBE_AMOUNT");
-    const { route: buy, spot } = await discover({ tokenIn: ANY_QUOTE_WETH, tokenOut: quoteAsset, amountIn: probe }, ctx, options);
-    const { route: sell } = await discover({ tokenIn: quoteAsset, tokenOut: ANY_QUOTE_WETH, amountIn: BigInt(buy.amountOut) }, ctx, options);
-    requireAnyQuoteNativeUnlockRouteV1(buy, "buy");
-    requireAnyQuoteNativeUnlockRouteV1(sell, "sell");
-    const marketUsd = multiplyAnyQuoteRationalsV1(ethPrice.usd, anyQuoteRationalV1(BigInt(spot.denominator) * 10n ** BigInt(decimals), BigInt(spot.numerator) * 10n ** 18n));
-    if (authoritative) {
+    const marketPrice = (spot: AnyQuoteRationalV1) => multiplyAnyQuoteRationalsV1(ethPrice.usd,
+      anyQuoteRationalV1(BigInt(spot.denominator) * 10n ** BigInt(decimals), BigInt(spot.numerator) * 10n ** 18n));
+    const qualifyReference = (spot: AnyQuoteRationalV1) => {
+      if (!authoritative) return;
       // Compare fee-free pool spot against the reference. Swap/hook fees are already in the quotes.
+      const marketUsd = marketPrice(spot);
       const market = BigInt(marketUsd.numerator) * BigInt(authoritative.usd.denominator);
       const reference = BigInt(authoritative.usd.numerator) * BigInt(marketUsd.denominator);
       const difference = market > reference ? market - reference : reference - market;
       if (difference * 10_000n > reference * 1_000n) throw new AnyQuoteErrorV1("REFERENCE_MARKET_PRICE_DISAGREEMENT");
-    }
+    };
+    const qualifyDepth = (smallIn: bigint): CandidateQualification => async ({ route }) => {
+      const [smallOut, largeOut] = await Promise.all([quoteHops(route.hops, smallIn, ctx), quoteHops(route.hops, smallIn * 100n, ctx)]);
+      qualifyAnyQuoteDepthV1(smallIn, smallOut, smallIn * 100n, largeOut);
+    };
+    const qualifyBuy: CandidateQualification = authoritative ? async ({ spot }) => qualifyReference(spot) : qualifyDepth(referenceEth);
+    const { route: buy, spot } = await discover({ tokenIn: ANY_QUOTE_WETH, tokenOut: quoteAsset, amountIn: probe }, ctx, options, qualifyBuy);
+    const sellDepthProbe = authoritative ? null : await quoteHops(buy.hops, referenceEth, ctx);
+    const { route: sell } = await discover({ tokenIn: quoteAsset, tokenOut: ANY_QUOTE_WETH, amountIn: BigInt(buy.amountOut) }, ctx, options,
+      sellDepthProbe === null ? undefined : qualifyDepth(sellDepthProbe));
+    requireAnyQuoteNativeUnlockRouteV1(buy, "buy");
+    requireAnyQuoteNativeUnlockRouteV1(sell, "sell");
+    const marketUsd = marketPrice(spot);
+    qualifyReference(spot);
     let price = authoritative;
     if (price === null) {
       const smallIn = referenceEth, largeIn = referenceEth * 100n;

--- a/lib/module-engine/availability-client.ts
+++ b/lib/module-engine/availability-client.ts
@@ -2,6 +2,8 @@ import type { Hex } from "viem";
 import { moduleModeReleaseQuery } from "@/lib/module-mode/release-selection";
 import { parseModuleEngineAvailability, type ModuleEngineAvailability } from "./catalog";
 import type { PreparedModuleEngineTransaction } from "./client";
+import { ANY_QUOTE_INFRASTRUCTURE } from "./any-quote/types";
+import { isModuleEngineAnyQuoteRelease } from "./profile";
 
 /** The normal Module Mode endpoint selects the exact source authority; URLs never supply authority. */
 export async function fetchModuleEngineAvailability(releaseDigest?: Hex, signal?: AbortSignal): Promise<ModuleEngineAvailability> {
@@ -27,7 +29,13 @@ export function assertModuleEngineOperationAvailability(prepared: PreparedModule
   if (!before.release || !latest.release || before.release.releaseDigest !== prepared.releaseDigest
     || latest.release.releaseDigest !== prepared.releaseDigest) throw new Error("The template version changed. Review the transaction again.");
   if (prepared.kind === "approve") {
-    if (prepared.spender.toLowerCase() !== latest.release.contracts.host.address.toLowerCase() || latest.templates.length === 0) {
+    const release = latest.release, shared = isModuleEngineAnyQuoteRelease(release);
+    const spender = shared ? ANY_QUOTE_INFRASTRUCTURE.permit2 : release.contracts.host.address;
+    // ERC20 approvals fund Permit2 itself; only Permit2 allowances name the reviewed router.
+    const routerAvailable = prepared.allowanceKind === "permit2"
+      ? shared && prepared.permit2Spender?.toLowerCase() === release.contracts.universalRouter.address.toLowerCase()
+      : prepared.permit2Spender === undefined;
+    if (prepared.spender.toLowerCase() !== spender.toLowerCase() || !routerAvailable || latest.templates.length === 0) {
       throw new Error("The approved funding contract is no longer available.");
     }
     return;

--- a/lib/robinhood-explore-policy.ts
+++ b/lib/robinhood-explore-policy.ts
@@ -16,6 +16,7 @@ const HIDDEN_ROBINHOOD_TOKENS = new Set([
   "0x08bdedb48ee01f29dd88e84e6d9296e84d736aa2", // M53FIX
   "0xdf23dac67139ebd3f66fcc4ea224c5c6ae850546", // M53SET
   "0xd9320af2762e711918358422594684756ad760cc", // PN20REF backfill canary
+  "0xb36271399c031ce270e0d1eed5f26dcd08367119", // AQLPTEST Any Quote LP release canary
 ]);
 
 export function isVisibleRobinhoodToken(address: string) {

--- a/lib/server/robinhood-index/README.md
+++ b/lib/server/robinhood-index/README.md
@@ -34,3 +34,25 @@ ranges contain at most 10,000 blocks. It runs every minute using the existing
 history is backfilled over bounded runs; the list reports `syncing` until caught up.
 Changing the canonical Router itself requires an explicit index migration;
 new tokens and custom hooks on that Router require no configuration.
+
+Engine sources can be indexed before their templates are published. The server
+discovers them through the authenticated backend source inventory and verifies
+their complete release, provenance and finality before updating the saved list.
+
+`config/module-engine/index-releases.json` binds additional Engine sources for
+the deployment read checks. Its `programmable.module-engine.index-releases.v1`
+schema contains only `schemaVersion` and `releases`. Each entry is a complete
+active Engine release, including the actual deployment, source-verification and
+lifecycle evidence digests. The canonical Engine binder verifies its identity;
+the backend remains responsible for validating the actual evidence bytes.
+The combined expected inventory is limited to 32 sources. Duplicate release
+digests or source addresses, including current and historical catalog sources,
+are rejected. Remove a technical entry when moving that same source into the
+public current or historical release configuration.
+
+The committed technical list starts empty. It is read only by deployment checks
+and grants no template availability, public launch version or backend source
+installation. Review identities are not imported into it. Before an additional
+backend source reaches the shared website index, its exact technical binding
+must be reviewed and included in the deployed website checkout. The unchanged
+runtime smoke still rejects any observed source outside those exact bindings.

--- a/scripts/perf/indexed-website-read-deploy-policy.mjs
+++ b/scripts/perf/indexed-website-read-deploy-policy.mjs
@@ -3,6 +3,7 @@
 import { appendFileSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { engineWire } from "../../contracts/scripts/module-engine/shared.mjs";
 
 import {
   evaluateReadModelDeployPolicy,
@@ -10,6 +11,7 @@ import {
 } from "./read-model-deploy-policy.mjs";
 
 export const INDEXED_WEBSITE_READ_MODE = "indexed-website-read";
+export const MODULE_ENGINE_INDEX_RELEASES_SCHEMA = "programmable.module-engine.index-releases.v1";
 export const INDEXED_WEBSITE_ROUTES = Object.freeze([
   Object.freeze({ chainId: 1, slug: "ethereum", path: "/api/explore/ethereum" }),
   Object.freeze({ chainId: 4663, slug: "robinhood", path: "/api/explore/robinhood" }),
@@ -17,10 +19,26 @@ export const INDEXED_WEBSITE_ROUTES = Object.freeze([
 
 const HASH = /^0x(?!0{64}$)[0-9a-f]{64}$/iu;
 const ADDRESS = /^0x(?!0{40}$)[0-9a-f]{40}$/iu;
+const MAX_MODULE_SOURCES = 32;
+
+function moduleSourceExpectation(release) {
+  const engine = ["module-engine-v1", "module-engine-any-quote-v1"].includes(release.sourceVersion);
+  const sourceAddress = engine
+    ? release.contracts?.host?.address : release.contracts?.launcher?.address;
+  if (release.chainId !== 4663 ||
+    !["module-native-v1", "module-native-v2", "module-engine-v1", "module-engine-any-quote-v1"].includes(release.sourceVersion) ||
+    !ADDRESS.test(sourceAddress ?? "") || !HASH.test(release.releaseDigest ?? "") ||
+    !/^[1-9][0-9]{0,19}$/u.test(release.startBlock ?? "")) {
+    throw new Error("indexed website Robinhood release identity is invalid");
+  }
+  // Authentication versions share the existing Engine index transport.
+  return Object.freeze({ source: engine ? "module-engine-v1" : release.sourceVersion, sourceVersion: release.sourceVersion,
+    sourceAddress: sourceAddress.toLowerCase(), releaseDigest: release.releaseDigest.toLowerCase(), startBlock: release.startBlock });
+}
 
 // Reuse the source identities already reviewed with this checkout. This does
 // not replace the server readers' release, provenance or finality validation.
-export function readIndexedWebsiteSourceExpectations(root = process.cwd()) {
+export async function readIndexedWebsiteSourceExpectations(root = process.cwd()) {
   const json = (path) => JSON.parse(readFileSync(resolve(root, path), "utf8"));
   const catalog = json("config/envio-classic-v4-catalog-release.v1.json");
   const envio = catalog.releaseBinding?.envio;
@@ -35,21 +53,32 @@ export function readIndexedWebsiteSourceExpectations(root = process.cwd()) {
     json("config/module-engine/robinhood.json"),
     ...json("config/module-mode/historical-releases.json").releases.map(({ release }) => release),
     ...json("config/module-engine/historical-releases.json").releases.map(({ release }) => release),
-  ].map((release) => {
-    const engine = ["module-engine-v1", "module-engine-any-quote-v1"].includes(release.sourceVersion);
-    const sourceAddress = engine
-      ? release.contracts?.host?.address : release.contracts?.launcher?.address;
-    if (release.chainId !== 4663 ||
-      !["module-native-v1", "module-native-v2", "module-engine-v1", "module-engine-any-quote-v1"].includes(release.sourceVersion) ||
-      !ADDRESS.test(sourceAddress ?? "") || !HASH.test(release.releaseDigest ?? "") ||
-      !/^[1-9][0-9]{0,19}$/u.test(release.startBlock ?? "")) {
-      throw new Error("indexed website Robinhood release identity is invalid");
+  ].map(moduleSourceExpectation);
+  const indexReleases = json("config/module-engine/index-releases.json");
+  if (!indexReleases || typeof indexReleases !== "object" || Array.isArray(indexReleases) ||
+    Object.keys(indexReleases).sort().join(",") !== "releases,schemaVersion" ||
+    indexReleases.schemaVersion !== MODULE_ENGINE_INDEX_RELEASES_SCHEMA ||
+    !Array.isArray(indexReleases.releases) || indexReleases.releases.length > MAX_MODULE_SOURCES) {
+    throw new Error("indexed website Engine index release configuration is invalid");
+  }
+  if (indexReleases.releases.length) {
+    // Explicit index bindings require the same complete release and evidence fields
+    // as the service collector. They never grant template publication or availability.
+    const { bindActiveModuleEngineRelease } = await engineWire();
+    const digests = new Set(modules.map(source => source.releaseDigest));
+    const addresses = new Set(modules.map(source => source.sourceAddress));
+    for (const value of indexReleases.releases) {
+      const release = bindActiveModuleEngineRelease(value);
+      const source = moduleSourceExpectation(release);
+      if (digests.has(source.releaseDigest) || addresses.has(source.sourceAddress)) {
+        throw new Error("indexed website Engine index release duplicates a configured source");
+      }
+      digests.add(source.releaseDigest);
+      addresses.add(source.sourceAddress);
+      modules.push(source);
     }
-    // The saved index uses one Engine transport. Keep the configured authentication
-    // version distinct; the immutable release digest still binds that exact version.
-    return Object.freeze({ source: engine ? "module-engine-v1" : release.sourceVersion, sourceVersion: release.sourceVersion, sourceAddress: sourceAddress.toLowerCase(),
-      releaseDigest: release.releaseDigest.toLowerCase(), startBlock: release.startBlock });
-  });
+    if (modules.length > MAX_MODULE_SOURCES) throw new Error("indexed website module source inventory exceeds its budget");
+  }
   const robinhood = json("contracts/deployments/robinhood-custom-launch-v1.json");
   const routerAddress = robinhood.contracts?.programmableLaunchStampRouter?.address;
   const startBlock = robinhood.deploymentEvidence?.blockNumber;
@@ -81,7 +110,7 @@ export function evaluateIndexedWebsiteReadDeployPolicy(contents) {
   });
 }
 
-function main() {
+async function main() {
   const args = {};
   const argv = process.argv.slice(2);
   for (let index = 0; index < argv.length; index += 2) {
@@ -100,7 +129,7 @@ function main() {
   );
   const policy = evaluateIndexedWebsiteReadDeployPolicy(readFileSync(resolve(args["env-file"]), "utf8"));
   if (!policy.policyReady) throw new Error(`indexed website policy rejected legacy flags: ${policy.rejectedFlagNames.join(", ")}`);
-  const sourceExpectations = readIndexedWebsiteSourceExpectations();
+  const sourceExpectations = await readIndexedWebsiteSourceExpectations();
   if (args["github-output"]) appendFileSync(resolve(args["github-output"]),
     `mode=${policy.mode}\nruntime_evidence_required=true\npublic_read_authentication=none\n`,
     { encoding: "utf8", mode: 0o600 });
@@ -108,8 +137,8 @@ function main() {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
-  try { main(); } catch (error) {
+  main().catch(error => {
     process.stderr.write(`${error instanceof Error ? error.message : "indexed website policy failed"}\n`);
     process.exitCode = 1;
-  }
+  });
 }

--- a/scripts/security/gitleaks-policy.test.mjs
+++ b/scripts/security/gitleaks-policy.test.mjs
@@ -14,6 +14,8 @@ const reviewAsset = "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512";
 const material = createHash("sha256").update("gitleaks negative control only").digest("hex");
 const catalog = "config/module-engine/catalog.json";
 const anyQuoteIndexFixture = "tests/fixtures/module-engine-any-quote-index.json";
+const visibilityTest = "tests/robinhood-website-index.test.ts";
+const anyQuoteCanary = "0xb36271399c031ce270e0d1eed5f26dcd08367119";
 // Public synthetic index evidence includes both sides of the final salt-domain correction.
 const anyQuoteAddresses = [
   "0xd803cd624d58e1f31d1043f630953e6dbdf6a128",
@@ -43,13 +45,14 @@ before(() => {
   assert.equal(version.stdout.trim(), "8.30.1");
 });
 
-function scan(t, files) {
+function scan(t, files, { raw = false } = {}) {
   const root = mkdtempSync(join(tmpdir(), "programmable-gitleaks-policy-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));
   for (const [path, value] of Object.entries(files)) {
     const target = join(root, path);
     mkdirSync(dirname(target), { recursive: true });
-    writeFileSync(target, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+    if (raw) assert.equal(typeof value, "string");
+    writeFileSync(target, `${raw ? value : JSON.stringify(value)}\n`, { mode: 0o600 });
   }
   for (const args of [["init", "--quiet"], ["add", "--force", "--", ...Object.keys(files)]]) {
     const result = spawnSync("git", args, { cwd: root, encoding: "utf8" });
@@ -151,5 +154,37 @@ test("keeps every Any Quote public fixture field detectable in adjacent and unli
       "config/module-engine/any-quote-index.json": fields,
     };
     assertFiles(scan(t, files), Object.keys(files));
+  }
+});
+
+test("accepts the exact public Any Quote canary tokenAddress field in its visibility test", (t) => {
+  assert.deepEqual(scan(t, {
+    [visibilityTest]: `const launch = { tokenAddress: "${anyQuoteCanary}", name: "Any Quote LP Internal Test", symbol: "AQLPTEST" };`,
+  }, { raw: true }), []);
+});
+
+test("keeps the public Any Quote canary detectable under a neighbouring credential field", (t) => {
+  assertFiles(scan(t, {
+    [visibilityTest]: `const launch = { tokenAddress: "${anyQuoteCanary}", apiKey: "${anyQuoteCanary}" };`,
+  }, { raw: true }), [visibilityTest]);
+});
+
+test("detects a changed tokenAddress value in the canary visibility test", (t) => {
+  assertFiles(scan(t, {
+    [visibilityTest]: `const launch = { tokenAddress: "0x${material.slice(0, 40)}" };`,
+  }, { raw: true }), [visibilityTest]);
+});
+
+test("keeps the exact canary field detectable in neighbouring and prefixed test paths", (t) => {
+  const paths = ["tests/robinhood-website-index-next.test.ts", `${visibilityTest}.backup`, `fixtures/${visibilityTest}`];
+  assertFiles(scan(t, Object.fromEntries(paths.map(path => [path,
+    `const launch = { tokenAddress: "${anyQuoteCanary}" };`,
+  ])), { raw: true }), paths);
+});
+
+test("detects another credential before or after the allowed canary field on the same line", (t) => {
+  const publicField = `tokenAddress: "${anyQuoteCanary}"`, credential = `apiKey: "${material}"`;
+  for (const fields of [`${publicField}, ${credential}`, `${credential}, ${publicField}`]) {
+    assertFiles(scan(t, { [visibilityTest]: `const launch = { ${fields} };` }, { raw: true }), [visibilityTest]);
   }
 });

--- a/scripts/smoke-indexed-website-reads.mjs
+++ b/scripts/smoke-indexed-website-reads.mjs
@@ -234,7 +234,7 @@ function htmlText(value) {
 
 async function observeReads(input, target, headers, observedAt) {
   const fetchImpl = input.fetchImpl ?? fetch;
-  const expectations = input.sourceExpectations ?? readIndexedWebsiteSourceExpectations();
+  const expectations = input.sourceExpectations ?? await readIndexedWebsiteSourceExpectations();
   async function request(path, contentType) {
     const url = new URL(path, target);
     check(url.origin === target.origin, "request origin");

--- a/scripts/test/any-quote-readiness-discovery.test.mjs
+++ b/scripts/test/any-quote-readiness-discovery.test.mjs
@@ -208,6 +208,87 @@ test("arbitrary quote readiness works without a Trading API key and independentl
   assert.ok(quotes.every(q => q.read.args[0].poolKey.fee === 0), "Empty pool is never quoted");
 });
 
+const ONE_DOLLAR_ETH = 10n ** 18n / 2500n;
+function quoteWithDepth(thinPools) {
+  return ({ method, params }) => {
+    if (method !== "eth_call") return;
+    const read = decodeFunctionData({ abi: readAbi, data: params[0].data });
+    if (read.functionName !== "quoteExactInputSingle") return;
+    const quote = read.args[0], thin = thinPools.some(p => p.poolId === a.anyQuotePoolIdV1(quote.poolKey));
+    const scale = thin ? (quote.exactAmount <= ONE_DOLLAR_ETH ? 100n : 90n) : 99n;
+    return encodeFunctionResult({ abi: readAbi, functionName: read.functionName, result: [quote.exactAmount * scale / 100n, 100_000n] });
+  };
+}
+
+test("a thin pool with the best small quote cannot displace a depth-qualified buy or sell route", async () => {
+  const thin = pool(), deep = pool(ZERO, Q, { fee: 500 });
+  const f = fixture([thin, deep], { override: quoteWithDepth([thin]) });
+  const result = await a.assessAnyQuoteAssetV1({ quoteAsset: Q }, f.options);
+  assert.equal(result.status, "compatible", JSON.stringify(result));
+  for (const side of ["buy", "sell"]) assert.equal(result.routes[side].hops[0].poolId, deep.poolId);
+  assert.equal(result.price.source, "qualified-amm");
+  const quotes = f.calls.filter(c => c.method === "eth_call")
+    .filter(c => decodeFunctionData({ abi: readAbi, data: c.params[0].data }).functionName === "quoteExactInputSingle");
+  const unique = new Set(quotes.map(c => `${c.provider}:${JSON.stringify(c.params)}`));
+  assert.equal(unique.size, quotes.length, "Final evidence reuses the same checkpoint-local depth quotes");
+});
+
+test("depth qualification retains the concrete policy failure when every candidate is too thin", async () => {
+  const pools = [pool(), pool(ZERO, Q, { fee: 500 })];
+  const f = fixture(pools, { override: quoteWithDepth(pools) });
+  const result = await a.assessAnyQuoteAssetV1({ quoteAsset: Q }, f.options);
+  assert.equal(result.status, "inconclusive"); assert.equal(result.retryable, true);
+  assert.equal(result.code, "MARKET_PRICE_IMPACT_TOO_HIGH");
+});
+
+test("direct depth failures allow an independently qualified intermediate route", async () => {
+  const thin = pool(), f = fixture([thin, pool(ZERO, MID), pool(MID, Q)], { override: quoteWithDepth([thin]) });
+  const result = await a.assessAnyQuoteAssetV1({ quoteAsset: Q }, f.options);
+  assert.equal(result.status, "compatible", JSON.stringify(result));
+  assert.deepEqual(result.routes.buy.hops.map(h => h.tokenOut.toLowerCase()), [MID, Q].map(x => x.toLowerCase()));
+  assert.deepEqual(result.routes.sell.hops.map(h => h.tokenOut.toLowerCase()), [MID, ZERO].map(x => x.toLowerCase()));
+});
+
+test("provider disagreement and malformed initial or depth quotes cannot fall back to a healthy pool", async () => {
+  const thin = pool(), deep = pool(ZERO, Q, { fee: 500 });
+  for (const stage of ["initial", "depth"]) for (const corruption of ["disagreement", "non-hex", "short-abi"]) {
+    const f = fixture([thin, deep], { override: info => {
+      if (info.method !== "eth_call") return;
+      const read = decodeFunctionData({ abi: readAbi, data: info.params[0].data });
+      if (read.functionName !== "quoteExactInputSingle") return;
+      const quote = read.args[0], targeted = quote.poolKey.fee === 0
+        && (stage === "initial" ? quote.exactAmount <= ONE_DOLLAR_ETH : quote.exactAmount > ONE_DOLLAR_ETH);
+      if (targeted && (info.provider === 1 || corruption === "short-abi")) {
+        if (corruption === "non-hex") return "malformed RPC bytes";
+        if (corruption === "short-abi") return "0x00";
+        return encodeFunctionResult({ abi: readAbi, functionName: read.functionName, result: [quote.exactAmount * 2n, 100_000n] });
+      }
+      return quoteWithDepth([thin])(info);
+    } });
+    const result = await a.assessAnyQuoteAssetV1({ quoteAsset: Q }, f.options);
+    assert.equal(result.status, "inconclusive", `${stage}/${corruption}: ${JSON.stringify(result)}`);
+    assert.equal(result.retryable, true);
+    assert.equal(result.code, corruption === "disagreement" ? "TRADE_PROVIDER_DISAGREEMENT" : "RPC_RESPONSE_INVALID");
+  }
+});
+
+test("authoritative reference-price checks qualify a candidate before its better small quote wins", async () => {
+  const asset = a.ANY_QUOTE_USDG, offReference = pool(ZERO, asset), matching = pool(ZERO, asset, { fee: 500 });
+  const f = fixture([offReference, matching], { override: info => {
+    if (info.method !== "eth_call") return;
+    const read = decodeFunctionData({ abi: readAbi, data: info.params[0].data });
+    if (read.functionName === "decimals" && info.params[0].to.toLowerCase() === "0x61b7e5650328764b076a108eff5fa7282a1b9ad2")
+      return encodeFunctionResult({ abi: readAbi, functionName: read.functionName, result: 8 });
+    if (read.functionName === "getSlot0" && read.args[0] === offReference.poolId)
+      return encodeFunctionResult({ abi: readAbi, functionName: read.functionName, result: [2n << 96n, 0, 0, 0] });
+    return quoteWithDepth([offReference])(info);
+  } });
+  const result = await a.assessAnyQuoteAssetV1({ quoteAsset: asset }, f.options);
+  assert.equal(result.status, "compatible", JSON.stringify(result));
+  assert.equal(result.routes.buy.hops[0].poolId, matching.poolId);
+  assert.equal(result.price.source, "chainlink");
+});
+
 test("discovery composes a native path through one independently verified intermediate", async () => {
   const f = fixture([pool(ZERO, MID), pool(MID, Q)]);
   const result = await a.assessAnyQuoteAssetV1({ quoteAsset: Q }, f.options);

--- a/scripts/test/any-quote-readiness-discovery.test.mjs
+++ b/scripts/test/any-quote-readiness-discovery.test.mjs
@@ -59,7 +59,7 @@ function fixture(pools, options = {}) {
       if (result !== undefined) return result;
     }
     if (method === "eth_chainId") return "0x1237";
-    if (method === "eth_getBlockByNumber") return { number: toHex(HEIGHT), hash: HASH, timestamp: toHex(NOW) };
+    if (method === "eth_getBlockByNumber") return { number: toHex(options.height ?? HEIGHT), hash: HASH, timestamp: toHex(NOW) };
     if (method === "eth_getCode") return fixtureCode.get(params[0].toLowerCase()) ?? "0x600055";
     if (method === "eth_getLogs") return filterLogs(records, params[0]);
     if (method !== "eth_call") throw Error("Unexpected fixture RPC method");
@@ -98,7 +98,7 @@ test("Initialize records bind the real key, indexed asset, manager and canonical
 });
 
 test("request-local discovery uses both providers and caches direct-pair logs for reverse routes", async () => {
-  const f = fixture([pool()]), discovery = a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint, agreed: a.agreedTradeRpcV1(f.rpcs) });
+  const f = fixture([pool()]), discovery = a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint, rpcs: f.rpcs });
   const [first, second] = await Promise.all([discovery.nativePools(Q), discovery.nativePools(Q)]);
   assert.deepEqual(first, second); assert.equal(first.length, 1);
   assert.equal(f.calls.length, 2); assert.deepEqual(f.calls.map(c => c.provider), [0, 1]);
@@ -108,16 +108,89 @@ test("request-local discovery uses both providers and caches direct-pair logs fo
 
 test("provider range limits split complete bounded ranges; failures and disagreement remain inconclusive", async () => {
   const f = fixture([pool()], { override: ({ method, params }) => { if (method === "eth_getLogs" && BigInt(params[0].toBlock) - BigInt(params[0].fromBlock) > 6000n) throw Error("range limit"); } });
-  const discovery = a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint, agreed: a.agreedTradeRpcV1(f.rpcs) });
+  const discovery = a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint, rpcs: f.rpcs });
   assert.equal((await discovery.nativePools(Q)).length, 1);
   assert.equal(f.calls.length, 6);
   const failed = fixture([], { override: () => { throw Error("Private provider details must not leak"); } });
-  await assert.rejects(() => a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint, agreed: a.agreedTradeRpcV1(failed.rpcs) }).nativePools(Q),
+  await assert.rejects(() => a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint, rpcs: failed.rpcs }).nativePools(Q),
     error => error.code === "V4_DISCOVERY_PROVIDER_UNAVAILABLE" && error.status === "inconclusive");
   assert.ok(failed.calls.length <= 14);
   const disagree = fixture([pool()], { override: ({ provider }) => provider === 1 ? [] : undefined });
-  await assert.rejects(() => a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint, agreed: a.agreedTradeRpcV1(disagree.rpcs) }).nativePools(Q), /V4_DISCOVERY_PROVIDER_DISAGREEMENT/);
+  await assert.rejects(() => a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint, rpcs: disagree.rpcs }).nativePools(Q), /V4_DISCOVERY_PROVIDER_DISAGREEMENT/);
   assert.equal(disagree.calls.length, 2);
+});
+
+const LONG_HEIGHT = 60_000_000n;
+const longCheckpoint = { ...checkpoint, number: String(LONG_HEIGHT) };
+const wideRange = params => BigInt(params[0].toBlock) - BigInt(params[0].fromBlock) >= 10_000n;
+function quickNodeRangeLimit({ provider, method, params }) {
+  if (provider === 0 && method === "eth_getLogs" && wideRange(params)) {
+    throw Object.assign(Error("eth_getLogs is limited to a 10,000 range"), { status: 413, code: -32614 });
+  }
+}
+
+test("60-million-block discovery verifies single-provider hints through both original RPCs in 10,000-block windows", async () => {
+  const f = fixture([pool(), pool(ZERO, Q, { fee: 500, block: 19_999n }), pool(ZERO, Q, { fee: 3000, block: 50_000_000n })], { override: quickNodeRangeLimit });
+  const discovery = a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint: longCheckpoint, rpcs: f.rpcs });
+  const result = await discovery.nativePools(Q);
+  assert.equal(result.length, 3);
+  assert.equal(discovery.hasIncompleteCoverage(), true, "Verified candidates do not certify single-source index completeness");
+  assert.equal(f.calls.length, 6, "One full-range attempt and two shared verification windows, each on both providers");
+  const verifications = f.calls.slice(2);
+  assert.ok(verifications.every(c => !wideRange(c.params)));
+  assert.deepEqual(verifications.map(c => c.provider), [0, 1, 0, 1]);
+  assert.deepEqual(await discovery.nativePools(Q), result);
+  assert.equal(f.calls.length, 6, "Reverse discovery reuses verified records");
+});
+
+test("invented hints and narrow-range provider disagreement fail closed without another fallback", async () => {
+  const p = pool(), real = log(p);
+  for (const override of [
+    info => { quickNodeRangeLimit(info); if (info.provider === 1 && wideRange(info.params)) return [{ ...real, blockHash: `0x${"bb".repeat(32)}` }]; },
+    info => { quickNodeRangeLimit(info); if (info.provider === 0) return []; },
+  ]) {
+    const f = fixture([p], { override });
+    await assert.rejects(() => a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint: longCheckpoint, rpcs: f.rpcs }).nativePools(Q),
+      error => error.code === "V4_DISCOVERY_PROVIDER_DISAGREEMENT" && error.status === "inconclusive");
+    assert.equal(f.calls.length, 4, "A rejected hint or disagreement cannot fall back to a preferred provider");
+  }
+  const disagree = fixture([p], { override: ({ provider }) => provider === 0 ? [] : undefined });
+  await assert.rejects(() => a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint: longCheckpoint, rpcs: disagree.rpcs }).nativePools(Q), /V4_DISCOVERY_PROVIDER_DISAGREEMENT/);
+  assert.equal(disagree.calls.length, 2, "Full-range disagreement is also terminal");
+});
+
+test("malformed successful responses are never treated as unavailable providers or accepted hints", async () => {
+  for (const provider of [0, 1]) {
+    const f = fixture([pool()], { override: info => {
+      if (info.provider === provider) return [{ ...log(pool()), data: "0x00" }];
+      quickNodeRangeLimit(info);
+    } });
+    await assert.rejects(() => a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint: longCheckpoint, rpcs: f.rpcs }).nativePools(Q),
+      error => error.code === "V4_DISCOVERY_RESPONSE_INVALID" && error.status === "inconclusive");
+    assert.equal(f.calls.length, 2);
+  }
+});
+
+test("hint verification retains the fixed request budget and never accepts an unverified pool", async () => {
+  const f = fixture(Array.from({ length: 24 }, (_, i) => pool(ZERO, Q, { fee: i * 500, block: 10_000n + BigInt(i) * 10_000n })), { override: quickNodeRangeLimit });
+  await assert.rejects(() => a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint: longCheckpoint, rpcs: f.rpcs }).nativePools(Q),
+    error => error.code === "V4_DISCOVERY_REQUEST_LIMIT" && error.status === "inconclusive");
+  assert.equal(f.calls.length, 2, "An over-budget hint set stops before requesting verification windows");
+});
+
+test("empty direct hints still allow an independently verified indirect route; empty coverage stays inconclusive", async () => {
+  const options = { height: LONG_HEIGHT, override: quickNodeRangeLimit };
+  const f = fixture([pool(ZERO, MID), pool(MID, Q)], options);
+  const result = await a.assessAnyQuoteAssetV1({ quoteAsset: Q }, f.options);
+  assert.equal(result.status, "compatible", JSON.stringify(result));
+  assert.deepEqual(result.routes.buy.hops.map(h => h.tokenOut.toLowerCase()), [MID, Q].map(x => x.toLowerCase()));
+  assert.deepEqual(result.routes.sell.hops.map(h => h.tokenOut.toLowerCase()), [MID, ZERO].map(x => x.toLowerCase()));
+  const reads = f.calls.filter(c => c.method === "eth_getLogs");
+  assert.equal(reads.length, 12, "Four discovery attempts and two verification windows on each original provider");
+  const absent = await a.assessAnyQuoteAssetV1({ quoteAsset: Q }, fixture([], options).options);
+  assert.equal(absent.status, "inconclusive");
+  assert.equal(absent.code, "V4_DISCOVERY_PROVIDER_UNAVAILABLE");
+  assert.equal(absent.retryable, true);
 });
 
 test("arbitrary quote readiness works without a Trading API key and independently requotes both directions", async () => {

--- a/scripts/test/any-quote-readiness-discovery.test.mjs
+++ b/scripts/test/any-quote-readiness-discovery.test.mjs
@@ -249,6 +249,23 @@ test("direct depth failures allow an independently qualified intermediate route"
   assert.deepEqual(result.routes.sell.hops.map(h => h.tokenOut.toLowerCase()), [MID, ZERO].map(x => x.toLowerCase()));
 });
 
+test("a reverted candidate quote stays non-executable without treating malformed successful data as a revert", async () => {
+  const reverting = pool(), deep = pool(ZERO, Q, { fee: 500 }), rejectedBy = new Set();
+  const f = fixture([reverting, deep], { override: info => {
+    if (info.method !== "eth_call") return;
+    const read = decodeFunctionData({ abi: readAbi, data: info.params[0].data });
+    if (read.functionName === "quoteExactInputSingle" && read.args[0].poolKey.fee === 0) {
+      rejectedBy.add(info.provider);
+      throw Object.assign(Error("execution reverted"), { code: 3, data: "0x" });
+    }
+    return quoteWithDepth([])(info);
+  } });
+  const result = await a.assessAnyQuoteAssetV1({ quoteAsset: Q }, f.options);
+  assert.equal(result.status, "compatible", JSON.stringify(result));
+  assert.deepEqual([...rejectedBy], [0, 1], "Both RPCs rejected the non-executable candidate call");
+  for (const side of ["buy", "sell"]) assert.equal(result.routes[side].hops[0].poolId, deep.poolId);
+});
+
 test("provider disagreement and malformed initial or depth quotes cannot fall back to a healthy pool", async () => {
   const thin = pool(), deep = pool(ZERO, Q, { fee: 500 });
   for (const stage of ["initial", "depth"]) for (const corruption of ["disagreement", "non-hex", "short-abi"]) {

--- a/scripts/test/indexed-website-reads.test.mjs
+++ b/scripts/test/indexed-website-reads.test.mjs
@@ -6,37 +6,41 @@ import test from "node:test";
 import { encodeAbiParameters, keccak256 } from "viem";
 
 import { RELEASE_GATED_FLAG_NAMES, WORKER_ACTIVATION_FLAG_NAMES } from "../perf/read-model-deploy-policy.mjs";
-import { evaluateIndexedWebsiteReadDeployPolicy, readIndexedWebsiteSourceExpectations } from "../perf/indexed-website-read-deploy-policy.mjs";
+import { evaluateIndexedWebsiteReadDeployPolicy, readIndexedWebsiteSourceExpectations, MODULE_ENGINE_INDEX_RELEASES_SCHEMA } from "../perf/indexed-website-read-deploy-policy.mjs";
 import { runIndexedWebsiteReadSmoke } from "../smoke-indexed-website-reads.mjs";
+import { engineWire } from "../../contracts/scripts/module-engine/shared.mjs";
 
 const NOW = Date.parse("2026-09-09T03:00:00.000Z");
 const UPDATED = new Date(NOW - 60_000).toISOString();
 const ADDRESS = (n) => `0x${n.toString(16).padStart(40, "0")}`;
 const HASH = (n) => `0x${n.toString(16).padStart(64, "0")}`;
 const DIGEST = `sha256:${"a".repeat(64)}`;
-const EXPECTATIONS = readIndexedWebsiteSourceExpectations();
+const EXPECTATIONS = await readIndexedWebsiteSourceExpectations();
 const DEPLOYMENT_ID = `dpl_${"a".repeat(24)}`;
 const SHA = "b".repeat(40);
 const BYPASS = "fixture-protection-bypass-0123456789";
 const PROJECT = "prj_programmablefixture";
 const PROJECTION_SOURCE = "https://api.programmable.market/v4/chains/4663/finalized-launch-projections";
 
-function sourceConfiguration(t, engineRelease) {
+function sourceConfiguration(t, engineRelease,
+  indexReleases = JSON.parse(readFileSync("config/module-engine/index-releases.json", "utf8"))) {
   const root = mkdtempSync(join(tmpdir(), "indexed-website-sources-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));
   for (const file of ["config/envio-classic-v4-catalog-release.v1.json", "config/module-mode/robinhood.preview.json",
     "config/module-engine/robinhood.json", "config/module-mode/historical-releases.json",
-    "config/module-engine/historical-releases.json", "contracts/deployments/robinhood-custom-launch-v1.json"]) {
+    "config/module-engine/historical-releases.json", "config/module-engine/index-releases.json",
+    "config/module-engine/catalog.json", "config/module-engine/review-release.json", "contracts/deployments/robinhood-custom-launch-v1.json"]) {
     const target = join(root, file);
     mkdirSync(dirname(target), { recursive: true });
-    writeFileSync(target, file === "config/module-engine/robinhood.json" ? JSON.stringify(engineRelease) : readFileSync(file));
+    writeFileSync(target, file === "config/module-engine/robinhood.json" && engineRelease !== undefined ? JSON.stringify(engineRelease)
+      : file === "config/module-engine/index-releases.json" ? JSON.stringify(indexReleases) : readFileSync(file));
   }
   return root;
 }
 
 test("Any Quote retains its authentication version and uses the existing Engine index transport", async t => {
   const release = JSON.parse(readFileSync("tests/fixtures/module-engine-any-quote-index.json", "utf8")).cases[0].release;
-  const root = sourceConfiguration(t, release), expectations = readIndexedWebsiteSourceExpectations(root);
+  const root = sourceConfiguration(t, release), expectations = await readIndexedWebsiteSourceExpectations(root);
   assert.deepEqual(expectations.robinhood.modules[1], { source: "module-engine-v1", sourceVersion: release.sourceVersion,
     sourceAddress: release.contracts.host.address, releaseDigest: release.releaseDigest, startBlock: release.startBlock });
   assert.equal(JSON.parse(readFileSync(join(root, "config/module-engine/robinhood.json"), "utf8")).sourceVersion, "module-engine-any-quote-v1");
@@ -55,7 +59,7 @@ test("Any Quote retains its authentication version and uses the existing Engine 
   await assert.rejects(runIndexedWebsiteReadSmoke(input({ fetchImpl: observations(release.sourceVersion).fetchImpl, sourceExpectations: expectations })), /module release binding/u);
 });
 
-test("source expectations reject unsupported authentication versions and wrong source-role dispatch", t => {
+test("source expectations reject unsupported authentication versions and wrong source-role dispatch", async t => {
   const release = JSON.parse(readFileSync("tests/fixtures/module-engine-any-quote-index.json", "utf8")).cases[0].release;
   for (const mutate of [
     value => { value.sourceVersion = "module-engine-any-quote-v2"; },
@@ -66,10 +70,99 @@ test("source expectations reject unsupported authentication versions and wrong s
     value => { value.startBlock = "0"; },
   ]) {
     const changed = structuredClone(release); mutate(changed);
-    assert.throws(() => readIndexedWebsiteSourceExpectations(sourceConfiguration(t, changed)), /Robinhood release identity is invalid/u);
+    await assert.rejects(readIndexedWebsiteSourceExpectations(sourceConfiguration(t, changed)), /Robinhood release identity is invalid/u);
   }
   for (const source of EXPECTATIONS.robinhood.modules) assert.equal(source.source,
     source.sourceVersion === "module-engine-any-quote-v1" ? "module-engine-v1" : source.sourceVersion);
+});
+
+function indexConfiguration(t, releases) {
+  return sourceConfiguration(t, undefined, { schemaVersion: MODULE_ENGINE_INDEX_RELEASES_SCHEMA, releases });
+}
+
+function engineSourceObservation(release) {
+  return fixture(({ url, spec }) => {
+    if (url.pathname !== "/api/explore/robinhood") return;
+    // The source still appears when its canary token is excluded from Explore items.
+    spec.body.sourceEvidence.modules = [{ ...robinhoodSource(), source: "module-engine-v1",
+      sourceAddress: release.contracts.host.address, releaseDigest: release.releaseDigest, startBlock: release.startBlock }];
+  });
+}
+
+test("an empty technical index list retains public source expectations and ignores review-only identity", async t => {
+  const root = indexConfiguration(t, []);
+  const before = await readIndexedWebsiteSourceExpectations(root);
+  const release = JSON.parse(readFileSync("tests/fixtures/module-engine-any-quote-index.json", "utf8")).cases[0].release;
+  writeFileSync(join(root, "config/module-engine/review-release.json"), JSON.stringify(release));
+  const expectations = await readIndexedWebsiteSourceExpectations(root);
+  assert.deepEqual(expectations, before);
+  const currentAndHistorical = [JSON.parse(readFileSync("config/module-mode/robinhood.preview.json", "utf8")),
+    JSON.parse(readFileSync("config/module-engine/robinhood.json", "utf8")),
+    ...JSON.parse(readFileSync("config/module-mode/historical-releases.json", "utf8")).releases.map(entry => entry.release),
+    ...JSON.parse(readFileSync("config/module-engine/historical-releases.json", "utf8")).releases.map(entry => entry.release)];
+  assert.deepEqual(expectations.robinhood.modules.map(source => source.releaseDigest), currentAndHistorical.map(source => source.releaseDigest));
+  await assert.rejects(runIndexedWebsiteReadSmoke(input({ sourceExpectations: expectations,
+    fetchImpl: engineSourceObservation(release).fetchImpl })), /Robinhood module release binding/u);
+});
+
+test("a complete technical Any Quote release binds index reads without changing the public catalogs", async t => {
+  const release = JSON.parse(readFileSync("tests/fixtures/module-engine-any-quote-index.json", "utf8")).cases[0].release;
+  const publicExpectations = await readIndexedWebsiteSourceExpectations(indexConfiguration(t, []));
+  const root = indexConfiguration(t, [release]), expectations = await readIndexedWebsiteSourceExpectations(root);
+  assert.deepEqual(expectations.robinhood.modules.slice(0, -1), publicExpectations.robinhood.modules);
+  assert.deepEqual(expectations.robinhood.modules.at(-1), { source: "module-engine-v1", sourceVersion: release.sourceVersion,
+    sourceAddress: release.contracts.host.address, releaseDigest: release.releaseDigest, startBlock: release.startBlock });
+  for (const path of ["config/module-engine/robinhood.json", "config/module-engine/catalog.json", "config/module-engine/historical-releases.json"]) {
+    assert.deepEqual(readFileSync(join(root, path)), readFileSync(path));
+  }
+  const result = await runIndexedWebsiteReadSmoke(input({ sourceExpectations: expectations,
+    fetchImpl: engineSourceObservation(release).fetchImpl }));
+  assert.equal(result.chains[1].pages[0].sourceEvidence.modules[0].releaseDigest, release.releaseDigest);
+  assert.equal(result.chains[1].totalItems, 1);
+});
+
+test("technical index sources require complete canonical identity and nonzero evidence commitments", async t => {
+  const release = JSON.parse(readFileSync("tests/fixtures/module-engine-any-quote-index.json", "utf8")).cases[0].release;
+  const mutations = [
+    value => { value.enabled = false; },
+    value => { value.status = "preview"; },
+    value => { value.sourceVersion = "module-engine-any-quote-v2"; },
+    value => { value.engineProfile = "programmable.module-engine-solidity@1"; },
+    value => { value.chainId = 1; },
+    value => { value.releaseDigest = HASH(99); },
+    value => { value.startBlock = String(BigInt(value.startBlock) + 1n); },
+    value => { value.contracts.host.address = ADDRESS(999); },
+    value => { value.contracts.host.runtimeCodeHash = HASH(999); },
+    value => { delete value.contracts.nativeRouteGuard; },
+    value => { value.contracts.unexpected = value.contracts.host; },
+    value => { value.unreviewed = true; },
+  ];
+  for (const field of ["deploymentEvidenceDigest", "sourceVerificationDigest", "lifecycleEvidenceDigest"]) {
+    mutations.push(value => { delete value[field]; }, value => { value[field] = HASH(0); }, value => { value[field] = "not-evidence"; });
+  }
+  for (const mutate of mutations) {
+    const changed = structuredClone(release); mutate(changed);
+    await assert.rejects(readIndexedWebsiteSourceExpectations(indexConfiguration(t, [changed])));
+  }
+  await assert.rejects(readIndexedWebsiteSourceExpectations(indexConfiguration(t, [{ sourceVersion: release.sourceVersion,
+    chainId: 4663, sourceAddress: release.contracts.host.address, releaseDigest: release.releaseDigest, startBlock: release.startBlock }])));
+});
+
+test("technical index configuration is closed, bounded and rejects duplicate or conflicting sources", async t => {
+  const release = JSON.parse(readFileSync("tests/fixtures/module-engine-any-quote-index.json", "utf8")).cases[0].release;
+  for (const value of [null, [], { releases: [] }, { schemaVersion: MODULE_ENGINE_INDEX_RELEASES_SCHEMA, releases: [], review: true },
+    { schemaVersion: "programmable.module-engine.index-releases.v2", releases: [] },
+    { schemaVersion: MODULE_ENGINE_INDEX_RELEASES_SCHEMA, releases: {} },
+    { schemaVersion: MODULE_ENGINE_INDEX_RELEASES_SCHEMA, releases: Array(33).fill(release) }]) {
+    await assert.rejects(readIndexedWebsiteSourceExpectations(sourceConfiguration(t, undefined, value)), /index release configuration/u);
+  }
+  await assert.rejects(readIndexedWebsiteSourceExpectations(indexConfiguration(t, [release, release])), /duplicates/u);
+  const current = JSON.parse(readFileSync("config/module-engine/robinhood.json", "utf8"));
+  await assert.rejects(readIndexedWebsiteSourceExpectations(indexConfiguration(t, [current])), /duplicates/u);
+  const { computeModuleEngineReleaseDigest } = await engineWire();
+  const changed = { ...release, startBlock: String(BigInt(release.startBlock) + 1n) };
+  changed.releaseDigest = computeModuleEngineReleaseDigest(changed);
+  await assert.rejects(readIndexedWebsiteSourceExpectations(indexConfiguration(t, [release, changed])), /duplicates/u);
 });
 
 function ethereumItem(n) {

--- a/tests/any-quote-integration.test.ts
+++ b/tests/any-quote-integration.test.ts
@@ -11,7 +11,8 @@ import { anyQuoteEvidenceHashV1, anyQuoteModulePoolKeyV1, anyQuotePoolIdV1, buil
 import { planAnyQuoteInitialPriceV1, encodeAnyQuoteConfigurationV1 } from "@/lib/module-engine/any-quote/price";
 import { anyQuoteLaunchIntent, anyQuoteMinimumOutput, anyQuotePoolFor, assertAnyQuoteConfiguration, assertAnyQuoteLaunchPreparation, predictAnyQuoteToken, type AnyQuoteLaunchPreparation, type AnyQuoteTradeQuote } from "@/lib/module-engine/any-quote/integration";
 import { compileModuleEngineLaunch, predictModuleEngineAddress } from "@/lib/module-engine/operation-plan";
-import { prepareModuleEngineAnyQuoteSwap, prepareModuleEngineClaim, readModuleEngineLaunch, readModuleEngineAdministration, readModuleEngineFeeControls, prepareModuleEngineFeeChange, revalidateModuleEngineTransaction, releaseModuleEnginePreparation, verifyModuleEngineLaunchReceipt, verifyModuleEngineClaimReceipt } from "@/lib/module-engine/client";
+import { prepareModuleEngineAnyQuoteSwap, prepareModuleEngineApproval, prepareModuleEngineClaim, readModuleEngineLaunch, readModuleEngineAdministration, readModuleEngineFeeControls, prepareModuleEngineFeeChange, revalidateModuleEngineTransaction, releaseModuleEnginePreparation, verifyModuleEngineLaunchReceipt, verifyModuleEngineClaimReceipt } from "@/lib/module-engine/client";
+import { assertModuleEngineOperationAvailability, fetchModuleEngineAvailability } from "@/lib/module-engine/availability-client";
 import { ENGINE_CONTEXT, moduleEngineAnyQuoteHookAbi, moduleEngineAnyQuoteLedgerAbi, moduleEngineHostAbi, moduleEngineLaunchParameters, moduleEnginePlanParameters } from "@/lib/module-engine/abi";
 import { readAnyQuoteLaunchPreview, readAnyQuoteReadiness } from "@/lib/server/module-engine/any-quote";
 import { readAnyQuoteIdentityLaunchPreviewV1 } from "@/lib/server/module-engine/any-quote-preparation";
@@ -264,6 +265,52 @@ describe("Any Quote source identity lifecycle preparation", () => {
 });
 
 describe("Any Quote financial integration", () => {
+  it("preserves public availability for genuine sell approvals and rejects other funding authorities", async () => {
+    const fetcher = vi.spyOn(globalThis, "fetch");
+    try {
+      for (const allowanceKind of ["erc20", "permit2"] as const) {
+        const f = tradeFixture(false); f.state.allowance = allowanceKind === "erc20" ? 0n : 1000n; f.allowance.amount = 0n;
+        vi.mocked(f.client.call).mockResolvedValue({ data: "0x" });
+        const required = await prepareModuleEngineAnyQuoteSwap({ ...f, account: ACCOUNT });
+        expect(required).toMatchObject({ kind: "approval-required", allowanceKind, spender: ANY_QUOTE_INFRASTRUCTURE.permit2 });
+        if (required.kind !== "approval-required") throw new Error("Expected the sell's funding approval");
+        const prepared = await prepareModuleEngineApproval({ ...required, client: f.client, release: f.release, account: ACCOUNT });
+        expect(prepared).toMatchObject({ kind: "approve", allowanceKind, amount: 1000n, spender: ANY_QUOTE_INFRASTRUCTURE.permit2 });
+        if (allowanceKind === "erc20") expect(prepared).not.toHaveProperty("permit2Spender");
+        else expect(prepared.permit2Spender).toBe(f.identity.contracts.universalRouter.address);
+
+        fetcher.mockImplementation(async () => Response.json(f.availability));
+        const current = await fetchModuleEngineAvailability(prepared.releaseDigest);
+        expect(() => assertModuleEngineOperationAvailability(prepared, f.availability, current)).not.toThrow();
+        await expect(revalidateModuleEngineTransaction(prepared, ACCOUNT)).resolves.toBe(prepared.transaction);
+        for (const spender of [f.release.contracts.host.address, addr(999)]) {
+          expect(() => assertModuleEngineOperationAvailability({ ...prepared, spender }, f.availability, current)).toThrow("funding contract");
+        }
+        expect(() => assertModuleEngineOperationAvailability({ ...prepared, permit2Spender: addr(999) }, f.availability, current)).toThrow("funding contract");
+        if (allowanceKind === "permit2") {
+          expect(() => assertModuleEngineOperationAvailability({ ...prepared, permit2Spender: undefined }, f.availability, current)).toThrow("funding contract");
+        }
+        expect(() => assertModuleEngineOperationAvailability(prepared, f.availability, { ...current, templates: [] })).toThrow("funding contract");
+        const replacement = structuredClone(current);
+        if (!replacement.release || !("universalRouter" in replacement.release.contracts)) throw new Error("Expected the shared release");
+        replacement.release.contracts.universalRouter = { ...replacement.release.contracts.universalRouter, address: addr(999) };
+        replacement.release.releaseDigest = computeModuleEngineReleaseDigest(replacement.release);
+        replacement.templates = [];
+        expect(() => assertModuleEngineOperationAvailability(prepared, f.availability, replacement)).toThrow("template version changed");
+      }
+
+      const legacy = fixture(); vi.mocked(legacy.client.call).mockResolvedValue({ data: "0x" });
+      const prepared = await prepareModuleEngineApproval({ client: legacy.client, release: legacy.release, account: ACCOUNT, token: QUOTE, amount: 1000n });
+      expect(prepared.spender).toBe(legacy.release.contracts.host.address);
+      expect(prepared).not.toHaveProperty("allowanceKind");
+      fetcher.mockImplementation(async () => Response.json(legacy.availability));
+      const current = await fetchModuleEngineAvailability(prepared.releaseDigest);
+      expect(() => assertModuleEngineOperationAvailability(prepared, legacy.availability, current)).not.toThrow();
+      await expect(revalidateModuleEngineTransaction(prepared, ACCOUNT)).resolves.toBe(prepared.transaction);
+      expect(() => assertModuleEngineOperationAvailability({ ...prepared, spender: ANY_QUOTE_INFRASTRUCTURE.permit2 }, legacy.availability, current)).toThrow("funding contract");
+      expect(() => assertModuleEngineOperationAvailability({ ...prepared, allowanceKind: "permit2", permit2Spender: ANY_QUOTE_INFRASTRUCTURE.universalRouter }, legacy.availability, current)).toThrow("funding contract");
+    } finally { fetcher.mockRestore(); }
+  });
   it("binds the real ledger commitment separately from Host config and retains claims after creator rotation", async () => {
     const f = sharedFixture();
     expect(f.feeState.configurationHash).not.toBe(f.launch.configurationHash);

--- a/tests/module-engine-catalog.test.ts
+++ b/tests/module-engine-catalog.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { keccak256, type Address, type Hex } from "viem";
 import frozen from "./fixtures/module-engine-review-build.json";
+import anyQuoteIndex from "./fixtures/module-engine-any-quote-index.json";
+import configuredRelease from "../config/module-engine/robinhood.json";
 import { bindActiveModuleEngineRelease, computeModuleEngineHostManifestHash, computeModuleEngineReleaseDigest, MODULE_ENGINE_AVAILABILITY_SCHEMA, MODULE_ENGINE_CONTRACTS, type ModuleEngineAvailability, type ModuleEngineCatalogDefinition, type ModuleEngineRelease, type ModuleEngineRevisionDefinition } from "../lib/module-engine/catalog";
 import { MODULE_MODE_ECONOMICS_POLICY_V2, MODULE_MODE_FINALITY_POLICY } from "../lib/module-mode/release";
 import { reviewDigest, type ReviewSubject } from "../lib/module-mode/review-contract";
@@ -209,6 +211,29 @@ describe("bounded Engine availability using the existing source authority", () =
 });
 
 describe("exact historical Engine generations", () => {
+  it("keeps technical index releases out of public availability and launch versions", async () => {
+    const before = await import("../lib/server/module-engine/catalog");
+    const digests = before.configuredModuleEngineReleaseDigests();
+    const release = bindActiveModuleEngineRelease(configuredRelease);
+    const read = vi.fn(async (): Promise<ModuleEngineAvailability> => ({ schemaVersion: MODULE_ENGINE_AVAILABILITY_SCHEMA,
+      release, templates: [], reason: null }));
+    const versions = await before.readModuleEngineLaunchVersions({ digests, read });
+    const technical = anyQuoteIndex.cases[0].release;
+    vi.doMock("../config/module-engine/index-releases.json", () => ({ default: {
+      schemaVersion: "programmable.module-engine.index-releases.v1", releases: [technical],
+    } }));
+    vi.resetModules();
+    try {
+      const after = await import("../lib/server/module-engine/catalog");
+      expect(after.configuredModuleEngineReleaseDigests()).toEqual(digests);
+      expect(after.configuredModuleEngineReleaseDigests()).not.toContain(technical.releaseDigest);
+      expect(await after.readModuleEngineLaunchVersions({ digests: after.configuredModuleEngineReleaseDigests(), read })).toEqual(versions);
+      expect((await after.readModuleEngineAvailability(technical.releaseDigest)).release).toBeNull();
+    } finally {
+      vi.doUnmock("../config/module-engine/index-releases.json");
+      vi.resetModules();
+    }
+  });
   it("retains an authenticated historical template without sampling mutable revision enablement", async () => {
     const f = fixture();
     const read = createModuleEngineHistoricalAvailabilityReader({ historical: { schemaVersion: MODULE_ENGINE_HISTORICAL_RELEASES_SCHEMA,

--- a/tests/module-mode-launch-ui.test.tsx
+++ b/tests/module-mode-launch-ui.test.tsx
@@ -2,7 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import { ModuleModeBuilder } from "@/components/module-mode-builder";
-import { ModuleModeLaunchResult } from "@/components/module-mode-launch-host";
+import { ModuleModeAnyQuoteLaunchEntry, ModuleModeLaunchResult } from "@/components/module-mode-launch-host";
 import { ModuleSchemaField } from "@/components/module-mode-fields";
 import { bindActiveModuleModeRelease, computeModuleModeReleaseDigest, MODULE_MODE_ECONOMICS_POLICY_V2 } from "@/lib/module-mode/release";
 import { moduleEvidenceFixture, a } from "./fixtures/module-mode-evidence";
@@ -17,6 +17,18 @@ const token = `0x${"12".repeat(20)}` as const;
 const transactionHash = `0x${"34".repeat(32)}` as const;
 
 describe("Module Mode launch presentation", () => {
+  it("names the Any Quote setup without version controls and disables entry during an existing wallet flow", () => {
+    const onSelect = vi.fn();
+    const available = renderToStaticMarkup(<ModuleModeAnyQuoteLaunchEntry disabled={false} onSelect={onSelect} />);
+    expect(available).toContain("Any Quote LP");
+    expect(available).toContain("Start a coin paired with a compatible token of your choice. Trade with ETH.");
+    expect(available).toContain('aria-labelledby="module-any-quote-title"');
+    expect(available).toMatch(/<button[^>]+type="button"[^>]*>Use Any Quote LP /);
+    expect(available).not.toMatch(/<select|Module version|sourceKind|releaseDigest/);
+    const locked = renderToStaticMarkup(<ModuleModeAnyQuoteLaunchEntry disabled onSelect={onSelect} />);
+    expect(locked).toMatch(/<button[^>]+disabled=""/);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
   it("renders the released plain fee for each generation and no V2 fee under a V1 release", () => {
     const v1 = bindActiveModuleModeRelease(moduleEvidenceFixture().release);
     const identity = { ...v1, schemaVersion: "programmable.module-mode-source.v2", sourceVersion: "module-native-v2", economicsPolicyId: MODULE_MODE_ECONOMICS_POLICY_V2 };

--- a/tests/module-mode-source-routing.test.tsx
+++ b/tests/module-mode-source-routing.test.tsx
@@ -3,9 +3,13 @@ import { ModuleEngineHost } from "@/components/module-engine-host";
 import { ModuleModeLaunchHost } from "@/components/module-mode-launch-host";
 import { ModuleCoinConsole } from "@/components/module-coin-console";
 import { fixture, TOKEN, hash } from "./module-engine-fixture";
+import { anyQuoteUiFixture } from "./module-engine-any-quote-ui-fixture";
+import reviewedAnyQuoteRelease from "@/config/module-engine/review-release.json";
+import { createAnyQuoteConfigurationSchema } from "@/lib/module-engine/any-quote-configuration";
+import { isModuleEngineAnyQuoteRelease } from "@/lib/module-engine/profile";
 import engineEvidence from "./fixtures/module-engine-index.json";
 import { normalizeModuleEngineLaunchV1 } from "@/lib/module-engine/index/provenance-v1";
-import { bindActiveModuleEngineRelease } from "@/lib/module-engine/catalog";
+import { bindActiveModuleEngineRelease, computeModuleEngineHostManifestHash, moduleEngineReleaseIdentity } from "@/lib/module-engine/catalog";
 import { moduleEnginePublicLaunch } from "@/lib/server/robinhood-index/module-source";
 const mocks = vi.hoisted(() => ({ native: vi.fn(), engine: vi.fn(), nativeVersions: vi.fn(), engineVersions: vi.fn(), token: vi.fn() }));
 vi.mock("@/components/module-engine-host", () => ({ ModuleEngineHost: () => null }));
@@ -20,7 +24,18 @@ import { GET } from "@/app/api/module-mode/route";
 import Page from "@/app/launch/modules/page";
 import ManagePage from "@/app/launch/modules/manage/[address]/page";
 
-beforeEach(() => { vi.clearAllMocks(); mocks.nativeVersions.mockResolvedValue([]); mocks.engineVersions.mockResolvedValue([]); mocks.token.mockResolvedValue({ token: null }); });
+beforeEach(() => { vi.clearAllMocks(); mocks.nativeVersions.mockResolvedValue([]); mocks.engineVersions.mockResolvedValue([]); mocks.engine.mockResolvedValue({ ...fixture().availability, release: null, templates: [] }); mocks.token.mockResolvedValue({ token: null }); });
+
+/** A mocked availability sample for route gating only, not a publication or activation claim. */
+function reviewedAnyQuoteAvailability() {
+  const f = anyQuoteUiFixture(), release = bindActiveModuleEngineRelease({ ...f.release, ...reviewedAnyQuoteRelease });
+  if (!isModuleEngineAnyQuoteRelease(release)) throw new Error("Expected the reviewed Any Quote profile");
+  const template = structuredClone(f.template);
+  template.manifest.manifest.release = moduleEngineReleaseIdentity(release);
+  template.manifest.manifest.catalogDefinition.schema = createAnyQuoteConfigurationSchema(release);
+  template.manifestHash = computeModuleEngineHostManifestHash(template.manifest);
+  return { ...f.availability, release, templates: [template] };
+}
 describe("source-specific Module Mode product routes", () => {
   it("keeps the current native reader and dispatches only explicit Engine selectors", async () => {
     const f = fixture(); mocks.native.mockResolvedValue({ release: null, catalog: [], reason: "Native disabled" }); mocks.engine.mockResolvedValue(f.availability);
@@ -41,6 +56,35 @@ describe("source-specific Module Mode product routes", () => {
     const engine = await Page({ searchParams: Promise.resolve({ sourceKind: "module-engine-v1", releaseDigest: f.release.releaseDigest }) });
     expect(engine.type).toBe(ModuleEngineHost); expect(engine.props).toMatchObject({ releaseDigest: f.release.releaseDigest, versions: [version] });
     const native = await Page({ searchParams: Promise.resolve({}) }); expect(native.type).toBe(ModuleModeLaunchHost);
+  });
+  it("offers the reviewed Any Quote setup only from current active availability with a matching publication", async () => {
+    const availability = reviewedAnyQuoteAvailability(); mocks.engine.mockResolvedValue(availability);
+    const page = await Page({ searchParams: Promise.resolve({}) });
+    expect(page.type).toBe(ModuleModeLaunchHost);
+    expect(page.props.anyQuoteReleaseDigest).toBe(reviewedAnyQuoteRelease.releaseDigest);
+    expect(mocks.engine).toHaveBeenCalledWith();
+    const selected = await Page({ searchParams: Promise.resolve({ sourceKind: "module-engine-v1", releaseDigest: page.props.anyQuoteReleaseDigest }) });
+    expect(selected.type).toBe(ModuleEngineHost);
+    expect(selected.props.releaseDigest).toBe(reviewedAnyQuoteRelease.releaseDigest);
+  });
+  it("keeps Any Quote hidden during HOLD, provider failure, empty or unbound publication, and other source generations", async () => {
+    const current = reviewedAnyQuoteAvailability();
+    mocks.engineVersions.mockResolvedValue([{ releaseDigest: reviewedAnyQuoteRelease.releaseDigest, sourceKind: "module-engine-v1", label: "Any Quote LP" }]);
+    for (const unavailable of [
+      { ...current, release: null, templates: [] },
+      { ...current, templates: [] },
+      { ...current, release: { ...current.release, enabled: false } },
+      { ...current, templates: [fixture().template] },
+      fixture().availability,
+      anyQuoteUiFixture().availability,
+    ]) {
+      mocks.engine.mockResolvedValue(unavailable);
+      const page = await Page({ searchParams: Promise.resolve({}) });
+      expect(page.type).toBe(ModuleModeLaunchHost);
+      expect(page.props.anyQuoteReleaseDigest).toBeUndefined();
+    }
+    mocks.engine.mockRejectedValue(new Error("Current source unavailable"));
+    expect((await Page({ searchParams: Promise.resolve({}) })).props.anyQuoteReleaseDigest).toBeUndefined();
   });
   it("dispatches exact management hints and uses the indexed source for a plain coin URL", async () => {
     const hinted = await ManagePage({ params: Promise.resolve({ address: TOKEN }), searchParams: Promise.resolve({ sourceKind: "module-engine-v1", releaseDigest: fixture().release.releaseDigest }) });

--- a/tests/robinhood-profile.test.ts
+++ b/tests/robinhood-profile.test.ts
@@ -65,9 +65,9 @@ describe("Robinhood creator launch history", () => {
     expect(result.page.totalItems).toBe(1);
   });
 
-  it("preserves hidden creator history and does not pin the main token in a profile", () => {
+  it.each([CLEAN_ROOM, "0xb36271399c031ce270e0d1eed5f26dcd08367119"])("preserves the hidden %s creator history and does not pin the main token in a profile", (tokenAddress) => {
     const main = launch(1, { tokenAddress: MAIN_TOKEN });
-    const cleanRoom = launch(2, { tokenAddress: CLEAN_ROOM, name: null, symbol: null });
+    const cleanRoom = launch(2, { tokenAddress, name: null, symbol: null });
     const recent = launch(3);
     const saved = snapshot([main, cleanRoom, recent]);
     expect(profileLaunchList(saved, OWNER).items).toEqual([recent, cleanRoom, main]);

--- a/tests/robinhood-website-index.test.ts
+++ b/tests/robinhood-website-index.test.ts
@@ -658,9 +658,12 @@ describe("Robinhood website launch list", () => {
     expect(result.page.totalItems).toBe(21);
   });
 
-  it("hides only the exact Clean Room address without removing canonical records or inventing a pinned token", () => {
-    const hidden = launch(1, 100, { tokenAddress: "0x15fca474b23cafe775120b1fafbcff0e7a827af2" });
-    const other = launch(2, 101, { name: "Robinhood Clean Room", symbol: "RHCR" });
+  it.each([
+    { tokenAddress: "0x15fca474b23cafe775120b1fafbcff0e7a827af2", name: "Robinhood Clean Room", symbol: "RHCR" },
+    { tokenAddress: "0xb36271399c031ce270e0d1eed5f26dcd08367119", name: "Any Quote LP Internal Test", symbol: "AQLPTEST" },
+  ])("hides only the exact $symbol canary without removing canonical records or other matching metadata", ({ tokenAddress, name, symbol }) => {
+    const hidden = launch(1, 100, { tokenAddress, name, symbol });
+    const other = launch(2, 101, { name, symbol });
     const saved = snapshot([hidden, other]);
     expect(launchList(saved, 1, "", NOW).items).toEqual([other]);
     expect(saved.items).toHaveLength(2);


### PR DESCRIPTION
Any Quote now has a catalog-gated entry in the normal Add modules picker and checks the correct Permit2 approval spender. The entry appears only when the existing public availability response authorizes the reviewed release. A separate, initially empty index-source configuration allows internal launch indexing to be prepared while public availability remains held; the exact internal canary is excluded from Explore.

Pool discovery now works with RPC providers that limit `eth_getLogs` ranges. When one provider cannot return the full Initialize history, the other response supplies block hints. Both original providers must then agree on the complete logs in each window of at most 10,000 blocks, and every accepted pool still passes the existing canonical state and bidirectional quote checks. Malformed or disagreeing responses fail closed; incomplete searches remain inconclusive. The existing request budget is retained.

Route selection now checks the existing depth or reference-price requirements before choosing a candidate. A thin pool with a slightly better small quote no longer rejects a token when a qualifying alternative exists. Direct and indirect candidates retain the same price thresholds and final evidence; provider disagreement and malformed successful responses remain terminal.

Validation: the existing desktop and mobile browser checks passed for the catalog entry and held states. Thirty focused discovery/readiness and route/price tests, focused TypeScript checks and lint passed. An actual read-only replay using the reviewed QuickNode and Alchemy endpoints classified the Programmable quote token as compatible and verified both native trading directions. This replay is not a launch or lifecycle proof. Protected CI is rerun for this exact final source.

This change does not enable the public Any Quote catalog, change deployed contracts or fee recipients, or replace the required internal launch, buy, sell, claim and indexing evidence. The narrow gitleaks exception applies only to the exact public canary address in its visibility fixture; negative controls remain covered.
