### PR TITLE
Keep Any Quote registration reads within RPC limits

### DIFF
--- a/lib/module-engine/client.ts
+++ b/lib/module-engine/client.ts
@@ -137,12 +137,22 @@ const quoteLedgerRegistrationAbi = parseAbi(["event QuoteLaunchRegistered(bytes3
 async function anyQuoteLedgerConfiguration(client: ModuleEngineClient, block: BoundBlock, launch: ModuleEngineLaunchRecord): Promise<Hex> {
   need(isModuleEngineAnyQuoteRelease(block.release), "Quote ledger source is unavailable.");
   need(typeof client.getLogs === "function", "Quote launch registration logs are unavailable on this client.");
-  const pins = block.release.contracts, fromBlock = BigInt(block.release.startBlock);
+  const pins = block.release.contracts;
+  let fromBlock = BigInt(block.release.startBlock), toBlock = block.blockNumber;
+  // The pinned Ledger registers each launch once: quoteAsset changes from zero to
+  // its permanent asset in that transaction. Narrow that transition before asking
+  // for logs, so a long-lived release never requires a full-history log scan.
+  while (toBlock - fromBlock >= 10_000n) {
+    const middle = (fromBlock + toBlock) / 2n;
+    const asset = await read(client, pins.ledger.address, "quoteAsset", [launch.launchId], middle, moduleEngineAnyQuoteLedgerAbi);
+    if (typeof asset === "string" && asset.toLowerCase() === ZERO) fromBlock = middle + 1n;
+    else { same(asset, launch.quoteAsset, "Quote launch registration historical asset"); toBlock = middle; }
+  }
   const logs = await client.getLogs({ address: pins.ledger.address, event: quoteLedgerRegistrationAbi[0],
-    args: { launchId: launch.launchId, asset: launch.quoteAsset }, fromBlock, toBlock: block.blockNumber, strict: true });
+    args: { launchId: launch.launchId, asset: launch.quoteAsset }, fromBlock, toBlock, strict: true });
   need(logs.length === 1, "Expected exactly one quote launch registration from the released ledger.");
   const log = logs[0];
-  need(!log.removed && log.blockNumber !== null && log.blockHash !== null && log.transactionHash !== null && log.blockNumber >= fromBlock && log.blockNumber <= block.blockNumber, "Quote launch registration is outside the canonical checkpoint.");
+  need(!log.removed && log.blockNumber !== null && log.blockHash !== null && log.transactionHash !== null && log.blockNumber >= fromBlock && log.blockNumber <= toBlock, "Quote launch registration is outside the canonical checkpoint.");
   same(log.address, pins.ledger.address, "Quote launch registration ledger");
   same((await client.getBlock({ blockNumber: log.blockNumber })).hash, log.blockHash, "Quote launch registration block");
   const { args } = decodeEventLog({ abi: quoteLedgerRegistrationAbi, eventName: "QuoteLaunchRegistered", data: log.data, topics: log.topics, strict: true });

--- a/tests/any-quote-integration.test.ts
+++ b/tests/any-quote-integration.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { decodeAbiParameters, decodeFunctionData, encodeAbiParameters, encodeEventTopics, encodeFunctionData, encodeFunctionResult, erc20Abi, getAddress, getCreate2Address, keccak256, parseAbi, parseAbiParameters, type Abi, type Address, type Hex, type TransactionReceipt } from "viem";
 import { fixture, ACCOUNT, CODE, CODE_HASH, QUOTE, TOKEN, addr, hash } from "./module-engine-fixture";
-import { moduleEngineReleaseIdentity, computeModuleEngineReleaseDigest, computeModuleEngineHostManifestHash, type ModuleEngineAnyQuoteReleaseIdentity } from "@/lib/module-engine/catalog";
+import { moduleEngineReleaseIdentity, computeModuleEngineReleaseDigest, computeModuleEngineHostManifestHash, ENGINE_ZERO_ADDRESS as ZERO, type ModuleEngineAnyQuoteReleaseIdentity } from "@/lib/module-engine/catalog";
 import { MODULE_ENGINE_ANY_QUOTE_SOURCE_VERSION, MODULE_ENGINE_ANY_QUOTE_SOURCE_ID, MODULE_ENGINE_ANY_QUOTE_PROFILE, MODULE_ENGINE_ANY_QUOTE_PROFILE_ID, MODULE_ENGINE_ANY_QUOTE_ECONOMICS_POLICY_ID } from "@/lib/module-engine/profile";
 import { ANY_QUOTE_CONFIGURATION_ABI, createAnyQuoteConfigurationSchema } from "@/lib/module-engine/any-quote-configuration";
 import { ANY_QUOTE_INFRASTRUCTURE, ANY_QUOTE_NATIVE, ANY_QUOTE_NATIVE_BUY_OPERATION_ID, ANY_QUOTE_WETH } from "@/lib/module-engine/any-quote/types";
@@ -319,6 +319,35 @@ describe("Any Quote financial integration", () => {
     const admin = await readModuleEngineAdministration({ ...f, account: ACCOUNT, token: TOKEN });
     expect(admin.fees.creatorWallets).toEqual([addr(111)]);
     await expect(prepareModuleEngineClaim({ ...f, account: ACCOUNT, token: TOKEN, recipient: ACCOUNT })).resolves.toMatchObject({ kind: "claim", minimumAmount: 9n });
+  });
+  it("finds the immutable quote registration within the provider log range after a long release history", async () => {
+    const f = sharedFixture(), checkpoint = 1_000_100n, registeredAt = 985_000n;
+    f.registration.blockNumber = registeredAt;
+    f.feeState.creatorWallets = [addr(111)];
+    vi.mocked(f.client.getBlock).mockImplementation(async input => ({ number: input?.blockNumber ?? checkpoint, hash: f.blockHash, timestamp: f.state.timestamp }) as never);
+    const originalRead = vi.mocked(f.client.readContract).getMockImplementation()!;
+    const registrationReads: bigint[] = [];
+    vi.mocked(f.client.readContract).mockImplementation(async input => {
+      if (input.functionName === "quoteAsset" && input.address === f.release.contracts.ledger.address) {
+        const at = input.blockNumber!; registrationReads.push(at);
+        return at < registeredAt ? ZERO : QUOTE;
+      }
+      return originalRead(input);
+    });
+    f.client.getLogs = vi.fn(async input => {
+      const from = input.fromBlock as bigint, to = input.toBlock as bigint;
+      if (to - from + 1n > 10_000n) throw new Error("eth_getLogs is limited to a 10,000 range");
+      expect(input).toMatchObject({ address: f.release.contracts.ledger.address, args: { launchId: f.launch.launchId, asset: QUOTE }, strict: true });
+      expect(from).toBeLessThanOrEqual(registeredAt); expect(to).toBeGreaterThanOrEqual(registeredAt);
+      return [f.registration];
+    }) as NonNullable<typeof f.client.getLogs>;
+    await expect(readModuleEngineLaunch({ ...f, token: TOKEN })).resolves.toEqual(f.launch);
+    expect(f.client.getLogs).toHaveBeenCalledTimes(1);
+    expect(registrationReads.some(at => at < registeredAt)).toBe(true);
+    expect(registrationReads.some(at => at >= registeredAt && at < checkpoint)).toBe(true);
+    expect(registrationReads.length).toBeLessThanOrEqual(8);
+    f.registration.data = encodeAbiParameters(parseAbiParameters("bytes32,address[],uint16[]"), [f.feeState.configurationHash, [addr(111)], [10_000]]);
+    await expect(readModuleEngineLaunch({ ...f, token: TOKEN })).rejects.toThrow("Quote launch registration configuration");
   });
   it("rejects the Host hash in ledger storage and rejects changed original recipients", async () => {
     const f = sharedFixture(), original = f.feeState.configurationHash;


### PR DESCRIPTION
A successful Any Quote launch could fail its receipt, trading, or fee-read checks once the release history exceeded QuickNode's 10,000-block log limit. Find the immutable ledger registration interval through historical quoteAsset reads, then request one bounded event range.

The existing unique event, canonical block, original recipient, share, asset, and configuration checks remain in place. No contracts, fees, or public availability gates change.

Validation: 73 focused Any Quote integration and existing module-client tests pass, including a million-block history with a rejecting RPC and a tampered-registration negative case. Targeted ESLint and diff checks pass.
