### PR TITLE
Keep Any Quote pool ticker visible

### DIFF
--- a/components/module-engine-any-quote-asset.tsx
+++ b/components/module-engine-any-quote-asset.tsx
@@ -5,7 +5,7 @@ import { isAddress, type Hex } from "viem";
 import { Check, CircleAlert, LoaderCircle, RefreshCw } from "lucide-react";
 import { fetchAnyQuoteReadiness } from "@/lib/module-engine/any-quote/integration-client";
 import type { AnyQuoteReadinessV1 } from "@/lib/module-engine/any-quote/types";
-import { forgetAnyQuoteDisplayCheck, readAnyQuoteDisplayCheck, rememberAnyQuoteDisplayCheck } from "@/lib/module-engine/any-quote/readiness-display-cache";
+import { forgetAnyQuoteDisplayCheck, readAnyQuoteDisplayCheck, readAnyQuoteDisplaySymbol, rememberAnyQuoteDisplayCheck } from "@/lib/module-engine/any-quote/readiness-display-cache";
 import styles from "./module-mode-builder.module.css";
 import engineStyles from "./module-engine-ui.module.css";
 
@@ -13,6 +13,7 @@ type AvailabilityStatus = "idle" | "invalid" | "checking" | AnyQuoteReadinessV1[
 export interface AnyQuoteAssetAvailability {
   status: AvailabilityStatus;
   result: AnyQuoteReadinessV1 | null;
+  symbol?: string;
   retry: () => void;
 }
 
@@ -81,7 +82,7 @@ export function useAnyQuoteAssetAvailability({ enabled, releaseDigest, templateI
   const current = latestCheck?.status === "compatible" ? cached ? latestCheck : null
     : latestCheck ?? (attempt === 0 && cached ? { status: "compatible" as const, result: cached } : null);
   const status = !enabled || !address ? "idle" : !validAddress ? "invalid" : current?.status ?? "checking";
-  return { status, result: current?.result ?? null, retry: () => { forgetAnyQuoteDisplayCheck(key); setAttempt(value => value + 1); } };
+  return { status, result: current?.result ?? null, symbol: enabled && validAddress ? readAnyQuoteDisplaySymbol(key) : undefined, retry: () => { forgetAnyQuoteDisplayCheck(key); setAttempt(value => value + 1); } };
 }
 
 export function ModuleEngineAnyQuoteAsset({ value, onChange, availability, inputId = "engine-quote" }: {

--- a/components/module-engine-builder.tsx
+++ b/components/module-engine-builder.tsx
@@ -214,7 +214,7 @@ export function ModuleEngineBuilder({ availability: raw, client: suppliedClient,
   const tokenImageSource = moduleModeImageSource(image, imageResource)
     ?? (imageUri ? moduleModeImageSource({ kind: "uri", uri: imageUri, contentVerified: false }, null) : null);
   const quoteLabel = anyQuote ? "Pool pair" : spot ? "Trading token" : "Funding token";
-  const quoteShort = readyQuote?.token.symbol || (quoteAsset ? `${quoteAsset.slice(0, 6)}…${quoteAsset.slice(-4)}` : "Not chosen");
+  const quoteShort = anyQuote ? anyQuoteAvailability.symbol || "Not selected" : quoteAsset ? `${quoteAsset.slice(0, 6)}…${quoteAsset.slice(-4)}` : "Not chosen";
 
   return <div className={`${styles.page} ${engineStyles.root} ${engineStyles.builderRoot}${anyQuote ? ` ${engineStyles.anyQuoteBuilder}` : ""}`}>
     <div className={engineStyles.pageTop}><a href="/launch"><ArrowLeft size={16} aria-hidden="true" />Back</a></div>

--- a/lib/module-engine/any-quote/readiness-display-cache.ts
+++ b/lib/module-engine/any-quote/readiness-display-cache.ts
@@ -3,6 +3,10 @@ import type { AnyQuoteReadinessV1 } from "./types";
 type CompatibleReadiness = Extract<AnyQuoteReadinessV1, { status: "compatible" }>;
 type Entry = { result: CompatibleReadiness; expiresAt: number };
 const displayed = new Map<string, Entry>();
+const symbols = new Map<string, string>();
+
+/** The ticker remains display-only after its price and route check expires. */
+export function readAnyQuoteDisplaySymbol(key: string): string | undefined { return symbols.get(key); }
 
 /** Reuses a recent display check across builders. Launch preparation still fetches fresh authority. */
 export function readAnyQuoteDisplayCheck(key: string, now = Date.now()): CompatibleReadiness | null {
@@ -18,6 +22,9 @@ export function rememberAnyQuoteDisplayCheck(key: string, result: CompatibleRead
   displayed.delete(key);
   displayed.set(key, { result, expiresAt });
   while (displayed.size > 32) displayed.delete(displayed.keys().next().value!);
+  symbols.delete(key);
+  symbols.set(key, result.token.symbol);
+  while (symbols.size > 32) symbols.delete(symbols.keys().next().value!);
 }
 
 export function forgetAnyQuoteDisplayCheck(key: string): void { displayed.delete(key); }

--- a/tests/any-quote-readiness-display-cache.test.ts
+++ b/tests/any-quote-readiness-display-cache.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { forgetAnyQuoteDisplayCheck, readAnyQuoteDisplayCheck, rememberAnyQuoteDisplayCheck } from "@/lib/module-engine/any-quote/readiness-display-cache";
+import { forgetAnyQuoteDisplayCheck, readAnyQuoteDisplayCheck, readAnyQuoteDisplaySymbol, rememberAnyQuoteDisplayCheck } from "@/lib/module-engine/any-quote/readiness-display-cache";
 import type { AnyQuoteReadinessV1 } from "@/lib/module-engine/any-quote/types";
 
 // These tests only exercise a display cache; the remaining readiness fields are opaque to it.
-const result = (validUntil: number) => ({ status: "compatible", validUntil: String(validUntil) }) as Extract<AnyQuoteReadinessV1, { status: "compatible" }>;
+const result = (validUntil: number) => ({ status: "compatible", validUntil: String(validUntil), token: { name: "Example", symbol: "PAIR", decimals: 18 } }) as Extract<AnyQuoteReadinessV1, { status: "compatible" }>;
 
 describe("short-lived Any Quote display handoff", () => {
   it("reuses a result only for its exact context and until its evidence expires", () => {
@@ -13,6 +13,8 @@ describe("short-lived Any Quote display handoff", () => {
     for (const other of ["release-b:template-a:quote-a", "release-a:template-b:quote-a", "release-a:template-a:quote-b"])
       expect(readAnyQuoteDisplayCheck(other, 1_000_000)).toBeNull();
     expect(readAnyQuoteDisplayCheck(key, 1_050_000)).toBeNull();
+    expect(readAnyQuoteDisplaySymbol(key)).toBe("PAIR");
+    expect(readAnyQuoteDisplaySymbol("release-a:template-a:another-quote")).toBeUndefined();
   });
   it("caps long-lived evidence and lets retry discard a previously successful display", () => {
     const key = "bounded-display", ready = result(5_000);
@@ -22,6 +24,7 @@ describe("short-lived Any Quote display handoff", () => {
     rememberAnyQuoteDisplayCheck(key, ready, 1_000_000);
     forgetAnyQuoteDisplayCheck(key);
     expect(readAnyQuoteDisplayCheck(key, 1_000_000)).toBeNull();
+    expect(readAnyQuoteDisplaySymbol(key)).toBe("PAIR");
     rememberAnyQuoteDisplayCheck(key, result(999), 1_000_000);
     expect(readAnyQuoteDisplayCheck(key, 1_000_000)).toBeNull();
   });


### PR DESCRIPTION
The Any Quote pool pair reverted from its ticker to a shortened contract address when its price and route check expired. Keep the known ticker in a bounded display cache scoped to the same release, template and token, and use it for both the pool summary and selected module. Expired readiness still blocks launch preparation until a fresh check succeeds.

Validation: 20 focused existing tests passed, including ticker retention after readiness expiry and retry; focused ESLint and diff checks passed.
