### PR TITLE
Bind native ETH Any Quote review identity while preserving public HOLD

### DIFF
--- a/config/module-engine/review-release.json
+++ b/config/module-engine/review-release.json
@@ -2,16 +2,16 @@
   "chainId": 4663,
   "contracts": {
     "host": {
-      "address": "0xfc4752006da554f086ba75a336b3525b9de5ce1d",
-      "runtimeCodeHash": "0xb793455747d315c40c77431556f653bd3cafb0d2adb55218e87baa735ed02313"
+      "address": "0xcec7d7a0fd6dabe473f3aff998eb054f161924e2",
+      "runtimeCodeHash": "0x67d13e69f9c1ce81e44fb531248fd317270870eb9c66860d449994a8a4ac8201"
     },
     "launchPolicy": {
       "address": "0xf3ff250759a66edc7893bba9d34daf4ba4ae4caa",
       "runtimeCodeHash": "0x1c485a64c77174e0b2a78adf2527128792180def26cbab2ca00fcfa74b73ba91"
     },
     "ledger": {
-      "address": "0xc6ec7c1b2edd91183e967a21c944d3dd6ff9a084",
-      "runtimeCodeHash": "0x04274a9f3daacee275f86fc2fdf817bd11a777c029d0990a3ffc51825eaba640"
+      "address": "0x029ac9c1f6f3dc8d7736bd254c156b43edad15ac",
+      "runtimeCodeHash": "0xd8de4394b0ee40a35dfad6bf9df05c2f27e08e2d40ea716228f95062986ec2dd"
     },
     "nativeRouteGuard": {
       "address": "0x92c1d5735a89488a77841634c48d922cd3f2c0e4",
@@ -26,8 +26,8 @@
       "runtimeCodeHash": "0x364028382d38d4d1d4994ad305e0538f72ef2f2360a0f671ae82912c44374fdd"
     },
     "sharedHook": {
-      "address": "0xcf533f717b787f6eb591498411aef8231366a0cc",
-      "runtimeCodeHash": "0x67720ca20962ddc3762c63d98b2dd900e268fc9ccc4b4306528ac09f630b12fa"
+      "address": "0x71bd471d449bd7283d01b4601109eb263bd260cc",
+      "runtimeCodeHash": "0x658ef474d7f0fa2f945cc3ac92679a896ccf9d29688c9c307e8da7640aee4553"
     },
     "tokenFactory": {
       "address": "0x754e8c1ade3c6c4c863590a91f2ed020baf8e779",
@@ -38,13 +38,13 @@
       "runtimeCodeHash": "0xbe8e8191bb42d843c2e948a5a55772eaab864ce01e54dcd47c9d089170b302d5"
     }
   },
-  "economicsPolicyId": "0xe5028630113d178a49b8fce74f39ed7b326081772695f9e3e2ffaacee81f504d",
-  "engineProfile": "robinhood-any-quote.shared-hook.v1",
+  "economicsPolicyId": "0x294c27492f663320407c435a8ff8c8d44a0ea1623f3d1ecaa9b730c4cf40e76e",
+  "engineProfile": "robinhood-any-quote.shared-hook.native-eth.v1",
   "finalityPolicy": "robinhood-ethereum-finalized-v1",
   "schemaVersion": "programmable.module-engine.release.v1",
-  "sourceCommit": "9824c23ca4954fde8b5f4861f2a537fd0600bbf7",
-  "sourceVersion": "module-engine-any-quote-v1",
+  "sourceCommit": "27a116440c4a894a1b11e03eab02b596d72dc9bd",
+  "sourceVersion": "module-engine-any-quote-eth-v1",
   "tokenCreationCodeHash": "0x445809d9f7a34e959de4a96dec1e1beddfb265755bf28c57c42744adea1128ef",
-  "startBlock": "59807048",
-  "releaseDigest": "0xac96d652e2043f34b3f736bad999ab673b17aa8750b5d62951e9ec928306273d"
+  "startBlock": "60331314",
+  "releaseDigest": "0x99c3214509ebb348a3a7ee97f7eeaef325362a20da475241c2752a277fe93cc2"
 }

--- a/lib/robinhood-explore-policy.ts
+++ b/lib/robinhood-explore-policy.ts
@@ -17,6 +17,7 @@ const HIDDEN_ROBINHOOD_TOKENS = new Set([
   "0xdf23dac67139ebd3f66fcc4ea224c5c6ae850546", // M53SET
   "0xd9320af2762e711918358422594684756ad760cc", // PN20REF backfill canary
   "0xb36271399c031ce270e0d1eed5f26dcd08367119", // AQLPTEST Any Quote LP release canary
+  "0x6dcad5b2373963a677d8e0e2d7dcafea192ea41b", // Native ETH Any Quote release canary
 ]);
 
 export function isVisibleRobinhoodToken(address: string) {

--- a/scripts/perf/indexed-website-read-deploy-policy.mjs
+++ b/scripts/perf/indexed-website-read-deploy-policy.mjs
@@ -22,11 +22,11 @@ const ADDRESS = /^0x(?!0{40}$)[0-9a-f]{40}$/iu;
 const MAX_MODULE_SOURCES = 32;
 
 function moduleSourceExpectation(release) {
-  const engine = ["module-engine-v1", "module-engine-any-quote-v1"].includes(release.sourceVersion);
+  const engine = ["module-engine-v1", "module-engine-any-quote-v1", "module-engine-any-quote-eth-v1"].includes(release.sourceVersion);
   const sourceAddress = engine
     ? release.contracts?.host?.address : release.contracts?.launcher?.address;
   if (release.chainId !== 4663 ||
-    !["module-native-v1", "module-native-v2", "module-engine-v1", "module-engine-any-quote-v1"].includes(release.sourceVersion) ||
+    !["module-native-v1", "module-native-v2", "module-engine-v1", "module-engine-any-quote-v1", "module-engine-any-quote-eth-v1"].includes(release.sourceVersion) ||
     !ADDRESS.test(sourceAddress ?? "") || !HASH.test(release.releaseDigest ?? "") ||
     !/^[1-9][0-9]{0,19}$/u.test(release.startBlock ?? "")) {
     throw new Error("indexed website Robinhood release identity is invalid");

--- a/scripts/test/indexed-website-reads.test.mjs
+++ b/scripts/test/indexed-website-reads.test.mjs
@@ -38,12 +38,15 @@ function sourceConfiguration(t, engineRelease,
   return root;
 }
 
-test("Any Quote retains its authentication version and uses the existing Engine index transport", async t => {
-  const release = JSON.parse(readFileSync("tests/fixtures/module-engine-any-quote-index.json", "utf8")).cases[0].release;
+for (const [label, fixturePath] of [
+  ["Any Quote", "tests/fixtures/module-engine-any-quote-index.json"],
+  ["Native ETH Any Quote", "tests/fixtures/module-engine-any-quote-eth-index.json"],
+]) test(`${label} retains its authentication version and uses the existing Engine index transport`, async t => {
+  const release = JSON.parse(readFileSync(fixturePath, "utf8")).cases[0].release;
   const root = sourceConfiguration(t, release), expectations = await readIndexedWebsiteSourceExpectations(root);
   assert.deepEqual(expectations.robinhood.modules[1], { source: "module-engine-v1", sourceVersion: release.sourceVersion,
     sourceAddress: release.contracts.host.address, releaseDigest: release.releaseDigest, startBlock: release.startBlock });
-  assert.equal(JSON.parse(readFileSync(join(root, "config/module-engine/robinhood.json"), "utf8")).sourceVersion, "module-engine-any-quote-v1");
+  assert.equal(JSON.parse(readFileSync(join(root, "config/module-engine/robinhood.json"), "utf8")).sourceVersion, release.sourceVersion);
   assert.deepEqual(expectations.robinhood.modules.filter((_value, index) => index !== 1), EXPECTATIONS.robinhood.modules.filter((_value, index) => index !== 1));
   const observations = transport => fixture(({ url, spec }) => {
     if (url.pathname !== "/api/explore/robinhood") return;
@@ -105,8 +108,11 @@ test("an empty technical index list retains public source expectations and ignor
     fetchImpl: engineSourceObservation(release).fetchImpl })), /Robinhood module release binding/u);
 });
 
-test("a complete technical Any Quote release binds index reads without changing the public catalogs", async t => {
-  const release = JSON.parse(readFileSync("tests/fixtures/module-engine-any-quote-index.json", "utf8")).cases[0].release;
+for (const [label, fixturePath] of [
+  ["Any Quote", "tests/fixtures/module-engine-any-quote-index.json"],
+  ["native ETH Any Quote", "tests/fixtures/module-engine-any-quote-eth-index.json"],
+]) test(`a complete technical ${label} release binds index reads without changing the public catalogs`, async t => {
+  const release = JSON.parse(readFileSync(fixturePath, "utf8")).cases[0].release;
   const publicExpectations = await readIndexedWebsiteSourceExpectations(indexConfiguration(t, []));
   const root = indexConfiguration(t, [release]), expectations = await readIndexedWebsiteSourceExpectations(root);
   assert.deepEqual(expectations.robinhood.modules.slice(0, -1), publicExpectations.robinhood.modules);
@@ -121,8 +127,11 @@ test("a complete technical Any Quote release binds index reads without changing 
   assert.equal(result.chains[1].totalItems, 1);
 });
 
-test("technical index sources require complete canonical identity and nonzero evidence commitments", async t => {
-  const release = JSON.parse(readFileSync("tests/fixtures/module-engine-any-quote-index.json", "utf8")).cases[0].release;
+for (const [label, fixturePath] of [
+  ["Any Quote", "tests/fixtures/module-engine-any-quote-index.json"],
+  ["native ETH Any Quote", "tests/fixtures/module-engine-any-quote-eth-index.json"],
+]) test(`${label} technical index sources require complete canonical identity and nonzero evidence commitments`, async t => {
+  const release = JSON.parse(readFileSync(fixturePath, "utf8")).cases[0].release;
   const mutations = [
     value => { value.enabled = false; },
     value => { value.status = "preview"; },

--- a/tests/module-mode-source-routing.test.tsx
+++ b/tests/module-mode-source-routing.test.tsx
@@ -6,12 +6,13 @@ import { fixture, TOKEN, hash } from "./module-engine-fixture";
 import { anyQuoteUiFixture } from "./module-engine-any-quote-ui-fixture";
 import reviewedAnyQuoteRelease from "@/config/module-engine/review-release.json";
 import { createAnyQuoteConfigurationSchema } from "@/lib/module-engine/any-quote-configuration";
-import { isModuleEngineAnyQuoteRelease } from "@/lib/module-engine/profile";
+import { isModuleEngineAnyQuoteRelease, isModuleEngineAnyQuoteEthRelease } from "@/lib/module-engine/profile";
 import engineEvidence from "./fixtures/module-engine-index.json";
 import { normalizeModuleEngineLaunchV1 } from "@/lib/module-engine/index/provenance-v1";
-import { bindActiveModuleEngineRelease, computeModuleEngineHostManifestHash, moduleEngineReleaseIdentity } from "@/lib/module-engine/catalog";
+import { bindActiveModuleEngineRelease, bindModuleEngineReleaseIdentity, computeModuleEngineHostManifestHash, moduleEngineReleaseIdentity } from "@/lib/module-engine/catalog";
 import { moduleEnginePublicLaunch } from "@/lib/server/robinhood-index/module-source";
-const mocks = vi.hoisted(() => ({ native: vi.fn(), engine: vi.fn(), nativeVersions: vi.fn(), engineVersions: vi.fn(), token: vi.fn() }));
+const mocks = vi.hoisted(() => ({ native: vi.fn(), engine: vi.fn(), nativeVersions: vi.fn(), engineVersions: vi.fn(), token: vi.fn(), reviewIdentity: null as unknown }));
+vi.mock("@/config/module-engine/review-release.json", () => ({ get default() { return mocks.reviewIdentity; } }));
 vi.mock("@/components/module-engine-host", () => ({ ModuleEngineHost: () => null }));
 vi.mock("@/components/module-mode-launch-host", () => ({ ModuleModeLaunchHost: () => null }));
 vi.mock("@/components/module-coin-console", () => ({ ModuleCoinConsole: () => null }));
@@ -24,7 +25,9 @@ import { GET } from "@/app/api/module-mode/route";
 import Page from "@/app/launch/modules/page";
 import ManagePage from "@/app/launch/modules/manage/[address]/page";
 
-beforeEach(() => { vi.clearAllMocks(); mocks.nativeVersions.mockResolvedValue([]); mocks.engineVersions.mockResolvedValue([]); mocks.engine.mockResolvedValue({ ...fixture().availability, release: null, templates: [] }); mocks.token.mockResolvedValue({ token: null }); });
+const { ANY_QUOTE_ETH_GUARD_RELEASE } = await import(new URL("../contracts/scripts/module-engine/any-quote-eth-basis.mjs", import.meta.url).href);
+
+beforeEach(() => { vi.clearAllMocks(); mocks.reviewIdentity = moduleEngineReleaseIdentity(ANY_QUOTE_ETH_GUARD_RELEASE); mocks.nativeVersions.mockResolvedValue([]); mocks.engineVersions.mockResolvedValue([]); mocks.engine.mockResolvedValue({ ...fixture().availability, release: null, templates: [] }); mocks.token.mockResolvedValue({ token: null }); });
 
 /** A mocked availability sample for route gating only, not a publication or activation claim. */
 function reviewedAnyQuoteAvailability() {
@@ -37,6 +40,19 @@ function reviewedAnyQuoteAvailability() {
   return { ...f.availability, release, templates: [template] };
 }
 describe("source-specific Module Mode product routes", () => {
+  it("keeps the installed native ETH review identity separate from public activation", async () => {
+    const { default: installed } = await vi.importActual<{ default: unknown }>("@/config/module-engine/review-release.json");
+    const identity = bindModuleEngineReleaseIdentity(installed);
+    expect(isModuleEngineAnyQuoteEthRelease(identity)).toBe(true);
+    expect(() => bindActiveModuleEngineRelease(identity)).toThrow();
+    mocks.reviewIdentity = identity;
+    // Review identity alone has no public activation or lifecycle evidence.
+    mocks.engine.mockResolvedValue({ ...fixture().availability, release: identity, templates: [] });
+    const page = await Page({ searchParams: Promise.resolve({}) });
+    expect(page.type).toBe(ModuleModeLaunchHost);
+    expect(page.props.anyQuoteReleaseDigest).toBeUndefined();
+    expect(page.props.versions).toEqual([]);
+  });
   it("keeps the current native reader and dispatches only explicit Engine selectors", async () => {
     const f = fixture(); mocks.native.mockResolvedValue({ release: null, catalog: [], reason: "Native disabled" }); mocks.engine.mockResolvedValue(f.availability);
     expect((await GET(new Request("http://localhost/api/module-mode"))).status).toBe(503); expect(mocks.native).toHaveBeenCalledOnce(); expect(mocks.engine).not.toHaveBeenCalled();


### PR DESCRIPTION
The admin review configuration still points to the earlier quote-fee deployment. Install the collected native-ETH deployment identity so review plans and acceptance bind to the actual native contracts, while keeping public publication on hold.

- Copy the collected identity exactly: release `0x99c3214509ebb348a3a7ee97f7eeaef325362a20da475241c2752a277fe93cc2`, original contract source `27a116440c4a894a1b11e03eab02b596d72dc9bd`, start block `60331314`. No activation or lifecycle fields are added.
- Hide only prepared canary `0x6dcad5b2373963a677d8e0e2d7dcafea192ea41b` from Explore. Canonical records and other tokens remain intact.
- Recognize exact `module-engine-any-quote-eth-v1` identities in deployment read expectations using the existing Engine transport. The active-release binder, evidence commitments, identity checks and source limits remain required.
- Keep the technical index list, public current/historical releases and catalog unchanged. The technical entry must wait for the actual complete release and lifecycle evidence.

Validation: 92 existing review, catalog and routing tests passed, including native review-only HOLD and explicit legacy behavior. Eight targeted index expectation tests passed for both quote and native ETH profiles, including missing or altered evidence rejection. Direct checks confirmed exact collected identity bytes, the original source commit, case-insensitive canary-only hiding and unchanged public configuration. Gitleaks 8.30.1 staged scan and diff check passed.

This PR does not activate or publish the module and does not claim lifecycle or finality completion.
