### PR TITLE
Fix MetaMask numeric nonce in custom swap quotes

### DIFF
--- a/lib/swap/custom-v4.ts
+++ b/lib/swap/custom-v4.ts
@@ -174,7 +174,11 @@ export async function prepareCustomV4SwapWallet(provider: LaunchWalletProviderV1
   if (!response.ok) throw new LaunchPlanTradeErrorV1(projectionObject(body) && typeof body.code === "string" ? body.code : "SWAP_UNAVAILABLE",
     projectionObject(body) && typeof body.error === "string" && body.error.length < 512 ? body.error : "The swap could not be prepared.", response.status === 400 ? 400 : response.status === 409 ? 409 : 503);
   const preparation = validateCustomV4SwapPreparation(body, { descriptor: input.descriptor, request });
-  const quantity = (value: unknown) => typeof value === "string" && /^0x[0-9a-f]{1,64}$/i.test(value) ? BigInt(value) : invalid("INVALID_WALLET_READ");
+  const quantity = (value: unknown) => {
+    // Wallet SDKs can normalize RPC quantities, including the pending nonce, to numbers.
+    if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) return BigInt(value);
+    return typeof value === "string" && /^0x[0-9a-f]{1,64}$/i.test(value) ? BigInt(value) : invalid("INVALID_WALLET_READ");
+  };
   const [chain, accounts, controllerCode] = await Promise.all([provider.request({ method: "eth_chainId" }), provider.request({ method: "eth_accounts" }),
     provider.request({ method: "eth_getCode", params: [from, "latest"] })]);
   if (quantity(chain) !== 4663n || !Array.isArray(accounts) || typeof accounts[0] !== "string" || getAddress(accounts[0]) !== from

--- a/tests/swap-custom-v4.test.ts
+++ b/tests/swap-custom-v4.test.ts
@@ -155,7 +155,7 @@ describe("historical V4 native swap adapter", () => {
     expect(() => parseCustomV4SwapRequest({ ...request(), amountIn: (1n << 128n).toString() })).toThrow();
     expect(() => buildCustomV4SwapApproval(request(), "token_approval")).toThrow();
   });
-  it("wallet preparation reconstructs and checks the transaction without sending", async () => {
+  it.each(["0x6d", 109])("wallet preparation accepts nonce %j and checks the transaction without sending", async nonce => {
     const value = await prepared(), source = await descriptor(), methods: string[] = [];
     const clock = vi.spyOn(Date, "now").mockReturnValue(Number(now * 1000n));
     try {
@@ -163,13 +163,13 @@ describe("historical V4 native swap adapter", () => {
         methods.push(method);
         if (method === "eth_accounts") return [owner]; if (method === "eth_chainId") return "0x1237";
         if (method === "eth_getCode") return String(params?.[0]).toLowerCase() === owner.toLowerCase() ? "0x" : runtime;
-        if (method === "eth_getTransactionCount") return "0x1";
+        if (method === "eth_getTransactionCount") return nonce;
         if (method === "eth_call") return "0x"; if (method === "eth_estimateGas") return "0x186a0";
         if (method === "eth_gasPrice") return "0x1"; if (method === "eth_getBalance") return toHex(10n ** 18n);
         throw new Error("Unexpected wallet request");
       } };
       const result = await prepareCustomV4SwapWallet(provider, owner, { action: "review", descriptor: source, request: request() }, (async () => Response.json(value)) as typeof fetch);
-      expect(result.transaction.to).toBe(getAddress(infra.universalRouter.address)); expect(result.transaction.nonce).toBe("0x1");
+      expect(result.transaction.to).toBe(getAddress(infra.universalRouter.address)); expect(result.transaction.nonce).toBe("0x6d");
       const originalMinimum = value.quote.amountOutMinimum;
       const sendReview = await prepareCustomV4SwapWallet(provider, owner, { action: "send", descriptor: source, request: request(), reviewed: result }, (async (_url, init) => {
         const sendRequest = JSON.parse(String(init?.body));
@@ -180,6 +180,12 @@ describe("historical V4 native swap adapter", () => {
       expect(sendReview.preparation.quote.amountOut).toBe("49900");
       await expect(prepareCustomV4Swap({ ...request(), amountOutMinimum: originalMinimum }, { loadLaunch: async () => launch(), rpcs: [fixtureRpc({ outputAmount: 49000n }), fixtureRpc({ outputAmount: 49000n })], now: () => now })).rejects.toThrow("minimum");
       expect(methods).not.toContain("eth_sendTransaction");
+      for (const invalidNonce of [-1, 1.5, Number.MAX_SAFE_INTEGER + 1, NaN, Infinity, "109", null]) {
+        const invalidProvider = { request: async (input: { method: string; params?: readonly unknown[] }) =>
+          input.method === "eth_getTransactionCount" ? invalidNonce : provider.request(input) };
+        await expect(prepareCustomV4SwapWallet(invalidProvider, owner, { action: "review", descriptor: source, request: request() },
+          (async () => Response.json(value)) as typeof fetch)).rejects.toMatchObject({ code: "INVALID_WALLET_READ" });
+      }
     } finally { clock.mockRestore(); }
   });
 });


### PR DESCRIPTION
MetaMask through the connected wallet SDK returns the pending transaction count as the number `109`. Custom swap quotes rejected that valid value because the wallet boundary expected hexadecimal RPC strings, leaving the live Swap page on “Quote unavailable”.

Accept non-negative safe integer quantities as well as the existing hexadecimal form. Transaction reconstruction, nonce binding, gas limits, runtime checks, and amount checks remain enforced.

Validation: captured the actual browser exception (`INVALID_WALLET_READ`) and numeric nonce at the failing boundary; 19 adapter tests pass, including numeric/hex nonce review and send preparation plus rejection of negative, fractional, unsafe, NaN, infinite, decimal-string and null values. Typecheck and targeted lint pass. No transactions sent.
