### PR TITLE
Bind finalized native ETH Any Quote index and hide canaries

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -412,6 +412,7 @@ condition = "AND"
 regexTarget = "match"
 paths = [
   '''^config/module-engine/robinhood\.json$''',
+  '''^config/module-engine/index-releases\.json$''',
   '''^config/module-engine/catalog\.json$''',
   '''^public/developers/modules/0x81185e910dec1032df4bd027f8139f524606f628c0a63dbae62c69bb86e470da/manifest\.json$''',
   '''^public/developers/modules/0x616f4584f5ec576a88bac5b6d5ee1ae841713f02129ab71a9b47e7e900312b2f/manifest\.json$''',

--- a/config/module-engine/index-releases.json
+++ b/config/module-engine/index-releases.json
@@ -1,4 +1,60 @@
 {
   "schemaVersion": "programmable.module-engine.index-releases.v1",
-  "releases": []
+  "releases": [
+    {
+      "chainId": 4663,
+      "contracts": {
+        "host": {
+          "address": "0xcec7d7a0fd6dabe473f3aff998eb054f161924e2",
+          "runtimeCodeHash": "0x67d13e69f9c1ce81e44fb531248fd317270870eb9c66860d449994a8a4ac8201"
+        },
+        "launchPolicy": {
+          "address": "0xf3ff250759a66edc7893bba9d34daf4ba4ae4caa",
+          "runtimeCodeHash": "0x1c485a64c77174e0b2a78adf2527128792180def26cbab2ca00fcfa74b73ba91"
+        },
+        "ledger": {
+          "address": "0x029ac9c1f6f3dc8d7736bd254c156b43edad15ac",
+          "runtimeCodeHash": "0xd8de4394b0ee40a35dfad6bf9df05c2f27e08e2d40ea716228f95062986ec2dd"
+        },
+        "nativeRouteGuard": {
+          "address": "0x92c1d5735a89488a77841634c48d922cd3f2c0e4",
+          "runtimeCodeHash": "0x704f8f3c1903e1f15dd041b2dd29673a8c98bee9c87f645da90978c2315cf4ee"
+        },
+        "poolManager": {
+          "address": "0x8366a39cc670b4001a1121b8f6a443a643e40951",
+          "runtimeCodeHash": "0xbd3881180b547f5fe817545743cfb4343e96b1bc6640dcd70c106b0066e95626"
+        },
+        "registry": {
+          "address": "0x0082094ebeb3817cd78b2bc3725ca23b5720d884",
+          "runtimeCodeHash": "0x364028382d38d4d1d4994ad305e0538f72ef2f2360a0f671ae82912c44374fdd"
+        },
+        "sharedHook": {
+          "address": "0x71bd471d449bd7283d01b4601109eb263bd260cc",
+          "runtimeCodeHash": "0x658ef474d7f0fa2f945cc3ac92679a896ccf9d29688c9c307e8da7640aee4553"
+        },
+        "tokenFactory": {
+          "address": "0x754e8c1ade3c6c4c863590a91f2ed020baf8e779",
+          "runtimeCodeHash": "0x9354ef051bafa1edccb95c91d999e31025c012ee8d93392a78a51d83594845f2"
+        },
+        "universalRouter": {
+          "address": "0x06afba43fd06227fa663b0daecf536f6eaa6bf99",
+          "runtimeCodeHash": "0xbe8e8191bb42d843c2e948a5a55772eaab864ce01e54dcd47c9d089170b302d5"
+        }
+      },
+      "economicsPolicyId": "0x294c27492f663320407c435a8ff8c8d44a0ea1623f3d1ecaa9b730c4cf40e76e",
+      "engineProfile": "robinhood-any-quote.shared-hook.native-eth.v1",
+      "finalityPolicy": "robinhood-ethereum-finalized-v1",
+      "schemaVersion": "programmable.module-engine.release.v1",
+      "sourceCommit": "27a116440c4a894a1b11e03eab02b596d72dc9bd",
+      "sourceVersion": "module-engine-any-quote-eth-v1",
+      "tokenCreationCodeHash": "0x445809d9f7a34e959de4a96dec1e1beddfb265755bf28c57c42744adea1128ef",
+      "startBlock": "60331314",
+      "releaseDigest": "0x99c3214509ebb348a3a7ee97f7eeaef325362a20da475241c2752a277fe93cc2",
+      "enabled": true,
+      "status": "active",
+      "deploymentEvidenceDigest": "0x784adea0ca139c61098704ff5fb46e52ba11c3272cec833f3b340834ab8b43b2",
+      "sourceVerificationDigest": "0x32fe600fd43cd9bae71a0917076d3ab69e46a6f3b9266ad5c31048c8e8acb9ca",
+      "lifecycleEvidenceDigest": "0xdca2ba3f7fbd80f15df1592f91c1156a5c6e23b090d4a7f9c9c33b8e0419ba01"
+    }
+  ]
 }

--- a/lib/robinhood-explore-policy.ts
+++ b/lib/robinhood-explore-policy.ts
@@ -18,6 +18,7 @@ const HIDDEN_ROBINHOOD_TOKENS = new Set([
   "0xd9320af2762e711918358422594684756ad760cc", // PN20REF backfill canary
   "0xb36271399c031ce270e0d1eed5f26dcd08367119", // AQLPTEST Any Quote LP release canary
   "0x6dcad5b2373963a677d8e0e2d7dcafea192ea41b", // Native ETH Any Quote release canary
+  "0x987de464bde48979ef92592e196cadb926602768", // AQINIT20 atomic initial-buy canary
 ]);
 
 export function isVisibleRobinhoodToken(address: string) {

--- a/scripts/security/gitleaks-policy.test.mjs
+++ b/scripts/security/gitleaks-policy.test.mjs
@@ -36,6 +36,7 @@ const anyQuotePublicFields = [
 ];
 const hashPaths = [
   "config/module-engine/robinhood.json",
+  "config/module-engine/index-releases.json",
   catalog,
   "public/developers/modules/0x81185e910dec1032df4bd027f8139f524606f628c0a63dbae62c69bb86e470da/manifest.json",
   "public/developers/modules/0x616f4584f5ec576a88bac5b6d5ee1ae841713f02129ab71a9b47e7e900312b2f/manifest.json",

--- a/scripts/test/indexed-website-reads.test.mjs
+++ b/scripts/test/indexed-website-reads.test.mjs
@@ -76,7 +76,7 @@ test("source expectations reject unsupported authentication versions and wrong s
     await assert.rejects(readIndexedWebsiteSourceExpectations(sourceConfiguration(t, changed)), /Robinhood release identity is invalid/u);
   }
   for (const source of EXPECTATIONS.robinhood.modules) assert.equal(source.source,
-    source.sourceVersion === "module-engine-any-quote-v1" ? "module-engine-v1" : source.sourceVersion);
+    ["module-engine-any-quote-v1", "module-engine-any-quote-eth-v1"].includes(source.sourceVersion) ? "module-engine-v1" : source.sourceVersion);
 });
 
 function indexConfiguration(t, releases) {
@@ -422,9 +422,11 @@ test("current Ethereum sources, finalized module sources and stale observations 
       spec.body.status = "stale";
       spec.headers["x-programmable-indexing-status"] = "stale";
       for (const [index, expected] of EXPECTATIONS.robinhood.modules.entries()) {
-        const source = { ...robinhoodSource(), ...expected };
+        const blockNumber = (BigInt(expected.startBlock) + 1n).toString();
+        const source = { ...robinhoodSource(), ...expected,
+          cursor: { number: blockNumber, hash: HASH(2000) }, finalizedBlock: blockNumber };
         spec.body.sourceEvidence.modules.push(source);
-        spec.body.items.push({ ...robinhoodItem(), tokenAddress: ADDRESS(101 + index), launchId: HASH(101 + index),
+        spec.body.items.push({ ...robinhoodItem(), blockNumber, tokenAddress: ADDRESS(101 + index), launchId: HASH(101 + index),
           sourceKind: source.source, sourceAddress: source.sourceAddress, sourceReleaseDigest: source.releaseDigest,
           routerAddress: null, stampHash: null, verificationDigest: HASH(2222) });
       }


### PR DESCRIPTION
Bind the finalized native-ETH Any Quote deployment and lifecycle to the existing website index reader so its launches can be resolved after the backend index rollout. Keep the public module catalog unchanged and hide the AQINIT20 canary alongside AQETHTEST in Explore.

The index identity uses the original deployment, source-verification and completed launch/buy/sell/direct-ETH-claim evidence. Existing source tests now recognize the native authentication version and derive synthetic checkpoints from each release start block.

Validation: 23 indexed-website-read tests passed; git diff --check passed. Public availability remains on hold.

The credential scanner retains its exact public-value restrictions at the additional index-evidence paths. Existing positive and adjacent-credential negative controls passed with checksum-pinned Gitleaks 8.30.1; the complete PR history scan reports no leaks.
