### PR TITLE
Fix Any Quote buys and require a public initial purchase

### DIFF
--- a/components/module-engine-builder.tsx
+++ b/components/module-engine-builder.tsx
@@ -62,7 +62,8 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
   const [quote, setQuote] = useState(""); const [quoteState, setQuoteState] = useState<(Awaited<ReturnType<typeof readModuleEngineQuoteAsset>> & { account: Address }) | null>(null);
   const [customInitialForm, setCustomInitialForm] = useState(emptyModuleEngineCustomOperation);
   const [creatorSaltInput, setCreatorSaltInput] = useState(""); const [engineSaltInput, setEngineSaltInput] = useState(""); const [launchData, setLaunchData] = useState("0x");
-  const [amount, setAmount] = useState(""); const [minimumTokens, setMinimumTokens] = useState(""); const [minimumEth, setMinimumEth] = useState(""); const [route, setRoute] = useState("");
+  const [amount, setAmount] = useState(""); const [amountError, setAmountError] = useState<string | null>(null); const amountFocus = useRef<HTMLInputElement>(null);
+  const [minimumTokens, setMinimumTokens] = useState(""); const [minimumEth, setMinimumEth] = useState(""); const [route, setRoute] = useState("");
   const [buyFee, setBuyFee] = useState("0"); const [sellFee, setSellFee] = useState("0"); const [beneficiary, setBeneficiary] = useState(""); const [refundTime, setRefundTime] = useState(""); const [obligation, setObligation] = useState("");
   const [prepared, setPrepared] = useState<PreparedModuleEngineTransaction | null>(null); const [approval, setApproval] = useState<ModuleEngineApprovalRequired | null>(null);
   const [error, setError] = useState<string | null>(null); const [notice, setNotice] = useState<string | null>(null); const [busy, setBusy] = useState(false);
@@ -93,7 +94,13 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
   }
   async function prepare() {
     if (!availability?.release || !template || !definition || !revision || !wallet.account) return;
-    if (imageBusy) return; setBusy(true); setError(null); setNotice(null);
+    if (imageBusy) return;
+    let initialBuyWei = 0n;
+    if (anyQuote) {
+      try { initialBuyWei = BigInt(parseExactUnits(amount, 18)); if (initialBuyWei <= 0n) throw new Error(); }
+      catch { setError(null); setAmountError("Enter an ETH amount greater than 0. Use up to 18 decimal places."); amountFocus.current?.focus(); return; }
+    }
+    setAmountError(null); setBusy(true); setError(null); setNotice(null);
     try {
       const account = moduleAddress(wallet.account, "account"); assertModuleModeWalletUnchanged(wallet, account);
       if (!quoteVerified || (anyQuote ? !readyQuote : !quoteState)) throw new Error(anyQuote ? "Wait for current token availability before reviewing the launch." : "Check the quote asset before reviewing the launch.");
@@ -122,7 +129,7 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
       } : undefined;
       const coin = { client, availability, templateId: definition.id, account, name, symbol, description, imageUri: resolvedImage, socialLinks: social.links, creatorSalt: customLaunch && creatorSaltInput.trim() ? moduleEngineOptionalHash(creatorSaltInput.trim(), "creator salt") : salts.current.creator, engineSalt: customLaunch && engineSaltInput.trim() ? moduleEngineOptionalHash(engineSaltInput.trim(), "engine salt") : salts.current.engine, creatorWallets: [account], creatorSharesBps: [10_000], buyCreatorFeeBps: Number(buyFee) * 100, sellCreatorFeeBps: Number(sellFee) * 100 };
       const result = anyQuote && readyQuote
-        ? await prepareModuleEngineAnyQuoteLaunch({ ...coin, quoteAsset: readyQuote.quoteAsset, readiness: readyQuote, initialBuyWei: amount.trim() ? BigInt(parseExactUnits(amount.trim(), 18)) : 0n, slippageBps: 100 })
+        ? await prepareModuleEngineAnyQuoteLaunch({ ...coin, quoteAsset: readyQuote.quoteAsset, readiness: readyQuote, initialBuyWei, slippageBps: 100 })
         : await prepareModuleEngineLaunch({ ...coin, quoteAsset: quoteState!.address, configuration: configurationFromForm(definition.schema, form, definition.fields), ...(customLaunch ? { launchData: moduleBytes(launchData.trim(), "initialization data", 16_384) } : {}), initialOperation });
       if (result.kind === "approval-required") setApproval(result); else setPrepared(result);
     } catch (caught) { setError(message(caught)); } finally { setBusy(false); }
@@ -183,9 +190,10 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
               {anyQuote ? <>
                 <ModuleEngineAnyQuoteAsset value={quoteAsset} availability={anyQuoteAvailability} onChange={value => edit(() => setQuote(value))} />
                 <div className={`${styles.field} ${engineStyles.anyQuoteInitialBuy}`}>
-                  <label htmlFor="engine-amount">Initial buy <span>Optional</span></label>
-                  <div className={engineStyles.anyQuoteAmount}><input id="engine-amount" aria-label="Initial buy in ETH" inputMode="decimal" placeholder="0" autoComplete="off" value={amount} onChange={event => edit(() => setAmount(event.target.value))} aria-describedby="engine-amount-help" /><span aria-hidden="true">ETH</span></div>
-                  <p id="engine-amount-help" className={styles.help}>Buy your coin in the launch transaction. Leave blank to launch without a buy.</p>
+                  <label htmlFor="engine-amount">Initial buy</label>
+                  <div className={engineStyles.anyQuoteAmount}><input ref={amountFocus} id="engine-amount" aria-label="Initial buy in ETH" inputMode="decimal" placeholder="0" autoComplete="off" required value={amount} onChange={event => edit(() => { setAmount(event.target.value); setAmountError(null); })} onInvalid={event => { event.preventDefault(); setAmountError("Enter an ETH amount greater than 0."); amountFocus.current?.focus(); }} aria-invalid={Boolean(amountError) || undefined} aria-describedby={amountError ? "engine-amount-help engine-amount-error" : "engine-amount-help"} /><span aria-hidden="true">ETH</span></div>
+                  <p id="engine-amount-help" className={styles.help}>Buy your coin in the launch transaction.</p>
+                  {amountError ? <p id="engine-amount-error" className={styles.fieldError} role="alert">{amountError}</p> : null}
                 </div>
                 <p className={engineStyles.sectionNote}>1 billion coins · approximately $5,000 starting value · permanently locked liquidity.</p>
                 <Disclosure className={engineStyles.moduleAbout}>
@@ -287,14 +295,14 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
           <dl className={engineStyles.previewFacts}>
             <div><dt>{quoteLabel}</dt><dd title={quoteAsset || undefined}>{quoteShort}</dd></div>
             {spot || customLaunch ? <div><dt>{customLaunch ? "Fee settings" : "Creator fees"}</dt><dd>{buyFee}% buy · {sellFee}% sell</dd></div> : null}
-            {anyQuote ? <><div><dt>Buy and sell with</dt><dd>ETH</dd></div><div><dt>Module fee</dt><dd>0.3%</dd></div><div><dt>Initial buy</dt><dd>{amount.trim() ? `${amount} ETH` : "None"}</dd></div></> : null}
+            {anyQuote ? <><div><dt>Buy and sell with</dt><dd>ETH</dd></div><div><dt>Module fee</dt><dd>0.3%</dd></div><div><dt>Initial buy</dt><dd>{amount.trim() ? `${amount} ETH` : "Not set"}</dd></div></> : null}
             {needsInitial && !customInitial ? <div><dt>{spot ? "First buy" : "Starting funds"}</dt><dd>{amount.trim() ? `${amount} tokens` : "Not set"}</dd></div> : null}
           </dl>
           </div>
           <Link href="/developers/modules" className={engineStyles.buildLink}><Puzzle size={16} aria-hidden="true" />Build your own module<ArrowUpRight size={16} aria-hidden="true" /></Link>
         </aside>
       </div>
-      <ModuleEnginePicker open={pickerOpen} templates={availability.templates} selectedId={definition.id} disabled={!hydrated || busy || imageBusy || blocked} onClose={() => setPickerOpen(false)} onSelect={item => { edit(() => { setSelected(item.manifest.manifest.catalogDefinition.id); setQuoteState(null); setAmount(""); salts.current = null; setCustomInitialForm(emptyModuleEngineCustomOperation()); setCreatorSaltInput(""); setEngineSaltInput(""); setLaunchData("0x"); setBuyFee("0"); setSellFee("0"); }); setPickerOpen(false); }} />
+      <ModuleEnginePicker open={pickerOpen} templates={availability.templates} selectedId={definition.id} disabled={!hydrated || busy || imageBusy || blocked} onClose={() => setPickerOpen(false)} onSelect={item => { edit(() => { setSelected(item.manifest.manifest.catalogDefinition.id); setQuoteState(null); setAmount(""); setAmountError(null); salts.current = null; setCustomInitialForm(emptyModuleEngineCustomOperation()); setCreatorSaltInput(""); setEngineSaltInput(""); setLaunchData("0x"); setBuyFee("0"); setSellFee("0"); }); setPickerOpen(false); }} />
       {approval && !prepared ? <section className={engineStyles.notice} role="status"><p>Allow the launch contract to use exactly {quoteState ? formatUnits(approval.amount, quoteState.decimals) : approval.amount.toString()} quote tokens to fund this launch.</p><button id="engine-approval-review" className={styles.secondaryButton} type="button" disabled={busy || blocked} onClick={() => void prepareApproval()}>{approval.currentAllowance > 0n ? "Review allowance reset" : "Review exact approval"}</button></section> : null}
       {prepared ? <ModuleEngineTransactionReview prepared={prepared} busy={busy} disabled={blocked || step !== "prepare"} onEdit={backToEdit} onConfirm={() => void confirm()} quoteAsset={readyQuote?.quoteAsset ?? quoteState?.address} quoteDecimals={readyQuote?.token.decimals ?? quoteState?.decimals} quoteSymbol={readyQuote?.token.symbol} anyQuote={anyQuote} tradeFees={spot || customLaunch} genericAction={customInitial} showLaunchInputs={customLaunch}>{prepared.kind === "launch" ? <div className={engineStyles.launchSummary}><strong>{name} · {symbol}</strong><p>{description}</p><p className={styles.help}>Image: {imageUri || MODULE_DEFAULT_TOKEN_IMAGE}</p>{checkedSocial.ok ? <dl className={styles.reviewRows}>{socialFields.filter(({ key }) => checkedSocial.links[key]).map(({ key, label }) => <div key={key}><dt>{label}</dt><dd>{checkedSocial.links[key]}</dd></div>)}</dl> : null}</div> : null}</ModuleEngineTransactionReview> : null}
     </>}

--- a/lib/server/module-engine/any-quote-preparation.ts
+++ b/lib/server/module-engine/any-quote-preparation.ts
@@ -52,10 +52,12 @@ async function quoteModule(pool: AnyQuoteTradeQuote["pool"], buy: boolean, amoun
   const runtime = await rpc("eth_getCode", [ANY_QUOTE_INFRASTRUCTURE.v4Quoter, ref], value => String(value) as Hex);
   if (keccak256(runtime) !== ANY_QUOTE_INFRASTRUCTURE.v4QuoterCodeHash) throw new AnyQuoteErrorV1("QUOTER_RUNTIME_MISMATCH");
   const data = encodeFunctionData({ abi: quoterAbi, functionName: "quoteExactInputSingle", args: [{ poolKey: key, zeroForOne: anyQuoteSameAddressV1(buy ? pool.quoteAsset : pool.token, key.currency0), exactAmount: amountIn, hookData: "0x" }] });
-  return rpc("eth_call", [{ to: ANY_QUOTE_INFRASTRUCTURE.v4Quoter, data }, ref], value => {
+  const output = await rpc("eth_call", [{ to: ANY_QUOTE_INFRASTRUCTURE.v4Quoter, data }, ref], value => {
     const result = decodeFunctionResult({ abi: quoterAbi, functionName: "quoteExactInputSingle", data: String(value) as Hex });
-    return anyQuoteUintV1(result[0].toString(), (1n << 128n) - 1n);
+    // Provider agreement compares canonical JSON; retain exact raw units as a decimal string there.
+    return anyQuoteUintV1(result[0].toString(), (1n << 128n) - 1n).toString();
   });
+  return BigInt(output);
 }
 /** Complete trade quote uses current onchain module fees and external AMM execution, never an indicative USD price. */
 export type AnyQuoteTradeQuoteInputV1 = Selection & { account: Address; token: Address; recipient: Address; buy: boolean; inputAmount: string; slippageBps?: number };

--- a/scripts/test/any-quote-readiness-discovery.test.mjs
+++ b/scripts/test/any-quote-readiness-discovery.test.mjs
@@ -16,12 +16,14 @@ for (const [index, name] of ["universalRouter", "poolManager", "stateView", "v4Q
   fixtureCode.set(contract.address.toLowerCase(), code);
   contract.runtimeCodeHash = keccak256(code);
 }
-const bundled = await build({ absWorkingDir: root, stdin: { contents: ["types", "route", "discovery.server", "readiness.server"].map(name => `export * from './lib/module-engine/any-quote/${name}'`).join("\n") + "; export { agreedTradeRpcV1 } from './lib/server/custom-launch/routed-trade-rpc-v1'", resolveDir: root },
+const bundled = await build({ absWorkingDir: root, stdin: { contents: ["types", "route", "discovery.server", "readiness.server"].map(name => `export * from './lib/module-engine/any-quote/${name}'`).join("\n") + "; export { agreedTradeRpcV1 } from './lib/server/custom-launch/routed-trade-rpc-v1'; export { quoteModule } from './lib/server/module-engine/any-quote-preparation'", resolveDir: root },
   bundle: true, format: "cjs", platform: "node", packages: "external", write: false,
   plugins: [{ name: "fixture-environment", setup(b) {
     b.onResolve({ filter: /^server-only$/ }, () => ({ path: "empty", namespace: "empty" }));
     b.onLoad({ filter: /.*/, namespace: "empty" }, () => ({ contents: "" }));
     b.onLoad({ filter: /chain-4663\.v1\.json$/ }, () => ({ contents: JSON.stringify(profile), loader: "json" }));
+    // Expose the unchanged private reader only to this test bundle; production exports remain closed.
+    b.onLoad({ filter: /any-quote-preparation\.ts$/ }, async args => ({ contents: `${await readFile(args.path, "utf8")}\nexport { quoteModule };`, loader: "ts" }));
   } }],
 });
 const loaded = { exports: {} };
@@ -39,6 +41,34 @@ const readAbi = parseAbi([
   "function getSlot0(bytes32) view returns (uint160,int24,uint24,uint24)", "function getLiquidity(bytes32) view returns (uint128)",
   "function quoteExactInputSingle(((address currency0,address currency1,uint24 fee,int24 tickSpacing,address hooks) poolKey,bool zeroForOne,uint128 exactAmount,bytes hookData) params) returns (uint256 amountOut,uint256 gasEstimate)",
 ]);
+
+test("module quotes compare exact canonical amounts through both RPCs for buys and sells", async () => {
+  const modulePool = { token: OTHER, quoteAsset: Q, sharedHook: MID,
+    poolId: a.anyQuotePoolIdV1({ currency0: OTHER, currency1: Q, fee: 0, tickSpacing: 200, hooks: MID }) };
+  const expected = (1n << 100n) + 7n, calls = [];
+  const rpcs = [0, 1].map(provider => async (method, params) => {
+    calls.push({ provider, method, params });
+    assert.deepEqual(params[1], { blockHash: HASH, requireCanonical: true });
+    if (method === "eth_getCode") return fixtureCode.get(a.ANY_QUOTE_INFRASTRUCTURE.v4Quoter.toLowerCase());
+    assert.equal(method, "eth_call");
+    return encodeFunctionResult({ abi: readAbi, functionName: "quoteExactInputSingle", result: [expected, 100_000n] });
+  });
+  for (const buy of [true, false]) assert.equal(await a.quoteModule(modulePool, buy, 1n, checkpoint, { options: { rpcs } }), expected);
+  assert.equal(calls.length, 8);
+  assert.equal(calls.filter(call => call.method === "eth_call" && call.provider === 0).length, 2);
+  assert.equal(calls.filter(call => call.method === "eth_call" && call.provider === 1).length, 2);
+});
+
+test("module quotes retain provider disagreement, positive uint128 and runtime checks", async () => {
+  const modulePool = { token: OTHER, quoteAsset: Q, sharedHook: MID,
+    poolId: a.anyQuotePoolIdV1({ currency0: OTHER, currency1: Q, fee: 0, tickSpacing: 200, hooks: MID }) };
+  const rpcPair = (amounts, runtime) => [0, 1].map(provider => async method => method === "eth_getCode"
+    ? runtime ?? fixtureCode.get(a.ANY_QUOTE_INFRASTRUCTURE.v4Quoter.toLowerCase())
+    : encodeFunctionResult({ abi: readAbi, functionName: "quoteExactInputSingle", result: [amounts[provider], 100_000n] }));
+  await assert.rejects(a.quoteModule(modulePool, true, 1n, checkpoint, { options: { rpcs: rpcPair([2n ** 100n, 2n ** 100n + 1n]) } }), error => error.code === "TRADE_PROVIDER_DISAGREEMENT");
+  for (const amount of [0n, 1n << 128n]) await assert.rejects(a.quoteModule(modulePool, true, 1n, checkpoint, { options: { rpcs: rpcPair([amount, amount]) } }), error => error.code === "TRADE_ANALYSIS_PENDING");
+  await assert.rejects(a.quoteModule(modulePool, true, 1n, checkpoint, { options: { rpcs: rpcPair([1n, 1n], "0x00") } }), /QUOTER_RUNTIME_MISMATCH/);
+});
 function pool(x = ZERO, y = Q, { fee = 0, liquidity = 10n ** 24n, hook = ZERO, block = 10_000n } = {}) {
   const key = { currency0: BigInt(x) < BigInt(y) ? x : y, currency1: BigInt(x) < BigInt(y) ? y : x, fee, tickSpacing: 60, hooks: hook };
   return { key, poolId: a.anyQuotePoolIdV1(key), liquidity, block };

--- a/tests/module-engine-any-quote-ui.test.tsx
+++ b/tests/module-engine-any-quote-ui.test.tsx
@@ -13,11 +13,14 @@ const actions = { wallet: { authenticated: false, sessionReady: true }, onConnec
 const base = { sourceKind: "module-engine-v1" as const, account: ACCOUNT, releaseDigest: hash(1), blockNumber: 100n, expiresAt: BigInt(Math.floor(Date.now() / 1_000) + 120), gasEstimate: 200_000n, transaction: { chainId: 4663 as const, action: "manage" as const, description: "Local Any Quote UI test", from: ACCOUNT, to: addr(2), data: "0x" as const, value: "0x0" as const }, token: TOKEN, launchId: hash(3), revisionId: hash(4), planHash: hash(5) };
 
 describe("Any Quote LP visible economic and availability boundaries", () => {
-  it("offers one CA and optional ETH buy before connecting, without pool, quote-funding or fee-conversion inputs", () => {
+  it("requires an ETH initial buy with one CA, without pool, quote-funding or fee-conversion inputs", () => {
     const html = renderToStaticMarkup(<ModuleEngineBuilder {...actions} {...anyQuoteUiFixture()} />);
     expect(html.match(/id="engine-quote"/g)).toHaveLength(1);
     expect(html).toContain("Pair with");
     expect(html).toContain("Initial buy");
+    expect(html.match(/<input[^>]*id="engine-amount"[^>]*>/)?.[0]).toContain('required=""');
+    expect(html).toContain('<label for="engine-amount">Initial buy</label>');
+    expect(html).not.toContain("Leave blank to launch without a buy");
     expect(html).toContain("Connect wallet");
     expect(html).toContain("0.3% module fee per buy and sell");
     expect(html).not.toContain("Check token");


### PR DESCRIPTION
Any Quote trade preparation failed before wallet review because its quoter returned a BigInt into the canonical JSON provider comparison. Compare the validated amount as an exact decimal string, then restore BigInt for arithmetic. The public Any Quote form now requires a positive ETH initial buy before uploading an image or preparing the launch.

Validation: 21 focused quote/discovery tests and 18 focused UI tests passed. Existing browser fixtures checked invalid amounts, field focus and ARIA, exact positive-wei forwarding, desktop and mobile rendering, and console errors. Source review confirms no contract, fee-recipient, provider-quorum, or public-availability changes. Internal zero-buy operator support is preserved for the already deployed canary.

The unchanged original operator also completed a read-only 0.0001 ETH buy simulation against the actual deployed Canary/Programmable pool. Both reviewed providers estimated 478,139 gas. No wallet request or buy transaction was sent by that observation.
