### PR TITLE
Read token decimals for projected Swap launches

### DIFF
--- a/lib/server/swap/token-metadata.ts
+++ b/lib/server/swap/token-metadata.ts
@@ -1,0 +1,20 @@
+import "server-only";
+import { getAddress, toHex } from "viem";
+import { agreedTradeRpcV1, bytesV1, productionTradeRpcsV1, quantityV1, tradeBlockV1, type TradeRpcV1 } from "@/lib/server/custom-launch/routed-trade-rpc-v1";
+import { SwapUnavailableError } from "@/lib/swap/types";
+
+/** Older projected launches intentionally omit ERC-20 metadata. Read units
+ * from the indexed token itself instead of assuming that it has 18 decimals. */
+export async function readRobinhoodSwapDecimals(token: string, rpcs: readonly [TradeRpcV1, TradeRpcV1] = productionTradeRpcsV1()): Promise<number> {
+  const rpc = agreedTradeRpcV1(rpcs);
+  const [chain, heads] = await Promise.all([
+    rpc("eth_chainId", [], value => quantityV1(value).toString()),
+    Promise.all(rpcs.map(async read => tradeBlockV1(await read("eth_getBlockByNumber", ["latest", false])))),
+  ]);
+  if (chain !== "4663") throw new SwapUnavailableError("The token network could not be verified. Try again.", "TOKEN_METADATA_UNAVAILABLE");
+  const height = BigInt(heads[0].number) < BigInt(heads[1].number) ? heads[0].number : heads[1].number;
+  const block = await rpc("eth_getBlockByNumber", [toHex(BigInt(height)), false], tradeBlockV1);
+  const value = await rpc("eth_call", [{ to: getAddress(token), data: "0x313ce567" }, { blockHash: block.hash, requireCanonical: true }], bytesV1);
+  if (value.length !== 66 || BigInt(value) > 36n) throw new SwapUnavailableError("The token’s decimals could not be verified. Try again.", "TOKEN_METADATA_UNAVAILABLE");
+  return Number(BigInt(value));
+}

--- a/lib/server/swap/token.ts
+++ b/lib/server/swap/token.ts
@@ -8,6 +8,7 @@ import { isRobinhoodNativeModuleLaunch, isRobinhoodEngineLaunch, robinhoodModule
 import { isModuleEngineSharedQuoteRelease } from "@/lib/module-engine/profile";
 import { resolveProjectionAddress } from "@/lib/custom-launch/launch-projection-v1";
 import { readCustomV4SwapDescriptor } from "./custom-v4";
+import { readRobinhoodSwapDecimals } from "./token-metadata";
 import { SWAP_TOKEN_SCHEMA, SwapUnavailableError, type SwapChainId, type SwapTokenDescriptor } from "@/lib/swap/types";
 
 const ZERO = "0x0000000000000000000000000000000000000000";
@@ -17,10 +18,11 @@ export interface SwapTokenDependencies {
   native: typeof readModuleModeAvailability;
   engine: typeof readModuleEngineAvailability;
   custom: typeof readCustomV4SwapDescriptor;
+  decimals: typeof readRobinhoodSwapDecimals;
 }
 const readers: SwapTokenDependencies = {
   robinhood: readRobinhoodToken, ethereum: readEthereumToken,
-  native: readModuleModeAvailability, engine: readModuleEngineAvailability, custom: readCustomV4SwapDescriptor,
+  native: readModuleModeAvailability, engine: readModuleEngineAvailability, custom: readCustomV4SwapDescriptor, decimals: readRobinhoodSwapDecimals,
 };
 
 function tokenMetadata(row: { tokenAddress: string; name: string | null; symbol: string | null; decimals?: number | null; tokenDecimals?: number }) {
@@ -59,7 +61,8 @@ export async function resolveSwapToken(input: { address: string; chainId?: SwapC
 }
 
 async function resolveRobinhoodSwapToken(row: RobinhoodLaunch, dependencies: SwapTokenDependencies): Promise<SwapTokenDescriptor> {
-  const base = { schemaVersion: SWAP_TOKEN_SCHEMA, chainId: 4663 as const, token: tokenMetadata(row), manageHref: robinhoodModuleManageHref(row) };
+  const decimals = row.decimals ?? await dependencies.decimals(row.tokenAddress);
+  const base = { schemaVersion: SWAP_TOKEN_SCHEMA, chainId: 4663 as const, token: tokenMetadata({ ...row, decimals }), manageHref: robinhoodModuleManageHref(row) };
   if (isRobinhoodNativeModuleLaunch(row)) {
     const availability = await dependencies.native(row.sourceReleaseDigest);
     if (!availability.release || availability.release.releaseDigest.toLowerCase() !== row.sourceReleaseDigest.toLowerCase()) return unavailable(base, "This coin’s original module version is temporarily unavailable. Try again.");

--- a/tests/swap-token-metadata.test.ts
+++ b/tests/swap-token-metadata.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { toHex } from "viem";
+import { readRobinhoodSwapDecimals } from "@/lib/server/swap/token-metadata";
+import type { TradeRpcV1 } from "@/lib/server/custom-launch/routed-trade-rpc-v1";
+
+vi.mock("server-only", () => ({}));
+const token = `0x${"12".repeat(20)}`;
+const block = { number: "0x64", hash: `0x${"34".repeat(32)}`, timestamp: "0x100" };
+function provider(decimals: number, chain = "0x1237") {
+  return vi.fn(async (method: string) => {
+    if (method === "eth_chainId") return chain;
+    if (method === "eth_getBlockByNumber") return block;
+    if (method === "eth_call") return toHex(decimals, { size: 32 });
+    throw new Error("Unexpected RPC method");
+  }) as unknown as TradeRpcV1;
+}
+
+describe("projected swap token units", () => {
+  it("reads actual token decimals at the same canonical block on both providers", async () => {
+    const a = provider(6), b = provider(6);
+    expect(await readRobinhoodSwapDecimals(token, [a, b])).toBe(6);
+    for (const rpc of [a, b]) expect(rpc).toHaveBeenCalledWith("eth_call", [
+      { to: token, data: "0x313ce567" }, { blockHash: block.hash, requireCanonical: true },
+    ]);
+  });
+  it("rejects providers that disagree about token units", async () => {
+    await expect(readRobinhoodSwapDecimals(token, [provider(6), provider(18)])).rejects.toThrow();
+  });
+  it("rejects a response from another network", async () => {
+    await expect(readRobinhoodSwapDecimals(token, [provider(18, "0x1"), provider(18, "0x1")])).rejects.toMatchObject({ code: "TOKEN_METADATA_UNAVAILABLE" });
+  });
+  it("rejects units outside the swap input range", async () => {
+    await expect(readRobinhoodSwapDecimals(token, [provider(255), provider(255)])).rejects.toMatchObject({ code: "TOKEN_METADATA_UNAVAILABLE" });
+  });
+});

--- a/tests/swap-token.test.ts
+++ b/tests/swap-token.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/lib/server/swap/custom-v4", () => ({ readCustomV4SwapDescriptor: vi.f
 function dependencies(row: RobinhoodLaunch) {
   return {
     robinhood: vi.fn(async () => ({ token: row, status: "ready" })), ethereum: vi.fn(),
-    native: vi.fn(), engine: vi.fn(), custom: vi.fn(async () => ({ launch: row })),
+    native: vi.fn(), engine: vi.fn(), custom: vi.fn(async () => ({ launch: row })), decimals: vi.fn(async () => 18),
   } as unknown as SwapTokenDependencies;
 }
 function nativeFixture(v2 = false) {
@@ -83,6 +83,23 @@ describe("swap source resolution", () => {
     vi.mocked(f.deps.robinhood).mockResolvedValue({ token: null, status: "ready" } as Awaited<ReturnType<SwapTokenDependencies["robinhood"]>>);
     await expect(resolveSwapToken({ address: a(900) }, f.deps)).rejects.toMatchObject({ code: "TOKEN_NOT_FOUND" });
     expect(f.deps.custom).not.toHaveBeenCalled();
+  });
+
+  it.each([0, 6, 18])("reads missing projected token units from the contract (%s decimals)", async decimals => {
+    const row = { ...nativeFixture().row, sourceKind: "multi-role-v2", decimals: null } as RobinhoodLaunch;
+    const deps = dependencies(row);
+    vi.mocked(deps.decimals).mockResolvedValue(decimals);
+    expect(await resolveSwapToken({ address: row.tokenAddress }, deps)).toMatchObject({ status: "ready", token: { decimals }, route: { kind: "custom-v4" } });
+    expect(deps.decimals).toHaveBeenCalledWith(row.tokenAddress);
+    expect(deps.custom).toHaveBeenCalledWith(row);
+  });
+
+  it("does not guess token units when the contract read fails", async () => {
+    const row = { ...nativeFixture().row, sourceKind: "multi-role-v2", decimals: null } as RobinhoodLaunch;
+    const deps = dependencies(row);
+    vi.mocked(deps.decimals).mockRejectedValue(new Error("Provider unavailable"));
+    await expect(resolveSwapToken({ address: row.tokenAddress }, deps)).rejects.toThrow("Provider unavailable");
+    expect(deps.custom).not.toHaveBeenCalled();
   });
 
   it("reuses the existing Ethereum classic adapter with token decimals", async () => {


### PR DESCRIPTION
The protected `/swap` rollout found that BLOB and other projected launches can have `decimals: null` in their canonical index row. Their verified trading adapter worked, but token discovery rejected the missing display metadata before reaching it.

Read missing ERC-20 decimals from the indexed contract using both existing independent Robinhood providers at the same canonical block. Preserve the original index row and launch descriptor, reject disagreement, and never assume 18 decimals.

Validation: 19 focused metadata/source-resolution tests pass, including 0/6/18 decimals, provider disagreement, wrong chain and missing reads. Whole-project typecheck and scoped lint pass. Protected production API checks already proved the BLOB trading route; the updated token-discovery endpoint will be checked before promotion.
