### PR TITLE
Fix native ETH fee copy and Module Engine RPC failover

### DIFF
--- a/components/module-engine-builder.tsx
+++ b/components/module-engine-builder.tsx
@@ -15,7 +15,7 @@ import { configurationFromForm, configurationToForm, defaultSchemaValue, parseEx
 import { moduleAddress, moduleBytes } from "@/lib/module-mode/release";
 import { ENGINE_ZERO_ADDRESS, ENGINE_ZERO_HASH, moduleEngineOptionalHash, parseModuleEngineAvailability, type ModuleEngineAvailability, type ModuleEngineCatalogDefinition } from "@/lib/module-engine/catalog";
 import { createModuleEngineClient, ENGINE_OPERATIONS, moduleEngineDepositIntent, moduleEngineSettlementRequestIntent, moduleEngineTradeIntent, prepareModuleEngineApproval, prepareModuleEngineLaunch, readModuleEngineQuoteAsset, type ModuleEngineApprovalRequired, type ModuleEngineClient, type ModuleEngineOperationIntent, type PreparedModuleEngineTransaction } from "@/lib/module-engine/client";
-import { isModuleEngineSharedQuoteRelease } from "@/lib/module-engine/profile";
+import { isModuleEngineAnyQuoteEthRelease, isModuleEngineSharedQuoteRelease } from "@/lib/module-engine/profile";
 import { prepareModuleEngineAnyQuoteLaunch } from "@/lib/module-engine/any-quote/integration-client";
 import { anyQuoteUserMessage, ModuleEngineAnyQuoteAsset, useAnyQuoteAssetAvailability } from "./module-engine-any-quote-asset";
 import { ModuleEnginePicker } from "./module-engine-library";
@@ -228,7 +228,7 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
               <summary><span>Creator fees</span><span className={engineStyles.optionalLabel}>{buyFee}% buy · {sellFee}% sell</span><ChevronDown size={16} aria-hidden="true" /></summary>
               <div className={engineStyles.detailsBody}>
                 <div className={styles.twoFields}>{[["buy", buyFee, setBuyFee], ["sell", sellFee, setSellFee]].map(([side, value, setValue]) => <div className={styles.field} key={side as string}><label htmlFor={`engine-${side}-fee`}>{side === "buy" ? "Buy" : "Sell"} fee</label><select id={`engine-${side}-fee`} value={value as string} onChange={event => edit(() => (setValue as (value: string) => void)(event.target.value))}>{Array.from({ length: 11 }, (_, i) => <option key={i} value={String(i)}>{i}%</option>)}</select></div>)}</div>
-                <p className={styles.help}>Your creator fees are separate from the fixed 0.3% module fee on every buy and sell. All fees accrue in the pool pair token. Creator rates stay fixed after launch.</p>
+                <p className={styles.help}>Your creator fees are separate from the fixed 0.3% module fee on every buy and sell. All fees accrue in {isModuleEngineAnyQuoteEthRelease(availability.release) ? "ETH" : "the pool pair token"}. Creator rates stay fixed after launch.</p>
               </div>
             </Disclosure> : <Disclosure className={`${engineStyles.launchSettings} ${engineStyles.optionalDetails}`}>
               <summary><span>Launch settings</span><ChevronDown size={16} aria-hidden="true" /></summary>

--- a/lib/module-engine/client.ts
+++ b/lib/module-engine/client.ts
@@ -1,5 +1,5 @@
 import { assertAnyQuoteNativeBacking, assertAnyQuoteNativeFeeSettlement } from "./any-quote/native-fee-evidence";
-import { concatHex, decodeAbiParameters, decodeEventLog, decodeFunctionResult, encodeAbiParameters, encodeEventTopics, encodeFunctionData, erc20Abi, getCreate2Address, keccak256, parseAbi, parseAbiParameters, toHex, type Abi, type Address, type Hex, type PublicClient, type TransactionReceipt } from "viem";
+import { concatHex, decodeAbiParameters, decodeEventLog, decodeFunctionResult, encodeAbiParameters, encodeEventTopics, encodeFunctionData, erc20Abi, fallback, getCreate2Address, http, keccak256, parseAbi, parseAbiParameters, toHex, type Abi, type Address, type Hex, type PublicClient, type TransactionReceipt } from "viem";
 import { compileOpenConfig, type OpenConfigValue } from "@/packages/classic-modules/src/open-config.mjs";
 import { createModuleNativeClient, type ModuleNativeClient, type ModuleNativeWalletTransaction } from "@/lib/module-mode/native-client";
 import { nativeCanonicalJson } from "@/lib/module-mode/native-catalog";
@@ -19,7 +19,12 @@ import { compileModuleEngineLaunch, moduleEngineOperation as operationFor } from
 export { materializeModuleEngineRuntime, predictModuleEngineAddress } from "./operation-plan";
 
 export type ModuleEngineClient = ModuleNativeClient & Partial<Pick<PublicClient, "getLogs">>;
-export const createModuleEngineClient = createModuleNativeClient;
+export function createModuleEngineClient(): ModuleEngineClient {
+  return createModuleNativeClient(fallback([
+    http(undefined, { timeout: 15_000, retryCount: 0 }),
+    http("https://rpc-robinhood.blockmachine.io", { timeout: 15_000, retryCount: 0 }),
+  ], { rank: false, retryCount: 0 }));
+}
 export interface ModuleEngineOperation { operationId: Hex; actor: Address; recipient: Address; inputAsset: Address; inputAmount: bigint; outputAsset: Address; minimumOutput: bigint; deadline: bigint; nonce: bigint; data: Hex }
 export type ModuleEngineOperationIntent = Omit<ModuleEngineOperation, "actor" | "nonce" | "deadline">;
 export interface ModuleEngineLaunchRecord { launchId: Hex; revisionId: Hex; creator: Address; token: Address; quoteAsset: Address; engine: Address; engineCodeHash: Hex; constructorHash: Hex; initCodeHash: Hex; configurationHash: Hex; planHash: Hex; resourcesHash: Hex; buyCreatorFeeBps: number; sellCreatorFeeBps: number }

--- a/lib/module-mode/native-client.ts
+++ b/lib/module-mode/native-client.ts
@@ -1,7 +1,7 @@
 import {
   createPublicClient, decodeEventLog, decodeFunctionResult, encodeAbiParameters, encodeEventTopics, encodeFunctionData,
   erc20Abi, getCreate2Address, http, keccak256, parseAbiParameters, sha256, toHex,
-  type Abi, type Address, type Hex, type PublicClient, type TransactionReceipt,
+  type Abi, type Address, type Hex, type PublicClient, type TransactionReceipt, type Transport,
 } from "viem";
 import { robinhoodChain } from "@/lib/chains";
 import { MAX_TOKEN_DESCRIPTION_BYTES, MAX_TOKEN_NAME_BYTES } from "@/lib/metadata-policy";
@@ -15,8 +15,8 @@ import type { ModuleManagementBuildInput } from "./management";
 import { moduleTokenMetadata, normalizeModuleSocialLinks } from "./token-metadata";
 
 export type ModuleNativeClient = Pick<PublicClient, "getChainId" | "getBlock" | "getCode" | "readContract" | "call" | "estimateGas" | "getTransaction" | "waitForTransactionReceipt">;
-export function createModuleNativeClient(): ModuleNativeClient {
-  return createPublicClient({ chain: robinhoodChain, transport: http(undefined, { timeout: 15_000, retryCount: 1 }), batch: { multicall: false } });
+export function createModuleNativeClient(transport: Transport = http(undefined, { timeout: 15_000, retryCount: 1 })): ModuleNativeClient {
+  return createPublicClient({ chain: robinhoodChain, transport, batch: { multicall: false } });
 }
 const ZERO = "0x0000000000000000000000000000000000000000" as Address;
 const SUPPLY = 1_000_000_000n * 10n ** 18n;

--- a/tests/module-engine-any-quote-ui.test.tsx
+++ b/tests/module-engine-any-quote-ui.test.tsx
@@ -23,6 +23,7 @@ describe("Any Quote LP visible economic and availability boundaries", () => {
     expect(html).not.toContain("Leave blank to launch without a buy");
     expect(html).toContain("Connect wallet");
     expect(html).toContain("0.3% module fee per buy and sell");
+    expect(html).toContain("All fees accrue in the pool pair token."); expect(html).not.toContain("All fees accrue in ETH.");
     expect(html).not.toContain("Check token");
     for (const technical of ["Minimum fees in ETH", "Conversion route", "Fixed module settings", "initialTick", "priceEvidenceHash", "Creator fees accrue in ETH"]) expect(html).not.toContain(technical);
   });
@@ -52,6 +53,7 @@ describe("Any Quote LP visible economic and availability boundaries", () => {
   });
   it("shows native fees in ETH without changing historical quote claims or adding launch controls", () => {
     const html = renderToStaticMarkup(<ModuleEngineBuilder {...actions} {...anyQuoteUiFixture(true)} />);
+    expect(html).toContain("All fees accrue in ETH."); expect(html).not.toContain("All fees accrue in the pool pair token.");
     expect(html.match(/id="engine-quote"/g)).toHaveLength(1); expect(html).toContain("Initial buy"); expect(html).not.toContain("Conversion route");
     const prepared: PreparedModuleEngineClaim = { ...base, kind: "claim", nativeEthFees: true, recipient: ACCOUNT, minimumAmount: 125n * 10n ** 16n, claimedBefore: 0n, feeAsset: addr(0), feeDecimals: 18 };
     const claim = renderToStaticMarkup(<ModuleEngineTransactionReview prepared={prepared} anyQuote quoteAsset={QUOTE} quoteDecimals={6} busy={false} onConfirm={vi.fn()} onEdit={vi.fn()} />);

--- a/tests/module-engine-client.test.ts
+++ b/tests/module-engine-client.test.ts
@@ -1,9 +1,42 @@
-import { describe, expect, it, vi } from "vitest";
-import { decodeFunctionData, encodeAbiParameters, encodeEventTopics, keccak256, type Hex, type TransactionReceipt } from "viem";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { decodeFunctionData, encodeAbiParameters, encodeEventTopics, encodeFunctionData, keccak256, type Hex, type TransactionReceipt } from "viem";
+import { ROBINHOOD_MAINNET_RPC_URL } from "@/lib/chains";
 import { moduleEngineHostAbi, moduleEnginePlanParameters } from "@/lib/module-engine/abi";
+import { MODULE_ENGINE_ANY_QUOTE_ETH_SOURCE_ID } from "@/lib/module-engine/profile";
 import { bindActiveModuleEngineRelease, bindModuleEngineTemplate, computeModuleEngineHostManifestHash, ENGINE_ZERO_ADDRESS as ZERO } from "@/lib/module-engine/catalog";
-import { assertModuleEngineRelease, materializeModuleEngineRuntime, moduleEngineTradeIntent, prepareModuleEngineLaunch, prepareModuleEngineOperation, readModuleEngineLaunch, revalidateModuleEngineTransaction, verifyModuleEngineOperationReceipt } from "@/lib/module-engine/client";
+import { assertModuleEngineRelease, createModuleEngineClient, materializeModuleEngineRuntime, moduleEngineTradeIntent, prepareModuleEngineLaunch, prepareModuleEngineOperation, readModuleEngineLaunch, revalidateModuleEngineTransaction, verifyModuleEngineOperationReceipt } from "@/lib/module-engine/client";
 import { fixture, ACCOUNT, QUOTE, TOKEN, CODE, CODE_HASH, addr, hash } from "./module-engine-fixture";
+
+describe("Module Engine public RPC failover", () => {
+  afterEach(() => vi.unstubAllGlobals());
+  const secondaryUrl = "https://rpc-robinhood.blockmachine.io";
+  const sourceRead = { address: addr(1), abi: moduleEngineHostAbi, functionName: "SOURCE_VERSION", blockNumber: 100n } as const;
+  function responses(secondaryAvailable: boolean) {
+    const attempts: { url: string; body: { id: number; method: string; params: unknown[] } }[] = [];
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init), body = await request.json();
+      const url = new URL(request.url).origin;
+      attempts.push({ url, body });
+      if (url === ROBINHOOD_MAINNET_RPC_URL || !secondaryAvailable) return new Response("Forbidden", { status: 403 });
+      expect(url).toBe(secondaryUrl);
+      return Response.json({ jsonrpc: "2.0", id: body.id, result: MODULE_ENGINE_ANY_QUOTE_ETH_SOURCE_ID });
+    }));
+    return attempts;
+  }
+  it("tries the secondary immediately after primary 403 and preserves the direct call and block", async () => {
+    const attempts = responses(true);
+    await expect(createModuleEngineClient().readContract(sourceRead)).resolves.toBe(MODULE_ENGINE_ANY_QUOTE_ETH_SOURCE_ID);
+    expect(attempts.map(attempt => attempt.url)).toEqual([ROBINHOOD_MAINNET_RPC_URL, secondaryUrl]);
+    const call = { method: "eth_call", params: [{ to: sourceRead.address, data: encodeFunctionData(sourceRead) }, "0x64"] };
+    expect(attempts.map(({ body: { method, params } }) => ({ method, params }))).toEqual([call, call]);
+  });
+  it("rejects when both public providers fail without retrying either provider", async () => {
+    const attempts = responses(false);
+    await expect(createModuleEngineClient().readContract(sourceRead)).rejects.toThrow("HTTP request failed");
+    expect(attempts.map(attempt => attempt.url)).toEqual([ROBINHOOD_MAINNET_RPC_URL, secondaryUrl]);
+  });
+});
+
 describe("isolated engine source and transaction bindings", () => {
   it("uses the actual Host ABI without native launch selectors", () => { expect(moduleEngineHostAbi.some(item => item.type === "event" && item.name === "EngineLaunchBound")).toBe(true); expect(moduleEngineHostAbi.some(item => item.type === "event" && item.name.includes("Native"))).toBe(false); });
   it("rejects another host source even with the same reviewed pins", async () => { const f = fixture(); f.state.wrongSource = true; await expect(assertModuleEngineRelease(f)).rejects.toThrow("source version"); });


### PR DESCRIPTION
Review launch could stop when the configured public Robinhood RPC returned HTTP 403 for a contract read. The Module Engine client now uses viem fallback with the configured chain RPC first and the existing public Blockmachine endpoint second. Each provider gets one attempt with a 15-second timeout; ranking and retries are disabled so a 403 immediately advances to the second provider. Multicall remains disabled, and all existing chain, block, runtime, source, and transaction checks remain in place.

The shared native client factory accepts an optional transport while preserving its existing default. The change adds no proxy, backend endpoint, credentials, signing, or submission logic.

The Any Quote Creator fees disclosure also incorrectly named the pool pair token for the native ETH profile. It now uses the existing native ETH predicate to show “All fees accrue in ETH.” and retains the legacy quote-denominated text. The nearby accepted About description already names native ETH correctly.

Validation:

- 48 focused client and browser-CSP tests passed. The new transport regression verifies primary 403 → secondary success with the identical direct call and block number, and rejection after both providers fail without retries.
- All nine existing Any Quote UI tests passed for the fee-copy change, including explicit assertions for both currencies.
- TypeScript, focused ESLint, and diff checks passed.

Production merge, deployment, and browser acceptance remain with the integration owner.
