### PR TITLE
Use the same module picker for Any Quote LP

### DIFF
--- a/app/launch/modules/page.tsx
+++ b/app/launch/modules/page.tsx
@@ -27,7 +27,8 @@ export default async function ModuleModePage({ searchParams }: { searchParams: P
   ]);
   const versions = [nativeVersions, engineVersions].flatMap(result => result.status === "fulfilled" ? result.value : []);
   if (selection.sourceKind === "module-engine-v1") return <ModuleEngineHost releaseDigest={selection.releaseDigest} versions={versions}
-    nativeCatalog={nativeAvailability.status === "fulfilled" ? nativeAvailability.value?.catalog ?? [] : []} />;
+    nativeCatalog={nativeAvailability.status === "fulfilled" ? nativeAvailability.value?.catalog ?? [] : []}
+    nativeRelease={nativeAvailability.status === "fulfilled" ? nativeAvailability.value?.release : undefined} />;
   let anyQuoteReleaseDigest;
   let anyQuoteModule;
   if (currentEngine.status === "fulfilled") {

--- a/app/launch/modules/page.tsx
+++ b/app/launch/modules/page.tsx
@@ -8,6 +8,8 @@ import reviewedAnyQuoteRelease from "@/config/module-engine/review-release.json"
 import { notFound } from "next/navigation";
 import { parseModuleModePageSelection } from "@/lib/module-mode/release-selection";
 import { readModuleModeLaunchVersions } from "@/lib/server/module-mode/launch-profiles";
+import { readModuleModeAvailability } from "@/lib/server/module-mode/catalog";
+import { anyQuoteLibraryEntry } from "@/lib/module-engine/library-entry";
 
 export const metadata: Metadata = {
   title: "Module Mode · Programmable",
@@ -19,19 +21,25 @@ export const metadata: Metadata = {
 export default async function ModuleModePage({ searchParams }: { searchParams: Promise<Record<string, string | string[] | undefined>> }) {
   let selection;
   try { selection = parseModuleModePageSelection(await searchParams); } catch { notFound(); }
-  const [nativeVersions, engineVersions, currentEngine] = await Promise.allSettled([
+  const [nativeVersions, engineVersions, currentEngine, nativeAvailability] = await Promise.allSettled([
     readModuleModeLaunchVersions(), readModuleEngineLaunchVersions(), readModuleEngineAvailability(reviewedAnyQuoteRelease.releaseDigest),
+    selection.sourceKind === "module-engine-v1" ? readModuleModeAvailability() : Promise.resolve(null),
   ]);
   const versions = [nativeVersions, engineVersions].flatMap(result => result.status === "fulfilled" ? result.value : []);
-  if (selection.sourceKind === "module-engine-v1") return <ModuleEngineHost releaseDigest={selection.releaseDigest} versions={versions} />;
+  if (selection.sourceKind === "module-engine-v1") return <ModuleEngineHost releaseDigest={selection.releaseDigest} versions={versions}
+    nativeCatalog={nativeAvailability.status === "fulfilled" ? nativeAvailability.value?.catalog ?? [] : []} />;
   let anyQuoteReleaseDigest;
+  let anyQuoteModule;
   if (currentEngine.status === "fulfilled") {
     try {
       const { release, templates } = parseModuleEngineAvailability(currentEngine.value);
       // The review identity only selects the entry; current public authority must independently admit it.
-      if (release && isModuleEngineSharedQuoteRelease(release) && release.releaseDigest === reviewedAnyQuoteRelease.releaseDigest
-        && templates.some(template => template.manifest.manifest.catalogDefinition.interface === "quote-shared-v1")) anyQuoteReleaseDigest = release.releaseDigest;
+      const template = templates.find(candidate => candidate.manifest.manifest.catalogDefinition.interface === "quote-shared-v1");
+      if (release && isModuleEngineSharedQuoteRelease(release) && release.releaseDigest === reviewedAnyQuoteRelease.releaseDigest && template) {
+        anyQuoteReleaseDigest = release.releaseDigest;
+        anyQuoteModule = anyQuoteLibraryEntry(template.manifest.manifest.catalogDefinition);
+      }
     } catch { /* Unavailable or unbound engine sources never create a launch entry. */ }
   }
-  return <ModuleModeLaunchHost releaseDigest={selection.releaseDigest} versions={versions} anyQuoteReleaseDigest={anyQuoteReleaseDigest} />;
+  return <ModuleModeLaunchHost releaseDigest={selection.releaseDigest} versions={versions} anyQuoteReleaseDigest={anyQuoteReleaseDigest} anyQuoteModule={anyQuoteModule} />;
 }

--- a/components/module-engine-builder.tsx
+++ b/components/module-engine-builder.tsx
@@ -6,12 +6,13 @@ import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
 import { formatUnits, keccak256, toHex, type Address, type Hex } from "viem";
-import { ArrowLeft, ArrowUpRight, Check, ChevronDown, Plus, Puzzle } from "lucide-react";
+import { ArrowLeft, ArrowUpRight, Check, ChevronDown, Plus, Puzzle, Settings2, X } from "lucide-react";
 import { MODULE_DEFAULT_TOKEN_IMAGE, validateModuleSocialLinks, type ModuleSocialLinks, type ModuleSocialIssue } from "@/lib/module-mode/token-metadata";
 import { ModuleModeImagePicker, moduleModeImageSource, type ModuleModeImageResource } from "@/components/module-mode-image";
 import { ModuleSchemaField } from "@/components/module-mode-fields";
 import { assertModuleModeWalletUnchanged, moduleModeWalletStep } from "@/components/module-mode-wallet-state";
-import { configurationFromForm, configurationToForm, defaultSchemaValue, parseExactUnits, utcDateTimeToSeconds, type FormValue, type ModuleModeImage } from "@/lib/module-mode/builder";
+import { configurationFromForm, configurationToForm, defaultSchemaValue, parseExactUnits, utcDateTimeToSeconds, type FormValue, type ModuleModeImage, type ModuleModeCatalogEntry, type ModuleModeState } from "@/lib/module-mode/builder";
+import { consumeModuleModeLaunchDraftHandoff, saveModuleModeLaunchDraftHandoff } from "@/lib/module-mode/launch-draft-handoff";
 import { moduleAddress, moduleBytes } from "@/lib/module-mode/release";
 import { ENGINE_ZERO_ADDRESS, ENGINE_ZERO_HASH, moduleEngineOptionalHash, parseModuleEngineAvailability, type ModuleEngineAvailability, type ModuleEngineCatalogDefinition } from "@/lib/module-engine/catalog";
 import { createModuleEngineClient, ENGINE_OPERATIONS, moduleEngineDepositIntent, moduleEngineSettlementRequestIntent, moduleEngineTradeIntent, prepareModuleEngineApproval, prepareModuleEngineLaunch, readModuleEngineQuoteAsset, type ModuleEngineApprovalRequired, type ModuleEngineClient, type ModuleEngineOperationIntent, type PreparedModuleEngineTransaction } from "@/lib/module-engine/client";
@@ -19,6 +20,9 @@ import { isModuleEngineAnyQuoteEthRelease, isModuleEngineSharedQuoteRelease } fr
 import { prepareModuleEngineAnyQuoteLaunch } from "@/lib/module-engine/any-quote/integration-client";
 import { anyQuoteUserMessage, ModuleEngineAnyQuoteAsset, useAnyQuoteAssetAvailability } from "./module-engine-any-quote-asset";
 import { ModuleEnginePicker } from "./module-engine-library";
+import { ModuleCategoryIcon, ModuleLibrary } from "./module-library";
+import { ModulePickerDialog } from "./module-picker-dialog";
+import { anyQuoteLibraryEntry } from "@/lib/module-engine/library-entry";
 import { ModuleEngineCustomOperationFields } from "./module-engine-custom-operation";
 import { emptyModuleEngineCustomOperation, moduleEngineCustomOperationIntent } from "@/lib/module-engine/custom-operation";
 import { ModuleEngineTransactionReview, type ModuleEngineWalletActions } from "./module-engine-transaction-review";
@@ -28,6 +32,7 @@ import engineStyles from "./module-engine-ui.module.css";
 export interface ModuleEngineBuilderProps extends ModuleEngineWalletActions {
   availability: ModuleEngineAvailability; client?: ModuleEngineClient;
   statusContent?: ReactNode; versionContent?: ReactNode;
+  nativeCatalog?: readonly ModuleModeCatalogEntry[]; onRemoveModule?: () => void;
   onUploadImage?: (image: Extract<ModuleModeImage, { kind: "local" }>, blob: Blob) => Promise<string>;
 }
 export function moduleEngineInitialForm(definition: ModuleEngineCatalogDefinition): FormValue { try { return configurationToForm(definition.schema, definition.defaults, definition.fields); } catch { return defaultSchemaValue(definition.schema, definition.fields); } }
@@ -48,7 +53,7 @@ function message(error: unknown) { return anyQuoteUserMessage(error, error insta
 function fixedConfiguration(schema: ModuleEngineCatalogDefinition["schema"]): boolean { return schema.binding?.mode === "fixed" || schema.type === "record" && Object.keys(schema.fields).length > 0 && Object.values(schema.fields).every(fixedConfiguration); }
 
 /** Configuration and wallet controls extend the existing Module Mode flow; no independent wallet is created. */
-export function ModuleEngineBuilder({ availability: raw, client: suppliedClient, wallet, onConnect, onSwitch, onSubmit, blocked, blockedReason, statusContent, versionContent, onUploadImage }: ModuleEngineBuilderProps) {
+export function ModuleEngineBuilder({ availability: raw, client: suppliedClient, wallet, onConnect, onSwitch, onSubmit, blocked, blockedReason, statusContent, versionContent, onUploadImage, nativeCatalog = [], onRemoveModule }: ModuleEngineBuilderProps) {
   const hydrated = useSyncExternalStore(subscribeToHydration, readHydrated, readServerHydrated);
   const client = useMemo(() => suppliedClient ?? createModuleEngineClient(), [suppliedClient]);
   const parsed = useMemo(() => { try { return { availability: parseModuleEngineAvailability(raw), error: null }; } catch (error) { return { availability: null, error: message(error) }; } }, [raw]);
@@ -58,7 +63,12 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
   const [socialLinks, setSocialLinks] = useState<ModuleSocialLinks>({}); const [socialIssues, setSocialIssues] = useState<ModuleSocialIssue[]>([]); const { expanded: moreLinks, setExpanded: setMoreLinks, toggle: toggleMoreLinks, panelProps: moreLinksPanel } = useDisclosureState();
   const [image, setImage] = useState<ModuleModeImage>({ kind: "none" }); const [imageResource, setImageResource] = useState<ModuleModeImageResource | null>(null); const [imageBusy, setImageBusy] = useState(false);
   const imageUrls = useRef(new Set<string>()), uploadedImage = useRef<{ hash: Hex; account: Address; uri: string } | null>(null);
-  useEffect(() => { const urls = imageUrls.current; return () => urls.forEach(url => URL.revokeObjectURL(url)); }, []);
+  const imageMounted = useRef(false), handoffConsumed = useRef(false), nativeDraft = useRef<ModuleModeState | undefined>(undefined);
+  useEffect(() => {
+    imageMounted.current = true;
+    const urls = imageUrls.current;
+    return () => { imageMounted.current = false; queueMicrotask(() => { if (!imageMounted.current) { urls.forEach(url => URL.revokeObjectURL(url)); urls.clear(); } }); };
+  }, []);
   const [quote, setQuote] = useState(""); const [quoteState, setQuoteState] = useState<(Awaited<ReturnType<typeof readModuleEngineQuoteAsset>> & { account: Address }) | null>(null);
   const [customInitialForm, setCustomInitialForm] = useState(emptyModuleEngineCustomOperation);
   const [creatorSaltInput, setCreatorSaltInput] = useState(""); const [engineSaltInput, setEngineSaltInput] = useState(""); const [launchData, setLaunchData] = useState("0x");
@@ -69,12 +79,27 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
   const [error, setError] = useState<string | null>(null); const [notice, setNotice] = useState<string | null>(null); const [busy, setBusy] = useState(false);
   const salts = useRef<{ creator: Hex; engine: Hex } | null>(null);
   const coinDetails = useRef<HTMLDetailsElement>(null);
-  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false), [pickerPointer, setPickerPointer] = useState(false);
   const template = availability?.templates.find(item => item.manifest.manifest.catalogDefinition.id === selected) ?? availability?.templates[0];
   const definition = template?.manifest.manifest.catalogDefinition, revision = template?.manifest.manifest.revision;
   const fixedQuote = revision && revision.fixedQuoteAsset !== ENGINE_ZERO_ADDRESS ? revision.fixedQuoteAsset : null;
   const quoteAsset = fixedQuote ?? quote; const form = definition ? forms[definition.id] ?? moduleEngineInitialForm(definition) : {};
   const anyQuote = Boolean(availability?.release && isModuleEngineSharedQuoteRelease(availability.release) && definition?.interface === "quote-shared-v1");
+  const anyQuoteEntry = anyQuote && definition ? anyQuoteLibraryEntry(definition) : null;
+  useEffect(() => {
+    if (!anyQuote || handoffConsumed.current) return;
+    handoffConsumed.current = true;
+    const draft = consumeModuleModeLaunchDraftHandoff("any-quote");
+    if (!draft) return;
+    nativeDraft.current = draft.nativeState;
+    if (draft.imageResource) imageUrls.current.add(draft.imageResource.objectUrl);
+    queueMicrotask(() => {
+      if (!imageMounted.current) return;
+      setName(draft.name); setSymbol(draft.symbol); setDescription(draft.description); setSocialLinks(draft.socialLinks ?? {});
+      setImage(draft.tokenImage); setImageResource(draft.imageResource); setImageUri(draft.tokenImage.kind === "uri" ? draft.tokenImage.uri : "");
+      setAmount(draft.initialBuyEth); setBuyFee(draft.buyFeePercent); setSellFee(draft.sellFeePercent);
+    });
+  }, [anyQuote]);
   const anyQuoteAvailability = useAnyQuoteAssetAvailability({ enabled: anyQuote, releaseDigest: availability?.release?.releaseDigest, templateId: definition?.id, quoteAsset });
   const readyQuote = anyQuoteAvailability.status === "compatible" && anyQuoteAvailability.result?.status === "compatible" ? anyQuoteAvailability.result : null;
   const needsInitial = !anyQuote && revision && revision.initialOperationId !== ENGINE_ZERO_HASH, spot = definition?.interface === "quote-v1" || anyQuote;
@@ -87,6 +112,17 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
   function changeImage(value: ModuleModeImage, resource: ModuleModeImageResource | null) { if (resource) imageUrls.current.add(resource.objectUrl); edit(() => { setImage(value); setImageResource(resource); uploadedImage.current = null; setImageUri(value.kind === "uri" ? value.uri : ""); }); }
   function backToEdit() { const id = prepared?.kind === "approve" ? "engine-approval-review" : "engine-launch-review"; setPrepared(null); requestAnimationFrame(() => document.getElementById(id)?.focus()); }
   function edit(change: () => void) { change(); setPrepared(null); setApproval(null); setError(null); setNotice(null); }
+  function removeAnyQuoteModule() {
+    if (!anyQuote || !onRemoveModule || !hydrated || busy || imageBusy || blocked || prepared) return;
+    saveModuleModeLaunchDraftHandoff("native", { name, symbol, description, socialLinks,
+      tokenImage: image.kind === "none" && imageUri ? { kind: "uri", uri: imageUri, contentVerified: false } : image,
+      imageResource, initialBuyEth: amount, buyFeePercent: buyFee, sellFeePercent: sellFee, nativeState: nativeDraft.current });
+    setPickerOpen(false); onRemoveModule();
+  }
+  function configureAnyQuoteModule() {
+    const input = document.getElementById("engine-quote");
+    input?.scrollIntoView({ block: "center" }); input?.focus({ preventScroll: true });
+  }
   async function checkQuote() {
     if (!availability?.release || !template || !wallet.account) return; setBusy(true); setError(null);
     try { const account = moduleAddress(wallet.account, "account"); const current = await readModuleEngineQuoteAsset({ client, release: availability.release, template, quoteAsset: moduleAddress(quoteAsset, "quote asset"), account }); setQuoteState({ ...current, account }); setRoute(current.routes[0]?.data ?? ""); if (spot && current.routes.length === 0) throw new Error("This template has no valid fixed fee route for the selected quote asset."); }
@@ -180,21 +216,22 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
               </Disclosure>
             </section>
 
-            <section className={styles.formSection} id="engine-modules">
-              <div className={engineStyles.sectionHeading}><h2>Modules</h2><p>Add features to your coin.</p></div>
-              <div className={engineStyles.selectedModule}>
+            <section className={anyQuote ? styles.modulesSection : styles.formSection} id="engine-modules">
+              {anyQuoteEntry ? <>
+                <div className={styles.moduleSectionHeading}><div><h2>Modules</h2><p>Add features to your coin.</p></div><Puzzle size={24} strokeWidth={1.6} aria-hidden="true" /></div>
+                <ul className={styles.selectedModules}><li id={`module-selection-${anyQuoteEntry.id}`}>
+                  <ModuleCategoryIcon category="pairs" size={20} />
+                  <button type="button" className={styles.configureModule} disabled={!hydrated || busy || imageBusy || blocked} onClick={configureAnyQuoteModule} aria-label={`Configure ${anyQuoteEntry.title}`}><span>{anyQuoteEntry.title}</span><Settings2 size={16} aria-hidden="true" /></button>
+                  <button type="button" className={styles.removeModule} disabled={!hydrated || busy || imageBusy || blocked || !onRemoveModule} onClick={removeAnyQuoteModule} aria-label={`Remove ${anyQuoteEntry.title}`}><X size={17} aria-hidden="true" /></button>
+                </li></ul>
+                <ModuleEngineAnyQuoteAsset value={quoteAsset} availability={anyQuoteAvailability} onChange={value => edit(() => setQuote(value))} />
+                <button type="button" className={styles.addModulesButton} data-module-add disabled={!hydrated || busy || imageBusy || blocked} onClick={event => { setPickerPointer(event.detail > 0); setPickerOpen(true); }} aria-haspopup="dialog"><Plus size={18} aria-hidden="true" />Add modules</button>
+              </> : <><div className={engineStyles.sectionHeading}><h2>Modules</h2><p>Add features to your coin.</p></div><div className={engineStyles.selectedModule}>
                 <Puzzle size={20} aria-hidden="true" />
                 <div><strong>{definition.title}</strong><p>{definition.summary}</p></div>
                 <button type="button" className={engineStyles.changeModule} disabled={!hydrated || busy || imageBusy || blocked} onClick={() => setPickerOpen(true)} aria-haspopup="dialog">Change</button>
-              </div>
+              </div></>}
               {anyQuote ? <>
-                <ModuleEngineAnyQuoteAsset value={quoteAsset} availability={anyQuoteAvailability} onChange={value => edit(() => setQuote(value))} />
-                <div className={`${styles.field} ${engineStyles.anyQuoteInitialBuy}`}>
-                  <label htmlFor="engine-amount">Initial buy</label>
-                  <div className={engineStyles.anyQuoteAmount}><input ref={amountFocus} id="engine-amount" aria-label="Initial buy in ETH" inputMode="decimal" placeholder="0" autoComplete="off" required value={amount} onChange={event => edit(() => { setAmount(event.target.value); setAmountError(null); })} onInvalid={event => { event.preventDefault(); setAmountError("Enter an ETH amount greater than 0."); amountFocus.current?.focus(); }} aria-invalid={Boolean(amountError) || undefined} aria-describedby={amountError ? "engine-amount-help engine-amount-error" : "engine-amount-help"} /><span aria-hidden="true">ETH</span></div>
-                  <p id="engine-amount-help" className={styles.help}>Buy your coin in the launch transaction.</p>
-                  {amountError ? <p id="engine-amount-error" className={styles.fieldError} role="alert">{amountError}</p> : null}
-                </div>
                 <p className={engineStyles.sectionNote}>1 billion coins · approximately $5,000 starting value · permanently locked liquidity.</p>
                 <Disclosure className={engineStyles.moduleAbout}>
                   <summary><span>About this module</span><ChevronDown size={16} aria-hidden="true" /></summary>
@@ -223,6 +260,15 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
                 </div>
               </Disclosure>}
             </section>
+
+            {anyQuote ? <section className={styles.formSection}>
+              <div className={styles.field}>
+                <label htmlFor="engine-amount">Initial buy</label>
+                <div className={styles.inputWithUnit}><input ref={amountFocus} id="engine-amount" aria-label="Initial buy in ETH" inputMode="decimal" placeholder="0" autoComplete="off" required value={amount} onChange={event => edit(() => { setAmount(event.target.value); setAmountError(null); })} onInvalid={event => { event.preventDefault(); setAmountError("Enter an ETH amount greater than 0."); amountFocus.current?.focus(); }} aria-invalid={Boolean(amountError) || undefined} aria-describedby={amountError ? "engine-amount-help engine-amount-error" : "engine-amount-help"} /><span aria-hidden="true">ETH</span></div>
+                <p id="engine-amount-help" className={styles.help}>Buy your coin in the launch transaction.</p>
+                {amountError ? <p id="engine-amount-error" className={styles.fieldError} role="alert">{amountError}</p> : null}
+              </div>
+            </section> : null}
 
             {anyQuote ? <Disclosure className={`${engineStyles.launchSettings} ${engineStyles.optionalDetails}`}>
               <summary><span>Creator fees</span><span className={engineStyles.optionalLabel}>{buyFee}% buy · {sellFee}% sell</span><ChevronDown size={16} aria-hidden="true" /></summary>
@@ -289,8 +335,8 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
           </div>
           <div className={engineStyles.attachmentLine} aria-hidden="true"><span /></div>
           <div className={engineStyles.previewModule}>
-            <span className={engineStyles.moduleIcon}><Puzzle size={20} aria-hidden="true" /></span>
-            <div><strong>{definition.title}</strong></div>
+            <span className={engineStyles.moduleIcon}>{anyQuoteEntry ? <ModuleCategoryIcon category="pairs" size={20} /> : <Puzzle size={20} aria-hidden="true" />}</span>
+            <div><strong>{anyQuoteEntry?.title ?? definition.title}</strong></div>
           </div>
           <dl className={engineStyles.previewFacts}>
             <div><dt>{quoteLabel}</dt><dd title={quoteAsset || undefined}>{quoteShort}</dd></div>
@@ -302,7 +348,14 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
           <Link href="/developers/modules" className={engineStyles.buildLink}><Puzzle size={16} aria-hidden="true" />Build your own module<ArrowUpRight size={16} aria-hidden="true" /></Link>
         </aside>
       </div>
-      <ModuleEnginePicker open={pickerOpen} templates={availability.templates} selectedId={definition.id} disabled={!hydrated || busy || imageBusy || blocked} onClose={() => setPickerOpen(false)} onSelect={item => { edit(() => { setSelected(item.manifest.manifest.catalogDefinition.id); setQuoteState(null); setAmount(""); setAmountError(null); salts.current = null; setCustomInitialForm(emptyModuleEngineCustomOperation()); setCreatorSaltInput(""); setEngineSaltInput(""); setLaunchData("0x"); setBuyFee("0"); setSellFee("0"); }); setPickerOpen(false); }} />
+      {anyQuoteEntry ? pickerOpen ? <ModulePickerDialog animateOpen={pickerPointer} title="Add modules" description="Modules are upgrades for your coin. Pick the features you want." onClose={() => setPickerOpen(false)}>
+        <ModuleLibrary catalog={[...nativeCatalog.filter(entry => entry.id !== anyQuoteEntry.id), anyQuoteEntry]} selectedIds={[anyQuoteEntry.id]}
+          disabled={!hydrated || busy || imageBusy || blocked || Boolean(prepared) || !onRemoveModule}
+          disabledFor={entry => entry.id === anyQuoteEntry.id ? undefined : "Remove Any Quote LP to use this module."}
+          feeDescriptionFor={entry => entry.id === anyQuoteEntry.id ? "Platform fee: 0.30% per trade." : undefined}
+          onAdd={entry => { if (entry.id === anyQuoteEntry.id) setPickerOpen(false); }}
+          onRemove={entry => { if (entry.id === anyQuoteEntry.id) removeAnyQuoteModule(); }} />
+      </ModulePickerDialog> : null : <ModuleEnginePicker open={pickerOpen} templates={availability.templates} selectedId={definition.id} disabled={!hydrated || busy || imageBusy || blocked} onClose={() => setPickerOpen(false)} onSelect={item => { edit(() => { setSelected(item.manifest.manifest.catalogDefinition.id); setQuoteState(null); setAmount(""); setAmountError(null); salts.current = null; setCustomInitialForm(emptyModuleEngineCustomOperation()); setCreatorSaltInput(""); setEngineSaltInput(""); setLaunchData("0x"); setBuyFee("0"); setSellFee("0"); }); setPickerOpen(false); }} />}
       {approval && !prepared ? <section className={engineStyles.notice} role="status"><p>Allow the launch contract to use exactly {quoteState ? formatUnits(approval.amount, quoteState.decimals) : approval.amount.toString()} quote tokens to fund this launch.</p><button id="engine-approval-review" className={styles.secondaryButton} type="button" disabled={busy || blocked} onClick={() => void prepareApproval()}>{approval.currentAllowance > 0n ? "Review allowance reset" : "Review exact approval"}</button></section> : null}
       {prepared ? <ModuleEngineTransactionReview prepared={prepared} busy={busy} disabled={blocked || step !== "prepare"} onEdit={backToEdit} onConfirm={() => void confirm()} quoteAsset={readyQuote?.quoteAsset ?? quoteState?.address} quoteDecimals={readyQuote?.token.decimals ?? quoteState?.decimals} quoteSymbol={readyQuote?.token.symbol} anyQuote={anyQuote} tradeFees={spot || customLaunch} genericAction={customInitial} showLaunchInputs={customLaunch}>{prepared.kind === "launch" ? <div className={engineStyles.launchSummary}><strong>{name} · {symbol}</strong><p>{description}</p><p className={styles.help}>Image: {imageUri || MODULE_DEFAULT_TOKEN_IMAGE}</p>{checkedSocial.ok ? <dl className={styles.reviewRows}>{socialFields.filter(({ key }) => checkedSocial.links[key]).map(({ key, label }) => <div key={key}><dt>{label}</dt><dd>{checkedSocial.links[key]}</dd></div>)}</dl> : null}</div> : null}</ModuleEngineTransactionReview> : null}
     </>}

--- a/components/module-engine-builder.tsx
+++ b/components/module-engine-builder.tsx
@@ -11,9 +11,9 @@ import { MODULE_DEFAULT_TOKEN_IMAGE, validateModuleSocialLinks, type ModuleSocia
 import { ModuleModeImagePicker, moduleModeImageSource, type ModuleModeImageResource } from "@/components/module-mode-image";
 import { ModuleSchemaField } from "@/components/module-mode-fields";
 import { assertModuleModeWalletUnchanged, moduleModeWalletStep } from "@/components/module-mode-wallet-state";
-import { configurationFromForm, configurationToForm, defaultSchemaValue, parseExactUnits, utcDateTimeToSeconds, type FormValue, type ModuleModeImage, type ModuleModeCatalogEntry, type ModuleModeState } from "@/lib/module-mode/builder";
+import { configurationFromForm, configurationToForm, createModuleModeState, defaultSchemaValue, moduleModeFeePolicy, parseExactUnits, setModuleSelected, utcDateTimeToSeconds, type FormValue, type ModuleModeImage, type ModuleModeCatalogEntry, type ModuleModeState } from "@/lib/module-mode/builder";
 import { consumeModuleModeLaunchDraftHandoff, saveModuleModeLaunchDraftHandoff } from "@/lib/module-mode/launch-draft-handoff";
-import { moduleAddress, moduleBytes } from "@/lib/module-mode/release";
+import { moduleAddress, moduleBytes, type ModuleModeRelease } from "@/lib/module-mode/release";
 import { ENGINE_ZERO_ADDRESS, ENGINE_ZERO_HASH, moduleEngineOptionalHash, parseModuleEngineAvailability, type ModuleEngineAvailability, type ModuleEngineCatalogDefinition } from "@/lib/module-engine/catalog";
 import { createModuleEngineClient, ENGINE_OPERATIONS, moduleEngineDepositIntent, moduleEngineSettlementRequestIntent, moduleEngineTradeIntent, prepareModuleEngineApproval, prepareModuleEngineLaunch, readModuleEngineQuoteAsset, type ModuleEngineApprovalRequired, type ModuleEngineClient, type ModuleEngineOperationIntent, type PreparedModuleEngineTransaction } from "@/lib/module-engine/client";
 import { isModuleEngineAnyQuoteEthRelease, isModuleEngineSharedQuoteRelease } from "@/lib/module-engine/profile";
@@ -32,7 +32,7 @@ import engineStyles from "./module-engine-ui.module.css";
 export interface ModuleEngineBuilderProps extends ModuleEngineWalletActions {
   availability: ModuleEngineAvailability; client?: ModuleEngineClient;
   statusContent?: ReactNode; versionContent?: ReactNode;
-  nativeCatalog?: readonly ModuleModeCatalogEntry[]; onRemoveModule?: () => void;
+  nativeCatalog?: readonly ModuleModeCatalogEntry[]; nativeRelease?: ModuleModeRelease | null; onRemoveModule?: () => void;
   onUploadImage?: (image: Extract<ModuleModeImage, { kind: "local" }>, blob: Blob) => Promise<string>;
 }
 export function moduleEngineInitialForm(definition: ModuleEngineCatalogDefinition): FormValue { try { return configurationToForm(definition.schema, definition.defaults, definition.fields); } catch { return defaultSchemaValue(definition.schema, definition.fields); } }
@@ -53,7 +53,7 @@ function message(error: unknown) { return anyQuoteUserMessage(error, error insta
 function fixedConfiguration(schema: ModuleEngineCatalogDefinition["schema"]): boolean { return schema.binding?.mode === "fixed" || schema.type === "record" && Object.keys(schema.fields).length > 0 && Object.values(schema.fields).every(fixedConfiguration); }
 
 /** Configuration and wallet controls extend the existing Module Mode flow; no independent wallet is created. */
-export function ModuleEngineBuilder({ availability: raw, client: suppliedClient, wallet, onConnect, onSwitch, onSubmit, blocked, blockedReason, statusContent, versionContent, onUploadImage, nativeCatalog = [], onRemoveModule }: ModuleEngineBuilderProps) {
+export function ModuleEngineBuilder({ availability: raw, client: suppliedClient, wallet, onConnect, onSwitch, onSubmit, blocked, blockedReason, statusContent, versionContent, onUploadImage, nativeCatalog = [], nativeRelease, onRemoveModule }: ModuleEngineBuilderProps) {
   const hydrated = useSyncExternalStore(subscribeToHydration, readHydrated, readServerHydrated);
   const client = useMemo(() => suppliedClient ?? createModuleEngineClient(), [suppliedClient]);
   const parsed = useMemo(() => { try { return { availability: parseModuleEngineAvailability(raw), error: null }; } catch (error) { return { availability: null, error: message(error) }; } }, [raw]);
@@ -80,6 +80,7 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
   const salts = useRef<{ creator: Hex; engine: Hex } | null>(null);
   const coinDetails = useRef<HTMLDetailsElement>(null);
   const [pickerOpen, setPickerOpen] = useState(false), [pickerPointer, setPickerPointer] = useState(false);
+  const [pickerAnyQuoteRemoved, setPickerAnyQuoteRemoved] = useState(false), [pickerNativeDraft, setPickerNativeDraft] = useState(createModuleModeState);
   const template = availability?.templates.find(item => item.manifest.manifest.catalogDefinition.id === selected) ?? availability?.templates[0];
   const definition = template?.manifest.manifest.catalogDefinition, revision = template?.manifest.manifest.revision;
   const fixedQuote = revision && revision.fixedQuoteAsset !== ENGINE_ZERO_ADDRESS ? revision.fixedQuoteAsset : null;
@@ -118,6 +119,26 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
       tokenImage: image.kind === "none" && imageUri ? { kind: "uri", uri: imageUri, contentVerified: false } : image,
       imageResource, initialBuyEth: amount, buyFeePercent: buyFee, sellFeePercent: sellFee, nativeState: nativeDraft.current });
     setPickerOpen(false); onRemoveModule();
+  }
+  function openAnyQuotePicker(pointer: boolean) {
+    setPickerAnyQuoteRemoved(false);
+    setPickerNativeDraft(structuredClone(nativeDraft.current ?? createModuleModeState()));
+    setPickerPointer(pointer); setPickerOpen(true);
+  }
+  function changePickerModule(id: string, selected: boolean) {
+    if (!hydrated || busy || imageBusy || blocked || prepared || !onRemoveModule) return;
+    if (id === anyQuoteEntry?.id) {
+      if (!selected || pickerNativeDraft.selectedModules.length === 0) setPickerAnyQuoteRemoved(!selected);
+      return;
+    }
+    if (!pickerAnyQuoteRemoved) return;
+    const entry = nativeCatalog.find(candidate => candidate.id === id);
+    if (entry) setPickerNativeDraft(current => setModuleSelected(current, entry, selected));
+  }
+  function closeAnyQuotePicker() {
+    nativeDraft.current = pickerNativeDraft;
+    if (pickerAnyQuoteRemoved) removeAnyQuoteModule();
+    setPickerOpen(false);
   }
   function configureAnyQuoteModule() {
     const input = document.getElementById("engine-quote");
@@ -218,14 +239,14 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
 
             <section className={anyQuote ? styles.modulesSection : styles.formSection} id="engine-modules">
               {anyQuoteEntry ? <>
-                <div className={styles.moduleSectionHeading}><div><h2>Modules</h2><p>Add features to your coin.</p></div><Puzzle size={24} strokeWidth={1.6} aria-hidden="true" /></div>
+                <div className={`${styles.moduleSectionHeading} ${engineStyles.sectionHeading}`}><div><h2>Modules</h2><p>Add features to your coin.</p></div><Puzzle size={24} strokeWidth={1.6} aria-hidden="true" /></div>
                 <ul className={styles.selectedModules}><li id={`module-selection-${anyQuoteEntry.id}`}>
                   <ModuleCategoryIcon category="pairs" size={20} />
                   <button type="button" className={styles.configureModule} disabled={!hydrated || busy || imageBusy || blocked} onClick={configureAnyQuoteModule} aria-label={`Configure ${anyQuoteEntry.title}`}><span>{anyQuoteEntry.title}</span><Settings2 size={16} aria-hidden="true" /></button>
                   <button type="button" className={styles.removeModule} disabled={!hydrated || busy || imageBusy || blocked || !onRemoveModule} onClick={removeAnyQuoteModule} aria-label={`Remove ${anyQuoteEntry.title}`}><X size={17} aria-hidden="true" /></button>
                 </li></ul>
                 <ModuleEngineAnyQuoteAsset value={quoteAsset} availability={anyQuoteAvailability} onChange={value => edit(() => setQuote(value))} />
-                <button type="button" className={styles.addModulesButton} data-module-add disabled={!hydrated || busy || imageBusy || blocked} onClick={event => { setPickerPointer(event.detail > 0); setPickerOpen(true); }} aria-haspopup="dialog"><Plus size={18} aria-hidden="true" />Add modules</button>
+                <button type="button" className={styles.addModulesButton} data-module-add disabled={!hydrated || busy || imageBusy || blocked} onClick={event => openAnyQuotePicker(event.detail > 0)} aria-haspopup="dialog"><Plus size={18} aria-hidden="true" />Add modules</button>
               </> : <><div className={engineStyles.sectionHeading}><h2>Modules</h2><p>Add features to your coin.</p></div><div className={engineStyles.selectedModule}>
                 <Puzzle size={20} aria-hidden="true" />
                 <div><strong>{definition.title}</strong><p>{definition.summary}</p></div>
@@ -328,7 +349,9 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
         <aside className={engineStyles.preview} aria-label="Coin summary">
           <div className={engineStyles.summaryContent}>
           <div className={engineStyles.coinIdentity}>
-            <div className={engineStyles.coinArtwork}><Image src={tokenImageSource ?? "/brand/loop/programmable-module-token-default-v1.png"} alt="" fill sizes="64px" unoptimized /></div>
+            <div className={`${engineStyles.coinArtwork}${anyQuoteEntry && !tokenImageSource ? ` ${engineStyles.coinPlaceholder}` : ""}`}>{anyQuoteEntry && !tokenImageSource
+              ? <span aria-hidden="true">{symbol.trim().slice(0, 2).toUpperCase() || <Puzzle size={28} strokeWidth={1.5} />}</span>
+              : <Image src={tokenImageSource ?? "/brand/loop/programmable-module-token-default-v1.png"} alt="" fill sizes="64px" unoptimized />}</div>
             <h2>{name.trim() || "Your coin"}</h2>
             <p>{symbol.trim() ? `$${symbol.trim()}` : "$COIN"}</p>
             {description.trim() ? <p className={engineStyles.coinDescription}>{description}</p> : null}
@@ -348,13 +371,16 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
           <Link href="/developers/modules" className={engineStyles.buildLink}><Puzzle size={16} aria-hidden="true" />Build your own module<ArrowUpRight size={16} aria-hidden="true" /></Link>
         </aside>
       </div>
-      {anyQuoteEntry ? pickerOpen ? <ModulePickerDialog animateOpen={pickerPointer} title="Add modules" description="Modules are upgrades for your coin. Pick the features you want." onClose={() => setPickerOpen(false)}>
-        <ModuleLibrary catalog={[...nativeCatalog.filter(entry => entry.id !== anyQuoteEntry.id), anyQuoteEntry]} selectedIds={[anyQuoteEntry.id]}
+      {anyQuoteEntry ? pickerOpen ? <ModulePickerDialog variant="library" animateOpen={pickerPointer} title="Add modules" description="Modules are upgrades for your coin. Pick the features you want." onClose={closeAnyQuotePicker}>
+        <ModuleLibrary catalog={[...nativeCatalog.filter(entry => entry.id !== anyQuoteEntry.id), anyQuoteEntry]} selectedIds={pickerAnyQuoteRemoved ? pickerNativeDraft.selectedModules : [anyQuoteEntry.id]}
           disabled={!hydrated || busy || imageBusy || blocked || Boolean(prepared) || !onRemoveModule}
-          disabledFor={entry => entry.id === anyQuoteEntry.id ? undefined : "Remove Any Quote LP to use this module."}
+          disabledFor={entry => entry.id === anyQuoteEntry.id
+            ? pickerAnyQuoteRemoved && pickerNativeDraft.selectedModules.length > 0 ? "Remove your other modules to use Any Quote LP." : undefined
+            : pickerAnyQuoteRemoved ? undefined : "Remove Any Quote LP to use this module."}
           feeDescriptionFor={entry => entry.id === anyQuoteEntry.id ? "Platform fee: 0.30% per trade." : undefined}
-          onAdd={entry => { if (entry.id === anyQuoteEntry.id) setPickerOpen(false); }}
-          onRemove={entry => { if (entry.id === anyQuoteEntry.id) removeAnyQuoteModule(); }} />
+          feePolicyFor={nativeRelease ? entry => moduleModeFeePolicy(nativeRelease, nativeCatalog.filter(candidate => candidate.id === entry.id || pickerNativeDraft.selectedModules.includes(candidate.id))) : undefined}
+          onAdd={entry => changePickerModule(entry.id, true)}
+          onRemove={entry => changePickerModule(entry.id, false)} />
       </ModulePickerDialog> : null : <ModuleEnginePicker open={pickerOpen} templates={availability.templates} selectedId={definition.id} disabled={!hydrated || busy || imageBusy || blocked} onClose={() => setPickerOpen(false)} onSelect={item => { edit(() => { setSelected(item.manifest.manifest.catalogDefinition.id); setQuoteState(null); setAmount(""); setAmountError(null); salts.current = null; setCustomInitialForm(emptyModuleEngineCustomOperation()); setCreatorSaltInput(""); setEngineSaltInput(""); setLaunchData("0x"); setBuyFee("0"); setSellFee("0"); }); setPickerOpen(false); }} />}
       {approval && !prepared ? <section className={engineStyles.notice} role="status"><p>Allow the launch contract to use exactly {quoteState ? formatUnits(approval.amount, quoteState.decimals) : approval.amount.toString()} quote tokens to fund this launch.</p><button id="engine-approval-review" className={styles.secondaryButton} type="button" disabled={busy || blocked} onClick={() => void prepareApproval()}>{approval.currentAllowance > 0n ? "Review allowance reset" : "Review exact approval"}</button></section> : null}
       {prepared ? <ModuleEngineTransactionReview prepared={prepared} busy={busy} disabled={blocked || step !== "prepare"} onEdit={backToEdit} onConfirm={() => void confirm()} quoteAsset={readyQuote?.quoteAsset ?? quoteState?.address} quoteDecimals={readyQuote?.token.decimals ?? quoteState?.decimals} quoteSymbol={readyQuote?.token.symbol} anyQuote={anyQuote} tradeFees={spot || customLaunch} genericAction={customInitial} showLaunchInputs={customLaunch}>{prepared.kind === "launch" ? <div className={engineStyles.launchSummary}><strong>{name} · {symbol}</strong><p>{description}</p><p className={styles.help}>Image: {imageUri || MODULE_DEFAULT_TOKEN_IMAGE}</p>{checkedSocial.ok ? <dl className={styles.reviewRows}>{socialFields.filter(({ key }) => checkedSocial.links[key]).map(({ key, label }) => <div key={key}><dt>{label}</dt><dd>{checkedSocial.links[key]}</dd></div>)}</dl> : null}</div> : null}</ModuleEngineTransactionReview> : null}

--- a/components/module-engine-host.tsx
+++ b/components/module-engine-host.tsx
@@ -15,7 +15,7 @@ import { ROBINHOOD_BLOCK_EXPLORER_URL } from "@/lib/chains";
 import { assertModuleEngineOperationAvailability, fetchModuleEngineAvailability } from "@/lib/module-engine/availability-client";
 import { MODULE_ENGINE_AVAILABILITY_SCHEMA, type ModuleEngineAvailability, type ModuleEngineTemplate } from "@/lib/module-engine/catalog";
 import { createModuleEngineClient, ModuleEngineTransactionRevertedError, observeModuleEngineReceipt, readModuleEngineLaunch, type ModuleEngineReceiptResult, type PreparedModuleEngineTransaction } from "@/lib/module-engine/client";
-import type { ModuleModeImage } from "@/lib/module-mode/builder";
+import type { ModuleModeImage, ModuleModeCatalogEntry } from "@/lib/module-mode/builder";
 import { moduleModeReleaseQuery, type ModuleModeLaunchVersion } from "@/lib/module-mode/release-selection";
 import { clearModuleModeOperation, moduleModeOperationPath, type ModuleModeOperation } from "@/lib/module-mode-operation-store";
 import { fetchModuleEngineOperationRelease, recoverModuleEngineOperation } from "@/lib/module-mode-operation-recovery";
@@ -39,7 +39,7 @@ function errorMessage(error: unknown) {
 }
 
 /** Shared wallet, source authority and durable operation recovery for each reviewed template. */
-export function ModuleEngineHost({ releaseDigest, token, versions = [] }: { releaseDigest?: Hex; token?: Address; versions?: readonly ModuleModeLaunchVersion[] }) {
+export function ModuleEngineHost({ releaseDigest, token, versions = [], nativeCatalog }: { releaseDigest?: Hex; token?: Address; versions?: readonly ModuleModeLaunchVersion[]; nativeCatalog?: readonly ModuleModeCatalogEntry[] }) {
   const router = useRouter();
   const [changingVersion, startVersionChange] = useTransition();
   const { wallet, authenticated, sessionReady, authReady, connecting, openingWallet, switchingNetwork, disconnecting, openWallet, switchNetwork, getAccessToken, sendModuleModeTransaction } = useWallet();
@@ -165,6 +165,12 @@ export function ModuleEngineHost({ releaseDigest, token, versions = [] }: { rele
     assertSession(); return binding.uri;
   }
 
+  function removeModule() {
+    if (busy.current || working || requestPending || unresolved || changingVersion) return;
+    generation.current += 1; setFlow({ phase: "idle" });
+    startVersionChange(() => router.push("/launch/modules", { scroll: false }));
+  }
+
   const versionContent = versions.length > 1 ? <div className={styles.field}><label htmlFor="engine-launch-version">Module version</label>
     <select id="engine-launch-version" value={releaseDigest ?? release?.releaseDigest ?? ""} disabled={working || unresolved || requestPending || changingVersion} onChange={event => {
       const version = versions.find(candidate => candidate.releaseDigest === event.target.value);
@@ -200,5 +206,5 @@ export function ModuleEngineHost({ releaseDigest, token, versions = [] }: { rele
   if (token) return release && boundManagement ? <ModuleEngineConsole {...actions} token={token} release={release} template={boundManagement.template} client={client} statusContent={statusContent} />
     : <section className={styles.page}><header className={styles.heading}><h1>Coin controls</h1><p>Load the version bound to this coin to read its available actions.</p></header>{statusContent}</section>;
   if (loadedSelection === null && !saved.blocked) return <ModuleBuilderLoading />;
-  return <ModuleEngineBuilder {...actions} availability={availability} client={client} statusContent={statusContent} versionContent={versionContent} onUploadImage={uploadImage} />;
+  return <ModuleEngineBuilder {...actions} availability={availability} client={client} statusContent={statusContent} versionContent={versionContent} onUploadImage={uploadImage} nativeCatalog={nativeCatalog} onRemoveModule={removeModule} />;
 }

--- a/components/module-engine-host.tsx
+++ b/components/module-engine-host.tsx
@@ -16,6 +16,7 @@ import { assertModuleEngineOperationAvailability, fetchModuleEngineAvailability 
 import { MODULE_ENGINE_AVAILABILITY_SCHEMA, type ModuleEngineAvailability, type ModuleEngineTemplate } from "@/lib/module-engine/catalog";
 import { createModuleEngineClient, ModuleEngineTransactionRevertedError, observeModuleEngineReceipt, readModuleEngineLaunch, type ModuleEngineReceiptResult, type PreparedModuleEngineTransaction } from "@/lib/module-engine/client";
 import type { ModuleModeImage, ModuleModeCatalogEntry } from "@/lib/module-mode/builder";
+import type { ModuleModeRelease } from "@/lib/module-mode/release";
 import { moduleModeReleaseQuery, type ModuleModeLaunchVersion } from "@/lib/module-mode/release-selection";
 import { clearModuleModeOperation, moduleModeOperationPath, type ModuleModeOperation } from "@/lib/module-mode-operation-store";
 import { fetchModuleEngineOperationRelease, recoverModuleEngineOperation } from "@/lib/module-mode-operation-recovery";
@@ -39,7 +40,7 @@ function errorMessage(error: unknown) {
 }
 
 /** Shared wallet, source authority and durable operation recovery for each reviewed template. */
-export function ModuleEngineHost({ releaseDigest, token, versions = [], nativeCatalog }: { releaseDigest?: Hex; token?: Address; versions?: readonly ModuleModeLaunchVersion[]; nativeCatalog?: readonly ModuleModeCatalogEntry[] }) {
+export function ModuleEngineHost({ releaseDigest, token, versions = [], nativeCatalog, nativeRelease }: { releaseDigest?: Hex; token?: Address; versions?: readonly ModuleModeLaunchVersion[]; nativeCatalog?: readonly ModuleModeCatalogEntry[]; nativeRelease?: ModuleModeRelease | null }) {
   const router = useRouter();
   const [changingVersion, startVersionChange] = useTransition();
   const { wallet, authenticated, sessionReady, authReady, connecting, openingWallet, switchingNetwork, disconnecting, openWallet, switchNetwork, getAccessToken, sendModuleModeTransaction } = useWallet();
@@ -206,5 +207,5 @@ export function ModuleEngineHost({ releaseDigest, token, versions = [], nativeCa
   if (token) return release && boundManagement ? <ModuleEngineConsole {...actions} token={token} release={release} template={boundManagement.template} client={client} statusContent={statusContent} />
     : <section className={styles.page}><header className={styles.heading}><h1>Coin controls</h1><p>Load the version bound to this coin to read its available actions.</p></header>{statusContent}</section>;
   if (loadedSelection === null && !saved.blocked) return <ModuleBuilderLoading />;
-  return <ModuleEngineBuilder {...actions} availability={availability} client={client} statusContent={statusContent} versionContent={versionContent} onUploadImage={uploadImage} nativeCatalog={nativeCatalog} onRemoveModule={removeModule} />;
+  return <ModuleEngineBuilder {...actions} availability={availability} client={client} statusContent={statusContent} versionContent={versionContent} onUploadImage={uploadImage} nativeCatalog={nativeCatalog} nativeRelease={nativeRelease} onRemoveModule={removeModule} />;
 }

--- a/components/module-engine-ui.module.css
+++ b/components/module-engine-ui.module.css
@@ -80,6 +80,7 @@
 .coinIdentity { align-items: flex-start; display: flex; flex-direction: column; gap: 0; }
 .coinArtwork { border-radius: 12px; grid-row: 1 / 3; height: 64px; outline: 1px solid rgb(255 255 255 / .1); overflow: hidden; position: relative; width: 64px; }
 .coinArtwork img { object-fit: cover; }
+.coinPlaceholder { align-items: center; background: #30242b; border: 1px solid #775568; color: #f0bfd6; display: flex; font-size: 24px; justify-content: center; }
 .coinIdentity h2 { align-self: auto; font-size: 20px; font-weight: 500; letter-spacing: -.02em; line-height: 28px; margin: 0; overflow-wrap: anywhere; text-wrap: balance; }
 .coinIdentity > p { align-self: auto; color: var(--engine-muted); font-size: 14px; line-height: 20px; margin: 4px 0 0; overflow-wrap: anywhere; }
 .coinIdentity > .coinDescription { display: -webkit-box; grid-column: 1 / -1; margin-top: 16px; overflow: hidden; text-wrap: pretty; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }

--- a/components/module-library.module.css
+++ b/components/module-library.module.css
@@ -11,7 +11,7 @@
 .categories button[aria-pressed="true"] { background: #e6dfd8; border-color: #e6dfd8; color: #292522; }
 .categoryIcon { align-items: center; background: #30272c; border-radius: 12px; color: #e7a9c6; display: inline-flex; flex: 0 0 auto; height: 40px; justify-content: center; width: 40px; }
 .resultCount { color: #b7b2ac; font-size: 13px; line-height: 20px; margin: 0 0 16px; overflow-wrap: anywhere; }
-.results { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr)); }
+.results { display: grid; gap: 12px; grid-template-columns: repeat(auto-fill, minmax(min(100%, 240px), 1fr)); }
 .module { background: #20201f; border: 1px solid #66615d; border-radius: 16px; display: flex; flex-direction: column; min-width: 0; padding: 20px; }
 .module[data-selected="true"] { background: #282026; border-color: #d393b2; }
 .moduleTop { align-items: center; color: #bdb5af; display: flex; font-size: 12px; gap: 8px; line-height: 20px; margin-bottom: 16px; }

--- a/components/module-library.module.css
+++ b/components/module-library.module.css
@@ -19,11 +19,13 @@
 .module h3 { color: #f5f3ef; font-size: 16px; font-weight: 500; letter-spacing: -.01em; line-height: 24px; margin: 0; overflow-wrap: anywhere; }
 .module > p { color: #bdb7b1; font-size: 14px; line-height: 21px; margin: 6px 0 20px; }
 .selectionFee { color: #d9c3cd; font-size: 13px; line-height: 20px; margin: -8px 0 16px; overflow-wrap: anywhere; }
+.disabledReason { color: #d5c4b1; font-size: 13px; line-height: 20px; margin: -8px 0 16px; overflow-wrap: anywhere; }
 .moduleBottom { align-items: center; display: flex; flex-wrap: wrap; gap: 8px; justify-content: space-between; margin-top: auto; }
 .author { align-items: center; color: #bdb7b1; display: inline-flex; font-size: 12px; line-height: 18px; min-height: 44px; text-decoration: none; overflow-wrap: anywhere; }
 .add { align-items: center; background: #302d2c; border: 1px solid #88817a; border-radius: 12px; color: #f5f3ef; cursor: pointer; display: inline-flex; flex: 0 0 104px; font: inherit; font-size: 14px; font-weight: 500; gap: 8px; justify-content: center; line-height: 20px; margin-left: auto; min-height: 44px; padding: 10px 12px; width: 104px; }
 .library .add { transition: none; }
 .add[aria-pressed="true"] { background: #e786b2; border-color: #e786b2; color: #21151b; }
+.add:disabled { cursor: not-allowed; opacity: .5; }
 .contribute { align-items: center; color: #d1c9c3; display: flex; font-size: 14px; gap: 8px; line-height: 20px; margin-top: 16px; min-height: 44px; text-decoration: none; }
 .contribute > svg:last-child { margin-left: auto; }
 .empty { background: #20201f; border: 1px solid #66615d; border-radius: 16px; padding: 24px; }
@@ -37,6 +39,6 @@
 .library :is(button,a) { touch-action: manipulation; }
 .toolbar[hidden], .categories[hidden], .resultCount[hidden] { display: none; }
 .srOnly { clip-path: inset(50%); height: 1px; overflow: hidden; position: absolute; white-space: nowrap; width: 1px; }
-@media (hover: hover) and (pointer: fine) { .add:hover { background: #44363d; border-color: #e786b2; } .add[aria-pressed="true"]:hover { background: #f19dc3; } .author:hover, .contribute:hover { color: #f0bfd6; text-decoration: underline; text-underline-offset: 4px; } }
+@media (hover: hover) and (pointer: fine) { .add:not(:disabled):hover { background: #44363d; border-color: #e786b2; } .add[aria-pressed="true"]:not(:disabled):hover { background: #f19dc3; } .author:hover, .contribute:hover { color: #f0bfd6; text-decoration: underline; text-underline-offset: 4px; } }
 @media (max-width: 600px) { .results { grid-template-columns: minmax(0,1fr); } .module { padding: 16px; } }
 @media (forced-colors: active) { .library :is(button,a):focus-visible { outline-color: Highlight; } .library button { border-color: ButtonText; } }

--- a/components/module-library.tsx
+++ b/components/module-library.tsx
@@ -55,7 +55,7 @@ export function ModuleLibrary<Entry extends ModuleLibraryEntry>({ catalog, selec
   const hasFilters = Boolean(query.trim() || category !== "all");
   const reset = () => { setQuery(""); setCategory("all"); setPage(1); };
   return <div className={styles.library}>
-    <div className={styles.toolbar} hidden={catalog.length < 5 && !query && category === "all"}>
+    <div className={styles.toolbar} hidden={catalog.length < 5}>
       <div className={styles.search}>
         <label className={styles.srOnly} htmlFor={`${id}-search`}>Search modules</label>
         <Search size={18} aria-hidden="true" />
@@ -71,7 +71,7 @@ export function ModuleLibrary<Entry extends ModuleLibraryEntry>({ catalog, selec
           {item.label}
         </button>)}
     </div>
-    <div className={styles.resultCount} hidden={!query.trim() && category === "all"} role="status" aria-live="polite">{results.length} {results.length === 1 ? "module" : "modules"}{query.trim() ? ` for “${query.trim()}”` : ""}</div>
+    <div className={styles.resultCount} hidden={!query.trim()} role="status" aria-live="polite">{results.length} {results.length === 1 ? "module" : "modules"}{query.trim() ? ` for “${query.trim()}”` : ""}</div>
     <div className={styles.results} aria-label="Module library">
       {visible.map(entry => {
         const added = selected.has(entry.id);

--- a/components/module-library.tsx
+++ b/components/module-library.tsx
@@ -11,8 +11,8 @@ import { ShieldCheckIcon } from "@phosphor-icons/react/dist/ssr/ShieldCheck";
 import { SlidersHorizontalIcon } from "@phosphor-icons/react/dist/ssr/SlidersHorizontal";
 import { WavesIcon } from "@phosphor-icons/react/dist/ssr/Waves";
 import { ArrowRight, ChevronLeft, ChevronRight, Plus, Search, X } from "lucide-react";
-import { feeBreakdown, type ModuleModeCatalogEntry, type ModuleModeFeePolicy } from "@/lib/module-mode/builder";
-import { MODULE_CATEGORIES, MODULE_LIBRARY_PAGE_SIZE, moduleAuthorLabel, moduleCategory, moduleDiscovery, searchModuleLibrary, type ModuleCategoryId } from "@/lib/module-mode/library";
+import { feeBreakdown, type ModuleModeFeePolicy } from "@/lib/module-mode/builder";
+import { MODULE_CATEGORIES, MODULE_LIBRARY_PAGE_SIZE, moduleAuthorLabel, moduleCategory, moduleDiscovery, searchModuleLibrary, type ModuleCategoryId, type ModuleLibraryEntry } from "@/lib/module-mode/library";
 import styles from "@/components/module-library.module.css";
 
 const icons = { rewards: GiftIcon, trading: ArrowsLeftRightIcon, fees: SlidersHorizontalIcon,
@@ -23,16 +23,23 @@ export function ModuleCategoryIcon({ category, size = 22 }: { category: ModuleCa
   return <span className={styles.categoryIcon} data-category={category}><Icon size={size} weight="regular" aria-hidden="true" /></span>;
 }
 
-export function ModuleAuthor({ entry }: { entry: ModuleModeCatalogEntry }) {
+export function ModuleAuthor({ entry }: { entry: ModuleLibraryEntry }) {
   const author = moduleDiscovery(entry).author;
   return author ? <Link href={`/profile?account=${author}&chain=4663`} className={styles.author} title={`Module author ${author}`}>By {moduleAuthorLabel(entry)}</Link> : null;
 }
 
-export function ModuleLibrary({ catalog, selectedIds, onAdd, onRemove, feePolicyFor }: {
-  catalog: readonly ModuleModeCatalogEntry[]; selectedIds: readonly string[];
-  onAdd: (entry: ModuleModeCatalogEntry) => void; onRemove: (entry: ModuleModeCatalogEntry) => void;
-  feePolicyFor?: (entry: ModuleModeCatalogEntry) => ModuleModeFeePolicy | null;
-}) {
+export interface ModuleLibraryProps<Entry extends ModuleLibraryEntry> {
+  catalog: readonly Entry[];
+  selectedIds: readonly string[];
+  onAdd: (entry: Entry) => void;
+  onRemove: (entry: Entry) => void;
+  feePolicyFor?: (entry: Entry) => ModuleModeFeePolicy | null;
+  feeDescriptionFor?: (entry: Entry) => string | undefined;
+  disabledFor?: (entry: Entry) => string | undefined;
+  disabled?: boolean;
+}
+
+export function ModuleLibrary<Entry extends ModuleLibraryEntry>({ catalog, selectedIds, onAdd, onRemove, feePolicyFor, feeDescriptionFor, disabledFor, disabled = false }: ModuleLibraryProps<Entry>) {
   const id = useId();
   const [query, setQuery] = useState("");
   const [category, setCategory] = useState("all");
@@ -66,13 +73,22 @@ export function ModuleLibrary({ catalog, selectedIds, onAdd, onRemove, feePolicy
     </div>
     <div className={styles.resultCount} hidden={!query.trim() && category === "all"} role="status" aria-live="polite">{results.length} {results.length === 1 ? "module" : "modules"}{query.trim() ? ` for “${query.trim()}”` : ""}</div>
     <div className={styles.results} aria-label="Module library">
-      {visible.map(entry => { const added = selected.has(entry.id); const group = moduleCategory(entry); const selectionPolicy = feePolicyFor?.(entry); return <article key={entry.id} className={styles.module} data-selected={added}>
+      {visible.map(entry => {
+        const added = selected.has(entry.id);
+        const group = moduleCategory(entry);
+        const feeOverride = feeDescriptionFor?.(entry);
+        const selectionPolicy = feeOverride === undefined ? feePolicyFor?.(entry) : undefined;
+        const feeDescription = feeOverride ?? (feePolicyFor ? selectionPolicy ? `Estimated platform fee: ${feeBreakdown("0", "0", selectionPolicy).programmable} per trade.` : "Platform fee unavailable." : undefined);
+        const disabledReason = disabledFor?.(entry);
+        const descriptionIds = [feeDescription !== undefined ? `${id}-${entry.id}-fee` : undefined, disabledReason ? `${id}-${entry.id}-disabled` : undefined].filter(Boolean).join(" ") || undefined;
+        return <article key={entry.id} className={styles.module} data-selected={added}>
         <div className={styles.moduleTop}><ModuleCategoryIcon category={group.id} />{entry.status === "preview" ? <span className={styles.preview}>Draft only</span> : null}</div>
         <h3 id={`module-${entry.id}-title`} tabIndex={-1}>{entry.title}</h3>
         <p>{entry.summary}</p>
-        {feePolicyFor ? <div className={styles.selectionFee} id={`${id}-${entry.id}-fee`}>{selectionPolicy ? `Estimated platform fee: ${feeBreakdown("0", "0", selectionPolicy).programmable} per trade.` : "Platform fee unavailable."}</div> : null}
+        {feeDescription !== undefined ? <div className={styles.selectionFee} id={`${id}-${entry.id}-fee`}>{feeDescription}</div> : null}
+        {disabledReason ? <div className={styles.disabledReason} id={`${id}-${entry.id}-disabled`}>{disabledReason}</div> : null}
         <div className={styles.moduleBottom}><ModuleAuthor entry={entry} />
-          <button type="button" className={styles.add} aria-label={`${added ? "Remove" : "Add"} ${entry.title}`} aria-pressed={added} aria-describedby={feePolicyFor ? `${id}-${entry.id}-fee` : undefined}
+          <button type="button" className={styles.add} aria-label={`${added ? "Remove" : "Add"} ${entry.title}`} aria-pressed={added} aria-describedby={descriptionIds} disabled={disabled || (!added && Boolean(disabledReason))}
             onClick={() => added ? onRemove(entry) : onAdd(entry)}>{added ? <X size={16} aria-hidden="true" /> : <Plus size={16} aria-hidden="true" />}{added ? "Remove" : "Add"}</button>
         </div>
       </article>; })}

--- a/components/module-mode-builder.tsx
+++ b/components/module-mode-builder.tsx
@@ -9,7 +9,8 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState, type FormEvent, 
 
 import { ModuleLibrary, ModuleCategoryIcon } from "@/components/module-library";
 import { ModulePickerDialog } from "@/components/module-picker-dialog";
-import { moduleCategory } from "@/lib/module-mode/library";
+import { moduleCategory, type ModuleLibraryEntry } from "@/lib/module-mode/library";
+import { consumeModuleModeLaunchDraftHandoff, saveModuleModeLaunchDraftHandoff } from "@/lib/module-mode/launch-draft-handoff";
 import { ModuleSchemaField } from "@/components/module-mode-fields";
 import { ModuleModeImagePicker, moduleModeImageSource, type ModuleModeImageResource } from "@/components/module-mode-image";
 import { useRouteViewChain } from "@/components/view-chain";
@@ -76,13 +77,13 @@ export interface ModuleModeBuilderProps {
   previewDescription?: string;
   statusContent?: ReactNode;
   versionContent?: ReactNode;
-  moduleLaunchContent?: ReactNode;
+  anyQuoteModule?: { entry: ModuleLibraryEntry; disabled: boolean; onSelect: () => void };
   reviewContent?: ReactNode;
   resultContent?: ReactNode;
   onEdit?: () => void;
 }
 
-export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = NATIVE_ENGINE_PROFILE, configurationContext = {}, launchAction, minimumInitialBuyWei, release, previewDescription, statusContent, moduleLaunchContent, reviewContent, resultContent, onEdit }: Readonly<ModuleModeBuilderProps>) {
+export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = NATIVE_ENGINE_PROFILE, configurationContext = {}, launchAction, minimumInitialBuyWei, release, previewDescription, statusContent, anyQuoteModule, reviewContent, resultContent, onEdit }: Readonly<ModuleModeBuilderProps>) {
   const { hydrated } = useRouteViewChain(4663);
   const [state, setState] = useState(createModuleModeState);
   const { expanded: detailsOpen, setExpanded: setDetailsOpen, toggle: toggleDetails, panelProps: detailsPanel } = useDisclosureState();
@@ -104,12 +105,33 @@ export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = N
   const [previousImage, setPreviousImage] = useState<{ image: ModuleModeImage; resource: ModuleModeImageResource | null } | null>(null);
   const [imageBusy, setImageBusy] = useState(false);
   const imageUrls = useRef(new Set<string>());
-  useEffect(() => {
-    const urls = imageUrls.current;
-    return () => { for (const url of urls) URL.revokeObjectURL(url); };
-  }, []);
+  const imageMounted = useRef(false);
+  const draftRestored = useRef(false);
   const form = useRef<HTMLFormElement>(null);
   const selectionFocus = useRef<{ kind: "add" } | { kind: "configure"; id: string } | null>(null);
+  useEffect(() => {
+    const urls = imageUrls.current;
+    imageMounted.current = true;
+    return () => {
+      imageMounted.current = false;
+      queueMicrotask(() => { if (!imageMounted.current) for (const url of urls) URL.revokeObjectURL(url); });
+    };
+  }, []);
+  useEffect(() => {
+    if (draftRestored.current) return;
+    draftRestored.current = true;
+    const handoff = consumeModuleModeLaunchDraftHandoff("native");
+    if (!handoff) return;
+    const { imageResource: restoredImage, nativeState, ...fields } = handoff;
+    if (restoredImage) imageUrls.current.add(restoredImage.objectUrl);
+    queueMicrotask(() => {
+      if (!imageMounted.current) return;
+      selectionFocus.current = { kind: "add" };
+      setState({ ...(nativeState ?? createModuleModeState()), ...fields });
+      setImageResource(restoredImage);
+      setAnnouncement("Any Quote LP removed. Your coin details are kept.");
+    });
+  }, []);
   useLayoutEffect(() => {
     const target = selectionFocus.current;
     selectionFocus.current = null;
@@ -153,6 +175,17 @@ export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = N
     if (fromEditor) selectionFocus.current = { kind: "add" };
     setState((current) => setModuleSelected(current, entry, false)); setRemoved(entry);
     setAnnouncement(`${entry.title} removed. Your settings are kept.`);
+  }
+  function addFromLibrary(entry: ModuleLibraryEntry) {
+    if (contextLocked || imageBusy || anyQuoteModule?.disabled) return;
+    if (anyQuoteModule && entry.id === anyQuoteModule.entry.id) {
+      if (state.selectedModules.length > 0) return;
+      saveModuleModeLaunchDraftHandoff("any-quote", { ...state, imageResource, nativeState: state });
+      anyQuoteModule.onSelect();
+      return;
+    }
+    const nativeEntry = catalog.find(candidate => candidate.id === entry.id);
+    if (nativeEntry) add(nativeEntry);
   }
   function showModules(pointer: boolean, id?: string) {
     setPickerPointer(pointer);
@@ -293,9 +326,12 @@ export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = N
         </aside> : null}
       </div>
       {pickerOpen ? <ModulePickerDialog animateOpen={pickerPointer} title="Add modules" description="Modules are upgrades for your coin. Pick the features you want." onClose={() => setPickerOpen(false)}>
-        {moduleLaunchContent}
-        <ModuleLibrary catalog={catalog} selectedIds={state.selectedModules} onAdd={add} onRemove={remove}
-          feePolicyFor={release ? entry => moduleModeFeePolicy(release, state.selectedModules.includes(entry.id) ? selected : [...selected, entry]) : undefined} />
+        <ModuleLibrary catalog={anyQuoteModule ? [...catalog, anyQuoteModule.entry] : catalog} selectedIds={state.selectedModules}
+          disabled={contextLocked || imageBusy || anyQuoteModule?.disabled} onAdd={addFromLibrary}
+          onRemove={entry => { const nativeEntry = catalog.find(candidate => candidate.id === entry.id); if (nativeEntry) remove(nativeEntry); }}
+          disabledFor={entry => entry.id === anyQuoteModule?.entry.id && state.selectedModules.length > 0 ? "Remove your other modules to use Any Quote LP." : undefined}
+          feeDescriptionFor={entry => entry.id === anyQuoteModule?.entry.id ? "Platform fee: 0.30% per trade." : undefined}
+          feePolicyFor={release ? entry => { const nativeEntry = catalog.find(candidate => candidate.id === entry.id); return nativeEntry ? moduleModeFeePolicy(release, state.selectedModules.includes(entry.id) ? selected : [...selected, nativeEntry]) : null; } : undefined} />
       </ModulePickerDialog> : null}
       {configuredEntry ? <ModulePickerDialog animateOpen={pickerPointer} title={configuredEntry.title} description={configuredEntry.summary} onClose={() => setConfigurationId(null)}>
         <fieldset className={styles.formFields} disabled={contextLocked}>{renderModuleConfiguration(configuredEntry)}</fieldset>

--- a/components/module-mode-builder.tsx
+++ b/components/module-mode-builder.tsx
@@ -90,6 +90,7 @@ export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = N
   const { expanded: feesOpen, setExpanded: setFeesOpen, toggle: toggleFees, panelProps: feesPanel } = useDisclosureState();
   const { expanded: moreLinks, setExpanded: setMoreLinks, toggle: toggleMoreLinks, panelProps: moreLinksPanel } = useDisclosureState();
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [pendingAnyQuote, setPendingAnyQuote] = useState(false);
   const [pickerPointer, setPickerPointer] = useState(false);
   const [configurationId, setConfigurationId] = useState<string | null>(null);
   const [checked, setChecked] = useState(false);
@@ -180,12 +181,20 @@ export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = N
     if (contextLocked || imageBusy || anyQuoteModule?.disabled) return;
     if (anyQuoteModule && entry.id === anyQuoteModule.entry.id) {
       if (state.selectedModules.length > 0) return;
-      saveModuleModeLaunchDraftHandoff("any-quote", { ...state, imageResource, nativeState: state });
-      anyQuoteModule.onSelect();
+      setPendingAnyQuote(true);
       return;
     }
+    if (pendingAnyQuote) return;
     const nativeEntry = catalog.find(candidate => candidate.id === entry.id);
     if (nativeEntry) add(nativeEntry);
+  }
+  function closeModulePicker() {
+    if (pendingAnyQuote && anyQuoteModule) {
+      if (contextLocked || imageBusy || anyQuoteModule.disabled) return;
+      saveModuleModeLaunchDraftHandoff("any-quote", { ...state, imageResource, nativeState: state });
+      setPickerOpen(false);
+      anyQuoteModule.onSelect();
+    } else setPickerOpen(false);
   }
   function showModules(pointer: boolean, id?: string) {
     setPickerPointer(pointer);
@@ -325,11 +334,13 @@ export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = N
           <Link href="/developers/modules" className={styles.buildModuleLink}><Puzzle size={16} aria-hidden="true" />Build your own module<ArrowRight size={16} aria-hidden="true" /></Link>
         </aside> : null}
       </div>
-      {pickerOpen ? <ModulePickerDialog animateOpen={pickerPointer} title="Add modules" description="Modules are upgrades for your coin. Pick the features you want." onClose={() => setPickerOpen(false)}>
-        <ModuleLibrary catalog={anyQuoteModule ? [...catalog, anyQuoteModule.entry] : catalog} selectedIds={state.selectedModules}
+      {pickerOpen ? <ModulePickerDialog variant="library" animateOpen={pickerPointer} title="Add modules" description="Modules are upgrades for your coin. Pick the features you want." onClose={closeModulePicker}>
+        <ModuleLibrary catalog={anyQuoteModule ? [...catalog, anyQuoteModule.entry] : catalog} selectedIds={pendingAnyQuote && anyQuoteModule ? [anyQuoteModule.entry.id] : state.selectedModules}
           disabled={contextLocked || imageBusy || anyQuoteModule?.disabled} onAdd={addFromLibrary}
-          onRemove={entry => { const nativeEntry = catalog.find(candidate => candidate.id === entry.id); if (nativeEntry) remove(nativeEntry); }}
-          disabledFor={entry => entry.id === anyQuoteModule?.entry.id && state.selectedModules.length > 0 ? "Remove your other modules to use Any Quote LP." : undefined}
+          onRemove={entry => { if (entry.id === anyQuoteModule?.entry.id) setPendingAnyQuote(false); else { const nativeEntry = catalog.find(candidate => candidate.id === entry.id); if (nativeEntry) remove(nativeEntry); } }}
+          disabledFor={entry => entry.id === anyQuoteModule?.entry.id
+            ? state.selectedModules.length > 0 ? "Remove your other modules to use Any Quote LP." : undefined
+            : pendingAnyQuote ? "Remove Any Quote LP to use this module." : undefined}
           feeDescriptionFor={entry => entry.id === anyQuoteModule?.entry.id ? "Platform fee: 0.30% per trade." : undefined}
           feePolicyFor={release ? entry => { const nativeEntry = catalog.find(candidate => candidate.id === entry.id); return nativeEntry ? moduleModeFeePolicy(release, state.selectedModules.includes(entry.id) ? selected : [...selected, nativeEntry]) : null; } : undefined} />
       </ModulePickerDialog> : null}

--- a/components/module-mode-launch-host.tsx
+++ b/components/module-mode-launch-host.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ArrowRight, ArrowUpRight, Check, Copy, LoaderCircle, RefreshCw } from "lucide-react";
+import { ArrowUpRight, Check, Copy, LoaderCircle, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useId, useMemo, useRef, useState, useSyncExternalStore, useTransition, type FormEvent } from "react";
 import { formatUnits, toHex, type Address, type Hex } from "viem";
 
@@ -19,6 +19,7 @@ import { browserWalletRequestIsPending, subscribeToBrowserWalletRequest } from "
 import { beginModuleModeOperation, clearModuleModeOperation, moduleModeOperationPath, rememberModuleModeTransactionHash, type ModuleModeOperation } from "@/lib/module-mode-operation-store";
 import { moduleModeReleaseQuery, type ModuleModeLaunchVersion } from "@/lib/module-mode/release-selection";
 import { fetchModuleModeOperationRelease, recoverModuleModeOperation } from "@/lib/module-mode-operation-recovery";
+import type { ModuleLibraryEntry } from "@/lib/module-mode/library";
 
 type LaunchFlow = {
   phase: "idle" | "uploading" | "preparing" | "signing" | "pending" | "mined" | "reverted" | "receipt-unavailable" | "error" | "uncertain";
@@ -65,7 +66,7 @@ function assertDraftAvailability(draft: ModuleModeDraft, current: ModuleModeAvai
   }
 }
 
-export function ModuleModeLaunchHost({ releaseDigest, versions = [], anyQuoteReleaseDigest }: { releaseDigest?: string; versions?: readonly ModuleModeLaunchVersion[]; anyQuoteReleaseDigest?: Hex }) {
+export function ModuleModeLaunchHost({ releaseDigest, versions = [], anyQuoteReleaseDigest, anyQuoteModule }: { releaseDigest?: string; versions?: readonly ModuleModeLaunchVersion[]; anyQuoteReleaseDigest?: Hex; anyQuoteModule?: ModuleLibraryEntry }) {
   const router = useRouter();
   const [changingVersion, startVersionChange] = useTransition();
   const requestedRelease = useRef(releaseDigest);
@@ -234,11 +235,11 @@ export function ModuleModeLaunchHost({ releaseDigest, versions = [], anyQuoteRel
 
   return <ModuleModeBuilder
     release={release}
-    moduleLaunchContent={anyQuoteReleaseDigest ? <ModuleModeAnyQuoteLaunchEntry disabled={working || requestPending || hasSubmission || changingVersion} onSelect={() => {
+    anyQuoteModule={anyQuoteReleaseDigest && anyQuoteModule ? { entry: anyQuoteModule, disabled: working || requestPending || hasSubmission || changingVersion, onSelect: () => {
       if (working || requestPending || hasSubmission || changingVersion) return;
       operation.current += 1; setFlow({ phase: "idle" });
       startVersionChange(() => router.push(`/launch/modules${moduleModeReleaseQuery({ sourceKind: "module-engine-v1", releaseDigest: anyQuoteReleaseDigest })}`, { scroll: false }));
-    }} /> : undefined}
+    } } : undefined}
     versionContent={versions.length > 1 ? <div className={styles.field}><label htmlFor="module-launch-version">Module version</label><select id="module-launch-version" value={releaseDigest ?? availability?.release?.releaseDigest ?? versions[0]?.releaseDigest} disabled={working || requestPending || hasSubmission || changingVersion} onChange={event => {
       const version = versions.find(candidate => candidate.releaseDigest === event.target.value);
       if (!version || working || requestPending || hasSubmission) return;
@@ -274,14 +275,6 @@ export function ModuleModeLaunchHost({ releaseDigest, versions = [], anyQuoteRel
       onRecover={recoveryOperation?.kind === "launch" && recoveryOperation.sourceKind !== "module-engine-v1" ? transactionHash => void checkRecoveredReceipt(transactionHash) : undefined}
     /> : undefined}
   />;
-}
-
-export function ModuleModeAnyQuoteLaunchEntry({ disabled, onSelect }: { disabled: boolean; onSelect: () => void }) {
-  return <section className={styles.catalogRow} aria-labelledby="module-any-quote-title"><div>
-    <h3 id="module-any-quote-title">Any Quote LP</h3>
-    <p>Start a coin paired with a compatible token of your choice. Trade with ETH.</p>
-    <button type="button" className={styles.textButton} disabled={disabled} onClick={onSelect}>Use Any Quote LP <ArrowRight size={16} aria-hidden="true" /></button>
-  </div></section>;
 }
 
 export function ModuleModeLaunchResult({ phase, token, symbol, transactionHash, message, checking = false, onCheck, onRecover }: {

--- a/components/module-picker-dialog.module.css
+++ b/components/module-picker-dialog.module.css
@@ -4,6 +4,7 @@
 .dialog[data-motion]::backdrop { transition: opacity 180ms cubic-bezier(0.16, 1, 0.3, 1); }
 .dialog[data-closing]::backdrop { transition-duration: 140ms; }
 .surface { background: #181818; border: 1px solid #494746; border-radius: 24px; display: flex; flex-direction: column; max-height: calc(100dvh - 48px); min-height: min(480px, calc(100dvh - 48px)); overflow: hidden; }
+.librarySurface { height: min(640px, calc(100dvh - 48px)); }
 .header { align-items: flex-start; display: flex; flex-shrink: 0; gap: 16px; padding: 24px 24px 16px; }
 .header > div { flex: 1; min-width: 0; padding-block: 8px; }
 .header h2 { font-size: 24px; font-weight: 500; letter-spacing: -.025em; line-height: 1.25; margin: 0; overflow-wrap: anywhere; }
@@ -18,4 +19,5 @@
 @media (hover: hover) and (pointer: fine) { .close:hover { background: #363232; } .done:hover { background: #f19dc3; border-color: #f19dc3; } }
 @media (max-width: 600px) { .dialog { max-width: calc(100vw - 24px); max-height: calc(100dvh - 24px); } .surface { border-radius: 20px; max-height: calc(100dvh - 24px); } .header { padding: 16px 16px 12px; } .header h2 { font-size: 22px; } .content { padding: 0 16px 20px; } .footer { padding: 12px 16px max(12px, env(safe-area-inset-bottom)); } }
 @media (forced-colors: active) { .dialog :is(button, a, input, select, textarea, summary):focus-visible { outline-color: Highlight; } .surface { border-color: CanvasText; } .dialog button { border-color: ButtonText; } }
+@media (max-width: 600px) { .librarySurface { height: calc(100dvh - 24px); } }
 @media (prefers-reduced-motion: reduce) { .dialog[data-motion]::backdrop { transition: none; } }

--- a/components/module-picker-dialog.tsx
+++ b/components/module-picker-dialog.tsx
@@ -4,13 +4,14 @@ import { X } from "lucide-react";
 import { useLayoutEffect, useId, useRef, type ReactNode } from "react";
 import styles from "./module-picker-dialog.module.css";
 
-export function ModulePickerDialog({ title, description, children, onClose, footer, animateOpen = false }: {
+export function ModulePickerDialog({ title, description, children, onClose, footer, animateOpen = false, variant }: {
   title: string;
   description?: string;
   children: ReactNode;
   footer?: ReactNode;
   onClose: () => void;
   animateOpen?: boolean;
+  variant?: "library";
 }) {
   const dialog = useRef<HTMLDialogElement>(null);
   const surface = useRef<HTMLDivElement>(null);
@@ -89,7 +90,7 @@ export function ModulePickerDialog({ title, description, children, onClose, foot
       else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first?.focus(); }
     }}
     onClick={event => { if (event.target === event.currentTarget) close(event.detail > 0); }}>
-    <div ref={surface} className={styles.surface}>
+    <div ref={surface} className={`${styles.surface}${variant === "library" ? ` ${styles.librarySurface}` : ""}`}>
       <header className={styles.header}>
         <div><h2 ref={heading} tabIndex={-1} id={`${id}-title`}>{title}</h2>{description ? <p id={`${id}-description`}>{description}</p> : null}</div>
         <button type="button" className={styles.close} onClick={event => close(event.detail > 0)} aria-label="Close modules"><X size={20} aria-hidden="true" /></button>

--- a/lib/module-engine/library-entry.ts
+++ b/lib/module-engine/library-entry.ts
@@ -1,0 +1,14 @@
+import type { ModuleEngineCatalogDefinition } from "./catalog";
+import type { ModuleLibraryEntry } from "@/lib/module-mode/library";
+
+/** Presentation only: the engine's reviewed manifest still owns launch eligibility. */
+export function anyQuoteLibraryEntry(definition: ModuleEngineCatalogDefinition): ModuleLibraryEntry {
+  return {
+    id: definition.id,
+    title: "Any Quote LP",
+    summary: "Pair your coin with another token. Buy and sell with ETH.",
+    status: "available",
+    discovery: { category: "pairs", tags: ["liquidity", "pair", "ERC-20", "ETH"] },
+    source: definition.source,
+  };
+}

--- a/lib/module-mode/launch-draft-handoff.ts
+++ b/lib/module-mode/launch-draft-handoff.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import type { ModuleModeImageResource } from "@/components/module-mode-image";
+import type { ModuleModeState } from "./builder";
+
+export type ModuleModeLaunchDraftTarget = "native" | "any-quote";
+export type ModuleModeLaunchDraftHandoff = Pick<ModuleModeState,
+  "name" | "symbol" | "description" | "socialLinks" | "tokenImage" |
+  "initialBuyEth" | "buyFeePercent" | "sellFeePercent"
+> & {
+  imageResource: ModuleModeImageResource | null;
+  /** Retained for returning to native; its module selections do not apply to Any Quote. */
+  nativeState?: ModuleModeState;
+};
+
+let pending: {
+  target: ModuleModeLaunchDraftTarget;
+  draft: Omit<ModuleModeLaunchDraftHandoff, "imageResource">;
+  imageBlob: Blob | null;
+} | null = null;
+
+/** A route transition transfers only draft fields, never a prepared transaction or wallet state. */
+export function saveModuleModeLaunchDraftHandoff(target: ModuleModeLaunchDraftTarget, draft: ModuleModeLaunchDraftHandoff): void {
+  if (typeof window === "undefined") return;
+  const { name, symbol, description, socialLinks, tokenImage, initialBuyEth, buyFeePercent, sellFeePercent, nativeState } = draft;
+  pending = {
+    target,
+    draft: structuredClone({ name, symbol, description, socialLinks, tokenImage, initialBuyEth, buyFeePercent, sellFeePercent,
+      ...(nativeState ? { nativeState } : {}) }),
+    imageBlob: tokenImage.kind === "local" ? draft.imageResource?.blob ?? null : null,
+  };
+}
+
+/** The destination owns the new object URL and revokes it through its usual image cleanup. */
+export function consumeModuleModeLaunchDraftHandoff(target: ModuleModeLaunchDraftTarget): ModuleModeLaunchDraftHandoff | null {
+  if (typeof window === "undefined" || !pending || pending.target !== target) return null;
+  const { draft, imageBlob } = pending;
+  const imageResource = imageBlob ? { blob: imageBlob, objectUrl: URL.createObjectURL(imageBlob) } : null;
+  pending = null;
+  return { ...draft, imageResource };
+}

--- a/lib/module-mode/library.ts
+++ b/lib/module-mode/library.ts
@@ -1,10 +1,19 @@
-import type { ModuleModeCatalogEntry } from "./builder";
-
 /** Discovery metadata is reviewed with a module. Categories never grant runtime capabilities. */
 export interface ModuleDiscovery {
   category: string;
   tags?: string[];
   author?: `0x${string}`;
+}
+
+/** Display data only; runtime admission and configuration stay with the caller. */
+export interface ModuleLibraryEntry {
+  id: string;
+  title: string;
+  summary: string;
+  status: "available" | "preview";
+  discovery?: ModuleDiscovery;
+  source?: { sha256: string };
+  nativeBinding?: { packageId?: string };
 }
 
 export const MODULE_CATEGORIES = [
@@ -33,27 +42,27 @@ const STARTER_DISCOVERY: Readonly<Record<string, ModuleDiscovery>> = {
   },
 };
 
-export function moduleDiscovery(entry: ModuleModeCatalogEntry): ModuleDiscovery {
+export function moduleDiscovery(entry: ModuleLibraryEntry): ModuleDiscovery {
   if (entry.discovery) return entry.discovery;
-  const binding = "nativeBinding" in entry ? entry.nativeBinding as { packageId?: string } : undefined;
+  const binding = entry.nativeBinding;
   const published = binding?.packageId ? STARTER_DISCOVERY[binding.packageId.toLowerCase()] : undefined;
   if (published) return published;
-  if (entry.source.sha256 === "ea0c547131d6e41878c0f75129db4a242059feda2e121edb8be024108cda9079") return { category: "trading/opening-limits", tags: ["Buy cap", "Opening window"] };
-  if (entry.source.sha256 === "0390c47404c11c9f15a2e6c87c8b8dc8e183623c7134e2903f9103168f6dfc0c") return { category: "rewards/buyer-rewards", tags: ["ETH", "Every Nth buy"] };
+  if (entry.source?.sha256 === "ea0c547131d6e41878c0f75129db4a242059feda2e121edb8be024108cda9079") return { category: "trading/opening-limits", tags: ["Buy cap", "Opening window"] };
+  if (entry.source?.sha256 === "0390c47404c11c9f15a2e6c87c8b8dc8e183623c7134e2903f9103168f6dfc0c") return { category: "rewards/buyer-rewards", tags: ["ETH", "Every Nth buy"] };
   return { category: "experiments" };
 }
 
-export function moduleCategory(entry: ModuleModeCatalogEntry) {
+export function moduleCategory(entry: ModuleLibraryEntry) {
   const parent = moduleDiscovery(entry).category.split("/")[0];
   return MODULE_CATEGORIES.find(category => category.id === parent) ?? MODULE_CATEGORIES[7];
 }
 
-export function moduleAuthorLabel(entry: ModuleModeCatalogEntry) {
+export function moduleAuthorLabel(entry: ModuleLibraryEntry) {
   const author = moduleDiscovery(entry).author;
   return author ? `${author.slice(0, 6)}…${author.slice(-4)}` : null;
 }
 
-export function searchModuleLibrary(catalog: readonly ModuleModeCatalogEntry[], query: string, category: string) {
+export function searchModuleLibrary<Entry extends ModuleLibraryEntry>(catalog: readonly Entry[], query: string, category: string): Entry[] {
   const words = query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
   return catalog.filter(entry => {
     if (category !== "all" && moduleCategory(entry).id !== category) return false;

--- a/tests/module-library-ui.test.tsx
+++ b/tests/module-library-ui.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { ModuleLibrary } from "@/components/module-library";
 import { ModuleEngineLibrary } from "@/components/module-engine-library";
 import { moduleModeFeePolicy } from "@/lib/module-mode/builder";
+import type { ModuleLibraryEntry } from "@/lib/module-mode/library";
 import { bindNativeCatalogEntry } from "@/lib/module-mode/native-catalog";
 import { bindActiveModuleModeRelease, computeModuleModeReleaseDigest, MODULE_MODE_ECONOMICS_POLICY_V2 } from "@/lib/module-mode/release";
 import catalog from "@/config/module-mode/catalog.json";
@@ -14,6 +15,10 @@ const base = moduleEvidenceFixture().release;
 const identity = { ...base, schemaVersion: "programmable.module-mode-source.v2", sourceVersion: "module-native-v2", economicsPolicyId: MODULE_MODE_ECONOMICS_POLICY_V2 };
 const release = bindActiveModuleModeRelease({ ...identity, releaseDigest: computeModuleModeReleaseDigest(identity) });
 const actions = { onAdd: vi.fn(), onRemove: vi.fn() };
+const engineEntry: ModuleLibraryEntry & { kind: "engine" } = {
+  id: "any-quote", title: "Any Quote", summary: "Choose a quote token", status: "available", kind: "engine",
+  discovery: { category: "pairs/quote-assets", author: "0xd88539d3c4c460136a733a3fd60cf6bf269079da" },
+};
 
 describe("Module selection presentation", () => {
   it("shows the release-bound fee before adding, and makes the selected action explicit", () => {
@@ -23,6 +28,45 @@ describe("Module selection presentation", () => {
     expect(html).toContain(`aria-label="Remove ${entry.title}"`);
     expect(html).toMatch(/>Remove<\/button>/);
     expect(html).not.toContain("Draft only");
+  });
+
+  it("uses the same cards for presentation entries, overriding their fee while retaining native fee policy", () => {
+    const feePolicyFor = vi.fn((candidate: typeof entry | typeof engineEntry) => {
+      if ("kind" in candidate) throw new Error("Presentation entries have no native fee policy.");
+      return moduleModeFeePolicy(release, [candidate]);
+    });
+    const html = renderToStaticMarkup(<ModuleLibrary catalog={[entry, engineEntry]} selectedIds={[]} {...actions}
+      feeDescriptionFor={candidate => "kind" in candidate ? "Platform fee: 0.30% in ETH per trade." : undefined}
+      feePolicyFor={feePolicyFor} />);
+    expect(html.match(/<article /gu)).toHaveLength(2);
+    expect(html).toContain('aria-label="Add Any Quote"');
+    expect(html).toContain('data-category="pairs"');
+    expect(html).toContain("Platform fee: 0.30% in ETH per trade.");
+    expect(html).toContain("Estimated platform fee: 0.30% per trade.");
+    expect(html).toContain("By 0xd885…79da");
+    expect(feePolicyFor).toHaveBeenCalledExactlyOnceWith(entry);
+  });
+
+  it("explains a blocked addition accessibly while allowing selected modules to be removed", () => {
+    const reason = "Remove the current module before adding this one.";
+    const html = renderToStaticMarkup(<ModuleLibrary catalog={[entry, engineEntry]} selectedIds={[entry.id]} {...actions}
+      feeDescriptionFor={() => "Platform fee: 0.30% per trade."} disabledFor={() => reason} />);
+    const add = html.match(/<button[^>]+aria-label="Add Any Quote"[^>]*>/u)?.[0];
+    const remove = html.match(new RegExp(`<button[^>]+aria-label="Remove ${entry.title}"[^>]*>`, "u"))?.[0];
+    expect(add).toContain('disabled=""');
+    expect(remove).toBeDefined();
+    expect(remove).not.toContain('disabled=""');
+    const descriptionIds = add?.match(/aria-describedby="([^"]+)"/u)?.[1].split(" ");
+    expect(descriptionIds).toHaveLength(2);
+    for (const id of descriptionIds ?? []) expect(html).toContain(`id="${id}"`);
+    expect(html).toContain(`>${reason}</div>`);
+  });
+
+  it("disables both addition and removal while a global operation is pending", () => {
+    const html = renderToStaticMarkup(<ModuleLibrary catalog={[entry, engineEntry]} selectedIds={[entry.id]} {...actions} disabled />);
+    const buttons = [...html.matchAll(/<button[^>]+aria-label="(?:Add|Remove) [^"]+"[^>]*>/gu)].map(match => match[0]);
+    expect(buttons).toHaveLength(2);
+    expect(buttons.every(button => button.includes('disabled=""'))).toBe(true);
   });
 
   it("does not invent an author fee for an ineligible family or missing eligibility", () => {

--- a/tests/module-mode-launch-draft-handoff.test.ts
+++ b/tests/module-mode-launch-draft-handoff.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModuleModeLaunchDraftHandoff } from "@/lib/module-mode/launch-draft-handoff";
+
+function draft(): ModuleModeLaunchDraftHandoff {
+  return { name: "My coin", symbol: "COIN", description: "A saved draft", socialLinks: { website: "https://example.com" },
+    tokenImage: { kind: "none" }, imageResource: null, initialBuyEth: "0.0075", buyFeePercent: "1", sellFeePercent: "2" };
+}
+
+beforeEach(() => { vi.stubGlobal("window", {}); });
+afterEach(() => { vi.unstubAllGlobals(); vi.resetModules(); });
+
+describe("one-shot launch draft handoff", () => {
+  it("preserves shared fields and independent native settings without retaining mutable source state", async () => {
+    const { saveModuleModeLaunchDraftHandoff, consumeModuleModeLaunchDraftHandoff } = await import("@/lib/module-mode/launch-draft-handoff");
+    const source = draft();
+    source.nativeState = { ...source, selectedModules: ["opening-buy-cap"], moduleValues: { "opening-buy-cap": { limit: "1" } }, moduleFundingEth: {} };
+    const expected = structuredClone(source);
+    saveModuleModeLaunchDraftHandoff("any-quote", source);
+    source.name = "Changed"; source.socialLinks!.website = "https://changed.example";
+    source.nativeState.selectedModules.length = 0; source.nativeState.moduleValues["opening-buy-cap"] = {};
+    const received = consumeModuleModeLaunchDraftHandoff("any-quote");
+    expect(received).toEqual(expected);
+    expect(received).not.toHaveProperty("selectedModules");
+    expect(consumeModuleModeLaunchDraftHandoff("any-quote")).toBeNull();
+  });
+
+  it("only consumes the intended destination and replaces an earlier pending transition", async () => {
+    const { saveModuleModeLaunchDraftHandoff, consumeModuleModeLaunchDraftHandoff } = await import("@/lib/module-mode/launch-draft-handoff");
+    saveModuleModeLaunchDraftHandoff("any-quote", draft());
+    expect(consumeModuleModeLaunchDraftHandoff("native")).toBeNull();
+    const latest = { ...draft(), name: "Latest draft" };
+    saveModuleModeLaunchDraftHandoff("native", latest);
+    expect(consumeModuleModeLaunchDraftHandoff("any-quote")).toBeNull();
+    expect(consumeModuleModeLaunchDraftHandoff("native")).toEqual(latest);
+    expect(consumeModuleModeLaunchDraftHandoff("native")).toBeNull();
+  });
+
+  it("recreates a usable local image URL after the source builder revokes its URL", async () => {
+    const { saveModuleModeLaunchDraftHandoff, consumeModuleModeLaunchDraftHandoff } = await import("@/lib/module-mode/launch-draft-handoff");
+    const blob = new Blob(["local image bytes"], { type: "image/webp" }), sourceUrl = URL.createObjectURL(blob);
+    const source: ModuleModeLaunchDraftHandoff = { ...draft(), tokenImage: { kind: "local", sha256: `0x${"ab".repeat(32)}`, mimeType: "image/webp", bytes: blob.size }, imageResource: { blob, objectUrl: sourceUrl } };
+    saveModuleModeLaunchDraftHandoff("any-quote", source);
+    URL.revokeObjectURL(sourceUrl);
+    const received = consumeModuleModeLaunchDraftHandoff("any-quote")!;
+    try {
+      expect(received.imageResource?.objectUrl).not.toBe(sourceUrl);
+      expect(received.imageResource?.blob).toBe(blob);
+      await expect(fetch(sourceUrl)).rejects.toThrow();
+      expect(await (await fetch(received.imageResource!.objectUrl)).text()).toBe("local image bytes");
+      expect(consumeModuleModeLaunchDraftHandoff("any-quote")).toBeNull();
+    } finally { URL.revokeObjectURL(received.imageResource!.objectUrl); }
+  });
+
+  it("keeps a public image URI without transferring an obsolete local image resource", async () => {
+    const { saveModuleModeLaunchDraftHandoff, consumeModuleModeLaunchDraftHandoff } = await import("@/lib/module-mode/launch-draft-handoff");
+    const source: ModuleModeLaunchDraftHandoff = { ...draft(), tokenImage: { kind: "uri", uri: "https://example.com/coin.webp", contentVerified: false }, imageResource: { blob: new Blob(["old"]), objectUrl: "blob:old" } };
+    saveModuleModeLaunchDraftHandoff("native", source);
+    expect(consumeModuleModeLaunchDraftHandoff("native")).toEqual({ ...source, imageResource: null });
+  });
+
+  it("does not save or consume a browser draft during server rendering", async () => {
+    const { saveModuleModeLaunchDraftHandoff, consumeModuleModeLaunchDraftHandoff } = await import("@/lib/module-mode/launch-draft-handoff");
+    vi.stubGlobal("window", undefined);
+    saveModuleModeLaunchDraftHandoff("native", draft());
+    expect(consumeModuleModeLaunchDraftHandoff("native")).toBeNull();
+    vi.stubGlobal("window", {});
+    expect(consumeModuleModeLaunchDraftHandoff("native")).toBeNull();
+    saveModuleModeLaunchDraftHandoff("any-quote", draft());
+    vi.stubGlobal("window", undefined);
+    expect(consumeModuleModeLaunchDraftHandoff("any-quote")).toBeNull();
+    vi.stubGlobal("window", {});
+    expect(consumeModuleModeLaunchDraftHandoff("any-quote")).toEqual(draft());
+  });
+});

--- a/tests/module-mode-launch-ui.test.tsx
+++ b/tests/module-mode-launch-ui.test.tsx
@@ -2,7 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import { ModuleModeBuilder } from "@/components/module-mode-builder";
-import { ModuleModeAnyQuoteLaunchEntry, ModuleModeLaunchResult } from "@/components/module-mode-launch-host";
+import { ModuleModeLaunchResult } from "@/components/module-mode-launch-host";
 import { ModuleSchemaField } from "@/components/module-mode-fields";
 import { bindActiveModuleModeRelease, computeModuleModeReleaseDigest, MODULE_MODE_ECONOMICS_POLICY_V2 } from "@/lib/module-mode/release";
 import { moduleEvidenceFixture, a } from "./fixtures/module-mode-evidence";
@@ -17,18 +17,6 @@ const token = `0x${"12".repeat(20)}` as const;
 const transactionHash = `0x${"34".repeat(32)}` as const;
 
 describe("Module Mode launch presentation", () => {
-  it("names the Any Quote setup without version controls and disables entry during an existing wallet flow", () => {
-    const onSelect = vi.fn();
-    const available = renderToStaticMarkup(<ModuleModeAnyQuoteLaunchEntry disabled={false} onSelect={onSelect} />);
-    expect(available).toContain("Any Quote LP");
-    expect(available).toContain("Start a coin paired with a compatible token of your choice. Trade with ETH.");
-    expect(available).toContain('aria-labelledby="module-any-quote-title"');
-    expect(available).toMatch(/<button[^>]+type="button"[^>]*>Use Any Quote LP /);
-    expect(available).not.toMatch(/<select|Module version|sourceKind|releaseDigest/);
-    const locked = renderToStaticMarkup(<ModuleModeAnyQuoteLaunchEntry disabled onSelect={onSelect} />);
-    expect(locked).toMatch(/<button[^>]+disabled=""/);
-    expect(onSelect).not.toHaveBeenCalled();
-  });
   it("renders the released plain fee for each generation and no V2 fee under a V1 release", () => {
     const v1 = bindActiveModuleModeRelease(moduleEvidenceFixture().release);
     const identity = { ...v1, schemaVersion: "programmable.module-mode-source.v2", sourceVersion: "module-native-v2", economicsPolicyId: MODULE_MODE_ECONOMICS_POLICY_V2 };

--- a/tests/module-mode-library.test.ts
+++ b/tests/module-mode-library.test.ts
@@ -1,10 +1,26 @@
 import { describe, expect, it } from "vitest";
 import { PREVIEW_MODULE_CATALOG } from "../lib/module-mode/builder";
-import { MODULE_LIBRARY_PAGE_SIZE, isModuleDiscovery, moduleCategory, searchModuleLibrary } from "../lib/module-mode/library";
+import { MODULE_LIBRARY_PAGE_SIZE, isModuleDiscovery, moduleAuthorLabel, moduleCategory, moduleDiscovery, searchModuleLibrary, type ModuleLibraryEntry } from "../lib/module-mode/library";
 import { AGENT_KEY_SCHEMA, AGENT_SCOPES, buildAgentConnection, buildAgentInstructions, PROGRAMMABLE_AGENT_ENTRY } from "../lib/agent-connection";
 import { apiKeyRotationVersion, apiKeyMutationPath, parseApiKeyMutationResult } from "../components/developer-api-keys";
 
 describe("module discovery and agent connections", () => {
+  it("discovers presentation entries without source bindings and preserves their caller data", () => {
+    const entry = {
+      id: "any-quote", title: "Any Quote", summary: "Choose a quote token", status: "available" as const,
+      discovery: { category: "pairs/quote-assets", tags: ["PGRAM"], author: "0xd88539d3c4c460136a733a3fd60cf6bf269079da" as const },
+      templateId: "caller-owned-template",
+    };
+    const matches = searchModuleLibrary([entry], "PGRAM D885", "pairs");
+    expect(matches).toEqual([entry]);
+    expect(matches[0]).toBe(entry);
+    expect(matches[0].templateId).toBe("caller-owned-template");
+    expect(moduleAuthorLabel(entry)).toBe("0xd885…79da");
+    const undiscovered: ModuleLibraryEntry = { id: "minimal", title: "Minimal", summary: "No discovery metadata", status: "preview" };
+    expect(moduleDiscovery(undiscovered)).toEqual({ category: "experiments" });
+    expect(moduleAuthorLabel(undiscovered)).toBeNull();
+  });
+
   it("finds category, tag and author across a thousand entries without changing their identities", () => {
     const catalog = Array.from({ length: 1000 }, (_, i) => ({ ...PREVIEW_MODULE_CATALOG[0], id: `fixture-${i}`, title: `Module ${i}`, discovery: { category: i === 999 ? "pairs/stocks" : "rewards/buyers", tags: i === 999 ? ["TSLA", "Tokenized stock"] : ["ETH"], author: "0x1111111111111111111111111111111111111111" as const } }));
     expect(searchModuleLibrary(catalog, "tsla stock", "pairs")).toEqual([catalog[999]]);


### PR DESCRIPTION
Any Quote LP now uses the same Add modules cards and selected-module row as Opening buy cap. Its pair address is inline; adding or removing modules keeps the dialog open and retains the current category. The engine switch is applied when the picker closes, preserving the coin name, image, links, initial buy, creator fees and native module settings.

Search no longer appears just because a category is selected. Category browsing omits the result counter, cards keep their width, and the picker keeps a stable height within the viewport. Incompatible combinations remain disabled with a reason, and launch/wallet locks remain enforced.

Validation: focused UI and draft tests, TypeScript and ESLint passed. Desktop browser checks verified Add/Remove, retained selection and identical dialog bounds across All/Pairs; final mobile and production acceptance is required before promotion.
