### PR TITLE
Stream Module Mode and configure Any Quote in the picker

### DIFF
--- a/app/launch/modules/loading.tsx
+++ b/app/launch/modules/loading.tsx
@@ -1,0 +1,5 @@
+import { ModuleBuilderLoading } from "@/components/module-builder-loading";
+
+export default function Loading() {
+  return <ModuleBuilderLoading />;
+}

--- a/app/launch/modules/page.tsx
+++ b/app/launch/modules/page.tsx
@@ -1,15 +1,10 @@
 import type { Metadata } from "next";
-import { ModuleModeLaunchHost } from "@/components/module-mode-launch-host";
-import { ModuleEngineHost } from "@/components/module-engine-host";
-import { readModuleEngineAvailability, readModuleEngineLaunchVersions } from "@/lib/server/module-engine/catalog";
-import { parseModuleEngineAvailability } from "@/lib/module-engine/catalog";
-import { isModuleEngineSharedQuoteRelease } from "@/lib/module-engine/profile";
+import type { Hex } from "viem";
+import { ModuleLaunchWorkspace } from "@/components/module-launch-workspace";
 import reviewedAnyQuoteRelease from "@/config/module-engine/review-release.json";
 import { notFound } from "next/navigation";
 import { parseModuleModePageSelection } from "@/lib/module-mode/release-selection";
-import { readModuleModeLaunchVersions } from "@/lib/server/module-mode/launch-profiles";
-import { readModuleModeAvailability } from "@/lib/server/module-mode/catalog";
-import { anyQuoteLibraryEntry } from "@/lib/module-engine/library-entry";
+import { createModuleLaunchWorkspaceRequests } from "@/lib/server/module-mode/launch-workspace";
 
 export const metadata: Metadata = {
   title: "Module Mode · Programmable",
@@ -21,26 +16,7 @@ export const metadata: Metadata = {
 export default async function ModuleModePage({ searchParams }: { searchParams: Promise<Record<string, string | string[] | undefined>> }) {
   let selection;
   try { selection = parseModuleModePageSelection(await searchParams); } catch { notFound(); }
-  const [nativeVersions, engineVersions, currentEngine, nativeAvailability] = await Promise.allSettled([
-    readModuleModeLaunchVersions(), readModuleEngineLaunchVersions(), readModuleEngineAvailability(reviewedAnyQuoteRelease.releaseDigest),
-    selection.sourceKind === "module-engine-v1" ? readModuleModeAvailability() : Promise.resolve(null),
-  ]);
-  const versions = [nativeVersions, engineVersions].flatMap(result => result.status === "fulfilled" ? result.value : []);
-  if (selection.sourceKind === "module-engine-v1") return <ModuleEngineHost releaseDigest={selection.releaseDigest} versions={versions}
-    nativeCatalog={nativeAvailability.status === "fulfilled" ? nativeAvailability.value?.catalog ?? [] : []}
-    nativeRelease={nativeAvailability.status === "fulfilled" ? nativeAvailability.value?.release : undefined} />;
-  let anyQuoteReleaseDigest;
-  let anyQuoteModule;
-  if (currentEngine.status === "fulfilled") {
-    try {
-      const { release, templates } = parseModuleEngineAvailability(currentEngine.value);
-      // The review identity only selects the entry; current public authority must independently admit it.
-      const template = templates.find(candidate => candidate.manifest.manifest.catalogDefinition.interface === "quote-shared-v1");
-      if (release && isModuleEngineSharedQuoteRelease(release) && release.releaseDigest === reviewedAnyQuoteRelease.releaseDigest && template) {
-        anyQuoteReleaseDigest = release.releaseDigest;
-        anyQuoteModule = anyQuoteLibraryEntry(template.manifest.manifest.catalogDefinition);
-      }
-    } catch { /* Unavailable or unbound engine sources never create a launch entry. */ }
-  }
-  return <ModuleModeLaunchHost releaseDigest={selection.releaseDigest} versions={versions} anyQuoteReleaseDigest={anyQuoteReleaseDigest} anyQuoteModule={anyQuoteModule} />;
+  const reviewedAnyQuoteDigest = reviewedAnyQuoteRelease.releaseDigest as Hex;
+  return <ModuleLaunchWorkspace initialSelection={selection} reviewedAnyQuoteDigest={reviewedAnyQuoteDigest}
+    requests={createModuleLaunchWorkspaceRequests(selection, reviewedAnyQuoteDigest)} />;
 }

--- a/components/custom-hook-builder.module.css
+++ b/components/custom-hook-builder.module.css
@@ -1,0 +1,122 @@
+.page:global(.page-width) {
+  --webde-surface: #181818;
+  --webde-control: #20201f;
+  --webde-line: #383736;
+  --webde-muted: #b4b1ad;
+  --webde-ink: #f5f3ef;
+  margin-inline: auto;
+  max-width: 1040px;
+  padding: 24px 20px 64px;
+  width: 100%;
+}
+
+.page .backLink {
+  background: #1c1c1c;
+  border: 1px solid #64615f;
+  border-radius: 24px;
+  color: var(--webde-ink);
+  padding-inline: 16px;
+}
+
+.layout {
+  align-items: stretch;
+  background: var(--webde-surface);
+  border: 1px solid #353433;
+  border-radius: 24px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  overflow: clip;
+}
+
+.formPanel { min-width: 0; padding: 32px; }
+.heading { margin-bottom: 28px; }
+.heading h1 { font-size: 30px; font-weight: 500; letter-spacing: -.035em; line-height: 1.2; text-wrap: initial; }
+.heading p { color: var(--webde-muted); font-size: 14px; line-height: 20px; margin-top: 12px; }
+.formPanel > ol { gap: 12px 24px; margin-bottom: 28px; }
+
+.formPanel > section[aria-labelledby="builder-prompt-title"] {
+  --module-muted: var(--webde-muted);
+  --module-line: var(--webde-line);
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  margin-bottom: 24px;
+  padding: 0;
+}
+
+.formPanel > section[aria-labelledby="builder-prompt-title"] h2 { font-size: 16px; line-height: 24px; }
+.formPanel > section[aria-labelledby="builder-prompt-title"] > header p { font-size: 13px; line-height: 20px; margin: 4px 0 20px; }
+.formPanel > section[aria-labelledby="builder-prompt-title"] form > div { max-width: none; }
+.formPanel > section[aria-labelledby="builder-prompt-title"] label > span { color: #c5c1bc; font-size: 13px; }
+.formPanel > section[aria-labelledby="builder-prompt-title"] textarea { background: var(--webde-control); font-size: 14px; min-height: 160px; }
+.formPanel > section[aria-labelledby="builder-prompt-title"] textarea::placeholder { color: #a8a39d; }
+.formPanel > section[aria-labelledby="builder-prompt-title"] > p { font-size: 13px; line-height: 20px; }
+.formPanel > section[aria-labelledby="builder-prompt-title"] > div > p { font-size: 13px; line-height: 20px; }
+
+.formPanel > section:has(#connect-title),
+.formPanel > section[aria-busy="true"],
+.formPanel > section[role="alert"] {
+  align-items: stretch;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  flex-direction: column;
+  gap: 20px;
+  justify-content: flex-start;
+  min-height: 144px;
+  padding: 0;
+}
+
+.formPanel section:has(> div > #create-key-title) { background: transparent; border: 0; border-radius: 0; padding: 0; }
+.formPanel form:has(#api-key-label) > div { grid-template-columns: minmax(0, 1fr); }
+.formPanel form:has(#api-key-label) > div > button { justify-self: stretch; min-width: 0; width: 100%; }
+.formPanel :is(input, textarea):focus { border-color: var(--api-accent); }
+
+.previewPanel {
+  align-items: center;
+  background: #222221;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+  padding: 32px;
+}
+
+.hookCard { background: #191919; border: 1px solid #484643; border-radius: 20px; min-width: 0; padding: 24px; width: 100%; }
+.hookIcon { align-items: center; background: #30242b; border: 1px solid #775568; border-radius: 16px; color: #f0bfd6; display: flex; height: 64px; justify-content: center; margin-bottom: 16px; width: 64px; }
+.hookCard h2 { color: var(--webde-ink); font-size: 22px; font-weight: 500; letter-spacing: -.02em; line-height: 28px; margin: 0; }
+.hookCard > p { color: var(--webde-muted); font-size: 14px; line-height: 20px; margin: 8px 0 0; }
+.hookDetails { border-block: 1px solid #353330; display: grid; gap: 16px; margin: 24px 0 0; padding-block: 20px; }
+.hookDetails > div { display: grid; gap: 12px; grid-template-columns: minmax(0, .7fr) minmax(0, 1.3fr); }
+.hookDetails dt { color: var(--webde-muted); font-size: 13px; line-height: 20px; }
+.hookDetails dd { color: var(--webde-ink); font-size: 13px; line-height: 20px; margin: 0; text-align: right; }
+.hookCard > .reviewNote { font-size: 12px; line-height: 18px; margin-top: 16px; }
+.docsLink { align-items: center; color: #c6c0bb; display: inline-flex; font-size: 13px; gap: 8px; justify-content: center; line-height: 20px; margin-top: 12px; min-height: 44px; text-decoration: none; width: 100%; }
+.docsLink > svg { flex-shrink: 0; }
+.page :is(button, a, input, textarea, select, summary):focus-visible { outline: 2px solid var(--api-accent); outline-offset: 3px; }
+.page :is(button, a, summary) { touch-action: manipulation; }
+
+@media (hover: hover) and (pointer: fine) {
+  .page .backLink:hover { background: #292827; color: #fff; }
+  .docsLink:hover { color: #f0bfd6; }
+}
+
+@media (max-width: 900px) { .formPanel, .previewPanel { padding: 24px; } }
+@media (max-width: 760px) {
+  .page:global(.page-width) { padding: 16px 16px 48px; }
+  .layout { grid-template-columns: minmax(0, 1fr); }
+  .formPanel, .previewPanel { padding: 24px 20px; }
+  .heading h1 { font-size: 28px; }
+  .hookCard { max-width: 440px; }
+  .formPanel > section[aria-labelledby="builder-prompt-title"] textarea { font-size: 16px; }
+}
+@media (max-width: 360px) {
+  .page:global(.page-width) { padding-inline: 12px; }
+  .formPanel, .previewPanel { padding: 20px 16px; }
+  .hookCard { padding: 20px; }
+  .hookDetails > div { gap: 8px; }
+}
+@media (forced-colors: active) {
+  .layout, .hookCard, .hookIcon { border-color: CanvasText; }
+  .page :is(button, a, input, textarea, select, summary):focus-visible { outline-color: Highlight; }
+}

--- a/components/developer-api-keys.tsx
+++ b/components/developer-api-keys.tsx
@@ -11,10 +11,12 @@ import {
   useSyncExternalStore,
   type FormEvent,
   type KeyboardEvent,
+  type ReactNode,
 } from "react";
 import {
   ArrowLeft,
   ArrowRight,
+  Braces,
   Check,
   Copy,
   ChevronDown,
@@ -25,6 +27,7 @@ import {
 } from "lucide-react";
 
 import styles from "@/components/developer-api-keys.module.css";
+import hookStyles from "@/components/custom-hook-builder.module.css";
 import { AGENT_KEY_SCHEMA, AGENT_SCOPES, buildAgentConnection, buildAgentInstructions } from "@/lib/agent-connection";
 import { DeveloperUniversalLaunchHistory } from "@/components/developer-universal-launch-history";
 import type { LaunchContractSetupV1 } from "@/lib/server/custom-launch/launch-contract-setup-v1";
@@ -899,6 +902,33 @@ export function DeveloperApiKeys({
   );
 }
 
+function CustomHookBuilderFrame({ enabled, children }: {
+  enabled: boolean;
+  children: ReactNode;
+}) {
+  if (!enabled) return <>{children}</>;
+
+  return (
+    <div className={hookStyles.layout}>
+      <div className={hookStyles.formPanel}>{children}</div>
+      <aside className={hookStyles.previewPanel} aria-label="About custom hooks">
+        <div className={hookStyles.hookCard}>
+          <span className={hookStyles.hookIcon}><Braces size={30} aria-hidden="true" /></span>
+          <h2>Custom hook</h2>
+          <p>A coin with your own trading rules.</p>
+          <dl className={hookStyles.hookDetails}>
+            <div><dt>Fees</dt><dd>Set your own logic</dd></div>
+            <div><dt>Rewards</dt><dd>Choose how they work</dd></div>
+            <div><dt>Pool</dt><dd>Define its behavior</dd></div>
+          </dl>
+          <p className={hookStyles.reviewNote}>Your builder checks what your idea needs before submitting it for review.</p>
+        </div>
+        <Link className={hookStyles.docsLink} href="/developer-reference/custom-launch">How custom hooks work <ArrowRight size={16} aria-hidden="true" /></Link>
+      </aside>
+    </div>
+  );
+}
+
 export function DeveloperApiKeysView({
   moduleBuilder = false,
   hookBuilder = false,
@@ -1577,7 +1607,7 @@ export function DeveloperApiKeysView({
   };
 
   return (
-    <div className={`${styles.page} ${builderKind ? styles.builderPage : ""} page-width`}>
+    <div className={`${styles.page} ${moduleBuilder ? styles.builderPage : ""} ${hookBuilder ? hookStyles.page : ""} page-width`}>
       <p
         className={styles.visuallyHidden}
         role="status"
@@ -1588,14 +1618,15 @@ export function DeveloperApiKeysView({
       </p>
 
       <nav className={styles.topNavigation} aria-label="Builder navigation">
-        <Link className={styles.backLink} href="/launch">
+        <Link className={`${styles.backLink} ${hookBuilder ? hookStyles.backLink : ""}`} href="/launch">
           <ArrowLeft aria-hidden="true" size={16} strokeWidth={1.9} />
           <span>Back</span>
         </Link>
         <Link className={styles.textLink} href={hookBuilder ? "/developers/api-keys?view=history" : "/profile?section=submissions#profile-modules-title"}>{hookBuilder ? "Your launches" : "Submissions"} <ArrowRight size={16} aria-hidden="true" /></Link>
       </nav>
 
-      <header className={styles.hero}>
+      <CustomHookBuilderFrame enabled={hookBuilder}>
+      <header className={`${styles.hero} ${hookBuilder ? hookStyles.heading : ""}`}>
         <div className={styles.heroCopy}>
           <h1>{activeSection === "keys" ? moduleBuilder ? "Build a module" : hookBuilder ? "Build a custom hook" : "API keys" : activeSection === "launch" ? "Launch a hook" : "Your launches"}</h1>
           <p className={styles.intro}>
@@ -2268,6 +2299,8 @@ export function DeveloperApiKeysView({
           )}
         </>
       )}
+
+      </CustomHookBuilderFrame>
 
       {launchContractSetup ? <details className={styles.connectionOptions} data-manifest-digest={launchContractSetup.manifestDigest}>
         <summary>Custom Launch Plan instructions</summary>

--- a/components/module-any-quote-configuration.module.css
+++ b/components/module-any-quote-configuration.module.css
@@ -1,0 +1,7 @@
+.panel { display: grid; gap: 24px; padding-top: 4px; }
+.fields { border: 0; margin: 0; min-width: 0; padding: 0; }
+.back, .remove { align-items: center; background: transparent; border: 0; color: #d7d5d0; cursor: pointer; display: inline-flex; font: inherit; font-size: 14px; gap: 8px; justify-self: start; min-height: 44px; padding: 8px 0; }
+.remove { color: #b9b6b2; }
+.back:focus-visible, .remove:focus-visible { border-radius: 4px; outline: 2px solid #e786b2; outline-offset: 4px; }
+.fields:disabled, .remove:disabled { opacity: .5; }
+@media (hover: hover) and (pointer: fine) { .back:hover, .remove:not(:disabled):hover { color: #fff; } }

--- a/components/module-any-quote-configuration.tsx
+++ b/components/module-any-quote-configuration.tsx
@@ -14,7 +14,10 @@ export function ModuleAnyQuoteConfiguration({ value, onChange, availability, onB
   disabled?: boolean;
 }) {
   const panel = useRef<HTMLDivElement>(null);
-  useLayoutEffect(() => { panel.current?.querySelector<HTMLInputElement>("input")?.focus({ preventScroll: true }); }, []);
+  useLayoutEffect(() => {
+    const input = panel.current?.querySelector<HTMLInputElement>("input");
+    queueMicrotask(() => { if (input?.isConnected) input.focus({ preventScroll: true }); });
+  }, []);
   return <div ref={panel} className={styles.panel}>
     <button type="button" className={styles.back} onClick={onBack}><ArrowLeft size={17} aria-hidden="true" />Back to modules</button>
     <fieldset disabled={disabled} className={styles.fields}>

--- a/components/module-any-quote-configuration.tsx
+++ b/components/module-any-quote-configuration.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+import { useLayoutEffect, useRef } from "react";
+import { ModuleEngineAnyQuoteAsset, type AnyQuoteAssetAvailability } from "./module-engine-any-quote-asset";
+import styles from "./module-any-quote-configuration.module.css";
+
+export function ModuleAnyQuoteConfiguration({ value, onChange, availability, onBack, onRemove, disabled }: {
+  value: string;
+  onChange: (value: string) => void;
+  availability: AnyQuoteAssetAvailability;
+  onBack: () => void;
+  onRemove: () => void;
+  disabled?: boolean;
+}) {
+  const panel = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => { panel.current?.querySelector<HTMLInputElement>("input")?.focus({ preventScroll: true }); }, []);
+  return <div ref={panel} className={styles.panel}>
+    <button type="button" className={styles.back} onClick={onBack}><ArrowLeft size={17} aria-hidden="true" />Back to modules</button>
+    <fieldset disabled={disabled} className={styles.fields}>
+      <ModuleEngineAnyQuoteAsset inputId="module-picker-quote" value={value} onChange={onChange} availability={availability} />
+    </fieldset>
+    <button type="button" disabled={disabled} className={styles.remove} onClick={onRemove}>Remove module</button>
+  </div>;
+}

--- a/components/module-engine-any-quote-asset.tsx
+++ b/components/module-engine-any-quote-asset.tsx
@@ -5,6 +5,7 @@ import { isAddress, type Hex } from "viem";
 import { Check, CircleAlert, LoaderCircle, RefreshCw } from "lucide-react";
 import { fetchAnyQuoteReadiness } from "@/lib/module-engine/any-quote/integration-client";
 import type { AnyQuoteReadinessV1 } from "@/lib/module-engine/any-quote/types";
+import { forgetAnyQuoteDisplayCheck, readAnyQuoteDisplayCheck, rememberAnyQuoteDisplayCheck } from "@/lib/module-engine/any-quote/readiness-display-cache";
 import styles from "./module-mode-builder.module.css";
 import engineStyles from "./module-engine-ui.module.css";
 
@@ -42,6 +43,14 @@ export function useAnyQuoteAssetAvailability({ enabled, releaseDigest, templateI
     const controller = new AbortController();
     let timeout: ReturnType<typeof setTimeout> | undefined;
     let expiry: ReturnType<typeof setTimeout> | undefined;
+    const cached = attempt === 0 ? readAnyQuoteDisplayCheck(key) : null;
+    if (cached) {
+      expiry = setTimeout(() => {
+        forgetAnyQuoteDisplayCheck(key);
+        setChecked({ key, attempt, status: "inconclusive", result: null });
+      }, Math.min(Number(cached.validUntil) * 1_000 - Date.now(), 180_000));
+      return () => clearTimeout(expiry);
+    }
     const timer = setTimeout(async () => {
       setChecked({ key, attempt, status: "checking", result: null });
       timeout = setTimeout(() => {
@@ -56,7 +65,8 @@ export function useAnyQuoteAssetAvailability({ enabled, releaseDigest, templateI
         if (result.status === "compatible") {
           const remaining = Number(result.validUntil) * 1_000 - Date.now();
           if (!Number.isFinite(remaining) || remaining <= 0) throw new Error("Availability expired.");
-          expiry = setTimeout(() => setChecked({ key, attempt, status: "inconclusive", result: null }), Math.min(remaining, 180_000));
+          rememberAnyQuoteDisplayCheck(key, result);
+          expiry = setTimeout(() => { forgetAnyQuoteDisplayCheck(key); setChecked({ key, attempt, status: "inconclusive", result: null }); }, Math.min(remaining, 180_000));
         }
         setChecked({ key, attempt, status: result.status, result });
       } catch {
@@ -66,13 +76,16 @@ export function useAnyQuoteAssetAvailability({ enabled, releaseDigest, templateI
     return () => { controller.abort(); clearTimeout(timer); clearTimeout(timeout); clearTimeout(expiry); };
   }, [enabled, releaseDigest, templateId, address, validAddress, key, attempt]);
 
-  const current = checked?.key === key && checked.attempt === attempt ? checked : null;
+  const cached = enabled && validAddress ? readAnyQuoteDisplayCheck(key) : null;
+  const latestCheck = checked?.key === key && checked.attempt === attempt ? checked : null;
+  const current = latestCheck?.status === "compatible" ? cached ? latestCheck : null
+    : latestCheck ?? (attempt === 0 && cached ? { status: "compatible" as const, result: cached } : null);
   const status = !enabled || !address ? "idle" : !validAddress ? "invalid" : current?.status ?? "checking";
-  return { status, result: current?.result ?? null, retry: () => setAttempt(value => value + 1) };
+  return { status, result: current?.result ?? null, retry: () => { forgetAnyQuoteDisplayCheck(key); setAttempt(value => value + 1); } };
 }
 
-export function ModuleEngineAnyQuoteAsset({ value, onChange, availability }: {
-  value: string; onChange: (value: string) => void; availability: AnyQuoteAssetAvailability;
+export function ModuleEngineAnyQuoteAsset({ value, onChange, availability, inputId = "engine-quote" }: {
+  value: string; onChange: (value: string) => void; availability: AnyQuoteAssetAvailability; inputId?: string;
 }) {
   const [blurred, setBlurred] = useState(false);
   const invalid = availability.status === "incompatible" || availability.status === "invalid" && blurred;
@@ -80,17 +93,19 @@ export function ModuleEngineAnyQuoteAsset({ value, onChange, availability }: {
   const message = availability.status === "checking" ? "Checking token, price and ETH routes…"
     : ready ? `${ready.token.name || ready.token.symbol} (${ready.token.symbol}) is available.`
     : availability.status === "incompatible" ? "Der Token ist leider nicht verfügbar."
-    : availability.status === "inconclusive" ? "Availability could not be checked. Please try again."
+    : availability.status === "inconclusive" ? availability.result?.status === "inconclusive" && /PRICE|ROUTE|DEPTH/.test(availability.result.code)
+      ? "A reliable price and ETH route could not be confirmed. Try again."
+      : "The token check is temporarily unavailable. Please try again."
     : invalid ? "Enter a valid token address on Robinhood Chain." : null;
   return <div className={engineStyles.anyQuoteAsset}>
     <div className={styles.field}>
-      <label htmlFor="engine-quote">Pair with</label>
-      <input id="engine-quote" value={value} placeholder="Token contract address, 0x…" spellCheck={false} autoComplete="off" autoCapitalize="none"
-        required aria-invalid={invalid || undefined} aria-describedby="engine-quote-help engine-quote-availability"
+      <label htmlFor={inputId}>Pair with</label>
+      <input id={inputId} value={value} placeholder="Token contract address, 0x…" spellCheck={false} autoComplete="off" autoCapitalize="none"
+        required aria-invalid={invalid || undefined} aria-describedby={`${inputId}-help ${inputId}-availability`}
         onBlur={() => setBlurred(true)} onChange={event => { setBlurred(false); onChange(event.target.value); }} />
-      <p id="engine-quote-help" className={styles.help}>Enter an ERC20 address on Robinhood Chain. Your coin trades with ETH; this token is its pool pair.</p>
+      <p id={`${inputId}-help`} className={styles.help}>Enter an ERC20 address on Robinhood Chain. Your coin trades with ETH; this token is its pool pair.</p>
     </div>
-    <div id="engine-quote-availability" className={engineStyles.anyQuoteAvailability} data-status={availability.status} role="status" aria-live="polite" aria-atomic="true">
+    <div id={`${inputId}-availability`} className={engineStyles.anyQuoteAvailability} data-status={availability.status} role="status" aria-live="polite" aria-atomic="true">
       {message ? <div className={engineStyles.anyQuoteStatusText}>
         {availability.status === "checking" ? <LoaderCircle className={engineStyles.anyQuoteSpinner} size={16} aria-hidden="true" /> : ready ? <Check size={16} aria-hidden="true" /> : <CircleAlert size={16} aria-hidden="true" />}
         <span>{message}{ready ? <small>ETH buys and sells available. No {ready.token.symbol} balance needed to launch.</small> : null}</span>

--- a/components/module-engine-builder.tsx
+++ b/components/module-engine-builder.tsx
@@ -23,6 +23,7 @@ import { ModuleEnginePicker } from "./module-engine-library";
 import { ModuleCategoryIcon, ModuleLibrary } from "./module-library";
 import { ModulePickerDialog } from "./module-picker-dialog";
 import { anyQuoteLibraryEntry } from "@/lib/module-engine/library-entry";
+import { ModuleAnyQuoteConfiguration } from "./module-any-quote-configuration";
 import { ModuleEngineCustomOperationFields } from "./module-engine-custom-operation";
 import { emptyModuleEngineCustomOperation, moduleEngineCustomOperationIntent } from "@/lib/module-engine/custom-operation";
 import { ModuleEngineTransactionReview, type ModuleEngineWalletActions } from "./module-engine-transaction-review";
@@ -81,6 +82,7 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
   const coinDetails = useRef<HTMLDetailsElement>(null);
   const [pickerOpen, setPickerOpen] = useState(false), [pickerPointer, setPickerPointer] = useState(false);
   const [pickerAnyQuoteRemoved, setPickerAnyQuoteRemoved] = useState(false), [pickerNativeDraft, setPickerNativeDraft] = useState(createModuleModeState);
+  const [pickerConfiguringQuote, setPickerConfiguringQuote] = useState(false);
   const template = availability?.templates.find(item => item.manifest.manifest.catalogDefinition.id === selected) ?? availability?.templates[0];
   const definition = template?.manifest.manifest.catalogDefinition, revision = template?.manifest.manifest.revision;
   const fixedQuote = revision && revision.fixedQuoteAsset !== ENGINE_ZERO_ADDRESS ? revision.fixedQuoteAsset : null;
@@ -99,6 +101,7 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
       setName(draft.name); setSymbol(draft.symbol); setDescription(draft.description); setSocialLinks(draft.socialLinks ?? {});
       setImage(draft.tokenImage); setImageResource(draft.imageResource); setImageUri(draft.tokenImage.kind === "uri" ? draft.tokenImage.uri : "");
       setAmount(draft.initialBuyEth); setBuyFee(draft.buyFeePercent); setSellFee(draft.sellFeePercent);
+      setQuote(draft.quoteAsset ?? "");
     });
   }, [anyQuote]);
   const anyQuoteAvailability = useAnyQuoteAssetAvailability({ enabled: anyQuote, releaseDigest: availability?.release?.releaseDigest, templateId: definition?.id, quoteAsset });
@@ -117,32 +120,34 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
     if (!anyQuote || !onRemoveModule || !hydrated || busy || imageBusy || blocked || prepared) return;
     saveModuleModeLaunchDraftHandoff("native", { name, symbol, description, socialLinks,
       tokenImage: image.kind === "none" && imageUri ? { kind: "uri", uri: imageUri, contentVerified: false } : image,
-      imageResource, initialBuyEth: amount, buyFeePercent: buyFee, sellFeePercent: sellFee, nativeState: nativeDraft.current });
+      imageResource, initialBuyEth: amount, buyFeePercent: buyFee, sellFeePercent: sellFee, nativeState: nativeDraft.current, quoteAsset });
     setPickerOpen(false); onRemoveModule();
   }
   function openAnyQuotePicker(pointer: boolean) {
     setPickerAnyQuoteRemoved(false);
+    setPickerConfiguringQuote(false);
     setPickerNativeDraft(structuredClone(nativeDraft.current ?? createModuleModeState()));
     setPickerPointer(pointer); setPickerOpen(true);
   }
   function changePickerModule(id: string, selected: boolean) {
     if (!hydrated || busy || imageBusy || blocked || prepared || !onRemoveModule) return;
     if (id === anyQuoteEntry?.id) {
-      if (!selected || pickerNativeDraft.selectedModules.length === 0) setPickerAnyQuoteRemoved(!selected);
+      if (!selected || pickerNativeDraft.selectedModules.length === 0) { setPickerAnyQuoteRemoved(!selected); setPickerConfiguringQuote(selected); }
       return;
     }
     if (!pickerAnyQuoteRemoved) return;
     const entry = nativeCatalog.find(candidate => candidate.id === id);
     if (entry) setPickerNativeDraft(current => setModuleSelected(current, entry, selected));
   }
-  function closeAnyQuotePicker() {
+  function completeAnyQuotePicker() {
+    if (!pickerAnyQuoteRemoved && pickerConfiguringQuote && anyQuoteAvailability.status !== "compatible") return;
     nativeDraft.current = pickerNativeDraft;
     if (pickerAnyQuoteRemoved) removeAnyQuoteModule();
     setPickerOpen(false);
   }
+  function closeAnyQuotePicker() { setPickerAnyQuoteRemoved(false); setPickerConfiguringQuote(false); setPickerOpen(false); }
   function configureAnyQuoteModule() {
-    const input = document.getElementById("engine-quote");
-    input?.scrollIntoView({ block: "center" }); input?.focus({ preventScroll: true });
+    openAnyQuotePicker(false); setPickerConfiguringQuote(true);
   }
   async function checkQuote() {
     if (!availability?.release || !template || !wallet.account) return; setBusy(true); setError(null);
@@ -371,8 +376,11 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
           <Link href="/developers/modules" className={engineStyles.buildLink}><Puzzle size={16} aria-hidden="true" />Build your own module<ArrowUpRight size={16} aria-hidden="true" /></Link>
         </aside>
       </div>
-      {anyQuoteEntry ? pickerOpen ? <ModulePickerDialog variant="library" animateOpen={pickerPointer} title="Add modules" description="Modules are upgrades for your coin. Pick the features you want." onClose={closeAnyQuotePicker}>
+      {anyQuoteEntry ? pickerOpen ? <ModulePickerDialog variant="library" animateOpen={pickerPointer} title={pickerConfiguringQuote ? "Any Quote LP" : "Add modules"} description={pickerConfiguringQuote ? "Choose the token for your coin’s liquidity pool." : "Modules are upgrades for your coin. Pick the features you want."}
+        onClose={closeAnyQuotePicker} onDone={completeAnyQuotePicker} doneDisabled={!pickerAnyQuoteRemoved && pickerConfiguringQuote && anyQuoteAvailability.status !== "compatible"}>
+        <div hidden={pickerConfiguringQuote}>
         <ModuleLibrary catalog={[...nativeCatalog.filter(entry => entry.id !== anyQuoteEntry.id), anyQuoteEntry]} selectedIds={pickerAnyQuoteRemoved ? pickerNativeDraft.selectedModules : [anyQuoteEntry.id]}
+          configurableIds={[anyQuoteEntry.id]} onConfigure={() => setPickerConfiguringQuote(true)}
           disabled={!hydrated || busy || imageBusy || blocked || Boolean(prepared) || !onRemoveModule}
           disabledFor={entry => entry.id === anyQuoteEntry.id
             ? pickerAnyQuoteRemoved && pickerNativeDraft.selectedModules.length > 0 ? "Remove your other modules to use Any Quote LP." : undefined
@@ -381,6 +389,9 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
           feePolicyFor={nativeRelease ? entry => moduleModeFeePolicy(nativeRelease, nativeCatalog.filter(candidate => candidate.id === entry.id || pickerNativeDraft.selectedModules.includes(candidate.id))) : undefined}
           onAdd={entry => changePickerModule(entry.id, true)}
           onRemove={entry => changePickerModule(entry.id, false)} />
+        </div>
+        {pickerConfiguringQuote ? <ModuleAnyQuoteConfiguration value={quoteAsset} onChange={value => edit(() => setQuote(value))} availability={anyQuoteAvailability}
+          disabled={!hydrated || busy || imageBusy || blocked || Boolean(prepared)} onBack={() => setPickerConfiguringQuote(false)} onRemove={() => changePickerModule(anyQuoteEntry.id, false)} /> : null}
       </ModulePickerDialog> : null : <ModuleEnginePicker open={pickerOpen} templates={availability.templates} selectedId={definition.id} disabled={!hydrated || busy || imageBusy || blocked} onClose={() => setPickerOpen(false)} onSelect={item => { edit(() => { setSelected(item.manifest.manifest.catalogDefinition.id); setQuoteState(null); setAmount(""); setAmountError(null); salts.current = null; setCustomInitialForm(emptyModuleEngineCustomOperation()); setCreatorSaltInput(""); setEngineSaltInput(""); setLaunchData("0x"); setBuyFee("0"); setSellFee("0"); }); setPickerOpen(false); }} />}
       {approval && !prepared ? <section className={engineStyles.notice} role="status"><p>Allow the launch contract to use exactly {quoteState ? formatUnits(approval.amount, quoteState.decimals) : approval.amount.toString()} quote tokens to fund this launch.</p><button id="engine-approval-review" className={styles.secondaryButton} type="button" disabled={busy || blocked} onClick={() => void prepareApproval()}>{approval.currentAllowance > 0n ? "Review allowance reset" : "Review exact approval"}</button></section> : null}
       {prepared ? <ModuleEngineTransactionReview prepared={prepared} busy={busy} disabled={blocked || step !== "prepare"} onEdit={backToEdit} onConfirm={() => void confirm()} quoteAsset={readyQuote?.quoteAsset ?? quoteState?.address} quoteDecimals={readyQuote?.token.decimals ?? quoteState?.decimals} quoteSymbol={readyQuote?.token.symbol} anyQuote={anyQuote} tradeFees={spot || customLaunch} genericAction={customInitial} showLaunchInputs={customLaunch}>{prepared.kind === "launch" ? <div className={engineStyles.launchSummary}><strong>{name} · {symbol}</strong><p>{description}</p><p className={styles.help}>Image: {imageUri || MODULE_DEFAULT_TOKEN_IMAGE}</p>{checkedSocial.ok ? <dl className={styles.reviewRows}>{socialFields.filter(({ key }) => checkedSocial.links[key]).map(({ key, label }) => <div key={key}><dt>{label}</dt><dd>{checkedSocial.links[key]}</dd></div>)}</dl> : null}</div> : null}</ModuleEngineTransactionReview> : null}

--- a/components/module-engine-builder.tsx
+++ b/components/module-engine-builder.tsx
@@ -83,6 +83,7 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
   const [pickerOpen, setPickerOpen] = useState(false), [pickerPointer, setPickerPointer] = useState(false);
   const [pickerAnyQuoteRemoved, setPickerAnyQuoteRemoved] = useState(false), [pickerNativeDraft, setPickerNativeDraft] = useState(createModuleModeState);
   const [pickerConfiguringQuote, setPickerConfiguringQuote] = useState(false);
+  const [quoteConfiguredInPicker, setQuoteConfiguredInPicker] = useState(false);
   const template = availability?.templates.find(item => item.manifest.manifest.catalogDefinition.id === selected) ?? availability?.templates[0];
   const definition = template?.manifest.manifest.catalogDefinition, revision = template?.manifest.manifest.revision;
   const fixedQuote = revision && revision.fixedQuoteAsset !== ENGINE_ZERO_ADDRESS ? revision.fixedQuoteAsset : null;
@@ -102,6 +103,7 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
       setImage(draft.tokenImage); setImageResource(draft.imageResource); setImageUri(draft.tokenImage.kind === "uri" ? draft.tokenImage.uri : "");
       setAmount(draft.initialBuyEth); setBuyFee(draft.buyFeePercent); setSellFee(draft.sellFeePercent);
       setQuote(draft.quoteAsset ?? "");
+      setQuoteConfiguredInPicker(Boolean(draft.quoteAsset));
     });
   }, [anyQuote]);
   const anyQuoteAvailability = useAnyQuoteAssetAvailability({ enabled: anyQuote, releaseDigest: availability?.release?.releaseDigest, templateId: definition?.id, quoteAsset });
@@ -141,6 +143,7 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
   }
   function completeAnyQuotePicker() {
     if (!pickerAnyQuoteRemoved && pickerConfiguringQuote && anyQuoteAvailability.status !== "compatible") return;
+    if (!pickerAnyQuoteRemoved && pickerConfiguringQuote) setQuoteConfiguredInPicker(true);
     nativeDraft.current = pickerNativeDraft;
     if (pickerAnyQuoteRemoved) removeAnyQuoteModule();
     setPickerOpen(false);
@@ -213,7 +216,7 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
   const quoteLabel = anyQuote ? "Pool pair" : spot ? "Trading token" : "Funding token";
   const quoteShort = readyQuote?.token.symbol || (quoteAsset ? `${quoteAsset.slice(0, 6)}…${quoteAsset.slice(-4)}` : "Not chosen");
 
-  return <div className={`${styles.page} ${engineStyles.root} ${engineStyles.builderRoot}`}>
+  return <div className={`${styles.page} ${engineStyles.root} ${engineStyles.builderRoot}${anyQuote ? ` ${engineStyles.anyQuoteBuilder}` : ""}`}>
     <div className={engineStyles.pageTop}><a href="/launch"><ArrowLeft size={16} aria-hidden="true" />Back</a></div>
     {statusContent}
     {!template || !definition || !availability?.release ? <section className={engineStyles.emptyState}><h1>Create a coin</h1><p role="status">No modules available yet.{parsed.error || availability?.reason ? ` ${parsed.error ?? availability?.reason}` : ""}</p></section> : <>
@@ -247,10 +250,11 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
                 <div className={`${styles.moduleSectionHeading} ${engineStyles.sectionHeading}`}><div><h2>Modules</h2><p>Add features to your coin.</p></div><Puzzle size={24} strokeWidth={1.6} aria-hidden="true" /></div>
                 <ul className={styles.selectedModules}><li id={`module-selection-${anyQuoteEntry.id}`}>
                   <ModuleCategoryIcon category="pairs" size={20} />
-                  <button type="button" className={styles.configureModule} disabled={!hydrated || busy || imageBusy || blocked} onClick={configureAnyQuoteModule} aria-label={`Configure ${anyQuoteEntry.title}`}><span>{anyQuoteEntry.title}</span><Settings2 size={16} aria-hidden="true" /></button>
+                  <button type="button" className={styles.configureModule} disabled={!hydrated || busy || imageBusy || blocked} onClick={configureAnyQuoteModule} aria-label={`Configure ${anyQuoteEntry.title}`}><span className={engineStyles.pairChoice}>{anyQuoteEntry.title}{quoteConfiguredInPicker ? <small>Paired with {quoteShort}</small> : null}</span><Settings2 size={16} aria-hidden="true" /></button>
                   <button type="button" className={styles.removeModule} disabled={!hydrated || busy || imageBusy || blocked || !onRemoveModule} onClick={removeAnyQuoteModule} aria-label={`Remove ${anyQuoteEntry.title}`}><X size={17} aria-hidden="true" /></button>
                 </li></ul>
-                <ModuleEngineAnyQuoteAsset value={quoteAsset} availability={anyQuoteAvailability} onChange={value => edit(() => setQuote(value))} />
+                {quoteConfiguredInPicker ? !quoteVerified ? <button type="button" className={engineStyles.anyQuoteRetry} onClick={configureAnyQuoteModule} disabled={!hydrated || busy || imageBusy || blocked}>{anyQuoteAvailability.status === "checking" ? "Checking pair…" : "Check pair to continue"}</button> : null
+                  : <ModuleEngineAnyQuoteAsset value={quoteAsset} availability={anyQuoteAvailability} onChange={value => edit(() => setQuote(value))} />}
                 <button type="button" className={styles.addModulesButton} data-module-add disabled={!hydrated || busy || imageBusy || blocked} onClick={event => openAnyQuotePicker(event.detail > 0)} aria-haspopup="dialog"><Plus size={18} aria-hidden="true" />Add modules</button>
               </> : <><div className={engineStyles.sectionHeading}><h2>Modules</h2><p>Add features to your coin.</p></div><div className={engineStyles.selectedModule}>
                 <Puzzle size={20} aria-hidden="true" />

--- a/components/module-engine-host.tsx
+++ b/components/module-engine-host.tsx
@@ -17,7 +17,7 @@ import { MODULE_ENGINE_AVAILABILITY_SCHEMA, type ModuleEngineAvailability, type 
 import { createModuleEngineClient, ModuleEngineTransactionRevertedError, observeModuleEngineReceipt, readModuleEngineLaunch, type ModuleEngineReceiptResult, type PreparedModuleEngineTransaction } from "@/lib/module-engine/client";
 import type { ModuleModeImage, ModuleModeCatalogEntry } from "@/lib/module-mode/builder";
 import type { ModuleModeRelease } from "@/lib/module-mode/release";
-import { moduleModeReleaseQuery, type ModuleModeLaunchVersion } from "@/lib/module-mode/release-selection";
+import { moduleModeReleaseQuery, type ModuleModeLaunchVersion, type ModuleModeReleaseSelection } from "@/lib/module-mode/release-selection";
 import { clearModuleModeOperation, moduleModeOperationPath, type ModuleModeOperation } from "@/lib/module-mode-operation-store";
 import { fetchModuleEngineOperationRelease, recoverModuleEngineOperation } from "@/lib/module-mode-operation-recovery";
 import styles from "@/components/module-mode-builder.module.css";
@@ -40,7 +40,11 @@ function errorMessage(error: unknown) {
 }
 
 /** Shared wallet, source authority and durable operation recovery for each reviewed template. */
-export function ModuleEngineHost({ releaseDigest, token, versions = [], nativeCatalog, nativeRelease }: { releaseDigest?: Hex; token?: Address; versions?: readonly ModuleModeLaunchVersion[]; nativeCatalog?: readonly ModuleModeCatalogEntry[]; nativeRelease?: ModuleModeRelease | null }) {
+export function ModuleEngineHost({ releaseDigest, token, versions = [], nativeCatalog, nativeRelease, initialAvailability, availabilityRequest, onNavigateSelection }: {
+  releaseDigest?: Hex; token?: Address; versions?: readonly ModuleModeLaunchVersion[]; nativeCatalog?: readonly ModuleModeCatalogEntry[]; nativeRelease?: ModuleModeRelease | null;
+  initialAvailability?: ModuleEngineAvailability; availabilityRequest?: Promise<ModuleEngineAvailability>;
+  onNavigateSelection?: (selection: ModuleModeReleaseSelection) => void;
+}) {
   const router = useRouter();
   const [changingVersion, startVersionChange] = useTransition();
   const { wallet, authenticated, sessionReady, authReady, connecting, openingWallet, switchingNetwork, disconnecting, openWallet, switchNetwork, getAccessToken, sendModuleModeTransaction } = useWallet();
@@ -50,9 +54,9 @@ export function ModuleEngineHost({ releaseDigest, token, versions = [], nativeCa
   const client = useMemo(() => createModuleEngineClient(), []);
   const saved = useModuleModeOperation(wallet?.account);
   const requestPending = useModuleWalletRequestPending(wallet?.account);
-  const [availability, setAvailability] = useState<ModuleEngineAvailability>(empty);
+  const [availability, setAvailability] = useState<ModuleEngineAvailability>(initialAvailability ?? empty);
   const [management, setManagement] = useState<{ token: Address; digest: Hex; template: ModuleEngineTemplate } | null>(null);
-  const [loadedSelection, setLoadedSelection] = useState<string | null>(null);
+  const [loadedSelection, setLoadedSelection] = useState<string | null>(initialAvailability && !token ? `${releaseDigest ?? "current"}:launch` : null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
   const [storedFlow, setFlow] = useState<Flow>({ phase: "idle" });
@@ -66,7 +70,8 @@ export function ModuleEngineHost({ releaseDigest, token, versions = [], nativeCa
     const controller = new AbortController();
     void (async () => {
       try {
-        const current = await fetchModuleEngineAvailability(releaseDigest, controller.signal);
+        const current = await (refreshKey === 0 && availabilityRequest ? availabilityRequest : fetchModuleEngineAvailability(releaseDigest, controller.signal));
+        if (releaseDigest && current.release && current.release.releaseDigest !== releaseDigest) throw new Error("The requested template version could not be verified.");
         let bound: typeof management = null;
         if (token && current.release) {
           const launch = await readModuleEngineLaunch({ client, release: current.release, token });
@@ -83,7 +88,7 @@ export function ModuleEngineHost({ releaseDigest, token, versions = [], nativeCa
       }
     })();
     return () => controller.abort();
-  }, [client, releaseDigest, token, selection, refreshKey]);
+  }, [client, releaseDigest, token, selection, refreshKey, availabilityRequest]);
 
   const loading = loadedSelection !== selection || changingVersion;
   const release = availability.release;
@@ -166,10 +171,15 @@ export function ModuleEngineHost({ releaseDigest, token, versions = [], nativeCa
     assertSession(); return binding.uri;
   }
 
+  function navigateSelection(next: ModuleModeReleaseSelection) {
+    if (onNavigateSelection) onNavigateSelection(next);
+    else router.push(`/launch/modules${moduleModeReleaseQuery(next)}`, { scroll: false });
+  }
+
   function removeModule() {
     if (busy.current || working || requestPending || unresolved || changingVersion) return;
     generation.current += 1; setFlow({ phase: "idle" });
-    startVersionChange(() => router.push("/launch/modules", { scroll: false }));
+    startVersionChange(() => navigateSelection({}));
   }
 
   const versionContent = versions.length > 1 ? <div className={styles.field}><label htmlFor="engine-launch-version">Module version</label>
@@ -177,7 +187,7 @@ export function ModuleEngineHost({ releaseDigest, token, versions = [], nativeCa
       const version = versions.find(candidate => candidate.releaseDigest === event.target.value);
       if (!version || busy.current || unresolved || requestPending) return;
       generation.current += 1; setFlow({ phase: "idle" });
-      startVersionChange(() => router.push(`/launch/modules${moduleModeReleaseQuery({ releaseDigest: version.releaseDigest, ...(version.sourceKind ? { sourceKind: version.sourceKind } : {}) })}`, { scroll: false }));
+      startVersionChange(() => navigateSelection({ releaseDigest: version.releaseDigest, ...(version.sourceKind ? { sourceKind: version.sourceKind } : {}) }));
     }}>{!versions.some(version => version.releaseDigest === (releaseDigest ?? release?.releaseDigest)) ? <option value={releaseDigest ?? release?.releaseDigest ?? ""}>Selected version unavailable</option> : null}
       {versions.map(version => <option key={`${version.sourceKind ?? "native"}:${version.releaseDigest}`} value={version.releaseDigest}>{version.label}</option>)}
     </select><p className={styles.help}>Each version keeps its published templates and fee rules.</p></div> : undefined;

--- a/components/module-engine-ui.module.css
+++ b/components/module-engine-ui.module.css
@@ -147,6 +147,25 @@
 .builderRoot .anyQuoteAmount > input { padding-right: 60px; }
 .anyQuoteAmount > span { color: var(--engine-muted, #b7b7b3); font-size: 14px; pointer-events: none; position: absolute; right: 16px; top: 50%; transform: translateY(-50%); }
 .anyQuoteSpinner { animation: anyQuoteSpin 1s linear infinite; }
+.builderRoot.anyQuoteBuilder { --engine-surface: #181818; --engine-muted: #b4b1ad; max-width: 1040px; padding: 24px 20px 64px; }
+.anyQuoteBuilder .studio { border-color: #353433; grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr); }
+.anyQuoteBuilder .builderForm, .anyQuoteBuilder .preview { border: 0; padding: 32px; }
+.anyQuoteBuilder .preview { background: #222221; }
+.anyQuoteBuilder .heading { margin-bottom: 28px; }
+.anyQuoteBuilder .identityFields { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.anyQuoteBuilder .pageTop a { background: #1c1c1c; border: 1px solid #64615f; border-radius: 24px; color: var(--engine-ink); padding-inline: 16px; }
+.pairChoice { display: grid; gap: 2px; min-width: 0; }
+.pairChoice small { color: var(--engine-muted); font-size: 12px; font-weight: 400; }
+@media (max-width: 900px) { .anyQuoteBuilder .builderForm, .anyQuoteBuilder .preview { padding: 24px; } }
+@media (max-width: 760px) {
+  .builderRoot.anyQuoteBuilder { padding: 16px 16px 48px; }
+  .anyQuoteBuilder .studio { grid-template-columns: minmax(0, 1fr); }
+  .anyQuoteBuilder .builderForm, .anyQuoteBuilder .preview { padding: 24px 20px; }
+}
+@media (max-width: 360px) {
+  .builderRoot.anyQuoteBuilder { padding-inline: 12px; }
+  .anyQuoteBuilder .builderForm, .anyQuoteBuilder .preview { padding: 20px 16px; }
+}
 @keyframes anyQuoteSpin { to { transform: rotate(360deg); } }
 @media (prefers-reduced-motion: reduce) { .anyQuoteSpinner { animation: none; } }
 @media (forced-colors: active) { .anyQuoteAvailability[data-status] .anyQuoteStatusText { color: CanvasText; } .anyQuoteRetry { border-color: ButtonText; } }

--- a/components/module-launch-workspace.tsx
+++ b/components/module-launch-workspace.tsx
@@ -6,7 +6,7 @@ import { ModuleModeLaunchHost } from "./module-mode-launch-host";
 import { ModuleEngineHost } from "./module-engine-host";
 import type { ModuleModeAvailability } from "@/lib/module-mode/native-catalog";
 import type { ModuleEngineAvailability } from "@/lib/module-engine/catalog";
-import { availableAnyQuoteLibraryEntry, moduleLaunchSelectionKey, moduleLaunchSelectionPath, type ModuleLaunchWorkspaceRequests } from "@/lib/module-mode/launch-workspace";
+import { availableAnyQuoteLibraryEntry, moduleLaunchRequestPromise, moduleLaunchSelectionKey, moduleLaunchSelectionPath, type ModuleLaunchWorkspaceRequests } from "@/lib/module-mode/launch-workspace";
 import { parseModuleModeReleaseSelection, type ModuleModeLaunchVersion, type ModuleModeReleaseSelection } from "@/lib/module-mode/release-selection";
 
 type Snapshot = { source: "native"; value: ModuleModeAvailability } | { source: "engine"; value: ModuleEngineAvailability };
@@ -36,14 +36,14 @@ export function ModuleLaunchWorkspace({ initialSelection, reviewedAnyQuoteDigest
   useEffect(() => {
     let active = true;
     for (const [key, source] of requestMap) {
-      void source.request.then(value => {
+      void moduleLaunchRequestPromise<ModuleModeAvailability | ModuleEngineAvailability>(source.request).then(value => {
         if (!active) return;
         const snapshot = source.source === "native" ? { source: "native" as const, value: value as ModuleModeAvailability }
           : { source: "engine" as const, value: value as ModuleEngineAvailability };
         setSnapshots(current => new Map(current).set(key, snapshot));
       }).catch(() => { /* The selected host exposes the retry; failed discovery adds no cards. */ });
     }
-    void requests.versions.then(next => { if (active) setVersions(next); }).catch(() => { /* Current setup does not depend on historical discovery. */ });
+    void moduleLaunchRequestPromise(requests.versions).then(next => { if (active) setVersions(next); }).catch(() => { /* Current setup does not depend on historical discovery. */ });
     return () => { active = false; };
   }, [requestMap, requests.versions]);
 

--- a/components/module-launch-workspace.tsx
+++ b/components/module-launch-workspace.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { Hex } from "viem";
+import { ModuleModeLaunchHost } from "./module-mode-launch-host";
+import { ModuleEngineHost } from "./module-engine-host";
+import type { ModuleModeAvailability } from "@/lib/module-mode/native-catalog";
+import type { ModuleEngineAvailability } from "@/lib/module-engine/catalog";
+import { availableAnyQuoteLibraryEntry, moduleLaunchSelectionKey, moduleLaunchSelectionPath, type ModuleLaunchWorkspaceRequests } from "@/lib/module-mode/launch-workspace";
+import { parseModuleModeReleaseSelection, type ModuleModeLaunchVersion, type ModuleModeReleaseSelection } from "@/lib/module-mode/release-selection";
+
+type Snapshot = { source: "native"; value: ModuleModeAvailability } | { source: "engine"; value: ModuleEngineAvailability };
+
+/** Keep the coin setup on screen while verified catalogs and version discovery arrive independently. */
+export function ModuleLaunchWorkspace({ initialSelection, reviewedAnyQuoteDigest, requests }: {
+  initialSelection: ModuleModeReleaseSelection;
+  reviewedAnyQuoteDigest: Hex;
+  requests: ModuleLaunchWorkspaceRequests;
+}) {
+  const initialKey = moduleLaunchSelectionKey(initialSelection);
+  const [chosenSelection, setChosenSelection] = useState({ routeKey: initialKey, value: initialSelection });
+  // A genuine route change wins over local picker navigation without an extra render pass.
+  const selection = chosenSelection.routeKey === initialKey ? chosenSelection.value : initialSelection;
+  const [snapshots, setSnapshots] = useState<ReadonlyMap<string, Snapshot>>(() => new Map());
+  const [versions, setVersions] = useState<readonly ModuleModeLaunchVersion[]>([]);
+  const requestMap = useMemo(() => {
+    const entries = new Map<string, { source: "native"; request: Promise<ModuleModeAvailability> } | { source: "engine"; request: Promise<ModuleEngineAvailability> }>([
+      [moduleLaunchSelectionKey({}), { source: "native", request: requests.native }],
+      [moduleLaunchSelectionKey({ sourceKind: "module-engine-v1", releaseDigest: reviewedAnyQuoteDigest }), { source: "engine", request: requests.anyQuote }],
+    ]);
+    if (requests.selectedNative) entries.set(initialKey, { source: "native", request: requests.selectedNative });
+    if (requests.selectedEngine) entries.set(initialKey, { source: "engine", request: requests.selectedEngine });
+    return entries;
+  }, [requests, reviewedAnyQuoteDigest, initialKey]);
+
+  useEffect(() => {
+    let active = true;
+    for (const [key, source] of requestMap) {
+      void source.request.then(value => {
+        if (!active) return;
+        const snapshot = source.source === "native" ? { source: "native" as const, value: value as ModuleModeAvailability }
+          : { source: "engine" as const, value: value as ModuleEngineAvailability };
+        setSnapshots(current => new Map(current).set(key, snapshot));
+      }).catch(() => { /* The selected host exposes the retry; failed discovery adds no cards. */ });
+    }
+    void requests.versions.then(next => { if (active) setVersions(next); }).catch(() => { /* Current setup does not depend on historical discovery. */ });
+    return () => { active = false; };
+  }, [requestMap, requests.versions]);
+
+  useEffect(() => {
+    const restoreSelection = () => {
+      if (window.location.pathname !== "/launch/modules") return;
+      try { setChosenSelection({ routeKey: initialKey, value: parseModuleModeReleaseSelection(new URLSearchParams(window.location.search)) }); }
+      catch { /* Invalid URLs remain the route validator's responsibility. */ }
+    };
+    window.addEventListener("popstate", restoreSelection);
+    return () => window.removeEventListener("popstate", restoreSelection);
+  }, [initialKey]);
+
+  const navigate = useCallback((next: ModuleModeReleaseSelection) => {
+    const path = moduleLaunchSelectionPath(next);
+    if (`${window.location.pathname}${window.location.search}` !== path) window.history.pushState(null, "", path);
+    setChosenSelection({ routeKey: initialKey, value: next });
+  }, [initialKey]);
+
+  const selectedKey = moduleLaunchSelectionKey(selection);
+  const selectedSnapshot = snapshots.get(selectedKey);
+  const selectedRequest = requestMap.get(selectedKey);
+  const nativeSnapshot = snapshots.get(moduleLaunchSelectionKey({}));
+  const anyQuoteSnapshot = snapshots.get(moduleLaunchSelectionKey({ sourceKind: "module-engine-v1", releaseDigest: reviewedAnyQuoteDigest }));
+  const anyQuote = useMemo(() => availableAnyQuoteLibraryEntry(anyQuoteSnapshot?.value, reviewedAnyQuoteDigest), [anyQuoteSnapshot, reviewedAnyQuoteDigest]);
+
+  if (selection.sourceKind === "module-engine-v1") return <ModuleEngineHost releaseDigest={selection.releaseDigest}
+    versions={versions} onNavigateSelection={navigate}
+    initialAvailability={selectedSnapshot?.source === "engine" ? selectedSnapshot.value : undefined}
+    availabilityRequest={selectedRequest?.source === "engine" ? selectedRequest.request : undefined}
+    nativeCatalog={nativeSnapshot?.source === "native" ? nativeSnapshot.value.catalog : []}
+    nativeRelease={nativeSnapshot?.source === "native" ? nativeSnapshot.value.release : undefined} />;
+  return <ModuleModeLaunchHost releaseDigest={selection.releaseDigest} versions={versions} onNavigateSelection={navigate}
+    initialAvailability={selectedSnapshot?.source === "native" ? selectedSnapshot.value : undefined}
+    availabilityRequest={selectedRequest?.source === "native" ? selectedRequest.request : undefined}
+    anyQuoteReleaseDigest={anyQuote?.releaseDigest} anyQuoteModule={anyQuote?.entry} />;
+}

--- a/components/module-library.tsx
+++ b/components/module-library.tsx
@@ -33,13 +33,15 @@ export interface ModuleLibraryProps<Entry extends ModuleLibraryEntry> {
   selectedIds: readonly string[];
   onAdd: (entry: Entry) => void;
   onRemove: (entry: Entry) => void;
+  onConfigure?: (entry: Entry) => void;
+  configurableIds?: readonly string[];
   feePolicyFor?: (entry: Entry) => ModuleModeFeePolicy | null;
   feeDescriptionFor?: (entry: Entry) => string | undefined;
   disabledFor?: (entry: Entry) => string | undefined;
   disabled?: boolean;
 }
 
-export function ModuleLibrary<Entry extends ModuleLibraryEntry>({ catalog, selectedIds, onAdd, onRemove, feePolicyFor, feeDescriptionFor, disabledFor, disabled = false }: ModuleLibraryProps<Entry>) {
+export function ModuleLibrary<Entry extends ModuleLibraryEntry>({ catalog, selectedIds, onAdd, onRemove, onConfigure, configurableIds = [], feePolicyFor, feeDescriptionFor, disabledFor, disabled = false }: ModuleLibraryProps<Entry>) {
   const id = useId();
   const [query, setQuery] = useState("");
   const [category, setCategory] = useState("all");
@@ -88,6 +90,7 @@ export function ModuleLibrary<Entry extends ModuleLibraryEntry>({ catalog, selec
         {feeDescription !== undefined ? <div className={styles.selectionFee} id={`${id}-${entry.id}-fee`}>{feeDescription}</div> : null}
         {disabledReason ? <div className={styles.disabledReason} id={`${id}-${entry.id}-disabled`}>{disabledReason}</div> : null}
         <div className={styles.moduleBottom}><ModuleAuthor entry={entry} />
+          {added && onConfigure && configurableIds.includes(entry.id) ? <button type="button" className={styles.add} disabled={disabled} aria-label={`Configure ${entry.title}`} onClick={() => onConfigure(entry)}>Edit</button> : null}
           <button type="button" className={styles.add} aria-label={`${added ? "Remove" : "Add"} ${entry.title}`} aria-pressed={added} aria-describedby={descriptionIds} disabled={disabled || (!added && Boolean(disabledReason))}
             onClick={() => added ? onRemove(entry) : onAdd(entry)}>{added ? <X size={16} aria-hidden="true" /> : <Plus size={16} aria-hidden="true" />}{added ? "Remove" : "Add"}</button>
         </div>

--- a/components/module-mode-builder.tsx
+++ b/components/module-mode-builder.tsx
@@ -10,6 +10,8 @@ import type { Hex } from "viem";
 
 import { ModuleLibrary, ModuleCategoryIcon } from "@/components/module-library";
 import { ModulePickerDialog } from "@/components/module-picker-dialog";
+import { ModuleAnyQuoteConfiguration } from "@/components/module-any-quote-configuration";
+import { useAnyQuoteAssetAvailability } from "@/components/module-engine-any-quote-asset";
 import { moduleCategory, type ModuleLibraryEntry } from "@/lib/module-mode/library";
 import { consumeModuleModeLaunchDraftHandoff, saveModuleModeLaunchDraftHandoff } from "@/lib/module-mode/launch-draft-handoff";
 import { ModuleSchemaField } from "@/components/module-mode-fields";
@@ -92,6 +94,9 @@ export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = N
   const { expanded: moreLinks, setExpanded: setMoreLinks, toggle: toggleMoreLinks, panelProps: moreLinksPanel } = useDisclosureState();
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pendingAnyQuote, setPendingAnyQuote] = useState(false);
+  const [configuringAnyQuote, setConfiguringAnyQuote] = useState(false);
+  const [quoteAsset, setQuoteAsset] = useState("");
+  const quoteAvailability = useAnyQuoteAssetAvailability({ enabled: pendingAnyQuote, releaseDigest: anyQuoteModule?.releaseDigest, templateId: anyQuoteModule?.entry.id, quoteAsset });
   const [pickerPointer, setPickerPointer] = useState(false);
   const [configurationId, setConfigurationId] = useState<string | null>(null);
   const [checked, setChecked] = useState(false);
@@ -124,13 +129,14 @@ export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = N
     draftRestored.current = true;
     const handoff = consumeModuleModeLaunchDraftHandoff("native");
     if (!handoff) return;
-    const { imageResource: restoredImage, nativeState, ...fields } = handoff;
+    const { imageResource: restoredImage, nativeState, quoteAsset: restoredQuote, ...fields } = handoff;
     if (restoredImage) imageUrls.current.add(restoredImage.objectUrl);
     queueMicrotask(() => {
       if (!imageMounted.current) return;
       selectionFocus.current = { kind: "add" };
       setState({ ...(nativeState ?? createModuleModeState()), ...fields });
       setImageResource(restoredImage);
+      setQuoteAsset(restoredQuote ?? "");
       setAnnouncement("Any Quote LP removed. Your coin details are kept.");
     });
   }, []);
@@ -183,19 +189,23 @@ export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = N
     if (anyQuoteModule && entry.id === anyQuoteModule.entry.id) {
       if (state.selectedModules.length > 0) return;
       setPendingAnyQuote(true);
+      setConfiguringAnyQuote(true);
       return;
     }
     if (pendingAnyQuote) return;
     const nativeEntry = catalog.find(candidate => candidate.id === entry.id);
     if (nativeEntry) add(nativeEntry);
   }
-  function closeModulePicker() {
+  function completeModulePicker() {
     if (pendingAnyQuote && anyQuoteModule) {
-      if (contextLocked || imageBusy || anyQuoteModule.disabled) return;
-      saveModuleModeLaunchDraftHandoff("any-quote", { ...state, imageResource, nativeState: state });
-      setPickerOpen(false);
+      if (contextLocked || imageBusy || anyQuoteModule.disabled || quoteAvailability.status !== "compatible") return;
+      saveModuleModeLaunchDraftHandoff("any-quote", { ...state, imageResource, nativeState: state, quoteAsset });
+      setPendingAnyQuote(false); setConfiguringAnyQuote(false); setPickerOpen(false);
       anyQuoteModule.onSelect();
     } else setPickerOpen(false);
+  }
+  function closeModulePicker() {
+    setPendingAnyQuote(false); setConfiguringAnyQuote(false); setPickerOpen(false);
   }
   function showModules(pointer: boolean, id?: string) {
     setPickerPointer(pointer);
@@ -335,15 +345,21 @@ export function ModuleModeBuilder({ catalog = PREVIEW_MODULE_CATALOG, engine = N
           <Link href="/developers/modules" className={styles.buildModuleLink}><Puzzle size={16} aria-hidden="true" />Build your own module<ArrowRight size={16} aria-hidden="true" /></Link>
         </aside> : null}
       </div>
-      {pickerOpen ? <ModulePickerDialog variant="library" animateOpen={pickerPointer} title="Add modules" description="Modules are upgrades for your coin. Pick the features you want." onClose={closeModulePicker}>
+      {pickerOpen ? <ModulePickerDialog variant="library" animateOpen={pickerPointer} title={configuringAnyQuote ? "Any Quote LP" : "Add modules"} description={configuringAnyQuote ? "Choose the token for your coin’s liquidity pool." : "Modules are upgrades for your coin. Pick the features you want."}
+        onClose={closeModulePicker} onDone={completeModulePicker} doneDisabled={pendingAnyQuote && quoteAvailability.status !== "compatible"}>
+        <div hidden={configuringAnyQuote}>
         <ModuleLibrary catalog={anyQuoteModule ? [...catalog, anyQuoteModule.entry] : catalog} selectedIds={pendingAnyQuote && anyQuoteModule ? [anyQuoteModule.entry.id] : state.selectedModules}
+          configurableIds={anyQuoteModule ? [anyQuoteModule.entry.id] : []} onConfigure={() => setConfiguringAnyQuote(true)}
           disabled={contextLocked || imageBusy || anyQuoteModule?.disabled} onAdd={addFromLibrary}
-          onRemove={entry => { if (entry.id === anyQuoteModule?.entry.id) setPendingAnyQuote(false); else { const nativeEntry = catalog.find(candidate => candidate.id === entry.id); if (nativeEntry) remove(nativeEntry); } }}
+          onRemove={entry => { if (entry.id === anyQuoteModule?.entry.id) { setPendingAnyQuote(false); setConfiguringAnyQuote(false); } else { const nativeEntry = catalog.find(candidate => candidate.id === entry.id); if (nativeEntry) remove(nativeEntry); } }}
           disabledFor={entry => entry.id === anyQuoteModule?.entry.id
             ? state.selectedModules.length > 0 ? "Remove your other modules to use Any Quote LP." : undefined
             : pendingAnyQuote ? "Remove Any Quote LP to use this module." : undefined}
           feeDescriptionFor={entry => entry.id === anyQuoteModule?.entry.id ? "Platform fee: 0.30% per trade." : undefined}
           feePolicyFor={release ? entry => { const nativeEntry = catalog.find(candidate => candidate.id === entry.id); return nativeEntry ? moduleModeFeePolicy(release, state.selectedModules.includes(entry.id) ? selected : [...selected, nativeEntry]) : null; } : undefined} />
+        </div>
+        {configuringAnyQuote ? <ModuleAnyQuoteConfiguration value={quoteAsset} onChange={setQuoteAsset} availability={quoteAvailability}
+          disabled={contextLocked || imageBusy || anyQuoteModule?.disabled} onBack={() => setConfiguringAnyQuote(false)} onRemove={() => { setPendingAnyQuote(false); setConfiguringAnyQuote(false); }} /> : null}
       </ModulePickerDialog> : null}
       {configuredEntry ? <ModulePickerDialog animateOpen={pickerPointer} title={configuredEntry.title} description={configuredEntry.summary} onClose={() => setConfigurationId(null)}>
         <fieldset className={styles.formFields} disabled={contextLocked}>{renderModuleConfiguration(configuredEntry)}</fieldset>

--- a/components/module-mode-builder.tsx
+++ b/components/module-mode-builder.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { ArrowLeft, ArrowRight, ChevronDown, Download, Plus, Puzzle, Settings2, X } from "lucide-react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from "react";
+import type { Hex } from "viem";
 
 import { ModuleLibrary, ModuleCategoryIcon } from "@/components/module-library";
 import { ModulePickerDialog } from "@/components/module-picker-dialog";
@@ -77,7 +78,7 @@ export interface ModuleModeBuilderProps {
   previewDescription?: string;
   statusContent?: ReactNode;
   versionContent?: ReactNode;
-  anyQuoteModule?: { entry: ModuleLibraryEntry; disabled: boolean; onSelect: () => void };
+  anyQuoteModule?: { entry: ModuleLibraryEntry; releaseDigest?: Hex; disabled: boolean; onSelect: () => void };
   reviewContent?: ReactNode;
   resultContent?: ReactNode;
   onEdit?: () => void;

--- a/components/module-mode-launch-host.tsx
+++ b/components/module-mode-launch-host.tsx
@@ -19,6 +19,7 @@ import { beginModuleModeOperation, clearModuleModeOperation, moduleModeOperation
 import { moduleModeReleaseQuery, type ModuleModeLaunchVersion, type ModuleModeReleaseSelection } from "@/lib/module-mode/release-selection";
 import { fetchModuleModeOperationRelease, recoverModuleModeOperation } from "@/lib/module-mode-operation-recovery";
 import type { ModuleLibraryEntry } from "@/lib/module-mode/library";
+import { moduleLaunchRequestPromise } from "@/lib/module-mode/launch-workspace";
 
 type LaunchFlow = {
   phase: "idle" | "uploading" | "preparing" | "signing" | "pending" | "mined" | "reverted" | "receipt-unavailable" | "error" | "uncertain";
@@ -96,7 +97,7 @@ export function ModuleModeLaunchHost({ releaseDigest, versions = [], anyQuoteRel
   useEffect(() => { mounted.current = true; return () => { mounted.current = false; operation.current += 1; }; }, []);
   useEffect(() => {
     const controller = new AbortController();
-    const request = refreshKey === 0 && availabilityRequest ? availabilityRequest : fetchAvailability(releaseDigest, controller.signal);
+    const request = moduleLaunchRequestPromise(refreshKey === 0 && availabilityRequest ? availabilityRequest : fetchAvailability(releaseDigest, controller.signal));
     void request.then((next) => {
       if (releaseDigest && next.release && next.release.releaseDigest !== releaseDigest) throw new Error("The requested launch version could not be verified.");
       if (!controller.signal.aborted) { setAvailability(next); setAvailabilityError(false); setAvailabilityLoading(false); setLoadedSelection(releaseDigest ?? "current"); }

--- a/components/module-mode-launch-host.tsx
+++ b/components/module-mode-launch-host.tsx
@@ -7,7 +7,6 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState, useSyncExtern
 import { formatUnits, toHex, type Address, type Hex } from "viem";
 
 import { ModuleModeBuilder, type ModuleModeLaunchAction } from "@/components/module-mode-builder";
-import { ModuleBuilderLoading } from "@/components/module-builder-loading";
 import { assertModuleModeWalletUnchanged, isModuleModeWalletRejection, moduleModeSubmissionIsUncertain, moduleModeWalletStep, switchModuleModeNetwork, uploadModuleModeImage, useModuleModeOperation, type ModuleModeWalletSnapshot } from "@/components/module-mode-wallet-state";
 import { useWallet } from "@/components/wallet-provider";
 import styles from "@/components/module-mode-builder.module.css";
@@ -17,7 +16,7 @@ import { moduleNativeCatalogDigest, parseModuleModeAvailability, type ModuleMode
 import { createModuleNativeClient, ModuleNativeTransactionRevertedError, prepareModuleNativeLaunch, waitForModuleNativeReceipt, type ModuleNativeImageBinding, type ModuleNativeReceiptResult, type PreparedModuleNativeLaunch } from "@/lib/module-mode/native-client";
 import { browserWalletRequestIsPending, subscribeToBrowserWalletRequest } from "@/lib/wallet-request-lock";
 import { beginModuleModeOperation, clearModuleModeOperation, moduleModeOperationPath, rememberModuleModeTransactionHash, type ModuleModeOperation } from "@/lib/module-mode-operation-store";
-import { moduleModeReleaseQuery, type ModuleModeLaunchVersion } from "@/lib/module-mode/release-selection";
+import { moduleModeReleaseQuery, type ModuleModeLaunchVersion, type ModuleModeReleaseSelection } from "@/lib/module-mode/release-selection";
 import { fetchModuleModeOperationRelease, recoverModuleModeOperation } from "@/lib/module-mode-operation-recovery";
 import type { ModuleLibraryEntry } from "@/lib/module-mode/library";
 
@@ -66,17 +65,21 @@ function assertDraftAvailability(draft: ModuleModeDraft, current: ModuleModeAvai
   }
 }
 
-export function ModuleModeLaunchHost({ releaseDigest, versions = [], anyQuoteReleaseDigest, anyQuoteModule }: { releaseDigest?: string; versions?: readonly ModuleModeLaunchVersion[]; anyQuoteReleaseDigest?: Hex; anyQuoteModule?: ModuleLibraryEntry }) {
+export function ModuleModeLaunchHost({ releaseDigest, versions = [], anyQuoteReleaseDigest, anyQuoteModule, initialAvailability, availabilityRequest, onNavigateSelection }: {
+  releaseDigest?: string; versions?: readonly ModuleModeLaunchVersion[]; anyQuoteReleaseDigest?: Hex; anyQuoteModule?: ModuleLibraryEntry;
+  initialAvailability?: ModuleModeAvailability; availabilityRequest?: Promise<ModuleModeAvailability>;
+  onNavigateSelection?: (selection: ModuleModeReleaseSelection) => void;
+}) {
   const router = useRouter();
   const [changingVersion, startVersionChange] = useTransition();
   const requestedRelease = useRef(releaseDigest);
   requestedRelease.current = releaseDigest;
-  const [loadedSelection, setLoadedSelection] = useState<string | null>(null);
+  const [loadedSelection, setLoadedSelection] = useState<string | null>(initialAvailability ? releaseDigest ?? "current" : null);
   const { wallet, authenticated, sessionReady, authReady, connecting, openingWallet, switchingNetwork, disconnecting, openWallet, switchNetwork, getAccessToken, sendModuleModeTransaction } = useWallet();
   const client = useMemo(() => createModuleNativeClient(), []);
-  const [availability, setAvailability] = useState<ModuleModeAvailability | null>(null);
+  const [availability, setAvailability] = useState<ModuleModeAvailability | null>(initialAvailability ?? null);
   const [availabilityError, setAvailabilityError] = useState(false);
-  const [availabilityLoading, setAvailabilityLoading] = useState(true);
+  const [availabilityLoading, setAvailabilityLoading] = useState(!initialAvailability);
   const [flow, setFlow] = useState<LaunchFlow>({ phase: "idle" });
   const [receiptChecking, setReceiptChecking] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -93,17 +96,20 @@ export function ModuleModeLaunchHost({ releaseDigest, versions = [], anyQuoteRel
   useEffect(() => { mounted.current = true; return () => { mounted.current = false; operation.current += 1; }; }, []);
   useEffect(() => {
     const controller = new AbortController();
-    void fetchAvailability(releaseDigest, controller.signal).then((next) => {
+    const request = refreshKey === 0 && availabilityRequest ? availabilityRequest : fetchAvailability(releaseDigest, controller.signal);
+    void request.then((next) => {
+      if (releaseDigest && next.release && next.release.releaseDigest !== releaseDigest) throw new Error("The requested launch version could not be verified.");
       if (!controller.signal.aborted) { setAvailability(next); setAvailabilityError(false); setAvailabilityLoading(false); setLoadedSelection(releaseDigest ?? "current"); }
     }).catch(() => {
       if (!controller.signal.aborted) { setAvailability(null); setAvailabilityError(true); setAvailabilityLoading(false); setLoadedSelection(releaseDigest ?? "current"); }
     });
     return () => controller.abort();
-  }, [refreshKey, releaseDigest]);
+  }, [refreshKey, releaseDigest, availabilityRequest]);
 
   const selectionPending = loadedSelection !== (releaseDigest ?? "current") || changingVersion;
   const release = selectionPending ? null : availability?.release ?? null;
-  const catalog = useMemo(() => availability ? release ? availability.catalog.filter((entry) => entry.status === "available") : availability.catalog : PREVIEW_MODULE_CATALOG, [availability, release]);
+  const catalog = useMemo(() => availability ? release ? availability.catalog.filter((entry) => entry.status === "available") : availability.catalog
+    : availabilityLoading ? [] : PREVIEW_MODULE_CATALOG, [availability, release, availabilityLoading]);
   const walletStep = moduleModeWalletStep({ account: wallet?.account, chainId: wallet?.chainId, authenticated, sessionReady });
   const walletAccount = wallet?.account;
   const configurationContext = useMemo(() => walletAccount ? { roles: { creator: walletAccount, launchWallet: walletAccount } } : {}, [walletAccount]);
@@ -231,20 +237,23 @@ export function ModuleModeLaunchHost({ releaseDigest, versions = [], anyQuoteRel
     setAvailabilityLoading(true); setAvailabilityError(false); setRefreshKey((key) => key + 1);
   }
 
-  if (loadedSelection === null && !hasSubmission) return <ModuleBuilderLoading />;
+  function navigateSelection(selection: ModuleModeReleaseSelection) {
+    if (onNavigateSelection) onNavigateSelection(selection);
+    else router.push(`/launch/modules${moduleModeReleaseQuery(selection)}`, { scroll: false });
+  }
 
   return <ModuleModeBuilder
     release={release}
-    anyQuoteModule={anyQuoteReleaseDigest && anyQuoteModule ? { entry: anyQuoteModule, disabled: working || requestPending || hasSubmission || changingVersion, onSelect: () => {
+    anyQuoteModule={anyQuoteReleaseDigest && anyQuoteModule ? { entry: anyQuoteModule, releaseDigest: anyQuoteReleaseDigest, disabled: working || requestPending || hasSubmission || changingVersion, onSelect: () => {
       if (working || requestPending || hasSubmission || changingVersion) return;
       operation.current += 1; setFlow({ phase: "idle" });
-      startVersionChange(() => router.push(`/launch/modules${moduleModeReleaseQuery({ sourceKind: "module-engine-v1", releaseDigest: anyQuoteReleaseDigest })}`, { scroll: false }));
+      startVersionChange(() => navigateSelection({ sourceKind: "module-engine-v1", releaseDigest: anyQuoteReleaseDigest }));
     } } : undefined}
     versionContent={versions.length > 1 ? <div className={styles.field}><label htmlFor="module-launch-version">Module version</label><select id="module-launch-version" value={releaseDigest ?? availability?.release?.releaseDigest ?? versions[0]?.releaseDigest} disabled={working || requestPending || hasSubmission || changingVersion} onChange={event => {
       const version = versions.find(candidate => candidate.releaseDigest === event.target.value);
       if (!version || working || requestPending || hasSubmission) return;
       operation.current += 1; setFlow({ phase: "idle" });
-      startVersionChange(() => router.push(`/launch/modules${moduleModeReleaseQuery({ releaseDigest: version.releaseDigest, ...(version.sourceKind ? { sourceKind: version.sourceKind } : {}) })}`, { scroll: false }));
+      startVersionChange(() => navigateSelection({ releaseDigest: version.releaseDigest, ...(version.sourceKind ? { sourceKind: version.sourceKind } : {}) }));
     }}>{releaseDigest && !versions.some(version => version.releaseDigest === releaseDigest) ? <option value={releaseDigest}>Selected version unavailable</option> : null}{versions.map(version => <option key={version.releaseDigest} value={version.releaseDigest}>{version.label}</option>)}</select><p className={styles.help}>Choose an earlier version to use its supported modules. Review its fees before launching.</p></div> : undefined}
     catalog={catalog}
     configurationContext={configurationContext}

--- a/components/module-picker-dialog.module.css
+++ b/components/module-picker-dialog.module.css
@@ -13,10 +13,11 @@
 .content { flex: 1; min-height: 0; overflow: auto; overscroll-behavior: contain; padding: 0 24px 24px; scrollbar-gutter: stable; }
 .footer { align-items: center; border-top: 1px solid #343332; display: flex; flex-shrink: 0; flex-wrap: wrap; gap: 12px; padding: 16px 24px; }
 .done { background: #e786b2; border: 1px solid #e786b2; border-radius: 12px; color: #21151b; cursor: pointer; font: inherit; font-size: 14px; font-weight: 500; margin-left: auto; min-height: 48px; padding: 12px 24px; min-width: 104px; }
+.done:disabled { cursor: not-allowed; opacity: .45; }
 .dialog :is(button, a, input, select, textarea, summary):focus-visible { outline: 2px solid #e786b2; outline-offset: 3px; }
 .header h2:focus { outline: none; }
 .dialog button { touch-action: manipulation; }
-@media (hover: hover) and (pointer: fine) { .close:hover { background: #363232; } .done:hover { background: #f19dc3; border-color: #f19dc3; } }
+@media (hover: hover) and (pointer: fine) { .close:hover { background: #363232; } .done:not(:disabled):hover { background: #f19dc3; border-color: #f19dc3; } }
 @media (max-width: 600px) { .dialog { max-width: calc(100vw - 24px); max-height: calc(100dvh - 24px); } .surface { border-radius: 20px; max-height: calc(100dvh - 24px); } .header { padding: 16px 16px 12px; } .header h2 { font-size: 22px; } .content { padding: 0 16px 20px; } .footer { padding: 12px 16px max(12px, env(safe-area-inset-bottom)); } }
 @media (forced-colors: active) { .dialog :is(button, a, input, select, textarea, summary):focus-visible { outline-color: Highlight; } .surface { border-color: CanvasText; } .dialog button { border-color: ButtonText; } }
 @media (max-width: 600px) { .librarySurface { height: calc(100dvh - 24px); } }

--- a/components/module-picker-dialog.tsx
+++ b/components/module-picker-dialog.tsx
@@ -4,12 +4,14 @@ import { X } from "lucide-react";
 import { useLayoutEffect, useId, useRef, type ReactNode } from "react";
 import styles from "./module-picker-dialog.module.css";
 
-export function ModulePickerDialog({ title, description, children, onClose, footer, animateOpen = false, variant }: {
+export function ModulePickerDialog({ title, description, children, onClose, onDone, doneDisabled = false, footer, animateOpen = false, variant }: {
   title: string;
   description?: string;
   children: ReactNode;
   footer?: ReactNode;
   onClose: () => void;
+  onDone?: () => void;
+  doneDisabled?: boolean;
   animateOpen?: boolean;
   variant?: "library";
 }) {
@@ -96,7 +98,7 @@ export function ModulePickerDialog({ title, description, children, onClose, foot
         <button type="button" className={styles.close} onClick={event => close(event.detail > 0)} aria-label="Close modules"><X size={20} aria-hidden="true" /></button>
       </header>
       <div className={styles.content}>{children}</div>
-      <footer className={styles.footer}>{footer}<button type="button" className={styles.done} onClick={event => close(event.detail > 0)}>Done</button></footer>
+      <footer className={styles.footer}>{footer}<button type="button" className={styles.done} disabled={doneDisabled} onClick={event => onDone ? onDone() : close(event.detail > 0)}>Done</button></footer>
     </div>
   </dialog>;
 }

--- a/lib/module-engine/any-quote/discovery.server.ts
+++ b/lib/module-engine/any-quote/discovery.server.ts
@@ -1,5 +1,6 @@
 import "server-only";
-import { decodeEventLog, keccak256, pad, parseAbi, stringToHex, toHex, type Address, type Hex } from "viem";
+import { decodeEventLog, decodeFunctionResult, encodeFunctionData, keccak256, pad, parseAbi, stringToHex, toHex, type Address, type Hex } from "viem";
+import { ROBINHOOD_MULTICALL3_ADDRESS, ROBINHOOD_MULTICALL3_RUNTIME_CODE_HASH } from "@/lib/chains";
 import { canonicalBrowserJsonV2 } from "@/lib/custom-launch/browser-authority-v2";
 import { agreedTradeRpcV1, type TradeRpcV1 } from "@/lib/server/custom-launch/routed-trade-rpc-v1";
 import { anyQuotePoolIdV1 } from "./route";
@@ -14,6 +15,10 @@ import {
 export const ANY_QUOTE_V4_START_BLOCK = 9070n;
 export const ANY_QUOTE_V4_MAX_POOL_CANDIDATES = 64;
 const MAX_LOG_REQUESTS = 24;
+const MAX_DISCOVERY_HINTS = 512;
+const MAX_ACTIVE_HINTS = 16;
+const liquidityAbi = parseAbi(["function getLiquidity(bytes32) view returns (uint128)"]);
+const aggregateAbi = parseAbi(["function aggregate3((address target,bool allowFailure,bytes callData)[] calls) payable returns ((bool success,bytes returnData)[] returnData)"]);
 const MAX_RANGE_SPLITS = 2;
 const MAX_VERIFICATION_BLOCKS = 10_000n;
 const initializeAbi = parseAbi(["event Initialize(bytes32 indexed id,address indexed currency0,address indexed currency1,uint24 fee,int24 tickSpacing,address hooks,uint160 sqrtPriceX96,int24 tick)"]);
@@ -27,7 +32,8 @@ const quantity = (value: unknown) => typeof value === "string" && /^0x[0-9a-f]{1
 export function parseAnyQuoteV4InitializeV1(value: unknown, input: {
   currency: Address; otherCurrency?: Address; fromBlock: bigint; toBlock: bigint;
 }): PoolRecord[] {
-  if (!Array.isArray(value) || value.length > ANY_QUOTE_V4_MAX_POOL_CANDIDATES) return invalid();
+  if (!Array.isArray(value)) return invalid();
+  if (value.length > MAX_DISCOVERY_HINTS) throw new AnyQuoteErrorV1("V4_DISCOVERY_CANDIDATE_LIMIT");
   try {
     const result = value.map((raw): PoolRecord => {
       if (!raw || typeof raw !== "object" || Array.isArray(raw)) return invalid();
@@ -100,10 +106,47 @@ export function createAnyQuoteV4InitializeDiscoveryV1(input: { checkpoint: AnyQu
   const requireSame = (a: PoolRecord[], b: PoolRecord[]) => {
     if (canonicalBrowserJsonV2(a) !== canonicalBrowserJsonV2(b)) throw new AnyQuoteErrorV1("V4_DISCOVERY_PROVIDER_DISAGREEMENT");
   };
+  const shortlist = async (hints: PoolRecord[]): Promise<PoolRecord[]> => {
+    if (hints.length <= MAX_ACTIVE_HINTS) return hints;
+    incompleteCoverage = true;
+    const block = { blockHash: input.checkpoint.hash, requireCanonical: true };
+    const bytes = (value: unknown): Hex => typeof value === "string" && /^0x(?:[0-9a-f]{2})*$/i.test(value)
+      ? value.toLowerCase() as Hex : invalid();
+    // Popular assets can have hundreds of empty historical pools. Rank current active liquidity
+    // in bounded read-only batches before spending the canonical-log verification budget.
+    // Neither a hint nor this ranking makes a pool executable: every selected log, key,
+    // price and bidirectional quote still passes the existing independent-provider checks.
+    await Promise.all([
+      [ROBINHOOD_MULTICALL3_ADDRESS, ROBINHOOD_MULTICALL3_RUNTIME_CODE_HASH],
+      [ANY_QUOTE_INFRASTRUCTURE.stateView, ANY_QUOTE_INFRASTRUCTURE.stateViewCodeHash],
+    ].map(async ([address, expected]) => {
+      const code = await agreed("eth_getCode", [address, block], bytes);
+      if (keccak256(code) !== expected) throw new AnyQuoteErrorV1("INFRASTRUCTURE_RUNTIME_MISMATCH");
+    }));
+    const active: { hint: PoolRecord; liquidity: bigint }[] = [];
+    for (let start = 0; start < hints.length; start += 64) {
+      const batch = hints.slice(start, start + 64);
+      const data = encodeFunctionData({ abi: aggregateAbi, functionName: "aggregate3", args: [batch.map(hint => ({
+        target: ANY_QUOTE_INFRASTRUCTURE.stateView, allowFailure: false,
+        callData: encodeFunctionData({ abi: liquidityAbi, functionName: "getLiquidity", args: [hint.poolId] }),
+      }))] });
+      const amounts = await agreed("eth_call", [{ to: ROBINHOOD_MULTICALL3_ADDRESS, data }, block], value => {
+        try {
+          const results = decodeFunctionResult({ abi: aggregateAbi, functionName: "aggregate3", data: bytes(value) });
+          if (results.length !== batch.length || results.some(result => !result.success)) return invalid();
+          return results.map(result => decodeFunctionResult({ abi: liquidityAbi, functionName: "getLiquidity", data: result.returnData }).toString());
+        } catch { return invalid(); }
+      });
+      for (const [index, amount] of amounts.entries()) if (BigInt(amount) > 0n) active.push({ hint: batch[index], liquidity: BigInt(amount) });
+    }
+    active.sort((a, b) => a.liquidity > b.liquidity ? -1 : a.liquidity < b.liquidity ? 1 : a.hint.poolId.localeCompare(b.hint.poolId));
+    return active.slice(0, MAX_ACTIVE_HINTS).map(value => value.hint);
+  };
   const filter = (topics: readonly (Hex | null)[], fromBlock: bigint, end: bigint) =>
     [{ address: ANY_QUOTE_INFRASTRUCTURE.poolManager, fromBlock: toHex(fromBlock), toBlock: toHex(end), topics }];
-  const verifyHints = async (hints: PoolRecord[], currency: Address, otherCurrency: Address | undefined, topics: readonly (Hex | null)[]) => {
+  const verifyHints = async (allHints: PoolRecord[], currency: Address, otherCurrency: Address | undefined, topics: readonly (Hex | null)[]) => {
     incompleteCoverage = true;
+    const hints = await shortlist(allHints);
     // A single-provider empty result may prompt an intermediate search, never an incompatibility verdict.
     const windows: PoolRecord[][] = [];
     for (const hint of [...hints].sort((a, b) => Number(BigInt(a.blockNumber) - BigInt(b.blockNumber)))) {
@@ -124,8 +167,10 @@ export function createAnyQuoteV4InitializeDiscoveryV1(input: { checkpoint: AnyQu
         const code = error && typeof error === "object" && "code" in error ? String(error.code) : "";
         throw new AnyQuoteErrorV1(code === "TRADE_PROVIDER_DISAGREEMENT" ? "V4_DISCOVERY_PROVIDER_DISAGREEMENT" : "V4_DISCOVERY_PROVIDER_UNAVAILABLE");
       }
-      requireSame(verified, window.sort((a, b) => a.poolId.localeCompare(b.poolId)));
-      return verified;
+      const selectedIds = new Set(window.map(hint => hint.poolId));
+      const selected = verified.filter(pool => selectedIds.has(pool.poolId));
+      requireSame(selected, window.sort((a, b) => a.poolId.localeCompare(b.poolId)));
+      return selected;
     }))).flat());
     return result.sort((a, b) => a.poolId.localeCompare(b.poolId));
   };
@@ -135,7 +180,7 @@ export function createAnyQuoteV4InitializeDiscoveryV1(input: { checkpoint: AnyQu
     // Invalid successful responses are terminal, not provider outages eligible for fallback.
     const records = responses.map(response => response.status === "fulfilled"
       ? parseAnyQuoteV4InitializeV1(response.value, { currency, otherCurrency, fromBlock, toBlock: end }) : null);
-    if (records[0] !== null && records[1] !== null) { requireSame(records[0], records[1]); return records[0]; }
+    if (records[0] !== null && records[1] !== null) { requireSame(records[0], records[1]); return shortlist(records[0]); }
     const hints = records[0] ?? records[1];
     if (hints !== null) return verifyHints(hints, currency, otherCurrency, topics);
     if (depth >= MAX_RANGE_SPLITS || fromBlock === end) throw new AnyQuoteErrorV1("V4_DISCOVERY_PROVIDER_UNAVAILABLE");

--- a/lib/module-engine/any-quote/readiness-display-cache.ts
+++ b/lib/module-engine/any-quote/readiness-display-cache.ts
@@ -1,0 +1,23 @@
+import type { AnyQuoteReadinessV1 } from "./types";
+
+type CompatibleReadiness = Extract<AnyQuoteReadinessV1, { status: "compatible" }>;
+type Entry = { result: CompatibleReadiness; expiresAt: number };
+const displayed = new Map<string, Entry>();
+
+/** Reuses a recent display check across builders. Launch preparation still fetches fresh authority. */
+export function readAnyQuoteDisplayCheck(key: string, now = Date.now()): CompatibleReadiness | null {
+  const entry = displayed.get(key);
+  if (!entry) return null;
+  if (entry.expiresAt <= now) { displayed.delete(key); return null; }
+  return entry.result;
+}
+
+export function rememberAnyQuoteDisplayCheck(key: string, result: CompatibleReadiness, now = Date.now()): void {
+  const expiresAt = Math.min(Number(result.validUntil) * 1_000, now + 180_000);
+  if (!Number.isFinite(expiresAt) || expiresAt <= now) return;
+  displayed.delete(key);
+  displayed.set(key, { result, expiresAt });
+  while (displayed.size > 32) displayed.delete(displayed.keys().next().value!);
+}
+
+export function forgetAnyQuoteDisplayCheck(key: string): void { displayed.delete(key); }

--- a/lib/module-engine/any-quote/readiness.server.ts
+++ b/lib/module-engine/any-quote/readiness.server.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { decodeFunctionResult, encodeFunctionData, keccak256, parseAbi, toHex, type Abi, type Address, type Hex } from "viem";
-import { agreedTradeRpcV1, productionTradeRpcsV1, tradeBlockV1, type TradeRpcV1 } from "@/lib/server/custom-launch/routed-trade-rpc-v1";
+import { agreedTradeRpcV1, productionTradeRpcsV1, tradeBlockV1, TradeRpcExecutionRevertedV1, type TradeRpcV1 } from "@/lib/server/custom-launch/routed-trade-rpc-v1";
 import {
   ANY_QUOTE_INFRASTRUCTURE as INFRA, ANY_QUOTE_NATIVE, ANY_QUOTE_WETH, ANY_QUOTE_USDG,
   AnyQuoteErrorV1, anyQuoteAddressV1, anyQuoteSameAddressV1, anyQuoteUintV1,
@@ -74,7 +74,7 @@ async function fetchJson(url: string, options: AnyQuoteReadinessOptionsV1, body?
 async function context(options: AnyQuoteReadinessOptionsV1) {
   const now = options.now ?? BigInt(Math.floor(Date.now() / 1000));
   const rpcs = options.rpcs ?? productionTradeRpcsV1();
-  const agreed = agreedTradeRpcV1(rpcs);
+  const agreed = agreedTradeRpcV1(rpcs, { preserveExecutionReverts: true });
   const chainId = await agreed("eth_chainId", [], value => quantity(value).toString());
   if (chainId !== "4663") throw new AnyQuoteErrorV1("PROVIDER_CHAIN_MISMATCH");
   const heads = await Promise.all(rpcs.map(async rpc => tradeBlockV1(await rpc("eth_getBlockByNumber", ["latest", false]))));
@@ -405,8 +405,15 @@ export async function assessAnyQuoteAssetV1(input: { quoteAsset: string; probeEt
       if (difference * 10_000n > reference * 1_000n) throw new AnyQuoteErrorV1("REFERENCE_MARKET_PRICE_DISAGREEMENT");
     };
     const qualifyDepth = (smallIn: bigint): CandidateQualification => async ({ route }) => {
-      const [smallOut, largeOut] = await Promise.all([quoteHops(route.hops, smallIn, ctx), quoteHops(route.hops, smallIn * 100n, ctx)]);
-      qualifyAnyQuoteDepthV1(smallIn, smallOut, smallIn * 100n, largeOut);
+      try {
+        const [smallOut, largeOut] = await Promise.all([quoteHops(route.hops, smallIn, ctx), quoteHops(route.hops, smallIn * 100n, ctx)]);
+        qualifyAnyQuoteDepthV1(smallIn, smallOut, smallIn * 100n, largeOut);
+      } catch (error) {
+        // An identical execution revert from both providers disqualifies this pool at the
+        // required depth. Provider errors and disagreement must not select a different pool.
+        if (error instanceof TradeRpcExecutionRevertedV1) throw new AnyQuoteErrorV1("MARKET_DEPTH_UNAVAILABLE");
+        throw error;
+      }
     };
     const qualifyBuy: CandidateQualification = authoritative ? async ({ spot }) => qualifyReference(spot) : qualifyDepth(referenceEth);
     const { route: buy, spot } = await discover({ tokenIn: ANY_QUOTE_WETH, tokenOut: quoteAsset, amountIn: probe }, ctx, options, qualifyBuy);

--- a/lib/module-mode/launch-draft-handoff.ts
+++ b/lib/module-mode/launch-draft-handoff.ts
@@ -9,6 +9,7 @@ export type ModuleModeLaunchDraftHandoff = Pick<ModuleModeState,
   "initialBuyEth" | "buyFeePercent" | "sellFeePercent"
 > & {
   imageResource: ModuleModeImageResource | null;
+  quoteAsset?: string;
   /** Retained for returning to native; its module selections do not apply to Any Quote. */
   nativeState?: ModuleModeState;
 };
@@ -22,11 +23,11 @@ let pending: {
 /** A route transition transfers only draft fields, never a prepared transaction or wallet state. */
 export function saveModuleModeLaunchDraftHandoff(target: ModuleModeLaunchDraftTarget, draft: ModuleModeLaunchDraftHandoff): void {
   if (typeof window === "undefined") return;
-  const { name, symbol, description, socialLinks, tokenImage, initialBuyEth, buyFeePercent, sellFeePercent, nativeState } = draft;
+  const { name, symbol, description, socialLinks, tokenImage, initialBuyEth, buyFeePercent, sellFeePercent, nativeState, quoteAsset } = draft;
   pending = {
     target,
     draft: structuredClone({ name, symbol, description, socialLinks, tokenImage, initialBuyEth, buyFeePercent, sellFeePercent,
-      ...(nativeState ? { nativeState } : {}) }),
+      ...(nativeState ? { nativeState } : {}), ...(quoteAsset !== undefined ? { quoteAsset } : {}) }),
     imageBlob: tokenImage.kind === "local" ? draft.imageResource?.blob ?? null : null,
   };
 }

--- a/lib/module-mode/launch-workspace.ts
+++ b/lib/module-mode/launch-workspace.ts
@@ -14,6 +14,11 @@ export interface ModuleLaunchWorkspaceRequests {
   versions: Promise<readonly ModuleModeLaunchVersion[]>;
 }
 
+/** React Flight supplies thenables whose then() is not a chainable native Promise. */
+export function moduleLaunchRequestPromise<T>(request: PromiseLike<T>): Promise<T> {
+  return Promise.resolve(request);
+}
+
 export function moduleLaunchSelectionKey(selection: ModuleModeReleaseSelection): string {
   return `${selection.sourceKind ?? "native"}:${selection.releaseDigest ?? "current"}`;
 }

--- a/lib/module-mode/launch-workspace.ts
+++ b/lib/module-mode/launch-workspace.ts
@@ -1,0 +1,35 @@
+import type { Hex } from "viem";
+import { parseModuleEngineAvailability, type ModuleEngineAvailability } from "@/lib/module-engine/catalog";
+import { anyQuoteLibraryEntry } from "@/lib/module-engine/library-entry";
+import { isModuleEngineSharedQuoteRelease } from "@/lib/module-engine/profile";
+import type { ModuleModeAvailability } from "./native-catalog";
+import { moduleModeReleaseQuery, type ModuleModeLaunchVersion, type ModuleModeReleaseSelection } from "./release-selection";
+
+/** Display data only. Every transaction still refreshes its exact source authority. */
+export interface ModuleLaunchWorkspaceRequests {
+  native: Promise<ModuleModeAvailability>;
+  anyQuote: Promise<ModuleEngineAvailability>;
+  selectedNative?: Promise<ModuleModeAvailability>;
+  selectedEngine?: Promise<ModuleEngineAvailability>;
+  versions: Promise<readonly ModuleModeLaunchVersion[]>;
+}
+
+export function moduleLaunchSelectionKey(selection: ModuleModeReleaseSelection): string {
+  return `${selection.sourceKind ?? "native"}:${selection.releaseDigest ?? "current"}`;
+}
+
+export function moduleLaunchSelectionPath(selection: ModuleModeReleaseSelection): string {
+  return `/launch/modules${moduleModeReleaseQuery(selection)}`;
+}
+
+/** A reviewed identity selects a reader; it cannot create an available library entry. */
+export function availableAnyQuoteLibraryEntry(value: unknown, reviewedReleaseDigest: Hex) {
+  try {
+    const { release, templates } = parseModuleEngineAvailability(value);
+    const template = templates.find(candidate => candidate.manifest.manifest.catalogDefinition.interface === "quote-shared-v1");
+    if (release && isModuleEngineSharedQuoteRelease(release) && release.releaseDigest === reviewedReleaseDigest && template) {
+      return { releaseDigest: release.releaseDigest, entry: anyQuoteLibraryEntry(template.manifest.manifest.catalogDefinition) };
+    }
+  } catch { /* Unavailable or unbound sources never create a launch entry. */ }
+  return null;
+}

--- a/lib/server/custom-launch/routed-trade-rpc-v1.ts
+++ b/lib/server/custom-launch/routed-trade-rpc-v1.ts
@@ -2,6 +2,10 @@ import { getAddress, toHex, type Address, type Hex } from "viem";
 import { canonicalBrowserJsonV2 } from "@/lib/custom-launch/browser-authority-v2";
 import { LaunchPlanTradeErrorV1 } from "@/lib/custom-launch/routed-trade-plan-v1";
 
+export class TradeRpcExecutionRevertedV1 extends Error {
+  readonly code = "TRADE_EXECUTION_REVERTED";
+  constructor(readonly data: Hex) { super("The simulated call reverted."); this.name = "TradeRpcExecutionRevertedV1"; }
+}
 export type TradeRpcV1 = (method: string, params: readonly unknown[]) => Promise<unknown>;
 export const pendingTradeV1 = (code = "TRADE_ANALYSIS_PENDING"): never => { throw new LaunchPlanTradeErrorV1(code, "The exact trade could not be verified across independent providers. Try again when its execution adapter is available.", 503); };
 export const objectV1 = (v: unknown): Record<string, unknown> => v && typeof v === "object" && !Array.isArray(v) ? v as Record<string, unknown> : pendingTradeV1();
@@ -39,15 +43,33 @@ export function productionTradeRpcsV1(env: Readonly<Record<string, string | unde
             if (size > 1_048_576) { await reader.cancel(); return pendingTradeV1(); } chunks.push(part.value); }
         } finally { reader.releaseLock(); }
         const data = objectV1(JSON.parse(Buffer.concat(chunks).toString("utf8")));
-        if (data.jsonrpc !== "2.0" || data.id !== 1 || data.error || !Object.hasOwn(data, "result")) return pendingTradeV1();
+        if (data.jsonrpc !== "2.0" || data.id !== 1) return pendingTradeV1();
+        if (method === "eth_call" && data.error && typeof data.error === "object" && !Array.isArray(data.error) && !Object.hasOwn(data, "result")) {
+          const error = data.error as Record<string, unknown>;
+          if (error.code === 3 && typeof error.message === "string" && /^execution reverted\b/i.test(error.message)
+            && typeof error.data === "string" && /^0x(?:[0-9a-f]{2}){0,32768}$/i.test(error.data)) {
+            throw new TradeRpcExecutionRevertedV1(error.data.toLowerCase() as Hex);
+          }
+        }
+        if (data.error || !Object.hasOwn(data, "result")) return pendingTradeV1();
         return data.result;
-      } catch { return pendingTradeV1(); } finally { clearTimeout(timeout); }
+      } catch (error) { if (error instanceof TradeRpcExecutionRevertedV1) throw error; return pendingTradeV1(); } finally { clearTimeout(timeout); }
     };
   }) as unknown as readonly [TradeRpcV1, TradeRpcV1];
 }
-export function agreedTradeRpcV1(rpcs: readonly [TradeRpcV1, TradeRpcV1]) {
+export function agreedTradeRpcV1(rpcs: readonly [TradeRpcV1, TradeRpcV1], options: { preserveExecutionReverts?: boolean } = {}) {
   return async <T>(method: string, params: readonly unknown[], parse: (value: unknown) => T): Promise<T> => {
     const values = await Promise.allSettled(rpcs.map(async rpc => parse(await rpc(method, params))));
+    if (options.preserveExecutionReverts) {
+      const [a, b] = values;
+      const first = a.status === "rejected" && a.reason instanceof TradeRpcExecutionRevertedV1 ? a.reason : null;
+      const second = b.status === "rejected" && b.reason instanceof TradeRpcExecutionRevertedV1 ? b.reason : null;
+      if (first && second) {
+        if (first.data !== second.data) return pendingTradeV1("TRADE_PROVIDER_DISAGREEMENT");
+        throw first;
+      }
+      if ((first && b.status === "fulfilled") || (second && a.status === "fulfilled")) return pendingTradeV1("TRADE_PROVIDER_DISAGREEMENT");
+    }
     if (values[0].status !== "fulfilled" || values[1].status !== "fulfilled") return pendingTradeV1();
     if (canonicalBrowserJsonV2(values[0].value) !== canonicalBrowserJsonV2(values[1].value)) return pendingTradeV1("TRADE_PROVIDER_DISAGREEMENT");
     return values[0].value;

--- a/lib/server/module-mode/launch-workspace.ts
+++ b/lib/server/module-mode/launch-workspace.ts
@@ -1,0 +1,38 @@
+import type { Hex } from "viem";
+import { MODULE_ENGINE_AVAILABILITY_SCHEMA, type ModuleEngineAvailability } from "@/lib/module-engine/catalog";
+import { MODULE_MODE_AVAILABILITY_SCHEMA, type ModuleModeAvailability } from "@/lib/module-mode/native-catalog";
+import type { ModuleModeReleaseSelection } from "@/lib/module-mode/release-selection";
+import type { ModuleLaunchWorkspaceRequests } from "@/lib/module-mode/launch-workspace";
+import { readModuleEngineAvailability, readModuleEngineLaunchVersions } from "../module-engine/catalog";
+import { readModuleModeAvailability } from "./catalog";
+import { readModuleModeLaunchVersions } from "./launch-profiles";
+
+type Readers = {
+  native: typeof readModuleModeAvailability;
+  engine: typeof readModuleEngineAvailability;
+  nativeVersions: typeof readModuleModeLaunchVersions;
+  engineVersions: typeof readModuleEngineLaunchVersions;
+};
+
+/** Start independent reads without putting historical discovery on the form's critical path. */
+export function createModuleLaunchWorkspaceRequests(selection: ModuleModeReleaseSelection, reviewedAnyQuoteDigest: Hex,
+  readers: Readers = { native: readModuleModeAvailability, engine: readModuleEngineAvailability,
+    nativeVersions: readModuleModeLaunchVersions, engineVersions: readModuleEngineLaunchVersions }): ModuleLaunchWorkspaceRequests {
+  const native = (digest?: string) => readers.native(digest).catch((): ModuleModeAvailability => ({
+    schemaVersion: MODULE_MODE_AVAILABILITY_SCHEMA, release: null, catalog: [], reason: "Module Mode is temporarily unavailable. Please try again shortly.",
+  }));
+  const engine = (digest?: string) => readers.engine(digest).catch((): ModuleEngineAvailability => ({
+    schemaVersion: MODULE_ENGINE_AVAILABILITY_SCHEMA, release: null, templates: [], reason: "This module is temporarily unavailable. Please try again shortly.",
+  }));
+  const nativeRequest = native();
+  const anyQuoteRequest = engine(reviewedAnyQuoteDigest);
+  return {
+    native: nativeRequest,
+    anyQuote: anyQuoteRequest,
+    ...(selection.sourceKind === "module-engine-v1"
+      ? { selectedEngine: selection.releaseDigest === reviewedAnyQuoteDigest ? anyQuoteRequest : engine(selection.releaseDigest) }
+      : { selectedNative: selection.releaseDigest ? native(selection.releaseDigest) : nativeRequest }),
+    versions: Promise.allSettled([readers.nativeVersions(), readers.engineVersions()])
+      .then(results => results.flatMap(result => result.status === "fulfilled" ? result.value : [])),
+  };
+}

--- a/scripts/test/any-quote-readiness-discovery.test.mjs
+++ b/scripts/test/any-quote-readiness-discovery.test.mjs
@@ -16,12 +16,16 @@ for (const [index, name] of ["universalRouter", "poolManager", "stateView", "v4Q
   fixtureCode.set(contract.address.toLowerCase(), code);
   contract.runtimeCodeHash = keccak256(code);
 }
-const bundled = await build({ absWorkingDir: root, stdin: { contents: ["types", "route", "discovery.server", "readiness.server"].map(name => `export * from './lib/module-engine/any-quote/${name}'`).join("\n") + "; export { agreedTradeRpcV1 } from './lib/server/custom-launch/routed-trade-rpc-v1'; export { quoteModule } from './lib/server/module-engine/any-quote-preparation'", resolveDir: root },
+const multicallAddress = "0xca11bde05977b3631167028862be2a173976ca11", multicallCode = "0x6006600055";
+fixtureCode.set(multicallAddress, multicallCode);
+const bundled = await build({ absWorkingDir: root, stdin: { contents: ["types", "route", "discovery.server", "readiness.server"].map(name => `export * from './lib/module-engine/any-quote/${name}'`).join("\n") + "; export { agreedTradeRpcV1, TradeRpcExecutionRevertedV1 } from './lib/server/custom-launch/routed-trade-rpc-v1'; export { quoteModule } from './lib/server/module-engine/any-quote-preparation'", resolveDir: root },
   bundle: true, format: "cjs", platform: "node", packages: "external", write: false,
   plugins: [{ name: "fixture-environment", setup(b) {
     b.onResolve({ filter: /^server-only$/ }, () => ({ path: "empty", namespace: "empty" }));
     b.onLoad({ filter: /.*/, namespace: "empty" }, () => ({ contents: "" }));
     b.onLoad({ filter: /chain-4663\.v1\.json$/ }, () => ({ contents: JSON.stringify(profile), loader: "json" }));
+    b.onLoad({ filter: /lib\/chains\.ts$/ }, async args => ({ contents: (await readFile(args.path, "utf8")).replace(
+      /"0xd5c15df687b16f2ff992fc8d767b4216323184a2bbc6ee2f9c398c318e770891"/, JSON.stringify(keccak256(multicallCode))), loader: "ts" }));
     // Expose the unchanged private reader only to this test bundle; production exports remain closed.
     b.onLoad({ filter: /any-quote-preparation\.ts$/ }, async args => ({ contents: `${await readFile(args.path, "utf8")}\nexport { quoteModule };`, loader: "ts" }));
   } }],
@@ -36,6 +40,7 @@ const HASH = `0x${"aa".repeat(32)}`, NOW = 1_000_000n, HEIGHT = 20_000n;
 const checkpoint = { number: String(HEIGHT), hash: HASH, timestamp: String(NOW) };
 const initializeAbi = parseAbi(["event Initialize(bytes32 indexed id,address indexed currency0,address indexed currency1,uint24 fee,int24 tickSpacing,address hooks,uint160 sqrtPriceX96,int24 tick)"]);
 const readAbi = parseAbi([
+  "function aggregate3((address target,bool allowFailure,bytes callData)[] calls) payable returns ((bool success,bytes returnData)[] returnData)",
   "function decimals() view returns (uint8)", "function totalSupply() view returns (uint256)", "function name() view returns (string)", "function symbol() view returns (string)",
   "function latestRoundData() view returns (uint80,int256,uint256,uint256,uint80)",
   "function getSlot0(bytes32) view returns (uint160,int24,uint24,uint24)", "function getLiquidity(bytes32) view returns (uint128)",
@@ -101,6 +106,14 @@ function fixture(pools, options = {}) {
     else if (functionName === "symbol") result = "Q";
     else if (functionName === "latestRoundData") result = [1n, 2500n * 10n ** 8n, NOW, NOW, 1n];
     else if (functionName === "getSlot0") result = [1n << 96n, 0, 0, 0];
+    else if (functionName === "aggregate3") result = args[0].map(call => {
+      assert.equal(call.target.toLowerCase(), a.ANY_QUOTE_INFRASTRUCTURE.stateView.toLowerCase());
+      assert.equal(call.allowFailure, false);
+      const read = decodeFunctionData({ abi: readAbi, data: call.callData });
+      assert.equal(read.functionName, "getLiquidity");
+      return { success: true, returnData: encodeFunctionResult({ abi: readAbi, functionName: "getLiquidity",
+        result: pools.find(p => p.poolId.toLowerCase() === read.args[0].toLowerCase())?.liquidity ?? 0n }) };
+    });
     else if (functionName === "getLiquidity") result = pools.find(p => p.poolId.toLowerCase() === args[0].toLowerCase())?.liquidity ?? 0n;
     else if (functionName === "quoteExactInputSingle") {
       const params = args[0], actual = pools.find(p => p.poolId.toLowerCase() === a.anyQuotePoolIdV1(params.poolKey).toLowerCase());
@@ -201,11 +214,52 @@ test("malformed successful responses are never treated as unavailable providers 
   }
 });
 
-test("hint verification retains the fixed request budget and never accepts an unverified pool", async () => {
-  const f = fixture(Array.from({ length: 24 }, (_, i) => pool(ZERO, Q, { fee: i * 500, block: 10_000n + BigInt(i) * 10_000n })), { override: quickNodeRangeLimit });
-  await assert.rejects(() => a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint: longCheckpoint, rpcs: f.rpcs }).nativePools(Q),
-    error => error.code === "V4_DISCOVERY_REQUEST_LIMIT" && error.status === "inconclusive");
-  assert.equal(f.calls.length, 2, "An over-budget hint set stops before requesting verification windows");
+test("popular tokens rank active pool hints in pinned batches before canonical verification", async () => {
+  const pools = Array.from({ length: 155 }, (_, i) => pool(ZERO, Q, { fee: i * 500, block: 10_000n + BigInt(i) * 10_000n,
+    liquidity: i < 130 ? 0n : BigInt(i + 1) }));
+  const f = fixture(pools, { override: quickNodeRangeLimit });
+  const discovery = a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint: longCheckpoint, rpcs: f.rpcs });
+  const selected = await discovery.nativePools(Q);
+  assert.equal(selected.length, 16);
+  assert.deepEqual(new Set(selected.map(value => value.poolId)), new Set(pools.slice(-16).map(value => value.poolId)));
+  assert.equal(discovery.hasIncompleteCoverage(), true, "A bounded shortlist never claims index completeness");
+  const logs = f.calls.filter(value => value.method === "eth_getLogs");
+  assert.equal(logs.length, 34, "One full-range hint query and16 canonical verification windows on each provider");
+  for (const selectedPool of selected) for (const provider of [0, 1]) assert.ok(logs.some(call => call.provider === provider
+    && BigInt(call.params[0].fromBlock) === BigInt(selectedPool.blockNumber) && !wideRange(call.params)));
+  const batches = f.calls.filter(call => call.method === "eth_call");
+  assert.equal(batches.length, 6, "155 pools use three liquidity reads per independent provider");
+  assert.ok(batches.every(call => call.params[1].blockHash === HASH && call.params[1].requireCanonical === true));
+  const priorCalls = f.calls.length;
+  assert.deepEqual(await discovery.nativePools(Q), selected);
+  assert.equal(f.calls.length, priorCalls, "The reverse route reuses this request's verified pool keys");
+});
+
+test("shortlist verification permits unrelated canonical logs in the same bounded window", async () => {
+  const pools = Array.from({ length: 24 }, (_, i) => pool(ZERO, Q, { fee: i * 500, block: 10_000n + BigInt(i), liquidity: i % 2 ? 1n : 0n }));
+  const f = fixture(pools, { override: quickNodeRangeLimit });
+  const selected = await a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint: longCheckpoint, rpcs: f.rpcs }).nativePools(Q);
+  assert.equal(selected.length, 12);
+  assert.deepEqual(new Set(selected.map(value => value.poolId)), new Set(pools.filter(p => p.liquidity > 0n).map(p => p.poolId)));
+});
+
+test("active pool ranking cannot ignore provider disagreement, malformed data or changed infrastructure", async () => {
+  const pools = Array.from({ length: 24 }, (_, i) => pool(ZERO, Q, { fee: i * 500, block: 10_000n + BigInt(i) * 10_000n }));
+  for (const corruption of ["disagreement", "malformed", "runtime"]) {
+    const f = fixture(pools, { override: info => {
+      quickNodeRangeLimit(info);
+      if (corruption === "runtime" && info.method === "eth_getCode" && info.params[0].toLowerCase() === multicallAddress) return "0x00";
+      if (info.method !== "eth_call" || info.params[0].to.toLowerCase() !== multicallAddress || info.provider !== 1) return;
+      if (corruption === "malformed") return "0x00";
+      if (corruption === "disagreement") {
+        const read = decodeFunctionData({ abi: readAbi, data: info.params[0].data });
+        return encodeFunctionResult({ abi: readAbi, functionName: "aggregate3", result: read.args[0].map(() => ({ success: true,
+          returnData: encodeFunctionResult({ abi: readAbi, functionName: "getLiquidity", result: 0n }) })) });
+      }
+    } });
+    await assert.rejects(() => a.createAnyQuoteV4InitializeDiscoveryV1({ checkpoint: longCheckpoint, rpcs: f.rpcs }).nativePools(Q));
+    assert.equal(f.calls.filter(call => call.method === "eth_getLogs").length, 2, "Untrusted ranking must never reach candidate verification");
+  }
 });
 
 test("empty direct hints still allow an independently verified indirect route; empty coverage stays inconclusive", async () => {
@@ -294,6 +348,36 @@ test("a reverted candidate quote stays non-executable without treating malformed
   assert.equal(result.status, "compatible", JSON.stringify(result));
   assert.deepEqual([...rejectedBy], [0, 1], "Both RPCs rejected the non-executable candidate call");
   for (const side of ["buy", "sell"]) assert.equal(result.routes[side].hops[0].poolId, deep.poolId);
+});
+
+test("an independently agreed depth revert can select another qualified pool", async () => {
+  const failing = pool(), deep = pool(ZERO, Q, { fee: 500 });
+  const f = fixture([failing, deep], { override: info => {
+    if (info.method !== "eth_call") return;
+    const read = decodeFunctionData({ abi: readAbi, data: info.params[0].data });
+    if (read.functionName === "quoteExactInputSingle" && read.args[0].poolKey.fee === 0 && read.args[0].exactAmount > ONE_DOLLAR_ETH)
+      throw new a.TradeRpcExecutionRevertedV1("0x1234");
+  } });
+  const result = await a.assessAnyQuoteAssetV1({ quoteAsset: Q }, f.options);
+  assert.equal(result.status, "compatible", JSON.stringify(result));
+  for (const side of ["buy", "sell"]) assert.equal(result.routes[side].hops[0].poolId, deep.poolId);
+});
+
+test("unconfirmed or inconsistent depth reverts never select another pool", async () => {
+  for (const other of ["success", "different-revert", "outage"]) {
+    const f = fixture([pool(), pool(ZERO, Q, { fee: 500 })], { override: info => {
+      if (info.method !== "eth_call") return;
+      const read = decodeFunctionData({ abi: readAbi, data: info.params[0].data });
+      if (read.functionName !== "quoteExactInputSingle" || read.args[0].poolKey.fee !== 0 || read.args[0].exactAmount <= ONE_DOLLAR_ETH) return;
+      if (info.provider === 0) throw new a.TradeRpcExecutionRevertedV1("0x1234");
+      if (other === "different-revert") throw new a.TradeRpcExecutionRevertedV1("0x5678");
+      if (other === "outage") throw Error("provider unavailable");
+    } });
+    const result = await a.assessAnyQuoteAssetV1({ quoteAsset: Q }, f.options);
+    assert.equal(result.status, "inconclusive", `${other}: ${JSON.stringify(result)}`);
+    assert.equal(result.retryable, true);
+    if (other !== "outage") assert.equal(result.code, "TRADE_PROVIDER_DISAGREEMENT");
+  }
 });
 
 test("provider disagreement and malformed initial or depth quotes cannot fall back to a healthy pool", async () => {

--- a/tests/any-quote-readiness-display-cache.test.ts
+++ b/tests/any-quote-readiness-display-cache.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { forgetAnyQuoteDisplayCheck, readAnyQuoteDisplayCheck, rememberAnyQuoteDisplayCheck } from "@/lib/module-engine/any-quote/readiness-display-cache";
+import type { AnyQuoteReadinessV1 } from "@/lib/module-engine/any-quote/types";
+
+// These tests only exercise a display cache; the remaining readiness fields are opaque to it.
+const result = (validUntil: number) => ({ status: "compatible", validUntil: String(validUntil) }) as Extract<AnyQuoteReadinessV1, { status: "compatible" }>;
+
+describe("short-lived Any Quote display handoff", () => {
+  it("reuses a result only for its exact context and until its evidence expires", () => {
+    const key = "release-a:template-a:quote-a", ready = result(1_050);
+    rememberAnyQuoteDisplayCheck(key, ready, 1_000_000);
+    expect(readAnyQuoteDisplayCheck(key, 1_049_999)).toBe(ready);
+    for (const other of ["release-b:template-a:quote-a", "release-a:template-b:quote-a", "release-a:template-a:quote-b"])
+      expect(readAnyQuoteDisplayCheck(other, 1_000_000)).toBeNull();
+    expect(readAnyQuoteDisplayCheck(key, 1_050_000)).toBeNull();
+  });
+  it("caps long-lived evidence and lets retry discard a previously successful display", () => {
+    const key = "bounded-display", ready = result(5_000);
+    rememberAnyQuoteDisplayCheck(key, ready, 1_000_000);
+    expect(readAnyQuoteDisplayCheck(key, 1_179_999)).toBe(ready);
+    expect(readAnyQuoteDisplayCheck(key, 1_180_000)).toBeNull();
+    rememberAnyQuoteDisplayCheck(key, ready, 1_000_000);
+    forgetAnyQuoteDisplayCheck(key);
+    expect(readAnyQuoteDisplayCheck(key, 1_000_000)).toBeNull();
+    rememberAnyQuoteDisplayCheck(key, result(999), 1_000_000);
+    expect(readAnyQuoteDisplayCheck(key, 1_000_000)).toBeNull();
+  });
+});

--- a/tests/any-quote-rpc-readiness.test.ts
+++ b/tests/any-quote-rpc-readiness.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { agreedTradeRpcV1, productionTradeRpcsV1, TradeRpcExecutionRevertedV1, type TradeRpcV1 } from "@/lib/server/custom-launch/routed-trade-rpc-v1";
+
+const environment = {
+  ROBINHOOD_V4_RPC_PRIMARY_URL: `https://lb.drpc.live/robinhood/${"fixture".repeat(4)}`,
+  ROBINHOOD_V4_RPC_SECONDARY_URL: `https://robinhood-mainnet.g.alchemy.com/v2/${"fixture".repeat(4)}`,
+};
+const response = (error: unknown): typeof fetch => async () => new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, error }));
+const revert = (data: `0x${string}`): TradeRpcV1 => async () => { throw new TradeRpcExecutionRevertedV1(data); };
+const success: TradeRpcV1 = async () => "0x01";
+const outage: TradeRpcV1 = async () => { throw Error("provider unavailable"); };
+
+describe("Any Quote opt-in execution-revert evidence", () => {
+  it("retains bounded EVM revert bytes while removing provider messages", async () => {
+    const rpc = productionTradeRpcsV1(environment, response({ code: 3, message: "execution reverted: private provider text", data: "0xABCD" }))[0];
+    await expect(rpc("eth_call", [])).rejects.toMatchObject({ code: "TRADE_EXECUTION_REVERTED", data: "0xabcd", message: "The simulated call reverted." });
+    await expect(rpc("eth_getLogs", [])).rejects.toMatchObject({ code: "TRADE_ANALYSIS_PENDING" });
+  });
+  it("does not turn malformed, oversized or provider errors into execution evidence", async () => {
+    for (const error of [
+      { code: 3, message: "rate limited", data: "0xabcd" },
+      { code: -32000, message: "execution reverted", data: "0xabcd" },
+      { code: 3, message: "execution reverted", data: "not bytes" },
+      { code: 3, message: "execution reverted", data: `0x${"ab".repeat(32_769)}` },
+    ]) await expect(productionTradeRpcsV1(environment, response(error))[0]("eth_call", [])).rejects.toMatchObject({ code: "TRADE_ANALYSIS_PENDING" });
+  });
+  it("rejects a malformed envelope containing both a result and an error", async () => {
+    const fetcher: typeof fetch = async () => new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x01",
+      error: { code: 3, message: "execution reverted", data: "0xabcd" } }));
+    await expect(productionTradeRpcsV1(environment, fetcher)[0]("eth_call", [])).rejects.toMatchObject({ code: "TRADE_ANALYSIS_PENDING" });
+  });
+  it("keeps default provider agreement behavior unchanged", async () => {
+    await expect(agreedTradeRpcV1([revert("0x12"), revert("0x12")])("eth_call", [], String)).rejects.toMatchObject({ code: "TRADE_ANALYSIS_PENDING" });
+  });
+  it("only confirms identical independent revert results when requested", async () => {
+    await expect(agreedTradeRpcV1([revert("0x12"), revert("0x12")], { preserveExecutionReverts: true })("eth_call", [], String))
+      .rejects.toMatchObject({ code: "TRADE_EXECUTION_REVERTED", data: "0x12" });
+    for (const pair of [[revert("0x12"), revert("0x34")], [revert("0x12"), success], [success, revert("0x12")]] as const)
+      await expect(agreedTradeRpcV1(pair, { preserveExecutionReverts: true })("eth_call", [], String)).rejects.toMatchObject({ code: "TRADE_PROVIDER_DISAGREEMENT" });
+    await expect(agreedTradeRpcV1([revert("0x12"), outage], { preserveExecutionReverts: true })("eth_call", [], String))
+      .rejects.toMatchObject({ code: "TRADE_ANALYSIS_PENDING" });
+  });
+});

--- a/tests/module-engine-any-quote-ui.test.tsx
+++ b/tests/module-engine-any-quote-ui.test.tsx
@@ -29,7 +29,7 @@ describe("Any Quote LP visible economic and availability boundaries", () => {
   });
   it("keeps provider trouble retryable without declaring the CA invalid", () => {
     const html = renderToStaticMarkup(<ModuleEngineAnyQuoteAsset value={QUOTE} onChange={vi.fn()} availability={{ status: "inconclusive", result: null, retry: vi.fn() }} />);
-    expect(html).toContain("Availability could not be checked"); expect(html).toContain("Retry");
+    expect(html).toContain("The token check is temporarily unavailable"); expect(html).toContain("Retry");
     expect(html).not.toContain('aria-invalid="true"'); expect(html).not.toContain("Der Token ist leider nicht verfügbar.");
     const unavailable = renderToStaticMarkup(<ModuleEngineAnyQuoteAsset value={QUOTE} onChange={vi.fn()} availability={{ status: "incompatible", result: { status: "incompatible", chainId: 4663, quoteAsset: QUOTE, code: "NON_ERC20", retryable: false }, retry: vi.fn() }} />);
     expect(unavailable).toContain('aria-invalid="true"'); expect(unavailable).toContain("Der Token ist leider nicht verfügbar.");

--- a/tests/module-launch-flight-promise.test.ts
+++ b/tests/module-launch-flight-promise.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { moduleLaunchRequestPromise } from "@/lib/module-mode/launch-workspace";
+
+describe("React Flight module availability", () => {
+  it("makes a non-chainable fulfilled thenable safe for availability observers", async () => {
+    const value = { release: "reviewed", catalog: [] };
+    const flight = { then(resolve: (result: typeof value) => void) { resolve(value); } };
+    expect(flight.then(() => {})).toBeUndefined();
+    const observed = moduleLaunchRequestPromise(flight as unknown as PromiseLike<typeof value>)
+      .then(result => result.release)
+      .catch(() => "unavailable");
+    expect(await observed).toBe("reviewed");
+  });
+
+  it("routes a rejected Flight thenable through the existing unavailable handler", async () => {
+    const failure = new Error("Source stream unavailable");
+    const flight = { then(_resolve: unknown, reject: (error: Error) => void) { reject(failure); } };
+    const observed = moduleLaunchRequestPromise(flight as unknown as PromiseLike<never>)
+      .then(() => "available")
+      .catch(error => error);
+    expect(await observed).toBe(failure);
+  });
+});

--- a/tests/module-launch-loading.test.tsx
+++ b/tests/module-launch-loading.test.tsx
@@ -1,0 +1,18 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { expect, it, vi } from "vitest";
+import { ModuleModeLaunchHost } from "@/components/module-mode-launch-host";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("@/components/wallet-provider", () => ({ useWallet: () => ({ authenticated: false, sessionReady: true, authReady: true }) }));
+vi.mock("@/components/view-chain", () => ({ useRouteViewChain: () => ({ hydrated: true }) }));
+
+it("renders editable coin fields while launch availability is still unresolved", () => {
+  const pending = new Promise<never>(() => {});
+  const html = renderToStaticMarkup(<ModuleModeLaunchHost availabilityRequest={pending} />);
+  expect(html).toContain("Create a coin");
+  expect(html).toContain("Coin name");
+  expect(html).toContain("<input");
+  expect(html).not.toContain("Loading coin setup");
+  expect(html).not.toContain("Every Nth buy reward");
+  expect(html).not.toContain("Opening buy cap");
+});

--- a/tests/module-mode-launch-draft-handoff.test.ts
+++ b/tests/module-mode-launch-draft-handoff.test.ts
@@ -3,7 +3,8 @@ import type { ModuleModeLaunchDraftHandoff } from "@/lib/module-mode/launch-draf
 
 function draft(): ModuleModeLaunchDraftHandoff {
   return { name: "My coin", symbol: "COIN", description: "A saved draft", socialLinks: { website: "https://example.com" },
-    tokenImage: { kind: "none" }, imageResource: null, initialBuyEth: "0.0075", buyFeePercent: "1", sellFeePercent: "2" };
+    tokenImage: { kind: "none" }, imageResource: null, initialBuyEth: "0.0075", buyFeePercent: "1", sellFeePercent: "2",
+    quoteAsset: "0x2e8c31162b855a2ffa90f6f8634643ad6f111e18" };
 }
 
 beforeEach(() => { vi.stubGlobal("window", {}); });

--- a/tests/module-mode-source-routing.test.tsx
+++ b/tests/module-mode-source-routing.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ModuleEngineHost } from "@/components/module-engine-host";
-import { ModuleModeLaunchHost } from "@/components/module-mode-launch-host";
+import { ModuleLaunchWorkspace } from "@/components/module-launch-workspace";
+import { availableAnyQuoteLibraryEntry } from "@/lib/module-mode/launch-workspace";
 import { ModuleCoinConsole } from "@/components/module-coin-console";
 import { fixture, TOKEN, hash } from "./module-engine-fixture";
 import { anyQuoteUiFixture } from "./module-engine-any-quote-ui-fixture";
@@ -15,6 +16,7 @@ const mocks = vi.hoisted(() => ({ native: vi.fn(), engine: vi.fn(), nativeVersio
 vi.mock("@/config/module-engine/review-release.json", () => ({ get default() { return mocks.reviewIdentity; } }));
 vi.mock("@/components/module-engine-host", () => ({ ModuleEngineHost: () => null }));
 vi.mock("@/components/module-mode-launch-host", () => ({ ModuleModeLaunchHost: () => null }));
+vi.mock("@/components/module-launch-workspace", () => ({ ModuleLaunchWorkspace: () => null }));
 vi.mock("@/components/module-coin-console", () => ({ ModuleCoinConsole: () => null }));
 vi.mock("next/navigation", () => ({ notFound: () => { throw new Error("NOT_FOUND"); } }));
 vi.mock("@/lib/server/module-mode/catalog", async original => ({ ...await original<typeof import("@/lib/server/module-mode/catalog")>(), readModuleModeAvailability: mocks.native }));
@@ -27,7 +29,7 @@ import ManagePage from "@/app/launch/modules/manage/[address]/page";
 
 const { ANY_QUOTE_ETH_GUARD_RELEASE } = await import(new URL("../contracts/scripts/module-engine/any-quote-eth-basis.mjs", import.meta.url).href);
 
-beforeEach(() => { vi.clearAllMocks(); mocks.reviewIdentity = moduleEngineReleaseIdentity(ANY_QUOTE_ETH_GUARD_RELEASE); mocks.nativeVersions.mockResolvedValue([]); mocks.engineVersions.mockResolvedValue([]); mocks.engine.mockResolvedValue({ ...fixture().availability, release: null, templates: [] }); mocks.token.mockResolvedValue({ token: null }); });
+beforeEach(() => { vi.clearAllMocks(); mocks.reviewIdentity = moduleEngineReleaseIdentity(ANY_QUOTE_ETH_GUARD_RELEASE); mocks.native.mockResolvedValue({ schemaVersion: "programmable.module-mode.availability.v1", release: null, catalog: [], reason: "Unavailable" }); mocks.nativeVersions.mockResolvedValue([]); mocks.engineVersions.mockResolvedValue([]); mocks.engine.mockResolvedValue({ ...fixture().availability, release: null, templates: [] }); mocks.token.mockResolvedValue({ token: null }); });
 
 /** A mocked availability sample for route gating only, not a publication or activation claim. */
 function reviewedAnyQuoteAvailability() {
@@ -49,9 +51,9 @@ describe("source-specific Module Mode product routes", () => {
     // Review identity alone has no public activation or lifecycle evidence.
     mocks.engine.mockResolvedValue({ ...fixture().availability, release: identity, templates: [] });
     const page = await Page({ searchParams: Promise.resolve({}) });
-    expect(page.type).toBe(ModuleModeLaunchHost);
-    expect(page.props.anyQuoteReleaseDigest).toBeUndefined();
-    expect(page.props.versions).toEqual([]);
+    expect(page.type).toBe(ModuleLaunchWorkspace);
+    expect(availableAnyQuoteLibraryEntry(await page.props.requests.anyQuote, page.props.reviewedAnyQuoteDigest)).toBeNull();
+    expect(await page.props.requests.versions).toEqual([]);
   });
   it("keeps the current native reader and dispatches only explicit Engine selectors", async () => {
     const f = fixture(); mocks.native.mockResolvedValue({ release: null, catalog: [], reason: "Native disabled" }); mocks.engine.mockResolvedValue(f.availability);
@@ -70,19 +72,22 @@ describe("source-specific Module Mode product routes", () => {
     const f = fixture(), version = { releaseDigest: f.release.releaseDigest, sourceKind: "module-engine-v1", label: "Fixture template version" };
     mocks.nativeVersions.mockRejectedValue(new Error("Native source unavailable")); mocks.engineVersions.mockResolvedValue([version]);
     const engine = await Page({ searchParams: Promise.resolve({ sourceKind: "module-engine-v1", releaseDigest: f.release.releaseDigest }) });
-    expect(engine.type).toBe(ModuleEngineHost); expect(engine.props).toMatchObject({ releaseDigest: f.release.releaseDigest, versions: [version] });
-    const native = await Page({ searchParams: Promise.resolve({}) }); expect(native.type).toBe(ModuleModeLaunchHost);
+    expect(engine.type).toBe(ModuleLaunchWorkspace); expect(engine.props.initialSelection).toEqual({ sourceKind: "module-engine-v1", releaseDigest: f.release.releaseDigest });
+    expect(await engine.props.requests.versions).toEqual([version]);
+    const native = await Page({ searchParams: Promise.resolve({}) }); expect(native.type).toBe(ModuleLaunchWorkspace);
   });
   it.each([false, true])("offers the exact reviewed public Any Quote generation (native ETH fees: %s)", async nativeEthFees => {
     mocks.reviewIdentity = moduleEngineReleaseIdentity(anyQuoteUiFixture(nativeEthFees).release);
     const availability = reviewedAnyQuoteAvailability(); mocks.engine.mockResolvedValue(availability);
     const page = await Page({ searchParams: Promise.resolve({}) });
-    expect(page.type).toBe(ModuleModeLaunchHost);
-    expect(page.props.anyQuoteReleaseDigest).toBe(reviewedAnyQuoteRelease.releaseDigest);
+    expect(page.type).toBe(ModuleLaunchWorkspace);
+    const entry = availableAnyQuoteLibraryEntry(await page.props.requests.anyQuote, page.props.reviewedAnyQuoteDigest);
+    expect(entry?.releaseDigest).toBe(reviewedAnyQuoteRelease.releaseDigest);
     expect(mocks.engine).toHaveBeenCalledWith(reviewedAnyQuoteRelease.releaseDigest);
-    const selected = await Page({ searchParams: Promise.resolve({ sourceKind: "module-engine-v1", releaseDigest: page.props.anyQuoteReleaseDigest }) });
-    expect(selected.type).toBe(ModuleEngineHost);
-    expect(selected.props.releaseDigest).toBe(reviewedAnyQuoteRelease.releaseDigest);
+    const selected = await Page({ searchParams: Promise.resolve({ sourceKind: "module-engine-v1", releaseDigest: entry?.releaseDigest }) });
+    expect(selected.type).toBe(ModuleLaunchWorkspace);
+    expect(selected.props.initialSelection.releaseDigest).toBe(reviewedAnyQuoteRelease.releaseDigest);
+    expect(selected.props.requests.selectedEngine).toBe(selected.props.requests.anyQuote);
   });
   it.each([false, true])("keeps Any Quote hidden without matching public authority (native ETH fees: %s)", async nativeEthFees => {
     mocks.reviewIdentity = moduleEngineReleaseIdentity(anyQuoteUiFixture(nativeEthFees).release);
@@ -98,12 +103,23 @@ describe("source-specific Module Mode product routes", () => {
     ]) {
       mocks.engine.mockResolvedValue(unavailable);
       const page = await Page({ searchParams: Promise.resolve({}) });
-      expect(page.type).toBe(ModuleModeLaunchHost);
-      expect(page.props.anyQuoteReleaseDigest).toBeUndefined();
+      expect(page.type).toBe(ModuleLaunchWorkspace);
+      expect(availableAnyQuoteLibraryEntry(await page.props.requests.anyQuote, page.props.reviewedAnyQuoteDigest)).toBeNull();
     }
     mocks.engine.mockRejectedValue(new Error("Current source unavailable"));
-    expect((await Page({ searchParams: Promise.resolve({}) })).props.anyQuoteReleaseDigest).toBeUndefined();
+    const unavailablePage = await Page({ searchParams: Promise.resolve({}) });
+    expect(availableAnyQuoteLibraryEntry(await unavailablePage.props.requests.anyQuote, unavailablePage.props.reviewedAnyQuoteDigest)).toBeNull();
   });
+  it("renders the setup without waiting for availability or historical discovery", async () => {
+    const pending = new Promise<never>(() => {});
+    mocks.native.mockReturnValue(pending); mocks.engine.mockReturnValue(pending);
+    mocks.nativeVersions.mockReturnValue(pending); mocks.engineVersions.mockReturnValue(pending);
+    const page = await Page({ searchParams: Promise.resolve({}) });
+    expect(page.type).toBe(ModuleLaunchWorkspace);
+    expect(page.props.requests.selectedNative).toBe(page.props.requests.native);
+    expect(mocks.native).toHaveBeenCalledExactlyOnceWith(undefined);
+    expect(mocks.engine).toHaveBeenCalledExactlyOnceWith(reviewedAnyQuoteRelease.releaseDigest);
+  }, 500);
   it("dispatches exact management hints and uses the indexed source for a plain coin URL", async () => {
     const hinted = await ManagePage({ params: Promise.resolve({ address: TOKEN }), searchParams: Promise.resolve({ sourceKind: "module-engine-v1", releaseDigest: fixture().release.releaseDigest }) });
     expect(hinted.type).toBe(ModuleEngineHost); expect(hinted.props.token).toBe(TOKEN);


### PR DESCRIPTION
Module Mode renders the editable coin form while verified catalogs load. Adding Any Quote opens its address check inside the existing picker; Done carries the checked pair and draft into the loaded host without another request. Configured pairs stay compact, and Custom Hook uses the same layout and controls as Module Mode.

Popular assets no longer fail because discovery returned many valid historical pools. Current liquidity narrows the bounded candidate set before canonical verification. An independently confirmed depth-quote revert skips that pool; provider failures and disagreement remain inconclusive. Streamed React Flight thenables are normalized before promise chaining.

Validation: focused UI, draft, display-cache, loading, discovery and RPC tests, TypeScript and ESLint passed. Real Next browser QA covers desktop/mobile rendering, inline address checks, local Done navigation, retained inputs and category selection, Add/Remove and return to native modules. Browser QA caught and corrected the Flight thenable issue and form-width change. Independent-provider read-only checks of AI, SHROOM and the PGRAM control passed. Protected production staging and public verification follow before publication.
